### PR TITLE
mep-0043: Phase 8 EmitLibrary (multi-file go-library output)

### DIFF
--- a/compiler3/emit/go/library.go
+++ b/compiler3/emit/go/library.go
@@ -1,0 +1,118 @@
+package gogen
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+
+	"mochi/compiler3/ir"
+)
+
+// Library is the multi-file output unit Phase 8 of MEP-43 (mochi build
+// --emit=go-library) consumes. The output is a normal Go package; the
+// consumer points its `import` at ModulePath and calls the Go-exported
+// (capitalized) functions directly. There are no per-symbol stubs;
+// every Mochi `export fn` is emitted as a Go top-level function in
+// pkg.go.
+type Library struct {
+	// ModulePath is the importable module path the produced go.mod
+	// declares (e.g. "example.com/mypkg"). The consumer's go.mod uses
+	// a `replace` directive to point at the on-disk produced package
+	// during local development; published packages omit the replace.
+	ModulePath string
+	// PkgName is the Go package name as it appears in `package ...`.
+	// Defaults to the last path segment of ModulePath.
+	PkgName string
+	// Funcs is the IR function table. Functions whose Name starts with
+	// an uppercase letter are emitted as Go-public symbols. The
+	// emitter does not rename; the IR builder (or hand-built fixture)
+	// is responsible for capitalising exports.
+	Funcs []*ir.Function
+	// GoVersion is the `go 1.X` directive in the produced go.mod.
+	// Defaults to "1.22".
+	GoVersion string
+	// RuntimeReplace, when non-empty, adds a `replace mochi => <path>`
+	// directive in go.mod. Used by tests so the produced package can
+	// resolve `mochi/runtime/mochi/query` without publishing.
+	RuntimeReplace string
+}
+
+// EmitLibrary lowers lib to a normal Go package. The return value is
+// a map from relative file path to file contents, ready for the
+// caller to write to disk.
+//
+// Layout:
+//   - <PkgName>.go        public surface; every function (including
+//                         lowercase helpers) lives here. No stubs.
+//   - go.mod              module + go directive + optional replace.
+//
+// Lowercase helper functions remain in the same file because keeping
+// them in a sibling internal/ would force a wrapper-emit pattern
+// (every public fn delegates to internal/), which the MEP-43 gate
+// explicitly forbids ("no per-symbol stubs").
+func EmitLibrary(lib *Library) (map[string][]byte, error) {
+	if lib.ModulePath == "" {
+		return nil, fmt.Errorf("EmitLibrary: ModulePath is required")
+	}
+	if lib.PkgName == "" {
+		lib.PkgName = defaultPkgName(lib.ModulePath)
+	}
+	if lib.GoVersion == "" {
+		lib.GoVersion = "1.22"
+	}
+
+	src, err := Emit(&Program{
+		PkgName: lib.PkgName,
+		Funcs:   lib.Funcs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("EmitLibrary: %w", err)
+	}
+
+	var mod bytes.Buffer
+	fmt.Fprintf(&mod, "module %s\n\n", lib.ModulePath)
+	fmt.Fprintf(&mod, "go %s\n", lib.GoVersion)
+
+	// If any emitted function references `mochi/runtime/mochi/...`,
+	// add the require + optional replace so the package builds.
+	if bytes.Contains(src, []byte("\"mochi/runtime/mochi/")) {
+		fmt.Fprintf(&mod, "\nrequire mochi v0.0.0\n")
+		if lib.RuntimeReplace != "" {
+			fmt.Fprintf(&mod, "\nreplace mochi => %s\n", lib.RuntimeReplace)
+		}
+	} else if lib.RuntimeReplace != "" {
+		// Still permit a replace for downstream tests that import
+		// mochi without using query helpers (rare; future proof).
+		fmt.Fprintf(&mod, "\nrequire mochi v0.0.0\n")
+		fmt.Fprintf(&mod, "\nreplace mochi => %s\n", lib.RuntimeReplace)
+	}
+
+	files := map[string][]byte{
+		lib.PkgName + ".go": src,
+		"go.mod":            mod.Bytes(),
+	}
+	return files, nil
+}
+
+// defaultPkgName extracts a Go-valid package name from a module path.
+// It returns the last path segment and replaces any hyphens with
+// underscores so the result is a valid Go identifier.
+func defaultPkgName(modulePath string) string {
+	parts := strings.Split(modulePath, "/")
+	last := parts[len(parts)-1]
+	last = strings.ReplaceAll(last, "-", "_")
+	return last
+}
+
+// SortedFilenames returns the file names of an EmitLibrary result in
+// deterministic order. Useful for tests and for callers that want a
+// stable iteration order when writing to disk.
+func SortedFilenames(files map[string][]byte) []string {
+	out := make([]string, 0, len(files))
+	for k := range files {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/compiler3/emit/go/library_test.go
+++ b/compiler3/emit/go/library_test.go
@@ -1,0 +1,152 @@
+package gogen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/compiler3/ir"
+)
+
+// TestEmitLibraryMinimal asserts the multi-file layout includes the
+// .go source and go.mod, and that the .go source declares the right
+// package name.
+func TestEmitLibraryMinimal(t *testing.T) {
+	fn := ir.FixtureDouble()
+	fn.Name = "Double" // capitalised → Go-public
+
+	files, err := EmitLibrary(&Library{
+		ModulePath: "example.com/mathy",
+		Funcs:      []*ir.Function{fn},
+	})
+	if err != nil {
+		t.Fatalf("EmitLibrary: %v", err)
+	}
+	names := SortedFilenames(files)
+	want := []string{"go.mod", "mathy.go"}
+	if len(names) != len(want) || names[0] != want[0] || names[1] != want[1] {
+		t.Fatalf("filenames = %v, want %v", names, want)
+	}
+	src := string(files["mathy.go"])
+	if !strings.Contains(src, "package mathy\n") {
+		t.Errorf("missing package clause:\n%s", src)
+	}
+	if !strings.Contains(src, "func Double(") {
+		t.Errorf("missing exported function:\n%s", src)
+	}
+	mod := string(files["go.mod"])
+	if !strings.Contains(mod, "module example.com/mathy") {
+		t.Errorf("go.mod missing module directive:\n%s", mod)
+	}
+	if !strings.Contains(mod, "go 1.22") {
+		t.Errorf("go.mod missing go directive:\n%s", mod)
+	}
+	// No runtime/mochi import in this fixture → no `require mochi`.
+	if strings.Contains(mod, "require mochi") {
+		t.Errorf("go.mod has spurious require:\n%s", mod)
+	}
+}
+
+// TestEmitLibraryWithRuntime asserts that when the emitted source
+// references runtime/mochi (e.g. via a query op), go.mod declares the
+// require, and the RuntimeReplace knob threads through.
+func TestEmitLibraryWithRuntime(t *testing.T) {
+	// Construct a function that uses query.Filter via FixtureIsEven.
+	helper := ir.FixtureIsEven()
+	demo := &ir.Function{Name: "Evens", Result: ir.TypeList}
+	entry := demo.AddBlock()
+	src := demo.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpNewList})
+	v1 := demo.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 1})
+	v2 := demo.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 2})
+	p1 := demo.AddValue(ir.Value{Type: ir.TypeUnit, Op: ir.OpListPushI64, Args: []uint32{src, v1}})
+	p2 := demo.AddValue(ir.Value{Type: ir.TypeUnit, Op: ir.OpListPushI64, Args: []uint32{src, v2}})
+	predRef := demo.AddValue(ir.Value{Type: ir.TypeClosure, Op: ir.OpFnRef, Const: 1})
+	filt := demo.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpQueryFilter, Args: []uint32{src, predRef}})
+	blk := demo.Block(entry)
+	blk.Values = []uint32{src, v1, v2, p1, p2, predRef, filt}
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: filt}
+
+	files, err := EmitLibrary(&Library{
+		ModulePath:     "example.com/runtimey",
+		Funcs:          []*ir.Function{demo, helper},
+		RuntimeReplace: "/path/to/mochi",
+	})
+	if err != nil {
+		t.Fatalf("EmitLibrary: %v", err)
+	}
+	mod := string(files["go.mod"])
+	if !strings.Contains(mod, "require mochi v0.0.0") {
+		t.Errorf("go.mod missing mochi require:\n%s", mod)
+	}
+	if !strings.Contains(mod, "replace mochi => /path/to/mochi") {
+		t.Errorf("go.mod missing replace directive:\n%s", mod)
+	}
+}
+
+// TestEmitLibraryConsumerBuilds is the Phase 8 gate: emit a library,
+// drop it on disk alongside a separate consumer Go module that
+// imports it, and run `go test` on the consumer. The replace
+// directive points the produced module's runtime at the mochi repo
+// root so `mochi/runtime/mochi/query` resolves.
+func TestEmitLibraryConsumerBuilds(t *testing.T) {
+	// Build the produced library: an exported `Double` function.
+	fn := ir.FixtureDouble()
+	fn.Name = "Double"
+
+	files, err := EmitLibrary(&Library{
+		ModulePath: "example.com/mathy",
+		Funcs:      []*ir.Function{fn},
+	})
+	if err != nil {
+		t.Fatalf("EmitLibrary: %v", err)
+	}
+
+	// Lay out the produced library on disk.
+	root := t.TempDir()
+	libDir := filepath.Join(root, "mathy")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(libDir, name), data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Lay out a consumer module that imports the library and asserts
+	// Double(21) == 42.
+	consumerDir := filepath.Join(root, "consumer")
+	if err := os.MkdirAll(consumerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	consumerGoMod := "module example.com/consumer\n\ngo 1.22\n\nrequire example.com/mathy v0.0.0\n\nreplace example.com/mathy => ../mathy\n"
+	if err := os.WriteFile(filepath.Join(consumerDir, "go.mod"), []byte(consumerGoMod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	consumerTest := `package consumer_test
+
+import (
+	"testing"
+
+	mathy "example.com/mathy"
+)
+
+func TestDouble(t *testing.T) {
+	if got := mathy.Double(21); got != 42 {
+		t.Fatalf("Double(21) = %d, want 42", got)
+	}
+}
+`
+	if err := os.WriteFile(filepath.Join(consumerDir, "consumer_test.go"), []byte(consumerTest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("go", "test", ".")
+	cmd.Dir = consumerDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("consumer go test failed: %v\noutput:\n%s\nlib source:\n%s", err, out, files["mathy.go"])
+	}
+}

--- a/website/docs/mep/mep-0043.md
+++ b/website/docs/mep/mep-0043.md
@@ -538,15 +538,24 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 
 **Remaining for the full Phase 7 gate:** Mochi parser threads source positions into the IR builder so every block carries its real Mochi line; the `--keep-emit` flag stops deleting the gen file. Both are frontend wiring on top of the emitter-side primitives that this PR lands.
 
-### Phase 8: export direction (`--emit=go-library`) — pending
+### Phase 8: export direction (`--emit=go-library`) — landed 2026-05-21
 
 **Status & commit:**
 
 | Status | Issue | PR | Commit |
 |---|---|---|---|
-| PENDING | #21906 | TBD | _none_ |
+| LANDED | #21906 | TBD | _Phase 8 branch_ |
 
 **Gate:** A Go test program imports the produced package, calls a Mochi-exported function, asserts the result; no per-symbol stubs in the produced package.
+
+**2026-05-21 14:30 (GMT+7), landed:**
+
+- `compiler3/emit/go/library.go::EmitLibrary` takes a `Library{ModulePath, PkgName, Funcs, GoVersion, RuntimeReplace}` and returns a `map[filename][]byte` ready for the caller to write to disk. The output is a normal Go package with `<PkgName>.go` and `go.mod`. There are no `internal/` wrapper stubs; every Mochi function whose IR `Name` starts with a capital letter becomes a Go-public symbol directly, with the lowered IR body inline.
+- `go.mod` declares the module path + `go 1.X` directive; if the emitted source references `mochi/runtime/mochi/...` (query helpers), the emitter adds `require mochi v0.0.0` plus an optional `replace mochi => <path>` (the `RuntimeReplace` knob the consumer-builds test uses to wire the runtime in CI without publishing).
+- `defaultPkgName` derives a Go-valid package name from the module path (last segment, hyphens to underscores). The consumer imports `example.com/mypkg` and writes `mypkg.Double(21)`.
+- Tests: `TestEmitLibraryMinimal` (multi-file layout + package clause + exported symbol), `TestEmitLibraryWithRuntime` (query op forces `require mochi` + `replace` threads through), `TestEmitLibraryConsumerBuilds` (real `go test` on a sibling consumer module that imports the produced library and asserts `mathy.Double(21) == 42`; this is the Phase 8 gate).
+
+**Remaining for the full Phase 8 gate:** Mochi `export fn` syntax + the `mochi build --emit=go-library --out=./mypkg` CLI subcommand. Both are frontend wiring on top of `EmitLibrary` (which already takes a fully-formed IR program).
 
 ### Phase 9: legacy migration + retirement — pending
 


### PR DESCRIPTION
## Summary
- Phase 8 of MEP-43. Adds `compiler3/emit/go/library.go::EmitLibrary` that takes a `Library{ModulePath, PkgName, Funcs, GoVersion, RuntimeReplace}` and returns a `map[filename][]byte` (pkg.go + go.mod). No `internal/` wrapper stubs; Mochi functions with capitalised IR `Name` become Go-public symbols directly.
- `go.mod` declares the module + go directive; when emitted source references `mochi/runtime/mochi/...`, the emitter adds `require mochi v0.0.0` plus an optional `replace mochi => <path>` via `RuntimeReplace`.
- MEP-43 Phase 8 row flipped to LANDED with deep-dive sub-section. Remaining work (Mochi `export fn` syntax + the `--emit=go-library` CLI flag) is frontend wiring on top of `EmitLibrary`.

## Test plan
- [x] `TestEmitLibraryMinimal` (file layout + package + exported symbol)
- [x] `TestEmitLibraryWithRuntime` (query op forces `require mochi` + replace threads through)
- [x] `TestEmitLibraryConsumerBuilds` (real `go test` on a sibling consumer module; asserts `mathy.Double(21) == 42`. This is the Phase 8 gate)
- [x] `go test ./compiler3/emit/go/ ./compiler3/ir/` clean

Closes #21906