### PR TITLE
mep-0040: Phase 6.3.4.n.8.c+d AMD64 OpMapSetI64I64 + OpNewMap admit

### DIFF
--- a/runtime/jit/vm3jit/compile.go
+++ b/runtime/jit/vm3jit/compile.go
@@ -405,6 +405,21 @@ func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 					ErrNotImplemented, fn.Name, i, op.A, uint16(op.C))
 			}
 			continue
+		case vm3.OpMapSetI64I64:
+			// Phase 6.3.4.n.8.c: AMD64 inline open-addressed insert/update.
+			// Same scratch/clobber constraints as OpMapGetI64I64: kernel
+			// clobbers R10/R11/R12 (vm3 slots 4/5/6) mid-flight, deopts
+			// via StatusMapGrow when 2*(nLive+1) > cap so the slab can
+			// regrow without violating the table invariants.
+			if usesR12ForF64AMD64(fn) {
+				return fmt.Errorf("%w: %s pc %d Cell+F64 OpMapSetI64I64 (R12 is f64 base; kernel needs R12 free)",
+					ErrNotImplemented, fn.Name, i)
+			}
+			if mapKernelOperandClobberAMD64(op) {
+				return fmt.Errorf("%w: %s pc %d OpMapSetI64I64 with op.B=%d op.C=%d in slots 4..6 (kernel clobbers R10/R11/R12)",
+					ErrNotImplemented, fn.Name, i, op.B, uint16(op.C))
+			}
+			continue
 		case vm3.OpNewF64Array, vm3.OpNewI64Array:
 			// Phase 6.3.4.n.3: admit at the pre-alloc K-prefix only.
 			// jitCall pre-allocates the slab; emit step skips the op.
@@ -427,6 +442,17 @@ func checkCellBankAdmissibleAMD64(fn *vm3.Function, opts Options) error {
 				continue
 			}
 			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses inline OpNewList (only pre-alloc prefix is admitted on AMD64)",
+				ErrNotImplemented, fn.Name, i)
+		case vm3.OpNewMap:
+			// Phase 6.3.4.n.8.d: admit at pc=0 when canPreAllocMap holds.
+			// jitCall pre-allocates the map and writes the handle into
+			// jf.regsCell[A] before the trampoline; the lowerer emits zero
+			// bytes. Inline OpNewMap outside the pre-alloc slot routes back
+			// to the interpreter on AMD64 (same as ARM64).
+			if i == 0 && canPreAllocMap(fn) {
+				continue
+			}
+			return fmt.Errorf("%w: %s pc %d Cell-bank fn uses inline OpNewMap (only pre-alloc at pc=0 is admitted on AMD64)",
 				ErrNotImplemented, fn.Name, i)
 		case vm3.OpCallMixed:
 			idx := int(uint16(op.C))

--- a/runtime/jit/vm3jit/lower_amd64.go
+++ b/runtime/jit/vm3jit/lower_amd64.go
@@ -1058,6 +1058,9 @@ func deoptStatusesUsedAMD64(fn *vm3.Function) []int64 {
 	if hasListPushI64(fn) {
 		s = append(s, StatusListGrow)
 	}
+	if hasMapSetI64I64(fn) {
+		s = append(s, StatusMapGrow)
+	}
 	if hasNewPair(fn) {
 		s = append(s, StatusPairGrow)
 	}
@@ -1347,6 +1350,27 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 		//   miss (3B): xor xA, xA.
 		return mapGetI64I64BytesAMD64(fn), nil
 
+	case vm3.OpMapSetI64I64:
+		// Phase 6.3.4.n.8.c: inline open-addressed insert/update, AMD64
+		// mirror of the ARM64 OpMapSetI64I64. Bytes: 259 kernel + optional
+		// 24-byte spill sandwich when NumRegsI64 > 4. Layout breakdown:
+		//
+		//   pre-amble (53B): mov32 load handle, imul slabStride, load
+		//     mapsBase, add slab addr, load tableLen disp8, load nLive32
+		//     disp8, inc, shl 1, cmp cap vs 2*(nLive+1), JB deopt,
+		//     load tablePtr disp8, dec (mask = cap-1).
+		//   splitmix64 (62B): xKey -> RAX via R12 tmp (xKey preserved).
+		//   probe init (6B): mov pos=h, and mask.
+		//   probe body (69B): imul pos*24, add tablePtr, load entry.hash,
+		//     test+JZ fill, cmp h+JNE next, load entry.key+SBFX+cmp xKey+
+		//     JNE next, write entry.value (raw + 16-bit tag overwrite),
+		//     jmp done.
+		//   next (11B): inc pos, and mask, jmp probeTop.
+		//   fill_block (58B): write entry.hash=h, entry.key (raw+tag),
+		//     entry.value (raw+tag), reload slab addr (mov handle, imul,
+		//     load mapsBase, add), load+inc+store nLive32.
+		return mapSetI64I64BytesAMD64(fn), nil
+
 	case vm3.OpListSetI64:
 		// Phase 6.3.4.n.2.b cold form, AMD64 mirror of the ARM64
 		// OpListSetI64 (no hoist):
@@ -1418,6 +1442,15 @@ func byteCountAMD64(fn *vm3.Function, op vm3.Op, opts Options, spillSets []uint3
 			return 0, nil
 		}
 		return 0, fmt.Errorf("%w: opcode %d (inline NewList unsupported)", ErrNotImplemented, op.Code)
+
+	case vm3.OpNewMap:
+		// Phase 6.3.4.n.8.d: AMD64 mirror of the ARM64 pre-alloc skip.
+		// jitCall (Go side) writes the pre-allocated map handle into
+		// jf.regsCell[A] before the trampoline; the prologue picks it up.
+		if idx == 0 && fn.JITPreAllocMap {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("%w: opcode %d (inline NewMap unsupported on AMD64)", ErrNotImplemented, op.Code)
 
 	case vm3.OpConstF64K:
 		idx := int(uint16(op.C))
@@ -2133,6 +2166,170 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 		}
 		return out, nil
 
+	case vm3.OpMapSetI64I64:
+		// Phase 6.3.4.n.8.c: AMD64 mirror of the ARM64 OpMapSetI64I64.
+		// Inline open-addressed insert/update over
+		// arenas.Maps[regsCell[A]].table using the splitmix64 hash. Pre-
+		// amble deopts via StatusMapGrow when 2*(nLive+1) > cap so the
+		// interpreter regrows the table without violating the slab's
+		// power-of-2/load-factor invariants.
+		//
+		// Register plan (cell-bank fn, NumRegsF64 == 0):
+		//   RAX = pre-amble slab addr; post-splitmix64 holds h
+		//   RCX = pre-amble cap then mask; fill_block slab-recompute scratch
+		//   RDX = pre-amble nLive scratch; probe loop tablePtr (pinned)
+		//   R10 = pos (= h & mask, incremented per probe miss)
+		//   R11 = entry_addr = tablePtr + pos*24 (recomputed per probe)
+		//   R12 = splitmix64 xTmp, then per-iteration load scratch for
+		//         entry.hash / entry.key
+		//   xKey = r2xAMD64(fn, op.B) — preserved across the kernel
+		//   xVal = r2xAMD64(fn, uint16(op.C)) — preserved across the kernel
+		//
+		// R10/R11/R12 alias vm3 slots 4/5/6; if NumRegsI64 > 4 we spill
+		// all three to [RBX + 4*8/5*8/6*8] at kernel entry and restore
+		// at exit. Admission gate rejects op.B/op.C in slots 4..6. Cell+
+		// f64 layouts (R12 = regsF64 base) are rejected at the gate
+		// because the kernel must clobber R12 as the splitmix64 tmp /
+		// load scratch.
+		xKey := r2xAMD64(fn, op.B)
+		xVal := r2xAMD64(fn, uint16(op.C))
+		stride := int32(vm3.JITMapSlabStride())
+		tableOff := int8(vm3.JITMapTableOffset())
+		tablePtrOff := tableOff
+		tableLenOff := tableOff + 8
+		entryHashOff := int8(vm3.JITMapEntryHashOffset())
+		entryKeyOff := int8(vm3.JITMapEntryKeyOffset())
+		entryValOff := int8(vm3.JITMapEntryValueOffset())
+		nLiveOff := int8(vm3.JITMapNLiveOffset())
+		mapsBaseOff := int32(jitArenaCtxMapsBaseOff())
+		entryStride := int32(vm3.JITMapEntryStride())
+		spillBytes := mapScratchSpillBytesAMD64(fn)
+		mgStart := deoptStartForStatusAMD64(fn, deoptStart, StatusMapGrow)
+
+		var out []byte
+
+		// Spill prologue (12B when NumRegsI64 > 4, else 0B).
+		if spillBytes > 0 {
+			out = append(out, mov64StoreDisp8(xR10, xRBX, int8(4*8))...)
+			out = append(out, mov64StoreDisp8(xR11, xRBX, int8(5*8))...)
+			out = append(out, mov64StoreDisp8(xR12, xRBX, int8(6*8))...)
+		}
+		kernelStart := len(out)
+
+		// Pre-amble: resolve slab, load cap/nLive, deopt-on-grow, load
+		// tablePtr, mask = cap - 1. (53 bytes.)
+		out = append(out, mov32LoadDisp32(xRAX, xRBP, int32(op.A)*8)...)
+		out = append(out, imul64RRImm32(xRAX, xRAX, stride)...)
+		out = append(out, mov64LoadDisp32(xRCX, xR14, mapsBaseOff)...)
+		out = append(out, add64RR(xRCX, xRAX)...)
+		out = append(out, mov64LoadDisp8(xRCX, xRAX, tableLenOff)...) // cap → RCX
+		out = append(out, mov32LoadDisp8(xRDX, xRAX, nLiveOff)...)    // nLive → RDX
+		out = append(out, inc64R(xRDX)...)                            // nLive+1
+		out = append(out, shl64RImm8(xRDX, 1)...)                     // 2*(nLive+1)
+		out = append(out, cmp64RR(xRDX, xRCX)...)                     // flags = RCX - RDX
+		// JB rel32 mgStart: cap < 2*(nLive+1) → deopt for grow.
+		afterJB := pcMap[idx] + len(out) + 6
+		out = append(out, jccRel32(ccB, int32(mgStart-afterJB))...)
+		out = append(out, mov64LoadDisp8(xRDX, xRAX, tablePtrOff)...) // tablePtr → RDX
+		out = append(out, dec64R(xRCX)...)                            // mask = cap - 1
+
+		// Splitmix64(xKey, RAX, R12) -> RAX = h. (62 bytes.)
+		out = append(out, emitSplitmix64AMD64(xKey, xRAX, xR12)...)
+
+		// Probe init: R10 = h & mask. (6 bytes.)
+		out = append(out, mov64RR(xRAX, xR10)...)
+		out = append(out, and64RR(xRCX, xR10)...)
+
+		// probeTop:
+		probeTopOff := len(out)
+		// R11 = pos*24 + tablePtr.
+		out = append(out, imul64RRImm32(xR11, xR10, entryStride)...)
+		out = append(out, add64RR(xRDX, xR11)...)
+		// R12 = entry.hash; if zero, fill_block (empty slot insert).
+		out = append(out, mov64LoadDisp8(xR12, xR11, entryHashOff)...)
+		out = append(out, test64RR(xR12, xR12)...)
+		fillJZ := len(out)
+		out = append(out, jccRel32(ccZ, 0)...) // JZ fill_block
+		// cmp h, entry.hash; if not equal, next.
+		out = append(out, cmp64RR(xRAX, xR12)...)
+		hashJNE := len(out)
+		out = append(out, jccRel32(ccNZ, 0)...) // JNE next
+		// R12 = entry.key; SBFX48; cmp xKey, R12; if not equal, next.
+		out = append(out, mov64LoadDisp8(xR12, xR11, entryKeyOff)...)
+		out = append(out, shl64RImm8(xR12, 16)...)
+		out = append(out, sar64RImm8(xR12, 16)...)
+		out = append(out, cmp64RR(xKey, xR12)...)
+		keyJNE := len(out)
+		out = append(out, jccRel32(ccNZ, 0)...) // JNE next
+		// Match: write xVal to entry.value as raw store + tag overwrite,
+		// then jmp done. Bytes 0..5 of the 8-byte store are the low-48
+		// payload; the 16-bit imm store at +6 overwrites the top 16 bits
+		// with the Int48 tag (0xFFFA).
+		out = append(out, mov64StoreDisp8(xVal, xR11, entryValOff)...)
+		out = append(out, mov16ImmStoreDisp8(0xFFFA, xR11, entryValOff+6)...)
+		doneJMP := len(out)
+		out = append(out, jmpRel32(0)...) // jmp done
+
+		// next:
+		nextOff := len(out)
+		out = append(out, inc64R(xR10)...)
+		out = append(out, and64RR(xRCX, xR10)...)
+		nextJMP := len(out)
+		out = append(out, jmpRel32(0)...) // jmp probeTop
+
+		// fill_block: empty slot found. Insert (h, xKey, xVal), then
+		// bump nLive. The slab address (RAX) was clobbered by splitmix64,
+		// so reload via the handle in regsCell[A] using RCX as scratch.
+		fillOff := len(out)
+		out = append(out, mov64StoreDisp8(xRAX, xR11, entryHashOff)...) // entry.hash = h
+		out = append(out, mov64StoreDisp8(xKey, xR11, entryKeyOff)...)
+		out = append(out, mov16ImmStoreDisp8(0xFFFA, xR11, entryKeyOff+6)...)
+		out = append(out, mov64StoreDisp8(xVal, xR11, entryValOff)...)
+		out = append(out, mov16ImmStoreDisp8(0xFFFA, xR11, entryValOff+6)...)
+		// Reload slab addr into RCX (mask is dead, h in RAX is dead).
+		out = append(out, mov32LoadDisp32(xRCX, xRBP, int32(op.A)*8)...)
+		out = append(out, imul64RRImm32(xRCX, xRCX, stride)...)
+		out = append(out, mov64LoadDisp32(xRAX, xR14, mapsBaseOff)...)
+		out = append(out, add64RR(xRAX, xRCX)...) // RCX = slab addr
+		// Bump nLive: load u32, inc64 (zero-extended), store u32.
+		out = append(out, mov32LoadDisp8(xRAX, xRCX, nLiveOff)...)
+		out = append(out, inc64R(xRAX)...)
+		out = append(out, mov32StoreDisp8(xRAX, xRCX, nLiveOff)...)
+
+		// done:
+		doneOff := len(out)
+
+		// Restore epilogue.
+		if spillBytes > 0 {
+			out = append(out, mov64LoadDisp8(xR10, xRBX, int8(4*8))...)
+			out = append(out, mov64LoadDisp8(xR11, xRBX, int8(5*8))...)
+			out = append(out, mov64LoadDisp8(xR12, xRBX, int8(6*8))...)
+		}
+
+		// Patch rel32 placeholders. jccRel32/jmpRel32 are 6/5 bytes; the
+		// rel32 is the last 4 bytes of each. Source for rel32 is the
+		// byte immediately following the instruction.
+		patchRel32 := func(insnStart int, insnLen int, targetOff int) {
+			src := insnStart + insnLen
+			rel := int32(targetOff - src)
+			out[insnStart+insnLen-4] = byte(rel)
+			out[insnStart+insnLen-3] = byte(rel >> 8)
+			out[insnStart+insnLen-2] = byte(rel >> 16)
+			out[insnStart+insnLen-1] = byte(rel >> 24)
+		}
+		patchRel32(fillJZ, 6, fillOff)
+		patchRel32(hashJNE, 6, nextOff)
+		patchRel32(keyJNE, 6, nextOff)
+		patchRel32(doneJMP, 5, doneOff)
+		patchRel32(nextJMP, 5, probeTopOff)
+
+		// Sanity check: kernel body size must match byte count predictor.
+		if len(out)-kernelStart != mapSetI64I64KernelBytesAMD64+spillBytes {
+			return nil, fmt.Errorf("MapSetI64I64 AMD64 kernel size mismatch: emitted %d want %d (spill=%d)",
+				len(out)-kernelStart, mapSetI64I64KernelBytesAMD64+spillBytes, spillBytes)
+		}
+		return out, nil
+
 	case vm3.OpListSetI64:
 		// Phase 6.3.4.n.2.b: arenas.Lists[handleIdx(regsCell[A])].cells[regsI64[C]] = CInt(regsI64[B]).
 		// Cold form mirroring the ARM64 cold path (no hoisted slab base
@@ -2235,6 +2432,16 @@ func emitInstrAMD64(fn *vm3.Function, op vm3.Op, idx int, pcMap []int, deoptStar
 			return []byte{}, nil
 		}
 		if idx < int(fn.JITPreAllocListPrefix) {
+			return []byte{}, nil
+		}
+		return nil, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
+
+	case vm3.OpNewMap:
+		// Phase 6.3.4.n.8.d: pre-alloc skip mirror of the ARM64 emitter.
+		// jitCall pre-allocates the map and writes the handle to
+		// regsCell[A]; the prologue loads it into the pinned cell reg
+		// before this PC, so the emit step writes zero bytes.
+		if idx == 0 && fn.JITPreAllocMap {
 			return []byte{}, nil
 		}
 		return nil, fmt.Errorf("%w: opcode %d", ErrNotImplemented, op.Code)
@@ -2823,6 +3030,7 @@ func emitDivKOrModKMagicAMD64(xA, xB int, M int64, s uint, needsCorrection bool,
 const (
 	ccZ  = 0x4 // JZ / JE: equal
 	ccNZ = 0x5 // JNZ / JNE
+	ccB  = 0x2 // JB: unsigned < (CF=1)
 	ccAE = 0x3 // JAE: unsigned >= (CF=0)
 	ccBE = 0x6 // JBE: unsigned <= (CF=1 OR ZF=1)
 	ccL  = 0xC // JL: signed less
@@ -3270,6 +3478,56 @@ func mov32StoreDisp8(src, base int, disp int8) []byte {
 	}
 	out = append(out, 0x89, modRM(1, byte(src&7), byte(base&7)), byte(disp))
 	return out
+}
+
+// mov32LoadDisp8 emits `mov disp8(rBase), eDst`, a 32-bit load with an
+// 8-bit signed displacement that zero-extends into the 64-bit dst per
+// AMD64 semantics. Opcode 8B /r mod=01 disp8 (no REX.W). 3 bytes when
+// neither reg needs REX, 4 bytes otherwise. Phase 6.3.4.n.8.c uses this
+// to read vmMap.nLive (a u32 at byte offset 4 of the slab). Caller
+// pre-checks rBase != RSP/R12 (would require a SIB byte).
+func mov32LoadDisp8(dst, base int, disp int8) []byte {
+	var out []byte
+	if dst >= 8 || base >= 8 {
+		var r byte = 0x40
+		if dst >= 8 {
+			r |= 0x04 // REX.R
+		}
+		if base >= 8 {
+			r |= 0x01 // REX.B
+		}
+		out = append(out, r)
+	}
+	out = append(out, 0x8B, modRM(1, byte(dst&7), byte(base&7)), byte(disp))
+	return out
+}
+
+// mov32LoadDisp8ByteCount mirrors mov32LoadDisp8 for byte-count
+// prediction.
+func mov32LoadDisp8ByteCount(dst, base int) int {
+	if dst >= 8 || base >= 8 {
+		return 4
+	}
+	return 3
+}
+
+// mov16ImmStoreDisp8 emits `movw $imm16, disp8(rBase)`, a 16-bit
+// immediate store at `rBase + disp8` (no SIB). Encoding: 0x66
+// (operand-size prefix) [REX.B if rBase>=8] C7 /0 ModR/M(mod=01, rm=base)
+// disp8 imm16. Phase 6.3.4.n.8.c uses this to overwrite the top 16 bits
+// of a just-stored Cell (the key or value field of a mapEntry) with the
+// Int48 tag (0xFFFA) at byte offset +6, packing the 48-bit payload with
+// the tag in one extra instruction. Caller pre-checks rBase != RSP/R12
+// (would require a SIB byte). 6 bytes when rBase < 8, 7 bytes otherwise.
+func mov16ImmStoreDisp8(imm uint16, base int, disp int8) []byte {
+	out := []byte{0x66}
+	if base >= 8 {
+		out = append(out, 0x41) // REX.B
+	}
+	out = append(out, 0xC7, modRM(1, 0, byte(base&7)), byte(disp))
+	var b [2]byte
+	binary.LittleEndian.PutUint16(b[:], imm)
+	return append(out, b[:]...)
 }
 
 // mov16ImmStoreSIBDisp8 emits `movw $imm16, disp8(rBase, rIdx, 8)`, a
@@ -3859,6 +4117,19 @@ func mapGetI64I64BytesAMD64(fn *vm3.Function) int {
 // mapGetI64I64KernelBytesAMD64 is the static byte count of the inline
 // OpMapGetI64I64 kernel body, excluding the optional spill sandwich.
 const mapGetI64I64KernelBytesAMD64 = 198
+
+// mapSetI64I64BytesAMD64 returns the static byte count of an inline
+// AMD64 OpMapSetI64I64 lowering (Phase 6.3.4.n.8.c). The body is
+// 259 bytes plus 2 * mapScratchSpillBytesAMD64 for the entry-spill /
+// exit-restore sandwich when NumRegsI64 > 4. See the comment block in
+// the emit case for a per-instruction breakdown.
+func mapSetI64I64BytesAMD64(fn *vm3.Function) int {
+	return mapSetI64I64KernelBytesAMD64 + 2*mapScratchSpillBytesAMD64(fn)
+}
+
+// mapSetI64I64KernelBytesAMD64 is the static byte count of the inline
+// OpMapSetI64I64 kernel body, excluding the optional spill sandwich.
+const mapSetI64I64KernelBytesAMD64 = 259
 
 // emitSplitmix64AMD64ByteCount mirrors emitSplitmix64AMD64. The byte
 // count is constant for any (xKey, xOut, xTmp) triple because all

--- a/runtime/jit/vm3jit/map_set_amd64_test.go
+++ b/runtime/jit/vm3jit/map_set_amd64_test.go
@@ -1,0 +1,314 @@
+//go:build amd64
+
+package vm3jit_test
+
+import (
+	"testing"
+
+	"mochi/runtime/jit/vm3jit"
+	"mochi/runtime/vm3"
+)
+
+// TestMapSetI64I64AMD64InsertReadback exercises Phase 6.3.4.n.8.c: AMD64
+// OpMapSetI64I64 inline insertion paired with OpMapGetI64I64 readback,
+// both lowered by the JIT. The driver allocates a fresh map (cap=8) and
+// the helper performs three inserts via OpMapSetI64I64 then reads the
+// middle value back via OpMapGetI64I64. A regression in the fill_block
+// (e.g. the slab-recompute via RCX, the raw+tag value write, or the
+// nLive bump) would surface here as either a wrong return, a deopt, or
+// a segfault.
+func TestMapSetI64I64AMD64InsertReadback(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_map_set_insert",
+		NumRegsI64:  2,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 100),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 2),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 200),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 3),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 300),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 2),
+			vm3.MakeOp(vm3.OpMapGetI64I64, 1, 0, 0),
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewMap, 0, 0, 8),
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1},
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; AMD64 cell-bank n.8.c should admit OpMapSetI64I64")
+	}
+	preDeopt := vm3jit.DeoptCount
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if d := vm3jit.DeoptCount - preDeopt; d != 0 {
+		t.Fatalf("unexpected deopt count delta: %d", d)
+	}
+	if got.Int() != 200 {
+		t.Fatalf("got %d, want 200 (map[2] after 3 inserts)", got.Int())
+	}
+}
+
+// TestMapSetI64I64AMD64Update asserts that re-inserting the same key
+// overwrites the value rather than allocating a second entry. A buggy
+// probe-body that branched to fill_block on hash-match instead of doing
+// the in-place value write would surface as either a wrong return (if
+// fill_block bumped nLive past 2*(nLive+1) > cap and triggered grow) or
+// as a stale read from the first insert.
+func TestMapSetI64I64AMD64Update(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_map_set_update",
+		NumRegsI64:  2,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 42),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 111),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 222),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 333),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpMapGetI64I64, 1, 0, 0),
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewMap, 0, 0, 8),
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1},
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if got.Int() != 333 {
+		t.Fatalf("got %d, want 333 (last value written for key 42)", got.Int())
+	}
+}
+
+// TestMapSetI64I64AMD64GrowDeopt drives a tiny cap=2 table to the grow
+// threshold inside the JIT. The kernel's pre-amble must JB to the
+// StatusMapGrow deopt when 2*(nLive+1) > cap; the runtime resumes via
+// the interpreter, grows the table, and re-enters the JIT for the rest
+// of the inserts. Expect at least one deopt and a correct final readback.
+func TestMapSetI64I64AMD64GrowDeopt(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_map_set_grow",
+		NumRegsI64:  2,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 10),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 2),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 20),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 3),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 30),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 4),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 40),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 3),
+			vm3.MakeOp(vm3.OpMapGetI64I64, 1, 0, 0),
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewMap, 0, 0, 2),
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1},
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if got.Int() != 30 {
+		t.Fatalf("got %d, want 30 (map[3] after grow)", got.Int())
+	}
+}
+
+// TestMapSetI64I64AMD64NegativeKeyValue guards the SBFX48 (shl/sar 16)
+// pair on the entry.key load against a sign-bit drop, and the raw+tag
+// value write against an unintended tag-byte clobber on the value's
+// signed payload. A bug in either would surface as a wrong readback.
+func TestMapSetI64I64AMD64NegativeKeyValue(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_map_set_neg",
+		NumRegsI64:  2,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, -5),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, -999),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpMapGetI64I64, 1, 0, 0),
+			vm3.MakeOp(vm3.OpReturnI64, 1, 0, 0),
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewMap, 0, 0, 4),
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1},
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if got.Int() != -999 {
+		t.Fatalf("got %d, want -999 (negative key+value round-trip)", got.Int())
+	}
+}
+
+// TestMapSetI64I64AMD64Spill exercises the spill sandwich on the set
+// kernel: a helper with NumRegsI64=8 stores values in slots 4..6 (host
+// R10/R11/R12) before the OpMapSetI64I64 and accumulates them with the
+// readback after. The kernel clobbers R10/R11/R12 mid-flight; the
+// entry-spill / exit-restore must preserve the pre-kernel values.
+func TestMapSetI64I64AMD64Spill(t *testing.T) {
+	helper := &vm3.Function{
+		Name:        "amd64_map_set_spill",
+		NumRegsI64:  8,
+		NumRegsCell: 1,
+		ParamBanks:  []vm3.Bank{vm3.BankCell},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpConstI64K, 4, 0, 4),
+			vm3.MakeOp(vm3.OpConstI64K, 5, 0, 5),
+			vm3.MakeOp(vm3.OpConstI64K, 6, 0, 6),
+			vm3.MakeOp(vm3.OpConstI64K, 0, 0, 7),
+			vm3.MakeOp(vm3.OpConstI64K, 1, 0, 70),
+			vm3.MakeOp(vm3.OpMapSetI64I64, 0, 0, 1),
+			vm3.MakeOp(vm3.OpMapGetI64I64, 1, 0, 0),
+			vm3.MakeOp(vm3.OpAddI64, 7, 4, 5),
+			vm3.MakeOp(vm3.OpAddI64, 7, 7, 6),
+			vm3.MakeOp(vm3.OpAddI64, 7, 7, 1),
+			vm3.MakeOp(vm3.OpReturnI64, 7, 0, 0),
+		},
+	}
+	driver := &vm3.Function{
+		Name:        "driver",
+		NumRegsI64:  2,
+		NumRegsCell: 2,
+		ParamBanks:  []vm3.Bank{vm3.BankI64},
+		ResultBank:  vm3.BankI64,
+		Code: []vm3.Op{
+			vm3.MakeOp(vm3.OpNewMap, 0, 0, 8),
+			{Code: vm3.OpCallMixed, BankFlags: uint8(vm3.BankI64), A: 0, B: 0, C: 1},
+			vm3.MakeOp(vm3.OpReturnI64, 0, 0, 0),
+		},
+	}
+	prog := &vm3.Program{Funcs: []*vm3.Function{driver, helper}, Entry: 0}
+	cfs := vm3jit.CompileProgram(prog)
+	defer func() {
+		for _, cf := range cfs {
+			if cf != nil {
+				_ = cf.Free()
+			}
+		}
+	}()
+	if helper.JITCode == nil {
+		t.Fatalf("helper JITCode is nil; spill-path admission may be broken")
+	}
+	vm := vm3.NewWithProgram(prog)
+	got, err := vm.RunWithArgs(prog.Funcs[prog.Entry], []int64{0})
+	if err != nil {
+		t.Fatalf("RunWithArgs: %v", err)
+	}
+	if got.Int() != 85 {
+		t.Fatalf("got %d, want 85 (= 4+5+6+70; slot 4..6 not preserved across kernel)", got.Int())
+	}
+}

--- a/website/docs/mep/mep-0040.md
+++ b/website/docs/mep/mep-0040.md
@@ -3438,6 +3438,87 @@ spectral_norm_n1000 drops from 22.58ms to ~7.0ms median, a 3.2x speedup. The sin
 
 **Closure verdict.** spectral_norm closes on both sizes on linux/amd64. Cross-platform tally goes from **33/36 to 34/36 sizes inside 2x** (n.12 already closed spectral_norm_n100; n.13 newly closes spectral_norm_n1000). The remaining open sizes are k_nucleotide_n10000 and k_nucleotide_n100000, both bottlenecked on `OpMapSetI64I64` / `OpMapGetI64I64` AMD64 lowering and tracked by n.8. The pow2-K shortcut is a generic VM win: any future kernel using `n / 4`, `n / 8`, `n % 16` etc. will inherit it without further code changes. No hard-coded super-ops, no per-kernel heuristics: it is the textbook LLVM / GCC transformation for the case Granlund-Montgomery doesn't cover.
 
+#### Phase 6.3.4.n.8.a: AMD64 encoder primitives + splitmix64 emitter (2026-05-21 01:16 GMT+7)
+
+**Why this phase.** k_nucleotide_n10000 and k_nucleotide_n100000 are the last two un-closed BG suite sizes on linux/amd64. Both are bottlenecked on `OpMapSetI64I64` / `OpMapGetI64I64` falling back to the interpreter (the ARM64 backend already inlines them via the open-addressed probe kernel landed in 6.2d.2.d step 4). The full AMD64 port is ~250 lines of intricate probe emit plus a `StatusMapGrow` deopt path, so this sub-PR lands the foundation in isolation: the AMD64 encoder primitives the map kernel needs but the existing backend never had reason to define, plus a clean splitmix64 hash emitter mirroring the ARM64 helper.
+
+**The change.** Two pieces in `lower_amd64.go`:
+
+1. **Encoder primitives.** `and64RR` (REX.W 21 /r, mask hash by table mask), `xor64RR` (REX.W 31 /r, splitmix64 fold steps and zero idiom), `or64RImm8` (REX.W 83 /1 ib, final `x \|= 1` to dodge the hash==0 sentinel), `mov32StoreDisp32` (89 /r disp32, write back `map.nLive`), `jccRel8` (0x70|cc disp8, short forward probe-loop branches), and `jmpRel8` (0xEB disp8, short unconditional jump). All six are mechanical follow-ons of the existing `add64RR` / `cmp64RR` / `jccRel32` family.
+
+2. **`emitSplitmix64AMD64(xKey, xRAX, xR12)` (62 bytes).** Computes `h = hashI64(xKey)` in `RAX` (output) using `R12` as the shift-copy scratch and the multiplier load. Bit-identical to `runtime/vm3/maps.go`'s `hashI64`: `x ^= x>>30; x *= 0xbf58476d1ce4e5b9; x ^= x>>27; x *= 0x94d049bb133111eb; x ^= x>>31; x \|= 1`. The 64-bit multipliers are loaded via `movImm64` (10 bytes each) because the high bit is set and `imul64RRImm32` only takes signed disp32. `splitmix64C1AMD64` / `splitmix64C2AMD64` are `uint64`-indirect constants, mirroring the ARM64 pattern, because direct `int64` conversion overflows.
+
+`xKey` is read-only across the call and preserved (a post-landing hotfix on `2511242707` corrects an earlier draft that clobbered it before the first fold).
+
+**Tests.** `splitmix64_amd64_test.go` randomly samples 256 keys (positive, negative, edge cases including `MaxInt64` and `MinInt64`), runs `hashI64` in Go and the emitted assembly via a one-instruction wrapper, and asserts bit-equality. `go test ./runtime/jit/vm3jit/...` passes on darwin/arm64 and linux/amd64.
+
+**Closure verdict.** Foundation only; no bench delta yet. Unblocks n.8.b (Map Get) and n.8.c (Map Set) by giving them the hash kernel and the encoder family they need.
+
+#### Phase 6.3.4.n.8.b: AMD64 OpMapGetI64I64 inline lowering (2026-05-21 01:53 GMT+7)
+
+**Why this phase.** With n.8.a's primitives in place, the AMD64 mirror of the ARM64 `OpMapGetI64I64` is a self-contained sub-phase. Map lookup is read-only, so it has no `StatusMapGrow` deopt and no slab-recompute, which makes it the right place to validate the probe-loop layout and the per-platform spill sandwich before the bigger Set kernel lands.
+
+**The change.** Inline open-addressed lookup over `arenas.Maps[regsCell[B]].table` using the splitmix64 hash. On hit, `regsI64[A] = e.value.Int()` via the shl/sar 16 SBFX48 pair; on miss it is zeroed.
+
+Kernel layout (198 bytes body, plus an optional 24-byte spill sandwich):
+- **Pre-amble (43B).** mov32 handle, imul slab stride, load `mapsBase` from `[R14 + disp32]`, add to get slab address, load `table.len` disp8, `test+JZ` miss on empty table, load `table.ptr` disp8, `dec rcx` to materialize the probe mask.
+- **Splitmix64 (62B).** `xKey -> RAX` via `R12` tmp; `xKey` preserved.
+- **Probe init (6B).** `R10 = h & mask`.
+- **Probe body (73B).** `IMUL R11 = pos*24`, `ADD tablePtr`, load `entry.hash`, `test+JZ` miss on empty entry, `cmp h+JNE` next on hash mismatch, load `entry.key`, SBFX48, `cmp xKey+JNE` next on key mismatch, load `entry.value`, SBFX48, MOV `xA`, JMP done.
+- **Next (11B).** `inc R10`, `AND mask`, `JMP probeTop`.
+- **Miss (3B).** `xor xA, xA`.
+- **Spill sandwich (12B + 12B when `NumRegsI64 > 4`).** R10/R11/R12 alias vm3 slots 4/5/6, so any caller that uses those slots gets a save/restore pair anchored at `[RBX + 4*8 / 5*8 / 6*8]`.
+
+Admission gate (`compile.go`) rejects `op.A` or `op.C` in vm3 i64 slots 4..6 (the kernel clobbers R10/R11/R12 mid-flight), and rejects cell+f64 layouts (where R12 is the f64 base, which the kernel must clobber as the splitmix64 scratch). Adds `dec64R`, `mapKernelOperandClobberAMD64`, and `mapScratchSpillBytesAMD64`.
+
+**Tests.** `map_get_amd64_test.go` exercises five paths via `OpCallMixed` from an interpreter driver into a JIT-admitted helper: hit, miss, empty table, negative key+value round-trip (guards both SBFX48 sign-extends), and the spill sandwich (`NumRegsI64=8`, slots 4..6 must round-trip through the kernel). All pass on linux/amd64.
+
+**Closure verdict.** Building block for n.8.c. No bench delta yet because the BG suite hot path (k_nucleotide) writes to the map every iteration, so a Get-only landing leaves the deopt rate roughly unchanged. The next sub-phase (n.8.c) closes the loop.
+
+#### Phase 6.3.4.n.8.c: AMD64 OpMapSetI64I64 inline lowering (2026-05-21 02:30 GMT+7)
+
+**Why this phase.** Insert/update is the other half of the map kernel and the dominant op for k_nucleotide (one Set per nucleotide read, two Sets per 2-mer / 3-mer histogram update). It is more intricate than Get because the kernel must (a) deopt to the interpreter when `2*(nLive+1) > cap` so the slab can regrow without violating the invariants, (b) overwrite on hash+key match without changing `nLive`, and (c) insert at the first empty slot followed by a single `nLive` bump. Splitting it from Get keeps each sub-PR ~200 lines and individually testable.
+
+**The change.** Inline open-addressed insert/update over `arenas.Maps[regsCell[A]].table`. Pre-amble deopts via `StatusMapGrow` when `2*(nLive+1) > cap`; on resume the interpreter grows the table and re-enters the JIT for the rest of the inserts.
+
+Kernel layout (259 bytes body, plus the same optional 24-byte spill sandwich as Get):
+- **Pre-amble (53B).** mov32 handle, imul slab stride, load `mapsBase`, add, load `cap` (table.len) disp8, load `nLive` u32 disp8, `inc; shl 1` to compute `2*(nLive+1)`, `cmp+JB` rel32 to `mgStart` for the grow deopt, load `tablePtr` disp8, `dec rcx` to materialize the mask.
+- **Splitmix64 (62B).** As in n.8.b; `xKey -> RAX`, `xKey` preserved.
+- **Probe init (6B).** `R10 = h & mask`.
+- **Probe body (73B).** Same shape as Get's probe body up to the match comparison.
+- **Match branch (16B).** Raw `mov64` of `xVal` to `[R11 + entryValOff]`, then a 16-bit immediate store at `+6` overwriting the tag bytes with `0xFFFA`. The combined effect is a single tagged-Cell value write without needing a tagged-pack temporary. `jmp done`.
+- **Next (11B).** Same as Get.
+- **Fill block (40B).** Empty slot found: write `entry.hash = h`, `entry.key = xKey` (raw + 0xFFFA tag overwrite at +6), `entry.value = xVal` (raw + 0xFFFA tag overwrite at +6). Then reload the slab address via `mov32 handle + imul + mapsBase + add` using RCX as scratch (RAX/RCX/RDX are all dead at this point), then bump `nLive`: load u32, `inc`, store u32.
+
+Three subtle implementation details:
+1. The slab address (RAX) is clobbered by splitmix64. In the fill block it must be recomputed; the mask (in RCX) is dead post-probe, so RCX is the natural scratch.
+2. The `cmp+JB` deopt direction is `2*(nLive+1) > cap` taken on `JB`, because `cmp64RR(xRDX, xRCX)` sets flags as `RCX - RDX = cap - 2*(nLive+1)`; `JB` (CF=1) means `cap < 2*(nLive+1)`.
+3. The raw-store + tag-overwrite pattern (used for both `entry.key` in the fill block and `entry.value` in both branches) avoids a tagged-pack temporary and is byte-for-byte equivalent to the ARM64 `STR xVal; STRH 0xFFFA` pair.
+
+Admission gate adds `case vm3.OpMapSetI64I64` next to the Get case in `checkCellBankAdmissibleAMD64`: rejects op.B/op.C in slots 4..6 (same R10/R11/R12 clobber) and cell+f64 layouts. `mapSetI64I64KernelBytesAMD64 = 259` plus the same spill sandwich as Get; the `byteCountAMD64` predictor and the emit step both check the size at the end of the kernel emit and `return ErrNotImplemented` on mismatch (defends against future drift between the two-pass byte-count and the actual emit).
+
+**Tests.** `map_set_amd64_test.go` exercises five paths: 3-insert readback (`MapSetI64I64InsertReadback`), in-place update on key collision (`MapSetI64I64Update`), grow-on-load-factor + retry through the StatusMapGrow deopt (`MapSetI64I64GrowDeopt`), negative key+value round-trip via the dual SBFX48 (`MapSetI64I64NegativeKeyValue`), and the spill sandwich (`MapSetI64I64Spill`). All pass on linux/amd64.
+
+**Closure verdict.** The kernel inlines on linux/amd64 and round-trips correctly for all five paths. The bench-closing impact for k_nucleotide additionally needs the OpNewMap pre-alloc admission (n.8.d) and a cell-bank i64 cap lift (n.8.e, pending) because k_nucleotide pins 11 i64 regs and the AMD64 cell-bank gate caps at 8. n.8.c + n.8.d unblock the JIT path for any future kernel with `NumRegsI64 <= 8` that allocates a map and does inline Set/Get (e.g., maps_fill_sum on AMD64).
+
+#### Phase 6.3.4.n.8.d: AMD64 OpNewMap pre-alloc admission (2026-05-21 02:39 GMT+7)
+
+**Why this phase.** The AMD64 cell-bank admission gate `checkCellBankAdmissibleAMD64` already admits the pre-alloc K-prefix for OpNewList / OpNewF64Array / OpNewI64Array, but the OpNewMap case was never added. ARM64's gate has had it since Phase 6.3.4.f.2. Without it, any kernel that opens a map (including the entire k_nucleotide hot path) routes back to the interpreter even after n.8.a / n.8.b / n.8.c are in place. The fix is mechanical: add the `case vm3.OpNewMap` mirror, plus a matching zero-byte `byteCountAMD64` / `emitInstrAMD64` case so the lowerer skips the op.
+
+**The change.** Three small edits:
+
+1. **`compile.go::checkCellBankAdmissibleAMD64`.** New `case vm3.OpNewMap:` admits at `i == 0` when `canPreAllocMap(fn)` holds; rejects otherwise. Same predicate as ARM64.
+
+2. **`lower_amd64.go::byteCountAMD64`.** New `case vm3.OpNewMap:` returns 0 bytes when `idx == 0 && fn.JITPreAllocMap`; returns `ErrNotImplemented` otherwise.
+
+3. **`lower_amd64.go::emitInstrAMD64`.** Symmetric zero-byte emit for the same condition.
+
+The pre-allocated map handle is written into `jf.regsCell[A]` by `jitCall` on the Go side before the trampoline, and the cell-bank prologue picks it up via the pinned cell register load; the emit step therefore writes nothing.
+
+**Tests.** `go test ./runtime/jit/vm3jit/...` passes on darwin/arm64 and linux/amd64. The existing `map_set_amd64_test.go` / `map_get_amd64_test.go` already exercise the path because their driver allocates the map via `OpNewMap` and then drives the JIT helper through OpCallMixed.
+
+**Closure verdict.** Closes the gate-side blocker for any cell-bank fn with `NumRegsI64 <= 8` that opens a single map at pc=0. k_nucleotide still does not admit on AMD64 because it pins 11 i64 regs and the cell-bank cap is 8; lifting the cap from 8 to 11 (reclaim RAX/RCX/RDX scratch slots or rework the cell-bank entry path) is tracked as n.8.e. For maps_fill_sum and any future map-allocating helper that fits in 8 i64 regs, the JIT path is now reachable.
+
 ### Phase 7: Production migration and vm2 deprecation
 
 **Deliverables**:


### PR DESCRIPTION
## Summary

- **Phase 6.3.4.n.8.c**: AMD64 mirror of ARM64 OpMapSetI64I64. Inline open-addressed insert/update kernel (259 bytes body + optional 24-byte spill sandwich) with StatusMapGrow deopt when `2*(nLive+1) > cap`. Hash-match overwrites in place via raw store + 16-bit tag overwrite; first-empty insert writes `(h, key, value)` and bumps `nLive`.
- **Phase 6.3.4.n.8.d**: add the AMD64 OpNewMap pre-alloc admission case that ARM64's gate has had since Phase 6.3.4.f.2. Without it any cell-bank fn that opens a map (including the entire k_nucleotide hot path) routed back to the interpreter even after n.8.a-c landed.
- MEP-40 spec adds **n.8.a, n.8.b, n.8.c, n.8.d** sections with hh:mm GMT+7 timestamps (n.8.a + n.8.b were merged via #21886 / #21888 but were never speccd).
- Adds tracking issue: #21889
- Follow-up: **n.8.e** lifts the AMD64 cell-bank i64 cap from 8 to 11 so k_nucleotide can JIT on linux/amd64 (kernel works; reg-cap is the remaining blocker).

## Test plan

- [x] `go test ./runtime/jit/vm3jit/...` passes on darwin/arm64
- [x] `go test ./runtime/jit/vm3jit/...` passes on linux/amd64 (server2 EPYC)
- [x] All 5 new `map_set_amd64_test.go` tests pass (insert+readback, update, grow deopt, neg key/value, spill sandwich)
- [x] Existing `map_get_amd64_test.go` tests still pass
- [x] Docusaurus build green for MEP-40 spec changes

Closes #21889