### PR TITLE
mep-0040: hotfix Phase 6.3.4.n.13 closure tally (35/36 -> 34/36)

### DIFF
--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -3436,7 +3436,7 @@ spectral_norm_n1000 drops from 22.58ms to ~7.0ms median, a 3.2x speedup. The sin
 
 **Tests.** `go test -count=1 ./runtime/jit/vm3jit/...` passes on darwin/arm64 and linux/amd64 (server2). ARM64 is unaffected because SDIV is cheap there (no shortcut needed) and the predicate / emitter changes are AMD64-only.
 
-**Closure verdict.** spectral_norm closes on both sizes on linux/amd64. Cross-platform tally goes from **33/36 to 35/36 sizes inside 2x**; the remaining open size is k_nucleotide_n100000, which is bottlenecked on `OpMapSetI64I64` / `OpMapGetI64I64` AMD64 lowering and is tracked by n.8. The pow2-K shortcut is a generic VM win: any future kernel using `n / 4`, `n / 8`, `n % 16` etc. will inherit it without further code changes. No hard-coded super-ops, no per-kernel heuristics: it is the textbook LLVM / GCC transformation for the case Granlund-Montgomery doesn't cover.
+**Closure verdict.** spectral_norm closes on both sizes on linux/amd64. Cross-platform tally goes from **33/36 to 34/36 sizes inside 2x** (n.12 already closed spectral_norm_n100; n.13 newly closes spectral_norm_n1000). The remaining open sizes are k_nucleotide_n10000 and k_nucleotide_n100000, both bottlenecked on `OpMapSetI64I64` / `OpMapGetI64I64` AMD64 lowering and tracked by n.8. The pow2-K shortcut is a generic VM win: any future kernel using `n / 4`, `n / 8`, `n % 16` etc. will inherit it without further code changes. No hard-coded super-ops, no per-kernel heuristics: it is the textbook LLVM / GCC transformation for the case Granlund-Montgomery doesn't cover.
 
 ### Phase 7: Production migration and vm2 deprecation
 


### PR DESCRIPTION
Tracks #21883.

The n.13 closure verdict in `website/docs/mep/mep-0040.md` overstated cross-platform progress: it claimed 33/36 -> 35/36 sizes inside 2x with only k_nucleotide_n100000 still open.

The correct tally is 33/36 -> 34/36:
- n.12 already closed spectral_norm_n100 (already counted in the 33/36 baseline).
- n.13 newly closes spectral_norm_n1000 (one new size, not two).
- Both k_nucleotide_n10000 AND k_nucleotide_n100000 remain over 2x on linux/amd64; they share the same missing AMD64 OpMapSet/Get lowering tracked by n.8.

## Test plan
- [x] Spec-only edit; no code change.