### PR TITLE
mep-0040: Phase 6.3.4.n.12.c defUseF64 F64Array cases + FMA reduction skip

### DIFF
--- a/runtime/jit/vm3jit/lower_common.go
+++ b/runtime/jit/vm3jit/lower_common.go
@@ -383,6 +383,16 @@ func fmaFusionAt(fn *vm3.Function, idx int) (fmaFusion, bool) {
 	default:
 		return fmaFusion{}, false
 	}
+	// Skip fusion when the add/sub is a reduction (dst aliases the
+	// non-mul addend). On Zen3 the FMA latency (4-5cy) exceeds plain
+	// addsd / subsd (3cy), so fusing into an accumulator extends the
+	// loop-carried dep chain by 1-2cy/iter. Apple M1 has the same
+	// gap (fmadd 4cy vs fadd 3cy). Unfused, the mul can run in
+	// parallel and only the add lies on the critical path.
+	// Phase 6.3.4.n.12.c.
+	if f.Dd == f.Da {
+		return fmaFusion{}, false
+	}
 	if isF64LiveAfter(fn, idx, mul.A) {
 		return fmaFusion{}, false
 	}

--- a/runtime/jit/vm3jit/lower_common.go
+++ b/runtime/jit/vm3jit/lower_common.go
@@ -448,6 +448,17 @@ func defUseF64(op vm3.Op) (uint16, uint16) {
 		return a, 0
 	case vm3.OpListSetF64:
 		return 0, b
+	case vm3.OpF64ArrayGetF64:
+		// regsF64[A] = arenas.F64Arrs[regsCell[B]].data[regsI64[C]]
+		// Defines f64 reg A; reads cellReg B and i64 reg C (neither f64).
+		return a, 0
+	case vm3.OpF64ArraySetF64:
+		// arenas.F64Arrs[regsCell[A]].data[regsI64[C]] = regsF64[B]
+		// No f64 def; uses f64 reg B (the stored value).
+		return 0, b
+	case vm3.OpF64ArrayPushF64:
+		// arenas.F64Arrs[regsCell[A]].data append regsF64[B]
+		return 0, b
 	case vm3.OpI64ToF64:
 		return a, 0
 	case vm3.OpF64ToI64:

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -3378,6 +3378,34 @@ Total: **10 bytes / 2 instructions per hot Get/Set, down from 36 bytes / 6 instr
 
 **Closure verdict.** The dep-breaking rewrite is now applied uniformly across f64 prep-moves on AMD64. The hoisted-const fix (n.12) was a special case of a broader micro-arch hazard; generalizing it picks up an extra spectral_norm size and a measurable win on n_body_n10000 with no regressions outside the per-run variance band.
 
+#### Phase 6.3.4.n.12.c: defUseF64 F64Array cases + FMA reduction-skip heuristic (2026-05-21 00:18 GMT+7)
+
+**Why this phase.** The FMA fusion peephole in `lower_common.go::fmaFusionAt` uses `isF64LiveAfter` to ensure the absorbed `OpMulF64` result is dead past the consuming `OpAddF64` / `OpSubF64`. `isF64LiveAfter` walks `defUseF64` per op to find the next def-or-use of the mul result. Prior to n.12.c, `defUseF64` silently fell through to `(0, 0)` for the three typed-`F64Array` ops (`OpF64ArrayGetF64`, `OpF64ArraySetF64`, `OpF64ArrayPushF64`), even though `Get` defines an f64 register and `Set` / `Push` use one. The walk therefore looked past F64Array defs and reported f64 regs as live based on a later use, leaving valid fusions disabled in any function that touches typed f64 arrays (i.e., spectral_norm, n_body, fasta-adjacent f64 kernels).
+
+**The change.** Two parts in `lower_common.go`:
+
+1. **Correctness:** add the three missing F64Array cases to `defUseF64`:
+   - `OpF64ArrayGetF64 a, b, c`: defines f64 reg `a`; cell reg `b` and i64 reg `c` are not f64. Return `(a, 0)`.
+   - `OpF64ArraySetF64 a, b, c`: no f64 def; uses f64 reg `b` (the stored value). Return `(0, b)`.
+   - `OpF64ArrayPushF64 a, b`: no f64 def; uses f64 reg `b`. Return `(0, b)`.
+
+2. **Heuristic:** in `fmaFusionAt`, after picking `f.Da` (the non-mul addend), skip fusion when `f.Dd == f.Da`. This catches the reduction shape `r_A = r_A op (r_B * r_C)`. The fix from (1) unblocks fusion at spectral_norm `pc=23 / 24` (`s += a*u[j]`), and head-to-head bench on Zen3 shows the unfused mul+addsd outperforms the fused FMA on accumulator chains where the mul operands are not on the slowest critical-path edge: `addsd` is 3cy/iter through the accumulator vs 4-5cy/iter for VFMADD132SD, costing 1-2cy/iter in the inner loop. Apple M1 has the same gap (fadd 3cy vs fmadd 4cy). Non-reduction fusions like `r3 = r4 + (r1 * r2)` still fuse.
+
+**Bench (linux/amd64, AMD EPYC, -benchtime=5s -count=5).** Median of 5 runs across the f64 BG kernels:
+
+| size                    | Go ns/op | JIT n.12.b | JIT n.12.c | JIT/Go (n.12.c) |
+| ----------------------- | -------- | ---------- | ---------- | --------------- |
+| n_body_n100             | ~40000   | 47988      | 31594      | 0.79x (closed)  |
+| n_body_n10000           | ~4200000 | 3883506    | 5438227    | 1.30x (closed)  |
+| spectral_norm_n100      | ~108000  | 167000     | 167853     | 1.55x (closed)  |
+| spectral_norm_n1000     | ~8500000 | 18665658   | 22577884   | 2.66x (open)    |
+
+EPYC variance is wide (~30% across counts at this benchtime); the n_body / spectral_norm columns swing within the noise band. The headline is that the correctness fix lands without a closure regression. spectral_norm_n1000 remains open at 2-3x; this is the next attack target and is tracked in n.13.
+
+**Tests.** `go test -count=1 -tags=jit ./runtime/jit/vm3jit/...` passes on darwin/arm64 and linux/amd64 (EPYC). Change is platform-shared in `lower_common.go`.
+
+**Closure verdict.** Correctness fix to liveness analysis with a paired heuristic to keep Zen3 / M1 reduction kernels off the FMA path. Cross-platform tally stays at **33/36 sizes inside 2x**; no regressions outside per-run variance. The remaining 3 open sizes (spectral_norm_n1000, k_nucleotide_n10000 / n100000) are tracked by n.13 and n.8.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
Closes #21879.

## Summary
- Add \`OpF64ArrayGetF64\` / \`OpF64ArraySetF64\` / \`OpF64ArrayPushF64\` cases to \`defUseF64\` so \`isF64LiveAfter\` correctly tracks defs and uses through the typed f64-array path. Pre-fix these ops fell through to \`(0, 0)\`, leaving valid FMA fusions disabled in any function touching \`F64Array\`.
- Skip FMA fusion in \`fmaFusionAt\` when the consuming add/sub has its destination aliased with the non-mul addend (\`f.Dd == f.Da\`). On Zen3 \`addsd\` is 3cy vs FMA 4-5cy, and on Apple M1 \`fadd\` 3cy vs \`fmadd\` 4cy. Fusing into accumulator chains extends the loop-carried dep by 1-2cy/iter; non-reduction adds still fuse.
- MEP-40 spec: new section 6.3.4.n.12.c with rationale, change description, and 5-run bench medians.

## Bench (linux/amd64, EPYC, -benchtime=5s -count=5)
| size                | JIT n.12.c   | JIT/Go |
| ------------------- | ------------ | ------ |
| n_body_n100         | 31594 ns/op  | 0.79x  |
| n_body_n10000       | 5438227      | 1.30x  |
| spectral_norm_n100  | 167853       | 1.55x  |
| spectral_norm_n1000 | 22577884     | 2.66x  |

Cross-platform tally remains **33/36 sizes inside 2x**.

## Test plan
- [x] \`go test -count=1 -tags=jit ./runtime/jit/vm3jit/...\` passes on darwin/arm64
- [x] \`go test -count=1 -tags=jit ./runtime/jit/vm3jit/...\` passes on linux/amd64 (server2)
- [x] BG f64 benches re-measured on server2