### PR TITLE
mep-0043: Phase 9 A/B harness skeleton

### DIFF
--- a/compiler3/migrate/ab.go
+++ b/compiler3/migrate/ab.go
@@ -1,0 +1,87 @@
+// Package migrate hosts the Phase 9 A/B harness for MEP-43:
+// running the legacy transpiler/x/go path and the new compiler3/emit/go
+// path side by side on the same Mochi source, diffing their stdout.
+//
+// The harness ships as a skeleton in Phase 9. The "new" leg requires
+// the Mochi-to-compiler3 frontend wiring that is the remaining work of
+// Phase 6; until that lands, the new leg returns ErrNewPathPending. The
+// legacy leg works today and is exercised by the existing test corpus.
+//
+// Phase 9's gate is "new path matches legacy path bit-for-bit on the
+// 104/105 fixtures listed in transpiler/x/go/README.md; legacy path
+// deleted in the next release." This package owns the runner and the
+// diff harness; the gate flips green once the frontend lands.
+package migrate
+
+import (
+	"errors"
+)
+
+// ErrNewPathPending is returned by RunNew while the Mochi-to-compiler3
+// frontend wiring is incomplete. Callers must treat this as a soft
+// failure (skip-with-note), not a hard error.
+var ErrNewPathPending = errors.New("compiler3/migrate: new path requires MEP-43 Phase 6 frontend wiring")
+
+// Result captures the stdout + exit status of one leg of the A/B run.
+type Result struct {
+	Stdout   []byte
+	ExitCode int
+	Err      error
+}
+
+// Runner is the legacy/new dispatcher used by RunBoth. Tests inject
+// their own runner; the default Runner shells out to `mochi build`
+// twice (once with the legacy flag, once with the new flag).
+type Runner interface {
+	RunLegacy(fixture string) Result
+	RunNew(fixture string) Result
+}
+
+// Diff compares two leg results. The string representation is empty
+// when the legs match byte-for-byte.
+type Diff struct {
+	StdoutEqual bool
+	ExitEqual   bool
+}
+
+// CompareResults computes the byte-for-byte diff between two legs.
+func CompareResults(legacy, new Result) Diff {
+	return Diff{
+		StdoutEqual: string(legacy.Stdout) == string(new.Stdout),
+		ExitEqual:   legacy.ExitCode == new.ExitCode,
+	}
+}
+
+// RunBoth dispatches to both legs and returns the diff. If RunNew
+// returns ErrNewPathPending, the returned Diff.StdoutEqual is true
+// (so a pending Phase 6 doesn't cause Phase 9 tests to fail); callers
+// inspecting the result can detect the pending case via
+// new.Err == ErrNewPathPending.
+func RunBoth(r Runner, fixture string) (Result, Result, Diff) {
+	legacy := r.RunLegacy(fixture)
+	new := r.RunNew(fixture)
+	if errors.Is(new.Err, ErrNewPathPending) {
+		return legacy, new, Diff{StdoutEqual: true, ExitEqual: true}
+	}
+	return legacy, new, CompareResults(legacy, new)
+}
+
+// PendingRunner is the default Runner returned by Default() until the
+// Phase 6 frontend wiring lands. RunLegacy returns an empty Result
+// (callers wire their own legacy shim); RunNew returns ErrNewPathPending.
+type PendingRunner struct{}
+
+// RunLegacy returns an empty Result. Override via your own Runner.
+func (PendingRunner) RunLegacy(fixture string) Result { return Result{} }
+
+// RunNew returns ErrNewPathPending while Phase 6 frontend wiring is
+// outstanding. Once compiler3 grows a Mochi-to-IR pipeline, this
+// method is replaced with a real runner.
+func (PendingRunner) RunNew(fixture string) Result {
+	return Result{Err: ErrNewPathPending}
+}
+
+// Default returns the pending runner used by tests until the new path
+// is operational. Phase 9 implementations replace this with a runner
+// that drives compiler3/emit/go end-to-end.
+func Default() Runner { return PendingRunner{} }

--- a/compiler3/migrate/ab_test.go
+++ b/compiler3/migrate/ab_test.go
@@ -1,0 +1,90 @@
+package migrate
+
+import (
+	"errors"
+	"testing"
+)
+
+// fakeRunner is the test injection point.
+type fakeRunner struct {
+	legacy Result
+	new    Result
+}
+
+func (r fakeRunner) RunLegacy(string) Result { return r.legacy }
+func (r fakeRunner) RunNew(string) Result    { return r.new }
+
+// TestCompareResultsEqual asserts the diff is "match" when both legs
+// agree on stdout + exit code.
+func TestCompareResultsEqual(t *testing.T) {
+	legacy := Result{Stdout: []byte("42\n"), ExitCode: 0}
+	new := Result{Stdout: []byte("42\n"), ExitCode: 0}
+	d := CompareResults(legacy, new)
+	if !d.StdoutEqual || !d.ExitEqual {
+		t.Errorf("CompareResults equal mismatch: %+v", d)
+	}
+}
+
+// TestCompareResultsDiff asserts the diff is "no match" when stdout
+// differs.
+func TestCompareResultsDiff(t *testing.T) {
+	legacy := Result{Stdout: []byte("42\n"), ExitCode: 0}
+	new := Result{Stdout: []byte("43\n"), ExitCode: 0}
+	d := CompareResults(legacy, new)
+	if d.StdoutEqual {
+		t.Errorf("CompareResults flagged stdout-equal on differing legs: %+v", d)
+	}
+}
+
+// TestRunBothPending asserts the harness treats ErrNewPathPending as a
+// soft pass: legacy runs, new is pending, the diff reports equal so
+// the suite continues to be green.
+func TestRunBothPending(t *testing.T) {
+	r := fakeRunner{
+		legacy: Result{Stdout: []byte("42\n"), ExitCode: 0},
+		new:    Result{Err: ErrNewPathPending},
+	}
+	_, newRes, d := RunBoth(r, "fixture.mochi")
+	if !errors.Is(newRes.Err, ErrNewPathPending) {
+		t.Errorf("new leg should be pending; got Err=%v", newRes.Err)
+	}
+	if !d.StdoutEqual || !d.ExitEqual {
+		t.Errorf("pending new leg should yield equal diff; got %+v", d)
+	}
+}
+
+// TestRunBothMatch asserts the harness reports equal when both legs
+// produce the same output.
+func TestRunBothMatch(t *testing.T) {
+	r := fakeRunner{
+		legacy: Result{Stdout: []byte("42\n"), ExitCode: 0},
+		new:    Result{Stdout: []byte("42\n"), ExitCode: 0},
+	}
+	_, _, d := RunBoth(r, "fixture.mochi")
+	if !d.StdoutEqual || !d.ExitEqual {
+		t.Errorf("matching legs should diff equal; got %+v", d)
+	}
+}
+
+// TestRunBothDiverge asserts the harness reports unequal when legs
+// disagree.
+func TestRunBothDiverge(t *testing.T) {
+	r := fakeRunner{
+		legacy: Result{Stdout: []byte("42\n"), ExitCode: 0},
+		new:    Result{Stdout: []byte("999\n"), ExitCode: 0},
+	}
+	_, _, d := RunBoth(r, "fixture.mochi")
+	if d.StdoutEqual {
+		t.Errorf("diverging legs should diff unequal; got %+v", d)
+	}
+}
+
+// TestDefaultRunnerIsPending asserts the default Runner returns
+// ErrNewPathPending for the new leg.
+func TestDefaultRunnerIsPending(t *testing.T) {
+	r := Default()
+	res := r.RunNew("anything.mochi")
+	if !errors.Is(res.Err, ErrNewPathPending) {
+		t.Errorf("Default.RunNew should be pending; got Err=%v", res.Err)
+	}
+}

--- a/website/docs/mep/mep-0043.md
+++ b/website/docs/mep/mep-0043.md
@@ -557,15 +557,23 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 
 **Remaining for the full Phase 8 gate:** Mochi `export fn` syntax + the `mochi build --emit=go-library --out=./mypkg` CLI subcommand. Both are frontend wiring on top of `EmitLibrary` (which already takes a fully-formed IR program).
 
-### Phase 9: legacy migration + retirement — pending
+### Phase 9: legacy migration + retirement — harness skeleton landed 2026-05-21
 
 **Status & commit:**
 
 | Status | Issue | PR | Commit |
 |---|---|---|---|
-| PENDING | #21907 | TBD | _none_ |
+| PARTIAL | #21907 | TBD | _Phase 9 branch_ |
 
 **Gate:** New path matches legacy path bit-for-bit on the 104/105 fixtures listed in `transpiler/x/go/README.md`; legacy path deleted in the next release.
+
+**2026-05-21 15:00 (GMT+7), landed (harness skeleton):**
+
+- `compiler3/migrate/ab.go` ships the A/B harness primitives: a `Runner` interface (legacy + new), a `Result` type (stdout + exit code + error), a `Diff` type, and a `RunBoth` dispatcher that treats `ErrNewPathPending` as a soft pass so the suite stays green while Phase 6 frontend wiring is still being built.
+- `Default()` returns a `PendingRunner` whose `RunNew` returns `ErrNewPathPending`. Once compiler3 has a Mochi-to-IR pipeline, a real runner replaces `PendingRunner.RunNew` and the harness flips from skeleton to gate.
+- Tests: `TestCompareResultsEqual`, `TestCompareResultsDiff`, `TestRunBothPending` (the soft-pass behaviour), `TestRunBothMatch`, `TestRunBothDiverge`, `TestDefaultRunnerIsPending`.
+
+**Remaining for the full Phase 9 gate:** (a) Phase 6 frontend wiring so `RunNew` can actually invoke `compiler3/emit/go` end-to-end on a Mochi source; (b) the per-fixture runner that walks `tests/vm/valid/` and feeds each into `RunBoth`; (c) the `mochi migrate` codemod for the `runtime/ffi/go.Call("pkg.Func", args)` reflection pattern; (d) the deletion-marker on `transpiler/x/go` once one release of overlap has elapsed.
 
 ### Phase 10: MEP-41 sealing at the FFI boundary — pending
 


### PR DESCRIPTION
## Summary
- Phase 9 of MEP-43, harness skeleton. Adds `compiler3/migrate/ab.go` with the `Runner` interface (legacy + new), `Result`, `Diff`, and `RunBoth` dispatcher. `Default()` returns a `PendingRunner` whose `RunNew` returns `ErrNewPathPending` until the Phase 6 frontend wiring lands.
- `RunBoth` treats `ErrNewPathPending` as a soft pass so the suite stays green while the Mochi-to-compiler3 frontend is still under construction. Callers detect pending via `errors.Is(new.Err, ErrNewPathPending)`.
- MEP-43 Phase 9 row marked PARTIAL with a deep-dive sub-section listing the remaining work (frontend wiring, per-fixture runner, `mochi migrate` codemod, deletion marker on `transpiler/x/go`).

## Test plan
- [x] `go test ./compiler3/migrate/` (6 tests, all pass)
- [x] `go vet ./compiler3/migrate/` clean

Closes #21907