### PR TITLE
vm3jit/amd64: generalize movsd->movaps for all f64 prep moves (n.12.b)

### DIFF
--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -1408,13 +1408,19 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		return movImm64ByteCount(bits, xRCX) + 5, nil
 
 	case vm3.OpMovF64:
-		// movsd xmm<A>, xmm<B>: 4 bytes (xmm0..7 only, no REX needed).
-		return 4, nil
+		// movaps xmm<A>, xmm<B>: 3 bytes (xmm0..7 only, no REX needed).
+		// movaps over movsd here because movsd reg-reg is a partial
+		// 64-bit write that creates a false dependency through the
+		// destination's upper bits; movaps writes all 128 bits and is
+		// treated by the renamer as dependency-breaking, which matters
+		// for the spectral_norm / n_body inner loops where xmm<A> is
+		// often the long-latency divsd output reg.
+		return 3, nil
 	case vm3.OpAddF64, vm3.OpSubF64, vm3.OpMulF64, vm3.OpDivF64:
 		// Phase 6.3.4.n.7 FMA fusion: an OpMulF64 absorbed into the
 		// following OpAddF64/OpSubF64 emits zero bytes here, and the
 		// consuming Add/Sub emits VFMADD/VFNMADD (5 bytes when Dd
-		// already aliases one of {Da, Dn, Dm}, else movsd+VFMADD = 9).
+		// already aliases one of {Da, Dn, Dm}, else movaps+VFMADD = 8).
 		if op.Code == vm3.OpMulF64 && fmaFusionAbsorbed(fn, idx) {
 			return 0, nil
 		}
@@ -1423,14 +1429,16 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 				if int(f.Dd) == int(f.Dn) || int(f.Dd) == int(f.Dm) || int(f.Dd) == int(f.Da) {
 					return 5, nil
 				}
-				return 4 + 5, nil
+				return 3 + 5, nil
 			}
 		}
 		// A == B: <op>sd xmm<A>, xmm<C> (4 bytes).
 		// A == C, commutative (Add/Mul): <op>sd xmm<A>, xmm<B> (4).
-		// A == C, non-commutative (Sub/Div): movsd xmm15, xmm<C> (5) ;
-		//   movsd xmm<A>, xmm<B> (4) ; <op>sd xmm<A>, xmm15 (5) = 14.
-		// Otherwise: movsd xmm<A>, xmm<B> (4) ; <op>sd xmm<A>, xmm<C> (4).
+		// A == C, non-commutative (Sub/Div): movaps xmm15, xmm<C> (4) ;
+		//   movaps xmm<A>, xmm<B> (3) ; <op>sd xmm<A>, xmm15 (5) = 12.
+		// Otherwise: movaps xmm<A>, xmm<B> (3) ; <op>sd xmm<A>, xmm<C> (4).
+		// See n.12.b prep-move false-dep fix for the rationale on
+		// using movaps instead of movsd here.
 		a, b, c := op.A, op.B, uint16(op.C)
 		if a == b {
 			return 4, nil
@@ -1439,16 +1447,16 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 			if op.Code == vm3.OpAddF64 || op.Code == vm3.OpMulF64 {
 				return 4, nil
 			}
-			return 14, nil
+			return 12, nil
 		}
-		return 8, nil
+		return 7, nil
 	case vm3.OpNegF64:
 		// mov $signbit, %rcx (10) ; movq xmm15, %rcx (5, REX.W+R) ;
-		// optional movsd xmm<A>, xmm<B> (4) ; xorpd xmm<A>, xmm15 (5, REX.B).
+		// optional movaps xmm<A>, xmm<B> (3) ; xorpd xmm<A>, xmm15 (5, REX.B).
 		if op.A == op.B {
 			return 10 + 5 + 5, nil
 		}
-		return 10 + 5 + 4 + 5, nil
+		return 10 + 5 + 3 + 5, nil
 
 	case vm3.OpFmaF64:
 		// Phase 6.3.4.h.2 AMD64 lowering: VFMADDxxxSD selected so dst
@@ -1456,7 +1464,7 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		// semantics A = B*mul2 + addend without extra moves when one of
 		// the operands already aliases A. All four code paths emit a
 		// single 5-byte VEX-encoded instruction; only the catch-all
-		// (no alias) needs a leading movsd (4 bytes) to set A := B
+		// (no alias) needs a leading movaps (3 bytes) to set A := B
 		// before the 132 form.
 		mul2 := int(uint16(op.C) & 0xFF)
 		addend := int((uint16(op.C) >> 8) & 0xFF)
@@ -1464,15 +1472,15 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		if a == b || a == addend || a == mul2 {
 			return 5, nil
 		}
-		return 4 + 5, nil
+		return 3 + 5, nil
 	case vm3.OpSqrtF64:
-		// optional movsd xmm<A>, xmm<B> (4) ; sqrtsd xmm<A>, xmm<A> (4).
+		// optional movaps xmm<A>, xmm<B> (3) ; sqrtsd xmm<A>, xmm<A> (4).
 		// (sqrtsd's source can match its dest, so we always operate
 		// in-place after the optional copy.)
 		if op.A == op.B {
 			return 4, nil
 		}
-		return 8, nil
+		return 7, nil
 
 	case vm3.OpCmpEqF64Br, vm3.OpCmpLtF64Br, vm3.OpCmpLeF64Br:
 		// ucomisd xmm<A>, xmm<B> (4) ; jp +6 (6) ; jcc rel32 (6).
@@ -2079,7 +2087,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		return out, nil
 
 	case vm3.OpMovF64:
-		return movsdRR(int(op.A), int(op.B)), nil
+		return movapsRR(int(op.A), int(op.B)), nil
 	case vm3.OpAddF64:
 		if f, ok := fmaFusionAt(fn, idx); ok && f.Kind == 'a' {
 			return emitFMA3SDFusedAMD64(false, f), nil
@@ -2103,7 +2111,7 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		out := movImm64(xRCX, int64(signBit))
 		out = append(out, movqXMMFromR64(15, xRCX)...)
 		if op.A != op.B {
-			out = append(out, movsdRR(int(op.A), int(op.B))...)
+			out = append(out, movapsRR(int(op.A), int(op.B))...)
 		}
 		out = append(out, xorpdRR(int(op.A), 15)...)
 		return out, nil
@@ -2120,13 +2128,13 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		case a == mul2:
 			return vfmaddSDRR(0xA8, a, b, addend), nil
 		default:
-			out := movsdRR(a, b)
+			out := movapsRR(a, b)
 			return append(out, vfmaddSDRR(0x98, a, addend, mul2)...), nil
 		}
 	case vm3.OpSqrtF64:
 		var out []byte
 		if op.A != op.B {
-			out = append(out, movsdRR(int(op.A), int(op.B))...)
+			out = append(out, movapsRR(int(op.A), int(op.B))...)
 		}
 		return append(out, sqrtsdRR(int(op.A), int(op.A))...), nil
 
@@ -3224,11 +3232,11 @@ func emitSSEArithAMD64(op func(dst, src int) []byte, a, b, c int, commutative bo
 		if commutative {
 			return op(a, b)
 		}
-		out := movsdRR(15, c)
-		out = append(out, movsdRR(a, b)...)
+		out := movapsRR(15, c)
+		out = append(out, movapsRR(a, b)...)
 		return append(out, op(a, 15)...)
 	}
-	out := movsdRR(a, b)
+	out := movapsRR(a, b)
 	return append(out, op(a, c)...)
 }
 
@@ -3288,7 +3296,7 @@ func emitFMA3SDFusedAMD64(neg bool, f fmaFusion) []byte {
 	case dd == dm:
 		return vfmaddSDRR(op213, dd, dn, da)
 	default:
-		out := movsdRR(dd, da)
+		out := movapsRR(dd, da)
 		return append(out, vfmaddSDRR(op231, dd, dn, dm)...)
 	}
 }

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -3355,6 +3355,29 @@ Total: **10 bytes / 2 instructions per hot Get/Set, down from 36 bytes / 6 instr
 
 **Closure verdict.** n.12 is a partial closure of spectral_norm and a regression-free restoration of n_body. The headline win is the dependency-breaking rewrite (movsd -> movaps for hoisted-const reloads), a well-known modern-OOO micro-architectural pitfall that has now been documented in `movapsRR`'s comment so future scratch-reg LICM passes pick up the right helper by default.
 
+#### Phase 6.3.4.n.12.b: generalize movsd -> movaps across all f64 reg-reg prep moves (2026-05-20 23:37 GMT+7)
+
+**Why this phase.** n.12 fixed the partial-write false dep only at the hoisted-const reload site. The same anti-pattern lives in every f64 arith prep move: `emitSSEArithAMD64` uses `movsd xmm<A>, xmm<B>` before `addsd / subsd / mulsd / divsd xmm<A>, xmm<C>` whenever the destination does not already alias an operand. Because addsd / mulsd / divsd also preserve the upper 64 bits of the destination, the false-dep chain through `xmm<A>`'s upper half cascades across iterations even when `<A>`'s prior value is logically dead. The renamer cannot prove the upper half is unused and serializes through it. Every f64 arith hot path on AMD64 carried this hazard; n.12 only fixed the one site where it was most visible.
+
+**Mechanism.** Replace every `movsdRR` reg-reg use in lower_amd64.go with `movapsRR` (full 128-bit copy, dep-breaking). The eight sites are: `OpMovF64`, `OpNegF64` prep, `OpFmaF64` default prep, `OpSqrtF64` prep, and the three sites inside `emitSSEArithAMD64` (xmm15 scratch save, A==C non-commutative prep, generic prep), plus `emitFMA3SDFusedAMD64` default. Each replacement saves 1 byte (3-byte movaps vs 4-byte movsd for xmm0..7, 4-byte vs 5-byte with REX) and breaks the cross-iteration dep. `byteCountAMD64` is updated to match: default arith case 8 -> 7, aliasing non-commutative case 14 -> 12, FMA-default 9 -> 8, OpNegF64 (a!=b) 24 -> 23, OpSqrtF64 (a!=b) 8 -> 7, OpMovF64 4 -> 3. Safety: every replaced site is a prep-move whose destination is immediately overwritten or read-modify-written, so the dst's prior value is never live; movaps is a sound substitute.
+
+**Results.** linux/amd64 (EPYC, server2; -benchtime=2s -count=10, medians):
+
+| size                    | Go ns/op | JIT n.12 (hoist-only) | JIT n.12.b (generalized) | JIT/Go |
+| ----------------------- | -------- | --------------------- | ------------------------- | ------ |
+| `n_body_n100`           | 41,530   | 47,228                | 51,937                    | 1.25x  |
+| `n_body_n10000`         | 4,192,563| 4,551,158             | 3,839,650                 | 0.92x  |
+| `spectral_norm_n100`    | 108,957  | 262,066               | 157,469                   | 1.45x  |
+| `spectral_norm_n1000`   | 8,441,157| 20,984,082            | 19,035,637                | 2.25x  |
+
+**Diagnosis.** spectral_norm_n100 drops from 2.40x to 1.45x (**newly closed**): the inner arith chain `mul; div; sub` had every prep-move serialized through the divsd output's upper 64 bits, and breaking that chain lets the renamer issue iterations in parallel. spectral_norm_n1000 improves from 2.49x to 2.25x but stays above 2x; the remaining gap is dominated by the divsd's own latency (14-20 cycles, non-pipelined) and the integer chain feeding cvtsi2sd, neither of which n.12.b touches. n_body_n10000 also improves modestly (1.09x -> 0.92x, faster than Go); n_body_n100 shows a 10% median regression that the trimmed-mean and best-3 windows do not (best-3 of n.12 ~42.3µs vs n.12.b ~42.4µs, identical), consistent with benchmark variance rather than codegen loss.
+
+**Composite gate.** linux/amd64 closure advances from **14/18** (n.12) to **15/18** sizes inside 2x with spectral_norm_n100 newly closed. Cross-platform tally moves from 32/36 to **33/36 sizes inside 2x** (18/18 macOS arm64 + 15/18 linux/amd64). The three remaining open sizes on linux/amd64 are spectral_norm_n1000 (2.25x; needs divsd ILP attack), k_nucleotide_n10000 / n100000 (tracked by n.8: AMD64 OpMapSetI64I64 / OpMapGetI64I64 lowering).
+
+**Tests.** `go test -count=1 -tags=jit ./runtime/jit/vm3jit/...` passes on darwin/arm64 and linux/amd64 (EPYC). ARM64 unaffected (change is AMD64-only inside `lower_amd64.go`).
+
+**Closure verdict.** The dep-breaking rewrite is now applied uniformly across f64 prep-moves on AMD64. The hoisted-const fix (n.12) was a special case of a broader micro-arch hazard; generalizing it picks up an extra spectral_norm size and a measurable win on n_body_n10000 with no regressions outside the per-run variance band.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
## Summary

Generalizes the n.12 false-dep fix across every f64 reg-reg prep move in `runtime/jit/vm3jit/lower_amd64.go`. Replaces all `movsdRR` reg-reg sites with `movapsRR` (full 128-bit dependency-breaking copy). Each replacement saves 1 byte and breaks the cross-iteration false-dep chain through the destination's upper 64 bits.

Touched sites: `OpMovF64`, `OpNegF64` prep, `OpFmaF64` default prep, `OpSqrtF64` prep, `emitSSEArithAMD64` (three sites), `emitFMA3SDFusedAMD64` default. `byteCountAMD64` updated to match.

## Results (linux/amd64 EPYC, -benchtime=2s -count=10, medians)

| size                  | Go ns/op | JIT n.12 | JIT n.12.b | JIT/Go |
| --------------------- | -------- | -------- | ---------- | ------ |
| `n_body_n100`         | 41,530   | 47,228   | 51,937     | 1.25x  |
| `n_body_n10000`       | 4,192,563| 4,551,158| 3,839,650  | 0.92x  |
| `spectral_norm_n100`  | 108,957  | 262,066  | 157,469    | 1.45x  |
| `spectral_norm_n1000` | 8,441,157| 20,984,082| 19,035,637| 2.25x  |

`spectral_norm_n100` newly closed under 2x. Cross-platform tally advances 32/36 -> 33/36 sizes inside 2x.

Spec: MEP-40 §6.3.4.n.12.b.

Tracking issue: #21877.

## Test plan
- [x] `go build ./runtime/jit/vm3jit/...` darwin/arm64 + linux/amd64 cross
- [x] `go test -count=1 -tags=jit ./runtime/jit/vm3jit/...` passes on both arches
- [x] BG bench on linux/amd64 EPYC shows spectral_norm/n_body movement listed above