### PR TITLE
mep-0043: Phase 7 source-mapped diagnostics (//line + diag filter)

### DIFF
--- a/compiler3/emit/go/diag.go
+++ b/compiler3/emit/go/diag.go
@@ -1,0 +1,142 @@
+package gogen
+
+import (
+	"bufio"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// FilterBuildErrors rewrites `go build` stderr so diagnostics that
+// reference the emitted Go file are remapped to Mochi-source
+// coordinates using the `//line` directives the emitter wrote.
+//
+// The Go toolchain already honours `//line` directives, so most errors
+// arrive with Mochi coords baked in. This filter handles the residual
+// cases:
+//   - errors emitted by `go build` itself (load/typecheck phase) that
+//     reference the gen file directly without honouring `//line`;
+//   - errors that point at a line of the gen file with no preceding
+//     `//line` directive (e.g. the package clause).
+//
+// genPath is the absolute or relative path of the emitted Go file as
+// it appears in the toolchain's stderr. genSrc is the source the
+// emitter produced; FilterBuildErrors scans it once to build a line-
+// to-(file:line) map. stderr is the raw `go build` output.
+func FilterBuildErrors(genPath, genSrc, stderr string) string {
+	dirMap := buildLineMap(genSrc)
+	genBase := filepath.Base(genPath)
+
+	// A diagnostic line looks like:
+	//   path/to/file.go:LINE:COL: message
+	// or
+	//   path/to/file.go:LINE: message
+	// We rewrite only when the path matches genPath (or its basename),
+	// or when the file appears to be a Mochi source we want to leave
+	// untouched.
+	re := regexp.MustCompile(`^(.*?):(\d+)(?::(\d+))?:\s*(.*)$`)
+
+	var out strings.Builder
+	scanner := bufio.NewScanner(strings.NewReader(stderr))
+	for scanner.Scan() {
+		line := scanner.Text()
+		m := re.FindStringSubmatch(strings.TrimSpace(line))
+		if m == nil {
+			out.WriteString(line)
+			out.WriteByte('\n')
+			continue
+		}
+		path := m[1]
+		// Match either the full path or just the basename: `go build`
+		// reports paths relative to the working directory, which may
+		// differ from how the caller named the file.
+		if path != genPath && filepath.Base(path) != genBase {
+			out.WriteString(line)
+			out.WriteByte('\n')
+			continue
+		}
+		n, err := strconv.Atoi(m[2])
+		if err != nil {
+			out.WriteString(line)
+			out.WriteByte('\n')
+			continue
+		}
+		mapped := remapLine(dirMap, n)
+		if mapped == "" {
+			out.WriteString(line)
+			out.WriteByte('\n')
+			continue
+		}
+		col := m[3]
+		msg := m[4]
+		if col != "" {
+			out.WriteString(mapped)
+			out.WriteString(": ")
+			out.WriteString(msg)
+		} else {
+			out.WriteString(mapped)
+			out.WriteString(": ")
+			out.WriteString(msg)
+		}
+		out.WriteByte('\n')
+	}
+	return out.String()
+}
+
+// lineDirective is one `//line file:N` parsed entry. From holds the
+// 1-based line number in the generated file at which the directive
+// appears; the next physical line of generated source is rewritten
+// to (File, BaseLine).
+type lineDirective struct {
+	From     int
+	File     string
+	BaseLine int
+}
+
+// buildLineMap scans genSrc and returns the ordered list of //line
+// directives.
+func buildLineMap(genSrc string) []lineDirective {
+	var dirs []lineDirective
+	scanner := bufio.NewScanner(strings.NewReader(genSrc))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		txt := scanner.Text()
+		if !strings.HasPrefix(txt, "//line ") {
+			continue
+		}
+		body := strings.TrimSpace(txt[len("//line "):])
+		idx := strings.LastIndex(body, ":")
+		if idx < 0 {
+			continue
+		}
+		file := body[:idx]
+		n, err := strconv.Atoi(body[idx+1:])
+		if err != nil {
+			continue
+		}
+		dirs = append(dirs, lineDirective{From: lineNum, File: file, BaseLine: n})
+	}
+	return dirs
+}
+
+// remapLine returns "file:N" for a 1-based generated-file line, using
+// the directive table. Returns "" when no directive precedes the line.
+func remapLine(dirs []lineDirective, genLine int) string {
+	var active *lineDirective
+	for i := range dirs {
+		if dirs[i].From >= genLine {
+			break
+		}
+		active = &dirs[i]
+	}
+	if active == nil {
+		return ""
+	}
+	// The line immediately after the directive (genLine = active.From+1)
+	// maps to active.BaseLine; each further generated line increments.
+	delta := genLine - active.From - 1
+	return active.File + ":" + strconv.Itoa(active.BaseLine+delta)
+}

--- a/compiler3/emit/go/diag_test.go
+++ b/compiler3/emit/go/diag_test.go
@@ -1,0 +1,124 @@
+package gogen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/compiler3/ir"
+)
+
+// TestEmitSourceMapDirective asserts that when fn.SourceFile is set,
+// the emitter writes `//line` directives at function and block
+// boundaries, and skips the final gofmt pass.
+func TestEmitSourceMapDirective(t *testing.T) {
+	fn := ir.FixtureFibIter()
+	fn.SourceFile = "fib.mochi"
+	fn.Blocks[0].SourceLine = 10
+	fn.Blocks[1].SourceLine = 12
+	fn.Blocks[2].SourceLine = 14
+	fn.Blocks[3].SourceLine = 16
+
+	src, err := Emit(&Program{PkgName: "demo", Funcs: []*ir.Function{fn}})
+	if err != nil {
+		t.Fatalf("Emit: %v\n%s", err, src)
+	}
+	s := string(src)
+	for _, want := range []string{
+		"//line fib.mochi:10",
+		"//line fib.mochi:12",
+		"//line fib.mochi:14",
+		"//line fib.mochi:16",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("emitted source missing %q\n%s", want, s)
+		}
+	}
+}
+
+// TestFilterBuildErrorsRemap exercises the diag filter on a synthetic
+// generated source and stderr, asserting the filter rewrites gen-file
+// coords to Mochi-source coords.
+func TestFilterBuildErrorsRemap(t *testing.T) {
+	gen := strings.Join([]string{
+		"package main",                 // L1
+		"",                             // L2
+		"//line fib.mochi:42",          // L3 directive
+		"func fib(n int64) int64 {",    // L4 -> fib.mochi:42
+		"\treturn n + \"oops\"",        // L5 -> fib.mochi:43
+		"}",                            // L6 -> fib.mochi:44
+	}, "\n") + "\n"
+
+	stderr := "./gen.go:5:11: cannot convert \"oops\" (untyped string constant) to int64\n"
+	got := FilterBuildErrors("./gen.go", gen, stderr)
+	if !strings.Contains(got, "fib.mochi:43") {
+		t.Errorf("filter did not remap line; got:\n%s", got)
+	}
+	if strings.Contains(got, "./gen.go:5") {
+		t.Errorf("filter left raw gen-file coord; got:\n%s", got)
+	}
+}
+
+// TestFilterBuildErrorsPassThrough asserts diagnostics for unrelated
+// files (e.g. runtime/mochi/query) are passed through untouched.
+func TestFilterBuildErrorsPassThrough(t *testing.T) {
+	gen := "//line foo.mochi:1\npackage main\n"
+	stderr := "/path/to/some/other/file.go:99:1: unrelated\n"
+	got := FilterBuildErrors("./gen.go", gen, stderr)
+	if !strings.Contains(got, "some/other/file.go:99:1") {
+		t.Errorf("filter mangled unrelated diagnostic; got:\n%s", got)
+	}
+}
+
+// TestSourceMapEndToEnd writes an emitted program with `//line`
+// directives plus a deliberate type error to a temp file, runs
+// `go build`, and asserts FilterBuildErrors produces Mochi-source
+// coordinates. This is the Phase 7 gate: a Go-side type error at the
+// FFI boundary surfaces with Mochi-source-line precision.
+func TestSourceMapEndToEnd(t *testing.T) {
+	// Construct a fixture whose emitted Go intentionally won't type
+	// check: we widen the OpConst type-name lie by using OpFnRef
+	// against a non-callable. Simpler path: emit a healthy fixture,
+	// then graft a bad line. That keeps the //line table honest.
+	fn := ir.FixtureFibIter()
+	fn.SourceFile = "fib.mochi"
+	fn.Blocks[0].SourceLine = 1
+	fn.Blocks[1].SourceLine = 4
+	fn.Blocks[2].SourceLine = 6
+	fn.Blocks[3].SourceLine = 8
+
+	src, err := Emit(&Program{PkgName: "main", Funcs: []*ir.Function{fn}, Main: "fib_iter"})
+	if err != nil {
+		t.Fatalf("Emit: %v\n%s", err, src)
+	}
+	s := string(src)
+
+	// Splice a deliberate type error into a block we know carries a
+	// //line directive: replace the body block's iNext assignment with
+	// a string add. We pick a recognizable target that appears once.
+	target := "= v6 + int64(1)"
+	if !strings.Contains(s, target) {
+		t.Skipf("emitter shape drifted; target %q not found in:\n%s", target, s)
+	}
+	broken := strings.Replace(s, target, "= v6 + \"oops\"", 1)
+
+	dir := t.TempDir()
+	genPath := filepath.Join(dir, "gen.go")
+	if err := os.WriteFile(genPath, []byte(broken), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("go", "build", "-o", filepath.Join(dir, "out"), genPath)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("go build unexpectedly succeeded\n%s", out)
+	}
+	rewritten := FilterBuildErrors(genPath, broken, string(out))
+	// The Go toolchain honors //line directives, so the build error
+	// should already reference fib.mochi. FilterBuildErrors is the
+	// belt-and-braces for diagnostics that bypass //line.
+	if !strings.Contains(rewritten, "fib.mochi:") && !strings.Contains(string(out), "fib.mochi:") {
+		t.Errorf("expected Mochi-source coord in diagnostic\nraw stderr:\n%s\nfiltered:\n%s", out, rewritten)
+	}
+}

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -28,9 +28,22 @@ type Program struct {
 // runtime/mochi/* only if the IR references it. Returns the source
 // bytes and any errors. The emitter does not invoke `go build`;
 // callers feed the bytes to the toolchain.
+//
+// When any function in p carries a SourceFile, the emitter writes
+// `//line file:N` directives at function and block boundaries so the
+// Go toolchain reports diagnostics with Mochi-source coordinates. In
+// that mode the final gofmt pass is skipped because gofmt may reflow
+// lines and break the directives' line-for-line mapping.
 func Emit(p *Program) ([]byte, error) {
 	if p.PkgName == "" {
 		p.PkgName = "main"
+	}
+	hasSourceMap := false
+	for _, fn := range p.Funcs {
+		if fn.SourceFile != "" {
+			hasSourceMap = true
+			break
+		}
 	}
 	var body bytes.Buffer
 	imports := map[string]bool{}
@@ -75,6 +88,12 @@ func Emit(p *Program) ([]byte, error) {
 	}
 	src.Write(body.Bytes())
 
+	if hasSourceMap {
+		// Phase 7: skip gofmt to preserve the line-for-line mapping
+		// between emitted Go and Mochi-source `//line` directives.
+		return src.Bytes(), nil
+	}
+
 	// gofmt the output. If gofmt rejects the source, return it
 	// verbatim so the caller can debug; the test pipeline runs
 	// `go vet` over the result so a broken emit will surface there.
@@ -87,6 +106,18 @@ func Emit(p *Program) ([]byte, error) {
 
 // emitFunc walks one Function and emits its Go form.
 func emitFunc(w *bytes.Buffer, fn *ir.Function, all []*ir.Function, imports map[string]bool) error {
+	// Optional source-map: anchor the function at the first block's
+	// SourceLine. Subsequent blocks emit their own //line directives.
+	if fn.SourceFile != "" {
+		line := uint32(0)
+		if len(fn.Blocks) > 0 {
+			line = fn.Blocks[0].SourceLine
+		}
+		if line == 0 {
+			line = 1
+		}
+		fmt.Fprintf(w, "//line %s:%d\n", fn.SourceFile, line)
+	}
 	// Header.
 	fmt.Fprintf(w, "func %s(", fn.Name)
 	for i, pid := range fn.Params {
@@ -133,6 +164,11 @@ func emitFunc(w *bytes.Buffer, fn *ir.Function, all []*ir.Function, imports map[
 	rpo := reversePostorder(fn)
 	for i, bid := range rpo {
 		blk := fn.Block(bid)
+		// Block-level //line directive so any error inside this block's
+		// emission shows the Mochi-source line, not the generated file.
+		if fn.SourceFile != "" && blk.SourceLine != 0 {
+			fmt.Fprintf(w, "//line %s:%d\n", fn.SourceFile, blk.SourceLine)
+		}
 		// Label for non-entry blocks so jumps and branches can target.
 		if i > 0 {
 			fmt.Fprintf(w, "L%d:\n", bid)

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -389,12 +389,18 @@ type Terminator struct {
 // Block is a basic block in the function's CFG. Values lists the IDs
 // of the SSA values produced by this block, in producer order. Phi
 // values, if present, must appear at the head of Values.
+//
+// SourceLine, when non-zero, is the Mochi-source line this block
+// originates from. Phase 7 of MEP-43 uses it to emit `//line` directives
+// at block boundaries so a `go build` error inside the generated file
+// surfaces with the user's Mochi coordinates.
 type Block struct {
-	ID     uint32
-	Values []uint32
-	Preds  []uint32
-	Succs  []uint32
-	Term   Terminator
+	ID         uint32
+	Values     []uint32
+	Preds      []uint32
+	Succs      []uint32
+	Term       Terminator
+	SourceLine uint32
 }
 
 // Function is the compilation unit handed from the type-aware build
@@ -405,6 +411,11 @@ type Block struct {
 // GoBindings names the Go symbols this function calls via the
 // `import go "path"` form; each OpCallGo Value indexes into this
 // table via Value.Const. Empty when the function does no FFI.
+//
+// SourceFile, when non-empty, is the Mochi-source file path. Phase 7
+// of MEP-43 pairs it with Block.SourceLine to emit `//line` directives
+// at every block boundary so Go-toolchain diagnostics can be rewritten
+// to point at the user's `.mochi` file.
 type Function struct {
 	Name       string
 	Params     []uint32
@@ -412,6 +423,7 @@ type Function struct {
 	Blocks     []Block
 	Values     []Value
 	GoBindings []GoBinding
+	SourceFile string
 }
 
 // Builder helpers ----------------------------------------------------

--- a/website/docs/mep/mep-0043.md
+++ b/website/docs/mep/mep-0043.md
@@ -518,15 +518,25 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 
 **Remaining for the full Phase 6 gate:** Mochi parser captures `import go "path" as alias` and `import go "path" _` (side-effect form); type checker invokes `compiler3/ffi/resolve.Resolve(path, cache)` from Phase 2 and registers the bindings under the alias; the Mochi-to-IR frontend translates each call site into an `OpCallGo`. The `tests/vm/valid/go_auto` and `tests/vm/valid/mix_go_python` corpora exercise this path end-to-end.
 
-### Phase 7: source-mapped diagnostics — pending
+### Phase 7: source-mapped diagnostics — landed 2026-05-21
 
 **Status & commit:**
 
 | Status | Issue | PR | Commit |
 |---|---|---|---|
-| PENDING | #21905 | TBD | _none_ |
+| LANDED | #21905 | TBD | _Phase 7 branch_ |
 
 **Gate:** A Mochi type error at an FFI boundary produces a Mochi-line-numbered diagnostic; no Go file path is visible to the user without `--keep-emit`.
+
+**2026-05-21 14:00 (GMT+7), landed:**
+
+- `ir.Function.SourceFile` and `ir.Block.SourceLine` carry the Mochi source coordinates. The frontend (and hand-written fixtures) populate them; everything downstream propagates verbatim.
+- `compiler3/emit/go` writes a `//line file:N` directive at function entry (anchored at block 0's line) and at every basic-block boundary whose `SourceLine` is non-zero. The Go toolchain honours these directives natively, so `go build` errors arrive with Mochi-source coordinates without any post-processing.
+- When `SourceFile` is set on any function in the program, `Emit` skips the final `format.Source` pass. `gofmt` reflows lines and would invalidate the line-for-line mapping; per §11.4 of this MEP, the source-map path stays pre-formatted. Programs without source-map info (existing Phase 4-6 corpus) keep the gofmt pass.
+- `compiler3/emit/go/diag.go` (`FilterBuildErrors`) is the belt-and-braces filter for diagnostics that bypass `//line` (load-phase errors, file-level messages). It scans the emitted source once to build a directive table, then rewrites `gen.go:L:C:` to `file.mochi:N:` for any diagnostic that points into the emitted file. Diagnostics for unrelated files pass through verbatim.
+- Tests: `TestEmitSourceMapDirective` (directive presence), `TestFilterBuildErrorsRemap` (filter rewrites gen-file coords), `TestFilterBuildErrorsPassThrough` (unrelated diagnostics untouched), `TestSourceMapEndToEnd` (real `go build` failure on an emitted program with a grafted type error, asserts Mochi coords surface). All four pass; the existing Phase 4-6 corpus continues to pass unchanged.
+
+**Remaining for the full Phase 7 gate:** Mochi parser threads source positions into the IR builder so every block carries its real Mochi line; the `--keep-emit` flag stops deleting the gen file. Both are frontend wiring on top of the emitter-side primitives that this PR lands.
 
 ### Phase 8: export direction (`--emit=go-library`) — pending
 


### PR DESCRIPTION
## Summary
- Phase 7 of MEP-43. Threads Mochi-source coordinates through the emitter via `ir.Function.SourceFile` + `ir.Block.SourceLine`, writes `//line file:N` directives at function and block boundaries, and adds `compiler3/emit/go/diag.go::FilterBuildErrors` as the belt-and-braces stderr rewriter.
- When any function in the program carries `SourceFile`, `Emit` skips `go/format.Source` so gofmt does not invalidate the directive-to-source mapping (per MEP-43 §11.4). Programs without source-map info keep gofmt as before, so the Phase 4-6 corpus is untouched.
- MEP-43 Phase 7 row flipped to LANDED with the deep-dive sub-section filled in. Remaining work (parser-side position threading, `--keep-emit`) is frontend wiring on top of these primitives.

## Test plan
- [x] `go test ./compiler3/emit/go/ -run 'TestEmitSourceMap|TestFilterBuildErrors|TestSourceMapEndToEnd'` (4 new tests pass)
- [x] `go test ./compiler3/emit/go/ ./compiler3/ir/` (full suites pass, no regressions)
- [x] `go vet ./compiler3/emit/go/ ./compiler3/ir/` (clean)

Closes #21905