### PR TITLE
mep-0043: Phase 6 OpCallGo + GoBinding (IR + emitter slice)

### DIFF
--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -34,7 +34,16 @@ func Emit(p *Program) ([]byte, error) {
 	}
 	var body bytes.Buffer
 	imports := map[string]bool{}
+	importAlias := map[string]string{}
 	for _, fn := range p.Funcs {
+		// Pre-seed importAlias from this function's Go bindings; the
+		// emitter never invents an alias different from the binding
+		// table's, so emission order is irrelevant for correctness.
+		for _, b := range fn.GoBindings {
+			if b.Alias != "" && b.Alias != defaultAlias(b.Pkg) {
+				importAlias[b.Pkg] = b.Alias
+			}
+		}
 		if err := emitFunc(&body, fn, p.Funcs, imports); err != nil {
 			return nil, fmt.Errorf("emit %s: %w", fn.Name, err)
 		}
@@ -56,7 +65,11 @@ func Emit(p *Program) ([]byte, error) {
 		sort.Strings(paths)
 		fmt.Fprintf(&src, "import (\n")
 		for _, ip := range paths {
-			fmt.Fprintf(&src, "\t%q\n", ip)
+			if a, ok := importAlias[ip]; ok {
+				fmt.Fprintf(&src, "\t%s %q\n", a, ip)
+			} else {
+				fmt.Fprintf(&src, "\t%q\n", ip)
+			}
 		}
 		fmt.Fprintf(&src, ")\n\n")
 	}
@@ -284,6 +297,28 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 		fmt.Fprintf(w, "\t%s = query.CrossJoin[int64, int64, int64](%s, %s, %s)\n",
 			name, valueName(v.Args[0]), valueName(v.Args[1]),
 			fnName(fn, all, v.Args[2]))
+	case ir.OpCallGo:
+		if int(v.Const) >= len(fn.GoBindings) {
+			return fmt.Errorf("OpCallGo v%d: Const %d out of range (have %d bindings)", v.ID, v.Const, len(fn.GoBindings))
+		}
+		b := fn.GoBindings[v.Const]
+		imports[b.Pkg] = true
+		alias := b.Alias
+		if alias == "" {
+			alias = defaultAlias(b.Pkg)
+		}
+		if b.Result == "" {
+			fmt.Fprintf(w, "\t%s.%s(", alias, b.Name)
+		} else {
+			fmt.Fprintf(w, "\t%s = %s.%s(", name, alias, b.Name)
+		}
+		for i, aid := range v.Args {
+			if i > 0 {
+				w.WriteString(", ")
+			}
+			w.WriteString(valueName(aid))
+		}
+		w.WriteString(")\n")
 	case ir.OpPhi:
 		// Declared in prelude; no body emit.
 		return nil
@@ -339,6 +374,20 @@ func emitTerminator(w *bytes.Buffer, fn *ir.Function, blk *ir.Block, all []*ir.F
 }
 
 func valueName(id uint32) string { return fmt.Sprintf("v%d", id) }
+
+// defaultAlias returns the last path segment of a Go import path,
+// matching the implicit package alias `go build` would assign. The
+// emitter uses this when a GoBinding leaves Alias blank.
+func defaultAlias(pkg string) string {
+	last := pkg
+	for i := len(pkg) - 1; i >= 0; i-- {
+		if pkg[i] == '/' {
+			last = pkg[i+1:]
+			break
+		}
+	}
+	return last
+}
 
 // fnName returns the Go function name referenced by an OpFnRef value.
 // The argument is the SSA value ID of an OpFnRef; the helper looks

--- a/compiler3/emit/go/emit_test.go
+++ b/compiler3/emit/go/emit_test.go
@@ -441,6 +441,70 @@ func TestEmitQueryEmitsRuntimeImport(t *testing.T) {
 	}
 }
 
+// TestEmitGoCallToUpper verifies that OpCallGo lowers `strings.ToUpper`
+// to a literal Go call, that the `"strings"` stdlib import appears in
+// the emitted source, and that running the result produces the upper
+// cased input. No Mochi-side reflection, no runtime registry.
+func TestEmitGoCallToUpper(t *testing.T) {
+	fn := ir.FixtureGoCallToUpper()
+	src, err := Emit(&Program{PkgName: "main", Funcs: []*ir.Function{fn}})
+	if err != nil {
+		t.Fatalf("Emit: %v\n%s", err, src)
+	}
+	srcStr := string(src)
+	if !strings.Contains(srcStr, "\"strings\"") {
+		t.Errorf("emitted source missing strings import:\n%s", srcStr)
+	}
+	if !strings.Contains(srcStr, "strings.ToUpper(") {
+		t.Errorf("emitted source missing strings.ToUpper call:\n%s", srcStr)
+	}
+	if strings.Contains(srcStr, "Call(") || strings.Contains(srcStr, "reflect.") {
+		t.Errorf("emitted source must not use reflection or Call(name, args...):\n%s", srcStr)
+	}
+	withMain := srcStr + "\nfunc main() {\n\tprintln(shout(\"hello\"))\n}\n"
+	if got := runGo(t, withMain); got != "HELLO\n" {
+		t.Errorf("shout(\"hello\") = %q, want HELLO", got)
+	}
+}
+
+// TestEmitGoCallContains exercises a 2-arg Go FFI call returning bool.
+func TestEmitGoCallContains(t *testing.T) {
+	fn := ir.FixtureGoCallContains()
+	src, err := Emit(&Program{PkgName: "main", Funcs: []*ir.Function{fn}})
+	if err != nil {
+		t.Fatalf("Emit: %v\n%s", err, src)
+	}
+	if !strings.Contains(string(src), "strings.Contains(") {
+		t.Errorf("emitted source missing strings.Contains call:\n%s", src)
+	}
+	withMain := string(src) + "\nfunc main() {\n\tprintln(has(\"hello\", \"ell\"))\n}\n"
+	if got := runGo(t, withMain); got != "true\n" {
+		t.Errorf("has(\"hello\",\"ell\") = %q, want true", got)
+	}
+}
+
+// TestEmitGoCallAlias asserts the emitter prints a non-default alias
+// (Mochi `import go "strings" as s`) as `import s "strings"` in the
+// generated file, and emits `s.ToUpper(...)` at call sites.
+func TestEmitGoCallAlias(t *testing.T) {
+	fn := ir.FixtureGoCallAlias()
+	src, err := Emit(&Program{PkgName: "main", Funcs: []*ir.Function{fn}})
+	if err != nil {
+		t.Fatalf("Emit: %v\n%s", err, src)
+	}
+	srcStr := string(src)
+	if !strings.Contains(srcStr, "s \"strings\"") {
+		t.Errorf("emitted source missing aliased import (s \"strings\"):\n%s", srcStr)
+	}
+	if !strings.Contains(srcStr, "s.ToUpper(") {
+		t.Errorf("emitted source missing s.ToUpper call:\n%s", srcStr)
+	}
+	withMain := srcStr + "\nfunc main() {\n\tprintln(shout(\"hi\"))\n}\n"
+	if got := runGo(t, withMain); got != "HI\n" {
+		t.Errorf("aliased shout(\"hi\") = %q, want HI", got)
+	}
+}
+
 func intStr(n int64) string {
 	if n == 0 {
 		return "0"

--- a/compiler3/ir/fixture.go
+++ b/compiler3/ir/fixture.go
@@ -192,6 +192,79 @@ func FixtureAddPair() *Function {
 	return fn
 }
 
+// FixtureGoCallToUpper builds the SSA IR for a single-arg FFI call:
+//
+//	fun shout(s: str) -> str { return strings.ToUpper(s) }
+//
+// The Mochi `import go "strings"` lowers to a single GoBinding in the
+// function's binding table; OpCallGo names it by index and the
+// emitter prints `strings.ToUpper(v0)` plus the `"strings"` import.
+func FixtureGoCallToUpper() *Function {
+	fn := &Function{Name: "shout", Result: TypeStr}
+	fn.GoBindings = []GoBinding{{
+		Pkg:      "strings",
+		Alias:    "strings",
+		Name:     "ToUpper",
+		ArgTypes: []string{"string"},
+		Result:   "string",
+	}}
+	sID := fn.AddValue(Value{Type: TypeStr, Op: OpParam})
+	fn.Params = []uint32{sID}
+	entryID := fn.AddBlock()
+	ret := fn.AddValue(Value{Type: TypeStr, Op: OpCallGo, Args: []uint32{sID}, Const: 0})
+	entry := fn.Block(entryID)
+	entry.Values = []uint32{ret}
+	entry.Term = Terminator{Kind: TermReturn, Value: ret}
+	return fn
+}
+
+// FixtureGoCallContains builds a two-arg FFI call:
+//
+//	fun has(s: str, sub: str) -> bool { return strings.Contains(s, sub) }
+//
+// Exercises multi-argument OpCallGo lowering.
+func FixtureGoCallContains() *Function {
+	fn := &Function{Name: "has", Result: TypeBool}
+	fn.GoBindings = []GoBinding{{
+		Pkg:      "strings",
+		Alias:    "strings",
+		Name:     "Contains",
+		ArgTypes: []string{"string", "string"},
+		Result:   "bool",
+	}}
+	sID := fn.AddValue(Value{Type: TypeStr, Op: OpParam})
+	subID := fn.AddValue(Value{Type: TypeStr, Op: OpParam})
+	fn.Params = []uint32{sID, subID}
+	entryID := fn.AddBlock()
+	ret := fn.AddValue(Value{Type: TypeBool, Op: OpCallGo, Args: []uint32{sID, subID}, Const: 0})
+	entry := fn.Block(entryID)
+	entry.Values = []uint32{ret}
+	entry.Term = Terminator{Kind: TermReturn, Value: ret}
+	return fn
+}
+
+// FixtureGoCallAlias builds a single-arg FFI call where the Mochi
+// `import go "strings" as s` shadows the default alias. The emitter
+// must produce `import s "strings"` and call `s.ToUpper(...)`.
+func FixtureGoCallAlias() *Function {
+	fn := &Function{Name: "shout", Result: TypeStr}
+	fn.GoBindings = []GoBinding{{
+		Pkg:      "strings",
+		Alias:    "s",
+		Name:     "ToUpper",
+		ArgTypes: []string{"string"},
+		Result:   "string",
+	}}
+	sID := fn.AddValue(Value{Type: TypeStr, Op: OpParam})
+	fn.Params = []uint32{sID}
+	entryID := fn.AddBlock()
+	ret := fn.AddValue(Value{Type: TypeStr, Op: OpCallGo, Args: []uint32{sID}, Const: 0})
+	entry := fn.Block(entryID)
+	entry.Values = []uint32{ret}
+	entry.Term = Terminator{Kind: TermReturn, Value: ret}
+	return fn
+}
+
 // FixtureFactRec builds the SSA IR for the recursive factorial
 // kernel. Source:
 //

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -176,6 +176,15 @@ const (
 	OpQueryLeftJoin   // same shape as OpQueryJoin; combineFn signature is func(L, R, hasR bool) Out
 	OpQueryOuterJoin  // same shape; combineFn signature is func(L, R, hasL, hasR bool) Out
 	OpQueryCrossJoin  // Args=[leftList, rightList, combineFnRef]
+
+	// OpCallGo invokes an imported Go symbol resolved at Mochi compile
+	// time by compiler3/ffi/resolve. The Value.Const indexes into the
+	// owning Function's GoBindings table; Args lists the SSA value IDs
+	// of the call arguments in declared order. The emitter prints a
+	// literal Go call (alias.Name(arg0, arg1, ...)) and registers the
+	// binding's import path so the generated file has a normal Go
+	// import. There is no Mochi-side reflection at the call site.
+	OpCallGo
 )
 
 // String renders an OpCode's short name. Used by Validate and IR
@@ -308,8 +317,35 @@ func (o OpCode) String() string {
 		return "query.outerjoin"
 	case OpQueryCrossJoin:
 		return "query.crossjoin"
+	case OpCallGo:
+		return "call.go"
 	}
 	return "?"
+}
+
+// GoBinding names an imported Go symbol resolved at Mochi compile
+// time. Phase 6 attaches one GoBinding per FFI call site; the IR
+// references it by index via OpCallGo.Const. ArgTypes and Result are
+// captured so a future Phase 7 type-check pass can validate without
+// re-querying the resolver.
+type GoBinding struct {
+	// Pkg is the Go import path, e.g. "strings", "math/big".
+	Pkg string
+	// Alias is the Go-source-level alias, e.g. "strings" or "big".
+	// The default is the last path segment; Mochi `as` shadows it.
+	Alias string
+	// Name is the function or method name as it appears under the
+	// alias in the emitted source.
+	Name string
+	// ArgTypes lists the static Go types of the call arguments in
+	// declared order. Each entry is a Go-source-shape string the
+	// emitter can paste verbatim (string, int64, []byte, ...).
+	ArgTypes []string
+	// Result is the Go-source-shape of the call's return type.
+	// Empty means void; a comma-joined list (e.g. "string,error")
+	// names a multi-value return, but Phase 6 sticks to single-value
+	// signatures and leaves error handling to Phase 7.
+	Result string
 }
 
 // Value is one SSA-form IR node. Type is mandatory; the type checker
@@ -365,12 +401,17 @@ type Block struct {
 // to the optimization pipeline. Values is indexed by ID. Blocks is
 // indexed by Block.ID. Params lists the parameter Values in declared
 // order (their Type is the param type; their Op is OpParam).
+//
+// GoBindings names the Go symbols this function calls via the
+// `import go "path"` form; each OpCallGo Value indexes into this
+// table via Value.Const. Empty when the function does no FFI.
 type Function struct {
-	Name   string
-	Params []uint32
-	Result Type
-	Blocks []Block
-	Values []Value
+	Name       string
+	Params     []uint32
+	Result     Type
+	Blocks     []Block
+	Values     []Value
+	GoBindings []GoBinding
 }
 
 // Builder helpers ----------------------------------------------------

--- a/website/docs/mep/mep-0043.md
+++ b/website/docs/mep/mep-0043.md
@@ -499,15 +499,24 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 - `TestEmitQueryEmitsRuntimeImport` asserts the emitter wires the `mochi/runtime/mochi/query` import exactly when query ops appear.
 - Group-by today returns `[]query.Group[int64, int64]`; the IR cannot yet destructure groups (`.Key` / `.Items` field access ships with the Phase 6 Mochi frontend), so the GroupBy test exercises compile + run cleanliness only.
 
-### Phase 6: `import go "path"` end-to-end — pending
+### Phase 6: `import go "path"` end-to-end — IR + emitter LANDED, frontend wiring pending
 
 **Status & commit:**
 
 | Status | Issue | PR | Commit |
 |---|---|---|---|
-| PENDING | #21904 | TBD | _none_ |
+| PARTIAL | #21904 | TBD (this branch) | _filled by merge_ |
 
-**Gate:** `tests/vm/valid/go_auto` and `tests/vm/valid/mix_go_python` pass under `--target=go`; no `Call(name, args...)` appears in the emitted source.
+**Gate (full Phase 6):** `tests/vm/valid/go_auto` and `tests/vm/valid/mix_go_python` pass under `--target=go`; no `Call(name, args...)` appears in the emitted source. The full gate sits on the Mochi-frontend-to-compiler3 lowering, which itself is the bulk of Phase 6's remaining work.
+
+**Result (this slice):** compiler3 now carries the FFI representation needed to compile `import go "path"` once the front-end wires it. The shipped pieces:
+
+- `compiler3/ir.GoBinding` (Pkg, Alias, Name, ArgTypes, Result) names a single resolved Go symbol; lives on `ir.Function.GoBindings`.
+- `OpCallGo` Value carries the binding index in `Const` and the call's arguments in `Args`; result Type is the bridged Mochi type (the type-bridge from Phase 1 maps the Go signature to compiler3 types at resolve time).
+- `compiler3/emit/go` lowers `OpCallGo` as a literal `alias.Name(arg0, arg1, ...)` call, registers `b.Pkg` in the imports map, and emits an aliased import (`import s "strings"`) when the binding's alias diverges from the path's default segment. No reflection. No registry.
+- Fixtures `FixtureGoCallToUpper`, `FixtureGoCallContains`, `FixtureGoCallAlias` exercise single-arg string, two-arg bool, and aliased-import lowering. `TestEmitGoCallToUpper` asserts the emitted source imports `"strings"`, calls `strings.ToUpper`, and contains neither `Call(` nor `reflect.` (the explicit MEP-43 anti-pattern check).
+
+**Remaining for the full Phase 6 gate:** Mochi parser captures `import go "path" as alias` and `import go "path" _` (side-effect form); type checker invokes `compiler3/ffi/resolve.Resolve(path, cache)` from Phase 2 and registers the bindings under the alias; the Mochi-to-IR frontend translates each call site into an `OpCallGo`. The `tests/vm/valid/go_auto` and `tests/vm/valid/mix_go_python` corpora exercise this path end-to-end.
 
 ### Phase 7: source-mapped diagnostics — pending
 


### PR DESCRIPTION
## Summary
- Adds `compiler3/ir.OpCallGo` and `compiler3/ir.GoBinding` (Pkg, Alias, Name, ArgTypes, Result). The binding lives on `ir.Function.GoBindings`; the call value references it by index via `Value.Const`.
- Extends `compiler3/emit/go` to lower `OpCallGo` as a literal `alias.Name(arg0, ...)` call, register the binding's Pkg in the imports map, and emit an aliased import (`import s "strings"`) when the binding's Alias diverges from the default last-segment alias. No reflection, no registry, no `Call(name, args...)`.
- IR helpers `FixtureGoCallToUpper`, `FixtureGoCallContains`, `FixtureGoCallAlias` drive single-arg string, two-arg bool, and aliased-import lowering. Tests assert the generated source contains the expected import + call site and produces the expected runtime output.

## Why now
The full Phase 6 gate (`tests/vm/valid/go_auto`, `tests/vm/valid/mix_go_python` passing under `--target=go`) sits on the Mochi-frontend-to-compiler3 lowering, which is the bulk of remaining Phase 6 work. This slice lands the IR contract + emitter half so the frontend wiring can land in a follow-up without breaking compatibility with downstream phases that already consume `OpCallGo`.

## Test plan
- [x] `go test ./compiler3/...`
- [x] `go vet ./compiler3/...`
- [x] `go build ./...`
- [x] `TestEmitGoCallToUpper` asserts the emitted source imports `"strings"`, calls `strings.ToUpper`, and contains neither `Call(` nor `reflect.`.
- [x] `TestEmitGoCallContains` runs `strings.Contains("hello","ell") == true`.
- [x] `TestEmitGoCallAlias` runs an aliased import (`import s "strings"`) and asserts the alias appears at both the import and call sites.

Tracks #21904 (full gate remains until Mochi frontend wiring lands).