### PR TITLE
mep-0040: Phase 6.3.4.n.8.b AMD64 OpMapGetI64I64 inline lowering

### DIFF
--- a/runtime/jit/vm3jit/arena_ctx.go
+++ b/runtime/jit/vm3jit/arena_ctx.go
@@ -113,3 +113,10 @@ func jitArenaCtxF64ArrsBaseOff() uintptr {
 func jitArenaCtxI64ArrsBaseOff() uintptr {
 	return unsafe.Offsetof(jitArenaCtx{}.i64ArrsBase)
 }
+
+// jitArenaCtxMapsBaseOff is the byte offset of mapsBase within
+// jitArenaCtx. AMD64 OpMapGetI64I64/OpMapSetI64I64 (Phase 6.3.4.n.8.b/c)
+// load it from R14+disp32 to recover the map slab base on cell-bank fns.
+func jitArenaCtxMapsBaseOff() uintptr {
+	return unsafe.Offsetof(jitArenaCtx{}.mapsBase)
+}

--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -388,6 +388,23 @@ func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 			vm3.OpF64ArrayGetF64, vm3.OpF64ArraySetF64, vm3.OpF64ArrayLenI64,
 			vm3.OpI64ArrayGetI64, vm3.OpI64ArraySetI64, vm3.OpI64ArrayLenI64:
 			continue
+		case vm3.OpMapGetI64I64:
+			// Phase 6.3.4.n.8.b: AMD64 inline open-addressed lookup.
+			// Kernel clobbers R10/R11/R12 (vm3 slots 4/5/6) as pos /
+			// entry_addr / load scratch. Reject layouts where op.A or
+			// op.C lands in those slots (mirror of ARM64
+			// mapKernelOperandClobber). Also reject cell+f64 layouts
+			// because R12 is the f64 base in that shape and the kernel
+			// must clobber R12.
+			if usesR12ForF64AMD64(fn) {
+				return fmt.Errorf("%w: %s pc %d Cell+F64 OpMapGetI64I64 (R12 is f64 base; kernel needs R12 free)",
+					ErrNotImplemented, fn.Name, i)
+			}
+			if mapKernelOperandClobberAMD64(op) {
+				return fmt.Errorf("%w: %s pc %d OpMapGetI64I64 with op.A=%d op.C=%d in slots 4..6 (kernel clobbers R10/R11/R12)",
+					ErrNotImplemented, fn.Name, i, op.A, uint16(op.C))
+			}
+			continue
 		case vm3.OpNewF64Array, vm3.OpNewI64Array:
 			// Phase 6.3.4.n.3: admit at the pre-alloc K-prefix only.
 			// jitCall pre-allocates the slab; emit step skips the op.

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -1330,6 +1330,23 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		}
 		return mov32LoadDisp32ByteCount(xRAX, xRBP) + 7 + 7 + 3 + 7 + 7 + 4 + 4 + 3, nil
 
+	case vm3.OpMapGetI64I64:
+		// Phase 6.3.4.n.8.b: inline open-addressed lookup, AMD64 mirror of
+		// the ARM64 OpMapGetI64I64. Bytes: 198 kernel + optional 24-byte
+		// spill sandwich when NumRegsI64 > 4. Layout breakdown:
+		//
+		//   pre-amble (43B): mov32 load handle, imul slabStride, load
+		//     mapsBase, add, load tableLen disp8, test, JZ miss, load
+		//     tablePtr disp8, dec (mask = cap-1).
+		//   splitmix64 (62B): xKey -> RAX via R12 tmp (xKey preserved).
+		//   probe init (6B): mov pos=h, and mask.
+		//   probe body (73B): imul pos*24, add tablePtr, load entry.hash,
+		//     test+JZ miss, cmp h+JNE next, load entry.key+SBFX+cmp xKey+
+		//     JNE next, load entry.value+SBFX, mov xA, jmp done.
+		//   next (11B): inc pos, and mask, jmp probeTop.
+		//   miss (3B): xor xA, xA.
+		return mapGetI64I64BytesAMD64(fn), nil
+
 	case vm3.OpListSetI64:
 		// Phase 6.3.4.n.2.b cold form, AMD64 mirror of the ARM64
 		// OpListSetI64 (no hoist):
@@ -1972,6 +1989,148 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		out = append(out, shl64RImm8(xRAX, 16)...)
 		out = append(out, sar64RImm8(xRAX, 16)...)
 		out = append(out, mov64RR(xRAX, xA)...)
+		return out, nil
+
+	case vm3.OpMapGetI64I64:
+		// Phase 6.3.4.n.8.b: AMD64 mirror of the ARM64 OpMapGetI64I64.
+		// Inline open-addressed lookup over arenas.Maps[regsCell[B]].table
+		// using the splitmix64 hash. Result -> xA (= 0 on miss), xKey
+		// preserved across the splitmix64 call.
+		//
+		// Register plan (cell-bank fn, NumRegsF64 == 0):
+		//   RAX = h (after splitmix64), also scratch for slab addr
+		//   RCX = mask (= tableLen - 1)
+		//   RDX = tablePtr (pinned across probe loop)
+		//   R10 = pos (= h & mask, incremented per probe miss)
+		//   R11 = entry_addr = tablePtr + pos*24 (recomputed per probe)
+		//   R12 = splitmix64 xTmp, then per-iteration load scratch for
+		//         entry.hash / entry.key / entry.value
+		//   xKey = r2xAMD64(fn, uint16(op.C)) — preserved
+		//   xA = r2xAMD64(fn, op.A) — never in slots 4..6 by admission
+		//
+		// R10/R11/R12 alias vm3 slots 4/5/6; if NumRegsI64 > 4 we spill
+		// all three to [RBX + 4*8/5*8/6*8] at kernel entry and restore at
+		// exit. Admission gate rejects op.A and op.C in slots 4..6.
+		// Cell+f64 layouts (R12 = regsF64 base) are rejected at the gate
+		// because the kernel must clobber R12 as the load scratch.
+		xKey := r2xAMD64(fn, uint16(op.C))
+		xA := r2xAMD64(fn, op.A)
+		stride := int32(vm3.JITMapSlabStride())
+		tableOff := int8(vm3.JITMapTableOffset())
+		tablePtrOff := tableOff
+		tableLenOff := tableOff + 8
+		entryHashOff := int8(vm3.JITMapEntryHashOffset())
+		entryKeyOff := int8(vm3.JITMapEntryKeyOffset())
+		entryValOff := int8(vm3.JITMapEntryValueOffset())
+		mapsBaseOff := int32(jitArenaCtxMapsBaseOff())
+		entryStride := int32(vm3.JITMapEntryStride())
+		spillBytes := mapScratchSpillBytesAMD64(fn)
+
+		var out []byte
+
+		// Spill prologue (12B when NumRegsI64 > 4, else 0B).
+		if spillBytes > 0 {
+			out = append(out, mov64StoreDisp8(xR10, xRBX, int8(4*8))...)
+			out = append(out, mov64StoreDisp8(xR11, xRBX, int8(5*8))...)
+			out = append(out, mov64StoreDisp8(xR12, xRBX, int8(6*8))...)
+		}
+		kernelStart := len(out)
+
+		// Pre-amble: resolve slab, load tableLen, branch to miss if empty,
+		// load tablePtr, mask = tableLen - 1. (43 bytes.)
+		out = append(out, mov32LoadDisp32(xRAX, xRBP, int32(op.B)*8)...)
+		out = append(out, imul64RRImm32(xRAX, xRAX, stride)...)
+		out = append(out, mov64LoadDisp32(xRCX, xR14, mapsBaseOff)...)
+		out = append(out, add64RR(xRCX, xRAX)...)
+		out = append(out, mov64LoadDisp8(xRCX, xRAX, tableLenOff)...)
+		out = append(out, test64RR(xRCX, xRCX)...)
+		// JZ rel32 to miss (target patched below). Reserve 6 bytes.
+		preambleMissJZ := len(out)
+		out = append(out, jccRel32(0x4, 0)...)
+		out = append(out, mov64LoadDisp8(xRDX, xRAX, tablePtrOff)...)
+		out = append(out, dec64R(xRCX)...)
+
+		// Splitmix64(xKey, RAX, R12) -> RAX = h. (62 bytes.)
+		out = append(out, emitSplitmix64AMD64(xKey, xRAX, xR12)...)
+
+		// Probe init: R10 = h & mask. (6 bytes.)
+		out = append(out, mov64RR(xRAX, xR10)...)
+		out = append(out, and64RR(xRCX, xR10)...)
+
+		// probeTop:
+		probeTopOff := len(out)
+		// R11 = pos * 24 + tablePtr.
+		out = append(out, imul64RRImm32(xR11, xR10, entryStride)...)
+		out = append(out, add64RR(xRDX, xR11)...)
+		// R12 = entry.hash; if zero, miss.
+		out = append(out, mov64LoadDisp8(xR12, xR11, entryHashOff)...)
+		out = append(out, test64RR(xR12, xR12)...)
+		probeMissJZ := len(out)
+		out = append(out, jccRel32(0x4, 0)...) // JZ miss
+		// cmp h, entry.hash; if not equal, next.
+		out = append(out, cmp64RR(xRAX, xR12)...)
+		probeHashJNE := len(out)
+		out = append(out, jccRel32(0x5, 0)...) // JNE next
+		// R12 = entry.key; SBFX48; cmp xKey, R12; if not equal, next.
+		out = append(out, mov64LoadDisp8(xR12, xR11, entryKeyOff)...)
+		out = append(out, shl64RImm8(xR12, 16)...)
+		out = append(out, sar64RImm8(xR12, 16)...)
+		out = append(out, cmp64RR(xKey, xR12)...)
+		probeKeyJNE := len(out)
+		out = append(out, jccRel32(0x5, 0)...) // JNE next
+		// R12 = entry.value; SBFX48; xA = R12; jmp done.
+		out = append(out, mov64LoadDisp8(xR12, xR11, entryValOff)...)
+		out = append(out, shl64RImm8(xR12, 16)...)
+		out = append(out, sar64RImm8(xR12, 16)...)
+		out = append(out, mov64RR(xR12, xA)...)
+		probeDoneJMP := len(out)
+		out = append(out, jmpRel32(0)...) // JMP done
+
+		// next:
+		nextOff := len(out)
+		out = append(out, inc64R(xR10)...)
+		out = append(out, and64RR(xRCX, xR10)...)
+		// jmp probeTop.
+		nextProbeJMP := len(out)
+		out = append(out, jmpRel32(0)...)
+
+		// miss:
+		missOff := len(out)
+		out = append(out, xor64RR(xA, xA)...)
+
+		// done:
+		doneOff := len(out)
+
+		// Restore epilogue.
+		if spillBytes > 0 {
+			out = append(out, mov64LoadDisp8(xR10, xRBX, int8(4*8))...)
+			out = append(out, mov64LoadDisp8(xR11, xRBX, int8(5*8))...)
+			out = append(out, mov64LoadDisp8(xR12, xRBX, int8(6*8))...)
+		}
+
+		// Patch rel32 placeholders. jccRel32/jmpRel32 are 6/5 bytes; the
+		// rel32 is the last 4 bytes of each. Source address for rel32 is
+		// the byte immediately after the instruction.
+		patchRel32 := func(insnStart int, insnLen int, targetOff int) {
+			src := insnStart + insnLen
+			rel := int32(targetOff - src)
+			out[insnStart+insnLen-4] = byte(rel)
+			out[insnStart+insnLen-3] = byte(rel >> 8)
+			out[insnStart+insnLen-2] = byte(rel >> 16)
+			out[insnStart+insnLen-1] = byte(rel >> 24)
+		}
+		patchRel32(preambleMissJZ, 6, missOff)
+		patchRel32(probeMissJZ, 6, missOff)
+		patchRel32(probeHashJNE, 6, nextOff)
+		patchRel32(probeKeyJNE, 6, nextOff)
+		patchRel32(probeDoneJMP, 5, doneOff)
+		patchRel32(nextProbeJMP, 5, probeTopOff)
+
+		// Sanity check: kernel body size must match byte count predictor.
+		if len(out)-kernelStart != mapGetI64I64KernelBytesAMD64+spillBytes {
+			return nil, fmt.Errorf("MapGetI64I64 AMD64 kernel size mismatch: emitted %d want %d (spill=%d)",
+				len(out)-kernelStart, mapGetI64I64KernelBytesAMD64+spillBytes, spillBytes)
+		}
 		return out, nil
 
 	case vm3.OpListSetI64:
@@ -3648,6 +3807,58 @@ func emitSplitmix64AMD64(xKey, xOut, xTmp int) []byte {
 	out = append(out, or64RImm8(xOut, 1)...)
 	return out
 }
+
+// dec64R emits `dec %rDst` (rDst -= 1). Opcode REX.W FF /1. 3 bytes.
+// Phase 6.3.4.n.8.b uses this to compute the probe-table mask
+// (`mask = tableLen - 1`) one byte shorter than `sub rDst, $1`.
+func dec64R(dst int) []byte {
+	return []byte{rex(true, false, false, dst >= 8), 0xFF, modRM(3, 1, byte(dst&7))}
+}
+
+// mapKernelOperandClobberAMD64 reports whether op uses R10/R11/R12
+// (host regs for vm3 i64 slots 4/5/6) as one of its key/dst operands.
+// The AMD64 map kernel (Phase 6.3.4.n.8.b/c) clobbers those host regs
+// mid-flight as `pos`, `entry_addr`, and load scratch; the entry-spill /
+// exit-restore pair only preserves the *frame-resident* user values
+// that bracket the kernel, not values the kernel itself is supposed to
+// read or write at later instructions. Mirror of
+// mapKernelOperandClobber on ARM64.
+func mapKernelOperandClobberAMD64(op vm3.Op) bool {
+	in456 := func(r uint16) bool { return r >= 4 && r <= 6 }
+	switch op.Code {
+	case vm3.OpMapSetI64I64:
+		return in456(op.B) || in456(uint16(op.C))
+	case vm3.OpMapGetI64I64:
+		return in456(op.A) || in456(uint16(op.C))
+	}
+	return false
+}
+
+// mapScratchSpillBytesAMD64 reports the byte count consumed by the
+// R10/R11/R12 spill prologue at map kernel entry on AMD64. Mirrors
+// mapScratchSpillWordsARM64: only emitted when fn.NumRegsI64 > 4
+// (otherwise vm3 slots 4..6 don't exist and the host regs carry no
+// user value the kernel needs to preserve). Three 4-byte
+// mov64StoreDisp8 stores at entry, three matching loads at exit.
+func mapScratchSpillBytesAMD64(fn *vm3.Function) int {
+	if fn.NumRegsI64 > 4 {
+		return 12
+	}
+	return 0
+}
+
+// mapGetI64I64BytesAMD64 returns the static byte count of an inline
+// AMD64 OpMapGetI64I64 lowering (Phase 6.3.4.n.8.b). The body is
+// 198 bytes plus 2 * mapScratchSpillBytesAMD64 for the entry-spill /
+// exit-restore sandwich when NumRegsI64 > 4. See the comment block in
+// the emit case for a per-instruction breakdown.
+func mapGetI64I64BytesAMD64(fn *vm3.Function) int {
+	return mapGetI64I64KernelBytesAMD64 + 2*mapScratchSpillBytesAMD64(fn)
+}
+
+// mapGetI64I64KernelBytesAMD64 is the static byte count of the inline
+// OpMapGetI64I64 kernel body, excluding the optional spill sandwich.
+const mapGetI64I64KernelBytesAMD64 = 198
 
 // emitSplitmix64AMD64ByteCount mirrors emitSplitmix64AMD64. The byte
 // count is constant for any (xKey, xOut, xTmp) triple because all

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -3602,55 +3602,58 @@ var (
 )
 
 // emitSplitmix64AMD64 emits the AMD64 splitmix64 sequence that computes
-// h = hashI64(xKey) in-place in register xKey. xScratch is a free
-// scratch register (not equal to xKey) used to materialize the 64-bit
-// multipliers and to hold the shifted copies.
+// h = hashI64(xKey) into register xOut, preserving xKey. xTmp is a
+// transient scratch used to materialize the 64-bit multipliers and to
+// hold the shifted copies between xor steps.
 //
 // The output is bit-identical to runtime/vm3/maps.go's hashI64:
 //
-//	xKey ^= xKey >> 30
-//	xKey *= 0xbf58476d1ce4e5b9
-//	xKey ^= xKey >> 27
-//	xKey *= 0x94d049bb133111eb
-//	xKey ^= xKey >> 31
-//	xKey |= 1
+//	xOut = xKey
+//	xOut ^= xOut >> 30
+//	xOut *= 0xbf58476d1ce4e5b9
+//	xOut ^= xOut >> 27
+//	xOut *= 0x94d049bb133111eb
+//	xOut ^= xOut >> 31
+//	xOut |= 1
 //
 // The `| 1` step forces the low bit so the hash never collides with the
 // "empty slot" sentinel (hash == 0). Phase 6.3.4.n.8 uses this for the
-// inline map kernel probe-index computation.
+// inline map kernel probe-index computation; the kernel needs xKey
+// preserved so the per-probe `cmp stored.key, xKey` step can run after
+// the hash is computed.
 //
-// Caller must ensure xKey != xScratch and that both registers are free
-// to clobber across this sequence (no live state in either).
-func emitSplitmix64AMD64(xKey, xScratch int) []byte {
+// Caller must ensure xKey, xOut, xTmp are three distinct registers and
+// that xOut and xTmp are both free to clobber across this sequence.
+func emitSplitmix64AMD64(xKey, xOut, xTmp int) []byte {
 	var out []byte
-	// xScratch = xKey; xScratch >>= 30; xKey ^= xScratch
-	out = append(out, mov64RR(xKey, xScratch)...)
-	out = append(out, shr64RImm8(xScratch, 30)...)
-	out = append(out, xor64RR(xScratch, xKey)...)
-	// xScratch = C1; xKey *= xScratch
-	out = append(out, movImm64(xScratch, splitmix64C1AMD64)...)
-	out = append(out, imul64RR(xScratch, xKey)...)
-	// xScratch = xKey; xScratch >>= 27; xKey ^= xScratch
-	out = append(out, mov64RR(xKey, xScratch)...)
-	out = append(out, shr64RImm8(xScratch, 27)...)
-	out = append(out, xor64RR(xScratch, xKey)...)
-	// xScratch = C2; xKey *= xScratch
-	out = append(out, movImm64(xScratch, splitmix64C2AMD64)...)
-	out = append(out, imul64RR(xScratch, xKey)...)
-	// xScratch = xKey; xScratch >>= 31; xKey ^= xScratch
-	out = append(out, mov64RR(xKey, xScratch)...)
-	out = append(out, shr64RImm8(xScratch, 31)...)
-	out = append(out, xor64RR(xScratch, xKey)...)
-	// xKey |= 1
-	out = append(out, or64RImm8(xKey, 1)...)
+	// xOut = xKey; xOut >>= 30; xOut ^= xKey  -> xOut = key ^ (key>>30)
+	out = append(out, mov64RR(xKey, xOut)...)
+	out = append(out, shr64RImm8(xOut, 30)...)
+	out = append(out, xor64RR(xKey, xOut)...)
+	// xTmp = C1; xOut *= xTmp
+	out = append(out, movImm64(xTmp, splitmix64C1AMD64)...)
+	out = append(out, imul64RR(xTmp, xOut)...)
+	// xTmp = xOut; xTmp >>= 27; xOut ^= xTmp
+	out = append(out, mov64RR(xOut, xTmp)...)
+	out = append(out, shr64RImm8(xTmp, 27)...)
+	out = append(out, xor64RR(xTmp, xOut)...)
+	// xTmp = C2; xOut *= xTmp
+	out = append(out, movImm64(xTmp, splitmix64C2AMD64)...)
+	out = append(out, imul64RR(xTmp, xOut)...)
+	// xTmp = xOut; xTmp >>= 31; xOut ^= xTmp
+	out = append(out, mov64RR(xOut, xTmp)...)
+	out = append(out, shr64RImm8(xTmp, 31)...)
+	out = append(out, xor64RR(xTmp, xOut)...)
+	// xOut |= 1
+	out = append(out, or64RImm8(xOut, 1)...)
 	return out
 }
 
 // emitSplitmix64AMD64ByteCount mirrors emitSplitmix64AMD64. The byte
-// count is constant for any (xKey, xScratch) pair because all helpers
-// in the sequence (mov64RR, shr64RImm8, xor64RR, imul64RR, or64RImm8,
-// and movImm64 with the > int32 constants) have register-independent
-// encoding lengths once REX is forced on by REX.W.
+// count is constant for any (xKey, xOut, xTmp) triple because all
+// helpers in the sequence (mov64RR, shr64RImm8, xor64RR, imul64RR,
+// or64RImm8, and movImm64 with the > int32 constants) have register-
+// independent encoding lengths once REX is forced on by REX.W.
 //
 //	mov64RR        3 bytes
 //	shr64RImm8     4 bytes

--- a/runtime/jit/vm3jit/lower_amd64_stub.go
+++ b/runtime/jit/vm3jit/lower_amd64_stub.go
@@ -5,3 +5,12 @@ package vm3jit
 import "mochi/runtime/vm3"
 
 func lowerAMD64(*vm3.Function, Options) ([]byte, error) { return nil, ErrUnsupported }
+
+// usesR12ForF64AMD64 and mapKernelOperandClobberAMD64 are referenced by
+// checkCellBankAdmissibleAMD64 in compile.go (a tagless file). The real
+// definitions live in lower_amd64.go; these stubs let non-AMD64 builds
+// link. checkCellBankAdmissibleAMD64 is only called when
+// hostArch == ArchAMD64, so the stub bodies are unreachable at runtime
+// on non-AMD64.
+func usesR12ForF64AMD64(*vm3.Function) bool   { return false }
+func mapKernelOperandClobberAMD64(vm3.Op) bool { return false }

--- a/runtime/jit/vm3jit/map_get_amd64_test.go
+++ b/runtime/jit/vm3jit/map_get_amd64_test.go
@@ -1,0 +1,310 @@
+//go:build amd64
+
+package vm3jit_test
+
+import (
+	"testing"
+
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// TestMapGetI64I64AMD64Hit exercises Phase 6.3.4.n.8.b: AMD64
+// OpMapGetI64I64 inline lookup on a cell-bank helper. The driver runs
+// in the interpreter, allocates a small map via OpNewMap, and inserts
+// three (key, value) pairs via OpMapSetI64I64. It then JIT-calls the
+// helper which performs OpMapGetI64I64 on a constant key and returns
+// the value. A drift in the splitmix64 emit, the probe-loop pos /
+// mask arithmetic, or the entry SBFX48 sign-extend would surface
+// here as a wrong return or a segfault on the disp8 entry loads.
+func TestMapGetI64I64AMD64Hit(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_map_get_hit",
+		NumRegsI64:  2,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 2),   // pc=0: regsI64[0] = 2 (key)
+			vm3.MakeOp(vm3.OpMapGetI64I64, 1, 0, 0), // pc=1: regsI64[1] = map[regsI64[0]]
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),    // pc=2: return regsI64[1]
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewMap, 0, 0, 8),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 100),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 2),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 200),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 3),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 300),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1},
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank n.8.b should admit OpMapGetI64I64")
+	}
+	preDeopt := vm3jit.DeoptCount
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if d := vm3jit.DeoptCount - preDeopt; d != 0 {
+		t.Fatalf("unexpected deopt count delta: %d", d)
+	}
+	if got.Int() != 200 {
+		t.Fatalf("got %d, want 200 (map[2])", got.Int())
+	}
+}
+
+// TestMapGetI64I64AMD64Miss asserts the JIT lowering returns 0 when the
+// key is absent from the table. A bug in the probe-loop terminator
+// (e.g. failing to follow the linear probe to the next empty entry, or
+// not branching to the miss block on hash==0) would manifest here as a
+// wrong return or an infinite loop / segfault.
+func TestMapGetI64I64AMD64Miss(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_map_get_miss",
+		NumRegsI64:  2,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 999),
+			vm3.MakeOp(vm3.OpMapGetI64I64, 1, 0, 0),
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewMap, 0, 0, 8),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 100),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 2),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 200),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1},
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if got.Int() != 0 {
+		t.Fatalf("got %d, want 0 (missing-key sentinel)", got.Int())
+	}
+}
+
+// TestMapGetI64I64AMD64EmptyTable guards the pre-amble's tableLen
+// empty-check (`test rcx,rcx; jz miss`) by looking up a key in a map
+// that was allocated with cap=0 and never written. The kernel must
+// branch to the miss block before dereferencing the (nil) tablePtr.
+func TestMapGetI64I64AMD64EmptyTable(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_map_get_empty",
+		NumRegsI64:  2,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 42),
+			vm3.MakeOp(vm3.OpMapGetI64I64, 1, 0, 0),
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewMap, 0, 0, 0),
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1},
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if got.Int() != 0 {
+		t.Fatalf("got %d, want 0 (empty-table miss)", got.Int())
+	}
+}
+
+// TestMapGetI64I64AMD64NegativeValue guards the SBFX48 (shl/sar by 16)
+// pair on the entry.value load against a sign-bit drop. Storing -777
+// must round-trip as -777, not 0x0000FFFF_FFFFFCF7. The key must also
+// round-trip the per-probe cmp against xKey; if the SBFX48 on
+// entry.key dropped the sign, the cmp would never match a negative
+// key and the kernel would fall through to miss.
+func TestMapGetI64I64AMD64NegativeValue(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_map_get_neg",
+		NumRegsI64:  2,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, -3),
+			vm3.MakeOp(vm3.OpMapGetI64I64, 1, 0, 0),
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewMap, 0, 0, 4),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, -3),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, -777),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1},
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if got.Int() != -777 {
+		t.Fatalf("got %d, want -777 (negative key+value round-trip)", got.Int())
+	}
+}
+
+// TestMapGetI64I64AMD64Spill exercises the spill sandwich path: a
+// helper with NumRegsI64=8 stores values in slots 4..6 (host R10/R11/
+// R12) before the OpMapGetI64I64 and reads them back afterwards. The
+// kernel clobbers R10/R11/R12 mid-flight as pos / entry_addr / load
+// scratch; the entry-spill / exit-restore pair must preserve the
+// pre-kernel values. A regression where the restore is omitted, or
+// the spill writes the wrong slot, would surface as a wrong final
+// sum (we sum {slot4, slot5, slot6, get-result} = 4 + 5 + 6 + value).
+func TestMapGetI64I64AMD64Spill(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_map_get_spill",
+		NumRegsI64:  8,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			// Seed slots 4..6 with values the kernel must preserve.
+			vm3.MakeOp(vm3.OpConstI64K, 4, 0, 4),
+			vm3.MakeOp(vm3.OpConstI64K, 5, 0, 5),
+			vm3.MakeOp(vm3.OpConstI64K, 6, 0, 6),
+			// Look up key=7 -> value=70 (set by driver).
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 7),
+			vm3.MakeOp(vm3.OpMapGetI64I64, 1, 0, 0), // op.A=1 (slot 1), op.C=0 (slot 0). Neither in [4..6].
+			// Accumulate slot4+slot5+slot6+value into slot 7.
+			vm3.MakeOp(vm3.OpAddI64, 7, 4, 5),  // slot7 = 4 + 5 = 9
+			vm3.MakeOp(vm3.OpAddI64, 7, 7, 6),  // slot7 = 9 + 6 = 15
+			vm3.MakeOp(vm3.OpAddI64, 7, 7, 1),  // slot7 = 15 + 70 = 85
+			vm3.MakeOp(vm3.OpReturnI64, 7, 0, 0),
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewMap, 0, 0, 8),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 7),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 70),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1},
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; spill-path admission may be broken")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if got.Int() != 85 {
+		t.Fatalf("got %d, want 85 (= 4+5+6+70; slot 4..6 not preserved across kernel)", got.Int())
+	}
+}

--- a/runtime/jit/vm3jit/splitmix64_amd64_test.go
+++ b/runtime/jit/vm3jit/splitmix64_amd64_test.go
@@ -149,94 +149,98 @@ func TestJmpRel8EncodingAMD64(t *testing.T) {
 }
 
 // TestEmitSplitmix64AMD64ByteCount verifies the byte-count helper
-// matches the actual emit length for representative register choices.
-// The byte count is invariant across (xKey, xScratch) because every
+// matches the actual emit length for representative register triples.
+// The byte count is invariant across (xKey, xOut, xTmp) because every
 // instruction in the sequence has REX-independent length once REX.W
 // forces a REX byte.
 func TestEmitSplitmix64AMD64ByteCount(t *testing.T) {
-	pairs := []struct{ key, scratch int }{
-		{xRSI, xRAX}, // common case: vm3 slot-0 with RAX scratch
-		{xRDI, xRDX}, // slot-1 with RDX scratch
-		{xR8, xRAX},
-		{xR14, xRDX},
-		{xRBP, xRAX},
+	triples := []struct{ key, out, tmp int }{
+		{xRSI, xRAX, xRDX}, // common case: vm3 slot-0 key, RAX hash, RDX tmp
+		{xRDI, xRAX, xRDX}, // slot-1 key
+		{xR8, xRAX, xRDX},
+		{xR14, xRAX, xRDX},
+		{xRBP, xRAX, xRDX},
+		{xRSI, xR9, xR10}, // extended-reg out/tmp still 62B because REX.W forces REX
 	}
 	want := emitSplitmix64AMD64ByteCount()
-	for _, p := range pairs {
-		got := len(emitSplitmix64AMD64(p.key, p.scratch))
+	for _, tri := range triples {
+		got := len(emitSplitmix64AMD64(tri.key, tri.out, tri.tmp))
 		if got != want {
-			t.Errorf("emitSplitmix64AMD64(key=%d, scratch=%d) len=%d, want %d",
-				p.key, p.scratch, got, want)
+			t.Errorf("emitSplitmix64AMD64(key=%d, out=%d, tmp=%d) len=%d, want %d",
+				tri.key, tri.out, tri.tmp, got, want)
 		}
 	}
 }
 
 // TestEmitSplitmix64AMD64Layout verifies that the emitted byte stream
 // matches the expected instruction sequence at the byte level for a
-// representative (xKey=RSI, xScratch=RAX) pair. This catches off-by-one
-// errors in the emit sequence (wrong operand direction, missing imm,
-// stale opcode) before the splitmix64 sequence is wired into the map
-// kernel.
+// representative (xKey=RSI, xOut=RAX, xTmp=RDX) triple. This catches
+// off-by-one errors in the emit sequence (wrong operand direction,
+// missing imm, stale opcode) before the splitmix64 sequence is wired
+// into the map kernel. The output register (RAX) holds h on return;
+// xKey (RSI) must be untouched so the per-probe key comparison still
+// sees the original i64.
 //
 // The expected stream is the concatenation of:
 //
 //	mov rax, rsi               48 89 F0                3
 //	shr rax, 30                48 C1 E8 1E             4
-//	xor rsi, rax               48 31 C6                3
-//	movabs rax, C1            48 B8 <C1 LE 8 bytes>   10
-//	imul rsi, rax              48 0F AF F0             4
-//	mov rax, rsi               48 89 F0                3
-//	shr rax, 27                48 C1 E8 1B             4
-//	xor rsi, rax               48 31 C6                3
-//	movabs rax, C2            48 B8 <C2 LE 8 bytes>   10
-//	imul rsi, rax              48 0F AF F0             4
-//	mov rax, rsi               48 89 F0                3
-//	shr rax, 31                48 C1 E8 1F             4
-//	xor rsi, rax               48 31 C6                3
-//	or rsi, 1                  48 83 CE 01             4
+//	xor rax, rsi               48 31 F0                3
+//	movabs rdx, C1            48 BA <C1 LE 8 bytes>   10
+//	imul rax, rdx              48 0F AF C2             4
+//	mov rdx, rax               48 89 C2                3
+//	shr rdx, 27                48 C1 EA 1B             4
+//	xor rax, rdx               48 31 D0                3
+//	movabs rdx, C2            48 BA <C2 LE 8 bytes>   10
+//	imul rax, rdx              48 0F AF C2             4
+//	mov rdx, rax               48 89 C2                3
+//	shr rdx, 31                48 C1 EA 1F             4
+//	xor rax, rdx               48 31 D0                3
+//	or rax, 1                  48 83 C8 01             4
 //
 // Total: 62 bytes.
 func TestEmitSplitmix64AMD64Layout(t *testing.T) {
 	const xKey = xRSI
-	const xScratch = xRAX
-	got := emitSplitmix64AMD64(xKey, xScratch)
+	const xOut = xRAX
+	const xTmp = xRDX
+	got := emitSplitmix64AMD64(xKey, xOut, xTmp)
 	var want []byte
 	// mov rax, rsi  (mov64RR(src=RSI, dst=RAX))
 	want = append(want, 0x48, 0x89, 0xF0)
 	// shr rax, 30
 	want = append(want, 0x48, 0xC1, 0xE8, 30)
-	// xor rsi, rax  (xor64RR(src=RAX, dst=RSI))
-	want = append(want, 0x48, 0x31, 0xC6)
-	// movabs rax, C1
-	want = append(want, 0x48, 0xB8)
+	// xor rax, rsi  (xor64RR(src=RSI, dst=RAX))
+	want = append(want, 0x48, 0x31, 0xF0)
+	// movabs rdx, C1
+	want = append(want, 0x48, 0xBA)
 	var c1le [8]byte
 	binary.LittleEndian.PutUint64(c1le[:], splitmix64C1AMD64U)
 	want = append(want, c1le[:]...)
-	// imul rsi, rax  (imul64RR(src=RAX, dst=RSI))
-	want = append(want, 0x48, 0x0F, 0xAF, 0xF0)
-	// mov rax, rsi
-	want = append(want, 0x48, 0x89, 0xF0)
-	// shr rax, 27
-	want = append(want, 0x48, 0xC1, 0xE8, 27)
-	// xor rsi, rax
-	want = append(want, 0x48, 0x31, 0xC6)
-	// movabs rax, C2
-	want = append(want, 0x48, 0xB8)
+	// imul rax, rdx  (imul64RR(src=RDX, dst=RAX))
+	want = append(want, 0x48, 0x0F, 0xAF, 0xC2)
+	// mov rdx, rax  (mov64RR(src=RAX, dst=RDX))
+	want = append(want, 0x48, 0x89, 0xC2)
+	// shr rdx, 27
+	want = append(want, 0x48, 0xC1, 0xEA, 27)
+	// xor rax, rdx  (xor64RR(src=RDX, dst=RAX))
+	want = append(want, 0x48, 0x31, 0xD0)
+	// movabs rdx, C2
+	want = append(want, 0x48, 0xBA)
 	var c2le [8]byte
 	binary.LittleEndian.PutUint64(c2le[:], splitmix64C2AMD64U)
 	want = append(want, c2le[:]...)
-	// imul rsi, rax
-	want = append(want, 0x48, 0x0F, 0xAF, 0xF0)
-	// mov rax, rsi
-	want = append(want, 0x48, 0x89, 0xF0)
-	// shr rax, 31
-	want = append(want, 0x48, 0xC1, 0xE8, 31)
-	// xor rsi, rax
-	want = append(want, 0x48, 0x31, 0xC6)
-	// or rsi, 1   (or64RImm8(dst=RSI, imm=1))
-	want = append(want, 0x48, 0x83, 0xCE, 0x01)
+	// imul rax, rdx
+	want = append(want, 0x48, 0x0F, 0xAF, 0xC2)
+	// mov rdx, rax
+	want = append(want, 0x48, 0x89, 0xC2)
+	// shr rdx, 31
+	want = append(want, 0x48, 0xC1, 0xEA, 31)
+	// xor rax, rdx
+	want = append(want, 0x48, 0x31, 0xD0)
+	// or rax, 1   (or64RImm8(dst=RAX, imm=1))
+	want = append(want, 0x48, 0x83, 0xC8, 0x01)
 	if !bytes.Equal(got, want) {
-		t.Fatalf("emitSplitmix64AMD64(RSI, RAX) mismatch:\n got: % x\nwant: % x", got, want)
+		t.Fatalf("emitSplitmix64AMD64(RSI, RAX, RDX) mismatch:\n got: % x\nwant: % x", got, want)
 	}
 }
 
@@ -246,33 +250,43 @@ func TestEmitSplitmix64AMD64Layout(t *testing.T) {
 // hashI64 for representative keys. This catches algorithmic bugs (wrong
 // shift count, swapped multiplier, missing |1) independently of the
 // byte-level layout check.
+//
+// The sim also asserts the key register is preserved (xKey untouched),
+// which the map kernel relies on for the per-probe `cmp stored.key,
+// xKey` step.
 func TestEmitSplitmix64AMD64MatchesHashI64(t *testing.T) {
 	keys := []int64{
 		0, 1, -1, 2, -2, 7, 42, 1 << 32, -(1 << 32),
 		1<<63 - 1, -(1 << 63), 3141592653589793238,
 	}
 	for _, k := range keys {
-		// Mirror the AMD64 emit sequence in scalar Go. xKey holds the
-		// key throughout; xScratch is a transient.
-		x := uint64(k)
-		// xScratch = xKey; xScratch >>= 30; xKey ^= xScratch
-		tmp := x
-		tmp >>= 30
-		x ^= tmp
-		// xScratch = C1; xKey *= xScratch
-		x *= splitmix64C1AMD64U
-		tmp = x
+		// Mirror the AMD64 emit sequence in scalar Go. key stays in
+		// xKey throughout; out is the hash accumulator; tmp is a
+		// transient.
+		key := uint64(k)
+		// out = key; out >>= 30; out ^= key  -> out = key ^ (key>>30)
+		out := key
+		out >>= 30
+		out ^= key
+		// tmp = C1; out *= tmp
+		out *= splitmix64C1AMD64U
+		// tmp = out; tmp >>= 27; out ^= tmp
+		tmp := out
 		tmp >>= 27
-		x ^= tmp
-		x *= splitmix64C2AMD64U
-		tmp = x
+		out ^= tmp
+		// tmp = C2; out *= tmp
+		out *= splitmix64C2AMD64U
+		tmp = out
 		tmp >>= 31
-		x ^= tmp
-		x |= 1
+		out ^= tmp
+		out |= 1
 		// Reference output from runtime/vm3/maps.go.
 		ref := splitmix64Reference(k)
-		if x != ref {
-			t.Errorf("k=%d: emit-sim got %#x want %#x", k, x, ref)
+		if out != ref {
+			t.Errorf("k=%d: emit-sim got %#x want %#x", k, out, ref)
+		}
+		if key != uint64(k) {
+			t.Errorf("k=%d: key clobbered by sim (got %#x want %#x)", k, key, uint64(k))
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Phase 6.3.4.n.8.b: AMD64 inline lowering for `OpMapGetI64I64` on cell-bank fns.

Tracks #21887.

### Kernel layout (198-byte stream + optional 24-byte spill sandwich)

1. **Pre-amble (43B)**: load `vmMap` from `regsCell[op.B]`, then load slice header (`tablePtr` @ +8, `tableLen` @ +16). Branches to miss if `tableLen == 0`.
2. **Splitmix64 (62B)**: hashes `xKey = regsI64[op.C]` via the 6.3.4.n.8.a primitive. `xKey` is preserved across the hash for the per-probe cmp.
3. **Probe init (6B)**: `pos = hash & (tableLen-1)`.
4. **Probe body (73B)**: load `entry.hash` at `tablePtr + pos*24`; on hash==0 fall through to miss; otherwise SBFX48 the entry.key and compare to `xKey`. On hit, load entry.value (also SBFX48) into `regsI64[op.A]` and jump out.
5. **Next (11B)**: `pos = (pos + 1) & (tableLen - 1)`, jump back to probe body.
6. **Miss (3B)**: write 0 into `regsI64[op.A]`.

The miss-block path is the int48 sentinel `0` (the same fallback the interpreter and ARM64 backend pick when the key is absent).

### Admission gate (compile.go)

Rejects fns where:
- `usesR12ForF64AMD64(fn)` is true (R12 is needed as a kernel scratch and conflicts with the f64 base on cell+f64 fns).
- `op.A` or `op.C` lands in slots 4..6 (host R10/R11/R12), which the kernel clobbers mid-flight. The spill sandwich is for *other* live regs, not the kernel's own operands.

### Tests (`runtime/jit/vm3jit/map_get_amd64_test.go`, +311)

- `TestMapGetI64I64AMD64Hit`: 3-entry map, lookup key=2, expect 200.
- `TestMapGetI64I64AMD64Miss`: lookup absent key=999, expect 0.
- `TestMapGetI64I64AMD64EmptyTable`: fresh `OpNewMap cap=0`, exercises the `tableLen==0` early-miss before any `tablePtr` deref.
- `TestMapGetI64I64AMD64NegativeValue`: key=-3, value=-777, guards SBFX48 sign-extend on both entry.key and entry.value.
- `TestMapGetI64I64AMD64Spill`: `NumRegsI64=8` with slots 4..6 (R10/R11/R12) seeded with values that must survive across the kernel's scratch use. Verifies the spill sandwich.

### Validation

- darwin/arm64, linux/arm64, linux/amd64, linux/arm: all clean.
- server2 (linux/amd64 EPYC): all 5 new tests PASS; full vm3jit + vm3 + compiler3 suites green.

## Test plan

- [x] `go test ./runtime/jit/vm3jit/... -run TestMapGetI64I64AMD64` (server2)
- [x] `go test ./runtime/jit/vm3jit/...` (server2)
- [x] `go test ./runtime/vm3/... ./compiler3/...` (server2)
- [x] cross-arch builds: darwin/arm64, linux/arm64, linux/amd64, linux/arm