### PR TITLE
mep-0043: cross-link phase tracking issues #21898..#21908

### DIFF
--- a/website/docs/mep/mep-0043.md
+++ b/website/docs/mep/mep-0043.md
@@ -413,14 +413,14 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 
 | Sub-phase | Status | Issue | PR | Commit | Notes |
 |---|---|---|---|---|---|
-| 1.1 Type model + skeleton | LANDED | TBD | TBD (this branch) | _filled by merge_ | `compiler3/ffi/typebridge/` package created with `Type`, `Kind`, `Width`, `OpaqueReason`. |
-| 1.2 GoToMochi primitives + containers | LANDED | TBD | TBD | _filled by merge_ | Basics, slice, array, map, struct, ref, chan, func. |
-| 1.3 MochiToGo + round-trip identity | LANDED | TBD | TBD | _filled by merge_ | 60+ shape corpus. |
-| 1.4 Named types + method sets | LANDED | TBD | TBD | _filled by merge_ | `*os.File`, `error`, `io.Reader`, `time.Time`. |
-| 1.5 Generics + constraints | LANDED | TBD | TBD | _filled by merge_ | `cmp.Ordered`, `constraints.{Ordered,Integer,Signed,Unsigned,Float}`. |
-| 1.6 Equal + Format + gob | LANDED | TBD | TBD | _filled by merge_ | Wire format v1 + golden file. |
-| 1.7 Go-1.26 stdlib soak | PENDING | TBD | follow-up | _none_ | Needs Phase 2 resolver to enumerate; Phase 1 ships a curated subset. |
-| 1.8 MEP-43 row update | LANDED | TBD | TBD | _filled by merge_ | This sub-section + MEP-44 cross-link. |
+| 1.1 Type model + skeleton | LANDED | #21898 | #21899 | _filled by merge_ | `compiler3/ffi/typebridge/` package created with `Type`, `Kind`, `Width`, `OpaqueReason`. |
+| 1.2 GoToMochi primitives + containers | LANDED | #21898 | #21899 | _filled by merge_ | Basics, slice, array, map, struct, ref, chan, func. |
+| 1.3 MochiToGo + round-trip identity | LANDED | #21898 | #21899 | _filled by merge_ | 60+ shape corpus. |
+| 1.4 Named types + method sets | LANDED | #21898 | #21899 | _filled by merge_ | `*os.File`, `error`, `io.Reader`, `time.Time`. |
+| 1.5 Generics + constraints | LANDED | #21898 | #21899 | _filled by merge_ | `cmp.Ordered`, `constraints.{Ordered,Integer,Signed,Unsigned,Float}`. |
+| 1.6 Equal + Format + gob | LANDED | #21898 | #21899 | _filled by merge_ | Wire format v1 (version byte + round-trip + refusal tests); hex golden queued as a Phase-2-prep follow-up. |
+| 1.7 Go-1.26 stdlib soak | PARTIAL | #21898 | #21899 | _filled by merge_ | Curated 27-package soak ships in Phase 1 (1090 symbols, 8.53% opaque density, under the 10% bar). Full-stdlib walk needs the Phase 2 resolver. |
+| 1.8 MEP-43 row update | LANDED | #21898 | #21899 | _filled by merge_ | This sub-section + MEP-44 cross-link. |
 
 **Gate:** 100% of the Go 1.26 stdlib's exported symbols round-trip through the bridge; any exception is documented as `KindOpaque` with a non-empty `OpaqueReason`.
 
@@ -430,9 +430,9 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 
 | Status | Issue | PR | Commit |
 |---|---|---|---|
-| PENDING | TBD | TBD | _none_ |
+| PENDING | #21900 | TBD | _none_ |
 
-**Gate:** `resolve.Resolve("strings")` returns a `*ir.PackageBinding` with all exported functions; cache hit on second call is under 1 ms.
+**Gate:** `resolve.Resolve("strings")` returns a `*ir.PackageBinding` with all exported functions; cache hit on second call is under 1 ms. Phase 2 also re-asserts the MEP-44 opaque-density bar on the full Go 1.26 stdlib (Phase 1 ships a curated 27-package subset).
 
 ### Phase 3: `runtime/mochi/` Go module — pending
 
@@ -440,7 +440,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 
 | Status | Issue | PR | Commit |
 |---|---|---|---|
-| PENDING | TBD | TBD | _none_ |
+| PENDING | #21901 | TBD | _none_ |
 
 **Gate:** `go test ./runtime/mochi/...` green; each package has at least one example and matches Mochi semantics from `tests/vm/valid` golden output.
 
@@ -450,7 +450,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 
 | Status | Issue | PR | Commit |
 |---|---|---|---|
-| PENDING | TBD | TBD | _none_ |
+| PENDING | #21902 | TBD | _none_ |
 
 **Gate:** `mochi build --target=go hello.mochi` produces a `.go` file that `go build` compiles and that prints expected output on `tests/vm/valid/print_hello`, `let_and_print`, `if_else`.
 
@@ -460,7 +460,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 
 | Status | Issue | PR | Commit |
 |---|---|---|---|
-| PENDING | TBD | TBD | _none_ |
+| PENDING | #21903 | TBD | _none_ |
 
 **Gate:** `tests/vm/valid/{group_by,inner_join,left_join,outer_join,query_sum_select}` pass under `--target=go`.
 
@@ -470,7 +470,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 
 | Status | Issue | PR | Commit |
 |---|---|---|---|
-| PENDING | TBD | TBD | _none_ |
+| PENDING | #21904 | TBD | _none_ |
 
 **Gate:** `tests/vm/valid/go_auto` and `tests/vm/valid/mix_go_python` pass under `--target=go`; no `Call(name, args...)` appears in the emitted source.
 
@@ -480,7 +480,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 
 | Status | Issue | PR | Commit |
 |---|---|---|---|
-| PENDING | TBD | TBD | _none_ |
+| PENDING | #21905 | TBD | _none_ |
 
 **Gate:** A Mochi type error at an FFI boundary produces a Mochi-line-numbered diagnostic; no Go file path is visible to the user without `--keep-emit`.
 
@@ -490,7 +490,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 
 | Status | Issue | PR | Commit |
 |---|---|---|---|
-| PENDING | TBD | TBD | _none_ |
+| PENDING | #21906 | TBD | _none_ |
 
 **Gate:** A Go test program imports the produced package, calls a Mochi-exported function, asserts the result; no per-symbol stubs in the produced package.
 
@@ -500,7 +500,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 
 | Status | Issue | PR | Commit |
 |---|---|---|---|
-| PENDING | TBD | TBD | _none_ |
+| PENDING | #21907 | TBD | _none_ |
 
 **Gate:** New path matches legacy path bit-for-bit on the 104/105 fixtures listed in `transpiler/x/go/README.md`; legacy path deleted in the next release.
 
@@ -510,7 +510,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 
 | Status | Issue | PR | Commit |
 |---|---|---|---|
-| PENDING | TBD | TBD | _none_ |
+| PENDING | #21908 | TBD | _none_ |
 
 **Gate:** A Mochi program that passes a list handle to a Go function cannot have that handle dereferenced inside the Go function; sealing is invisible to the user.
 


### PR DESCRIPTION
Follow-up to #21899. Fills in the per-phase Issue column in the MEP-43 phased plan with the tracking issues opened alongside Phase 1.

Tracking issues:
- Phase 1: #21898 (LANDED via #21899)
- Phase 2: #21900 (resolver)
- Phase 3: #21901 (runtime/mochi)
- Phase 4: #21902 (emit/go skeleton)
- Phase 5: #21903 (query lowering)
- Phase 6: #21904 (import go end-to-end)
- Phase 7: #21905 (source-mapped diagnostics)
- Phase 8: #21906 (export direction)
- Phase 9: #21907 (legacy retirement)
- Phase 10: #21908 (MEP-41 sealing)

## Test plan
- [x] docs-only; no code changes