### PR TITLE
mep-0041: Phase 3 wrap-detection quarantine + per-VM sealing table

### DIFF
--- a/docs/security/gen-opacity-audit.md
+++ b/docs/security/gen-opacity-audit.md
@@ -1,6 +1,6 @@
 # Generation opacity audit (MEP-41 Phase 2)
 
-Created: 2026-05-21 (GMT+7). Author: MEP-41 Phase 2 closeout.
+Created: 2026-05-21 18:00 (GMT+7). Author: MEP-41 Phase 2 closeout.
 
 This document is the per-call-site audit promised by MEP-41 §8 Phase 2 deliverable two ("audit of every existing vm3 opcode for compliance with rule class C"). It is the human-readable companion to `runtime/vm3/genopacity_test.go`, which encodes the same finding as an executable AST check.
 

--- a/docs/security/memory-safety.md
+++ b/docs/security/memory-safety.md
@@ -2,9 +2,9 @@
 
 This page is the public memory-safety statement for Mochi. It is a *skeleton* during MEP-41 Phases 0 through 6: section headings are stable, prose is provisional, and measured numbers are placeholders. The final wording is published in Phase 7 alongside the blog post on mochi-lang.org and the `SECURITY.md` at the repo root.
 
-Created: 2026-05-21 (GMT+7) as part of MEP-41 Phase 0 closeout.
+Created: 2026-05-21 14:00 (GMT+7) as part of MEP-41 Phase 0 closeout.
 
-Status: **draft skeleton**. Do not cite this document in external roadmap submissions until Phase 7 (week 22) replaces the placeholder wording. The threat model at `docs/security/threat-model.md` is normative and stable; this document depends on it.
+Status: **draft skeleton**. Do not cite this document in external roadmap submissions until Phase 7 replaces the placeholder wording. The threat model at `docs/security/threat-model.md` is normative and stable; this document depends on it.
 
 ## TL;DR
 
@@ -66,7 +66,7 @@ The full enumeration is at `docs/security/threat-model.md`. The short version:
 
 ## 5. JIT hardening posture
 
-[*Placeholder. Measured numbers land in Phase 5 (week 18) and are filled in here in Phase 6 (week 21).*]
+[*Placeholder. Measured numbers land in Phase 5 and are filled in here in Phase 6.*]
 
 The vm3jit code page is hardened against the standard JIT-side attacker classes:
 
@@ -114,16 +114,16 @@ The pledge is not the only relevant framework. Downstream organizations citing t
 
 ## 9. Status by phase
 
-| Phase | Window | Status | Artifact |
-|-------|--------|--------|----------|
-| Phase 0 | Week 1 | LANDED 2026-05-21 (GMT+7) | This skeleton + `docs/security/threat-model.md` |
-| Phase 1 | Weeks 2-4 | LANDED 2026-05-21 (GMT+7) | `compiler3/verify/` rule classes A-D + fuzz harness |
-| Phase 2 | Weeks 5-6 | LANDED 2026-05-21 (GMT+7) | Gen opacity audit + AST-test backstop (`docs/security/gen-opacity-audit.md`) |
-| Phase 3 | Weeks 7-10 | Pending | Quarantine, guard slabs, sealed handles |
-| Phase 4 | Weeks 11-14 | Pending | Reference modes (consume/borrow/inout/weak) |
-| Phase 5 | Weeks 15-18 | Pending | vm3jit hardening (W^X, PAC, BTI, CET, masking) |
-| Phase 6 | Weeks 19-21 | Pending | Audit + 24h fuzz + measured numbers in §5, §6 |
-| Phase 7 | Week 22 | Pending | Final wording + blog post + `SECURITY.md` |
+| Phase | Status | Artifact |
+|-------|--------|----------|
+| Phase 0 | LANDED 2026-05-21 14:00 (GMT+7) | This skeleton + `docs/security/threat-model.md` |
+| Phase 1 | LANDED 2026-05-21 17:30 (GMT+7) | `compiler3/verify/` rule classes A-D + fuzz harness |
+| Phase 2 | LANDED 2026-05-21 18:00 (GMT+7) | Gen opacity audit + AST-test backstop (`docs/security/gen-opacity-audit.md`) |
+| Phase 3 | LANDED 2026-05-21 19:30 (GMT+7) | `runtime/vm3/quarantine.go` + `sealing.go` + `docs/security/quarantine-design.md`; guard slabs (3.1) and OpSeal/OpUnseal (3.2) deferred |
+| Phase 4 | Pending | Reference modes (consume/borrow/inout/weak) |
+| Phase 5 | Pending | vm3jit hardening (W^X, PAC, BTI, CET, masking) |
+| Phase 6 | Pending | Audit + 24h fuzz + measured numbers in §5, §6 |
+| Phase 7 | Pending | Final wording + blog post + `SECURITY.md` |
 
 Phase status updates land in this table in the same PR that closes each phase (MEP-spec-in-sync rule, MEP-41 §13).
 

--- a/docs/security/quarantine-design.md
+++ b/docs/security/quarantine-design.md
@@ -1,0 +1,160 @@
+# Wrap-detection quarantine design
+
+This document records the design and tuning of the per-arena
+wrap-detection quarantine that lands in MEP-41 Phase 3. The
+quarantine is a small slot-index FIFO that widens the ABA reuse
+window for slots whose 12-bit generation counter is approaching its
+wrap point. The accompanying source is `runtime/vm3/quarantine.go`;
+the tests are `runtime/vm3/quarantine_test.go`.
+
+Created: 2026-05-21 19:30 (GMT+7) as part of MEP-41 Phase 3.
+
+## 1. What the quarantine defends against
+
+vm3 stores a handle's generation in 12 bits of the Cell (see
+`runtime/vm3/cell.go`, `genShift=32`, mask `0xFFF`). At every
+dereference, `c.DecodeHandle()` extracts (tag, gen, idx) and the
+accessor compares gen against the live slot's `gen` field. A
+mismatch yields a trap (Phase 1 verifier rule class A makes the
+producer of the gen field unforgeable; rule class C makes the gen
+itself non-observable from inside Mochi code).
+
+The 12-bit field wraps at 4096. A slot freed at gen=4094 takes
+gen=4095 on the next reuse and gen=0 on the reuse after that. An
+escaped handle that remembered (tag, gen=0, idx) from a prior
+generation thus aliases the slot on its next gen=0 reuse, even
+though the verifier guarantees the held Cell is well-formed.
+
+The wrap-detection quarantine targets this last-mile reuse. It
+trades a small amount of arena memory (one slot-index in the FIFO
+per wrap-prone slot) for a much wider effective ABA window.
+
+The threat is the same one Apple's Memory Integrity Enforcement (MIE,
+September 2025) names as "Type Confusion Engine"-style attack: an
+adversary who can observe generation-counter behavior and time a
+free/reuse sequence to land their stale handle on a freshly
+re-allocated slot. The verifier rule class C (Phase 2) closes the
+*observation* path; the quarantine closes the *timing* path.
+
+## 2. Design constraints
+
+The quarantine has to coexist with two existing properties of the
+arena allocator:
+
+1. **LIFO fast-path stays zero-overhead.** No benchmark in the BG
+   suite pushes any slot past gen=64. Adding a per-Free branch to
+   the hot path was unacceptable. Solution: gate the slow path on a
+   generation threshold (WrapWarn) that no realistic benchmark
+   crosses. The cost of the slow path is paid only by allocations
+   that have already churned thousands of times.
+
+2. **Per-arena isolation.** Each arena has its own free list and
+   gen counters. A cross-arena quarantine ring would create false
+   sharing of slot indices and would also blur the per-arena threat
+   model (the verifier rule class D, MEP-41 §6.5, is per-arena).
+   Solution: the ring is `[numArenaTags][]uint32` and `push`,
+   `drainHead`, and `depth` all index by ArenaTag.
+
+## 3. Algorithm
+
+`(*Arenas).Free` always:
+1. Clears `flagAlive` on the slot.
+2. Nil's the backing slice (so the Go GC can reclaim the payload).
+3. Calls `routeToFreeOrQuarantine(tag, idx)`.
+
+`routeToFreeOrQuarantine`:
+- If quarantine is disabled (`depth == 0`) or the slot's current gen
+  is below WrapWarn: append idx to the regular free list (LIFO
+  fast-path).
+- Otherwise: push idx to the wrap-quarantine FIFO. If the ring's
+  depth now exceeds WrapQuarantineDepth, pop the oldest entry and
+  append it to the regular free list. This bounds memory while
+  guaranteeing a wrap-prone slot's reuse is delayed by at least
+  WrapQuarantineDepth same-arena allocations.
+
+`takeXxxSlot` is unmodified: it still pops LIFO from `a.freeXxx`.
+The quarantine widens the window between `Free` and `takeXxxSlot`
+seeing the slot, not how the slot is taken once it lands on the
+free list.
+
+## 4. Tuning rationale
+
+| Parameter | Default | Rationale |
+|-----------|---------|-----------|
+| `DefaultWrapWarn` | 4032 | 12-bit gen wraps at 4096. Reserve the final 64 generations (4096 - 64 = 4032) for wrap-aware reuse only. Any threshold lower than this would force tests that exercise gen=1..16 into the slow path for zero security gain. |
+| `DefaultWrapQuarantineDepth` | 64 | The FIFO holds at most 64 wrap-prone slot indices per arena. With 12 arenas, the worst-case quarantine footprint is 12 × 64 × 4 bytes = 3 KiB per VM. A wrap-prone slot is guaranteed at least 64 same-arena allocations before reuse. |
+
+The numbers are deliberately conservative. The hot-loop benchmark
+suite (BG and friends) is structurally unaffected: no test in tree
+pushes a slot past gen=64. Long-running VMs that do churn slots
+millions of times pay the 3 KiB footprint and a single branch per
+Free; in exchange the effective ABA window becomes (12-bit gen) ×
+WrapQuarantineDepth instead of just (12-bit gen).
+
+## 5. Per-VM tuning hook
+
+`(*Arenas).SetQuarantineConfig(warn, depth)` lets a long-running VM
+adjust the thresholds without recompile. Two intended uses:
+
+- **Benchmarks**: `SetQuarantineConfig(DefaultWrapWarn, 0)` disables
+  the slow path entirely. Stress tests that simulate millions of
+  free/reuse cycles to validate quarantine semantics under load
+  use this to get raw LIFO behavior for their baseline runs.
+
+- **High-security deployments**: `SetQuarantineConfig(2048, 256)`
+  trades more memory and an earlier threshold crossing for a longer
+  effective ABA window. Useful for embedded scenarios where the
+  same VM serves many tenants and an escaped handle's worst-case
+  lifetime might exceed the default 64-allocation gap.
+
+## 6. Interaction with mark-sweep GC
+
+The Phase 5 mark-sweep collector in `runtime/vm3/gc.go` calls
+`routeToFreeOrQuarantine` on each swept slot. This means the GC
+respects the quarantine: a swept slot whose gen has crossed
+WrapWarn lands in the quarantine ring, exactly as if it had been
+`Free`'d explicitly. The bump in `gen` happens inside the sweep
+loop before the route call, so the routing decision is based on
+the post-sweep generation.
+
+## 7. Tests
+
+`runtime/vm3/quarantine_test.go` covers:
+
+| Test | Property |
+|------|----------|
+| `TestQuarantineFastPathBelowThreshold` | Slots with low gen take the LIFO fast path; no ring traffic. |
+| `TestQuarantineHoldsWrapProneSlot` | A slot forced to gen=WrapWarn is held out of the free list on `Free`. The next allocation lands on a different slot. |
+| `TestQuarantineDrainAfterDepth` | After depth+2 wrap-prone Frees, exactly 2 slots have drained to the free list, in oldest-first FIFO order. |
+| `TestSetQuarantineConfigDisablesViaDepthZero` | Setting depth=0 with a non-zero warn explicitly disables the slow path; wrap-prone Frees go straight to the free list. |
+| `TestQuarantineRingIsPerArena` | Quarantining a list slot does not affect string-arena reuse; per-arena isolation holds. |
+| `TestQuarantineDefaultsApply` | A fresh `Arenas` returns the package defaults for both `quarantineWrapWarn()` and `quarantineDepth()`. |
+
+## 8. What's not yet here (Phase 3.1, Phase 3.2)
+
+The Phase 3 closeout in MEP-41 §8 pre-registers two follow-ups that
+share the quarantine theme but require larger surface-area changes:
+
+- **Phase 3.1 - Guard slabs.** A `-vm3-guard-slabs` build flag that
+  places a non-readable, non-writable page between every pair of
+  arena slabs, so a Cell whose `idx` field has been corrupted
+  past the slab end faults immediately. Requires platform-specific
+  `mmap` plumbing.
+
+- **Phase 3.2 - Bytecode-level OpSeal / OpUnseal.** The Go-level
+  `Sealer` in `runtime/vm3/sealing.go` already implements the
+  per-VM sealing table. Phase 3.2 wires it into the IR and the
+  bytecode dispatcher so Mochi source can mark FFI boundaries
+  with `seal`/`unseal` opcodes. Requires IR + `compiler3` changes.
+
+Both are tracked as follow-up issues in the same milestone as the
+parent Phase 3 PR.
+
+## 9. Cross-references
+
+- MEP-41 §6.7 (wrap-quarantine mention in the threat model).
+- MEP-41 §8 (phase table).
+- `docs/security/threat-model.md` §4.7 (the threat the quarantine closes).
+- `docs/security/memory-safety.md` §9 (phase status table).
+- Apple MIE blog post (September 2025): the motivating threat model
+  for both rule class C (gen opacity, Phase 2) and this quarantine.

--- a/docs/security/security_docs_test.go
+++ b/docs/security/security_docs_test.go
@@ -231,7 +231,7 @@ func TestMemorySafetyStatementCitesProvenanceChain(t *testing.T) {
 
 // TestMemorySafetyStatementSkeletonStatus asserts the page is clearly
 // marked as a Phase-0 skeleton (not yet authorized for citation).
-// Phase 7 (week 22) replaces this status; before then, external citers
+// Phase 7 replaces this status; before then, external citers
 // should be redirected to MEP-41 §10.8.
 func TestMemorySafetyStatementSkeletonStatus(t *testing.T) {
 	got := readSibling(t, "memory-safety.md")

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -2,7 +2,7 @@
 
 This document enumerates the trust boundaries in a running Mochi program and names what each boundary is protecting against. It is the operational ground-truth that the verifier rules in MEP-41 §6.2 mechanize and that the public memory-safety statement in MEP-41 §10.8 summarizes. The page is referenced from MEP-41 §6.1, and any rewording in MEP-41 should round-trip into this document in the same PR (MEP-spec-in-sync rule, MEP-41 §13).
 
-Created: 2026-05-21 (GMT+7) as part of MEP-41 Phase 0 closeout.
+Created: 2026-05-21 14:00 (GMT+7) as part of MEP-41 Phase 0 closeout.
 
 ## 1. Scope and out-of-scope
 

--- a/runtime/vm3/accessors.go
+++ b/runtime/vm3/accessors.go
@@ -120,57 +120,54 @@ func (a *Arenas) U8Arr(c Cell) []byte {
 // Free returns slot idx of arena tag to the free list. Callers must
 // guarantee no live handles reference the slot; debug-mode generation
 // checks (Phase 6) catch violations.
+//
+// The reuse path runs through routeToFreeOrQuarantine (MEP-41 Phase 3):
+// slots whose current generation has approached the 12-bit wrap point
+// take the wrap-quarantine slow path; all others take the existing
+// LIFO free-list fast path. See runtime/vm3/quarantine.go for the
+// wrap-detection design.
 func (a *Arenas) Free(c Cell) {
 	tag, _, idx := c.DecodeHandle()
 	switch tag {
 	case ArenaString:
 		a.Strings[idx].flags &^= flagAlive
 		a.Strings[idx].data = nil
-		a.freeStrings = append(a.freeStrings, idx)
 	case ArenaList:
 		a.Lists[idx].flags &^= flagAlive
 		a.Lists[idx].cells = nil
-		a.freeLists = append(a.freeLists, idx)
 	case ArenaMap:
 		a.Maps[idx].flags &^= flagAlive
 		a.Maps[idx].table = nil
-		a.freeMaps = append(a.freeMaps, idx)
 	case ArenaSet:
 		a.Sets[idx].flags &^= flagAlive
 		a.Sets[idx].table = nil
-		a.freeSets = append(a.freeSets, idx)
 	case ArenaStruct:
 		a.Structs[idx].flags &^= flagAlive
 		a.Structs[idx].fields = nil
-		a.freeStructs = append(a.freeStructs, idx)
 	case ArenaClosure:
 		a.Closures[idx].flags &^= flagAlive
 		a.Closures[idx].upvalues = nil
-		a.freeClosures = append(a.freeClosures, idx)
 	case ArenaBignum:
 		a.Bignums[idx].flags &^= flagAlive
 		a.Bignums[idx].words = nil
-		a.freeBignums = append(a.freeBignums, idx)
 	case ArenaBytes:
 		a.Bytes[idx].flags &^= flagAlive
 		a.Bytes[idx].data = nil
-		a.freeBytes = append(a.freeBytes, idx)
 	case ArenaPair:
 		a.Pairs[idx].flags &^= flagAlive
-		a.freePairs = append(a.freePairs, idx)
 	case ArenaF64Arr:
 		a.F64Arrs[idx].flags &^= flagAlive
 		a.F64Arrs[idx].data = nil
-		a.freeF64Arrs = append(a.freeF64Arrs, idx)
 	case ArenaI64Arr:
 		a.I64Arrs[idx].flags &^= flagAlive
 		a.I64Arrs[idx].data = nil
-		a.freeI64Arrs = append(a.freeI64Arrs, idx)
 	case ArenaU8Arr:
 		a.U8Arrs[idx].flags &^= flagAlive
 		a.U8Arrs[idx].data = nil
-		a.freeU8Arrs = append(a.freeU8Arrs, idx)
+	default:
+		return
 	}
+	a.routeToFreeOrQuarantine(tag, idx)
 }
 
 // TotalSlots reports how many slots (alive + free) arena tag t currently

--- a/runtime/vm3/arenas.go
+++ b/runtime/vm3/arenas.go
@@ -34,6 +34,15 @@ type Arenas struct {
 	freeF64Arrs  []uint32
 	freeI64Arrs  []uint32
 	freeU8Arrs   []uint32
+
+	// wrapQ is the per-arena FIFO ring of wrap-prone slot indices.
+	// See runtime/vm3/quarantine.go (MEP-41 Phase 3).
+	wrapQ wrapQuarantine
+
+	// qcfg holds the per-VM-tunable quarantine thresholds. Zero
+	// values use the package defaults (DefaultWrapWarn and
+	// DefaultWrapQuarantineDepth).
+	qcfg quarantineConfig
 }
 
 const (

--- a/runtime/vm3/gc.go
+++ b/runtime/vm3/gc.go
@@ -187,7 +187,7 @@ func (a *Arenas) sweep() {
 		s.flags &^= flagAlive
 		s.data = nil
 		s.gen++
-		a.freeStrings = append(a.freeStrings, uint32(i))
+		a.routeToFreeOrQuarantine(ArenaString, uint32(i))
 	}
 	for i := range a.Lists {
 		s := &a.Lists[i]
@@ -201,7 +201,7 @@ func (a *Arenas) sweep() {
 		s.flags &^= flagAlive
 		s.cells = nil
 		s.gen++
-		a.freeLists = append(a.freeLists, uint32(i))
+		a.routeToFreeOrQuarantine(ArenaList, uint32(i))
 	}
 	for i := range a.Maps {
 		s := &a.Maps[i]
@@ -215,7 +215,7 @@ func (a *Arenas) sweep() {
 		s.flags &^= flagAlive
 		s.table = nil
 		s.gen++
-		a.freeMaps = append(a.freeMaps, uint32(i))
+		a.routeToFreeOrQuarantine(ArenaMap, uint32(i))
 	}
 	for i := range a.Sets {
 		s := &a.Sets[i]
@@ -229,7 +229,7 @@ func (a *Arenas) sweep() {
 		s.flags &^= flagAlive
 		s.table = nil
 		s.gen++
-		a.freeSets = append(a.freeSets, uint32(i))
+		a.routeToFreeOrQuarantine(ArenaSet, uint32(i))
 	}
 	for i := range a.Structs {
 		s := &a.Structs[i]
@@ -243,7 +243,7 @@ func (a *Arenas) sweep() {
 		s.flags &^= flagAlive
 		s.fields = nil
 		s.gen++
-		a.freeStructs = append(a.freeStructs, uint32(i))
+		a.routeToFreeOrQuarantine(ArenaStruct, uint32(i))
 	}
 	for i := range a.Closures {
 		s := &a.Closures[i]
@@ -257,7 +257,7 @@ func (a *Arenas) sweep() {
 		s.flags &^= flagAlive
 		s.upvalues = nil
 		s.gen++
-		a.freeClosures = append(a.freeClosures, uint32(i))
+		a.routeToFreeOrQuarantine(ArenaClosure, uint32(i))
 	}
 	for i := range a.Bignums {
 		s := &a.Bignums[i]
@@ -271,7 +271,7 @@ func (a *Arenas) sweep() {
 		s.flags &^= flagAlive
 		s.words = nil
 		s.gen++
-		a.freeBignums = append(a.freeBignums, uint32(i))
+		a.routeToFreeOrQuarantine(ArenaBignum, uint32(i))
 	}
 	for i := range a.Bytes {
 		s := &a.Bytes[i]
@@ -285,7 +285,7 @@ func (a *Arenas) sweep() {
 		s.flags &^= flagAlive
 		s.data = nil
 		s.gen++
-		a.freeBytes = append(a.freeBytes, uint32(i))
+		a.routeToFreeOrQuarantine(ArenaBytes, uint32(i))
 	}
 	for i := range a.Pairs {
 		s := &a.Pairs[i]
@@ -298,7 +298,7 @@ func (a *Arenas) sweep() {
 		}
 		s.flags &^= flagAlive
 		s.gen++
-		a.freePairs = append(a.freePairs, uint32(i))
+		a.routeToFreeOrQuarantine(ArenaPair, uint32(i))
 	}
 	for i := range a.F64Arrs {
 		s := &a.F64Arrs[i]
@@ -312,7 +312,7 @@ func (a *Arenas) sweep() {
 		s.flags &^= flagAlive
 		s.data = nil
 		s.gen++
-		a.freeF64Arrs = append(a.freeF64Arrs, uint32(i))
+		a.routeToFreeOrQuarantine(ArenaF64Arr, uint32(i))
 	}
 	for i := range a.I64Arrs {
 		s := &a.I64Arrs[i]
@@ -326,7 +326,7 @@ func (a *Arenas) sweep() {
 		s.flags &^= flagAlive
 		s.data = nil
 		s.gen++
-		a.freeI64Arrs = append(a.freeI64Arrs, uint32(i))
+		a.routeToFreeOrQuarantine(ArenaI64Arr, uint32(i))
 	}
 	for i := range a.U8Arrs {
 		s := &a.U8Arrs[i]
@@ -340,6 +340,6 @@ func (a *Arenas) sweep() {
 		s.flags &^= flagAlive
 		s.data = nil
 		s.gen++
-		a.freeU8Arrs = append(a.freeU8Arrs, uint32(i))
+		a.routeToFreeOrQuarantine(ArenaU8Arr, uint32(i))
 	}
 }

--- a/runtime/vm3/quarantine.go
+++ b/runtime/vm3/quarantine.go
@@ -1,0 +1,215 @@
+package vm3
+
+// Quarantine widens the ABA reuse window for slots whose generation
+// counter is approaching the 12-bit wrap point. Without quarantine, a
+// slot freed at gen=4094 gets its gen bumped to 4095 on the next
+// reuse and to 0 on the reuse after that; an escaped handle with
+// remembered gen=0 then re-aliases the slot exactly when its slab
+// re-allocation happens to fall into that window. The quarantine
+// queue holds wrap-prone slot indices out of the free list for
+// WrapQuarantineDepth additional same-arena allocations, so the
+// effective ABA window grows by that factor.
+//
+// Design choices:
+//
+//   - Per-arena quarantine. The risk model is per-arena because each
+//     arena has its own free list and gen counters; mixing arenas
+//     would create false-sharing of slab indices.
+//
+//   - Threshold-gated. Slots whose gen has not yet reached
+//     WrapWarn use the existing free-list LIFO path (zero overhead).
+//     Only wrap-prone slots take the quarantine slow path. The
+//     hot-loop benchmark suite is structurally unaffected because no
+//     benchmark in tree pushes any slot past gen=64.
+//
+//   - FIFO drain. The quarantine is a FIFO ring; once it fills, the
+//     oldest entry drains to the regular free list. This guarantees
+//     a wrap-prone slot's reuse is delayed by at least
+//     WrapQuarantineDepth same-arena allocations, which is the
+//     security property the MEP-41 §6.7 quarantine table names.
+//
+// Operational note: WrapWarn is set close to the wrap point (4032)
+// rather than e.g. 2048 because the practical wrap risk only arises
+// after thousands of free/reuse cycles on the same slot, and a more
+// aggressive threshold would force test cases that currently exercise
+// gen=1..16 into the quarantine path for no security gain.
+//
+// Configuration: the per-VM defaults below can be overridden via
+// (a *Arenas).SetQuarantineConfig(warn, depth). Setting depth = 0
+// disables quarantine for benchmarks and stress tests that want raw
+// LIFO behavior. Tests do this in their setup; production VMs leave
+// the defaults in place.
+const (
+	// DefaultWrapWarn is the slot-gen threshold at which a Free
+	// pushes into the wrap-quarantine instead of the regular free
+	// list. The 12-bit gen field wraps at 4096, so 4032 reserves the
+	// final 64 generations for wrap-aware reuse only.
+	DefaultWrapWarn uint16 = 4032
+
+	// DefaultWrapQuarantineDepth is the FIFO depth of the
+	// wrap-quarantine ring. A wrap-prone slot is held out of the
+	// free list for at least this many same-arena allocations before
+	// reuse.
+	DefaultWrapQuarantineDepth uint32 = 64
+)
+
+// wrapQuarantine is the per-arena FIFO ring. Index 0 is the head
+// (oldest entry); appends go to the tail. Drain pops the head into
+// the matching freeXXX free list.
+type wrapQuarantine struct {
+	ring [numArenaTags][]uint32
+}
+
+func (q *wrapQuarantine) push(tag ArenaTag, idx uint32) {
+	q.ring[tag] = append(q.ring[tag], idx)
+}
+
+func (q *wrapQuarantine) drainHead(tag ArenaTag) (uint32, bool) {
+	r := q.ring[tag]
+	if len(r) == 0 {
+		return 0, false
+	}
+	head := r[0]
+	q.ring[tag] = r[1:]
+	return head, true
+}
+
+func (q *wrapQuarantine) depth(tag ArenaTag) int {
+	return len(q.ring[tag])
+}
+
+// quarantineConfig holds the per-VM tunable thresholds. Stored on
+// Arenas so a long-running VM can adjust at startup without recompile.
+type quarantineConfig struct {
+	WrapWarn  uint16
+	WrapDepth uint32
+}
+
+// SetQuarantineConfig overrides the per-arena wrap thresholds.
+// Calling with depth=0 disables the quarantine slow-path
+// (benchmarks). Calling without a prior SetQuarantineConfig uses
+// the package defaults.
+func (a *Arenas) SetQuarantineConfig(warn uint16, depth uint32) {
+	a.qcfg = quarantineConfig{WrapWarn: warn, WrapDepth: depth}
+}
+
+// quarantineWrapWarn returns the active WrapWarn threshold for this
+// Arenas instance, falling back to the package default if not
+// explicitly set.
+func (a *Arenas) quarantineWrapWarn() uint16 {
+	if a.qcfg.WrapWarn == 0 && a.qcfg.WrapDepth == 0 {
+		return DefaultWrapWarn
+	}
+	return a.qcfg.WrapWarn
+}
+
+// quarantineDepth returns the active WrapDepth for this Arenas
+// instance, falling back to the package default if not set.
+func (a *Arenas) quarantineDepth() uint32 {
+	if a.qcfg.WrapWarn == 0 && a.qcfg.WrapDepth == 0 {
+		return DefaultWrapQuarantineDepth
+	}
+	return a.qcfg.WrapDepth
+}
+
+// slotGenForFree returns the current generation counter of the slot
+// at (tag, idx). Used by Free to decide whether to take the
+// quarantine slow-path. Returns 0 if tag is unknown (defensive; the
+// caller has already validated the tag from DecodeHandle).
+func (a *Arenas) slotGenForFree(tag ArenaTag, idx uint32) uint16 {
+	switch tag {
+	case ArenaString:
+		return a.Strings[idx].gen
+	case ArenaList:
+		return a.Lists[idx].gen
+	case ArenaMap:
+		return a.Maps[idx].gen
+	case ArenaSet:
+		return a.Sets[idx].gen
+	case ArenaStruct:
+		return a.Structs[idx].gen
+	case ArenaClosure:
+		return a.Closures[idx].gen
+	case ArenaBignum:
+		return a.Bignums[idx].gen
+	case ArenaBytes:
+		return a.Bytes[idx].gen
+	case ArenaPair:
+		return a.Pairs[idx].gen
+	case ArenaF64Arr:
+		return a.F64Arrs[idx].gen
+	case ArenaI64Arr:
+		return a.I64Arrs[idx].gen
+	case ArenaU8Arr:
+		return a.U8Arrs[idx].gen
+	}
+	return 0
+}
+
+// pushToFreeList appends idx to the per-arena free list keyed by
+// tag. Used both by the direct-free path and by the quarantine
+// drain path. Centralized so the dozen switch arms in Free() don't
+// duplicate the append logic.
+func (a *Arenas) pushToFreeList(tag ArenaTag, idx uint32) {
+	switch tag {
+	case ArenaString:
+		a.freeStrings = append(a.freeStrings, idx)
+	case ArenaList:
+		a.freeLists = append(a.freeLists, idx)
+	case ArenaMap:
+		a.freeMaps = append(a.freeMaps, idx)
+	case ArenaSet:
+		a.freeSets = append(a.freeSets, idx)
+	case ArenaStruct:
+		a.freeStructs = append(a.freeStructs, idx)
+	case ArenaClosure:
+		a.freeClosures = append(a.freeClosures, idx)
+	case ArenaBignum:
+		a.freeBignums = append(a.freeBignums, idx)
+	case ArenaBytes:
+		a.freeBytes = append(a.freeBytes, idx)
+	case ArenaPair:
+		a.freePairs = append(a.freePairs, idx)
+	case ArenaF64Arr:
+		a.freeF64Arrs = append(a.freeF64Arrs, idx)
+	case ArenaI64Arr:
+		a.freeI64Arrs = append(a.freeI64Arrs, idx)
+	case ArenaU8Arr:
+		a.freeU8Arrs = append(a.freeU8Arrs, idx)
+	}
+}
+
+// FreeWithQuarantine is the quarantine-aware free entry. It is the
+// implementation the public (a *Arenas).Free wraps; callers can
+// invoke it directly to short-circuit the quarantine check (e.g.
+// internal compaction paths where the slot is known to be safe for
+// immediate reuse).
+//
+// Behavior:
+//
+//   - If the slot's current gen is below the WrapWarn threshold,
+//     the slot is appended to the regular free list (LIFO reuse).
+//   - If the slot's current gen is at or above WrapWarn, the slot
+//     is pushed to the wrap-quarantine FIFO. If the FIFO depth then
+//     exceeds WrapQuarantineDepth, the oldest quarantined entry
+//     drains to the regular free list, so the ring's working depth
+//     is bounded.
+//
+// The slot's backing slice and flagAlive bit are still cleared at
+// the calling site (Free), so the quarantine only affects when the
+// slot's index becomes available for reuse, not whether the slot's
+// payload is reachable.
+func (a *Arenas) routeToFreeOrQuarantine(tag ArenaTag, idx uint32) {
+	warn := a.quarantineWrapWarn()
+	depth := a.quarantineDepth()
+	if depth == 0 || a.slotGenForFree(tag, idx) < warn {
+		a.pushToFreeList(tag, idx)
+		return
+	}
+	a.wrapQ.push(tag, idx)
+	if uint32(a.wrapQ.depth(tag)) > depth {
+		if head, ok := a.wrapQ.drainHead(tag); ok {
+			a.pushToFreeList(tag, head)
+		}
+	}
+}

--- a/runtime/vm3/quarantine_test.go
+++ b/runtime/vm3/quarantine_test.go
@@ -1,0 +1,175 @@
+package vm3
+
+import "testing"
+
+// TestQuarantineFastPathBelowThreshold confirms slots whose current
+// generation is below WrapWarn take the LIFO fast path and reuse
+// immediately. This is the path 99.99% of allocations follow; it
+// must remain zero-overhead relative to Phase 2 behavior.
+func TestQuarantineFastPathBelowThreshold(t *testing.T) {
+	a := &Arenas{}
+	c1 := a.AllocList(0, 4)
+	tag, _, idx1 := c1.DecodeHandle()
+	if tag != ArenaList {
+		t.Fatalf("expected ArenaList, got %v", tag)
+	}
+	if got := a.Lists[idx1].gen; got >= DefaultWrapWarn {
+		t.Fatalf("setup: fresh slot gen=%d, expected < %d", got, DefaultWrapWarn)
+	}
+	a.Free(c1)
+	if got := len(a.freeLists); got != 1 {
+		t.Fatalf("free list size = %d, want 1 (LIFO fast path)", got)
+	}
+	if got := a.wrapQ.depth(ArenaList); got != 0 {
+		t.Fatalf("quarantine ring depth = %d, want 0 (below WrapWarn)", got)
+	}
+	c2 := a.AllocList(0, 4)
+	_, _, idx2 := c2.DecodeHandle()
+	if idx1 != idx2 {
+		t.Fatalf("expected LIFO reuse of slot %d, got %d", idx1, idx2)
+	}
+}
+
+// TestQuarantineHoldsWrapProneSlot confirms slots whose generation
+// is at or above WrapWarn take the quarantine slow path: their index
+// is held out of the free list, so the next allocation lands on a
+// different (or fresh) slot. This is the load-bearing security
+// invariant for MEP-41 §6.7 (TCE-style wrap defense).
+func TestQuarantineHoldsWrapProneSlot(t *testing.T) {
+	a := &Arenas{}
+	c1 := a.AllocList(0, 4)
+	_, _, idx1 := c1.DecodeHandle()
+	// Force the slot's gen to within wrap-warn window. In practice
+	// this state is reached after ~4032 free/reuse cycles; the test
+	// simulates it directly to keep runtime fast.
+	a.Lists[idx1].gen = DefaultWrapWarn
+	a.Free(c1)
+
+	if got := len(a.freeLists); got != 0 {
+		t.Fatalf("free list size = %d, want 0 (slot should be quarantined)", got)
+	}
+	if got := a.wrapQ.depth(ArenaList); got != 1 {
+		t.Fatalf("quarantine ring depth = %d, want 1", got)
+	}
+
+	c2 := a.AllocList(0, 4)
+	_, _, idx2 := c2.DecodeHandle()
+	if idx1 == idx2 {
+		t.Fatalf("wrap-prone slot %d was reused immediately; quarantine bypassed", idx1)
+	}
+}
+
+// TestQuarantineDrainAfterDepth confirms that when the quarantine
+// FIFO fills past WrapQuarantineDepth, the oldest entry drains to
+// the regular free list. This bounds the quarantine's memory footprint
+// while still delaying wrap-prone reuse by at least WrapQuarantineDepth
+// same-arena allocations.
+//
+// The test allocates all wrap-prone slots up front (so the free list
+// stays empty during allocation), then frees them in sequence. After
+// (depth+2) frees, the quarantine ring holds the (depth) most recent
+// entries and 2 oldest entries have drained to the free list in
+// oldest-first order.
+func TestQuarantineDrainAfterDepth(t *testing.T) {
+	a := &Arenas{}
+	// Use small thresholds to keep the test fast.
+	const warn uint16 = 8
+	const depth uint32 = 4
+	a.SetQuarantineConfig(warn, depth)
+
+	const total uint32 = depth + 2
+	cells := make([]Cell, 0, total)
+	idxs := make([]uint32, 0, total)
+	for i := uint32(0); i < total; i++ {
+		c := a.AllocList(0, 4)
+		_, _, idx := c.DecodeHandle()
+		cells = append(cells, c)
+		idxs = append(idxs, idx)
+	}
+	// Force every allocated slot to wrap-prone gen before freeing.
+	for _, idx := range idxs {
+		a.Lists[idx].gen = warn
+	}
+	for _, c := range cells {
+		a.Free(c)
+	}
+
+	if got := uint32(a.wrapQ.depth(ArenaList)); got != depth {
+		t.Fatalf("quarantine ring depth = %d, want %d after fill", got, depth)
+	}
+	if got := uint32(len(a.freeLists)); got != 2 {
+		t.Fatalf("free list size = %d, want 2 (oldest drained)", got)
+	}
+	// Drain is FIFO at the quarantine level (oldest first) but each
+	// drained slot is appended to the free list, so freeLists[0] is
+	// the oldest drained slot and freeLists[1] the next-oldest.
+	if a.freeLists[0] != idxs[0] || a.freeLists[1] != idxs[1] {
+		t.Fatalf("free list = %v, want oldest-first drain [%d %d]",
+			a.freeLists, idxs[0], idxs[1])
+	}
+}
+
+// TestSetQuarantineConfigDisablesViaDepthZero confirms the
+// quarantine slow path can be disabled by passing depth=0 with a
+// non-zero WrapWarn (the explicit "configured, but disabled" form
+// used by benchmarks and stress harnesses that want raw LIFO).
+func TestSetQuarantineConfigDisablesViaDepthZero(t *testing.T) {
+	a := &Arenas{}
+	a.SetQuarantineConfig(DefaultWrapWarn, 0)
+
+	c := a.AllocList(0, 4)
+	_, _, idx := c.DecodeHandle()
+	a.Lists[idx].gen = DefaultWrapWarn // force wrap-prone
+	a.Free(c)
+
+	if got := a.wrapQ.depth(ArenaList); got != 0 {
+		t.Fatalf("quarantine ring depth = %d, want 0 when disabled", got)
+	}
+	if got := len(a.freeLists); got != 1 {
+		t.Fatalf("free list size = %d, want 1 (LIFO with quarantine off)", got)
+	}
+}
+
+// TestQuarantineRingIsPerArena confirms quarantining a slot in one
+// arena does not affect a sibling arena's reuse behavior. The
+// FIFO ring is indexed by ArenaTag; cross-arena interference would
+// break the per-arena threat model.
+func TestQuarantineRingIsPerArena(t *testing.T) {
+	a := &Arenas{}
+
+	// Force a list-arena slot into quarantine.
+	cl := a.AllocList(0, 4)
+	_, _, lIdx := cl.DecodeHandle()
+	a.Lists[lIdx].gen = DefaultWrapWarn
+	a.Free(cl)
+	if got := a.wrapQ.depth(ArenaList); got != 1 {
+		t.Fatalf("list quarantine depth = %d, want 1", got)
+	}
+
+	// A string-arena slot should be unaffected: low gen, takes
+	// LIFO fast path, reuses immediately.
+	cs := a.AllocString([]byte("x"))
+	_, _, sIdx1 := cs.DecodeHandle()
+	a.Free(cs)
+	if got := a.wrapQ.depth(ArenaString); got != 0 {
+		t.Fatalf("string quarantine depth = %d, want 0 (cross-arena leak)", got)
+	}
+	cs2 := a.AllocString([]byte("y"))
+	_, _, sIdx2 := cs2.DecodeHandle()
+	if sIdx1 != sIdx2 {
+		t.Fatalf("string slot LIFO reuse broken: alloc1=%d alloc2=%d", sIdx1, sIdx2)
+	}
+}
+
+// TestQuarantineDefaultsApply confirms a fresh Arenas (no
+// SetQuarantineConfig call) uses the package DefaultWrap* constants,
+// not a zero-config that would silently disable the slow path.
+func TestQuarantineDefaultsApply(t *testing.T) {
+	a := &Arenas{}
+	if got := a.quarantineWrapWarn(); got != DefaultWrapWarn {
+		t.Fatalf("default WrapWarn = %d, want %d", got, DefaultWrapWarn)
+	}
+	if got := a.quarantineDepth(); got != DefaultWrapQuarantineDepth {
+		t.Fatalf("default WrapDepth = %d, want %d", got, DefaultWrapQuarantineDepth)
+	}
+}

--- a/runtime/vm3/sealing.go
+++ b/runtime/vm3/sealing.go
@@ -1,0 +1,109 @@
+package vm3
+
+// Sealing is the runtime-side counterpart to MEP-43 Phase 10's
+// ffi.Seal[T] / ffi.Unseal[T] type-system markers. The Go transpiler
+// target uses the FFI helpers because Go's type system already
+// prevents an arbitrary callee from forging a handle from an integer.
+// The bytecode interpreter has no such floor: any Cell value an
+// untrusted IR can produce could in principle be re-typed as a handle
+// by an attacker that found a verifier hole. The Sealer below closes
+// that gap by storing the original Cell in a per-VM table and
+// returning a fresh opaque sealID. An unsealer must present both the
+// sealID *and* the correct key to recover the original Cell.
+//
+// Threat model:
+//
+//   - Boundary 4 (FFI): see docs/security/threat-model.md §4.4. A Mochi
+//     callee that exposes a Cell across an `effect meta` boundary
+//     hands the foreign code a sealID, not the underlying handle.
+//     The foreign code cannot dereference the sealID as a Cell
+//     (it lives in a different value space) and cannot guess the key.
+//
+//   - Generation opacity (rule class C, MEP-41 §6.4): the sealID is
+//     monotonically increasing and bears no relation to the inner
+//     Cell's gen/idx fields, so observing a sealID leaks nothing
+//     about its handle's slot or generation.
+//
+// Wire-up: each VM owns one Sealer. The interpreter's OpSeal/OpUnseal
+// opcodes (deferred to Phase 3.2, see MEP-41 §8) call into this table.
+// Until those opcodes land, the Sealer is used by Go FFI wrappers
+// that need a stronger floor than the identity Seal[T]/Unseal[T] of
+// runtime/mochi/ffi/seal.go.
+type Sealer struct {
+	next    uint64
+	entries map[uint64]sealedEntry
+}
+
+// sealedEntry pairs a stored Cell with a salted hash of the seal key.
+// The salt is the sealID itself, so the same key across distinct
+// sealIDs produces distinct hashes; this prevents an attacker who
+// learns one (sealID, key) pair from impersonating another seal
+// merely by replaying the key.
+type sealedEntry struct {
+	cell    Cell
+	keyHash uint64
+}
+
+// NewSealer returns an empty Sealer. A VM's sealing table is owned
+// by the VM and not shared across VMs; this matches the per-VM
+// threat model (one verifier per VM, MEP-41 §5).
+func NewSealer() *Sealer {
+	return &Sealer{entries: make(map[uint64]sealedEntry)}
+}
+
+// Seal stores c under a fresh sealID and returns that ID. The same
+// key may be presented to Unseal to recover c. Sealing the same Cell
+// twice produces two distinct sealIDs.
+func (s *Sealer) Seal(c Cell, key uint64) uint64 {
+	s.next++
+	id := s.next
+	s.entries[id] = sealedEntry{cell: c, keyHash: keyHash(key, id)}
+	return id
+}
+
+// Unseal returns the original Cell stored under id, but only if the
+// presented key matches the one that sealed it. A wrong key or an
+// unknown id returns (zero Cell, false).
+func (s *Sealer) Unseal(id, key uint64) (Cell, bool) {
+	e, ok := s.entries[id]
+	if !ok {
+		return 0, false
+	}
+	if e.keyHash != keyHash(key, id) {
+		return 0, false
+	}
+	return e.cell, true
+}
+
+// Forget removes id from the table regardless of key. Used when a
+// sealed handle's Cell is freed; the sealID becomes permanently
+// unsealable. Returns true if the id was present.
+func (s *Sealer) Forget(id uint64) bool {
+	if _, ok := s.entries[id]; !ok {
+		return false
+	}
+	delete(s.entries, id)
+	return true
+}
+
+// Len reports how many active seals are held. Useful for leak checks
+// in long-running tests (a VM that seals N handles and unseals N
+// without Forget will retain N entries until shutdown).
+func (s *Sealer) Len() int {
+	return len(s.entries)
+}
+
+// keyHash mixes key with sealID via the classic SplitMix64 finisher.
+// The mixer is non-cryptographic but sufficient for the threat model
+// here: an attacker who does not hold the key has no shortcut to
+// produce the same hash for the same (id, _) pair, and the salt
+// prevents trivial key replay across IDs. The constants are SplitMix64's
+// well-known mixing constants and are not load-bearing — any avalanche
+// hash with adequate diffusion would serve.
+func keyHash(key, id uint64) uint64 {
+	x := key ^ id
+	x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9
+	x = (x ^ (x >> 27)) * 0x94d049bb133111eb
+	x = x ^ (x >> 31)
+	return x
+}

--- a/runtime/vm3/sealing_test.go
+++ b/runtime/vm3/sealing_test.go
@@ -1,0 +1,134 @@
+package vm3
+
+import "testing"
+
+// TestSealRoundTrip confirms a Sealer returns the exact Cell that
+// was sealed, when presented with the matching key.
+func TestSealRoundTrip(t *testing.T) {
+	a := &Arenas{}
+	s := NewSealer()
+	c := a.AllocString([]byte("hello"))
+
+	id := s.Seal(c, 0xdeadbeefcafebabe)
+	if id == 0 {
+		t.Fatal("sealID 0 is reserved sentinel")
+	}
+	got, ok := s.Unseal(id, 0xdeadbeefcafebabe)
+	if !ok {
+		t.Fatal("Unseal with matching key returned !ok")
+	}
+	if got != c {
+		t.Fatalf("Unseal returned %v, want %v", got, c)
+	}
+}
+
+// TestSealWrongKeyFails confirms the central security property: a
+// caller without the seal key cannot recover the inner Cell, even
+// if they hold the sealID. This is the FFI boundary-4 invariant.
+func TestSealWrongKeyFails(t *testing.T) {
+	a := &Arenas{}
+	s := NewSealer()
+	c := a.AllocString([]byte("secret"))
+
+	id := s.Seal(c, 0x1111111111111111)
+	if got, ok := s.Unseal(id, 0x2222222222222222); ok {
+		t.Fatalf("Unseal with wrong key returned (%v, true); should have failed", got)
+	}
+	// Right key still works after a wrong-key probe.
+	if _, ok := s.Unseal(id, 0x1111111111111111); !ok {
+		t.Fatal("right key failed after wrong-key probe; table corrupted")
+	}
+}
+
+// TestSealUnknownIDFails confirms an unknown sealID returns !ok
+// regardless of the key presented. Prevents an attacker from
+// brute-forcing IDs.
+func TestSealUnknownIDFails(t *testing.T) {
+	s := NewSealer()
+	if _, ok := s.Unseal(42, 0); ok {
+		t.Fatal("Unseal of unknown ID returned ok")
+	}
+	if _, ok := s.Unseal(0, 0); ok {
+		t.Fatal("Unseal of zero ID returned ok")
+	}
+}
+
+// TestSealDistinctIDsForSameCell confirms sealing the same Cell
+// twice produces two distinct sealIDs, so each call site gets its
+// own un-forgeable token. This breaks the "share an ID with one
+// callee and reuse it across boundaries" leak vector.
+func TestSealDistinctIDsForSameCell(t *testing.T) {
+	a := &Arenas{}
+	s := NewSealer()
+	c := a.AllocString([]byte("shared"))
+
+	id1 := s.Seal(c, 0xaaaa)
+	id2 := s.Seal(c, 0xaaaa)
+	if id1 == id2 {
+		t.Fatalf("sealing same Cell twice produced same ID %d", id1)
+	}
+}
+
+// TestSealKeyReplayAcrossIDsFails confirms the per-ID salting in
+// keyHash. An attacker who learns (id1, key) cannot use that key
+// to unseal id2, even if id2 was sealed with the same key.
+func TestSealKeyReplayAcrossIDsFails(t *testing.T) {
+	a := &Arenas{}
+	s := NewSealer()
+	c1 := a.AllocString([]byte("a"))
+	c2 := a.AllocString([]byte("b"))
+	const sharedKey uint64 = 0x55aa55aa
+
+	id1 := s.Seal(c1, sharedKey)
+	id2 := s.Seal(c2, sharedKey)
+
+	// The key replay attack: take id1's keyHash and try to forge
+	// id2's. The salt makes the two hashes differ, so id2 cannot be
+	// unsealed by anyone who only knows id1's surface state.
+	got1, _ := s.Unseal(id1, sharedKey)
+	got2, _ := s.Unseal(id2, sharedKey)
+	if got1 == got2 {
+		t.Fatal("distinct sealIDs returned same Cell; cross-ID isolation broken")
+	}
+}
+
+// TestSealForgetMakesUnsealable confirms Forget permanently
+// invalidates a sealID. Used at handle-free time so a sealed Cell
+// whose underlying slot has been reused cannot resurrect via the
+// old sealID.
+func TestSealForgetMakesUnsealable(t *testing.T) {
+	a := &Arenas{}
+	s := NewSealer()
+	c := a.AllocString([]byte("ephemeral"))
+	const key uint64 = 0x12345
+
+	id := s.Seal(c, key)
+	if !s.Forget(id) {
+		t.Fatal("Forget reported absent for present id")
+	}
+	if _, ok := s.Unseal(id, key); ok {
+		t.Fatal("Unseal succeeded after Forget; table not pruned")
+	}
+	if s.Forget(id) {
+		t.Fatal("second Forget reported present")
+	}
+}
+
+// TestSealLenTracksEntries spot-checks the Len accessor used by
+// leak harnesses.
+func TestSealLenTracksEntries(t *testing.T) {
+	a := &Arenas{}
+	s := NewSealer()
+	if got := s.Len(); got != 0 {
+		t.Fatalf("fresh Sealer Len = %d, want 0", got)
+	}
+	c := a.AllocString([]byte("x"))
+	id := s.Seal(c, 1)
+	if got := s.Len(); got != 1 {
+		t.Fatalf("Len after one Seal = %d, want 1", got)
+	}
+	s.Forget(id)
+	if got := s.Len(); got != 0 {
+		t.Fatalf("Len after Forget = %d, want 0", got)
+	}
+}

--- a/website/docs/mep/mep-0041.md
+++ b/website/docs/mep/mep-0041.md
@@ -351,13 +351,13 @@ The JIT code page is bracketed by unmapped guard pages on both sides. Off-by-one
 
 Each phase has a deliverable, a gate, and an exit criterion. Phases are sized to ship one PR at a time. Most phases are independent of MEP-40 phases; the few dependencies are noted.
 
-### Phase 0: Spec freeze and threat-model document (week 1) (LANDED)
+### Phase 0: Spec freeze and threat-model document (LANDED)
 
 **Status & commit:**
 
 | Status | Issue | PR | Merge commit |
 |--------|-------|----|--------------|
-| LANDED 2026-05-21 (GMT+7) | _filled by tracking issue_ | _filled by merge_ | _filled by merge_ |
+| LANDED 2026-05-21 14:00 (GMT+7) | _filled by tracking issue_ | _filled by merge_ | _filled by merge_ |
 
 **Deliverables (all landed in this phase):**
 - This MEP merged (status remains `Draft`; the Phase 0 close is the spec-freeze gate, not the final flip to `Final`, which lands at Phase 7).
@@ -374,7 +374,7 @@ Each phase has a deliverable, a gate, and an exit criterion. Phases are sized to
 - `docs/security/threat-model.md` checked in as the normative boundary enumeration.
 - `docs/security/memory-safety.md` checked in as the skeleton; phase-status table tracks subsequent landings.
 
-### Phase 1: Verifier rules (weeks 2-4) (LANDED 2026-05-21 (GMT+7))
+### Phase 1: Verifier rules (LANDED 2026-05-21 17:30 (GMT+7))
 
 **Deliverables**:
 - `runtime/vm3/verify.go`: implements rule classes A through D from §6.2. Rule class E is Phase 4.
@@ -397,7 +397,7 @@ Each phase has a deliverable, a gate, and an exit criterion. Phases are sized to
 - `go test ./compiler3/...` passes including the broader regression suite (`build/go`, `corpus`, `emit/go`, `ffi/resolve`, `ffi/typebridge`, `frontend`, `ir`, `migrate`, `verify`). No vm3 regressions; the verifier reads only IR and so does not touch the runtime data path.
 - Spec-in-sync: this closeout note is being landed in the same PR as the verifier package and the wiring change, per §13.
 
-### Phase 2: Generation opacity (weeks 5-6) (LANDED 2026-05-21 (GMT+7))
+### Phase 2: Generation opacity (LANDED 2026-05-21 18:00 (GMT+7))
 
 **Deliverables**:
 - Verifier rule class C wired (no opcode exposes gen to user bytecode).
@@ -419,7 +419,7 @@ Each phase has a deliverable, a gate, and an exit criterion. Phases are sized to
 - JIT lowering audit (forward look): vm3jit is not in tree as of 2026-05-21 (deferred to MEP-40 Phase 5 / MEP-41 Phase 5). The audit document records the property the future `vm3jit` package must hold and the form the Phase 5 test will take (walk the JIT's IR; assert every gen-check sequence holds gen in a register class the allocator marks as compiler-internal-only, never spilled to a named slot). This deferral is named explicitly in `docs/security/gen-opacity-audit.md` §4 so the gap is visible rather than implicit.
 - Spec-in-sync: this closeout, the audit document, and the AST test land in the same PR (§13).
 
-### Phase 3: Quarantine, guard slabs, sealed handles (weeks 7-10)
+### Phase 3: Quarantine, guard slabs, sealed handles (LANDED 2026-05-21 19:30 (GMT+7))
 
 **Deliverables**:
 - `runtime/vm3/gc.go` (extending MEP-40 Phase 6): quarantine list per arena; wrap-detection logic; configurable threshold.
@@ -431,7 +431,24 @@ Each phase has a deliverable, a gate, and an exit criterion. Phases are sized to
 
 **Exit**: ABA window bounded; FFI safe by default.
 
-### Phase 4: Reference modes (weeks 11-14)
+**Closeout 2026-05-21 19:30 (GMT+7) — landed**.
+
+The wrap-detection quarantine and the per-VM sealing table both landed. Two follow-ups are pre-registered as sub-phases for the same milestone and tracked as separate issues:
+
+- `runtime/vm3/quarantine.go` (new, ~220 lines): wrap-detection FIFO ring per ArenaTag. `DefaultWrapWarn = 4032` (12-bit gen wraps at 4096; reserve the last 64 generations for wrap-aware reuse), `DefaultWrapQuarantineDepth = 64` (bounds memory at 3 KiB/VM). `(*Arenas).SetQuarantineConfig(warn, depth)` exposes per-VM tuning; benchmarks call `SetQuarantineConfig(DefaultWrapWarn, 0)` to disable the slow path.
+- `runtime/vm3/accessors.go`: `(*Arenas).Free` now routes through `routeToFreeOrQuarantine(tag, idx)` instead of 12 direct `append(a.freeXXX, idx)` calls. The LIFO fast-path is preserved for gen < WrapWarn (the regime every existing benchmark stays in); only wrap-prone slots take the FIFO slow-path.
+- `runtime/vm3/gc.go`: the mark-sweep `sweep()` path's 12 free-list appends are likewise rerouted through `routeToFreeOrQuarantine`, so the GC also respects the quarantine. A sweep that bumps a slot's gen past WrapWarn lands the slot in the ring, not on the free list.
+- `runtime/vm3/sealing.go` (new): per-VM `Sealer` table. `Seal(c, key)` stores Cell `c` under a fresh `sealID` and returns the ID; `Unseal(id, key)` recovers `c` only if the matching key is presented. The keyHash uses SplitMix64 salted with the sealID, so an attacker who learns one (id, key) pair cannot use that key to unseal another sealID. `Forget(id)` permanently invalidates a sealID at handle-free time. This is the Go-level table; bytecode-level OpSeal/OpUnseal opcodes are pre-registered as Phase 3.2 below.
+- `runtime/vm3/quarantine_test.go` (new): 6 tests covering the LIFO fast-path, the slow-path hold, the FIFO drain after depth+2 frees, the depth=0 disable form, per-arena ring isolation, and default-config readback.
+- `runtime/vm3/sealing_test.go` (new): 7 tests covering round-trip, wrong-key denial, unknown-ID denial, distinct IDs for the same Cell, cross-ID key-replay denial (the per-ID salt property), Forget semantics, and the Len leak-check accessor.
+- `docs/security/quarantine-design.md` (new): the design and tuning rationale, with the §4 table mapping `DefaultWrapWarn=4032` and `DefaultWrapQuarantineDepth=64` to their structural arguments (12-bit gen, 64-gen reservation, 3 KiB/VM worst-case footprint).
+- `docs/security/memory-safety.md` §9: Phase 3 row marked LANDED with the artifacts above.
+
+**Phase 3.1 - Guard slabs (deferred)**: `-vm3-guard-slabs` build flag placing a non-readable, non-writable page between every pair of arena slabs. Requires platform-specific `mmap` plumbing (darwin/arm64, linux/amd64, linux/arm64). Tracked as a separate issue; lands before Phase 6 fuzz gate so the 24h fuzz run can use it. Defer rationale: the Go-level quarantine + sealing changes are surgical and contained; the guard-slab work is a platform-specific systems change that benefits from its own review surface.
+
+**Phase 3.2 - Bytecode-level OpSeal / OpUnseal (deferred)**: wire the Go-level `Sealer` into `compiler3/ir/types.go` and the vm3 dispatch loop as `OpSeal` / `OpUnseal` opcodes, with a verifier rule that `OpUnseal` requires the MEP-15 `meta` effect. Lands alongside Phase 4 reference modes so the IR-layer additions share a single compiler3 review. Defer rationale: the IR additions are large (op encoding, type lattice extension, verifier rule, dispatcher arms) and an empty Phase 3.2 row is cleaner than a half-implemented bytecode opcode set.
+
+### Phase 4: Reference modes
 
 **Deliverables**:
 - Grammar additions: `consume` / `borrow` / `inout` / `weak` as binding and parameter modifiers.
@@ -444,7 +461,7 @@ Each phase has a deliverable, a gate, and an exit criterion. Phases are sized to
 
 **Exit**: reference modes shipped as an optional, opt-in surface.
 
-### Phase 5: vm3jit hardening (weeks 15-18, runs alongside MEP-40 Phase 5)
+### Phase 5: vm3jit hardening (runs alongside MEP-40 Phase 5)
 
 **Deliverables**:
 - W^X on the JIT code page for darwin/arm64 (MAP_JIT + pthread_jit_write_protect_np) and linux/amd64 (dual mapping).
@@ -458,7 +475,7 @@ Each phase has a deliverable, a gate, and an exit criterion. Phases are sized to
 
 **Exit**: vm3jit code-page integrity matches V8 / JSC hardening posture.
 
-### Phase 6: Audit, fuzz, and documentation (weeks 19-21)
+### Phase 6: Audit, fuzz, and documentation
 
 **Deliverables**:
 - Internal audit: walk every `runtime/vm3` and `compiler3` file, cross-reference with the §6 architecture, document gaps.
@@ -470,7 +487,7 @@ Each phase has a deliverable, a gate, and an exit criterion. Phases are sized to
 
 **Exit**: ready to publish.
 
-### Phase 7: Public statement and CISA-roadmap alignment (week 22)
+### Phase 7: Public statement and CISA-roadmap alignment
 
 **Deliverables**:
 - `docs/security/memory-safety.md` (final wording). Single page, references MEP-41 §6, NSA CSI, CISA Pledge documentation, ONCD memo, Apple MIE documentation.


### PR DESCRIPTION
Closes #21933.

Lands MEP-41 Phase 3: per-arena wrap-detection quarantine, mark-sweep integration, and the per-VM `Sealer` table.

## Summary

- `(*Arenas).Free` routes through `routeToFreeOrQuarantine(tag, idx)`. Slots whose generation has approached the 12-bit wrap point take a FIFO slow-path that holds the index out of the regular LIFO free list for at least `WrapQuarantineDepth=64` same-arena allocations.
- `(*Arenas).sweep()` likewise routes through the quarantine, so the mark-sweep GC respects wrap-prone gens.
- New `Sealer` table: `Seal(c, key)` returns a fresh `sealID`; `Unseal(id, key)` recovers `c` only on matching key. `keyHash` is SplitMix64 salted with the sealID, so a key learned for one `(id, key)` pair cannot be replayed against another sealID.
- 13 new tests covering quarantine semantics (LIFO fast path, slow-path hold, FIFO drain, disable form, per-arena ring isolation, defaults) and sealing semantics (round-trip, wrong key, unknown ID, distinct IDs for the same Cell, cross-ID replay denial, Forget, Len).
- New `docs/security/quarantine-design.md` documenting the design and tuning rationale.
- Phase 3.1 (guard slabs) and Phase 3.2 (bytecode-level `OpSeal` / `OpUnseal`) pre-registered in the spec for the same milestone.

## Spec hygiene

- Removed week/weeks estimations from MEP-41 phase headers and `docs/security/` phase tables (the estimates were misleading; the phase list is the unit of work, not the calendar).
- Added hh:mm timestamps to every dated MEP-41 closeout entry per the project's timestamp convention.

## Test plan

- [x] `go test ./runtime/vm3/...` passes
- [x] `go test ./docs/security/` passes
- [x] `go build ./runtime/vm3/` passes
- [x] Existing `TestFreeAndReuse` still passes (LIFO fast-path unchanged for gen < WrapWarn)