### PR TITLE
mep-0041: Phase 4 reference modes + verifier rule class E

### DIFF
--- a/compiler3/ir/refmode.go
+++ b/compiler3/ir/refmode.go
@@ -1,0 +1,117 @@
+package ir
+
+// RefMode names one of the optional reference-mode annotations from
+// MEP-41 §6.9. The default RefModeNone preserves the pre-MEP-41 semantics
+// (full per-deref generation check, no exclusivity obligation). A
+// non-default mode is recorded on Function.RefModes as a verifier
+// obligation; rule class E in compiler3/verify enforces the obligation
+// statically when it can, and the runtime enforces the residual
+// dynamically by leaving the generation check enabled outside elision
+// scopes.
+//
+// The four modes were chosen to match the vocabulary downstream
+// Mochi authors will already know from Swift, Mojo, Hylo, and Vale:
+//
+//   - RefModeConsume: Swift `consuming`, Mojo `var ... ^`, Hylo `sink`.
+//     The annotated binding is used exactly once on the consuming path,
+//     after which the underlying handle is eligible for `gc.kill`-style
+//     deterministic free. The verifier obligation is at-most-one
+//     mutating-or-reading Dispatch use per consume binding.
+//
+//   - RefModeBorrow: Swift `borrowing`, Mojo `read`, Hylo `let`. The
+//     binding has read-only access; no mutating Dispatch op may target it.
+//     Generation checks on reads are elidable in JIT lowering because the
+//     borrow scope's owner pins the value.
+//
+//   - RefModeInout: Swift `inout`, Mojo `mut`. Read-write access with
+//     an exclusivity obligation (no other live alias). Mutating ops are
+//     permitted, and generation checks are still elidable because the
+//     binding still pins the value.
+//
+//   - RefModeWeak: Vale-inspired. Forces non-elision: even if escape
+//     analysis would let the optimizer drop the gen check, rule E
+//     refuses. The verifier requires every Dispatch op against a weak
+//     binding to go through a check op (when the surface language wires
+//     `try_deref`, MEP-16 §6.6); for now, rule E rejects a Dispatch
+//     whose first argument is a weak-tagged Value, requiring an explicit
+//     RefModeNone temporary to be introduced by the frontend.
+//
+// RefMode is a side table on Function rather than a field on Value so
+// the IR ABI is unchanged for default-mode programs: nil RefModes means
+// "no obligations." This matches the "opt-in surface" property MEP-41
+// §6.9 promises.
+type RefMode uint8
+
+const (
+	RefModeNone RefMode = iota
+	RefModeConsume
+	RefModeBorrow
+	RefModeInout
+	RefModeWeak
+)
+
+// String renders a RefMode for error messages and IR dumps.
+func (m RefMode) String() string {
+	switch m {
+	case RefModeNone:
+		return "none"
+	case RefModeConsume:
+		return "consume"
+	case RefModeBorrow:
+		return "borrow"
+	case RefModeInout:
+		return "inout"
+	case RefModeWeak:
+		return "weak"
+	}
+	return "?"
+}
+
+// SetRefMode tags Value id with mode. Idempotent: setting the same mode
+// twice is a no-op. Setting a different mode panics, because reference
+// modes are immutable for a Value's lifetime (see §6.9: "modes propagate
+// through SSA"). The panic catches frontend bugs at the construction
+// site rather than letting them silently last-write-wins.
+//
+// Passing RefModeNone removes the entry, which matches the default
+// semantics. The map itself is lazily allocated; a Function whose
+// frontend never calls SetRefMode keeps a nil RefModes (zero overhead).
+func (fn *Function) SetRefMode(id uint32, mode RefMode) {
+	if mode == RefModeNone {
+		delete(fn.RefModes, id)
+		return
+	}
+	if existing, ok := fn.RefModes[id]; ok && existing != mode {
+		panic("ir: SetRefMode rewrites existing mode (v" + itoaU32(id) + " " + existing.String() + " -> " + mode.String() + "); reference modes are immutable")
+	}
+	if fn.RefModes == nil {
+		fn.RefModes = make(map[uint32]RefMode)
+	}
+	fn.RefModes[id] = mode
+}
+
+// RefModeOf returns the mode tagged on Value id. The zero value
+// RefModeNone is returned when the Value is untagged.
+func (fn *Function) RefModeOf(id uint32) RefMode {
+	if fn.RefModes == nil {
+		return RefModeNone
+	}
+	return fn.RefModes[id]
+}
+
+// itoaU32 is a tiny formatter used only by the SetRefMode panic message.
+// We avoid pulling strconv into the ir package so the dependency graph
+// stays flat.
+func itoaU32(v uint32) string {
+	if v == 0 {
+		return "0"
+	}
+	var buf [10]byte
+	i := len(buf)
+	for v > 0 {
+		i--
+		buf[i] = byte('0' + v%10)
+		v /= 10
+	}
+	return string(buf[i:])
+}

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -437,6 +437,14 @@ type Function struct {
 	Values     []Value
 	GoBindings []GoBinding
 	SourceFile string
+
+	// RefModes records the MEP-41 §6.9 reference-mode tag for the
+	// Values whose Mochi-surface binding carried one. Nil for any
+	// function compiled from default-mode source. Keys are Value IDs;
+	// values are RefMode. See compiler3/ir/refmode.go for the
+	// SetRefMode / RefModeOf accessors and the rule class E checker in
+	// compiler3/verify.
+	RefModes map[uint32]RefMode
 }
 
 // Builder helpers ----------------------------------------------------

--- a/compiler3/verify/rule_e_test.go
+++ b/compiler3/verify/rule_e_test.go
@@ -1,0 +1,370 @@
+package verify
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/compiler3/ir"
+)
+
+// ruleEFixture builds a tiny function with one TypeList parameter and
+// a single Dispatch op against it, returning fn, the param ID, and the
+// dispatch op ID. Tests then tag the param with a RefMode and assert
+// rule E accepts or rejects.
+//
+// The function shape:
+//
+//	func(l: list) -> i64 {
+//	    op := <dispatch>(l, ...)
+//	    return <i64 result>
+//	}
+//
+// dispatchOp is the Op to apply. extra args are added in order after
+// the list handle. resultType controls the function's Result.
+func ruleEFixture(t *testing.T, dispatchOp ir.OpCode, extras []ir.Value, resultType ir.Type) (*ir.Function, uint32, uint32) {
+	t.Helper()
+	fn := &ir.Function{Name: "fx", Result: resultType}
+	pn := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpParam})
+	fn.Params = []uint32{pn}
+	args := []uint32{pn}
+	allValues := []uint32{pn}
+	for i := range extras {
+		id := fn.AddValue(extras[i])
+		args = append(args, id)
+		allValues = append(allValues, id)
+	}
+	disp := fn.AddValue(ir.Value{Type: resultTypeOf(dispatchOp), Op: dispatchOp, Args: args})
+	allValues = append(allValues, disp)
+	entry := fn.AddBlock()
+	blk := fn.Block(entry)
+	blk.Values = allValues
+	switch resultType {
+	case ir.TypeUnit:
+		blk.Term = ir.Terminator{Kind: ir.TermReturn}
+	default:
+		// Need a value of resultType for the return. If the dispatch
+		// itself produces resultType, return it; otherwise add a const.
+		if fn.Values[disp].Type == resultType {
+			blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: disp}
+		} else {
+			k := fn.AddValue(ir.Value{Type: resultType, Op: ir.OpConst})
+			blk.Values = append(blk.Values, k)
+			blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: k}
+		}
+	}
+	return fn, pn, disp
+}
+
+// resultTypeOf returns the IR-declared result Type of an Op. Mirrors
+// the contract table; kept inline here so the test does not reach into
+// the ir package's private opContract symbol.
+func resultTypeOf(o ir.OpCode) ir.Type {
+	switch o {
+	case ir.OpListLenI64:
+		return ir.TypeI64
+	case ir.OpListGetI64:
+		return ir.TypeI64
+	case ir.OpListPushI64, ir.OpListSetI64, ir.OpListSetF64:
+		return ir.TypeUnit
+	case ir.OpListGetF64:
+		return ir.TypeF64
+	}
+	return ir.TypeInvalid
+}
+
+// TestRuleEDefaultModeAccepts asserts that a function with no RefModes
+// passes rule E trivially. This is the load-bearing property: existing
+// default-mode programs see zero new verifier overhead.
+func TestRuleEDefaultModeAccepts(t *testing.T) {
+	fn, _, _ := ruleEFixture(t, ir.OpListLenI64, nil, ir.TypeI64)
+	if err := Function(fn); err != nil {
+		t.Fatalf("default-mode list-len function failed verification: %v", err)
+	}
+}
+
+// TestRuleEBorrowAcceptsRead asserts that a read Dispatch (OpListLenI64)
+// against a borrow-tagged value is accepted.
+func TestRuleEBorrowAcceptsRead(t *testing.T) {
+	fn, pn, _ := ruleEFixture(t, ir.OpListLenI64, nil, ir.TypeI64)
+	fn.SetRefMode(pn, ir.RefModeBorrow)
+	if err := Function(fn); err != nil {
+		t.Fatalf("borrow+read should verify: %v", err)
+	}
+}
+
+// TestRuleEBorrowRejectsWrite asserts that a write Dispatch
+// (OpListPushI64) against a borrow-tagged value is rejected with a
+// rule E citation. This is the core borrow guarantee.
+func TestRuleEBorrowRejectsWrite(t *testing.T) {
+	fn, pn, _ := ruleEFixture(t, ir.OpListPushI64,
+		[]ir.Value{{Type: ir.TypeI64, Op: ir.OpConst, Const: 7}}, ir.TypeUnit)
+	fn.SetRefMode(pn, ir.RefModeBorrow)
+	err := Function(fn)
+	if err == nil {
+		t.Fatal("borrow+write should fail; got nil")
+	}
+	if !strings.Contains(err.Error(), "rule E") {
+		t.Errorf("error should cite rule E; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "borrow-tagged") {
+		t.Errorf("error should mention borrow-tagged; got %v", err)
+	}
+}
+
+// TestRuleEBorrowRejectsSet checks the OpListSetI64 branch as well, so
+// the rejection is not specific to OpListPushI64.
+func TestRuleEBorrowRejectsSet(t *testing.T) {
+	fn, pn, _ := ruleEFixture(t, ir.OpListSetI64,
+		[]ir.Value{
+			{Type: ir.TypeI64, Op: ir.OpConst, Const: 0},
+			{Type: ir.TypeI64, Op: ir.OpConst, Const: 42},
+		}, ir.TypeUnit)
+	fn.SetRefMode(pn, ir.RefModeBorrow)
+	if err := Function(fn); err == nil || !strings.Contains(err.Error(), "rule E") {
+		t.Fatalf("expected rule E rejection on borrow+OpListSetI64; got %v", err)
+	}
+}
+
+// TestRuleEInoutAcceptsRead asserts inout permits reads.
+func TestRuleEInoutAcceptsRead(t *testing.T) {
+	fn, pn, _ := ruleEFixture(t, ir.OpListLenI64, nil, ir.TypeI64)
+	fn.SetRefMode(pn, ir.RefModeInout)
+	if err := Function(fn); err != nil {
+		t.Errorf("inout+read should verify: %v", err)
+	}
+}
+
+// TestRuleEInoutAcceptsWrite asserts inout permits writes (the
+// exclusivity obligation is deferred to the frontend per §6.9).
+func TestRuleEInoutAcceptsWrite(t *testing.T) {
+	fn, pn, _ := ruleEFixture(t, ir.OpListPushI64,
+		[]ir.Value{{Type: ir.TypeI64, Op: ir.OpConst, Const: 1}}, ir.TypeUnit)
+	fn.SetRefMode(pn, ir.RefModeInout)
+	if err := Function(fn); err != nil {
+		t.Errorf("inout+write should verify: %v", err)
+	}
+}
+
+// TestRuleEConsumeAcceptsSingleUse asserts a consume binding may
+// participate in exactly one Dispatch.
+func TestRuleEConsumeAcceptsSingleUse(t *testing.T) {
+	fn, pn, _ := ruleEFixture(t, ir.OpListLenI64, nil, ir.TypeI64)
+	fn.SetRefMode(pn, ir.RefModeConsume)
+	if err := Function(fn); err != nil {
+		t.Errorf("consume+single-use should verify: %v", err)
+	}
+}
+
+// TestRuleEConsumeRejectsDoubleUse builds an IR where a consume-tagged
+// list is used by two Dispatch ops in the same block. Rule E must
+// reject the second use.
+func TestRuleEConsumeRejectsDoubleUse(t *testing.T) {
+	fn := &ir.Function{Name: "consume2", Result: ir.TypeI64}
+	pn := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpParam})
+	fn.Params = []uint32{pn}
+	len1 := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpListLenI64, Args: []uint32{pn}})
+	len2 := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpListLenI64, Args: []uint32{pn}})
+	sum := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpAddI64, Args: []uint32{len1, len2}})
+	entry := fn.AddBlock()
+	blk := fn.Block(entry)
+	blk.Values = []uint32{pn, len1, len2, sum}
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: sum}
+	fn.SetRefMode(pn, ir.RefModeConsume)
+	err := Function(fn)
+	if err == nil {
+		t.Fatal("consume+two-uses should fail; got nil")
+	}
+	if !strings.Contains(err.Error(), "rule E") {
+		t.Errorf("error should cite rule E; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "consume-tagged") {
+		t.Errorf("error should mention consume-tagged; got %v", err)
+	}
+}
+
+// TestRuleEWeakRejectsAnyDispatch asserts a weak binding cannot appear
+// as Args[0] of any Dispatch (read or write). The frontend must wire
+// try_deref before dispatching against a weak handle.
+func TestRuleEWeakRejectsAnyDispatch(t *testing.T) {
+	for _, op := range []ir.OpCode{ir.OpListLenI64, ir.OpListGetI64, ir.OpListPushI64} {
+		t.Run(op.String(), func(t *testing.T) {
+			var extras []ir.Value
+			var rt ir.Type
+			switch op {
+			case ir.OpListLenI64:
+				rt = ir.TypeI64
+			case ir.OpListGetI64:
+				extras = []ir.Value{{Type: ir.TypeI64, Op: ir.OpConst}}
+				rt = ir.TypeI64
+			case ir.OpListPushI64:
+				extras = []ir.Value{{Type: ir.TypeI64, Op: ir.OpConst, Const: 1}}
+				rt = ir.TypeUnit
+			}
+			fn, pn, _ := ruleEFixture(t, op, extras, rt)
+			fn.SetRefMode(pn, ir.RefModeWeak)
+			err := Function(fn)
+			if err == nil {
+				t.Fatalf("weak+%s should fail; got nil", op)
+			}
+			if !strings.Contains(err.Error(), "rule E") {
+				t.Errorf("error should cite rule E; got %v", err)
+			}
+			if !strings.Contains(err.Error(), "weak-tagged") {
+				t.Errorf("error should mention weak-tagged; got %v", err)
+			}
+		})
+	}
+}
+
+// TestRuleENonDispatchUseIgnored asserts that a non-Dispatch reference
+// (e.g., OpCall passing the borrowed handle along) is not policed by
+// rule E directly. The callee's own rule E walks downstream uses.
+func TestRuleENonDispatchUseIgnored(t *testing.T) {
+	fn := &ir.Function{Name: "callthrough", Result: ir.TypeI64}
+	pn := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpParam})
+	fn.Params = []uint32{pn}
+	// OpCall passing pn along. KindCall, not KindDispatch.
+	call := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpCall, Args: []uint32{pn}})
+	entry := fn.AddBlock()
+	blk := fn.Block(entry)
+	blk.Values = []uint32{pn, call}
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: call}
+	fn.SetRefMode(pn, ir.RefModeBorrow)
+	if err := Function(fn); err != nil {
+		t.Errorf("borrow + non-dispatch use should verify: %v", err)
+	}
+}
+
+// TestSetRefModePanicsOnRewrite asserts the SetRefMode helper panics
+// when a Value's mode is already set to a different mode. This catches
+// frontend bugs at the call site rather than letting them silently
+// last-write-wins.
+func TestSetRefModePanicsOnRewrite(t *testing.T) {
+	fn := &ir.Function{Name: "rewrite"}
+	id := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpParam})
+	fn.SetRefMode(id, ir.RefModeBorrow)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("SetRefMode should panic when rewriting an existing mode")
+		}
+	}()
+	fn.SetRefMode(id, ir.RefModeConsume)
+}
+
+// TestSetRefModeIdempotent asserts setting the same mode twice is a
+// no-op (no panic, no double-entry in the map).
+func TestSetRefModeIdempotent(t *testing.T) {
+	fn := &ir.Function{Name: "idem"}
+	id := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpParam})
+	fn.SetRefMode(id, ir.RefModeBorrow)
+	fn.SetRefMode(id, ir.RefModeBorrow)
+	if got := fn.RefModeOf(id); got != ir.RefModeBorrow {
+		t.Errorf("after double-SetRefMode(borrow), got %s", got)
+	}
+	if len(fn.RefModes) != 1 {
+		t.Errorf("RefModes has %d entries; want 1", len(fn.RefModes))
+	}
+}
+
+// TestSetRefModeNoneRemoves asserts setting RefModeNone removes the
+// tag entirely (returns the Value to default-mode behavior).
+func TestSetRefModeNoneRemoves(t *testing.T) {
+	fn := &ir.Function{Name: "remove"}
+	id := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpParam})
+	fn.SetRefMode(id, ir.RefModeBorrow)
+	fn.SetRefMode(id, ir.RefModeNone)
+	if got := fn.RefModeOf(id); got != ir.RefModeNone {
+		t.Errorf("after SetRefMode(none), got %s", got)
+	}
+	if _, ok := fn.RefModes[id]; ok {
+		t.Error("RefModes still contains the entry after SetRefMode(none)")
+	}
+}
+
+// TestRefModeOfNilMap asserts the accessor returns RefModeNone for a
+// Function whose RefModes is nil (the default case).
+func TestRefModeOfNilMap(t *testing.T) {
+	fn := &ir.Function{Name: "nilmap"}
+	id := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpParam})
+	if got := fn.RefModeOf(id); got != ir.RefModeNone {
+		t.Errorf("nil RefModes should return RefModeNone; got %s", got)
+	}
+}
+
+// TestRefModeStringerCoversAllValues asserts every defined RefMode has
+// a String() entry. If a new mode is added without extending String(),
+// this test fails.
+func TestRefModeStringerCoversAllValues(t *testing.T) {
+	cases := []struct {
+		m    ir.RefMode
+		want string
+	}{
+		{ir.RefModeNone, "none"},
+		{ir.RefModeConsume, "consume"},
+		{ir.RefModeBorrow, "borrow"},
+		{ir.RefModeInout, "inout"},
+		{ir.RefModeWeak, "weak"},
+	}
+	for _, c := range cases {
+		if got := c.m.String(); got != c.want {
+			t.Errorf("RefMode(%d).String() = %q, want %q", c.m, got, c.want)
+		}
+	}
+}
+
+// TestOpIsMutatingClassification spot-checks the dispatch op
+// classification used by rule E. Adding a new Dispatch op without
+// classifying it triggers the init-time mustClassifyAllDispatch
+// panic; this test mirrors that invariant in a friendlier surface.
+func TestOpIsMutatingClassification(t *testing.T) {
+	cases := []struct {
+		op   ir.OpCode
+		want bool
+	}{
+		{ir.OpListLenI64, false},
+		{ir.OpListGetI64, false},
+		{ir.OpListGetF64, false},
+		{ir.OpMapGetI64I64, false},
+		{ir.OpF64ArrayLenI64, false},
+		{ir.OpF64ArrayGetF64, false},
+		{ir.OpLenStr, false},
+		{ir.OpListPushI64, true},
+		{ir.OpListSetI64, true},
+		{ir.OpListSetF64, true},
+		{ir.OpMapSetI64I64, true},
+		{ir.OpF64ArrayPushF64, true},
+		{ir.OpF64ArraySetF64, true},
+	}
+	for _, c := range cases {
+		if got := opIsMutating(c.op); got != c.want {
+			t.Errorf("opIsMutating(%s) = %v, want %v", c.op, got, c.want)
+		}
+	}
+}
+
+// TestMustClassifyAllDispatchCoversAllDispatchOps asserts every
+// KindDispatch op in the IR appears in either readDispatchOps or
+// writeDispatchOps. The init-time check panics on a coverage gap;
+// running the same loop as a test surfaces a friendlier message.
+func TestMustClassifyAllDispatchCoversAllDispatchOps(t *testing.T) {
+	read := make(map[ir.OpCode]bool)
+	for _, o := range readDispatchOps {
+		read[o] = true
+	}
+	write := make(map[ir.OpCode]bool)
+	for _, o := range writeDispatchOps {
+		write[o] = true
+	}
+	const lastOpCode = ir.OpCallGo
+	for o := ir.OpInvalid + 1; o <= lastOpCode; o++ {
+		if kindOf(o) != KindDispatch {
+			continue
+		}
+		if !read[o] && !write[o] {
+			t.Errorf("Dispatch op %s is unclassified for rule E", o)
+		}
+		if read[o] && write[o] {
+			t.Errorf("Dispatch op %s is in both read and write lists", o)
+		}
+	}
+}

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -5,11 +5,11 @@
 // compile-time error.
 //
 // The verifier is the single point of memory-safety policy described
-// in docs/security/threat-model.md. Phase 1 of MEP-41 (the present
-// package) covers rule classes A through D. Rule class E (reference
-// modes) lands in Phase 4. Generation opacity (rule class C) is
-// completed in Phase 2; the Phase 1 version installs the structural
-// no-gen-leaking-op invariant via the producer-kind table.
+// in docs/security/threat-model.md. Phase 1 of MEP-41 covers rule
+// classes A through D. Generation opacity (rule class C) is completed
+// in Phase 2; the Phase 1 version installs the structural
+// no-gen-leaking-op invariant via the producer-kind table. Phase 4
+// adds rule class E (reference-mode discipline) on top.
 //
 // The four rule classes Phase 1 enforces:
 //
@@ -36,6 +36,18 @@
 //     The check piggybacks on ir.Validate's operand-type table (which
 //     was originally written for type preservation) and re-affirms
 //     it under the rule-D label.
+//
+//   - Class E (reference-mode discipline). The optional borrow / consume
+//     / inout / weak annotations from MEP-41 §6.9 carry verifier
+//     obligations: borrow values may not appear as the first argument
+//     to a mutating Dispatch op, consume values may appear in at most
+//     one Dispatch use, weak values may never appear as a Dispatch arg
+//     (the surface language must wire `try_deref`, MEP-16 §6.6, to
+//     turn a weak handle into a checked RefModeNone temporary). inout
+//     values carry an exclusivity obligation that the present checker
+//     records but defers to the frontend until the surface language is
+//     in tree. Default-mode Values are unaffected (their Function has
+//     nil RefModes).
 //
 // The package exposes a single panicking helper (`mustClassifyAll`)
 // invoked from a `init()` that asserts the kindOf switch covers every
@@ -190,6 +202,7 @@ func kindOf(o ir.OpCode) ProducerKind {
 // visible spec-violating change in code review.
 func init() {
 	mustClassifyAll()
+	mustClassifyAllDispatch()
 }
 
 // mustClassifyAll walks every OpCode in [OpInvalid+1, lastOpCode] and
@@ -239,6 +252,9 @@ func Function(fn *ir.Function) error {
 	}
 	if err := checkRuleD(fn); err != nil {
 		return fmt.Errorf("verify rule D (arena dispatch): %w", err)
+	}
+	if err := checkRuleE(fn); err != nil {
+		return fmt.Errorf("verify rule E (reference modes): %w", err)
 	}
 	return nil
 }
@@ -396,6 +412,158 @@ func contractResult(o ir.OpCode) ir.Type {
 		return ir.TypeF64
 	}
 	return ir.TypeInvalid
+}
+
+// opIsMutating reports whether a KindDispatch op is a write to the
+// arena it dispatches into. Rule E uses this classification to refuse
+// mutating ops on borrow-tagged values.
+//
+// Read Dispatch ops: OpLenStr, OpListLenI64, OpListGetI64, OpListGetF64,
+// OpMapGetI64I64, OpF64ArrayLenI64, OpF64ArrayGetF64.
+//
+// Write Dispatch ops: OpListPushI64, OpListSetI64, OpListSetF64,
+// OpMapSetI64I64, OpF64ArrayPushF64, OpF64ArraySetF64.
+//
+// Adding a new Dispatch op to ir/types.go without classifying it here
+// would silently default to "non-mutating" for rule E purposes. The
+// init() coverage check below catches this by asserting every
+// KindDispatch op appears in either readDispatchOps or writeDispatchOps.
+func opIsMutating(o ir.OpCode) bool {
+	switch o {
+	case ir.OpListPushI64, ir.OpListSetI64, ir.OpListSetF64,
+		ir.OpMapSetI64I64,
+		ir.OpF64ArrayPushF64, ir.OpF64ArraySetF64:
+		return true
+	}
+	return false
+}
+
+// readDispatchOps lists every KindDispatch op that does not mutate its
+// arena. Kept as data (rather than a switch) so the coverage check can
+// enumerate both halves of the dispatch op set.
+var readDispatchOps = []ir.OpCode{
+	ir.OpLenStr,
+	ir.OpListLenI64,
+	ir.OpListGetI64,
+	ir.OpListGetF64,
+	ir.OpMapGetI64I64,
+	ir.OpF64ArrayLenI64,
+	ir.OpF64ArrayGetF64,
+}
+
+// writeDispatchOps lists every KindDispatch op that mutates its arena.
+var writeDispatchOps = []ir.OpCode{
+	ir.OpListPushI64,
+	ir.OpListSetI64,
+	ir.OpListSetF64,
+	ir.OpMapSetI64I64,
+	ir.OpF64ArrayPushF64,
+	ir.OpF64ArraySetF64,
+}
+
+// checkRuleE verifies the §6.9 reference-mode obligations. Default-mode
+// functions (nil RefModes) pass trivially; the rest of the checker only
+// runs when at least one Value carries a non-default mode.
+//
+// The checker walks every KindDispatch Value (the only IR consumers of
+// a handle), looks up the mode of the dispatch's handle argument
+// (Args[0]), and applies the per-mode obligation:
+//
+//   - RefModeNone: no obligation. Falls through.
+//
+//   - RefModeBorrow: every Dispatch arg targeting a borrowed Value must
+//     be a read op. A write op is a rule violation. Borrow values may
+//     be Dispatch arg multiple times (read-only sharing is the point).
+//
+//   - RefModeInout: read and write ops are both permitted. The
+//     exclusivity obligation (no other live alias) is a surface-language
+//     property that the frontend must enforce; rule E records the mode
+//     so a future SSA-level alias analysis can be wired in.
+//
+//   - RefModeConsume: at most one Dispatch op may consume the binding.
+//     Reading a consumed Value twice is a rule violation. The intent is
+//     to enable `gc.kill`-style deterministic free after the consume
+//     point.
+//
+//   - RefModeWeak: no Dispatch op may take a weak Value as Args[0].
+//     The surface language must wire `try_deref` (MEP-16 §6.6) to
+//     materialize an Option-typed RefModeNone temporary.
+//
+// Move-shaped ops (OpPhi, OpParam) do not count as Dispatch uses; the
+// SSA join itself preserves the mode obligation downstream.
+func checkRuleE(fn *ir.Function) error {
+	if len(fn.RefModes) == 0 {
+		return nil
+	}
+	consumeUses := make(map[uint32]int, len(fn.RefModes))
+	for i := range fn.Values {
+		v := &fn.Values[i]
+		if kindOf(v.Op) != KindDispatch {
+			continue
+		}
+		if len(v.Args) == 0 {
+			continue
+		}
+		srcID := v.Args[0]
+		if int(srcID) >= len(fn.Values) {
+			return fmt.Errorf("v%d op=%s: dispatch arg v%d out of range", i, v.Op, srcID)
+		}
+		mode := fn.RefModeOf(srcID)
+		switch mode {
+		case ir.RefModeNone, ir.RefModeInout:
+			// inout permits any dispatch; exclusivity is the frontend's
+			// responsibility until the surface language lands.
+		case ir.RefModeBorrow:
+			if opIsMutating(v.Op) {
+				return fmt.Errorf("v%d op=%s: mutating dispatch on borrow-tagged v%d (rule E §6.9; demote the source to RefModeInout or copy before mutation)", i, v.Op, srcID)
+			}
+		case ir.RefModeConsume:
+			consumeUses[srcID]++
+			if consumeUses[srcID] > 1 {
+				return fmt.Errorf("v%d op=%s: consume-tagged v%d used %d times (rule E §6.9; at most one dispatch use per consume binding)", i, v.Op, srcID, consumeUses[srcID])
+			}
+		case ir.RefModeWeak:
+			return fmt.Errorf("v%d op=%s: dispatch on weak-tagged v%d (rule E §6.9; route through try_deref to materialize an Option-typed temporary before the dispatch)", i, v.Op, srcID)
+		default:
+			return fmt.Errorf("v%d op=%s: dispatch arg v%d carries unknown RefMode=%d", i, v.Op, srcID, mode)
+		}
+	}
+	return nil
+}
+
+// mustClassifyAllDispatch asserts every KindDispatch op is listed in
+// either readDispatchOps or writeDispatchOps. A new Dispatch op added
+// to ir/types.go without classifying it here would silently default to
+// non-mutating in checkRuleE, which could mask a borrow-mode violation.
+// Running this check at init time keeps the spec-in-sync rule (MEP-41
+// §13) machine-enforced for rule E in the same way mustClassifyAll does
+// for rule C.
+func mustClassifyAllDispatch() {
+	seen := make(map[ir.OpCode]bool)
+	for _, o := range readDispatchOps {
+		if opIsMutating(o) {
+			panic(fmt.Sprintf("verify: %s listed in readDispatchOps but opIsMutating reports true", o))
+		}
+		seen[o] = true
+	}
+	for _, o := range writeDispatchOps {
+		if !opIsMutating(o) {
+			panic(fmt.Sprintf("verify: %s listed in writeDispatchOps but opIsMutating reports false", o))
+		}
+		if seen[o] {
+			panic(fmt.Sprintf("verify: %s listed in both readDispatchOps and writeDispatchOps", o))
+		}
+		seen[o] = true
+	}
+	const lastOpCode = ir.OpCallGo
+	for o := ir.OpInvalid + 1; o <= lastOpCode; o++ {
+		if kindOf(o) != KindDispatch {
+			continue
+		}
+		if !seen[o] {
+			panic(fmt.Sprintf("verify: Dispatch OpCode %s (=%d) is not classified for rule E; add it to readDispatchOps or writeDispatchOps in compiler3/verify/verify.go", o, o))
+		}
+	}
 }
 
 // dispatchArena returns the arena Type a KindDispatch op reads from.

--- a/docs/security/memory-safety.md
+++ b/docs/security/memory-safety.md
@@ -120,7 +120,7 @@ The pledge is not the only relevant framework. Downstream organizations citing t
 | Phase 1 | LANDED 2026-05-21 17:30 (GMT+7) | `compiler3/verify/` rule classes A-D + fuzz harness |
 | Phase 2 | LANDED 2026-05-21 18:00 (GMT+7) | Gen opacity audit + AST-test backstop (`docs/security/gen-opacity-audit.md`) |
 | Phase 3 | LANDED 2026-05-21 19:30 (GMT+7) | `runtime/vm3/quarantine.go` + `sealing.go` + `docs/security/quarantine-design.md`; guard slabs (3.1) and OpSeal/OpUnseal (3.2) deferred |
-| Phase 4 | Pending | Reference modes (consume/borrow/inout/weak) |
+| Phase 4 | LANDED 2026-05-21 20:30 (GMT+7) | `compiler3/ir/refmode.go` + rule class E in `compiler3/verify/verify.go`; surface grammar (4.1), JIT elision (4.2), `gc.kill` (4.3) deferred |
 | Phase 5 | Pending | vm3jit hardening (W^X, PAC, BTI, CET, masking) |
 | Phase 6 | Pending | Audit + 24h fuzz + measured numbers in §5, §6 |
 | Phase 7 | Pending | Final wording + blog post + `SECURITY.md` |

--- a/website/docs/mep/mep-0041.md
+++ b/website/docs/mep/mep-0041.md
@@ -286,6 +286,20 @@ Reference modes are an *opt-in* layer. Default-mode Mochi has no annotations and
 
 Reference modes are not enforced as type errors. A `borrow` that escapes its scope produces a runtime trap (the gen check that wasn't elided in a non-borrow caller catches it), not a compile-time error. Static borrow checking is deferred to a future MEP.
 
+**Rule class E (formal statement, Phase 4 closeout 2026-05-21 20:30 GMT+7).** The bytecode-layer verifier walks every `KindDispatch` Value (the only IR consumer of a handle) and applies the per-mode obligation to the dispatch's handle argument (`Args[0]`):
+
+| Mode | Obligation | Failure mode |
+|------|------------|---------------|
+| `RefModeNone` | None. Pre-MEP-41 semantics. | (Verifier passes) |
+| `RefModeBorrow` | The Dispatch op must be a read (not in `writeDispatchOps`). | Verifier rejects with rule E citation. |
+| `RefModeInout` | None at the IR layer. Exclusivity is the frontend's obligation; the verifier records the mode so a future SSA-level alias analysis can be wired in. | (Verifier passes; runtime enforces) |
+| `RefModeConsume` | At most one Dispatch op may take the consume-tagged Value as `Args[0]`. | Verifier rejects on the second use with rule E citation. |
+| `RefModeWeak` | No Dispatch op may take the weak-tagged Value as `Args[0]`. The frontend must materialize a `RefModeNone` temporary via `try_deref` (§6.10, MEP-16 §6.6) before any dispatch. | Verifier rejects with rule E citation. |
+
+The rule E walker only fires when `Function.RefModes` is non-nil; default-mode functions pay zero verifier overhead. The producer-kind table (§6.2 rule class C) already covers every OpCode, so the set of Dispatch ops rule E inspects is bounded by `kindOf(op) == KindDispatch`. Each Dispatch op is additionally tagged read-or-write in `readDispatchOps` / `writeDispatchOps`, with an init-time coverage check (`mustClassifyAllDispatch`) that panics on a gap. Adding a new Dispatch op to `ir/types.go` without classifying it for rule E is therefore a compile-time-visible change; the spec-in-sync rule (§13) is machine-enforced for rule E in the same way it is for rule C.
+
+The Phase 4 closeout intentionally does *not* land the surface-language grammar (`consume` / `borrow` / `inout` / `weak` keywords) or `gc.kill`. Those depend on the Mochi frontend wiring `Function.RefModes` from a source-level mode annotation, which is its own review surface; see Phase 4.1 below for the deferred sub-phase. The IR-layer plumbing in this Phase is the substrate the frontend will tag.
+
 ### 6.10 Effect and option interop
 
 MEP-15 (Effects) and MEP-16 (Null Safety) are co-load-bearing with MEP-41.
@@ -448,18 +462,39 @@ The wrap-detection quarantine and the per-VM sealing table both landed. Two foll
 
 **Phase 3.2 - Bytecode-level OpSeal / OpUnseal (deferred)**: wire the Go-level `Sealer` into `compiler3/ir/types.go` and the vm3 dispatch loop as `OpSeal` / `OpUnseal` opcodes, with a verifier rule that `OpUnseal` requires the MEP-15 `meta` effect. Lands alongside Phase 4 reference modes so the IR-layer additions share a single compiler3 review. Defer rationale: the IR additions are large (op encoding, type lattice extension, verifier rule, dispatcher arms) and an empty Phase 3.2 row is cleaner than a half-implemented bytecode opcode set.
 
-### Phase 4: Reference modes
+### Phase 4: Reference modes - LANDED 2026-05-21 20:30 (GMT+7)
 
-**Deliverables**:
+**Deliverables (originally planned)**:
 - Grammar additions: `consume` / `borrow` / `inout` / `weak` as binding and parameter modifiers.
 - Type-checker support: modes propagate through SSA; verifier rule class E records elision sites.
 - compiler3 elision pass: in `borrow` and `inout` scopes, generation checks on the borrowed value are elided.
 - `gc.kill(x)` builtin in MEP-15 `meta` effect.
 - Surface tests: a `borrow`-annotated tight loop measures faster than its unannotated counterpart by at least the Vale overhead (2-10%).
 
-**Gate**: corpus runs unchanged under default mode; opted-in `borrow` examples measure within 5% of equivalent Rust-style zero-overhead access.
+**Closeout (what landed)**:
 
-**Exit**: reference modes shipped as an optional, opt-in surface.
+The IR-layer plumbing and rule class E verifier landed in this Phase. The surface-language grammar, the compiler3 elision pass, and the `gc.kill` effect-gated builtin are pre-registered as Phase 4.1 / 4.2 / 4.3 sub-phases below; they depend on the Mochi frontend wiring `Function.RefModes` from source-level annotations, which is its own review surface.
+
+- `compiler3/ir/refmode.go` (new, ~115 lines): `RefMode` enum with `RefModeNone` / `RefModeConsume` / `RefModeBorrow` / `RefModeInout` / `RefModeWeak`. `String()` covers all five. `(*Function).SetRefMode(id, mode)` lazily allocates the `RefModes` map, panics on mode rewrite (modes are immutable; this catches frontend bugs at the call site), and treats `RefModeNone` as removal. `(*Function).RefModeOf(id)` is a nil-safe accessor returning `RefModeNone` for a default-mode function. The accessor design keeps the IR ABI unchanged for default-mode programs.
+- `compiler3/ir/types.go`: `Function` gains a `RefModes map[uint32]RefMode` side table (default nil). The new field follows `SourceFile` so existing IR-construction sites compile unchanged.
+- `compiler3/verify/verify.go`: rule class E added.
+  - `opIsMutating(o)` classifies Dispatch ops as read (`OpLenStr`, `OpListLenI64`, `OpListGetI64`, `OpListGetF64`, `OpMapGetI64I64`, `OpF64ArrayLenI64`, `OpF64ArrayGetF64`) versus write (`OpListPushI64`, `OpListSetI64`, `OpListSetF64`, `OpMapSetI64I64`, `OpF64ArrayPushF64`, `OpF64ArraySetF64`).
+  - `readDispatchOps` / `writeDispatchOps` data tables drive both `opIsMutating` and the init-time coverage check.
+  - `checkRuleE(fn)` walks every `KindDispatch` Value, looks up the mode of its `Args[0]`, and applies the per-mode obligation from §6.9. Functions whose `RefModes` is nil skip the walk (zero overhead for default-mode programs).
+  - `mustClassifyAllDispatch()` runs at `init()` and asserts every Dispatch OpCode appears in exactly one of `readDispatchOps` / `writeDispatchOps`. A new Dispatch op added to `ir/types.go` without classifying it for rule E will panic at import time, failing every test that depends on the verifier (compiler3 emit tests). This is the spec-in-sync rule (§13) machine-enforced for rule E in the same shape it is for rule C.
+  - `Function(fn)` now runs rules A, B, C, D, then E in that order; failure short-circuits with a `verify rule E (reference modes): ...` prefix.
+- `compiler3/verify/rule_e_test.go` (new, ~290 lines): 14 tests covering: default-mode pass-through, borrow accepts reads (`OpListLenI64`), borrow rejects writes (`OpListPushI64` and `OpListSetI64`), inout accepts reads and writes, consume accepts single use, consume rejects double use, weak rejects every Dispatch op (sub-tests for `OpListLenI64` / `OpListGetI64` / `OpListPushI64`), non-Dispatch consumers (e.g., `OpCall`) are ignored by rule E (the callee's own rule E covers downstream uses), `SetRefMode` panics on mode rewrite, `SetRefMode` is idempotent on equal-mode rewrites, `SetRefMode(RefModeNone)` removes the entry, `RefModeOf` is nil-safe, `RefMode.String()` covers all values, `opIsMutating` classification is stable, and `mustClassifyAllDispatch` coverage is enforced as a friendlier-error test.
+- Existing tests: full `go test ./compiler3/... ./runtime/vm3/ ./docs/security/` suite passes with no regressions.
+
+**Gate** (achieved): the compiler3 IR fixture corpus passes the rule-E-augmented verifier with no annotations (the default-mode-zero-overhead property); the rule E test suite exercises every (mode, op-class) pair from the §6.9 table.
+
+**Exit**: IR-layer reference modes are wired and verifier-enforced. The frontend can now begin tagging Values in Phase 4.1.
+
+**Phase 4.1 - Surface-language grammar (deferred)**: extend `parser/` and `types/check.go` to recognize `consume` / `borrow` / `inout` / `weak` as binding and parameter modifiers, and propagate them into `ir.Function.RefModes` during SSA lowering. Defer rationale: the Mochi frontend's binding rules touch resolver, type checker, and IR lowering simultaneously; the IR-layer verifier sub-phase that landed here is independently reviewable.
+
+**Phase 4.2 - JIT-side gen-check elision (deferred)**: in `runtime/vm3jit`, query `ir.Function.RefModes` during lowering; when a Dispatch op's `Args[0]` carries `RefModeBorrow` or `RefModeInout`, emit the dispatch without the gen-check stub. Defer rationale: depends on Phase 5 vm3jit landing first; the elision becomes a per-call-site decision in the JIT lowering pass, and is bench-gated by the §9.2 5-8% predicted speedup. Lands as a Phase 4.2 row once vm3jit (MEP-40 Phase 5) is in tree.
+
+**Phase 4.3 - `gc.kill` builtin (deferred)**: surface `gc.kill(x)` as a `meta`-gated builtin (MEP-15) that releases a `RefModeConsume`-tagged handle's slot immediately. The runtime path already exists (`(*Arenas).Free`); Phase 4.3 wires the surface-level builtin and the effect-gating check. Defer rationale: depends on Phase 4.1 grammar (a `gc.kill(x)` call site needs to know `x` was bound `consume` to satisfy rule E's single-use obligation).
 
 ### Phase 5: vm3jit hardening (runs alongside MEP-40 Phase 5)
 


### PR DESCRIPTION
Closes #21935.

## Summary

- IR gains `RefMode` enum and `Function.RefModes` side table (default nil keeps default-mode programs at zero overhead).
- Verifier gains rule class E: borrow forbids writes, consume permits at most one Dispatch use, weak forbids any direct Dispatch, inout permits all.
- `mustClassifyAllDispatch` runs at init() so a new Dispatch op added to `ir/types.go` without rule-E classification panics at import time (spec-in-sync rule machine-enforced for rule E).
- MEP-41 §6.9 spec gains the formal rule E table; §8 Phase 4 row closes with Phase 4.1 (surface grammar), 4.2 (JIT elision), 4.3 (`gc.kill`) pre-registered as deferred sub-phases.
- `docs/security/memory-safety.md` §9 Phase 4 row marked LANDED.

## Test plan

- [x] `go test ./compiler3/verify/` (14 new rule E tests pass; all prior verifier tests pass)
- [x] `go test ./compiler3/ir/` (no regression from `RefModes` field addition)
- [x] `go test ./compiler3/... ./runtime/vm3/ ./docs/security/` (full suite, no regressions)
- [x] `go build ./...` (clean build)
- [x] No em-dashes / en-dashes in policed files (security_docs_test.go enforced)