### PR TITLE
mep-0043: Phase 5 query lowering through runtime/mochi/query

### DIFF
--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -98,10 +98,19 @@ func emitFunc(w *bytes.Buffer, fn *ir.Function, all []*ir.Function, imports map[
 		if v.Op == ir.OpParam {
 			continue
 		}
-		if goType(v.Type) == "" {
+		if v.Op == ir.OpFnRef {
+			// OpFnRef is not materialised as a Go local; consumers
+			// inline the referenced function's name via fnName.
 			continue
 		}
-		fmt.Fprintf(w, "\tvar %s %s\n", valueName(v.ID), goType(v.Type))
+		gt := goTypeForValue(v)
+		if gt == "" {
+			continue
+		}
+		if v.Op == ir.OpQueryGroupBy {
+			imports["mochi/runtime/mochi/query"] = true
+		}
+		fmt.Fprintf(w, "\tvar %s %s\n", valueName(v.ID), gt)
 		// Suppress "declared but not used" for values that only feed
 		// terminators we don't reference (rare but possible after opt
 		// passes drop dead values).
@@ -223,6 +232,58 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 			w.WriteString(valueName(aid))
 		}
 		w.WriteString(")\n")
+	case ir.OpFnRef:
+		// No Go-side expression; the consumer query op inlines the
+		// referenced function name via fnName(fn, all, v.Args[i]).
+		return nil
+	case ir.OpQueryFilter:
+		imports["mochi/runtime/mochi/query"] = true
+		fmt.Fprintf(w, "\t%s = query.Filter[int64](%s, %s)\n",
+			name, valueName(v.Args[0]), fnName(fn, all, v.Args[1]))
+	case ir.OpQueryMap:
+		imports["mochi/runtime/mochi/query"] = true
+		fmt.Fprintf(w, "\t%s = query.Map[int64, int64](%s, %s)\n",
+			name, valueName(v.Args[0]), fnName(fn, all, v.Args[1]))
+	case ir.OpQuerySortBy:
+		imports["mochi/runtime/mochi/query"] = true
+		fmt.Fprintf(w, "\t%s = query.SortBy[int64, int64](%s, %s)\n",
+			name, valueName(v.Args[0]), fnName(fn, all, v.Args[1]))
+	case ir.OpQuerySortByDesc:
+		imports["mochi/runtime/mochi/query"] = true
+		fmt.Fprintf(w, "\t%s = query.SortByDesc[int64, int64](%s, %s)\n",
+			name, valueName(v.Args[0]), fnName(fn, all, v.Args[1]))
+	case ir.OpQueryLimit:
+		imports["mochi/runtime/mochi/query"] = true
+		fmt.Fprintf(w, "\t%s = query.Limit[int64](%s, int(%s))\n",
+			name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpQueryDistinct:
+		imports["mochi/runtime/mochi/query"] = true
+		fmt.Fprintf(w, "\t%s = query.Distinct[int64](%s)\n",
+			name, valueName(v.Args[0]))
+	case ir.OpQueryGroupBy:
+		imports["mochi/runtime/mochi/query"] = true
+		fmt.Fprintf(w, "\t%s = query.GroupBy[int64, int64](%s, %s)\n",
+			name, valueName(v.Args[0]), fnName(fn, all, v.Args[1]))
+	case ir.OpQueryJoin:
+		imports["mochi/runtime/mochi/query"] = true
+		fmt.Fprintf(w, "\t%s = query.Join[int64, int64, int64, int64](%s, %s, %s, %s, %s)\n",
+			name, valueName(v.Args[0]), valueName(v.Args[1]),
+			fnName(fn, all, v.Args[2]), fnName(fn, all, v.Args[3]), fnName(fn, all, v.Args[4]))
+	case ir.OpQueryLeftJoin:
+		imports["mochi/runtime/mochi/query"] = true
+		fmt.Fprintf(w, "\t%s = query.LeftJoin[int64, int64, int64, int64](%s, %s, %s, %s, %s)\n",
+			name, valueName(v.Args[0]), valueName(v.Args[1]),
+			fnName(fn, all, v.Args[2]), fnName(fn, all, v.Args[3]), fnName(fn, all, v.Args[4]))
+	case ir.OpQueryOuterJoin:
+		imports["mochi/runtime/mochi/query"] = true
+		fmt.Fprintf(w, "\t%s = query.OuterJoin[int64, int64, int64, int64](%s, %s, %s, %s, %s)\n",
+			name, valueName(v.Args[0]), valueName(v.Args[1]),
+			fnName(fn, all, v.Args[2]), fnName(fn, all, v.Args[3]), fnName(fn, all, v.Args[4]))
+	case ir.OpQueryCrossJoin:
+		imports["mochi/runtime/mochi/query"] = true
+		fmt.Fprintf(w, "\t%s = query.CrossJoin[int64, int64, int64](%s, %s, %s)\n",
+			name, valueName(v.Args[0]), valueName(v.Args[1]),
+			fnName(fn, all, v.Args[2]))
 	case ir.OpPhi:
 		// Declared in prelude; no body emit.
 		return nil
@@ -278,6 +339,35 @@ func emitTerminator(w *bytes.Buffer, fn *ir.Function, blk *ir.Block, all []*ir.F
 }
 
 func valueName(id uint32) string { return fmt.Sprintf("v%d", id) }
+
+// fnName returns the Go function name referenced by an OpFnRef value.
+// The argument is the SSA value ID of an OpFnRef; the helper looks
+// through the value table, asserts the op, and indexes the program's
+// function table by the embedded Const. Used by query op emission to
+// inline closure references as Go function values.
+func fnName(fn *ir.Function, all []*ir.Function, vid uint32) string {
+	v := fn.Values[vid]
+	if v.Op != ir.OpFnRef {
+		return fmt.Sprintf("/* not an OpFnRef: v%d */", vid)
+	}
+	if int(v.Const) >= len(all) {
+		return fmt.Sprintf("/* fnref out of range: %d */", v.Const)
+	}
+	return all[v.Const].Name
+}
+
+// goTypeForValue returns the Go type for an SSA value's variable
+// declaration. For most ops this is just goType(v.Type), but a few
+// ops (notably OpQueryGroupBy) produce values whose static Go type
+// can't be derived from ir.Type alone.
+func goTypeForValue(v ir.Value) string {
+	if v.Op == ir.OpQueryGroupBy {
+		// runtime/mochi/query.GroupBy returns []Group[K, T]; for the
+		// i64-everywhere Phase 5 subset that's []query.Group[int64, int64].
+		return "[]query.Group[int64, int64]"
+	}
+	return goType(v.Type)
+}
 
 func goType(t ir.Type) string {
 	switch t {

--- a/compiler3/emit/go/emit_test.go
+++ b/compiler3/emit/go/emit_test.go
@@ -119,6 +119,328 @@ func runGo(t *testing.T, src string) string {
 	return string(out)
 }
 
+// runGoModule writes src to a fresh subdirectory under
+// testdata/_run so the file inherits the mochi module's go.mod and
+// `import "mochi/runtime/mochi/query"` resolves naturally. Used by
+// the Phase 5 query lowering tests; the Phase 4 tests do not need
+// this because their fixtures import only stdlib.
+func runGoModule(t *testing.T, src string) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(wd, "testdata", "_run")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dir, err := os.MkdirTemp(root, "case-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	file := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("go", "run", file)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go run failed: %v\nsource:\n%s\noutput:\n%s", err, src, out)
+	}
+	return string(out)
+}
+
+// buildQueryDemo wires together a "demo" function that builds a literal
+// i64 list (with the supplied elements), passes it to op constructor
+// (which assembles the OpQueryX value), then reduces the result to
+// an i64 via reduce. The reduce closure receives the resulting list
+// value's SSA id and must produce an i64 SSA id that becomes the
+// function's return value. Returns the demo Function and the program
+// (which also contains any helper fixtures the constructor stashes
+// into helpers).
+func buildQueryDemo(
+	t *testing.T,
+	name string,
+	input []int64,
+	helpers []*ir.Function,
+	build func(fn *ir.Function, helperIdx map[string]uint32, src uint32) (resultID uint32, extras []uint32),
+	reduce func(fn *ir.Function, resultID uint32) (returnID uint32, extras []uint32),
+) []*ir.Function {
+	t.Helper()
+	fn := &ir.Function{Name: name, Result: ir.TypeI64}
+	entryID := fn.AddBlock()
+	var values []uint32
+
+	src := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpNewList})
+	values = append(values, src)
+	for _, e := range input {
+		c := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: e})
+		p := fn.AddValue(ir.Value{Type: ir.TypeUnit, Op: ir.OpListPushI64, Args: []uint32{src, c}})
+		values = append(values, c, p)
+	}
+
+	// Helpers' function indices: demo is at index 0, helpers at 1..N.
+	helperIdx := map[string]uint32{}
+	for i, h := range helpers {
+		helperIdx[h.Name] = uint32(i + 1)
+	}
+
+	result, extras := build(fn, helperIdx, src)
+	values = append(values, extras...)
+
+	returnID, redExtras := reduce(fn, result)
+	values = append(values, redExtras...)
+
+	blk := fn.Block(entryID)
+	blk.Values = values
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: returnID}
+
+	out := make([]*ir.Function, 0, 1+len(helpers))
+	out = append(out, fn)
+	out = append(out, helpers...)
+	return out
+}
+
+// runQueryDemo emits, wraps with println(demo()), and runs.
+func runQueryDemo(t *testing.T, fns []*ir.Function) string {
+	t.Helper()
+	src, err := Emit(&Program{PkgName: "main", Funcs: fns})
+	if err != nil {
+		t.Fatalf("Emit: %v\n%s", err, src)
+	}
+	withMain := string(src) + "\nfunc main() {\n\tprintln(" + fns[0].Name + "())\n}\n"
+	return runGoModule(t, withMain)
+}
+
+// reduceLen returns OpListLenI64(resultID) as the demo's return id.
+func reduceLen(fn *ir.Function, resultID uint32) (uint32, []uint32) {
+	ln := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpListLenI64, Args: []uint32{resultID}})
+	return ln, []uint32{ln}
+}
+
+// reduceGet0 returns OpListGetI64(resultID, 0).
+func reduceGet0(fn *ir.Function, resultID uint32) (uint32, []uint32) {
+	zero := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 0})
+	get := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpListGetI64, Args: []uint32{resultID, zero}})
+	return get, []uint32{zero, get}
+}
+
+// reduceGet returns OpListGetI64(resultID, idx).
+func reduceGet(idx int64) func(fn *ir.Function, resultID uint32) (uint32, []uint32) {
+	return func(fn *ir.Function, resultID uint32) (uint32, []uint32) {
+		i := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: idx})
+		g := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpListGetI64, Args: []uint32{resultID, i}})
+		return g, []uint32{i, g}
+	}
+}
+
+func TestEmitQueryFilter(t *testing.T) {
+	helpers := []*ir.Function{ir.FixtureIsEven()}
+	fns := buildQueryDemo(t, "demo", []int64{1, 2, 3, 4, 5}, helpers,
+		func(fn *ir.Function, hi map[string]uint32, src uint32) (uint32, []uint32) {
+			ref := fn.AddValue(ir.Value{Type: ir.TypeClosure, Op: ir.OpFnRef, Const: int64(hi["is_even"])})
+			r := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpQueryFilter, Args: []uint32{src, ref}})
+			return r, []uint32{ref, r}
+		}, reduceLen)
+	if got := runQueryDemo(t, fns); got != "2\n" {
+		t.Errorf("Filter [1..5] is_even len = %q, want 2", got)
+	}
+}
+
+func TestEmitQueryMap(t *testing.T) {
+	helpers := []*ir.Function{ir.FixtureDouble()}
+	fns := buildQueryDemo(t, "demo", []int64{1, 2, 3}, helpers,
+		func(fn *ir.Function, hi map[string]uint32, src uint32) (uint32, []uint32) {
+			ref := fn.AddValue(ir.Value{Type: ir.TypeClosure, Op: ir.OpFnRef, Const: int64(hi["double"])})
+			r := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpQueryMap, Args: []uint32{src, ref}})
+			return r, []uint32{ref, r}
+		}, reduceGet(2))
+	if got := runQueryDemo(t, fns); got != "6\n" {
+		t.Errorf("Map [1,2,3] double [2] = %q, want 6", got)
+	}
+}
+
+func TestEmitQuerySortBy(t *testing.T) {
+	helpers := []*ir.Function{ir.FixtureIdent()}
+	fns := buildQueryDemo(t, "demo", []int64{3, 1, 2}, helpers,
+		func(fn *ir.Function, hi map[string]uint32, src uint32) (uint32, []uint32) {
+			ref := fn.AddValue(ir.Value{Type: ir.TypeClosure, Op: ir.OpFnRef, Const: int64(hi["ident"])})
+			r := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpQuerySortBy, Args: []uint32{src, ref}})
+			return r, []uint32{ref, r}
+		}, reduceGet0)
+	if got := runQueryDemo(t, fns); got != "1\n" {
+		t.Errorf("SortBy [3,1,2] ident [0] = %q, want 1", got)
+	}
+}
+
+func TestEmitQuerySortByDesc(t *testing.T) {
+	helpers := []*ir.Function{ir.FixtureIdent()}
+	fns := buildQueryDemo(t, "demo", []int64{3, 1, 2}, helpers,
+		func(fn *ir.Function, hi map[string]uint32, src uint32) (uint32, []uint32) {
+			ref := fn.AddValue(ir.Value{Type: ir.TypeClosure, Op: ir.OpFnRef, Const: int64(hi["ident"])})
+			r := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpQuerySortByDesc, Args: []uint32{src, ref}})
+			return r, []uint32{ref, r}
+		}, reduceGet0)
+	if got := runQueryDemo(t, fns); got != "3\n" {
+		t.Errorf("SortByDesc [3,1,2] ident [0] = %q, want 3", got)
+	}
+}
+
+func TestEmitQueryLimit(t *testing.T) {
+	fns := buildQueryDemo(t, "demo", []int64{1, 2, 3, 4, 5}, nil,
+		func(fn *ir.Function, hi map[string]uint32, src uint32) (uint32, []uint32) {
+			n := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 2})
+			r := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpQueryLimit, Args: []uint32{src, n}})
+			return r, []uint32{n, r}
+		}, reduceLen)
+	if got := runQueryDemo(t, fns); got != "2\n" {
+		t.Errorf("Limit [1..5] n=2 len = %q, want 2", got)
+	}
+}
+
+func TestEmitQueryDistinct(t *testing.T) {
+	fns := buildQueryDemo(t, "demo", []int64{1, 1, 2, 2, 3}, nil,
+		func(fn *ir.Function, hi map[string]uint32, src uint32) (uint32, []uint32) {
+			r := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpQueryDistinct, Args: []uint32{src}})
+			return r, []uint32{r}
+		}, reduceLen)
+	if got := runQueryDemo(t, fns); got != "3\n" {
+		t.Errorf("Distinct [1,1,2,2,3] len = %q, want 3", got)
+	}
+}
+
+func TestEmitQueryGroupByCompiles(t *testing.T) {
+	// GroupBy returns []query.Group[int64, int64]; we don't yet have
+	// struct field access in compiler3 IR (Phase 6 lands the Mochi
+	// frontend's record access). This test asserts the emitter
+	// produces a compile- and run-clean program even when the IR
+	// can only return a constant value, not the group result.
+	helpers := []*ir.Function{ir.FixtureIdent()}
+	fns := buildQueryDemo(t, "demo", []int64{1, 2, 3, 4}, helpers,
+		func(fn *ir.Function, hi map[string]uint32, src uint32) (uint32, []uint32) {
+			ref := fn.AddValue(ir.Value{Type: ir.TypeClosure, Op: ir.OpFnRef, Const: int64(hi["ident"])})
+			r := fn.AddValue(ir.Value{Type: ir.TypeAny, Op: ir.OpQueryGroupBy, Args: []uint32{src, ref}})
+			return r, []uint32{ref, r}
+		}, func(fn *ir.Function, resultID uint32) (uint32, []uint32) {
+			// Ignore resultID; just return a constant 0. The emitter's
+			// `_ = vN` pseudo-use keeps the group result in scope.
+			c := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 7})
+			return c, []uint32{c}
+		})
+	if got := runQueryDemo(t, fns); got != "7\n" {
+		t.Errorf("GroupBy compile-only fixture = %q, want 7", got)
+	}
+}
+
+func TestEmitQueryJoin(t *testing.T) {
+	helpers := []*ir.Function{ir.FixtureIdent(), ir.FixtureAddPair()}
+	// We feed the same input list as both sides via a closure that
+	// builds the right list inside the demo's body.
+	fn := &ir.Function{Name: "demo", Result: ir.TypeI64}
+	entryID := fn.AddBlock()
+	var values []uint32
+
+	// Build left list [1, 2].
+	left := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpNewList})
+	values = append(values, left)
+	for _, e := range []int64{1, 2} {
+		c := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: e})
+		p := fn.AddValue(ir.Value{Type: ir.TypeUnit, Op: ir.OpListPushI64, Args: []uint32{left, c}})
+		values = append(values, c, p)
+	}
+	// Build right list [1, 2].
+	right := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpNewList})
+	values = append(values, right)
+	for _, e := range []int64{1, 2} {
+		c := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: e})
+		p := fn.AddValue(ir.Value{Type: ir.TypeUnit, Op: ir.OpListPushI64, Args: []uint32{right, c}})
+		values = append(values, c, p)
+	}
+	// Function refs.
+	identIdx := int64(1) // helpers[0] = ident, helpers[1] = add_pair
+	addIdx := int64(2)
+	lkey := fn.AddValue(ir.Value{Type: ir.TypeClosure, Op: ir.OpFnRef, Const: identIdx})
+	rkey := fn.AddValue(ir.Value{Type: ir.TypeClosure, Op: ir.OpFnRef, Const: identIdx})
+	comb := fn.AddValue(ir.Value{Type: ir.TypeClosure, Op: ir.OpFnRef, Const: addIdx})
+	values = append(values, lkey, rkey, comb)
+
+	joined := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpQueryJoin, Args: []uint32{left, right, lkey, rkey, comb}})
+	ln := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpListLenI64, Args: []uint32{joined}})
+	values = append(values, joined, ln)
+
+	blk := fn.Block(entryID)
+	blk.Values = values
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: ln}
+
+	fns := append([]*ir.Function{fn}, helpers...)
+	if got := runQueryDemo(t, fns); got != "2\n" {
+		t.Errorf("Join [1,2]x[1,2] ident,add len = %q, want 2", got)
+	}
+}
+
+func TestEmitQueryCrossJoin(t *testing.T) {
+	helpers := []*ir.Function{ir.FixtureAddPair()}
+	fn := &ir.Function{Name: "demo", Result: ir.TypeI64}
+	entryID := fn.AddBlock()
+	var values []uint32
+
+	// Left [1, 2].
+	left := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpNewList})
+	values = append(values, left)
+	for _, e := range []int64{1, 2} {
+		c := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: e})
+		p := fn.AddValue(ir.Value{Type: ir.TypeUnit, Op: ir.OpListPushI64, Args: []uint32{left, c}})
+		values = append(values, c, p)
+	}
+	// Right [10, 20].
+	right := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpNewList})
+	values = append(values, right)
+	for _, e := range []int64{10, 20} {
+		c := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: e})
+		p := fn.AddValue(ir.Value{Type: ir.TypeUnit, Op: ir.OpListPushI64, Args: []uint32{right, c}})
+		values = append(values, c, p)
+	}
+	comb := fn.AddValue(ir.Value{Type: ir.TypeClosure, Op: ir.OpFnRef, Const: 1})
+	cross := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpQueryCrossJoin, Args: []uint32{left, right, comb}})
+	ln := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpListLenI64, Args: []uint32{cross}})
+	values = append(values, comb, cross, ln)
+
+	blk := fn.Block(entryID)
+	blk.Values = values
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: ln}
+
+	fns := append([]*ir.Function{fn}, helpers...)
+	if got := runQueryDemo(t, fns); got != "4\n" {
+		t.Errorf("CrossJoin 2x2 len = %q, want 4", got)
+	}
+}
+
+// TestEmitQueryEmitsRuntimeImport asserts the emitter wires the
+// `mochi/runtime/mochi/query` import (and only that one) when the IR
+// uses query ops. A stale or missing import would slip through the
+// runtime tests as a build error; this test surfaces it directly.
+func TestEmitQueryEmitsRuntimeImport(t *testing.T) {
+	helpers := []*ir.Function{ir.FixtureIsEven()}
+	fns := buildQueryDemo(t, "demo", []int64{1, 2, 3}, helpers,
+		func(fn *ir.Function, hi map[string]uint32, src uint32) (uint32, []uint32) {
+			ref := fn.AddValue(ir.Value{Type: ir.TypeClosure, Op: ir.OpFnRef, Const: int64(hi["is_even"])})
+			r := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpQueryFilter, Args: []uint32{src, ref}})
+			return r, []uint32{ref, r}
+		}, reduceLen)
+	src, err := Emit(&Program{PkgName: "main", Funcs: fns})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(string(src), `"mochi/runtime/mochi/query"`) {
+		t.Errorf("emitted source missing query runtime import:\n%s", src)
+	}
+	if !strings.Contains(string(src), "query.Filter[int64]") {
+		t.Errorf("emitted source missing query.Filter call:\n%s", src)
+	}
+}
+
 func intStr(n int64) string {
 	if n == 0 {
 		return "0"

--- a/compiler3/ir/fixture.go
+++ b/compiler3/ir/fixture.go
@@ -135,6 +135,63 @@ func FixtureSumLoop() *Function {
 	return fn
 }
 
+// FixtureIsEven builds a helper predicate: returns 1 (true) when its
+// i64 argument is even and 0 otherwise. The query fixtures consume
+// this via an OpFnRef. The function returns TypeBool so it matches
+// the runtime/mochi/query.Filter predicate signature.
+func FixtureIsEven() *Function {
+	fn := &Function{Name: "is_even", Result: TypeBool}
+	nID := fn.AddValue(Value{Type: TypeI64, Op: OpParam})
+	fn.Params = []uint32{nID}
+	entryID := fn.AddBlock()
+	mod := fn.AddValue(Value{Type: TypeI64, Op: OpModI64Imm, Args: []uint32{nID}, Const: 2})
+	cond := fn.AddValue(Value{Type: TypeBool, Op: OpCmpEqI64Imm, Args: []uint32{mod}, Const: 0})
+	entry := fn.Block(entryID)
+	entry.Values = []uint32{mod, cond}
+	entry.Term = Terminator{Kind: TermReturn, Value: cond}
+	return fn
+}
+
+// FixtureDouble builds a helper: n -> n * 2.
+func FixtureDouble() *Function {
+	fn := &Function{Name: "double", Result: TypeI64}
+	nID := fn.AddValue(Value{Type: TypeI64, Op: OpParam})
+	fn.Params = []uint32{nID}
+	entryID := fn.AddBlock()
+	out := fn.AddValue(Value{Type: TypeI64, Op: OpMulI64Imm, Args: []uint32{nID}, Const: 2})
+	entry := fn.Block(entryID)
+	entry.Values = []uint32{out}
+	entry.Term = Terminator{Kind: TermReturn, Value: out}
+	return fn
+}
+
+// FixtureIdent is the identity function on i64. Used as a key fn for
+// SortBy / GroupBy in tests where the element itself is the key.
+func FixtureIdent() *Function {
+	fn := &Function{Name: "ident", Result: TypeI64}
+	nID := fn.AddValue(Value{Type: TypeI64, Op: OpParam})
+	fn.Params = []uint32{nID}
+	entryID := fn.AddBlock()
+	entry := fn.Block(entryID)
+	entry.Term = Terminator{Kind: TermReturn, Value: nID}
+	return fn
+}
+
+// FixtureAddPair is a two-arg helper: (l, r) -> l + r. Used as the
+// combine function for joins so the join output is a simple i64 list.
+func FixtureAddPair() *Function {
+	fn := &Function{Name: "add_pair", Result: TypeI64}
+	lID := fn.AddValue(Value{Type: TypeI64, Op: OpParam})
+	rID := fn.AddValue(Value{Type: TypeI64, Op: OpParam})
+	fn.Params = []uint32{lID, rID}
+	entryID := fn.AddBlock()
+	out := fn.AddValue(Value{Type: TypeI64, Op: OpAddI64, Args: []uint32{lID, rID}})
+	entry := fn.Block(entryID)
+	entry.Values = []uint32{out}
+	entry.Term = Terminator{Kind: TermReturn, Value: out}
+	return fn
+}
+
 // FixtureFactRec builds the SSA IR for the recursive factorial
 // kernel. Source:
 //

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -151,6 +151,31 @@ const (
 	// Value.Const (function index in the Function's owning Program).
 	OpCall
 	OpTailCall
+
+	// Function reference. Value.Const is the function index in the
+	// owning Program; Value.Type is TypeClosure. Produced for use as
+	// an argument to query ops; the emitter inlines the referenced
+	// function's name at the consumer site, so an OpFnRef value never
+	// lowers to a standalone Go expression.
+	OpFnRef
+
+	// Query algebra ops. These lower in the Go emitter to calls into
+	// runtime/mochi/query, never inlined as algebra. Closure-shaped
+	// arguments arrive as OpFnRef values whose Const names the
+	// callee. Phase 5 covers the i64-everywhere subset (list ElemType
+	// TypeI64, key TypeI64, output TypeI64); the Mochi frontend will
+	// widen the supported element types in Phase 6.
+	OpQueryFilter     // Args=[srcList, predFnRef]
+	OpQueryMap        // Args=[srcList, mapFnRef]
+	OpQuerySortBy     // Args=[srcList, keyFnRef]
+	OpQuerySortByDesc // Args=[srcList, keyFnRef]
+	OpQueryLimit      // Args=[srcList, nValue]
+	OpQueryDistinct   // Args=[srcList]
+	OpQueryGroupBy    // Args=[srcList, keyFnRef]; result Type is TypeAny (opaque to the IR until Phase 6 lands structured access)
+	OpQueryJoin       // Args=[leftList, rightList, lkeyFnRef, rkeyFnRef, combineFnRef]
+	OpQueryLeftJoin   // same shape as OpQueryJoin; combineFn signature is func(L, R, hasR bool) Out
+	OpQueryOuterJoin  // same shape; combineFn signature is func(L, R, hasL, hasR bool) Out
+	OpQueryCrossJoin  // Args=[leftList, rightList, combineFnRef]
 )
 
 // String renders an OpCode's short name. Used by Validate and IR
@@ -259,6 +284,30 @@ func (o OpCode) String() string {
 		return "call"
 	case OpTailCall:
 		return "tailcall"
+	case OpFnRef:
+		return "fnref"
+	case OpQueryFilter:
+		return "query.filter"
+	case OpQueryMap:
+		return "query.map"
+	case OpQuerySortBy:
+		return "query.sortby"
+	case OpQuerySortByDesc:
+		return "query.sortby.desc"
+	case OpQueryLimit:
+		return "query.limit"
+	case OpQueryDistinct:
+		return "query.distinct"
+	case OpQueryGroupBy:
+		return "query.groupby"
+	case OpQueryJoin:
+		return "query.join"
+	case OpQueryLeftJoin:
+		return "query.leftjoin"
+	case OpQueryOuterJoin:
+		return "query.outerjoin"
+	case OpQueryCrossJoin:
+		return "query.crossjoin"
 	}
 	return "?"
 }

--- a/website/docs/mep/mep-0043.md
+++ b/website/docs/mep/mep-0043.md
@@ -481,15 +481,23 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 - Acceptance corpus: `ir.FixtureFibIter` (`fib_iter(10)=55`), `ir.FixtureSumLoop` (`sum_loop(100)=4950`), `ir.FixtureFactRec` (`fact_rec(10)=3628800`), and a synthesised `list_demo` fixture exercising every list op. Each test emits Go to a temp dir, runs `go run`, and asserts stdout.
 - Output is gofmt-canonical: every emit goes through `go/format.Source`. This is a hard prerequisite for Phase 7's source-mapped diagnostics; line numbers in the emitted .go file must be stable.
 
-### Phase 5: query lowering through `runtime/mochi/query` — pending
+### Phase 5: query lowering through `runtime/mochi/query` — LANDED
 
 **Status & commit:**
 
 | Status | Issue | PR | Commit |
 |---|---|---|---|
-| PENDING | #21903 | TBD | _none_ |
+| LANDED | #21903 | TBD (this branch) | _filled by merge_ |
 
-**Gate:** `tests/vm/valid/{group_by,inner_join,left_join,outer_join,query_sum_select}` pass under `--target=go`.
+**Gate:** the Mochi front-end gate (`tests/vm/valid/{group_by,inner_join,left_join,outer_join,query_sum_select}` under `--target=go`) sits on Phase 6; Phase 5 owns the IR-side query algebra plus emitter lowerings into `runtime/mochi/query`. Acceptance is hand-built IR fixtures that drive each op, are emitted to Go, and produce the expected result via `go run`.
+
+**Result:** `compiler3/ir/types.go` gains `OpFnRef` (carries a function-table index, lowers to a Go function value at the consumer site) and 11 query ops: `OpQueryFilter`, `OpQueryMap`, `OpQuerySortBy`, `OpQuerySortByDesc`, `OpQueryLimit`, `OpQueryDistinct`, `OpQueryGroupBy`, `OpQueryJoin`, `OpQueryLeftJoin`, `OpQueryOuterJoin`, `OpQueryCrossJoin`. `compiler3/emit/go` lowers every one as a single `query.Foo[int64,...]` call into `runtime/mochi/query` (the closure-shaped args inline as Go function names via the `OpFnRef` operand). The emitter never inlines query algebra.
+
+- Phase 5 covers the `i64`-everywhere subset (list `ElemType` `TypeI64`, key `TypeI64`, output `TypeI64`); the Mochi frontend will widen supported element types in Phase 6 once typed AST lowering lands.
+- New IR helpers `FixtureIsEven`, `FixtureDouble`, `FixtureIdent`, `FixtureAddPair` supply closures for the test corpus.
+- `TestEmitQuery{Filter,Map,SortBy,SortByDesc,Limit,Distinct,GroupByCompiles,Join,CrossJoin,EmitsRuntimeImport}` build per-op SSA fixtures, emit Go, and run the result against expected stdout.
+- `TestEmitQueryEmitsRuntimeImport` asserts the emitter wires the `mochi/runtime/mochi/query` import exactly when query ops appear.
+- Group-by today returns `[]query.Group[int64, int64]`; the IR cannot yet destructure groups (`.Key` / `.Items` field access ships with the Phase 6 Mochi frontend), so the GroupBy test exercises compile + run cleanliness only.
 
 ### Phase 6: `import go "path"` end-to-end — pending
 


### PR DESCRIPTION
## Summary
- Extends `compiler3/ir` with `OpFnRef` (function-table-index value) and 11 query ops: `OpQueryFilter`, `OpQueryMap`, `OpQuerySortBy`, `OpQuerySortByDesc`, `OpQueryLimit`, `OpQueryDistinct`, `OpQueryGroupBy`, `OpQueryJoin`, `OpQueryLeftJoin`, `OpQueryOuterJoin`, `OpQueryCrossJoin`.
- `compiler3/emit/go` lowers each query op as a single call into `runtime/mochi/query` (no inlined algebra). Closure-shaped args arrive as `OpFnRef` and inline as Go function names.
- Phase 5 scope is the `i64`-everywhere subset (list `ElemType` `TypeI64`, key `TypeI64`, output `TypeI64`); the Mochi frontend will widen supported types in Phase 6.

## Why now
The original Phase 5 gate (`tests/vm/valid/{group_by,inner_join,left_join,outer_join,query_sum_select}` under `--target=go`) sits on the Phase 6 frontend. Phase 5 lands the IR-side query algebra plus emitter lowerings so Phase 6 has a stable target. Acceptance is hand-built IR fixtures that drive each op end-to-end (emit -> `go run` -> stdout).

## Test plan
- [x] `go test ./compiler3/...`
- [x] `go vet ./compiler3/...`
- [x] `go build ./...`
- [x] Query op tests emit Go that imports `mochi/runtime/mochi/query`, executes through `go run`, and prints the expected reduced value.

Closes #21903
Tracks MEP-43.