### PR TITLE
mep-0043+44: flip Phase 1 to LANDED, strip em-dashes from both specs

### DIFF
--- a/website/docs/mep/mep-0043.md
+++ b/website/docs/mep/mep-0043.md
@@ -50,7 +50,7 @@ The Go-target stdlib is also re-derived. Mochi-side `append`, `len`, `keys`, `va
 
 The current `runtime/ffi/go/ffi.go` is a registry: `map[string]any` plus `reflect.Value.Call` plus `reflect.Value.Convert` per argument plus a per-return-shape unpacker. The fallback path `AttrAuto` is worse: it synthesises a one-shot `main.go` per call, runs `go run` (cold-start: hundreds of milliseconds), JSON-encodes the argument list into `MOCHI_ARGS`, JSON-decodes the result. Every call costs at minimum one `reflect.ValueOf` per argument plus one `reflect.Value.Interface` per return; calls through `AttrAuto` cost one fork+exec+compile cycle. Neither model is suitable for production Mochi-from-Go code, neither model exposes static type errors at the Mochi call site (the user discovers them only at runtime), and the `AttrAuto` model requires the user to install the Go toolchain and have a writable temp directory at *runtime*, not just at build time.
 
-The `Register(name, fn)` API forces the user (or the Mochi maintainers, package by package) to enumerate every callable symbol before it can be invoked. The reflection registry pattern (Python `ctypes`, the original `otto` JS bridge, every "embed Lua in your Go program" library before LuaJIT) has been the canonical pre-2020 FFI shape, and every measured comparison (cffi vs. ctypes, pybind11 vs. ctypes, Cython vs. ctypes) shows it is 10-100x slower than direct emission and still demands per-package glue.
+The `Register(name, fn)` API forces the user (or the Mochi maintainers, package by package) to enumerate every callable symbol before it can be invoked. The reflection registry pattern (Python `ctypes`, the original `otto` JS bridge, every "embed Lua in your Go program" library before LuaJIT) was the dominant pre-2020 FFI shape, and every measured comparison (cffi vs. ctypes, pybind11 vs. ctypes, Cython vs. ctypes) shows it is 10-100x slower than direct emission and still demands per-package glue.
 
 ### What changed between v0.10 and May 2026
 
@@ -60,7 +60,7 @@ Three things between the v0.10 transpiler and May 2026 make this MEP unavoidable
 
 **`go/packages` plus generics matured.** Since Go 1.21 (August 2023), `*types.TypeParam`, `*types.Union`, and `types.Instantiate` are stable; `packages.Load(NeedTypes | NeedTypesInfo | NeedSyntax | NeedDeps | NeedImports)` returns a fully resolved package graph including generic instantiations, embedded fields, method sets, and interface-satisfaction proofs. Everything Mochi needs to drive a build-time binding resolver is in the standard `golang.org/x/tools` module. There is no missing API.
 
-**The reflection-registry pattern lost industry consensus.** .NET 7 (November 2022) shipped `LibraryImportAttribute` as a source generator replacing `DllImportAttribute` (runtime marshalling); Rust `bindgen` is the standard for C FFI; Swift's clang importer is built into the compiler; Python's CFFI and Cython have outpaced ctypes for years. The 2020-2026 consensus is **consume the foreign type system at build time and emit native calls**, never marshal at runtime. Mochi is one of the last languages still shipping a `Call(name, args...)` registry as its primary FFI.
+**The reflection-registry pattern lost industry consensus.** .NET 7 (November 2022) shipped `LibraryImportAttribute` as a source generator replacing `DllImportAttribute` (runtime marshalling); Rust `bindgen` is the standard for C FFI; Swift's clang importer is built into the compiler; Python's CFFI and Cython have outpaced ctypes for years. The recent consensus is **consume the foreign type system at build time and emit native calls**, never marshal at runtime. Mochi is one of the last languages still shipping a `Call(name, args...)` registry as its primary FFI.
 
 ### Why one MEP for two pieces
 
@@ -100,7 +100,7 @@ Out of scope (deferred to successor MEPs):
 
 ## Background: zero-glue interop landscape (May 2026)
 
-The material below is a six-axis summary of the 2024-2026 state of the art. Each axis names the precedents Mochi should learn from and the anti-patterns to avoid.
+The material below walks six axes of the current interop landscape. Each axis names the precedents Mochi should learn from and the anti-patterns to avoid.
 
 ### 1. Source-to-source language hosts for Go
 
@@ -393,7 +393,7 @@ Phase 1 through 5 are the transpiler track; Phase 6 through 8 are the FFI track;
 
 Phase rows below carry their own deep-dive section once work begins. Phase 1 has its own sibling MEP, [MEP-44](./mep-0044), because the type bridge is the only hand-maintained mapping in the entire pipeline and re-deriving its decisions at implementation time would invalidate every consumer. Subsequent phases (2-10) get a sub-section in this MEP rather than a sibling MEP, unless their internal complexity warrants the same treatment.
 
-### Phase 0: Spec freeze, sidebar entry, MEP index update — LANDED
+### Phase 0: Spec freeze, sidebar entry, MEP index update (LANDED)
 
 **Status & commit:**
 
@@ -405,7 +405,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 
 **Result:** MEP-43 is on the sidebar under "Codegen" (sidebar group `min: 42, max: 9999` in `website/scripts/gen-meps.js`), `website/src/data/meps.json` carries the number-43 entry (lines 345-352), and `gen-meps.js` regenerates both files from frontmatter on every `prebuild`. No follow-up needed.
 
-### Phase 1: `compiler3/ffi/typebridge/` + Go-stdlib soak — IN FLIGHT
+### Phase 1: `compiler3/ffi/typebridge/` + Go-stdlib soak (LANDED)
 
 **Deep dive:** [MEP-44 (Type Bridge: a structural Go-to-Mochi type mapping)](./mep-0044). The bridge is the only hand-maintained mapping in the MEP-43 pipeline; every later phase consumes its output. Re-deriving the type model at implementation time would force soak-test re-runs and cache-format breaks for users. MEP-44 pins the type model, the gob format, the constraint table, and the eight internal sub-phases (1.1 type model through 1.8 MEP-43 row update).
 
@@ -419,12 +419,12 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 | 1.4 Named types + method sets | LANDED | #21898 | #21899 | _filled by merge_ | `*os.File`, `error`, `io.Reader`, `time.Time`. |
 | 1.5 Generics + constraints | LANDED | #21898 | #21899 | _filled by merge_ | `cmp.Ordered`, `constraints.{Ordered,Integer,Signed,Unsigned,Float}`. |
 | 1.6 Equal + Format + gob | LANDED | #21898 | #21899 | _filled by merge_ | Wire format v1 (version byte + round-trip + refusal tests); hex golden queued as a Phase-2-prep follow-up. |
-| 1.7 Go-1.26 stdlib soak | PARTIAL | #21898 | #21899 | _filled by merge_ | Curated 27-package soak ships in Phase 1 (1090 symbols, 8.53% opaque density, under the 10% bar). Full-stdlib walk needs the Phase 2 resolver. |
+| 1.7 Go-1.26 stdlib soak | LANDED | #21898 | #21899 / #21920 | _filled by merge_ | Curated 27-package soak (`TestStdlibSoakCurated`: 1090 symbols, 8.53% opaque density under the 10% bar) plus full-stdlib walk (`TestStdlibSoakFull`: 179 packages, 8002 symbols, 7994 type refs, 0.00% unexpected opaque density; every opaque case classified as expected per MEP-44 §6). |
 | 1.8 MEP-43 row update | LANDED | #21898 | #21899 | _filled by merge_ | This sub-section + MEP-44 cross-link. |
 
-**Gate:** 100% of the Go 1.26 stdlib's exported symbols round-trip through the bridge; any exception is documented as `KindOpaque` with a non-empty `OpaqueReason`.
+**Gate:** 100% of the Go 1.26 stdlib's exported symbols round-trip through the bridge; any exception is documented as `KindOpaque` with a non-empty `OpaqueReason`. Met: see sub-phase 1.7 row.
 
-### Phase 2: `compiler3/ffi/resolve/` + cache — LANDED
+### Phase 2: `compiler3/ffi/resolve/` + cache (LANDED)
 
 **Status & commit:**
 
@@ -440,7 +440,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 - Cache hit on second call: memo path best-of-3 < 1 ms (gate); cold disk hit < 100 ms (bounded by gob decode of the largest stdlib package). Cache keys on `(import_path, go.sum_hash, mochi_version)`; the on-disk format carries a leading version byte (0x01) so corrupted or tampered entries fall through as misses.
 - Soak (`stdlib_test.go::TestStdlibFullSoak`): 185 stdlib packages enumerated from `$GOROOT/src`, 8256 symbols, 13445 type-references, 0 `KindInvalid`, 17.93% opaque density. The `builtin` package (godoc-only) and the `unsafe` package (definitionally opaque) are excluded. The full-stdlib bar is 20%; per-reason histogram (`uintptr=1447`, `unsafe.Pointer=819`, `unknown=89`, `complex=56`) is logged on `-v`. See MEP-44 §6 for the curated-10% vs full-stdlib-20% bar split.
 
-### Phase 3: `runtime/mochi/` Go module — LANDED
+### Phase 3: `runtime/mochi/` Go module (LANDED)
 
 **Status & commit:**
 
@@ -463,7 +463,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 - `runtime/mochi/decimal`: `New`, `FromString`/`MustFromString`, `Add`/`Sub`/`Mul`/`Div` (panics on division by zero), `Neg`, `Cmp`, `IsZero`, `String`, `Float64`, `Round` with half-away-from-zero. Built on `math/big.Rat` so no new dependency.
 - `runtime/mochi/time`: `Now`, `NowMono`, `FormatRFC3339`, `ParseRFC3339`, `Sleep`.
 
-### Phase 4: `compiler3/emit/go/` skeleton — LANDED
+### Phase 4: `compiler3/emit/go/` skeleton (LANDED)
 
 **Status & commit:**
 
@@ -481,7 +481,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 - Acceptance corpus: `ir.FixtureFibIter` (`fib_iter(10)=55`), `ir.FixtureSumLoop` (`sum_loop(100)=4950`), `ir.FixtureFactRec` (`fact_rec(10)=3628800`), and a synthesised `list_demo` fixture exercising every list op. Each test emits Go to a temp dir, runs `go run`, and asserts stdout.
 - Output is gofmt-canonical: every emit goes through `go/format.Source`. This is a hard prerequisite for Phase 7's source-mapped diagnostics; line numbers in the emitted .go file must be stable.
 
-### Phase 5: query lowering through `runtime/mochi/query` — LANDED
+### Phase 5: query lowering through `runtime/mochi/query` (LANDED)
 
 **Status & commit:**
 
@@ -499,7 +499,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 - `TestEmitQueryEmitsRuntimeImport` asserts the emitter wires the `mochi/runtime/mochi/query` import exactly when query ops appear.
 - Group-by today returns `[]query.Group[int64, int64]`; the IR cannot yet destructure groups (`.Key` / `.Items` field access ships with the Phase 6 Mochi frontend), so the GroupBy test exercises compile + run cleanliness only.
 
-### Phase 6: `import go "path"` end-to-end — LANDED 2026-05-21
+### Phase 6: `import go "path"` end-to-end (LANDED 2026-05-21)
 
 **Status & commit:**
 
@@ -516,7 +516,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 - `compiler3/emit/go` lowers `OpCallGo` as a literal `alias.Name(arg0, arg1, ...)` call, registers `b.Pkg` in the imports map, and emits an aliased import (`import s "strings"`) when the binding's alias diverges from the path's default segment. No reflection. No registry.
 - Fixtures `FixtureGoCallToUpper`, `FixtureGoCallContains`, `FixtureGoCallAlias` exercise single-arg string, two-arg bool, and aliased-import lowering. `TestEmitGoCallToUpper` asserts the emitted source imports `"strings"`, calls `strings.ToUpper`, and contains neither `Call(` nor `reflect.` (the explicit MEP-43 anti-pattern check).
 
-**2026-05-21 18:00 (GMT+7), closeout — Mochi-to-IR frontend landed:**
+**2026-05-21 18:00 (GMT+7), closeout (Mochi-to-IR frontend landed):**
 
 - `compiler3/frontend` ships a min-viable Mochi-to-IR lowering. `Lower(prog *parser.Program) (*gogen.Program, error)` consumes a parsed `*parser.Program` and produces the emit-side `Program` the rest of the pipeline already accepts. The MVP covers the i64-everywhere surface that's load-bearing across the rest of the phases: integer literals, `let` / `var` bindings, plain assignments, binary arithmetic (`+ - * / %`), comparisons (`== != < <= > >=`), unary negate, `if / else`, `return`, user-declared `fun` (including recursion), and `print(int_expr)` lowered as a `fmt.Println` `OpCallGo`. Anything else returns an explicit "unsupported in MVP" error so the A/B harness can mark the fixture as skipped (`ErrNewPathPending`), not regressed.
 - `compiler3/build/go.BuildSource(srcPath, opts)` is the single entry point the user-facing CLI calls: it parses, lowers, and hands the result to `Build`. This is the deferred wiring Phase 7 / 8 / 9 / 10 closeouts all named as the residual gate.
@@ -525,7 +525,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 
 **Remaining for the full Phase 6 gate:** Mochi parser captures `import go "path" as alias` and `import go "path" _` (side-effect form); type checker invokes `compiler3/ffi/resolve.Resolve(path, cache)` from Phase 2 and registers the bindings under the alias; the Mochi-to-IR frontend translates each call site into an `OpCallGo`. The `tests/vm/valid/go_auto` and `tests/vm/valid/mix_go_python` corpora exercise this path end-to-end. (The MVP frontend covers a strict subset of the typed AST; the `go_auto` / `mix_go_python` paths need the typed AST + resolver integration, which is independent of the lowering surface this PR shipped.)
 
-### Phase 7: source-mapped diagnostics — landed 2026-05-21
+### Phase 7: source-mapped diagnostics (LANDED 2026-05-21)
 
 **Status & commit:**
 
@@ -553,7 +553,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 - `cmd/mochi build <file>` is the user-facing shell: it accepts `--target=go`, `--emit=executable|go-library`, `--out`, `--keep-emit`, `--module`, `--package`, `--runtime-replace` and threads them through to `gobuild.BuildSource`. The frontend lowering from Phase 6 makes this end-to-end: `mochi build foo.mochi --keep-emit --out /tmp/out` writes `gen.go` that `go run` executes to the expected stdout. Verified by smoke-test on `let_and_print.mochi` (stdout `30`).
 - `--keep-emit` is now reachable from the command line as well as from the library API. The Phase 7 source-map directives (`//line file:N`) are emitted by the frontend automatically once `ir.Function.SourceFile` carries the source path (the MVP frontend leaves it blank for now; the typed-AST wiring populates it for the full corpus).
 
-### Phase 8: export direction (`--emit=go-library`) — landed 2026-05-21
+### Phase 8: export direction (`--emit=go-library`) (LANDED 2026-05-21)
 
 **Status & commit:**
 
@@ -580,7 +580,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 - `cmd/mochi build foo.mochi --emit=go-library --module=example.com/mathy --out=./mathy` is now reachable end-to-end: the CLI shell from the Phase 7 closeout dispatches `--emit=go-library` to `gobuild.ModeLibrary`, with the `--module` flag mapped to `Options.ModulePath` and `--runtime-replace` mapped to `Options.RuntimeReplace`. Module mode without `--module` errors with the usage message instead of silently producing a broken `go.mod`.
 - Remaining surface in the Mochi frontend (the `export fn` keyword annotation that drives which Mochi funs become public Go symbols) is one frontend extension on top of the existing capitalisation rule the emitter already enforces. The MVP frontend treats every user `fun` as a candidate; the `export` keyword wiring lands with the typed-AST closeout that completes the full Phase 6 gate.
 
-### Phase 9: legacy migration + retirement — LANDED 2026-05-21
+### Phase 9: legacy migration + retirement (LANDED 2026-05-21)
 
 **Status & commit:**
 
@@ -608,7 +608,7 @@ Phase rows below carry their own deep-dive section once work begins. Phase 1 has
 - (c) Codemod scanner: `compiler3/migrate/codemod.go` walks a Go source tree, parses each `*.go` (skipping `_test.go`), and reports every `goffi.Call("pkg.Func", args...)` call site with file:line, package, function name, and arg count. Sites with a non-literal callee are still reported with `Pkg`/`Func` empty so the migrator can flag them for manual review. Tests: `TestScanCallSitesFindsLiteralCallee`, `TestScanCallSitesNonLiteralCallee`, `TestSiteReportLine`, `TestScanSkipsTestFiles`. The rewriter half (replacing each call site with a typed FFI call) is parameterised on the bridge resolver and lands with Phase 6 frontend wiring.
 - (d) Deletion marker: `transpiler/x/go/README.md` now carries a "Deprecation notice (MEP-43 Phase 9)" section that pins the flip-date semantics and the gate the deletion is keyed to (two consecutive releases with `StdoutEqual && ExitEqual` on every fixture from the 104/105 list).
 
-### Phase 10: MEP-41 sealing at the FFI boundary — landed 2026-05-21
+### Phase 10: MEP-41 sealing at the FFI boundary (LANDED 2026-05-21)
 
 **Status & commit:**
 

--- a/website/docs/mep/mep-0044.md
+++ b/website/docs/mep/mep-0044.md
@@ -27,11 +27,11 @@ description: "Deep-dive specification of MEP-43 Phase 1: the structural type bri
 
 MEP-43 specifies a three-piece architecture for the zero-glue Go target: a **type bridge** (this MEP), a **build-time binding resolver** (MEP-43 Phase 2), and a **typed-IR to Go-source emitter** (MEP-43 Phase 4). The resolver and the emitter are mechanical once the bridge is correct; the bridge is where every interesting design decision lives. MEP-43 §2 covers the bridge in two pages; that is enough to communicate intent but not enough to ship code without re-deriving five different decisions at implementation time. This MEP is the deep dive.
 
-The bridge is **the only hand-maintained mapping in the MEP-43 pipeline**. It is finite (under ~40 cases), purely structural, and changes only when Go itself gains a new structural type — the last such addition was type parameters in Go 1.18 (March 2022). Everything else in MEP-43 is generic over the bridge: the resolver walks `*types.Package`, the emitter walks compiler3 IR, the runtime is a normal Go module. If a reviewer ever sees a `case "strings.ToUpper":` arm in any MEP-43 code, that PR is rejected on sight (MEP-43 §13). This bridge is the shape of the contract that makes the rejection rule enforceable.
+The bridge is **the only hand-maintained mapping in the MEP-43 pipeline**. It is finite (under ~40 cases), purely structural, and changes only when Go itself gains a new structural type. The last such addition was type parameters in Go 1.18 (March 2022). Everything else in MEP-43 is generic over the bridge: the resolver walks `*types.Package`, the emitter walks compiler3 IR, the runtime is a normal Go module. If a reviewer ever sees a `case "strings.ToUpper":` arm in any MEP-43 code, that PR is rejected on sight (MEP-43 §13). This bridge is the shape of the contract that makes the rejection rule enforceable.
 
 Three concrete decisions distinguish this MEP from MEP-43 §2:
 
-1. **The bridge produces a structural `typebridge.Type` value, not a `compiler3/ir.Type` enum.** The existing `ir.Type` is a uint8 enum sized to vm3 lowering (~18 kinds, no children). The bridge needs a recursive structural type carrying element type for lists, key/value for maps, fields for structs, params/results for functions, method set for named/interface types. We ship that as `compiler3/ffi/typebridge.Type` — a Go struct with a `Kind` and optional children — and leave `compiler3/ir.Type` alone. Later MEPs may collapse the two; Phase 1 explicitly does not.
+1. **The bridge produces a structural `typebridge.Type` value, not a `compiler3/ir.Type` enum.** The existing `ir.Type` is a uint8 enum sized to vm3 lowering (~18 kinds, no children). The bridge needs a recursive structural type carrying element type for lists, key/value for maps, fields for structs, params/results for functions, method set for named/interface types. We ship that as `compiler3/ffi/typebridge.Type` (a Go struct with a `Kind` and optional children) and leave `compiler3/ir.Type` alone. Later MEPs may collapse the two; Phase 1 explicitly does not.
 2. **`KindOpaque` is a first-class structural shape, not a fallback.** A Go type that the bridge cannot decompose (a `chan struct{ private fields }`, an anonymous interface with no name, an `unsafe.Pointer`) maps to `KindOpaque` with a carrier of the original `*types.Type` and a documented reason code (`OpaqueUnsafePointer`, `OpaqueUnexportedField`, `OpaqueIncomplete`, etc.). Opaque values can still be passed through Mochi code; they cannot be destructured. The `OpaqueWithReason` discipline (MEP-43 §11.8) is enforced here.
 3. **Stable gob serialisation is a Phase 1 deliverable, not a Phase 2 deliverable.** The binding resolver (Phase 2) caches `*ir.PackageBinding` values on disk; every `Binding` carries a `typebridge.Type`. If the cache encoding changes incompatibly, every user's cache is silently corrupt. Phase 1 ships `Type` with a `gob.GobEncoder` / `gob.GobDecoder` pair that includes a format version byte, so a Mochi upgrade that adds a new `Kind` invalidates caches cleanly instead of returning garbage.
 
@@ -52,7 +52,7 @@ These are not philosophical questions; they are pieces of code anyone implementi
 
 ### Why pin the type model now rather than evolve it
 
-Phase 1's gate is "100% Go 1.26 stdlib coverage." That gate is meaningful only if the type model is fixed before the soak runs. If we ship Phase 1 with a `Type` model that has, say, no `Width` field, then either we leave width-narrowing bugs in the emitted Go (assigning a Mochi `i64` into a Go `int32` field) or we extend the model after the soak passes — and the soak has to re-run. The cost of pinning the model in Phase 1 is small (an extra 30 minutes of design review); the cost of re-running the soak after every model change is the bottleneck for the whole MEP-43 schedule.
+Phase 1's gate is "100% Go 1.26 stdlib coverage." That gate is meaningful only if the type model is fixed before the soak runs. If we ship Phase 1 with a `Type` model that has, say, no `Width` field, then either we leave width-narrowing bugs in the emitted Go (assigning a Mochi `i64` into a Go `int32` field) or we extend the model after the soak passes, and the soak has to re-run. The cost of pinning the model in Phase 1 is small (an extra 30 minutes of design review); the cost of re-running the soak after every model change is the bottleneck for the whole MEP-43 schedule.
 
 The same argument applies to the gob format. The cache format is consumed by Phase 2 and on; a v0 format that we have to break adds a release of churn for every Mochi user with a populated `~/.cache/mochi/bindings/`. Versioning the format from the first byte avoids that.
 
@@ -215,7 +215,7 @@ The struct is intentionally large by value. Calls to the bridge are not on any h
 | `*types.Basic` `Int`                  | `{Kind: KindInt, Width: 0}`                                                         |
 | `*types.Basic` `Int8/Int16/Int32/Int64` | `{Kind: KindInt, Width: 8/16/32/64}`                                              |
 | `*types.Basic` `Uint`                 | `{Kind: KindUint, Width: 0}`                                                        |
-| `*types.Basic` `Uint8`                | `{Kind: KindUint, Width: 8}` — Go's `byte` is `Uint8`; the bridge does not preserve the alias |
+| `*types.Basic` `Uint8`                | `{Kind: KindUint, Width: 8}` (Go's `byte` is `Uint8`; the bridge does not preserve the alias) |
 | `*types.Basic` `Uint16/Uint32/Uint64` | `{Kind: KindUint, Width: 16/32/64}`                                                 |
 | `*types.Basic` `Uintptr`              | `{Kind: KindOpaque, OpaqueReason: OpaqueUintptr}`                                   |
 | `*types.Basic` `Float32/Float64`      | `{Kind: KindFloat, Width: 32/64}`                                                   |
@@ -228,7 +228,7 @@ The struct is intentionally large by value. Calls to the bridge are not on any h
 | `*types.Map` `K -> V`                 | `{Kind: KindMap, Key: GoToMochi(K), Elem: GoToMochi(V)}`                            |
 | `*types.Struct`                       | `{Kind: KindStruct, Fields: ...}`; unexported fields are kept (with `Exported=false`) so the bridge can still pass the struct around, but emitter will treat them as opaque-by-field |
 | `*types.Pointer` to `T`               | `{Kind: KindRef, Elem: GoToMochi(T)}`                                               |
-| `*types.Interface` (anonymous)        | `{Kind: KindIface, Name: "", Methods: ...}` if the interface has methods; `{Kind: KindOpaque, OpaqueReason: OpaqueAnonInterface}` if the interface has zero methods (it is `any`) — handled separately as `KindIface{Name: "", Methods: nil}` to preserve `any` |
+| `*types.Interface` (anonymous)        | `{Kind: KindIface, Name: "", Methods: ...}` if the interface has methods; `{Kind: KindOpaque, OpaqueReason: OpaqueAnonInterface}` if the interface has zero methods (it is `any`), which is handled separately as `KindIface{Name: "", Methods: nil}` to preserve `any` |
 | `*types.Interface` named (`*types.Named` wrapping one) | `{Kind: KindIface, Name: pkg.Type, PkgPath: pkg.Path(), Methods: ...}` |
 | `*types.Named` non-interface          | `{Kind: KindNamed, Name: pkg.Type, PkgPath: pkg.Path(), Underlying: ..., Methods: ...}` |
 | `*types.Signature`                    | `{Kind: KindFunc, Params: ..., Results: ..., Variadic: sig.Variadic()}`             |
@@ -424,10 +424,10 @@ Each sub-phase lands as its own PR with the same commit pattern MEP-40 establish
 | 1.4 Named types + method sets | LANDED | (this PR) | _filled by merge_ | Covers `*os.File`, `error`, `io.Reader`, `time.Time`. |
 | 1.5 Generics + constraints | LANDED | (this PR) | _filled by merge_ | `cmp.Ordered`, `constraints.{Ordered,Integer,Signed,Unsigned,Float}` are recognised. |
 | 1.6 Equal + Format + gob | LANDED | (this PR) | _filled by merge_ | `gob_test.go` validates wire format v1 against golden hex strings. |
-| 1.7 Go-1.26 stdlib soak | PENDING | (follow-up) | _none_ | Stdlib soak runs against a curated subset in CI; full-stdlib walk requires the resolver (Phase 2) to enumerate packages. |
+| 1.7 Go-1.26 stdlib soak | LANDED | #21920 | _filled by merge_ | `TestStdlibSoakCurated` keeps the curated 27-package bar (1090 symbols, 8.53% opaque, under the 10% Phase-1 ceiling). `TestStdlibSoakFull` walks the entire Go 1.26 stdlib (179 user-facing packages after the `internal/` + `vendor/` filter; 8002 symbols; 7994 type references) and asserts 0.00% *unexpected* opaque density: every opaque case classifies as expected per §6 (`uintptr`, `unsafe.Pointer`, `complex`, `chan struct{}` self-referential shapes, deeply-anonymous interface). The full soak runs at `go test -timeout 600s ./compiler3/ffi/typebridge/ -run TestStdlibSoakFull` in well under a minute and is part of the default CI run. |
 | 1.8 MEP-43 row update | LANDED | (this PR) | _filled by merge_ | MEP-43 Phase 1 row gains LANDED marker and link to MEP-44. |
 
-The first commit ships sub-phases 1.1 through 1.6 together because they are tightly coupled (each tests the previous). Sub-phase 1.7 (the full stdlib soak) lands in a follow-up PR because it needs the Phase 2 binding resolver to enumerate packages; a Phase-1-only soak walks a curated list of packages instead, which is what `stdlib_test.go` ships here.
+Sub-phases 1.1 through 1.6 shipped together in the first PR (tightly coupled; each tested the previous). Sub-phase 1.7 landed in #21920 as part of the MEP-43 Phase 7-10 closeout, once the Phase 2 binding resolver was in place to enumerate the full package set; `stdlib_test.go` carries both the curated and the full-stdlib tests today.
 
 ## §11 Risks
 
@@ -463,21 +463,21 @@ The `constraints.go` table covers the Go stdlib's named constraints (~10 entries
 
 The MEP-43 §12 reference list applies. Additionally:
 
-- **`go/types` documentation**: https://pkg.go.dev/go/types — authoritative for the structural shapes the bridge consumes.
-- **`golang.org/x/tools/go/types/typeutil`**: https://pkg.go.dev/golang.org/x/tools/go/types/typeutil — `Hasher` for cache keys (Phase 2; the bridge itself does not call it).
-- **Yaegi `extract.go`**: https://github.com/traefik/yaegi/blob/master/extract/extract.go — the canonical example of `go/types`-driven binding extraction; the bridge here is a structural cousin.
-- **gomobile `bind/genobjc.go`**: https://cs.opensource.google/go/x/mobile/+/master:bind/genobjc.go — the gobind type-to-target-string renderer; the model `MochiToGo` follows.
-- **Go generics introduction**: https://go.dev/blog/intro-generics — for `types.Instantiate` semantics.
-- **Russ Cox's `gob` spec**: https://pkg.go.dev/encoding/gob — for the wire-format guarantees and forward-compatibility rules.
+- **`go/types` documentation**: https://pkg.go.dev/go/types. Authoritative for the structural shapes the bridge consumes.
+- **`golang.org/x/tools/go/types/typeutil`**: https://pkg.go.dev/golang.org/x/tools/go/types/typeutil. `Hasher` for cache keys (Phase 2; the bridge itself does not call it).
+- **Yaegi `extract.go`**: https://github.com/traefik/yaegi/blob/master/extract/extract.go. The canonical example of `go/types`-driven binding extraction; the bridge here is a structural cousin.
+- **gomobile `bind/genobjc.go`**: https://cs.opensource.google/go/x/mobile/+/master:bind/genobjc.go. The gobind type-to-target-string renderer; the model `MochiToGo` follows.
+- **Go generics introduction**: https://go.dev/blog/intro-generics. Background on `types.Instantiate` semantics.
+- **Russ Cox's `gob` spec**: https://pkg.go.dev/encoding/gob. Wire-format guarantees and forward-compatibility rules.
 
 ## §13 Cross-references
 
-- **MEP-43 §2** — high-level type-bridge architecture (this MEP is the deep dive of that section).
-- **MEP-43 §11.8** — opaque-density risk that this MEP's stdlib soak enforces.
-- **MEP-43 §13** — workflow note that forbids per-package arms; this MEP is the shape that makes the rule enforceable.
-- **MEP-4 / MEP-5** — Mochi's type system and inference; the bridge's `Type` is a Mochi-side type that the type checker will consume in Phase 2.
-- **MEP-40 §7.1** — compiler3 IR op set; the bridge output drives `OpCallGo` and `OpCallRuntime` arg/result typing.
-- **MEP-41 §6** — sealed handles; Phase 10 of MEP-43 wraps Go calls with seal/unseal based on the bridge's typed signature.
+- **MEP-43 §2**: high-level type-bridge architecture (this MEP is the deep dive of that section).
+- **MEP-43 §11.8**: opaque-density risk that this MEP's stdlib soak enforces.
+- **MEP-43 §13**: workflow note that forbids per-package arms; this MEP is the shape that makes the rule enforceable.
+- **MEP-4 / MEP-5**: Mochi's type system and inference; the bridge's `Type` is a Mochi-side type that the type checker will consume in Phase 2.
+- **MEP-40 §7.1**: compiler3 IR op set; the bridge output drives `OpCallGo` and `OpCallRuntime` arg/result typing.
+- **MEP-41 §6**: sealed handles; Phase 10 of MEP-43 wraps Go calls with seal/unseal based on the bridge's typed signature.
 
 ## Copyright
 


### PR DESCRIPTION
Tracks #21923. Audit-pass follow-up on #21922; addresses the stop-hook callout that Phase 1 of MEP-43 still read \"IN FLIGHT\" even though the full Go-1.26 stdlib soak shipped in #21920.

## Summary

- MEP-43 Phase 1 row flips PARTIAL/IN FLIGHT to LANDED. Sub-phase 1.7 now cites \`TestStdlibSoakFull\` (typebridge, 179 packages, 8002 symbols, 7994 type refs, 0.00% unexpected opaque density per MEP-44 §6) alongside the existing curated \`TestStdlibSoakCurated\`.
- MEP-44 sub-phase 1.7 (\"PENDING\") flips to LANDED with the same numbers and a pointer to PR #21920 where it actually landed.
- Em-dash audit on both specs. The two specs carried 12 + 17 occurrences; all replaced with parens, periods, colons, or semicolons per the project's no-em-dash rule. Two date-bracketed phrasings (\"2020-2026 consensus\", \"2024-2026 state of the art\") softened to read less synthesised.

## Test plan
- [x] \`go test -timeout 600s -run 'TestStdlibSoakFull|TestStdlibFullSoak' ./compiler3/ffi/typebridge/ ./compiler3/ffi/resolve/\` (both green)
- [x] \`grep -c '—' website/docs/mep/mep-0043.md website/docs/mep/mep-0044.md\` returns 0 / 0
- [x] No other Unicode dashes / smart quotes in either file