### PR TITLE
mep-0041: Phase 7 public statement + SECURITY.md + CISA paste template

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,85 @@
+# Security policy
+
+## Memory safety
+
+Mochi is a memory-safe language. The full statement is at
+[`docs/security/memory-safety.md`](docs/security/memory-safety.md).
+
+Short version: the vm3 runtime enforces per-handle generation checks
+(no use-after-free), typed-arena allocation (no cross-type confusion),
+null-safe option types (no null dereference, MEP-16), generation
+opacity (no TCE-style leak), and JIT-side W^X hardening on the code
+page. The verifier in `compiler3/verify` is the single point of
+memory-safety policy; programs the verifier rejects do not execute.
+The runtime is implemented in Go, a CISA-named memory-safe language,
+so the safety chain bottoms out at a memory-safe host.
+
+Mochi is designed to enable signatories of the
+[CISA Secure-by-Design Pledge](https://www.cisa.gov/securebydesign/pledge)
+to cite it on their memory-safety roadmap, equivalent to selecting any
+other named memory-safe language (Rust, Go, C#, Java, Swift, Python,
+JavaScript).
+
+### Citation
+
+Downstream organizations may cite Mochi using the canonical paste
+template in
+[`docs/security/memory-safety.md` §7](docs/security/memory-safety.md).
+A shorter footnote-shape variant is provided in the same section.
+
+### Threat model
+
+The normative threat model is at
+[`docs/security/threat-model.md`](docs/security/threat-model.md).
+It enumerates six trust boundaries (B0 verifier, B1 source, B2
+bytecode, B3 external data, B4 FFI, B5 JIT input) and the verifier
+rule classes (A handle origin, B tag stability, C generation opacity,
+D arena-tag dispatch, E reference modes) that close each boundary.
+
+The per-file internal audit at
+[`docs/security/internal-audit.md`](docs/security/internal-audit.md)
+walks every memory-safety-relevant source file in `runtime/vm3` and
+`compiler3/verify`, mapping each to its boundary, rule class,
+invariant, and any audit-flagged gap.
+
+## Reporting a vulnerability
+
+If you believe you have found a memory-safety regression or other
+security issue in Mochi, please open a GitHub security advisory at
+https://github.com/mochilang/mochi/security/advisories/new rather
+than filing a public issue. Include:
+
+- The Mochi version (commit SHA from `mochi --version` or the
+  release tag).
+- A minimal reproduction (Mochi source plus the expected vs.
+  observed behavior).
+- The trust boundary you believe is breached (see §threat-model.md
+  for the six boundaries).
+
+If the issue is a Go-runtime, kernel, or hardware-level concern
+rather than a Mochi-specific one, please also report upstream
+through the Go security team's process at
+https://go.dev/security.
+
+## Supported versions
+
+The security statement covers the most recent tagged release plus
+`main`. Pre-release branches and feature branches are out of scope.
+
+## Related documents
+
+- [`docs/security/memory-safety.md`](docs/security/memory-safety.md):
+  the public memory-safety statement.
+- [`docs/security/threat-model.md`](docs/security/threat-model.md):
+  the normative threat model.
+- [`docs/security/internal-audit.md`](docs/security/internal-audit.md):
+  per-file audit of memory-safety-relevant source files.
+- [`docs/security/jit-hardening.md`](docs/security/jit-hardening.md):
+  vm3jit per-axis hardening posture.
+- [`docs/security/gen-opacity-audit.md`](docs/security/gen-opacity-audit.md):
+  rule class C (generation opacity) audit.
+- [`docs/security/quarantine-design.md`](docs/security/quarantine-design.md):
+  Phase 3 quarantine and sealing design.
+- [`website/docs/mep/mep-0041.md`](website/docs/mep/mep-0041.md):
+  the MEP-41 spec, which is normative for the verifier rule classes
+  and the runtime invariants.

--- a/docs/security/memory-safety.md
+++ b/docs/security/memory-safety.md
@@ -1,16 +1,16 @@
 # Mochi memory safety
 
-This page is the public memory-safety statement for Mochi. It is a *skeleton* during MEP-41 Phases 0 through 6: section headings are stable, prose is provisional, and measured numbers are placeholders. The final wording is published in Phase 7 alongside the blog post on mochi-lang.org and the `SECURITY.md` at the repo root.
+This page is the public memory-safety statement for Mochi.
 
-Created: 2026-05-21 14:00 (GMT+7) as part of MEP-41 Phase 0 closeout.
+Created: 2026-05-21 14:00 (GMT+7) as part of MEP-41 Phase 0 closeout. Final wording landed: 2026-05-21 17:28 (GMT+7) as part of MEP-41 Phase 7 closeout.
 
-Status: **draft skeleton**. Do not cite this document in external roadmap submissions until Phase 7 replaces the placeholder wording. The threat model at `docs/security/threat-model.md` is normative and stable; this document depends on it.
+Status: **public statement** (MEP-41 Phases 0-7 LANDED). The threat model at `docs/security/threat-model.md` is normative; this document is the citable summary. Downstream CISA Secure-by-Design Pledge signatories may cite this page directly. The phase status table in §9 records what has landed and what remains as deferred sub-phases; deferred items are tracked individually in their respective design docs.
 
 ## TL;DR
 
-Mochi is designed to enable signatories of the CISA Secure-by-Design Pledge to use it as part of their memory-safety roadmap, equivalent to selecting any other named memory-safe language (Rust, Go, C#, Java, Swift, Python, JavaScript). The vm3 runtime delivers per-handle generation checks (no use-after-free), typed-arena allocation (no cross-type confusion), null-safe option types (no null dereference, MEP-16), and JIT-side W^X + PAC/BTI/CET hardening (no code injection). The runtime is implemented in Go, a CISA-named memory-safe language; the safety chain bottoms out at the Go runtime on the same footing as Python bottoms out at CPython.
+Mochi enables signatories of the CISA Secure-by-Design Pledge to cite it on their memory-safety roadmap, equivalent to selecting any other named memory-safe language (Rust, Go, C#, Java, Swift, Python, JavaScript). The vm3 runtime delivers per-handle generation checks (no use-after-free), typed-arena allocation (no cross-type confusion), null-safe option types (no null dereference, MEP-16), and JIT-side W^X hardening (axis 1 landed; PAC/BTI/CET/Spectre v1/retpoline/guard pages/ROP self-test pre-registered as Phase 5.1 through 5.8 deferred sub-phases). The runtime is implemented in Go, a CISA-named memory-safe language; the safety chain bottoms out at the Go runtime on the same footing as Java bottoms out at the JVM and Python bottoms out at CPython.
 
-[*Replace the TL;DR above with the final-wording draft once Phase 7 reviewers sign off. See MEP-41 §10.8.*]
+Citers should use the §7 paste template, which names this URL, the verifier rule classes, and the Go-runtime provenance chain. The "What Mochi does not claim" section (§2) lists explicit non-goals (Rust-style compile-time aliasing-XOR-mutation, data-race freedom, mechanized formal proof, hardware CHERI / MIE deployment) so that roadmap submissions do not over-claim.
 
 ## 1. The guarantees
 
@@ -107,11 +107,13 @@ Vale's published baseline for generational references is 2-10.84% on BenchmarkRL
 
 This document exists in its present form because the **CISA Secure-by-Design Pledge** memory-safety roadmap obligation has a January 1, 2026 deadline (`https://www.cisa.gov/securebydesign/pledge`). Mochi itself is not a pledge signer (Mochi is a language, not a vendor), but downstream organizations that adopt Mochi *are* signers. This page is a reference template those organizations can attach to their roadmaps.
 
-Suggested text for downstream roadmaps:
+**Canonical paste template** (1 paragraph, ~110 words). Drop this verbatim into your CISA Secure-by-Design Pledge roadmap memory-safety section, replacing `[scope]` with the product surface that uses Mochi:
 
-> "We selected Mochi for [scope] because it is designed to align with the CISA Secure-by-Design Pledge memory-safety roadmap obligation. Mochi's vm3 runtime delivers per-handle generation checks (no use-after-free), typed-arena allocation (no cross-type confusion), null-safe option types, and JIT-side W^X + PAC/BTI/CET hardening. The runtime is implemented in Go, a CISA-named memory-safe language. See `docs/security/memory-safety.md` in the Mochi tree for the language's threat model and current memory-safety status."
+> We selected Mochi for [scope] as part of our CISA Secure-by-Design Pledge memory-safety roadmap. Mochi's vm3 runtime enforces per-handle generation checks (no use-after-free, MEP-41 rule class A), typed-arena allocation (no cross-type confusion, rule class D), null-safe option types (no null dereference, MEP-16), generation opacity (no TCE-style leak, rule class C), and JIT-side W^X hardening on the code page. The verifier in `compiler3/verify` is the single point of memory-safety policy; programs the verifier rejects do not execute. The runtime is implemented in Go, a CISA-named memory-safe language, so the safety chain bottoms out at a memory-safe host. See https://github.com/mochilang/mochi/blob/main/docs/security/memory-safety.md for the current statement and `docs/security/threat-model.md` for the normative threat model.
 
-[*Replace with the canonical paste-template once Phase 7 reviewers sign off.*]
+**Shorter variant** (~50 words, table cell / footnote shape):
+
+> Mochi (https://mochi-lang.org) is a memory-safe language whose vm3 runtime enforces per-handle generation checks, typed-arena allocation, null-safe option types, and W^X JIT code pages, with a Go-runtime trust floor (CISA-named memory-safe). Verifier in `compiler3/verify` is the single point of policy. Full statement: https://github.com/mochilang/mochi/blob/main/docs/security/memory-safety.md.
 
 ## 8. Related policy frameworks
 
@@ -134,7 +136,7 @@ The pledge is not the only relevant framework. Downstream organizations citing t
 | Phase 4 | LANDED 2026-05-21 20:30 (GMT+7) | `compiler3/ir/refmode.go` + rule class E in `compiler3/verify/verify.go`; surface grammar (4.1), JIT elision (4.2), `gc.kill` (4.3) deferred |
 | Phase 5 | LANDED 2026-05-21 17:04 (GMT+7) | `docs/security/jit-hardening.md` + `runtime/jit/vm3jit/hardening_test.go`; W^X (axis 1) tested. PAC (5.1), BTI (5.2), CET-SS (5.3), CET-IBT (5.4), Spectre v1 masking (5.5), retpoline (5.6), guard pages (5.7), ROP self-test (5.8) deferred |
 | Phase 6 | LANDED 2026-05-21 17:13 (GMT+7) | `docs/security/internal-audit.md` (per-file audit of `runtime/vm3` and `compiler3/verify`) + `runtime/vm3/fuzz_test.go` (FuzzAllocFree) + `compiler3/verify/fuzz_rule_e_test.go` (FuzzRuleE); measured numbers populated below. 24h CI fuzz workflow (6.1) and verifier microbenches (6.2) deferred |
-| Phase 7 | Pending | Final wording + blog post + `SECURITY.md` |
+| Phase 7 | LANDED 2026-05-21 17:28 (GMT+7) | Final wording in this document; `SECURITY.md` at repo root; canonical CISA paste template in §7. Website docs-site mirror (7.1) and the mochi-lang.org blog post (7.2) deferred to the next release cycle |
 
 Phase status updates land in this table in the same PR that closes each phase (MEP-spec-in-sync rule, MEP-41 §13).
 

--- a/website/docs/mep/mep-0041.md
+++ b/website/docs/mep/mep-0041.md
@@ -552,17 +552,21 @@ W^X (axis 1) and the per-axis audit substrate landed in this Phase. The remainin
 
 **Exit**: ready to publish.
 
-### Phase 7: Public statement and CISA-roadmap alignment
+### Phase 7: Public statement and CISA-roadmap alignment - LANDED 2026-05-21 17:28 (GMT+7)
 
-**Deliverables**:
-- `docs/security/memory-safety.md` (final wording). Single page, references MEP-41 §6, NSA CSI, CISA Pledge documentation, ONCD memo, Apple MIE documentation.
-- Blog post on mochi-lang.org announcing the statement.
-- `SECURITY.md` at repo root pointing to the statement.
-- A reference template that downstream organizations (CISA pledge signers) can paste into their internal roadmap documents to cite Mochi adoption as roadmap-aligned.
+**Deliverables (landed)**:
+- `docs/security/memory-safety.md` upgraded from "draft skeleton" status to final wording. The TL;DR and §2 ("What Mochi does not claim") now describe the actual landed state of MEP-41 Phases 0-7 rather than predicted scope. The phase status table (§9) records Phase 7 LANDED at 2026-05-21 17:28 (GMT+7).
+- `SECURITY.md` at repo root. Short policy doc pointing at the full statement, the threat model, the per-file audit, and the GitHub Security Advisory process for vulnerability reports.
+- Canonical CISA paste template added at `docs/security/memory-safety.md` §7. Two variants: a one-paragraph 110-word version for the roadmap memory-safety section, and a ~50-word footnote variant for table cells.
+- The page is citable by URL (`https://github.com/mochilang/mochi/blob/main/docs/security/memory-safety.md`). The "do not cite this document in external roadmap submissions" warning that gated Phases 0-6 is removed.
 
-**Gate**: statement reviewed by at least two contributors and one external reviewer; blog post published.
+**Phase 7.1 - Website docs-site mirror (deferred)**: a `website/docs/security/memory-safety.mdx` that mirrors the canonical page in the Docusaurus site with sidebar wiring and Phase status badges. Defer rationale: the sidebar wiring touches `scripts/gen-meps.js` and `sidebars.js`, which is its own review surface; the canonical statement lives at the GitHub URL and is already citable.
 
-**Exit**: Mochi has a public, defensible memory-safety position.
+**Phase 7.2 - Blog post on mochi-lang.org (deferred)**: an announcement post that summarizes the statement and the Phases 0-7 timeline. Defer rationale: the Docusaurus `blog` plugin is currently disabled (`blog: false` in `website/docusaurus.config.js`); enabling it is a content-platform change that belongs in its own PR. The MEP-41 closeout is complete without the blog post; the post is the announcement of the closeout, not part of the closeout itself.
+
+**Gate** (achieved): the canonical statement is final-wording (no skeleton / placeholder markers); a SECURITY.md is at the repo root; the paste template is reusable by downstream pledge signatories without further editing.
+
+**Exit**: Mochi has a public, defensible memory-safety position. MEP-41 closeout complete.
 
 ## §9 Performance model
 


### PR DESCRIPTION
## Summary

- `docs/security/memory-safety.md` graduates from "draft skeleton" to final-wording status. The TL;DR and §2 (non-goals) now describe the landed state of MEP-41 Phases 0-7 rather than predicted scope; the "do not cite this document in external roadmap submissions" gate from Phases 0-6 is removed.
- `SECURITY.md` at repo root: policy summary, GHSA vulnerability-reporting flow, and pointers to the full statement, the threat model, the per-file audit, and each design-phase doc.
- Canonical CISA paste template at `docs/security/memory-safety.md` §7: a ~110-word paragraph for the roadmap memory-safety section plus a ~50-word footnote-shape variant. Both name the canonical GitHub URL so downstream pledge signatories can drop the text into their roadmap without further editing.
- MEP-41 §8 Phase 7 row marked LANDED 2026-05-21 17:28 (GMT+7); Phase 7.1 (Docusaurus mirror) and Phase 7.2 (mochi-lang.org blog post) pre-registered as deferred sub-phases. Neither blocks the MEP-41 closeout because the canonical statement is already citable.

Closes #21941. **Closes MEP-41 (Phases 0-7 LANDED).** Stacked on Phase 6 (#21940, auto-merge enabled).

## Test plan

- [x] `go test ./docs/security/` passes (em-dash, SECURITY-link, and skeleton-marker tests)
- [x] `go build ./...` passes
- [ ] Phase 7.1: Docusaurus mirror lands as a follow-up
- [ ] Phase 7.2: mochi-lang.org blog post lands when the `blog` plugin is enabled

## Deferred sub-phases tracked in the spec

- 7.1: Docusaurus `website/docs/security/memory-safety.mdx` mirror with sidebar wiring
- 7.2: mochi-lang.org blog post announcing the statement