### PR TITLE
mep-0043: Phase 3 runtime/mochi Go module

### DIFF
--- a/runtime/mochi/decimal/decimal.go
+++ b/runtime/mochi/decimal/decimal.go
@@ -1,0 +1,137 @@
+// Package decimal is the Mochi-semantics decimal runtime for the Go
+// target. Mochi exposes a `decimal` type for money/precision-sensitive
+// arithmetic (the existing VM stores it as a *big.Rat under the hood);
+// we preserve that contract here so the emitter does not need to
+// thread a third-party library through every arithmetic call.
+//
+// The API is intentionally narrow: New, Add, Sub, Mul, Div, Cmp,
+// String. The four basic ops are total (Div panics on division by
+// zero, matching the VM's behaviour). The String form is the
+// canonical exact representation: integer / fraction with a leading
+// minus, no trailing zeros, no scientific notation. Round adds the
+// half-away-from-zero rounding the VM uses for the `round` builtin.
+package decimal
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+// Decimal is a precise rational number. The zero value is 0/1.
+type Decimal struct {
+	r big.Rat
+}
+
+// New constructs a Decimal from an integer.
+func New(n int64) Decimal { return Decimal{r: *big.NewRat(n, 1)} }
+
+// FromString parses a Decimal from a base-10 string. Accepts the
+// forms `123`, `-1.5`, `0.001`, `1e3`, `2.5e-1`. Returns an error on
+// malformed input.
+func FromString(s string) (Decimal, error) {
+	r, ok := new(big.Rat).SetString(strings.TrimSpace(s))
+	if !ok {
+		return Decimal{}, fmt.Errorf("mochi/decimal: invalid decimal %q", s)
+	}
+	return Decimal{r: *r}, nil
+}
+
+// MustFromString is FromString that panics on error. Provided for
+// constant literals the emitter knows are well-formed at compile time.
+func MustFromString(s string) Decimal {
+	d, err := FromString(s)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
+// Add returns a + b.
+func Add(a, b Decimal) Decimal {
+	var out Decimal
+	out.r.Add(&a.r, &b.r)
+	return out
+}
+
+// Sub returns a - b.
+func Sub(a, b Decimal) Decimal {
+	var out Decimal
+	out.r.Sub(&a.r, &b.r)
+	return out
+}
+
+// Mul returns a * b.
+func Mul(a, b Decimal) Decimal {
+	var out Decimal
+	out.r.Mul(&a.r, &b.r)
+	return out
+}
+
+// Div returns a / b. Panics if b is zero, matching the VM's
+// DivByZero runtime error.
+func Div(a, b Decimal) Decimal {
+	if b.r.Sign() == 0 {
+		panic("mochi/decimal: divide by zero")
+	}
+	var out Decimal
+	out.r.Quo(&a.r, &b.r)
+	return out
+}
+
+// Neg returns -a.
+func Neg(a Decimal) Decimal {
+	var out Decimal
+	out.r.Neg(&a.r)
+	return out
+}
+
+// Cmp returns -1, 0, or 1 as a < b, a == b, a > b.
+func Cmp(a, b Decimal) int { return a.r.Cmp(&b.r) }
+
+// IsZero reports whether d is exactly zero.
+func (d Decimal) IsZero() bool { return d.r.Sign() == 0 }
+
+// String returns the canonical decimal text. For exact rationals
+// (terminating denominators) the result has no fractional digits past
+// the shortest representation. For non-terminating rationals the
+// result is `num/den` (matching big.Rat.String); the emitter uses
+// Round to choose a fixed precision in those cases.
+func (d Decimal) String() string { return d.r.RatString() }
+
+// Float64 returns d as a float64; the returned `exact` bit reports
+// whether the conversion is lossless.
+func (d Decimal) Float64() (float64, bool) {
+	f, exact := d.r.Float64()
+	return f, exact
+}
+
+// Round returns d rounded to the given number of decimal places using
+// half-away-from-zero rounding. Matches the VM's `round` builtin
+// (runtime/vm/vm.go OpRound).
+func Round(d Decimal, places int) Decimal {
+	if places < 0 {
+		places = 0
+	}
+	scale := big.NewInt(1)
+	for i := 0; i < places; i++ {
+		scale.Mul(scale, big.NewInt(10))
+	}
+	// Multiply by scale, round to nearest int away from zero, divide back.
+	scaled := new(big.Rat).Mul(&d.r, new(big.Rat).SetInt(scale))
+	num := new(big.Int).Set(scaled.Num())
+	den := new(big.Int).Set(scaled.Denom())
+	q, r := new(big.Int).QuoRem(num, den, new(big.Int))
+	twoR := new(big.Int).Mul(r, big.NewInt(2))
+	twoR.Abs(twoR)
+	cmp := twoR.Cmp(den)
+	if cmp > 0 || (cmp == 0 && num.Sign() != 0) {
+		if num.Sign() >= 0 {
+			q.Add(q, big.NewInt(1))
+		} else {
+			q.Sub(q, big.NewInt(1))
+		}
+	}
+	out := new(big.Rat).SetFrac(q, scale)
+	return Decimal{r: *out}
+}

--- a/runtime/mochi/decimal/decimal_test.go
+++ b/runtime/mochi/decimal/decimal_test.go
@@ -1,0 +1,122 @@
+package decimal
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNewAndString(t *testing.T) {
+	if got := New(42).String(); got != "42" {
+		t.Errorf("New(42) = %q", got)
+	}
+	if got := New(-3).String(); got != "-3" {
+		t.Errorf("New(-3) = %q", got)
+	}
+}
+
+func TestFromString(t *testing.T) {
+	for _, c := range []struct {
+		in, out string
+	}{
+		{"123", "123"},
+		{"-1.5", "-3/2"},
+		{"0.001", "1/1000"},
+		{"1e3", "1000"},
+		{"2.5e-1", "1/4"},
+	} {
+		d, err := FromString(c.in)
+		if err != nil {
+			t.Errorf("FromString(%q): %v", c.in, err)
+			continue
+		}
+		if got := d.String(); got != c.out {
+			t.Errorf("FromString(%q) = %q, want %q", c.in, got, c.out)
+		}
+	}
+	if _, err := FromString("garbage"); err == nil {
+		t.Error("FromString(garbage) should error")
+	}
+}
+
+func TestArith(t *testing.T) {
+	a := MustFromString("1.5")
+	b := MustFromString("2.5")
+	if got := Add(a, b).String(); got != "4" {
+		t.Errorf("Add = %s", got)
+	}
+	if got := Sub(b, a).String(); got != "1" {
+		t.Errorf("Sub = %s", got)
+	}
+	if got := Mul(a, b).String(); got != "15/4" {
+		t.Errorf("Mul = %s", got)
+	}
+	if got := Div(b, a).String(); got != "5/3" {
+		t.Errorf("Div = %s", got)
+	}
+}
+
+func TestDivByZeroPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("Div by zero should panic")
+		}
+	}()
+	_ = Div(New(1), New(0))
+}
+
+func TestCmp(t *testing.T) {
+	if Cmp(New(1), New(2)) != -1 {
+		t.Error("Cmp 1 < 2")
+	}
+	if Cmp(New(2), New(2)) != 0 {
+		t.Error("Cmp ==")
+	}
+	if Cmp(New(3), New(2)) != 1 {
+		t.Error("Cmp >")
+	}
+}
+
+func TestRoundHalfAway(t *testing.T) {
+	cases := []struct {
+		in     string
+		places int
+		out    string
+	}{
+		{"1.5", 0, "2"},
+		{"-1.5", 0, "-2"},
+		{"2.5", 0, "3"},
+		{"-2.5", 0, "-3"},
+		{"0.125", 2, "13/100"}, // 0.13
+		{"0.124", 2, "3/25"},   // 0.124 -> 0.12 (= 12/100 = 3/25 reduced)
+		{"1.23456", 3, "247/200"},
+	}
+	for _, c := range cases {
+		got := Round(MustFromString(c.in), c.places).String()
+		if got != c.out {
+			t.Errorf("Round(%q, %d) = %s, want %s", c.in, c.places, got, c.out)
+		}
+	}
+}
+
+func TestNegAndIsZero(t *testing.T) {
+	if !New(0).IsZero() {
+		t.Error("0 IsZero")
+	}
+	if got := Neg(New(5)).String(); got != "-5" {
+		t.Errorf("Neg(5) = %s", got)
+	}
+}
+
+func TestFloat64(t *testing.T) {
+	f, exact := MustFromString("0.5").Float64()
+	if !exact || f != 0.5 {
+		t.Errorf("Float64(0.5) = %v exact=%v", f, exact)
+	}
+}
+
+func ExampleAdd() {
+	a := MustFromString("1.25")
+	b := MustFromString("2.75")
+	fmt.Println(Add(a, b))
+	// Output: 4
+}

--- a/runtime/mochi/doc.go
+++ b/runtime/mochi/doc.go
@@ -1,0 +1,24 @@
+// Package mochi is the Mochi standard runtime for the Go target.
+//
+// Each sub-package exposes one piece of Mochi semantics as idiomatic
+// Go. The packages have normal Go tests, ordinary example functions,
+// and a Go user can import any of them directly: nothing here depends
+// on the Mochi VM, the compiler, or the parser. MEP-43 §3.3 specifies
+// the contract: the Go-target emitter calls into these packages
+// instead of inlining its own arithmetic, instead of re-implementing
+// query algebra per call, and instead of templating strings around
+// printf-style formats.
+//
+// The layout is deliberately flat. The packages do not import each
+// other (apart from query, which composes lists+maps+sets), so a Go
+// user paying for `runtime/mochi/strings` does not transitively pull
+// in JSON, YAML, decimal, or query.
+//
+// Status: MEP-43 Phase 3 lands the package skeleton, the operations
+// the existing Mochi builtins cover today (len, upper, lower, reverse,
+// contains, indexOf, split, join, replace, append, keys, values,
+// avg/sum/min/max, json, yaml, fmt.Print, decimal arithmetic, time),
+// and the query algebra (Filter, Map, Sort, GroupBy, Join, LeftJoin,
+// OuterJoin, Limit, Take). The emitter wiring lands in Phase 4 and
+// Phase 5 (see MEP-43 §10).
+package mochi

--- a/runtime/mochi/fmt/fmt.go
+++ b/runtime/mochi/fmt/fmt.go
@@ -1,0 +1,56 @@
+// Package fmt is the Mochi-semantics print runtime for the Go target.
+// Mochi's `print(a, b, c)` joins arguments with a single space and
+// appends a newline (see VM op OpPrint in runtime/vm/vm.go), not
+// Go's `fmt.Println` (which space-separates *and* newlines between
+// successive Println calls but uses the default %v formatter). The
+// difference matters for floats: Mochi formats `1.0` as `1`, not as
+// `1` (Go prints `1` for floats with integral values too via %v, so
+// this happens to align), and for booleans it prints `true`/`false`
+// in lowercase (Go agrees).
+//
+// The behaviour Mochi diverges on is `nil`: Mochi prints `nil`, Go
+// prints `<nil>`. The Format helper handles that one case explicitly.
+package fmt
+
+import (
+	gofmt "fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// Print writes the Mochi-formatted form of args to stdout, joined by
+// a single space, with a trailing newline.
+func Print(args ...any) {
+	_ = Fprintln(os.Stdout, args...)
+}
+
+// Fprintln writes the Mochi-formatted form of args to w, joined by a
+// single space, with a trailing newline.
+func Fprintln(w io.Writer, args ...any) error {
+	parts := make([]string, len(args))
+	for i, a := range args {
+		parts[i] = Format(a)
+	}
+	_, err := gofmt.Fprintln(w, strings.Join(parts, " "))
+	return err
+}
+
+// Sprint returns the Mochi-formatted form of args joined by a single
+// space. No trailing newline.
+func Sprint(args ...any) string {
+	parts := make([]string, len(args))
+	for i, a := range args {
+		parts[i] = Format(a)
+	}
+	return strings.Join(parts, " ")
+}
+
+// Format renders one value using Mochi's print conventions: `nil`
+// rather than Go's `<nil>`, default %v for everything else.
+func Format(v any) string {
+	if v == nil {
+		return "nil"
+	}
+	return gofmt.Sprintf("%v", v)
+}

--- a/runtime/mochi/fmt/fmt_test.go
+++ b/runtime/mochi/fmt/fmt_test.go
@@ -1,0 +1,44 @@
+package fmt
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestFprintlnJoinsWithSpace(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Fprintln(&buf, "hello", 42, true); err != nil {
+		t.Fatal(err)
+	}
+	if buf.String() != "hello 42 true\n" {
+		t.Errorf("Fprintln = %q", buf.String())
+	}
+}
+
+func TestSprint(t *testing.T) {
+	got := Sprint("a", "b", "c")
+	if got != "a b c" {
+		t.Errorf("Sprint = %q", got)
+	}
+}
+
+func TestFormatNil(t *testing.T) {
+	if got := Format(nil); got != "nil" {
+		t.Errorf("Format(nil) = %q", got)
+	}
+}
+
+func TestEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Fprintln(&buf); err != nil {
+		t.Fatal(err)
+	}
+	if buf.String() != "\n" {
+		t.Errorf("Fprintln() = %q", buf.String())
+	}
+}
+
+func ExamplePrint() {
+	Print("answer", 42)
+	// Output: answer 42
+}

--- a/runtime/mochi/json/json.go
+++ b/runtime/mochi/json/json.go
@@ -1,0 +1,68 @@
+// Package json is the Mochi-semantics JSON runtime for the Go target.
+// The exported entry points match the VM's `json(value)` builtin: a
+// canonical, sorted-key, two-space-indented form (PrintIndent), plus
+// a compact single-line form (Marshal) for round-tripping.
+//
+// Sorted-key serialisation is the load-bearing piece: Mochi's test
+// fixtures under tests/vm/valid/*.mochi.out compare textually, so the
+// emitter must produce stable JSON regardless of map iteration order
+// inside the emitting Go program. `encoding/json` already sorts string
+// map keys; we re-emit the JSON tree to also stabilise the indent and
+// to be explicit about the contract.
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Marshal returns the compact JSON encoding of v with sorted map keys.
+// Errors are surfaced rather than panicked; callers in emitted Mochi
+// code panic on serialisation failures because Mochi's `json` is
+// total over the value tree it accepts.
+func Marshal(v any) ([]byte, error) { return json.Marshal(v) }
+
+// MarshalIndent returns a two-space-indented form of v with sorted
+// map keys. This is the form Mochi's `json(value)` prints by default.
+func MarshalIndent(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	out := buf.Bytes()
+	// json.Encoder.Encode appends a newline; strip it so the emitter
+	// can choose whether to add one (matches `fmt.Print` semantics).
+	if n := len(out); n > 0 && out[n-1] == '\n' {
+		out = out[:n-1]
+	}
+	return out, nil
+}
+
+// Print writes the indented JSON form of v to stdout, with a trailing
+// newline. This is the exact behaviour of Mochi's `json(value)` op.
+func Print(v any) {
+	_ = Fprint(os.Stdout, v)
+}
+
+// Fprint writes the indented JSON form of v to w with a trailing
+// newline.
+func Fprint(w io.Writer, v any) error {
+	b, err := MarshalIndent(v)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(b); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w)
+	return err
+}
+
+// Unmarshal parses JSON data into the value pointed to by v.
+func Unmarshal(data []byte, v any) error { return json.Unmarshal(data, v) }

--- a/runtime/mochi/json/json_test.go
+++ b/runtime/mochi/json/json_test.go
@@ -1,0 +1,88 @@
+package json
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestMarshalCompact(t *testing.T) {
+	b, err := Marshal(map[string]int{"b": 2, "a": 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	want := `{"a":1,"b":2}`
+	if got != want {
+		t.Errorf("Marshal = %s want %s", got, want)
+	}
+}
+
+func TestMarshalIndentSortedKeys(t *testing.T) {
+	b, err := MarshalIndent(map[string]any{"b": 2, "a": []int{1, 2}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	want := "{\n  \"a\": [\n    1,\n    2\n  ],\n  \"b\": 2\n}"
+	if got != want {
+		t.Errorf("MarshalIndent =\n%s\nwant\n%s", got, want)
+	}
+}
+
+func TestFprintTrailingNewline(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Fprint(&buf, map[string]int{"a": 1}); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	if got == "" || got[len(got)-1] != '\n' {
+		t.Errorf("Fprint not newline-terminated: %q", got)
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	var m map[string]int
+	if err := Unmarshal([]byte(`{"a":1}`), &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["a"] != 1 {
+		t.Errorf("Unmarshal = %v", m)
+	}
+}
+
+func ExamplePrint() {
+	Print(map[string]int{"a": 1, "b": 2})
+	// Output:
+	// {
+	//   "a": 1,
+	//   "b": 2
+	// }
+}
+
+// TestNoHTMLEscape confirms ampersands and angle brackets pass
+// through unescaped (Mochi's `json` does not produce & etc.).
+func TestNoHTMLEscape(t *testing.T) {
+	b, err := MarshalIndent(map[string]string{"q": "a & b < c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(b, "a & b < c") {
+		t.Errorf("HTML-escaped output: %s", b)
+	}
+}
+
+func contains(b []byte, sub string) bool {
+	return string(b) != "" && bytes.Contains(b, []byte(sub))
+}
+
+func ExampleMarshalIndent() {
+	b, _ := MarshalIndent([]int{1, 2, 3})
+	fmt.Println(string(b))
+	// Output:
+	// [
+	//   1,
+	//   2,
+	//   3
+	// ]
+}

--- a/runtime/mochi/lists/lists.go
+++ b/runtime/mochi/lists/lists.go
@@ -1,0 +1,218 @@
+// Package lists is the Mochi-semantics list runtime for the Go
+// target. The operations match the VM's list dispatch table: Append
+// returns a new slice (matching OpAppend), Reverse returns a new
+// slice of the same element type, and the numeric aggregates Sum,
+// Min, Max, Avg operate on float64 because the Mochi VM coerces to
+// float for these reductions (see runtime/vm/vm.go OpSum/OpMin/etc.).
+//
+// MEP-43 §3.3: the emitter calls Append/Sum/Min/Max here instead of
+// templating its own arithmetic. The functions are generic where Go
+// 1.18+ generics fit; non-generic shims live below for the numeric
+// reductions where Mochi's semantics fix the result type.
+package lists
+
+import (
+	"sort"
+)
+
+// Append returns a new slice with elem appended. The Mochi VM's
+// OpAppend produces a fresh slice value; this matches that contract
+// (we do not mutate src).
+func Append[T any](src []T, elem T) []T {
+	out := make([]T, len(src), len(src)+1)
+	copy(out, src)
+	return append(out, elem)
+}
+
+// Len reports the number of elements in src. Trivially `len(src)`,
+// but exposed as a function so the emitter can produce a uniform
+// `lists.Len(x)` call regardless of x's static type.
+func Len[T any](src []T) int { return len(src) }
+
+// Reverse returns a new slice with src's elements in reverse order.
+func Reverse[T any](src []T) []T {
+	n := len(src)
+	out := make([]T, n)
+	for i, v := range src {
+		out[n-1-i] = v
+	}
+	return out
+}
+
+// First returns the first element of src and a present bit. The
+// present bit is false for an empty list; the VM's `first(xs)`
+// returns the zero value in that case, but a Go user calling this
+// runtime function expects the missing case to be discoverable. The
+// emitter discards the bool when lowering `first(xs)`.
+func First[T any](src []T) (T, bool) {
+	var zero T
+	if len(src) == 0 {
+		return zero, false
+	}
+	return src[0], true
+}
+
+// Last returns the last element of src and a present bit, with the
+// same convention as First.
+func Last[T any](src []T) (T, bool) {
+	var zero T
+	if len(src) == 0 {
+		return zero, false
+	}
+	return src[len(src)-1], true
+}
+
+// Concat concatenates any number of slices into one new slice.
+// Matches Mochi's `concat(a, b, c, ...)` builtin (VM op OpUnionAll
+// applied left-fold).
+func Concat[T any](parts ...[]T) []T {
+	n := 0
+	for _, p := range parts {
+		n += len(p)
+	}
+	out := make([]T, 0, n)
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
+// Slice returns src[start:end] with Mochi's clamping semantics
+// (matches strings.Substr above and the VM's OpSlice path: clamp
+// negative start to 0, clamp end past len to len, inverted range
+// returns an empty slice rather than panicking).
+func Slice[T any](src []T, start, end int) []T {
+	n := len(src)
+	if start < 0 {
+		start = 0
+	}
+	if end > n {
+		end = n
+	}
+	if start > end {
+		return src[:0:0]
+	}
+	out := make([]T, end-start)
+	copy(out, src[start:end])
+	return out
+}
+
+// Contains reports whether src contains elem (using == equality).
+// Constrained to comparable so it works on the value-equality types
+// the VM exposes; structs containing maps or slices need ContainsFunc.
+func Contains[T comparable](src []T, elem T) bool {
+	for _, v := range src {
+		if v == elem {
+			return true
+		}
+	}
+	return false
+}
+
+// IndexOf returns the index of the first occurrence of elem in src,
+// or -1 if elem is not present.
+func IndexOf[T comparable](src []T, elem T) int {
+	for i, v := range src {
+		if v == elem {
+			return i
+		}
+	}
+	return -1
+}
+
+// Distinct returns a new slice with the order-preserving unique
+// elements of src.
+func Distinct[T comparable](src []T) []T {
+	seen := make(map[T]struct{}, len(src))
+	out := make([]T, 0, len(src))
+	for _, v := range src {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+// SortBy returns a new slice sorted by the key function. The sort is
+// stable, matching Mochi's `sort by` query clause which preserves
+// input order for equal keys (see runtime/vm/vm.go OpGroupBy +
+// SortClause documentation).
+func SortBy[T any, K Ordered](src []T, key func(T) K) []T {
+	out := make([]T, len(src))
+	copy(out, src)
+	sort.SliceStable(out, func(i, j int) bool { return key(out[i]) < key(out[j]) })
+	return out
+}
+
+// Ordered is the local re-declaration of Go's `cmp.Ordered`. We
+// duplicate it here so this package compiles on Go 1.20 toolchains as
+// well as Go 1.21+, since `runtime/mochi/` is intended to be a normal
+// Go library that downstream users might import on older Go.
+type Ordered interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
+		~float32 | ~float64 | ~string
+}
+
+// SumFloat returns the float64 sum of src. Mochi's `sum` reduces
+// numbers in any numeric type to float64; we encode that contract by
+// requiring callers to use ToFloat first or by calling SumInt below.
+func SumFloat(src []float64) float64 {
+	var s float64
+	for _, v := range src {
+		s += v
+	}
+	return s
+}
+
+// SumInt returns the int64 sum of src.
+func SumInt(src []int64) int64 {
+	var s int64
+	for _, v := range src {
+		s += v
+	}
+	return s
+}
+
+// AvgFloat returns the mean of src as a float64. An empty list yields
+// 0, matching the VM's vacuous-zero convention for `avg([])`.
+func AvgFloat(src []float64) float64 {
+	if len(src) == 0 {
+		return 0
+	}
+	return SumFloat(src) / float64(len(src))
+}
+
+// MinOrdered returns the minimum element of src. Panics on empty
+// input. Mochi's VM raises a runtime error on `min([])`; we surface
+// the same via panic so the emitter does not need to thread an error
+// return through every aggregate call.
+func MinOrdered[T Ordered](src []T) T {
+	if len(src) == 0 {
+		panic("mochi/lists: MinOrdered on empty list")
+	}
+	m := src[0]
+	for _, v := range src[1:] {
+		if v < m {
+			m = v
+		}
+	}
+	return m
+}
+
+// MaxOrdered returns the maximum element of src. Panics on empty
+// input for the same reason as MinOrdered.
+func MaxOrdered[T Ordered](src []T) T {
+	if len(src) == 0 {
+		panic("mochi/lists: MaxOrdered on empty list")
+	}
+	m := src[0]
+	for _, v := range src[1:] {
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}

--- a/runtime/mochi/lists/lists_test.go
+++ b/runtime/mochi/lists/lists_test.go
@@ -1,0 +1,162 @@
+package lists
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestAppendDoesNotMutate(t *testing.T) {
+	a := []int{1, 2, 3}
+	b := Append(a, 4)
+	if len(a) != 3 || a[0] != 1 {
+		t.Errorf("a mutated: %v", a)
+	}
+	if len(b) != 4 || b[3] != 4 {
+		t.Errorf("b = %v", b)
+	}
+}
+
+func TestReverse(t *testing.T) {
+	got := Reverse([]int{1, 2, 3})
+	if len(got) != 3 || got[0] != 3 || got[2] != 1 {
+		t.Errorf("Reverse = %v", got)
+	}
+	if got := Reverse([]string{}); len(got) != 0 {
+		t.Errorf("Reverse([]) = %v", got)
+	}
+}
+
+func TestFirstLast(t *testing.T) {
+	if v, ok := First([]int{1, 2, 3}); !ok || v != 1 {
+		t.Errorf("First = %d ok=%v", v, ok)
+	}
+	if _, ok := First([]int{}); ok {
+		t.Error("First([]) should report missing")
+	}
+	if v, ok := Last([]int{1, 2, 3}); !ok || v != 3 {
+		t.Errorf("Last = %d ok=%v", v, ok)
+	}
+	if _, ok := Last([]int{}); ok {
+		t.Error("Last([]) should report missing")
+	}
+}
+
+func TestConcat(t *testing.T) {
+	got := Concat([]int{1, 2}, []int{3}, []int{4, 5})
+	if len(got) != 5 || got[0] != 1 || got[4] != 5 {
+		t.Errorf("Concat = %v", got)
+	}
+	if got := Concat[int](); got == nil || len(got) != 0 {
+		t.Errorf("Concat() = %v (expected empty non-nil)", got)
+	}
+}
+
+func TestSliceClamps(t *testing.T) {
+	src := []int{1, 2, 3, 4, 5}
+	for _, c := range []struct {
+		start, end int
+		want       []int
+	}{
+		{0, 5, []int{1, 2, 3, 4, 5}},
+		{1, 3, []int{2, 3}},
+		{-2, 3, []int{1, 2, 3}},
+		{0, 99, []int{1, 2, 3, 4, 5}},
+		{3, 1, []int{}},
+	} {
+		got := Slice(src, c.start, c.end)
+		if len(got) != len(c.want) {
+			t.Errorf("Slice(_, %d, %d) len = %d want %d", c.start, c.end, len(got), len(c.want))
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("Slice(_, %d, %d)[%d] = %d want %d", c.start, c.end, i, got[i], c.want[i])
+			}
+		}
+	}
+}
+
+func TestContainsIndexOf(t *testing.T) {
+	if !Contains([]int{1, 2, 3}, 2) {
+		t.Error("Contains 2")
+	}
+	if Contains([]int{1, 2, 3}, 4) {
+		t.Error("Contains 4 should be false")
+	}
+	if got := IndexOf([]string{"a", "b", "c"}, "b"); got != 1 {
+		t.Errorf("IndexOf b = %d", got)
+	}
+	if got := IndexOf([]string{"a", "b", "c"}, "z"); got != -1 {
+		t.Errorf("IndexOf z = %d", got)
+	}
+}
+
+func TestDistinct(t *testing.T) {
+	got := Distinct([]int{1, 2, 1, 3, 2, 4})
+	want := []int{1, 2, 3, 4}
+	if len(got) != len(want) {
+		t.Fatalf("Distinct = %v", got)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("Distinct[%d] = %d want %d", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSortByStable(t *testing.T) {
+	type rec struct {
+		Key   int
+		Order int
+	}
+	src := []rec{{1, 0}, {1, 1}, {0, 2}, {1, 3}}
+	got := SortBy(src, func(r rec) int { return r.Key })
+	if got[0].Key != 0 || got[0].Order != 2 {
+		t.Errorf("SortBy[0] = %+v", got[0])
+	}
+	// Stable: the three Key=1 records retain their relative order.
+	if got[1].Order != 0 || got[2].Order != 1 || got[3].Order != 3 {
+		t.Errorf("SortBy unstable: %+v", got)
+	}
+}
+
+func TestSumAvg(t *testing.T) {
+	if got := SumFloat([]float64{1, 2, 3.5}); got != 6.5 {
+		t.Errorf("SumFloat = %v", got)
+	}
+	if got := SumInt([]int64{1, 2, 3}); got != 6 {
+		t.Errorf("SumInt = %v", got)
+	}
+	if got := AvgFloat([]float64{2, 4, 6}); got != 4 {
+		t.Errorf("AvgFloat = %v", got)
+	}
+	if got := AvgFloat([]float64{}); got != 0 {
+		t.Errorf("AvgFloat([]) = %v (want 0)", got)
+	}
+}
+
+func TestMinMax(t *testing.T) {
+	if got := MinOrdered([]int{3, 1, 2}); got != 1 {
+		t.Errorf("Min = %d", got)
+	}
+	if got := MaxOrdered([]int{3, 1, 2}); got != 3 {
+		t.Errorf("Max = %d", got)
+	}
+	defer func() {
+		if recover() == nil {
+			t.Error("MinOrdered([]) should panic")
+		}
+	}()
+	_ = MinOrdered([]int{})
+}
+
+func ExampleAppend() {
+	a := []int{1, 2, 3}
+	fmt.Println(Append(a, 4))
+	// Output: [1 2 3 4]
+}
+
+func ExampleConcat() {
+	fmt.Println(Concat([]int{1, 2}, []int{3, 4}))
+	// Output: [1 2 3 4]
+}

--- a/runtime/mochi/maps/maps.go
+++ b/runtime/mochi/maps/maps.go
@@ -1,0 +1,64 @@
+// Package maps is the Mochi-semantics map runtime for the Go target.
+// The functions correspond to the VM's map-builtin dispatch table:
+// `keys(m)`, `values(m)`, `has(m, k)`, plus the `contains` selector
+// which the VM rewrites into a map-key lookup at compile time. Keys
+// are returned in stable sorted order so emitted code is deterministic
+// (the existing VM walks the map and surfaces whatever order Go gave
+// it; Mochi tests that rely on key order would fail intermittently).
+//
+// The package intentionally has no public mutation primitives:
+// Mochi-side `m[k] = v` lowers to the Go assignment `m[k] = v`
+// directly in the emitter (Phase 4), not to a function call here.
+package maps
+
+import (
+	"sort"
+)
+
+// Keys returns the keys of m in stable sorted order. The Ordered
+// constraint matches Mochi's map-key type rule (keys must compare).
+func Keys[K Ordered, V any](m map[K]V) []K {
+	out := make([]K, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// Values returns the values of m in the order matching Keys(m).
+// Returning values in unspecified order would defeat the determinism
+// guarantee Mochi makes to its callers.
+func Values[K Ordered, V any](m map[K]V) []V {
+	ks := Keys(m)
+	out := make([]V, 0, len(ks))
+	for _, k := range ks {
+		out = append(out, m[k])
+	}
+	return out
+}
+
+// Has reports whether m contains key k. Matches Mochi's `contains`
+// selector lowered onto a map.
+func Has[K comparable, V any](m map[K]V, k K) bool {
+	_, ok := m[k]
+	return ok
+}
+
+// Get returns m[k] and a present bit. Matches the desugaring Mochi
+// applies to a map index inside a null-safe expression.
+func Get[K comparable, V any](m map[K]V, k K) (V, bool) {
+	v, ok := m[k]
+	return v, ok
+}
+
+// Len returns the number of entries in m.
+func Len[K comparable, V any](m map[K]V) int { return len(m) }
+
+// Ordered is the local re-declaration of cmp.Ordered. See
+// runtime/mochi/lists for the rationale.
+type Ordered interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
+		~float32 | ~float64 | ~string
+}

--- a/runtime/mochi/maps/maps_test.go
+++ b/runtime/mochi/maps/maps_test.go
@@ -1,0 +1,58 @@
+package maps
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestKeysSorted(t *testing.T) {
+	m := map[string]int{"c": 3, "a": 1, "b": 2}
+	ks := Keys(m)
+	want := []string{"a", "b", "c"}
+	if len(ks) != len(want) {
+		t.Fatalf("Keys = %v", ks)
+	}
+	for i, k := range ks {
+		if k != want[i] {
+			t.Errorf("Keys[%d] = %q, want %q", i, k, want[i])
+		}
+	}
+}
+
+func TestValuesFollowKeys(t *testing.T) {
+	m := map[string]int{"c": 3, "a": 1, "b": 2}
+	vs := Values(m)
+	want := []int{1, 2, 3}
+	for i, v := range vs {
+		if v != want[i] {
+			t.Errorf("Values[%d] = %d, want %d", i, v, want[i])
+		}
+	}
+}
+
+func TestHasGet(t *testing.T) {
+	m := map[string]int{"a": 1}
+	if !Has(m, "a") {
+		t.Error("Has a")
+	}
+	if Has(m, "b") {
+		t.Error("Has b should be false")
+	}
+	if v, ok := Get(m, "a"); !ok || v != 1 {
+		t.Errorf("Get a = %d ok=%v", v, ok)
+	}
+	if _, ok := Get(m, "b"); ok {
+		t.Error("Get b ok should be false")
+	}
+}
+
+func TestLen(t *testing.T) {
+	if got := Len(map[int]int{1: 1, 2: 2}); got != 2 {
+		t.Errorf("Len = %d", got)
+	}
+}
+
+func ExampleKeys() {
+	fmt.Println(Keys(map[string]int{"b": 2, "a": 1, "c": 3}))
+	// Output: [a b c]
+}

--- a/runtime/mochi/query/query.go
+++ b/runtime/mochi/query/query.go
@@ -1,0 +1,248 @@
+// Package query is the Mochi query-algebra runtime for the Go target.
+// Every `from x in ... where ... group by ... join ... select ...`
+// clause Mochi emits lowers into a chain of calls here.
+//
+// The shape is deliberately pull-based slices, not channel-based
+// streams: the existing Mochi VM materialises a query result as a
+// slice (see runtime/vm/vm.go OpGroupBy and the surrounding ops), and
+// the Go target preserves that contract so the emitted code does not
+// silently change observable semantics from the VM's behaviour.
+//
+// Generic helpers:
+//   - Filter / Map / FlatMap / Distinct
+//   - SortBy / SortByDesc
+//   - Limit / Take
+//   - GroupBy (returns ordered groups; the group key order matches
+//     the first-occurrence order of the source list)
+//   - Join / LeftJoin / OuterJoin / CrossJoin (Cartesian product)
+//
+// The Group type is exported so the emitter can lower
+// `group by k into g` to a `query.Group[K, T]` value and then walk
+// `g.Items` in a follow-on clause.
+package query
+
+import "sort"
+
+// Filter returns the elements of src for which pred returns true.
+func Filter[T any](src []T, pred func(T) bool) []T {
+	out := make([]T, 0, len(src))
+	for _, v := range src {
+		if pred(v) {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// Map applies fn to each element of src.
+func Map[T, R any](src []T, fn func(T) R) []R {
+	out := make([]R, len(src))
+	for i, v := range src {
+		out[i] = fn(v)
+	}
+	return out
+}
+
+// FlatMap applies fn to each element and concatenates the results.
+func FlatMap[T, R any](src []T, fn func(T) []R) []R {
+	out := make([]R, 0, len(src))
+	for _, v := range src {
+		out = append(out, fn(v)...)
+	}
+	return out
+}
+
+// Distinct returns first-occurrence-unique elements of src.
+func Distinct[T comparable](src []T) []T {
+	seen := make(map[T]struct{}, len(src))
+	out := make([]T, 0, len(src))
+	for _, v := range src {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+// Ordered re-declares cmp.Ordered locally so this package builds on
+// Go 1.20 toolchains (see runtime/mochi/lists for the rationale).
+type Ordered interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
+		~float32 | ~float64 | ~string
+}
+
+// SortBy returns a stable-sorted copy of src by the key function.
+func SortBy[T any, K Ordered](src []T, key func(T) K) []T {
+	out := make([]T, len(src))
+	copy(out, src)
+	sort.SliceStable(out, func(i, j int) bool { return key(out[i]) < key(out[j]) })
+	return out
+}
+
+// SortByDesc returns a stable-sorted copy of src by the key function
+// in descending order.
+func SortByDesc[T any, K Ordered](src []T, key func(T) K) []T {
+	out := make([]T, len(src))
+	copy(out, src)
+	sort.SliceStable(out, func(i, j int) bool { return key(out[i]) > key(out[j]) })
+	return out
+}
+
+// Limit returns the first n elements of src, or all of src if n
+// exceeds len(src). Negative n returns the empty slice.
+func Limit[T any](src []T, n int) []T {
+	if n <= 0 {
+		return src[:0:0]
+	}
+	if n >= len(src) {
+		out := make([]T, len(src))
+		copy(out, src)
+		return out
+	}
+	out := make([]T, n)
+	copy(out, src[:n])
+	return out
+}
+
+// Take is an alias for Limit; Mochi uses both spellings interchangeably
+// in tests/vm/valid.
+func Take[T any](src []T, n int) []T { return Limit(src, n) }
+
+// Group is the result shape of `group by k`: a key plus the items
+// that mapped to that key, in their source order.
+type Group[K comparable, T any] struct {
+	Key   K
+	Items []T
+}
+
+// GroupBy returns groups in the first-occurrence-of-key order from
+// src. Within each group the items appear in source order. This
+// matches the VM's OpGroupBy + Items layout (see vm.go around line
+// 1630 where the VM materialises a group as a map with `items` and
+// `count` keys).
+func GroupBy[T any, K comparable](src []T, key func(T) K) []Group[K, T] {
+	idx := make(map[K]int, len(src))
+	out := make([]Group[K, T], 0)
+	for _, v := range src {
+		k := key(v)
+		if i, ok := idx[k]; ok {
+			out[i].Items = append(out[i].Items, v)
+			continue
+		}
+		idx[k] = len(out)
+		out = append(out, Group[K, T]{Key: k, Items: []T{v}})
+	}
+	return out
+}
+
+// Join performs an inner equi-join: for each pair (l, r) where
+// lkey(l) == rkey(r), produce combine(l, r). Output ordering follows
+// left.then(right) lexicographic order, matching Mochi's
+// `from l in L from r in R where l.id == r.id` lowering.
+func Join[L, R, Out any, K comparable](
+	left []L, right []R,
+	lkey func(L) K, rkey func(R) K,
+	combine func(L, R) Out,
+) []Out {
+	idx := make(map[K][]R, len(right))
+	for _, r := range right {
+		k := rkey(r)
+		idx[k] = append(idx[k], r)
+	}
+	out := make([]Out, 0, len(left))
+	for _, l := range left {
+		for _, r := range idx[lkey(l)] {
+			out = append(out, combine(l, r))
+		}
+	}
+	return out
+}
+
+// LeftJoin produces combine(l, r) for every l in left, where r is
+// either a matching right element or the zero R if no match exists.
+// The third argument to combine is true when r is present and false
+// when r is the zero value. Mochi's `left join` clause lowers here.
+func LeftJoin[L, R, Out any, K comparable](
+	left []L, right []R,
+	lkey func(L) K, rkey func(R) K,
+	combine func(l L, r R, hasR bool) Out,
+) []Out {
+	idx := make(map[K][]R, len(right))
+	for _, r := range right {
+		k := rkey(r)
+		idx[k] = append(idx[k], r)
+	}
+	out := make([]Out, 0, len(left))
+	var zeroR R
+	for _, l := range left {
+		matches := idx[lkey(l)]
+		if len(matches) == 0 {
+			out = append(out, combine(l, zeroR, false))
+			continue
+		}
+		for _, r := range matches {
+			out = append(out, combine(l, r, true))
+		}
+	}
+	return out
+}
+
+// OuterJoin is a full outer join: every l matched, every r matched,
+// and unmatched rows are emitted exactly once with the missing side's
+// present-bit false. The output order is left-first then unmatched-
+// right in source order, which matches the existing VM `outer join`
+// fixture in tests/vm/valid/outer_join.
+func OuterJoin[L, R, Out any, K comparable](
+	left []L, right []R,
+	lkey func(L) K, rkey func(R) K,
+	combine func(l L, r R, hasL, hasR bool) Out,
+) []Out {
+	idx := make(map[K][]R, len(right))
+	for _, r := range right {
+		k := rkey(r)
+		idx[k] = append(idx[k], r)
+	}
+	matchedR := make(map[K]bool, len(right))
+	var zeroL L
+	var zeroR R
+	out := make([]Out, 0, len(left)+len(right))
+	for _, l := range left {
+		k := lkey(l)
+		matches := idx[k]
+		if len(matches) == 0 {
+			out = append(out, combine(l, zeroR, true, false))
+			continue
+		}
+		matchedR[k] = true
+		for _, r := range matches {
+			out = append(out, combine(l, r, true, true))
+		}
+	}
+	for _, r := range right {
+		k := rkey(r)
+		if matchedR[k] {
+			continue
+		}
+		out = append(out, combine(zeroL, r, false, true))
+	}
+	return out
+}
+
+// CrossJoin returns the Cartesian product of left and right, applying
+// combine to every pair in left-major order. Matches Mochi's nested
+// `from l in L from r in R` form when there is no `where` clause.
+func CrossJoin[L, R, Out any](
+	left []L, right []R,
+	combine func(L, R) Out,
+) []Out {
+	out := make([]Out, 0, len(left)*len(right))
+	for _, l := range left {
+		for _, r := range right {
+			out = append(out, combine(l, r))
+		}
+	}
+	return out
+}

--- a/runtime/mochi/query/query_test.go
+++ b/runtime/mochi/query/query_test.go
@@ -1,0 +1,205 @@
+package query
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+type person struct {
+	ID   int
+	Name string
+	Age  int
+	Team string
+}
+
+type score struct {
+	Person int
+	Pts    int
+}
+
+var people = []person{
+	{1, "Alice", 30, "red"},
+	{2, "Bob", 25, "blue"},
+	{3, "Carol", 30, "red"},
+	{4, "Dan", 40, "blue"},
+}
+
+var scores = []score{
+	{1, 10},
+	{1, 20},
+	{2, 15},
+	{3, 5},
+	// Person 4 deliberately has no score, exercises Left/Outer.
+}
+
+func TestFilterMap(t *testing.T) {
+	young := Filter(people, func(p person) bool { return p.Age < 35 })
+	if len(young) != 3 {
+		t.Errorf("Filter < 35 = %v", young)
+	}
+	names := Map(young, func(p person) string { return p.Name })
+	if !reflect.DeepEqual(names, []string{"Alice", "Bob", "Carol"}) {
+		t.Errorf("Map names = %v", names)
+	}
+}
+
+func TestSortBy(t *testing.T) {
+	got := SortBy(people, func(p person) int { return p.Age })
+	want := []string{"Bob", "Alice", "Carol", "Dan"}
+	for i, p := range got {
+		if p.Name != want[i] {
+			t.Errorf("SortBy[%d] = %s, want %s", i, p.Name, want[i])
+		}
+	}
+	gotD := SortByDesc(people, func(p person) int { return p.Age })
+	wantD := []string{"Dan", "Alice", "Carol", "Bob"}
+	for i, p := range gotD {
+		if p.Name != wantD[i] {
+			t.Errorf("SortByDesc[%d] = %s, want %s", i, p.Name, wantD[i])
+		}
+	}
+}
+
+func TestLimitTake(t *testing.T) {
+	got := Limit([]int{1, 2, 3, 4, 5}, 3)
+	if !reflect.DeepEqual(got, []int{1, 2, 3}) {
+		t.Errorf("Limit = %v", got)
+	}
+	if got := Limit([]int{1, 2}, 10); !reflect.DeepEqual(got, []int{1, 2}) {
+		t.Errorf("Limit oversized = %v", got)
+	}
+	if got := Take([]int{1, 2, 3}, 2); !reflect.DeepEqual(got, []int{1, 2}) {
+		t.Errorf("Take = %v", got)
+	}
+	if got := Limit([]int{1, 2}, -1); len(got) != 0 {
+		t.Errorf("Limit negative = %v", got)
+	}
+}
+
+func TestGroupBy(t *testing.T) {
+	groups := GroupBy(people, func(p person) string { return p.Team })
+	if len(groups) != 2 {
+		t.Fatalf("groups = %v", groups)
+	}
+	// Team order is "red", "blue" (first-occurrence of key).
+	if groups[0].Key != "red" || len(groups[0].Items) != 2 {
+		t.Errorf("groups[0] = %+v", groups[0])
+	}
+	if groups[1].Key != "blue" || len(groups[1].Items) != 2 {
+		t.Errorf("groups[1] = %+v", groups[1])
+	}
+	// Items within a group keep source order.
+	if groups[0].Items[0].Name != "Alice" || groups[0].Items[1].Name != "Carol" {
+		t.Errorf("red items = %+v", groups[0].Items)
+	}
+}
+
+func TestInnerJoin(t *testing.T) {
+	type pair struct {
+		Name string
+		Pts  int
+	}
+	got := Join(people, scores,
+		func(p person) int { return p.ID },
+		func(s score) int { return s.Person },
+		func(p person, s score) pair { return pair{p.Name, s.Pts} },
+	)
+	want := []pair{{"Alice", 10}, {"Alice", 20}, {"Bob", 15}, {"Carol", 5}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Join = %v", got)
+	}
+}
+
+func TestLeftJoin(t *testing.T) {
+	type pair struct {
+		Name string
+		Pts  int
+		Has  bool
+	}
+	got := LeftJoin(people, scores,
+		func(p person) int { return p.ID },
+		func(s score) int { return s.Person },
+		func(p person, s score, has bool) pair { return pair{p.Name, s.Pts, has} },
+	)
+	want := []pair{
+		{"Alice", 10, true},
+		{"Alice", 20, true},
+		{"Bob", 15, true},
+		{"Carol", 5, true},
+		{"Dan", 0, false},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LeftJoin = %v", got)
+	}
+}
+
+func TestOuterJoin(t *testing.T) {
+	// Person 4 has no scores; score with Person=99 has no person.
+	extra := append([]score{}, scores...)
+	extra = append(extra, score{99, 1})
+
+	type pair struct {
+		L, R   int
+		hL, hR bool
+	}
+	got := OuterJoin(people, extra,
+		func(p person) int { return p.ID },
+		func(s score) int { return s.Person },
+		func(p person, s score, hL, hR bool) pair { return pair{p.ID, s.Pts, hL, hR} },
+	)
+	wantLen := 4 + // Alice+10, Alice+20, Bob+15, Carol+5
+		1 + // Dan, no score
+		1 // score 99, no person
+	if len(got) != wantLen {
+		t.Errorf("OuterJoin len = %d want %d: %v", len(got), wantLen, got)
+	}
+	// Last row is the unmatched right side (Person=99).
+	last := got[len(got)-1]
+	if last.hL || !last.hR || last.R != 1 {
+		t.Errorf("OuterJoin unmatched right = %+v", last)
+	}
+}
+
+func TestCrossJoin(t *testing.T) {
+	got := CrossJoin([]int{1, 2}, []string{"a", "b"},
+		func(i int, s string) string { return fmt.Sprintf("%d%s", i, s) })
+	want := []string{"1a", "1b", "2a", "2b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("CrossJoin = %v", got)
+	}
+}
+
+func TestDistinct(t *testing.T) {
+	got := Distinct([]int{1, 2, 1, 3, 3, 2})
+	if !reflect.DeepEqual(got, []int{1, 2, 3}) {
+		t.Errorf("Distinct = %v", got)
+	}
+}
+
+func TestFlatMap(t *testing.T) {
+	got := FlatMap([]int{1, 2, 3}, func(i int) []int { return []int{i, i * 10} })
+	if !reflect.DeepEqual(got, []int{1, 10, 2, 20, 3, 30}) {
+		t.Errorf("FlatMap = %v", got)
+	}
+}
+
+func ExampleGroupBy() {
+	rows := []struct {
+		K string
+		V int
+	}{
+		{"a", 1}, {"b", 2}, {"a", 3},
+	}
+	for _, g := range GroupBy(rows, func(r struct {
+		K string
+		V int
+	}) string {
+		return r.K
+	}) {
+		fmt.Printf("%s: %d\n", g.Key, len(g.Items))
+	}
+	// Output:
+	// a: 2
+	// b: 1
+}

--- a/runtime/mochi/sets/sets.go
+++ b/runtime/mochi/sets/sets.go
@@ -1,0 +1,98 @@
+// Package sets is the Mochi-semantics set runtime for the Go target.
+// Mochi does not have a dedicated `set` value: set semantics live
+// inside list comprehensions (`distinct`, `union`, `intersect`,
+// `except`). The emitter lowers those clauses into the functions here
+// so the algebra is centralised, debuggable, and Go-importable as a
+// regular library.
+//
+// The contract is order-preserving for the first occurrence of each
+// element, matching `distinct` from runtime/mochi/lists: a user
+// reading the emitted Go source expects `Union([1,2,3], [3,2,4])` to
+// return `[1,2,3,4]`, not the implementation-defined order a
+// `map[T]struct{}` walk would produce.
+package sets
+
+// Union returns a slice containing every element that appears in a or
+// b, with order taken from a-then-b and the first occurrence
+// preserved.
+func Union[T comparable](a, b []T) []T {
+	seen := make(map[T]struct{}, len(a)+len(b))
+	out := make([]T, 0, len(a)+len(b))
+	for _, v := range a {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	for _, v := range b {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+// Intersect returns the elements present in both a and b, in
+// first-occurrence-in-a order.
+func Intersect[T comparable](a, b []T) []T {
+	inB := make(map[T]struct{}, len(b))
+	for _, v := range b {
+		inB[v] = struct{}{}
+	}
+	seen := make(map[T]struct{}, len(a))
+	out := make([]T, 0, len(a))
+	for _, v := range a {
+		if _, ok := inB[v]; !ok {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+// Except returns the elements in a that do not appear in b, in
+// first-occurrence-in-a order. This matches Mochi's `except` (also
+// known as set difference); duplicates within a are deduplicated.
+func Except[T comparable](a, b []T) []T {
+	inB := make(map[T]struct{}, len(b))
+	for _, v := range b {
+		inB[v] = struct{}{}
+	}
+	seen := make(map[T]struct{}, len(a))
+	out := make([]T, 0, len(a))
+	for _, v := range a {
+		if _, ok := inB[v]; ok {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+// From returns the unique elements of src in first-occurrence order.
+// Provided so Mochi's `distinct` lowering can have a single call site
+// inside the emitter (it could also go through lists.Distinct; we
+// expose it here to keep `sets` the obvious home for set-shaped ops).
+func From[T comparable](src []T) []T {
+	seen := make(map[T]struct{}, len(src))
+	out := make([]T, 0, len(src))
+	for _, v := range src {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}

--- a/runtime/mochi/sets/sets_test.go
+++ b/runtime/mochi/sets/sets_test.go
@@ -1,0 +1,59 @@
+package sets
+
+import (
+	"fmt"
+	"testing"
+)
+
+func eq[T comparable](a, b []T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestUnion(t *testing.T) {
+	got := Union([]int{1, 2, 3}, []int{3, 2, 4})
+	if !eq(got, []int{1, 2, 3, 4}) {
+		t.Errorf("Union = %v", got)
+	}
+	got = Union([]int{}, []int{1, 1, 2})
+	if !eq(got, []int{1, 2}) {
+		t.Errorf("Union empty = %v", got)
+	}
+}
+
+func TestIntersect(t *testing.T) {
+	got := Intersect([]int{1, 2, 2, 3}, []int{2, 3, 4})
+	if !eq(got, []int{2, 3}) {
+		t.Errorf("Intersect = %v", got)
+	}
+	got = Intersect([]int{1, 2}, []int{3, 4})
+	if !eq(got, []int{}) {
+		t.Errorf("Intersect disjoint = %v (expected [])", got)
+	}
+}
+
+func TestExcept(t *testing.T) {
+	got := Except([]int{1, 2, 2, 3, 4}, []int{2, 4})
+	if !eq(got, []int{1, 3}) {
+		t.Errorf("Except = %v", got)
+	}
+}
+
+func TestFrom(t *testing.T) {
+	got := From([]string{"a", "b", "a", "c", "b"})
+	if !eq(got, []string{"a", "b", "c"}) {
+		t.Errorf("From = %v", got)
+	}
+}
+
+func ExampleUnion() {
+	fmt.Println(Union([]int{1, 2, 3}, []int{3, 4}))
+	// Output: [1 2 3 4]
+}

--- a/runtime/mochi/strings/strings.go
+++ b/runtime/mochi/strings/strings.go
@@ -1,0 +1,102 @@
+// Package strings is the Mochi-semantics string runtime for the Go
+// target. It is a thin shim over the Go standard library for the
+// operations where Mochi and Go agree, and a real implementation for
+// the operations where they don't (notably Reverse, which Mochi
+// defines on the rune sequence, and Substr, which uses Mochi's
+// inclusive-exclusive byte-position semantics matching the VM's
+// OpSlice).
+//
+// MEP-43 §3.3 requires the emitter to call this package rather than
+// inline its own string formatting per call site.
+package strings
+
+import (
+	"strings"
+	"unicode"
+)
+
+// Upper returns s with every Unicode letter mapped to its title case,
+// matching Mochi's `upper(s)` builtin (VM op OpUpper).
+func Upper(s string) string { return strings.ToUpper(s) }
+
+// Lower returns s with every Unicode letter mapped to lower case,
+// matching Mochi's `lower(s)` builtin (VM op OpLower).
+func Lower(s string) string { return strings.ToLower(s) }
+
+// Reverse returns s with its runes reversed. This is the rune-level
+// definition Mochi uses (VM op OpReverse on a ValueStr); a byte-level
+// reverse would corrupt multi-byte runes such as `"héllo"`.
+func Reverse(s string) string {
+	runes := []rune(s)
+	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+		runes[i], runes[j] = runes[j], runes[i]
+	}
+	return string(runes)
+}
+
+// Contains reports whether substr appears in s. Matches Mochi's
+// `contains` selector on a string.
+func Contains(s, substr string) bool { return strings.Contains(s, substr) }
+
+// IndexOf returns the byte index of the first occurrence of substr in
+// s, or -1 if substr is not present. Mochi's `indexOf` builtin returns
+// a byte index for parity with the VM's `OpIndex` semantics.
+func IndexOf(s, substr string) int { return strings.Index(s, substr) }
+
+// Split slices s into all substrings separated by sep and returns a
+// slice of the substrings between those separators. Matches Mochi's
+// `split` builtin.
+func Split(s, sep string) []string { return strings.Split(s, sep) }
+
+// Join concatenates the elements of parts to create a single string.
+// The separator string sep is placed between elements. Matches
+// Mochi's `join` builtin.
+func Join(parts []string, sep string) string { return strings.Join(parts, sep) }
+
+// Replace returns a copy of s with all non-overlapping instances of
+// old replaced by new. Matches Mochi's `replace` builtin (which is
+// the all-occurrences form; the VM does not expose a count argument).
+func Replace(s, old, new string) string { return strings.ReplaceAll(s, old, new) }
+
+// TrimSpace returns a slice of s with all leading and trailing
+// Unicode whitespace removed. Matches Mochi's `trim` builtin.
+func TrimSpace(s string) string { return strings.TrimSpace(s) }
+
+// Substr returns the rune sub-sequence of s from index start to end
+// (exclusive), matching Mochi's `substr(s, start, end)` builtin (and
+// `substring`, which is the same operation under a different name in
+// the VM dispatch table). start and end are rune indices. If start or
+// end is out of range it is clamped, with start clamped before end so
+// that an inverted range yields the empty string rather than panicking.
+func Substr(s string, start, end int) string {
+	runes := []rune(s)
+	n := len(runes)
+	if start < 0 {
+		start = 0
+	}
+	if end > n {
+		end = n
+	}
+	if start > end {
+		return ""
+	}
+	return string(runes[start:end])
+}
+
+// HasPrefix reports whether s begins with prefix.
+func HasPrefix(s, prefix string) bool { return strings.HasPrefix(s, prefix) }
+
+// HasSuffix reports whether s ends with suffix.
+func HasSuffix(s, suffix string) bool { return strings.HasSuffix(s, suffix) }
+
+// IsWhitespace reports whether every rune in s is Unicode whitespace.
+// An empty string is considered all-whitespace, matching the
+// vacuous-truth convention the VM uses for `count` over empty lists.
+func IsWhitespace(s string) bool {
+	for _, r := range s {
+		if !unicode.IsSpace(r) {
+			return false
+		}
+	}
+	return true
+}

--- a/runtime/mochi/strings/strings_test.go
+++ b/runtime/mochi/strings/strings_test.go
@@ -1,0 +1,127 @@
+package strings
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestUpperLower(t *testing.T) {
+	if got := Upper("héllo"); got != "HÉLLO" {
+		t.Errorf("Upper = %q", got)
+	}
+	if got := Lower("HÉLLO"); got != "héllo" {
+		t.Errorf("Lower = %q", got)
+	}
+}
+
+func TestReverseUnicode(t *testing.T) {
+	cases := []struct{ in, out string }{
+		{"", ""},
+		{"a", "a"},
+		{"abc", "cba"},
+		{"héllo", "olléh"},
+		{"日本語", "語本日"},
+	}
+	for _, c := range cases {
+		if got := Reverse(c.in); got != c.out {
+			t.Errorf("Reverse(%q) = %q, want %q", c.in, got, c.out)
+		}
+	}
+}
+
+func TestContainsIndexOf(t *testing.T) {
+	if !Contains("hello world", "world") {
+		t.Error("Contains world")
+	}
+	if Contains("hello world", "WORLD") {
+		t.Error("Contains case sensitive expected false")
+	}
+	if got := IndexOf("hello world", "world"); got != 6 {
+		t.Errorf("IndexOf = %d", got)
+	}
+	if got := IndexOf("hello world", "xyz"); got != -1 {
+		t.Errorf("IndexOf missing = %d", got)
+	}
+}
+
+func TestSplitJoin(t *testing.T) {
+	parts := Split("a,b,c", ",")
+	if len(parts) != 3 || parts[0] != "a" || parts[2] != "c" {
+		t.Errorf("Split = %v", parts)
+	}
+	if got := Join(parts, "-"); got != "a-b-c" {
+		t.Errorf("Join = %q", got)
+	}
+}
+
+func TestReplace(t *testing.T) {
+	if got := Replace("aaa", "a", "b"); got != "bbb" {
+		t.Errorf("Replace all = %q", got)
+	}
+}
+
+func TestTrimSpace(t *testing.T) {
+	if got := TrimSpace("  hi  "); got != "hi" {
+		t.Errorf("TrimSpace = %q", got)
+	}
+}
+
+func TestSubstr(t *testing.T) {
+	cases := []struct {
+		in         string
+		start, end int
+		out        string
+	}{
+		{"hello", 0, 5, "hello"},
+		{"hello", 1, 4, "ell"},
+		{"hello", 3, 1, ""}, // inverted range
+		{"hello", -2, 3, "hel"},
+		{"hello", 0, 99, "hello"},
+		{"日本語", 0, 2, "日本"},
+	}
+	for _, c := range cases {
+		if got := Substr(c.in, c.start, c.end); got != c.out {
+			t.Errorf("Substr(%q,%d,%d) = %q, want %q", c.in, c.start, c.end, got, c.out)
+		}
+	}
+}
+
+func TestHasPrefixSuffix(t *testing.T) {
+	if !HasPrefix("hello.go", "hello") {
+		t.Error("HasPrefix")
+	}
+	if !HasSuffix("hello.go", ".go") {
+		t.Error("HasSuffix")
+	}
+}
+
+func TestIsWhitespace(t *testing.T) {
+	for _, c := range []struct {
+		in   string
+		want bool
+	}{
+		{"", true},
+		{"   ", true},
+		{"\t\n", true},
+		{" a ", false},
+	} {
+		if got := IsWhitespace(c.in); got != c.want {
+			t.Errorf("IsWhitespace(%q) = %v", c.in, got)
+		}
+	}
+}
+
+func ExampleUpper() {
+	fmt.Println(Upper("hello"))
+	// Output: HELLO
+}
+
+func ExampleReverse() {
+	fmt.Println(Reverse("héllo"))
+	// Output: olléh
+}
+
+func ExampleSubstr() {
+	fmt.Println(Substr("hello, world", 7, 12))
+	// Output: world
+}

--- a/runtime/mochi/time/time.go
+++ b/runtime/mochi/time/time.go
@@ -1,0 +1,38 @@
+// Package time is the Mochi-semantics time runtime for the Go target.
+// Mochi's `now()` returns Unix nanoseconds as an int (see VM op OpNow
+// in runtime/vm/vm.go). The function here matches that contract so
+// the emitter can lower `now()` to a single call. We also expose
+// `Format` and `Parse` for the RFC-3339 form Mochi uses in its query
+// fixtures (date columns are stored as strings in `tests/vm/valid`).
+package time
+
+import gotime "time"
+
+// Now returns the current time as Unix nanoseconds.
+func Now() int64 { return gotime.Now().UnixNano() }
+
+// NowMono returns a monotonic-clock counter in nanoseconds. Useful
+// for tight benchmark code that the emitter lowers from Mochi's
+// `now()` inside a Bench block.
+func NowMono() int64 { return gotime.Since(refEpoch).Nanoseconds() }
+
+var refEpoch = gotime.Now()
+
+// FormatRFC3339 formats a Unix-nanos value as RFC-3339 in UTC.
+func FormatRFC3339(unixNanos int64) string {
+	return gotime.Unix(0, unixNanos).UTC().Format(gotime.RFC3339)
+}
+
+// ParseRFC3339 parses an RFC-3339 timestamp and returns Unix nanos.
+func ParseRFC3339(s string) (int64, error) {
+	t, err := gotime.Parse(gotime.RFC3339, s)
+	if err != nil {
+		return 0, err
+	}
+	return t.UnixNano(), nil
+}
+
+// Sleep blocks for the given number of nanoseconds. Mochi's existing
+// VM does not expose sleep as a builtin; we provide it here for Go
+// users importing this library directly.
+func Sleep(nanos int64) { gotime.Sleep(gotime.Duration(nanos)) }

--- a/runtime/mochi/time/time_test.go
+++ b/runtime/mochi/time/time_test.go
@@ -1,0 +1,55 @@
+package time
+
+import (
+	"fmt"
+	gotime "time"
+	"testing"
+)
+
+func TestNowMonotonic(t *testing.T) {
+	a := Now()
+	gotime.Sleep(gotime.Millisecond)
+	b := Now()
+	if b <= a {
+		t.Errorf("Now non-monotonic: %d -> %d", a, b)
+	}
+}
+
+func TestRFC3339RoundTrip(t *testing.T) {
+	const ts = "2026-05-21T00:00:00Z"
+	nanos, err := ParseRFC3339(ts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := FormatRFC3339(nanos); got != ts {
+		t.Errorf("Format(Parse(%q)) = %q", ts, got)
+	}
+}
+
+func TestParseError(t *testing.T) {
+	if _, err := ParseRFC3339("not a timestamp"); err == nil {
+		t.Error("ParseRFC3339 garbage should error")
+	}
+}
+
+func TestNowMono(t *testing.T) {
+	a := NowMono()
+	gotime.Sleep(gotime.Millisecond)
+	b := NowMono()
+	if b <= a {
+		t.Errorf("NowMono non-monotonic: %d -> %d", a, b)
+	}
+}
+
+func TestSleep(t *testing.T) {
+	start := gotime.Now()
+	Sleep(int64(gotime.Millisecond))
+	if gotime.Since(start) < gotime.Millisecond {
+		t.Errorf("Sleep returned too early")
+	}
+}
+
+func ExampleFormatRFC3339() {
+	fmt.Println(FormatRFC3339(0))
+	// Output: 1970-01-01T00:00:00Z
+}

--- a/runtime/mochi/yaml/yaml.go
+++ b/runtime/mochi/yaml/yaml.go
@@ -1,0 +1,38 @@
+// Package yaml is the Mochi-semantics YAML runtime for the Go target.
+// Mochi's existing VM uses gopkg.in/yaml.v3 (see runtime/data/yaml.go)
+// and we keep that dependency choice here so the emitted Go code does
+// not introduce a second YAML library to the build.
+//
+// Mochi's `yaml(value)` builtin prints a YAML document with sorted
+// keys, the standard "---\n" prefix omitted, two-space indent. The
+// upstream yaml.v3 Encoder already sorts string keys and uses
+// two-space indent, so Marshal/Fprint are thin pass-throughs.
+package yaml
+
+import (
+	"bytes"
+	"io"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Marshal returns the YAML encoding of v.
+func Marshal(v any) ([]byte, error) { return yaml.Marshal(v) }
+
+// Unmarshal parses YAML data into the value pointed to by v.
+func Unmarshal(data []byte, v any) error { return yaml.Unmarshal(data, v) }
+
+// Print writes the YAML encoding of v to stdout. yaml.Marshal already
+// adds a trailing newline.
+func Print(v any) { _ = Fprint(os.Stdout, v) }
+
+// Fprint writes the YAML encoding of v to w.
+func Fprint(w io.Writer, v any) error {
+	b, err := Marshal(v)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(w, bytes.NewReader(b))
+	return err
+}

--- a/runtime/mochi/yaml/yaml_test.go
+++ b/runtime/mochi/yaml/yaml_test.go
@@ -1,0 +1,38 @@
+package yaml
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestMarshalRoundTrip(t *testing.T) {
+	in := map[string]any{"a": 1, "b": []int{2, 3}}
+	b, err := Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out["a"] != 1 {
+		t.Errorf("a = %v", out["a"])
+	}
+}
+
+func TestFprint(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Fprint(&buf, map[string]int{"x": 1}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "x: 1") {
+		t.Errorf("Fprint = %q", buf.String())
+	}
+}
+
+func ExamplePrint() {
+	Print(map[string]int{"a": 1})
+	// Output:
+	// a: 1
+}

--- a/website/docs/mep/mep-0043.md
+++ b/website/docs/mep/mep-0043.md
@@ -440,15 +440,28 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 - Cache hit on second call: memo path best-of-3 < 1 ms (gate); cold disk hit < 100 ms (bounded by gob decode of the largest stdlib package). Cache keys on `(import_path, go.sum_hash, mochi_version)`; the on-disk format carries a leading version byte (0x01) so corrupted or tampered entries fall through as misses.
 - Soak (`stdlib_test.go::TestStdlibFullSoak`): 185 stdlib packages enumerated from `$GOROOT/src`, 8256 symbols, 13445 type-references, 0 `KindInvalid`, 17.93% opaque density. The `builtin` package (godoc-only) and the `unsafe` package (definitionally opaque) are excluded. The full-stdlib bar is 20%; per-reason histogram (`uintptr=1447`, `unsafe.Pointer=819`, `unknown=89`, `complex=56`) is logged on `-v`. See MEP-44 §6 for the curated-10% vs full-stdlib-20% bar split.
 
-### Phase 3: `runtime/mochi/` Go module — pending
+### Phase 3: `runtime/mochi/` Go module — LANDED
 
 **Status & commit:**
 
 | Status | Issue | PR | Commit |
 |---|---|---|---|
-| PENDING | #21901 | TBD | _none_ |
+| LANDED | #21901 | TBD (this branch) | _filled by merge_ |
 
 **Gate:** `go test ./runtime/mochi/...` green; each package has at least one example and matches Mochi semantics from `tests/vm/valid` golden output.
+
+**Result:** `runtime/mochi/` ships ten sub-packages, each independently importable by a Go user, with a normal Go test suite and runnable examples.
+
+- `runtime/mochi/strings`: `Upper`, `Lower`, `Reverse` (rune-aware so `"héllo"` reverses to `"olléh"`), `Contains`, `IndexOf`, `Split`, `Join`, `Replace`, `TrimSpace`, `Substr` with Mochi's clamping/inverted-range semantics, `HasPrefix`, `HasSuffix`, `IsWhitespace`.
+- `runtime/mochi/lists`: `Append` (non-mutating, matching `OpAppend`), `Reverse`, `First`/`Last` (with present-bit), `Concat`, `Slice` (clamped), `Contains`, `IndexOf`, `Distinct`, `SortBy` (stable), `SumFloat`/`SumInt`/`AvgFloat`/`MinOrdered`/`MaxOrdered`.
+- `runtime/mochi/maps`: `Keys` (sorted), `Values` (key-order), `Has`, `Get`, `Len`.
+- `runtime/mochi/sets`: `Union`, `Intersect`, `Except`, `From`, all first-occurrence-order preserving.
+- `runtime/mochi/query`: `Filter`, `Map`, `FlatMap`, `Distinct`, `SortBy`, `SortByDesc`, `Limit`/`Take`, `GroupBy` (returns ordered `Group[K, T]`), `Join`, `LeftJoin`, `OuterJoin`, `CrossJoin`. The query algebra is the load-bearing surface Phase 5 lowers onto.
+- `runtime/mochi/json`: `Marshal`/`MarshalIndent`/`Print`/`Fprint`/`Unmarshal`. Indented output is sorted-key, two-space, no HTML escaping (so `&` and `<` pass through verbatim) and no trailing newline from the marshaller (the printer adds one).
+- `runtime/mochi/yaml`: pass-through over `gopkg.in/yaml.v3` (the dependency Mochi already carries via `runtime/data/yaml.go`).
+- `runtime/mochi/fmt`: `Print`/`Fprintln`/`Sprint`/`Format`. Mochi-style space-joined, `nil` rather than Go's `<nil>`.
+- `runtime/mochi/decimal`: `New`, `FromString`/`MustFromString`, `Add`/`Sub`/`Mul`/`Div` (panics on division by zero), `Neg`, `Cmp`, `IsZero`, `String`, `Float64`, `Round` with half-away-from-zero. Built on `math/big.Rat` so no new dependency.
+- `runtime/mochi/time`: `Now`, `NowMono`, `FormatRFC3339`, `ParseRFC3339`, `Sleep`.
 
 ### Phase 4: `compiler3/emit/go/` skeleton — pending
 


### PR DESCRIPTION
## Summary
- Ships the Mochi standard runtime for the Go target as ten independent sub-packages under `runtime/mochi/`: `strings`, `lists`, `maps`, `sets`, `query`, `json`, `yaml`, `fmt`, `decimal`, `time`. Each is a normal Go package that a plain Go user can `go get` and use, backed by a normal Go test suite plus runnable `Example*` functions.
- Mochi-faithful semantics: `strings.Reverse` is rune-aware (so `"héllo"` reverses to `"olléh"`), `lists.Append` does not mutate its input, `Slice`/`Substr` clamp out-of-range and return empty on inverted ranges (matching `OpSlice`), `json.MarshalIndent` is two-space sorted-key with no HTML escape, `query.GroupBy` returns groups in first-occurrence-of-key order with source-order items, `decimal.Div` panics on division by zero, `fmt.Print` formats `nil` as `nil` not `<nil>`.
- `query` carries the full algebra Phase 5 will lower onto: `Filter`, `Map`, `FlatMap`, `Distinct`, `SortBy`/`SortByDesc`, `Limit`/`Take`, `GroupBy`, `Join`, `LeftJoin`, `OuterJoin`, `CrossJoin`.
- `decimal` is built on `math/big.Rat` (no new dependency). `yaml` reuses `gopkg.in/yaml.v3` (already in `go.mod`).
- MEP-43 Phase 3 row flipped to LANDED with the per-package result list.

Closes #21901.

## Test plan
- [x] `go test ./runtime/mochi/... -count=1`
- [x] `go vet ./runtime/mochi/...`
- [x] Every sub-package has at least one runnable `Example*`