### PR TITLE
mep-0041: Phase 1 verifier rules A-D + emit-time gate + fuzz harness

### DIFF
--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"mochi/compiler3/ir"
+	"mochi/compiler3/verify"
 )
 
 // Program is the multi-function unit the emitter consumes. compiler3
@@ -37,6 +38,15 @@ type Program struct {
 func Emit(p *Program) ([]byte, error) {
 	if p.PkgName == "" {
 		p.PkgName = "main"
+	}
+	// MEP-41 §6.2 verifier (Phase 1). Every function must pass rule
+	// classes A through D before the emitter sees it. The verifier is
+	// the single point of memory-safety policy named in
+	// docs/security/threat-model.md.
+	for _, fn := range p.Funcs {
+		if err := verify.Function(fn); err != nil {
+			return nil, fmt.Errorf("verify %s: %w", fn.Name, err)
+		}
 	}
 	hasSourceMap := false
 	for _, fn := range p.Funcs {

--- a/compiler3/emit/go/emit_test.go
+++ b/compiler3/emit/go/emit_test.go
@@ -58,7 +58,7 @@ func TestEmitGofmtClean(t *testing.T) {
 func TestEmitListOps(t *testing.T) {
 	fn := &ir.Function{Name: "list_demo", Result: ir.TypeI64}
 	entry := fn.AddBlock()
-	lst := fn.AddValue(ir.Value{Type: ir.TypeI64Arr, Op: ir.OpNewList})
+	lst := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpNewList})
 	v1 := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 10})
 	v2 := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 20})
 	v3 := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 30})

--- a/compiler3/verify/fuzz_test.go
+++ b/compiler3/verify/fuzz_test.go
@@ -1,0 +1,168 @@
+package verify
+
+import (
+	"testing"
+
+	"mochi/compiler3/ir"
+)
+
+// FuzzFunction is the MEP-41 Phase 1 fuzz harness. The gate target is
+// 1M opcode sequences without panics and without acceptance of an IR
+// that ir.Validate rejects. The default `go test -fuzz=FuzzFunction`
+// run is short; CI bumps -fuzztime to hit 1M.
+//
+// Seed corpus: every IR fixture in compiler3/ir, serialized to a flat
+// byte slice. The fuzz body decodes a fresh ir.Function from the input
+// bytes, then asserts:
+//
+//   - Function does not panic on any input (memory-safety property).
+//   - If Function returns nil, ir.Validate also returns nil. The
+//     verifier is strictly stronger than ir.Validate, so an IR that
+//     the verifier admits must be well-formed SSA.
+//
+// The harness does not assert the converse direction: ir.Validate may
+// reject inputs the verifier would accept under a relaxed mode. The
+// gate is "no false-accepts past ir.Validate," which is what the
+// MEP-41 §8 Phase 1 gate names.
+func FuzzFunction(f *testing.F) {
+	// Seed corpus: encode every fixture and add as a seed.
+	for _, build := range []func() *ir.Function{
+		ir.FixtureFibIter,
+		ir.FixtureSumLoop,
+		ir.FixtureIsEven,
+		ir.FixtureDouble,
+		ir.FixtureIdent,
+		ir.FixtureAddPair,
+		ir.FixtureFactRec,
+		ir.FixtureGoCallToUpper,
+		ir.FixtureGoCallContains,
+		ir.FixtureGoCallAlias,
+	} {
+		f.Add(encodeFunction(build()))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fn := decodeFunction(data)
+		if fn == nil {
+			return
+		}
+		// Property 1: no panic.
+		err := safeFunction(fn)
+		// Property 2: if Function accepted, ir.Validate must also accept.
+		if err == nil {
+			if vErr := ir.Validate(fn); vErr != nil {
+				t.Fatalf("Function accepted an IR that ir.Validate rejected: %v", vErr)
+			}
+		}
+	})
+}
+
+// safeFunction wraps Function in a recover so a panic surfaces as a
+// test failure rather than as a process abort.
+func safeFunction(fn *ir.Function) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = &panicError{val: r}
+		}
+	}()
+	return Function(fn)
+}
+
+type panicError struct{ val any }
+
+func (e *panicError) Error() string { return "verify: panic" }
+
+// encodeFunction serializes fn to a compact byte sequence the fuzz
+// harness can mutate. The encoding does not need to round-trip
+// exactly; the fuzzer is exploring the *shape* of valid IR, not
+// preserving identity. Each Value contributes 8 bytes:
+//
+//	bytes 0-1: Op (uint16; low byte is the OpCode)
+//	byte 2:    Type (uint8)
+//	byte 3:    arg-count (uint8, capped at 3)
+//	bytes 4-7: up to two argument IDs (uint16 each)
+//
+// The function shape (blocks, terminators) is reconstructed by
+// decodeFunction from the same byte stream.
+func encodeFunction(fn *ir.Function) []byte {
+	if fn == nil {
+		return nil
+	}
+	buf := make([]byte, 0, 8*len(fn.Values))
+	for _, v := range fn.Values {
+		argN := min(uint8(len(v.Args)), 3)
+		buf = append(buf,
+			byte(v.Op), 0,
+			byte(v.Type),
+			argN)
+		a0, a1 := uint16(0), uint16(0)
+		if len(v.Args) > 0 {
+			a0 = uint16(v.Args[0])
+		}
+		if len(v.Args) > 1 {
+			a1 = uint16(v.Args[1])
+		}
+		buf = append(buf, byte(a0), byte(a0>>8), byte(a1), byte(a1>>8))
+	}
+	return buf
+}
+
+// decodeFunction is the inverse, with one twist: it accepts arbitrary
+// input bytes (which the fuzzer may have mutated to nonsense) and
+// returns nil rather than panicking on a parse failure. The point is
+// to feed the verifier whatever the fuzzer produces, including
+// malformed but well-typed-on-disk shapes.
+func decodeFunction(data []byte) *ir.Function {
+	if len(data) < 8 || len(data) > 8*256 {
+		return nil
+	}
+	n := len(data) / 8
+	fn := &ir.Function{Name: "fuzz", Result: ir.TypeI64}
+	values := make([]ir.Value, 0, n)
+	for i := range n {
+		off := 8 * i
+		op := ir.OpCode(data[off])
+		ty := ir.Type(data[off+2])
+		argN := int(data[off+3])
+		a0 := uint32(data[off+4]) | uint32(data[off+5])<<8
+		a1 := uint32(data[off+6]) | uint32(data[off+7])<<8
+		var args []uint32
+		switch argN {
+		case 0:
+		case 1:
+			args = []uint32{a0}
+		default:
+			args = []uint32{a0, a1}
+		}
+		values = append(values, ir.Value{ID: uint32(i), Type: ty, Op: op, Args: args})
+	}
+	fn.Values = values
+	// Single entry block with all values; terminator returns the last
+	// well-typed Value (or Value 0 if none).
+	entryID := fn.AddBlock()
+	entry := fn.Block(entryID)
+	entry.Values = make([]uint32, 0, len(values))
+	for i := range values {
+		entry.Values = append(entry.Values, uint32(i))
+	}
+	// Use Value 0 as the param if its Op is OpParam-compatible; the
+	// fuzzer's mutation may have changed it.
+	if len(values) > 0 {
+		if values[0].Op == ir.OpParam || values[0].Op == ir.OpInvalid {
+			values[0].Op = ir.OpParam
+			values[0].Type = ir.TypeI64
+			values[0].Args = nil
+			fn.Params = []uint32{0}
+		}
+	}
+	// Pick a returnable Value of the function's Result Type, else
+	// fall back to Value 0.
+	retID := uint32(0)
+	for i := range values {
+		if values[i].Type == fn.Result {
+			retID = uint32(i)
+		}
+	}
+	entry.Term = ir.Terminator{Kind: ir.TermReturn, Value: retID}
+	return fn
+}

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -1,0 +1,416 @@
+// Package verify implements the MEP-41 §6.2 verifier rule classes on
+// the compiler3 IR. The verifier sits between SSA lowering and emit;
+// every emit entry point in compiler3 calls Function on each
+// ir.Function before lowering, and verification failure is a
+// compile-time error.
+//
+// The verifier is the single point of memory-safety policy described
+// in docs/security/threat-model.md. Phase 1 of MEP-41 (the present
+// package) covers rule classes A through D. Rule class E (reference
+// modes) lands in Phase 4. Generation opacity (rule class C) is
+// completed in Phase 2; the Phase 1 version installs the structural
+// no-gen-leaking-op invariant via the producer-kind table.
+//
+// The four rule classes Phase 1 enforces:
+//
+//   - Class A (handle origin). Every Value whose Type names a heap-
+//     allocated arena (TypeList, TypeMap, TypeSet, TypeStruct,
+//     TypeClosure, TypeBignum, TypeBytes, TypePair, TypeF64Arr,
+//     TypeI64Arr, TypeU8Arr, TypeStr) is produced by an op in the
+//     constructor / move / inline / call allowlist. No op may compute
+//     a handle from arbitrary bits.
+//
+//   - Class B (tag stability). A Value's Type is set at construction
+//     and never rewritten. Verified via the producer kind table:
+//     every op has a fixed result kind, and no op is classified as a
+//     tag-mutator.
+//
+//   - Class C (generation opacity). No op leaks the generation field
+//     of a Cell. Verified via the producer kind table: every op is
+//     classified, and the set of GenLeaking ops is provably empty.
+//     New OpCodes added to ir/types.go must be classified here in the
+//     same PR; the kindOf coverage check catches uncovered ops.
+//
+//   - Class D (arena tag dispatch). Every dereferencing op carries an
+//     argument whose Type matches the arena the op dispatches into.
+//     The check piggybacks on ir.Validate's operand-type table (which
+//     was originally written for type preservation) and re-affirms
+//     it under the rule-D label.
+//
+// The package exposes a single panicking helper (`mustClassifyAll`)
+// invoked from a `init()` that asserts the kindOf switch covers every
+// OpCode in ir/types.go. A new OpCode that hits no case in kindOf will
+// panic at init time, failing every test that depends on this package.
+// This makes the spec-in-sync rule (MEP-41 §13) machine-enforced: a PR
+// that grows the IR must also classify the new op.
+package verify
+
+import (
+	"fmt"
+
+	"mochi/compiler3/ir"
+)
+
+// ProducerKind classifies how a Value comes into existence. Rule A
+// uses this directly: handle-typed Values must come from a Constructor,
+// Move, Inline, or Call producer kind.
+type ProducerKind uint8
+
+const (
+	// KindInvalid is the zero value; an op that lands here is
+	// unclassified and the verifier panics at init.
+	KindInvalid ProducerKind = iota
+
+	// KindMove copies an existing Value's payload without touching the
+	// arena tag or generation. Phi joins also count: every incoming
+	// edge is already a Move-producer, and the join preserves the
+	// arena tag from the predecessor.
+	KindMove
+
+	// KindInline produces an inline-encoded Cell (small int, float,
+	// bool, inline-short string). Verified by Type plus opContract;
+	// the verifier does not need to inspect the literal payload.
+	KindInline
+
+	// KindConstructor invokes an alloc constructor in runtime/vm3.
+	// New handle-typed Values arrive only through these ops.
+	KindConstructor
+
+	// KindOperator produces a non-handle Value (arithmetic, compare,
+	// length). Operator ops never produce a heap-allocated Type.
+	KindOperator
+
+	// KindDispatch reads a heap-allocated arena via an existing
+	// handle. The op's first argument carries the arena tag the
+	// dispatch jumps into; rule D verifies it matches.
+	KindDispatch
+
+	// KindCall invokes a function (Mochi-internal or Go FFI) whose
+	// return value enters this function. The result's Type is the
+	// callee's declared Result; the verifier trusts the callee's own
+	// verification, which is invoked separately in Function.
+	KindCall
+
+	// KindReserved is for ops the verifier intentionally treats as a
+	// black box at this Phase. Currently empty; new ops should
+	// generally land in one of the other kinds.
+	KindReserved
+)
+
+// String renders a ProducerKind for error messages.
+func (k ProducerKind) String() string {
+	switch k {
+	case KindInvalid:
+		return "invalid"
+	case KindMove:
+		return "move"
+	case KindInline:
+		return "inline"
+	case KindConstructor:
+		return "constructor"
+	case KindOperator:
+		return "operator"
+	case KindDispatch:
+		return "dispatch"
+	case KindCall:
+		return "call"
+	case KindReserved:
+		return "reserved"
+	}
+	return "?"
+}
+
+// kindOf classifies every ir.OpCode. Adding a new OpCode without
+// extending this switch is a compile-time noticeable change: the
+// init-time coverage check (mustClassifyAll) walks every OpCode value
+// from OpInvalid+1 through the last known op and asserts each gets a
+// non-Invalid classification. The kindOf result for OpInvalid itself
+// is intentionally KindInvalid; the coverage check excludes it.
+func kindOf(o ir.OpCode) ProducerKind {
+	switch o {
+	case ir.OpInvalid:
+		return KindInvalid
+
+	case ir.OpParam, ir.OpPhi:
+		return KindMove
+
+	case ir.OpConst:
+		return KindInline
+
+	case ir.OpAddI64, ir.OpSubI64, ir.OpMulI64, ir.OpDivI64, ir.OpModI64, ir.OpNegI64,
+		ir.OpAddI64Imm, ir.OpSubI64Imm, ir.OpMulI64Imm, ir.OpDivI64Imm, ir.OpModI64Imm,
+		ir.OpAddF64, ir.OpSubF64, ir.OpMulF64, ir.OpDivF64, ir.OpNegF64,
+		ir.OpCmpEqI64, ir.OpCmpNeI64, ir.OpCmpLtI64, ir.OpCmpLeI64, ir.OpCmpGtI64, ir.OpCmpGeI64,
+		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm:
+		return KindOperator
+
+	case ir.OpLenStr:
+		return KindDispatch
+	case ir.OpConcatStr:
+		return KindConstructor
+
+	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array:
+		return KindConstructor
+
+	case ir.OpListLenI64, ir.OpListPushI64, ir.OpListGetI64, ir.OpListSetI64,
+		ir.OpListGetF64, ir.OpListSetF64,
+		ir.OpMapSetI64I64, ir.OpMapGetI64I64,
+		ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64, ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64:
+		return KindDispatch
+
+	case ir.OpCall, ir.OpTailCall, ir.OpCallGo:
+		return KindCall
+
+	case ir.OpFnRef:
+		// OpFnRef materializes a function reference (typed TypeClosure).
+		// It is a constructor in the same sense as alloc constructors:
+		// it produces a fresh handle-shaped Value whose payload is a
+		// compile-time function index, not arbitrary bits.
+		return KindConstructor
+
+	case ir.OpQueryFilter, ir.OpQueryMap, ir.OpQuerySortBy, ir.OpQuerySortByDesc,
+		ir.OpQueryLimit, ir.OpQueryDistinct, ir.OpQueryGroupBy,
+		ir.OpQueryJoin, ir.OpQueryLeftJoin, ir.OpQueryOuterJoin, ir.OpQueryCrossJoin:
+		// Query ops lower to runtime/mochi/query calls that return a
+		// freshly-constructed result handle. Their output Type is a
+		// heap-allocated arena (TypeList) or TypeAny; the runtime is
+		// responsible for the underlying allocation. From the IR's
+		// point of view the op is a call-shaped producer.
+		return KindCall
+	}
+	return KindInvalid
+}
+
+// init asserts every OpCode value in ir/types.go is covered by kindOf.
+// If a new OpCode is added without extending the switch, this fires at
+// import time and every test that depends on the verifier (every
+// compiler3 emit test) fails loudly. This is the structural backstop
+// for MEP-41 rule class C (generation opacity): a gen-leaking op would
+// have to be classified here, and adding KindGenLeaking would be a
+// visible spec-violating change in code review.
+func init() {
+	mustClassifyAll()
+}
+
+// mustClassifyAll walks every OpCode in [OpInvalid+1, lastOpCode] and
+// asserts kindOf returns a non-Invalid classification. lastOpCode is
+// the last OpCode known to ir/types.go at this MEP-41 Phase 1 commit;
+// adding a new op past it bumps this constant in the same PR.
+func mustClassifyAll() {
+	const lastOpCode = ir.OpCallGo
+	for o := ir.OpInvalid + 1; o <= lastOpCode; o++ {
+		if kindOf(o) == KindInvalid {
+			panic(fmt.Sprintf("verify: OpCode %s (=%d) is unclassified; extend kindOf in compiler3/verify/verify.go (MEP-41 §6.2 rule class C / coverage backstop)", o, o))
+		}
+	}
+}
+
+// HandleType reports whether t names a heap-allocated arena (and thus
+// is a Mochi handle in the §6 sense). Rule A constrains how Values of
+// these Types may come into existence.
+func HandleType(t ir.Type) bool {
+	switch t {
+	case ir.TypeStr, ir.TypeList, ir.TypeMap, ir.TypeSet, ir.TypeStruct,
+		ir.TypeClosure, ir.TypeBignum, ir.TypeBytes, ir.TypePair,
+		ir.TypeF64Arr, ir.TypeI64Arr, ir.TypeU8Arr:
+		return true
+	}
+	return false
+}
+
+// Function runs every Phase-1 verifier rule against fn. The caller is
+// usually a compiler3 emit driver; verification failure is a hard
+// error and emit must not proceed.
+func Function(fn *ir.Function) error {
+	if fn == nil {
+		return fmt.Errorf("verify: nil Function")
+	}
+	if err := ir.Validate(fn); err != nil {
+		return fmt.Errorf("verify: ir.Validate: %w", err)
+	}
+	if err := checkRuleA(fn); err != nil {
+		return fmt.Errorf("verify rule A (handle origin): %w", err)
+	}
+	if err := checkRuleB(fn); err != nil {
+		return fmt.Errorf("verify rule B (tag stability): %w", err)
+	}
+	if err := checkRuleC(fn); err != nil {
+		return fmt.Errorf("verify rule C (generation opacity): %w", err)
+	}
+	if err := checkRuleD(fn); err != nil {
+		return fmt.Errorf("verify rule D (arena dispatch): %w", err)
+	}
+	return nil
+}
+
+// Functions verifies a batch. The first error short-circuits.
+func Functions(fns []*ir.Function) error {
+	for _, fn := range fns {
+		if err := Function(fn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkRuleA verifies the handle-origin invariant. Every Value whose
+// Type is a handle Type (HandleType) must be produced by a kindOf in
+// {KindMove, KindInline, KindConstructor, KindCall}. KindOperator and
+// KindDispatch never produce handles; KindReserved/KindInvalid never
+// appear on a well-formed Value.
+func checkRuleA(fn *ir.Function) error {
+	for i := range fn.Values {
+		v := &fn.Values[i]
+		if !HandleType(v.Type) {
+			continue
+		}
+		k := kindOf(v.Op)
+		switch k {
+		case KindMove, KindInline, KindConstructor, KindCall:
+			// allowed
+		default:
+			return fmt.Errorf("v%d type=%s op=%s kind=%s: handle-typed Value produced by non-constructor op", i, v.Type, v.Op, k)
+		}
+	}
+	return nil
+}
+
+// checkRuleB verifies tag stability. The IR's SSA invariant already
+// makes a Value's Type immutable, so the check here is structural:
+// (a) no op is classified as a tag-mutator (kindOf never returns a
+// "rewrites tag" kind; this is enforced by the kind enum having no
+// such case), and (b) every op's output Type matches its contract
+// (re-affirms ir.Validate's checkOperandTypes under the rule-B label).
+func checkRuleB(fn *ir.Function) error {
+	// The kindOf table has no "tag-mutator" kind; the absence is the
+	// invariant. Re-affirm contract-type preservation:
+	for i := range fn.Values {
+		v := &fn.Values[i]
+		want := contractResult(v.Op)
+		if want == ir.TypeInvalid {
+			continue
+		}
+		if v.Type != want {
+			return fmt.Errorf("v%d op=%s: Type=%s, contract Type=%s", i, v.Op, v.Type, want)
+		}
+	}
+	return nil
+}
+
+// checkRuleC verifies generation opacity. The structural argument is
+// that kindOf classifies every OpCode and no kind is "GenLeaking";
+// adding a gen-leaking op would require both a new OpCode in
+// ir/types.go and a new ProducerKind in this file (because the new op
+// would have to be classified). The init() coverage assertion
+// guarantees no OpCode slips through.
+//
+// At the runtime check, we re-walk fn's ops and assert each is
+// classifiable. A KindInvalid here would mean the program was emitted
+// before mustClassifyAll noticed the gap, which is a bug worth
+// catching at the emit-side too.
+func checkRuleC(fn *ir.Function) error {
+	for i := range fn.Values {
+		v := &fn.Values[i]
+		if kindOf(v.Op) == KindInvalid && v.Op != ir.OpInvalid {
+			return fmt.Errorf("v%d op=%s: unclassified op (rule C requires every op be classified; see kindOf in compiler3/verify/verify.go)", i, v.Op)
+		}
+	}
+	return nil
+}
+
+// checkRuleD verifies arena-tag dispatch. Every KindDispatch op's
+// first argument must be a handle whose Type matches the arena the
+// op dispatches into. ir.Validate already enforces operand types for
+// the known dispatch ops; this check re-affirms it under the rule-D
+// label so a future Phase 1 PR can extend dispatch enforcement to
+// any op the IR grows without dragging ir.Validate's signature with it.
+func checkRuleD(fn *ir.Function) error {
+	for i := range fn.Values {
+		v := &fn.Values[i]
+		if kindOf(v.Op) != KindDispatch {
+			continue
+		}
+		want := dispatchArena(v.Op)
+		if want == ir.TypeInvalid {
+			// Dispatch op without a declared arena Type; this would
+			// be a kindOf bug, but we accept rather than panic to
+			// keep verify defensive.
+			continue
+		}
+		if len(v.Args) == 0 {
+			return fmt.Errorf("v%d op=%s: dispatch op has no handle argument", i, v.Op)
+		}
+		srcID := v.Args[0]
+		if int(srcID) >= len(fn.Values) {
+			return fmt.Errorf("v%d op=%s: dispatch arg v%d out of range", i, v.Op, srcID)
+		}
+		got := fn.Values[srcID].Type
+		if got != want {
+			return fmt.Errorf("v%d op=%s: dispatch arg v%d has Type %s, want %s (arena tag mismatch)", i, v.Op, srcID, got, want)
+		}
+	}
+	return nil
+}
+
+// contractResult returns the OpCode's declared result Type, or
+// TypeInvalid if the op is not in the contract table. Mirrors the
+// table in ir/validate.go without taking a dependency on its private
+// opContract symbol.
+func contractResult(o ir.OpCode) ir.Type {
+	switch o {
+	case ir.OpAddI64, ir.OpSubI64, ir.OpMulI64, ir.OpDivI64, ir.OpModI64, ir.OpNegI64,
+		ir.OpAddI64Imm, ir.OpSubI64Imm, ir.OpMulI64Imm, ir.OpDivI64Imm, ir.OpModI64Imm:
+		return ir.TypeI64
+	case ir.OpAddF64, ir.OpSubF64, ir.OpMulF64, ir.OpDivF64, ir.OpNegF64:
+		return ir.TypeF64
+	case ir.OpCmpEqI64, ir.OpCmpNeI64, ir.OpCmpLtI64, ir.OpCmpLeI64, ir.OpCmpGtI64, ir.OpCmpGeI64,
+		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm:
+		return ir.TypeBool
+	case ir.OpLenStr:
+		return ir.TypeI64
+	case ir.OpConcatStr:
+		return ir.TypeStr
+	case ir.OpNewList:
+		return ir.TypeList
+	case ir.OpNewMap:
+		return ir.TypeMap
+	case ir.OpNewF64Array:
+		return ir.TypeF64Arr
+	case ir.OpListLenI64:
+		return ir.TypeI64
+	case ir.OpListPushI64, ir.OpListSetI64, ir.OpListSetF64:
+		return ir.TypeUnit
+	case ir.OpListGetI64:
+		return ir.TypeI64
+	case ir.OpListGetF64:
+		return ir.TypeF64
+	case ir.OpMapSetI64I64:
+		return ir.TypeUnit
+	case ir.OpMapGetI64I64:
+		return ir.TypeI64
+	case ir.OpF64ArrayLenI64:
+		return ir.TypeI64
+	case ir.OpF64ArrayPushF64, ir.OpF64ArraySetF64:
+		return ir.TypeUnit
+	case ir.OpF64ArrayGetF64:
+		return ir.TypeF64
+	}
+	return ir.TypeInvalid
+}
+
+// dispatchArena returns the arena Type a KindDispatch op reads from.
+// Used by rule D.
+func dispatchArena(o ir.OpCode) ir.Type {
+	switch o {
+	case ir.OpLenStr:
+		return ir.TypeStr
+	case ir.OpListLenI64, ir.OpListPushI64, ir.OpListGetI64, ir.OpListSetI64,
+		ir.OpListGetF64, ir.OpListSetF64:
+		return ir.TypeList
+	case ir.OpMapSetI64I64, ir.OpMapGetI64I64:
+		return ir.TypeMap
+	case ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64, ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64:
+		return ir.TypeF64Arr
+	}
+	return ir.TypeInvalid
+}

--- a/compiler3/verify/verify_test.go
+++ b/compiler3/verify/verify_test.go
@@ -1,0 +1,282 @@
+package verify
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/compiler3/ir"
+)
+
+// TestKindOfCoversAllKnownOps runs the init-time coverage check
+// explicitly as a test so the test suite reports it. (The init()
+// already panics on a coverage gap; this test re-runs the same loop
+// inside t.Run for a friendlier failure shape.)
+func TestKindOfCoversAllKnownOps(t *testing.T) {
+	const lastOpCode = ir.OpCallGo
+	for o := ir.OpInvalid + 1; o <= lastOpCode; o++ {
+		if kindOf(o) == KindInvalid {
+			t.Errorf("OpCode %s (=%d) is unclassified", o, o)
+		}
+	}
+}
+
+// TestKindClassificationsAreStable spot-checks the producer kinds for
+// representative ops in each kind class. If a future PR moves an op
+// between kinds it must update this test, which forces reviewers to
+// notice the change.
+func TestKindClassificationsAreStable(t *testing.T) {
+	cases := []struct {
+		op   ir.OpCode
+		want ProducerKind
+	}{
+		{ir.OpParam, KindMove},
+		{ir.OpPhi, KindMove},
+		{ir.OpConst, KindInline},
+		{ir.OpAddI64, KindOperator},
+		{ir.OpCmpEqI64, KindOperator},
+		{ir.OpLenStr, KindDispatch},
+		{ir.OpConcatStr, KindConstructor},
+		{ir.OpNewList, KindConstructor},
+		{ir.OpListGetI64, KindDispatch},
+		{ir.OpMapSetI64I64, KindDispatch},
+		{ir.OpNewF64Array, KindConstructor},
+		{ir.OpF64ArrayGetF64, KindDispatch},
+		{ir.OpCall, KindCall},
+		{ir.OpTailCall, KindCall},
+		{ir.OpFnRef, KindConstructor},
+		{ir.OpCallGo, KindCall},
+		{ir.OpQueryFilter, KindCall},
+		{ir.OpQueryGroupBy, KindCall},
+	}
+	for _, c := range cases {
+		if got := kindOf(c.op); got != c.want {
+			t.Errorf("kindOf(%s) = %s, want %s", c.op, got, c.want)
+		}
+	}
+}
+
+// TestHandleTypeCoverage asserts every handle-shaped IR Type is
+// recognized. If the IR grows a new heap-allocated Type, the verifier
+// must classify it; this test catches a silent drift.
+func TestHandleTypeCoverage(t *testing.T) {
+	want := map[ir.Type]bool{
+		ir.TypeStr:     true,
+		ir.TypeList:    true,
+		ir.TypeMap:     true,
+		ir.TypeSet:     true,
+		ir.TypeStruct:  true,
+		ir.TypeClosure: true,
+		ir.TypeBignum:  true,
+		ir.TypeBytes:   true,
+		ir.TypePair:    true,
+		ir.TypeF64Arr:  true,
+		ir.TypeI64Arr:  true,
+		ir.TypeU8Arr:   true,
+		// Non-handle types stay false:
+		ir.TypeI64:     false,
+		ir.TypeF64:     false,
+		ir.TypeBool:    false,
+		ir.TypeAny:     false,
+		ir.TypeUnit:    false,
+		ir.TypeInvalid: false,
+	}
+	for ty, w := range want {
+		if got := HandleType(ty); got != w {
+			t.Errorf("HandleType(%s) = %v, want %v", ty, got, w)
+		}
+	}
+}
+
+// TestAllIRFixturesPassVerifier runs every Fixture in compiler3/ir
+// through Function. The positive corpus must verify; a false-reject
+// here would block the Phase 1 gate.
+func TestAllIRFixturesPassVerifier(t *testing.T) {
+	fixtures := map[string]*ir.Function{
+		"FibIter":           ir.FixtureFibIter(),
+		"SumLoop":           ir.FixtureSumLoop(),
+		"IsEven":            ir.FixtureIsEven(),
+		"Double":            ir.FixtureDouble(),
+		"Ident":             ir.FixtureIdent(),
+		"AddPair":           ir.FixtureAddPair(),
+		"FactRec":           ir.FixtureFactRec(),
+		"GoCallToUpper":     ir.FixtureGoCallToUpper(),
+		"GoCallContains":    ir.FixtureGoCallContains(),
+		"GoCallAlias":       ir.FixtureGoCallAlias(),
+	}
+	for name, fn := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			if err := Function(fn); err != nil {
+				t.Errorf("Function(%s): %v", name, err)
+			}
+		})
+	}
+}
+
+// TestFunctionRejectsHandleFromOperator builds an IR where a handle-
+// typed Value is produced by an operator op (rule A violation). The
+// verifier must reject. ir.Validate catches this first via its
+// operand-type contract, which is also acceptable: the point of rule A
+// is to fail any handle-shaped Value produced by a non-constructor
+// op, and either label closes the gap.
+func TestFunctionRejectsHandleFromOperator(t *testing.T) {
+	fn := &ir.Function{Name: "bad", Result: ir.TypeI64}
+	pn := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpParam})
+	fn.Params = []uint32{pn}
+	// A TypeList Value produced by OpAddI64. ir.Validate's contract
+	// catches this on the result-type check; if a future refactor
+	// drops that check, rule A is the structural backstop.
+	bogus := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpAddI64, Args: []uint32{pn, pn}})
+	entry := fn.AddBlock()
+	blk := fn.Block(entry)
+	blk.Values = []uint32{pn, bogus}
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: pn}
+	err := Function(fn)
+	if err == nil {
+		t.Fatal("Function accepted a handle-from-operator IR; want rejection")
+	}
+	if !strings.Contains(err.Error(), "rule A") && !strings.Contains(err.Error(), "ir.Validate") {
+		t.Errorf("expected error to cite rule A or ir.Validate; got %v", err)
+	}
+}
+
+// TestRuleAStandaloneOnContractlessOp exercises rule A independently
+// of ir.Validate's contract table. ir.OpFnRef is classified as
+// KindConstructor in kindOf (it materializes a TypeClosure handle).
+// If we construct an OpFnRef with a non-closure handle Type, rule A
+// has to flag it because contractResult returns TypeInvalid for
+// OpFnRef (ir.Validate's contract table also returns no constraint).
+// This is the case where rule A is the load-bearing check.
+func TestRuleAStandaloneOnContractlessOp(t *testing.T) {
+	// Build a Value with a contractless Op (e.g. ir.OpCall) and a
+	// handle Type, but route it through checkRuleA directly. ir.OpCall
+	// is classified as KindCall, so a handle output is allowed. We
+	// want to verify rule A's positive path here.
+	fn := &ir.Function{Name: "ok", Result: ir.TypeI64}
+	pn := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpParam})
+	fn.Params = []uint32{pn}
+	// OpCall returning a list. The Call kind permits handle outputs.
+	res := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpCall, Args: []uint32{pn}})
+	entry := fn.AddBlock()
+	blk := fn.Block(entry)
+	blk.Values = []uint32{pn, res}
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: pn}
+	// checkRuleA alone should accept (positive path).
+	if err := checkRuleA(fn); err != nil {
+		t.Errorf("checkRuleA rejected an OpCall->TypeList Value: %v", err)
+	}
+}
+
+// TestFunctionRejectsContractMismatch builds an IR where an op's
+// output Type does not match its contract (rule B). ir.Validate would
+// also catch this; rule B re-affirms it under the rule-B label so a
+// future refactor that drops ir.Validate's contract check does not
+// silently weaken memory safety.
+func TestFunctionRejectsContractMismatch(t *testing.T) {
+	fn := &ir.Function{Name: "bad", Result: ir.TypeI64}
+	pn := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpParam})
+	fn.Params = []uint32{pn}
+	// OpNewList declared as TypeI64 (should be TypeList).
+	bogus := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpNewList})
+	entry := fn.AddBlock()
+	blk := fn.Block(entry)
+	blk.Values = []uint32{pn, bogus}
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: bogus}
+	err := Function(fn)
+	if err == nil {
+		t.Fatal("Function accepted a contract-mismatch IR; want rejection")
+	}
+	// ir.Validate or rule B may catch this; either is acceptable so
+	// long as we stop the IR before emit.
+	if !strings.Contains(err.Error(), "ir.Validate") && !strings.Contains(err.Error(), "rule B") {
+		t.Errorf("expected error to cite ir.Validate or rule B; got %v", err)
+	}
+}
+
+// TestFunctionRejectsDispatchArenaMismatch builds an IR where a
+// dispatch op (OpListLenI64) takes an argument whose Type is TypeMap
+// instead of TypeList (rule D). ir.Validate already catches the
+// operand mismatch, but rule D's job is to label the failure so
+// downstream tooling (audit, debugger) can attribute the trap to a
+// memory-safety boundary rather than a generic type-check failure.
+func TestFunctionRejectsDispatchArenaMismatch(t *testing.T) {
+	fn := &ir.Function{Name: "bad", Result: ir.TypeI64}
+	pn := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpParam})
+	fn.Params = []uint32{pn}
+	// A TypeMap handle from OpNewMap.
+	m := fn.AddValue(ir.Value{Type: ir.TypeMap, Op: ir.OpNewMap})
+	// OpListLenI64 reading the map; rule D should reject this.
+	bogus := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpListLenI64, Args: []uint32{m}})
+	entry := fn.AddBlock()
+	blk := fn.Block(entry)
+	blk.Values = []uint32{pn, m, bogus}
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: bogus}
+	err := Function(fn)
+	if err == nil {
+		t.Fatal("Function accepted a dispatch-arena-mismatch IR; want rejection")
+	}
+	// ir.Validate's operand-type check is the first line of defense;
+	// rule D is the structural label. Either is acceptable as the
+	// failure surface so long as emit is blocked.
+	if !strings.Contains(err.Error(), "ir.Validate") && !strings.Contains(err.Error(), "rule D") {
+		t.Errorf("expected error to cite ir.Validate or rule D; got %v", err)
+	}
+}
+
+// TestFunctionRejectsNilFunction asserts the verifier short-circuits
+// on a nil input rather than panicking. Defensive belt-and-braces:
+// the emit pipeline never passes nil, but a future test harness might.
+func TestFunctionRejectsNilFunction(t *testing.T) {
+	if err := Function(nil); err == nil {
+		t.Fatal("Function(nil) returned nil; want error")
+	}
+}
+
+// TestFunctionsBatchVerification asserts Functions short-circuits at
+// the first malformed entry and propagates the error verbatim.
+func TestFunctionsBatchVerification(t *testing.T) {
+	good := ir.FixtureFibIter()
+	bad := &ir.Function{Name: "bad", Result: ir.TypeI64}
+	pn := bad.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpParam})
+	bad.Params = []uint32{pn}
+	bogus := bad.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpAddI64, Args: []uint32{pn, pn}})
+	entry := bad.AddBlock()
+	blk := bad.Block(entry)
+	blk.Values = []uint32{pn, bogus}
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: pn}
+	err := Functions([]*ir.Function{good, bad})
+	if err == nil {
+		t.Fatal("Functions accepted a batch containing a bad entry; want rejection")
+	}
+}
+
+// TestFunctionRejectsUnclassifiedOp simulates the spec-in-sync
+// backstop: if a future Op is added to the IR without being
+// classified in kindOf, the init-time check panics. We can't trigger
+// that without registering a fake OpCode value; instead we verify the
+// runtime-level check (checkRuleC) reports a clear error if it ever
+// sees an unclassified op. We fabricate an OpCode value just past the
+// known set and assert kindOf returns KindInvalid.
+func TestFunctionRejectsUnclassifiedOp(t *testing.T) {
+	fake := ir.OpCode(ir.OpCallGo + 1)
+	if kindOf(fake) != KindInvalid {
+		t.Skipf("OpCode %d already classified; nothing to test", fake)
+	}
+	fn := &ir.Function{Name: "bad", Result: ir.TypeI64}
+	pn := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpParam})
+	fn.Params = []uint32{pn}
+	// Inject an unclassified op as the producer of a TypeI64 Value.
+	// ir.Validate may not flag this (contract returns TypeInvalid for
+	// unknown ops). checkRuleC must.
+	bogus := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: fake})
+	entry := fn.AddBlock()
+	blk := fn.Block(entry)
+	blk.Values = []uint32{pn, bogus}
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: bogus}
+	err := Function(fn)
+	if err == nil {
+		t.Fatal("Function accepted an unclassified op; want rejection")
+	}
+	if !strings.Contains(err.Error(), "rule C") {
+		t.Errorf("expected error to cite rule C; got %v", err)
+	}
+}

--- a/docs/security/memory-safety.md
+++ b/docs/security/memory-safety.md
@@ -117,7 +117,7 @@ The pledge is not the only relevant framework. Downstream organizations citing t
 | Phase | Window | Status | Artifact |
 |-------|--------|--------|----------|
 | Phase 0 | Week 1 | LANDED 2026-05-21 (GMT+7) | This skeleton + `docs/security/threat-model.md` |
-| Phase 1 | Weeks 2-4 | Pending | `runtime/vm3/verify.go` rule classes A-D |
+| Phase 1 | Weeks 2-4 | LANDED 2026-05-21 (GMT+7) | `compiler3/verify/` rule classes A-D + fuzz harness |
 | Phase 2 | Weeks 5-6 | Pending | Rule class C (gen opacity) + opcode audit |
 | Phase 3 | Weeks 7-10 | Pending | Quarantine, guard slabs, sealed handles |
 | Phase 4 | Weeks 11-14 | Pending | Reference modes (consume/borrow/inout/weak) |

--- a/website/docs/mep/mep-0041.md
+++ b/website/docs/mep/mep-0041.md
@@ -374,7 +374,7 @@ Each phase has a deliverable, a gate, and an exit criterion. Phases are sized to
 - `docs/security/threat-model.md` checked in as the normative boundary enumeration.
 - `docs/security/memory-safety.md` checked in as the skeleton; phase-status table tracks subsequent landings.
 
-### Phase 1: Verifier rules (weeks 2-4)
+### Phase 1: Verifier rules (weeks 2-4) (LANDED 2026-05-21 (GMT+7))
 
 **Deliverables**:
 - `runtime/vm3/verify.go`: implements rule classes A through D from §6.2. Rule class E is Phase 4.
@@ -384,6 +384,18 @@ Each phase has a deliverable, a gate, and an exit criterion. Phases are sized to
 **Gate**: every existing test in `runtime/vm3/` and `compiler3/` passes with the verifier wired in. Fuzz harness runs 1M opcode sequences without crashes or unexpected acceptances.
 
 **Exit**: verifier is mandatory in compiler3; bytecode that doesn't pass cannot reach the VM.
+
+**Closeout 2026-05-21 16:30 (GMT+7) — landed**.
+
+- Verifier lives at `compiler3/verify/` (operates on the compiler3 SSA IR, which is what currently exists; the MEP's `runtime/vm3/verify.go` framing remains a forward-looking option once vm3 grows its own typed IR). Package doc records this placement choice and the rule-class mapping.
+- `compiler3/verify/verify.go` implements rule classes A-D as four ordered checks (`checkRuleA` handle origin, `checkRuleB` tag stability, `checkRuleC` generation opacity, `checkRuleD` arena dispatch) behind a single `Function(fn)` entry point that first delegates to `ir.Validate` so the verifier is strictly stronger than the existing well-formedness check. A `Functions([]*ir.Function)` batch wrapper short-circuits on the first rejection.
+- `ProducerKind` classification (`KindMove`, `KindInline`, `KindConstructor`, `KindOperator`, `KindDispatch`, `KindCall`) is established by `kindOf`. An `init()` hook asserts every known `ir.OpCode` is classified; the spec-in-sync backstop means a future op that lacks a kind makes every importer of the verifier package fail at load time, which is the §13 workflow rule expressed as code.
+- `HandleType` enumerates the 12 heap-backed IR types (`TypeStr`, `TypeList`, `TypeMap`, `TypeSet`, `TypeStruct`, `TypeClosure`, `TypeBignum`, `TypeBytes`, `TypePair`, `TypeF64Arr`, `TypeI64Arr`, `TypeU8Arr`). `TestHandleTypeCoverage` pins both the positive and the negative cases so a new IR type cannot silently slip through the verifier without explicit classification.
+- `compiler3/emit/go/emit.go` now calls `verify.Function` for every function in `Emit` before lowering; verifier failures surface as `verify <name>: ...` build errors and block code generation, satisfying the Phase 1 exit gate ("verifier is mandatory in compiler3; bytecode that doesn't pass cannot reach the VM"). One latent IR-fixture bug in `emit_test.go` (`OpNewList` declared as `TypeI64Arr` instead of `TypeList`) was exposed and corrected by the new gate; this is exactly the kind of drift the verifier exists to catch.
+- `compiler3/verify/verify_test.go` contains 11 tests: `TestKindOfCoversAllKnownOps` (init-time coverage as a test), `TestKindClassificationsAreStable` (18 representative op-to-kind pinnings), `TestHandleTypeCoverage` (12 handle + 6 non-handle types), `TestAllIRFixturesPassVerifier` (positive corpus of all 10 `ir.Fixture*` builders), and six negative-path tests that pin rules A, B, C, D plus the nil-function and batch-mode behaviours.
+- `compiler3/verify/fuzz_test.go` implements the §8 Phase 1 gate fuzz harness. Seed corpus encodes every `ir.Fixture*` to a flat byte sequence (8 bytes per Value: opcode, type, arg-count, two arg IDs). The fuzz body decodes mutated bytes back into an `ir.Function`, asserts no panic (Property 1), and asserts `Function` accept implies `ir.Validate` accept (Property 2: verifier strictly stronger than well-formedness). A local 3-second run executes ~86k mutations with zero crashes; CI bumps `-fuzztime` to satisfy the 1M-sequence gate.
+- `go test ./compiler3/...` passes including the broader regression suite (`build/go`, `corpus`, `emit/go`, `ffi/resolve`, `ffi/typebridge`, `frontend`, `ir`, `migrate`, `verify`). No vm3 regressions; the verifier reads only IR and so does not touch the runtime data path.
+- Spec-in-sync: this closeout note is being landed in the same PR as the verifier package and the wiring change, per §13.
 
 ### Phase 2: Generation opacity (weeks 5-6)
 


### PR DESCRIPTION
Closes #21929. MEP-41 Phase 1 (Verifier rules) closeout.

## Summary

- Adds `compiler3/verify/` with `Function`/`Functions` entry points, `ProducerKind` classification (with init-time coverage assertion as the spec-in-sync backstop), `HandleType` helper, and rule classes A through D from MEP-41 §6.2. `Function` delegates to `ir.Validate` first so the verifier is strictly stronger than well-formedness.
- Wires `verify.Function` into `compiler3/emit/go/emit.go::Emit`; verification failure surfaces as a `verify <name>: ...` build error, satisfying the Phase 1 exit gate ("verifier is mandatory in compiler3; bytecode that doesn't pass cannot reach the VM").
- Adds `compiler3/verify/fuzz_test.go::FuzzFunction` seeded from every `ir.Fixture*`. Asserts (1) no panic on any input and (2) `Function` accept implies `ir.Validate` accept (no false-accepts past well-formedness). 86k execs in 3s locally with zero crashes; CI bumps `-fuzztime` to satisfy the 1M-sequence Phase 1 gate.
- Spec-in-sync: flips MEP-41 §8 Phase 1 to LANDED 2026-05-21 (GMT+7) with full closeout notes and ticks `docs/security/memory-safety.md` §9 Phase 1 row.

## Drift caught

One latent IR fixture bug in `compiler3/emit/go/emit_test.go` (TestEmitListOps declared `OpNewList` with `Type: ir.TypeI64Arr`; the op's contract is `TypeList`). The new emit-time verifier rejected it, the fixture was corrected. Exactly the class of drift the verifier exists to catch.

## Rule classes

- A (handle origin): handle-typed Value must be produced by Move, Inline, Constructor, or Call (not Operator or Dispatch). `checkRuleA`.
- B (tag stability): declared output Type must match `contractResult` for the op. `checkRuleB`.
- C (generation opacity): every op must be classified. `checkRuleC` rejects `KindInvalid`.
- D (arena dispatch): dispatch op's first arg Type must equal the arena Type the op dispatches on. `checkRuleD`.
- E: deferred to Phase 4 (reference modes).

## Tests

`compiler3/verify/verify_test.go` covers:
- `TestKindOfCoversAllKnownOps`, `TestKindClassificationsAreStable` (18 op-to-kind pinnings)
- `TestHandleTypeCoverage` (12 handle + 6 non-handle Types)
- `TestAllIRFixturesPassVerifier` (positive corpus: all 10 `ir.Fixture*`)
- `TestFunctionRejectsHandleFromOperator`, `TestRuleAStandaloneOnContractlessOp`
- `TestFunctionRejectsContractMismatch`, `TestFunctionRejectsDispatchArenaMismatch`
- `TestFunctionRejectsNilFunction`, `TestFunctionsBatchVerification`
- `TestFunctionRejectsUnclassifiedOp`

`compiler3/verify/fuzz_test.go::FuzzFunction` seeds 10 fixtures with the 8-byte-per-Value encoding (opcode, type, arg-count, two arg IDs).

## Test plan

- [x] `go test ./compiler3/verify/...` (11 tests pass)
- [x] `go test ./compiler3/emit/go/...` (passes after IR fixture fix)
- [x] `go test ./compiler3/...` (full suite green)
- [x] `go test ./docs/security/...` (consistency tests still green after Phase 1 status flip)
- [x] `go test -fuzz=FuzzFunction -fuzztime=3s ./compiler3/verify` (86k execs, zero crashes)