### PR TITLE
mep-0042: Phase 2 non-allocating stencil set + multi-block emit

### DIFF
--- a/compiler3/emit/copypatch/emit.go
+++ b/compiler3/emit/copypatch/emit.go
@@ -1,6 +1,7 @@
 package copypatch
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 
@@ -8,51 +9,82 @@ import (
 )
 
 // ErrUnsupportedArch is returned by Compile when no stencil table is
-// available for the host GOARCH. Phase 1 ships an amd64 table only;
-// aarch64 lands in 1.5.
-var ErrUnsupportedArch = errors.New("copypatch: no stencil table for this GOARCH (phase 1 ships amd64 only)")
+// available for the host GOARCH. Phase 1 shipped an amd64 table only;
+// Phase 2 widens the table to cover the full non-allocating opcode set
+// (still amd64-only); aarch64 lands in Phase 2.1.
+var ErrUnsupportedArch = errors.New("copypatch: no stencil table for this GOARCH (phase 2 ships amd64 only)")
 
 // ErrNoStencil is returned by Compile when a Function references an
 // IR opcode the stencil table does not cover. The expected response
 // is fall-back to the vm3 interpreter; the JIT does not synthesize
-// missing stencils. Phase 1.2 widens the table to cover all non-
-// allocating ops.
+// missing stencils. Phase 2.3 introduces the cross-op register
+// allocator that unlocks OpPhi support; until then, OpPhi reports
+// ErrNoStencil.
 var ErrNoStencil = errors.New("copypatch: stencil table does not cover this opcode")
+
+// ErrBranchOutOfRange is returned by Compile when an inter-block
+// branch displacement exceeds the int32 range an E9/0F 85 rel32
+// instruction can express. The amd64 ISA tops out at ±2 GiB; a Mochi
+// function that produces a buffer larger than that is far outside the
+// Phase 2 envelope and triggers fall-back to vm3.
+var ErrBranchOutOfRange = errors.New("copypatch: inter-block branch displacement exceeds int32 range")
 
 // Emitter walks a compiler3 IR Function and produces a buffer of
 // machine code plus the relocations the runtime patcher applies. It
 // is the JIT analog of compiler3/emit/go: same input shape (an
 // ir.Function), different output (machine bytes vs Go source).
 //
-// One Emitter instance compiles one Function. The instance is cheap
-// to construct (no syscalls, no allocations beyond a small slice
-// preallocation); the per-VM JIT keeps a sync.Pool of them in
-// Phase 1.6 once the BG parity gate lands.
+// One Emitter instance compiles one Function. Construction is cheap
+// (no syscalls, no allocations beyond a small slice preallocation);
+// the per-VM JIT keeps a sync.Pool of them in Phase 1.6 once the BG
+// parity gate lands.
+//
+// Phase 2 extends Phase 1's single-block emitter to walk multi-block
+// CFGs with TermJump and TermBranch terminators. The walk happens in
+// fn.Blocks order (the IR's stable block ID order); branches that
+// target a block emitted later in the buffer are recorded as
+// blockFixups and patched after the whole function is emitted. Block
+// ordering is the IR builder's responsibility; the emitter does not
+// reorder.
 type Emitter struct {
 	stencils map[ir.OpCode]Stencil
 
-	// out is the accumulating machine-code buffer. The emitter
-	// appends one stencil's Bytes per IR op (the "copy" half of
-	// copy-and-patch); the "patch" half walks the parallel relocs
-	// slice at the end and rewrites offsets in place.
+	// out is the accumulating machine-code buffer. The emitter appends
+	// one stencil's Bytes per IR op (the "copy" half of copy-and-patch);
+	// the "patch" half walks the parallel relocs slice plus blockFixups
+	// at the end and rewrites offsets in place.
 	out []byte
 
 	// relocs accumulates the patch sites for the whole function, with
-	// each RelocSite.Offset re-based to the function-buffer offset
-	// (not the per-stencil offset). The runtime patcher applies these
-	// after the buffer is mmap'd into the code cache.
+	// each RelocSite.Offset re-based to the function-buffer offset (not
+	// the per-stencil offset). The runtime patcher applies these after
+	// the buffer is mmap'd into the code cache.
 	relocs []RelocSite
 
-	// fnReturnTerm, when non-zero, names the SSA value the function's
-	// TermReturn carries; the emitter loads it into the trampoline's
-	// result slot via the OpInvalid (ret) stencil at the end of the
-	// last block.
-	fnReturnTerm uint32
+	// blockStarts records the function-buffer offset at which each
+	// block's code begins. Indexed by ir.Block.ID (which equals the
+	// block's position in fn.Blocks, per the IR's AddBlock contract).
+	blockStarts []uint32
+
+	// blockFixups records every inter-block branch instruction that
+	// references a yet-unresolved block start. After the whole function
+	// is emitted, finalizeBranches walks this slice and writes the
+	// resolved rel32 displacement at each site.
+	blockFixups []blockFixup
+}
+
+// blockFixup names a 4-byte little-endian int32 displacement slot in
+// e.out whose value is target-block-start minus the end of the rel32
+// field. site is the offset of the displacement word itself; targetID
+// is the ir.Block.ID the branch jumps to.
+type blockFixup struct {
+	site     uint32
+	targetID uint32
 }
 
 // NewEmitter constructs an Emitter for the host architecture. Returns
-// ErrUnsupportedArch on non-amd64 hosts (Phase 1 scope). Callers
-// must check Supported() if they want a non-error precheck.
+// ErrUnsupportedArch on non-amd64 hosts (Phase 2 scope). Callers must
+// check Supported() if they want a non-error precheck.
 func NewEmitter() (*Emitter, error) {
 	tab := archStencils()
 	if tab == nil {
@@ -62,7 +94,7 @@ func NewEmitter() (*Emitter, error) {
 }
 
 // Supported reports whether the host architecture has a stencil
-// table. False on non-amd64 in Phase 1. The runtime gates
+// table. False on non-amd64 in Phase 2. The runtime gates
 // `mochi run --jit=copypatch` on this and falls back to vm3 when
 // false.
 func Supported() bool {
@@ -73,44 +105,48 @@ func Supported() bool {
 // relocations. The returned buffer is RW; the caller must hand it to
 // a code-cache slab (cache.go) for the W^X flip before jumping to it.
 //
-// Phase 1 covers a tiny IR shape: a single basic block whose values
-// are exactly one OpConst followed by zero or more OpAddI64 values,
-// terminated by a TermReturn that names the last value. Anything
-// else returns ErrNoStencil and falls back to the interpreter. The
-// Phase 1.2 widening lifts this restriction.
+// Phase 2 covers the non-allocating opcode set: OpConst, the i64
+// arithmetic ops (Add/Sub/Mul/Neg plus the matching Imm variants),
+// the six i64 comparisons (Eq/Ne/Lt/Le/Gt/Ge plus Imm variants), and
+// the three terminators TermReturn / TermJump / TermBranch across
+// multi-block CFGs. OpPhi triggers ErrNoStencil because the cross-op
+// register allocator that unlocks join-point liveness handling lands
+// in Phase 2.3. OpDivI64 / OpModI64 trigger ErrNoStencil because
+// their overflow handling needs a slow-path call (Phase 2.5). f64
+// arithmetic is deferred to Phase 2.2. Anything else falls back to
+// vm3.
 func (e *Emitter) Compile(fn *ir.Function) ([]byte, []RelocSite, error) {
 	if fn == nil {
 		return nil, nil, fmt.Errorf("copypatch.Compile: nil Function")
 	}
-	if len(fn.Blocks) != 1 {
-		return nil, nil, fmt.Errorf("%w: phase 1 requires exactly one block, got %d",
-			ErrNoStencil, len(fn.Blocks))
+	if len(fn.Blocks) == 0 {
+		return nil, nil, fmt.Errorf("%w: function has no blocks", ErrNoStencil)
 	}
 	e.out = e.out[:0]
 	e.relocs = e.relocs[:0]
-	blk := &fn.Blocks[0]
-	for _, vid := range blk.Values {
-		v := &fn.Values[vid]
-		if v.Op == ir.OpParam {
-			continue // params are arena-base-relative loads inserted by 1.2
+	if cap(e.blockStarts) < len(fn.Blocks) {
+		e.blockStarts = make([]uint32, len(fn.Blocks))
+	} else {
+		e.blockStarts = e.blockStarts[:len(fn.Blocks)]
+		for i := range e.blockStarts {
+			e.blockStarts[i] = 0
 		}
-		s, ok := e.stencils[v.Op]
-		if !ok {
-			return nil, nil, fmt.Errorf("%w: %s", ErrNoStencil, v.Op)
+	}
+	e.blockFixups = e.blockFixups[:0]
+
+	for bi := range fn.Blocks {
+		blk := &fn.Blocks[bi]
+		e.blockStarts[bi] = uint32(len(e.out))
+		if err := e.emitBlock(fn, blk); err != nil {
+			return nil, nil, err
 		}
-		e.appendStencil(&s, v)
+		if err := e.emitTerm(blk); err != nil {
+			return nil, nil, err
+		}
 	}
-	if blk.Term.Kind != ir.TermReturn {
-		return nil, nil, fmt.Errorf("%w: phase 1 requires TermReturn terminator, got kind %d",
-			ErrNoStencil, blk.Term.Kind)
+	if err := e.finalizeBranches(); err != nil {
+		return nil, nil, err
 	}
-	// Append the ret stencil (registered under OpInvalid in the
-	// Phase 1 amd64 table).
-	ret, ok := e.stencils[ir.OpInvalid]
-	if !ok {
-		return nil, nil, fmt.Errorf("%w: ret stencil missing from table", ErrNoStencil)
-	}
-	e.appendStencil(&ret, nil)
 	// Defensive copy so the caller's mutation cannot disturb the
 	// emitter's internal buffers (and vice versa).
 	outCopy := make([]byte, len(e.out))
@@ -120,18 +156,110 @@ func (e *Emitter) Compile(fn *ir.Function) ([]byte, []RelocSite, error) {
 	return outCopy, relocsCopy, nil
 }
 
+// emitBlock emits the value-producing instructions of blk. OpParam is
+// skipped (params are arena-base-relative loads inserted by Phase 2.2's
+// register allocator). OpPhi triggers ErrNoStencil (deferred to 2.3).
+// Every other opcode must have a Phase 2 stencil; anything missing
+// reports ErrNoStencil so the caller can fall back to vm3.
+func (e *Emitter) emitBlock(fn *ir.Function, blk *ir.Block) error {
+	for _, vid := range blk.Values {
+		v := &fn.Values[vid]
+		switch v.Op {
+		case ir.OpParam:
+			continue
+		case ir.OpPhi:
+			return fmt.Errorf("%w: phi (deferred to phase 2.3 cross-op register allocator)",
+				ErrNoStencil)
+		}
+		s, ok := e.stencils[v.Op]
+		if !ok {
+			return fmt.Errorf("%w: %s", ErrNoStencil, v.Op)
+		}
+		e.appendStencil(&s, v)
+	}
+	return nil
+}
+
+// emitTerm emits the block's terminator. TermReturn appends the ret
+// stencil (registered under OpInvalid in the amd64 table). TermJump
+// emits E9 + rel32 and records a blockFixup. TermBranch emits
+// test rax,rax + jne rel32 + jmp rel32, recording two blockFixups.
+// Any other kind reports ErrNoStencil.
+func (e *Emitter) emitTerm(blk *ir.Block) error {
+	switch blk.Term.Kind {
+	case ir.TermReturn:
+		ret, ok := e.stencils[ir.OpInvalid]
+		if !ok {
+			return fmt.Errorf("%w: ret stencil missing from table", ErrNoStencil)
+		}
+		e.appendStencil(&ret, nil)
+		return nil
+
+	case ir.TermJump:
+		// E9 cd  jmp rel32
+		base := uint32(len(e.out))
+		e.out = append(e.out, 0xE9, 0, 0, 0, 0)
+		e.blockFixups = append(e.blockFixups, blockFixup{
+			site:     base + 1,
+			targetID: blk.Term.Target,
+		})
+		return nil
+
+	case ir.TermBranch:
+		// test rax, rax       (48 85 C0)
+		// jne IfTrue          (0F 85 cd)
+		// jmp IfFalse         (E9 cd)
+		base := uint32(len(e.out))
+		e.out = append(e.out,
+			0x48, 0x85, 0xC0,
+			0x0F, 0x85, 0, 0, 0, 0,
+			0xE9, 0, 0, 0, 0,
+		)
+		e.blockFixups = append(e.blockFixups,
+			blockFixup{site: base + 5, targetID: blk.Term.IfTrue},
+			blockFixup{site: base + 10, targetID: blk.Term.IfFalse},
+		)
+		return nil
+
+	default:
+		return fmt.Errorf("%w: unsupported terminator kind %d", ErrNoStencil, blk.Term.Kind)
+	}
+}
+
+// finalizeBranches walks e.blockFixups and writes the resolved rel32
+// displacement at each site. A displacement is the target block's
+// start offset minus the end of the rel32 field (site + 4). The
+// resulting int64 must fit in int32; if not, ErrBranchOutOfRange is
+// returned and the caller falls back to vm3.
+func (e *Emitter) finalizeBranches() error {
+	for _, f := range e.blockFixups {
+		if int(f.targetID) >= len(e.blockStarts) {
+			return fmt.Errorf("%w: branch target block ID %d out of range (have %d blocks)",
+				ErrNoStencil, f.targetID, len(e.blockStarts))
+		}
+		target := int64(e.blockStarts[f.targetID])
+		end := int64(f.site) + 4
+		disp := target - end
+		if disp < -(1<<31) || disp > (1<<31)-1 {
+			return fmt.Errorf("%w: displacement %d at site %d", ErrBranchOutOfRange, disp, f.site)
+		}
+		binary.LittleEndian.PutUint32(e.out[f.site:f.site+4], uint32(int32(disp)))
+	}
+	return nil
+}
+
 // appendStencil copies s.Bytes into e.out, rebasing each reloc's
-// Offset to the function-buffer coordinate. The caller's Value v is
-// passed through so the Addend on an immediate stencil can carry the
-// IR's Value.Const (the Phase 1 OpConst path). v may be nil for
-// terminator stencils.
+// Offset to the function-buffer coordinate. The caller's Value v
+// flows through so the Addend on an immediate stencil can carry the
+// IR's Value.Const (the OpConst path on RelocImm64 and the *Imm
+// opcode path on RelocImm32). v may be nil for terminator stencils.
 //
-// Phase 1 trick on OpConst: the reloc names SymOpRetTarget as a
-// placeholder symbol; the actual i64 literal flows through Addend.
-// At Install time the SymbolTable resolves SymOpRetTarget to zero so
-// the patcher writes the Addend value verbatim. Phase 1.1 replaces
-// this with a dedicated SymImmI64 once stencilgen drives symbol
-// selection from real Clang relocations.
+// Phase 2 trick on immediates: the reloc names SymOpRetTarget as a
+// placeholder symbol; the actual literal flows through Addend. At
+// Install time the SymbolTable resolves SymOpRetTarget to zero so the
+// patcher writes the Addend value verbatim. Phase 1.1's stencilgen
+// pipeline will replace this with a dedicated SymImmI64 once Clang
+// drives symbol selection from real relocations.
 func (e *Emitter) appendStencil(s *Stencil, v *ir.Value) {
 	base := uint32(len(e.out))
 	e.out = append(e.out, s.Bytes...)
@@ -139,8 +267,34 @@ func (e *Emitter) appendStencil(s *Stencil, v *ir.Value) {
 	e.relocs = append(e.relocs, s.Relocs...)
 	for i := first; i < len(e.relocs); i++ {
 		e.relocs[i].Offset += base
-		if v != nil && v.Op == ir.OpConst && e.relocs[i].Kind == RelocImm64 {
-			e.relocs[i].Addend = int32(v.Const)
+		if v == nil {
+			continue
+		}
+		switch e.relocs[i].Kind {
+		case RelocImm64:
+			if v.Op == ir.OpConst {
+				e.relocs[i].Addend = int32(v.Const)
+			}
+		case RelocImm32:
+			if isImmediateOp(v.Op) {
+				e.relocs[i].Addend = int32(v.Const)
+			}
 		}
 	}
+}
+
+// isImmediateOp reports whether op is one of the *Imm IR opcodes
+// whose Value.Const carries a 32-bit literal the stencil patches into
+// its imm32 field. Used by appendStencil to decide whether to copy
+// Value.Const into the reloc's Addend.
+func isImmediateOp(op ir.OpCode) bool {
+	switch op {
+	case ir.OpAddI64Imm, ir.OpSubI64Imm, ir.OpMulI64Imm,
+		ir.OpDivI64Imm, ir.OpModI64Imm,
+		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm,
+		ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm,
+		ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm:
+		return true
+	}
+	return false
 }

--- a/compiler3/emit/copypatch/emit_test.go
+++ b/compiler3/emit/copypatch/emit_test.go
@@ -1,6 +1,7 @@
 package copypatch
 
 import (
+	"encoding/binary"
 	"errors"
 	"testing"
 
@@ -27,7 +28,7 @@ func TestEmitterSupportedMatchesArch(t *testing.T) {
 // the ret stencil's bytes, with the imm64 patched in.
 func TestCompileConstReturn(t *testing.T) {
 	if !Supported() {
-		t.Skip("phase 1 ships amd64 only")
+		t.Skip("phase 2 ships amd64 only")
 	}
 	fn := buildConstReturn(123456789)
 	e, err := NewEmitter()
@@ -55,12 +56,12 @@ func TestCompileConstReturn(t *testing.T) {
 	}
 }
 
-// TestCompileAddChain covers the multi-op path: Const + Add + Return.
-// The emitter walks the block's Values, picks a stencil per op, and
-// rebases each stencil's relocs to the function-buffer offset.
+// TestCompileAddChain covers the multi-op path: Const + Const + Add +
+// Return. The emitter walks the block's Values, picks a stencil per
+// op, and rebases each stencil's relocs to the function-buffer offset.
 func TestCompileAddChain(t *testing.T) {
 	if !Supported() {
-		t.Skip("phase 1 ships amd64 only")
+		t.Skip("phase 2 ships amd64 only")
 	}
 	fn := buildConstAddReturn(100, 23)
 	e, err := NewEmitter()
@@ -75,7 +76,6 @@ func TestCompileAddChain(t *testing.T) {
 	if got, want := len(code), 24; got != want {
 		t.Errorf("len(code) = %d, want %d", got, want)
 	}
-	// Two relocs, one per OpConst, each at offset (idx * 10) + 2.
 	if got, want := len(relocs), 2; got != want {
 		t.Errorf("len(relocs) = %d, want %d", got, want)
 	}
@@ -90,21 +90,349 @@ func TestCompileAddChain(t *testing.T) {
 	}
 }
 
-// TestCompileNoStencil checks the fallback path: when the IR
-// references an opcode the stencil table does not cover, Compile
-// returns ErrNoStencil and the caller is expected to fall back to
-// vm3 interpretation.
-func TestCompileNoStencil(t *testing.T) {
+// TestCompileBinaryArith covers OpSubI64, OpMulI64, and OpNegI64.
+// Each variant is exercised end-to-end: two-constant feed plus the
+// arith op plus ret, and we check the buffer length plus the stencil
+// bytes that appear at the arith-op offset.
+func TestCompileBinaryArith(t *testing.T) {
 	if !Supported() {
-		t.Skip("phase 1 ships amd64 only")
+		t.Skip("phase 2 ships amd64 only")
 	}
-	fn := &ir.Function{
-		Name:   "unsupported",
-		Result: ir.TypeI64,
+	cases := []struct {
+		name   string
+		op     ir.OpCode
+		bytes  []byte
+		opSize int
+	}{
+		{"sub", ir.OpSubI64, []byte{0x48, 0x29, 0xF8}, 3},
+		{"mul", ir.OpMulI64, []byte{0x48, 0x0F, 0xAF, 0xC7}, 4},
 	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fn := buildBinaryOp(c.op, 11, 22)
+			e, err := NewEmitter()
+			if err != nil {
+				t.Fatalf("NewEmitter: %v", err)
+			}
+			code, _, err := e.Compile(fn)
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			// Two OpConst (10 bytes each) + arith + ret.
+			wantLen := 20 + c.opSize + 1
+			if got := len(code); got != wantLen {
+				t.Fatalf("len(code) = %d, want %d", got, wantLen)
+			}
+			arith := code[20 : 20+c.opSize]
+			for i, b := range c.bytes {
+				if arith[i] != b {
+					t.Errorf("arith[%d] = %#02x, want %#02x", i, arith[i], b)
+				}
+			}
+		})
+	}
+}
+
+// TestCompileNegI64 walks the unary OpNegI64 lowering: one OpConst
+// feeds the neg, the result is returned. neg rax = 48 F7 D8.
+func TestCompileNegI64(t *testing.T) {
+	if !Supported() {
+		t.Skip("phase 2 ships amd64 only")
+	}
+	fn := &ir.Function{Name: "neg", Result: ir.TypeI64}
 	bid := fn.AddBlock()
-	// OpMulI64 has no stencil in the Phase 1 table.
-	v := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpMulI64})
+	va := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 7})
+	vr := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpNegI64, Args: []uint32{va}})
+	fn.Block(bid).Values = append(fn.Block(bid).Values, va, vr)
+	fn.Block(bid).Term = ir.Terminator{Kind: ir.TermReturn, Value: vr}
+	e, err := NewEmitter()
+	if err != nil {
+		t.Fatalf("NewEmitter: %v", err)
+	}
+	code, _, err := e.Compile(fn)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	// OpConst (10) + neg (3) + ret (1) = 14.
+	if got, want := len(code), 14; got != want {
+		t.Fatalf("len(code) = %d, want %d", got, want)
+	}
+	want := []byte{0x48, 0xF7, 0xD8}
+	for i, b := range want {
+		if code[10+i] != b {
+			t.Errorf("code[%d] = %#02x, want %#02x", 10+i, code[10+i], b)
+		}
+	}
+}
+
+// TestCompileImmOps walks the three i64 arith-Imm stencils and checks
+// the imm32 Addend lands in the reloc. The IR uses one OpConst feeding
+// the *Imm op (whose Value.Const carries the immediate) and returns
+// the result.
+func TestCompileImmOps(t *testing.T) {
+	if !Supported() {
+		t.Skip("phase 2 ships amd64 only")
+	}
+	cases := []struct {
+		name   string
+		op     ir.OpCode
+		imm    int64
+		opSize int
+		// relocOffsetInOp names where in the *Imm stencil the imm32 sits.
+		relocOffsetInOp uint32
+	}{
+		{"add_imm", ir.OpAddI64Imm, 99, 6, 2},
+		{"sub_imm", ir.OpSubI64Imm, -7, 6, 2},
+		{"mul_imm", ir.OpMulI64Imm, 3, 7, 3},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fn := buildImmOp(c.op, 5, c.imm)
+			e, err := NewEmitter()
+			if err != nil {
+				t.Fatalf("NewEmitter: %v", err)
+			}
+			code, relocs, err := e.Compile(fn)
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			// OpConst (10) + *Imm (c.opSize) + ret (1).
+			if got, want := len(code), 11+c.opSize; got != want {
+				t.Fatalf("len(code) = %d, want %d", got, want)
+			}
+			// Two relocs: OpConst RelocImm64 at offset 2, *Imm RelocImm32
+			// at offset 10 + relocOffsetInOp.
+			if got, want := len(relocs), 2; got != want {
+				t.Fatalf("len(relocs) = %d, want %d", got, want)
+			}
+			want := uint32(10) + c.relocOffsetInOp
+			if relocs[1].Offset != want {
+				t.Errorf("imm reloc offset = %d, want %d", relocs[1].Offset, want)
+			}
+			if relocs[1].Kind != RelocImm32 {
+				t.Errorf("imm reloc kind = %s, want imm32", relocs[1].Kind)
+			}
+			if int64(relocs[1].Addend) != c.imm {
+				t.Errorf("imm addend = %d, want %d", relocs[1].Addend, c.imm)
+			}
+		})
+	}
+}
+
+// TestCompileCompare exercises the six i64 comparison lowerings. Each
+// must emit cmp rax, rdi (48 39 F8) + setCC al (0F XX C0) + movzx rax, al
+// (48 0F B6 C0), with the setCC opcode varying per relation.
+func TestCompileCompare(t *testing.T) {
+	if !Supported() {
+		t.Skip("phase 2 ships amd64 only")
+	}
+	cases := []struct {
+		name      string
+		op        ir.OpCode
+		setOpcode byte
+	}{
+		{"eq", ir.OpCmpEqI64, 0x94},
+		{"ne", ir.OpCmpNeI64, 0x95},
+		{"lt", ir.OpCmpLtI64, 0x9C},
+		{"le", ir.OpCmpLeI64, 0x9E},
+		{"gt", ir.OpCmpGtI64, 0x9F},
+		{"ge", ir.OpCmpGeI64, 0x9D},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fn := buildBinaryOp(c.op, 1, 2)
+			fn.Values[2].Type = ir.TypeBool
+			e, err := NewEmitter()
+			if err != nil {
+				t.Fatalf("NewEmitter: %v", err)
+			}
+			code, _, err := e.Compile(fn)
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			// Two OpConst (20) + cmp+setCC+movzx (10) + ret (1) = 31.
+			if got, want := len(code), 31; got != want {
+				t.Fatalf("len(code) = %d, want %d", got, want)
+			}
+			// cmp prefix at offset 20.
+			if code[20] != 0x48 || code[21] != 0x39 || code[22] != 0xF8 {
+				t.Errorf("cmp prefix = % x, want 48 39 F8", code[20:23])
+			}
+			// setCC opcode at offset 23+1.
+			if code[23] != 0x0F || code[24] != c.setOpcode || code[25] != 0xC0 {
+				t.Errorf("setCC = % x, want 0F %02x C0", code[23:26], c.setOpcode)
+			}
+			// movzx tail.
+			if code[26] != 0x48 || code[27] != 0x0F || code[28] != 0xB6 || code[29] != 0xC0 {
+				t.Errorf("movzx tail = % x, want 48 0F B6 C0", code[26:30])
+			}
+		})
+	}
+}
+
+// TestCompileCompareImm exercises the six i64-imm comparison
+// lowerings. The cmp prefix is 48 3D + imm32, the setCC opcode varies
+// per relation, and the imm32 Addend is set from Value.Const.
+func TestCompileCompareImm(t *testing.T) {
+	if !Supported() {
+		t.Skip("phase 2 ships amd64 only")
+	}
+	cases := []struct {
+		name      string
+		op        ir.OpCode
+		setOpcode byte
+	}{
+		{"eq", ir.OpCmpEqI64Imm, 0x94},
+		{"ne", ir.OpCmpNeI64Imm, 0x95},
+		{"lt", ir.OpCmpLtI64Imm, 0x9C},
+		{"le", ir.OpCmpLeI64Imm, 0x9E},
+		{"gt", ir.OpCmpGtI64Imm, 0x9F},
+		{"ge", ir.OpCmpGeI64Imm, 0x9D},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fn := buildImmOp(c.op, 42, 7)
+			fn.Values[1].Type = ir.TypeBool
+			e, err := NewEmitter()
+			if err != nil {
+				t.Fatalf("NewEmitter: %v", err)
+			}
+			code, relocs, err := e.Compile(fn)
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			// OpConst (10) + cmp+setCC+movzx (13) + ret (1) = 24.
+			if got, want := len(code), 24; got != want {
+				t.Fatalf("len(code) = %d, want %d", got, want)
+			}
+			// cmp prefix at offset 10.
+			if code[10] != 0x48 || code[11] != 0x3D {
+				t.Errorf("cmp prefix = % x, want 48 3D", code[10:12])
+			}
+			// setCC opcode at offset 16+1.
+			if code[16] != 0x0F || code[17] != c.setOpcode || code[18] != 0xC0 {
+				t.Errorf("setCC = % x, want 0F %02x C0", code[16:19], c.setOpcode)
+			}
+			// Two relocs: OpConst RelocImm64 at 2, *Imm RelocImm32 at 12.
+			if got, want := len(relocs), 2; got != want {
+				t.Fatalf("len(relocs) = %d, want %d", got, want)
+			}
+			if relocs[1].Offset != 12 || relocs[1].Kind != RelocImm32 {
+				t.Errorf("imm reloc = %+v, want offset=12 kind=imm32", relocs[1])
+			}
+			if relocs[1].Addend != 7 {
+				t.Errorf("imm addend = %d, want 7", relocs[1].Addend)
+			}
+		})
+	}
+}
+
+// TestCompileMultiBlockJump checks the multi-block TermJump path. Two
+// blocks: block 0 holds Const + TermJump to block 1; block 1 holds the
+// ret. The jump's rel32 must point from the end of the rel32 field to
+// the start of block 1.
+func TestCompileMultiBlockJump(t *testing.T) {
+	if !Supported() {
+		t.Skip("phase 2 ships amd64 only")
+	}
+	fn := &ir.Function{Name: "jump", Result: ir.TypeI64}
+	b0 := fn.AddBlock()
+	b1 := fn.AddBlock()
+	v := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 9})
+	fn.Block(b0).Values = append(fn.Block(b0).Values, v)
+	fn.Block(b0).Term = ir.Terminator{Kind: ir.TermJump, Target: b1}
+	fn.Block(b1).Term = ir.Terminator{Kind: ir.TermReturn, Value: v}
+	e, err := NewEmitter()
+	if err != nil {
+		t.Fatalf("NewEmitter: %v", err)
+	}
+	code, _, err := e.Compile(fn)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	// OpConst (10) + jmp E9+rel32 (5) + ret (1) = 16.
+	if got, want := len(code), 16; got != want {
+		t.Fatalf("len(code) = %d, want %d", got, want)
+	}
+	if code[10] != 0xE9 {
+		t.Errorf("expected E9 at offset 10, got %#02x", code[10])
+	}
+	// rel32 = block1 start (15) - end of rel32 field (15) = 0.
+	disp := int32(binary.LittleEndian.Uint32(code[11:15]))
+	if disp != 0 {
+		t.Errorf("jump disp = %d, want 0", disp)
+	}
+	if code[15] != 0xC3 {
+		t.Errorf("expected ret (C3) at offset 15, got %#02x", code[15])
+	}
+}
+
+// TestCompileMultiBlockBranch checks the TermBranch lowering. Three
+// blocks: block 0 produces a bool, branches to block 1 (true) or
+// block 2 (false). The emitter must lay down test rax,rax + jne IfTrue
+// + jmp IfFalse, with both rel32 displacements pointing at the right
+// block starts.
+func TestCompileMultiBlockBranch(t *testing.T) {
+	if !Supported() {
+		t.Skip("phase 2 ships amd64 only")
+	}
+	fn := &ir.Function{Name: "branch", Result: ir.TypeI64}
+	b0 := fn.AddBlock()
+	b1 := fn.AddBlock()
+	b2 := fn.AddBlock()
+	vcond := fn.AddValue(ir.Value{Type: ir.TypeBool, Op: ir.OpConst, Const: 1})
+	vone := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 1})
+	vtwo := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 2})
+	fn.Block(b0).Values = append(fn.Block(b0).Values, vcond)
+	fn.Block(b0).Term = ir.Terminator{Kind: ir.TermBranch, Value: vcond, IfTrue: b1, IfFalse: b2}
+	fn.Block(b1).Values = append(fn.Block(b1).Values, vone)
+	fn.Block(b1).Term = ir.Terminator{Kind: ir.TermReturn, Value: vone}
+	fn.Block(b2).Values = append(fn.Block(b2).Values, vtwo)
+	fn.Block(b2).Term = ir.Terminator{Kind: ir.TermReturn, Value: vtwo}
+	e, err := NewEmitter()
+	if err != nil {
+		t.Fatalf("NewEmitter: %v", err)
+	}
+	code, _, err := e.Compile(fn)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	// b0: OpConst (10) + test (3) + jne (6) + jmp (5) = 24.
+	// b1: OpConst (10) + ret (1) = 11. Starts at 24.
+	// b2: OpConst (10) + ret (1) = 11. Starts at 35.
+	// Total 46.
+	if got, want := len(code), 46; got != want {
+		t.Fatalf("len(code) = %d, want %d", got, want)
+	}
+	if code[10] != 0x48 || code[11] != 0x85 || code[12] != 0xC0 {
+		t.Errorf("test rax,rax bytes = % x, want 48 85 C0", code[10:13])
+	}
+	if code[13] != 0x0F || code[14] != 0x85 {
+		t.Errorf("jne prefix = % x, want 0F 85", code[13:15])
+	}
+	// jne rel32: site=15, end=19, target=24 → disp=5.
+	if disp := int32(binary.LittleEndian.Uint32(code[15:19])); disp != 5 {
+		t.Errorf("jne disp = %d, want 5", disp)
+	}
+	if code[19] != 0xE9 {
+		t.Errorf("jmp opcode = %#02x, want E9", code[19])
+	}
+	// jmp rel32: site=20, end=24, target=35 → disp=11.
+	if disp := int32(binary.LittleEndian.Uint32(code[20:24])); disp != 11 {
+		t.Errorf("jmp disp = %d, want 11", disp)
+	}
+}
+
+// TestCompileRejectsPhi checks that OpPhi triggers ErrNoStencil so
+// the caller falls back to vm3. Phase 2.3's cross-op register
+// allocator unlocks phi support.
+func TestCompileRejectsPhi(t *testing.T) {
+	if !Supported() {
+		t.Skip("phase 2 ships amd64 only")
+	}
+	fn := &ir.Function{Name: "phi", Result: ir.TypeI64}
+	bid := fn.AddBlock()
+	v := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpPhi})
 	fn.Block(bid).Values = append(fn.Block(bid).Values, v)
 	fn.Block(bid).Term = ir.Terminator{Kind: ir.TermReturn, Value: v}
 	e, err := NewEmitter()
@@ -113,7 +441,24 @@ func TestCompileNoStencil(t *testing.T) {
 	}
 	_, _, err = e.Compile(fn)
 	if !errors.Is(err, ErrNoStencil) {
-		t.Errorf("Compile err = %v, want ErrNoStencil", err)
+		t.Errorf("Compile(phi) err = %v, want ErrNoStencil", err)
+	}
+}
+
+// TestCompileRejectsDiv covers the OpDivI64 fallback. Division needs
+// an overflow slow-path (Phase 2.5); until then it must fall back.
+func TestCompileRejectsDiv(t *testing.T) {
+	if !Supported() {
+		t.Skip("phase 2 ships amd64 only")
+	}
+	fn := buildBinaryOp(ir.OpDivI64, 10, 2)
+	e, err := NewEmitter()
+	if err != nil {
+		t.Fatalf("NewEmitter: %v", err)
+	}
+	_, _, err = e.Compile(fn)
+	if !errors.Is(err, ErrNoStencil) {
+		t.Errorf("Compile(div) err = %v, want ErrNoStencil", err)
 	}
 }
 
@@ -121,7 +466,7 @@ func TestCompileNoStencil(t *testing.T) {
 // path must not segfault on a misuse.
 func TestCompileNilFunction(t *testing.T) {
 	if !Supported() {
-		t.Skip("phase 1 ships amd64 only")
+		t.Skip("phase 2 ships amd64 only")
 	}
 	e, err := NewEmitter()
 	if err != nil {
@@ -132,45 +477,67 @@ func TestCompileNilFunction(t *testing.T) {
 	}
 }
 
-// TestCompileMultiBlock checks the Phase 1 one-block restriction. A
-// Function with two blocks must reject as ErrNoStencil so the
-// fallback path engages cleanly.
-func TestCompileMultiBlock(t *testing.T) {
+// TestCompileEmptyFunction checks the no-block guard. An IR Function
+// with zero Blocks is a malformed input; the emitter rejects it as
+// ErrNoStencil so the caller falls back rather than emitting an empty
+// buffer the runtime would jump into.
+func TestCompileEmptyFunction(t *testing.T) {
 	if !Supported() {
-		t.Skip("phase 1 ships amd64 only")
+		t.Skip("phase 2 ships amd64 only")
 	}
-	fn := &ir.Function{Name: "twoblocks", Result: ir.TypeI64}
-	fn.AddBlock()
-	fn.AddBlock()
-	fn.Blocks[0].Term = ir.Terminator{Kind: ir.TermJump, Target: 1}
-	fn.Blocks[1].Term = ir.Terminator{Kind: ir.TermReturn}
+	fn := &ir.Function{Name: "empty", Result: ir.TypeI64}
 	e, err := NewEmitter()
 	if err != nil {
 		t.Fatalf("NewEmitter: %v", err)
 	}
 	_, _, err = e.Compile(fn)
 	if !errors.Is(err, ErrNoStencil) {
-		t.Errorf("Compile multi-block err = %v, want ErrNoStencil", err)
+		t.Errorf("Compile(empty) err = %v, want ErrNoStencil", err)
 	}
 }
 
-// TestCompileMissingTerminator covers the TermReturn-only check. A
-// function without TermReturn is rejected; Phase 1.4 lifts this
-// restriction once branch stencils land.
-func TestCompileMissingTerminator(t *testing.T) {
+// TestCompileBadTerminator checks the TermInvalid fallback. The IR
+// validator should already have caught this, but the emitter must
+// refuse defensively so the runtime never lands on an unterminated
+// buffer.
+func TestCompileBadTerminator(t *testing.T) {
 	if !Supported() {
-		t.Skip("phase 1 ships amd64 only")
+		t.Skip("phase 2 ships amd64 only")
 	}
-	fn := &ir.Function{Name: "nojump", Result: ir.TypeI64}
+	fn := &ir.Function{Name: "bad_term", Result: ir.TypeI64}
 	bid := fn.AddBlock()
-	fn.Block(bid).Term = ir.Terminator{Kind: ir.TermJump, Target: 0}
+	fn.Block(bid).Term = ir.Terminator{Kind: ir.TermInvalid}
 	e, err := NewEmitter()
 	if err != nil {
 		t.Fatalf("NewEmitter: %v", err)
 	}
 	_, _, err = e.Compile(fn)
 	if !errors.Is(err, ErrNoStencil) {
-		t.Errorf("Compile missing-Return err = %v, want ErrNoStencil", err)
+		t.Errorf("Compile(bad_term) err = %v, want ErrNoStencil", err)
+	}
+}
+
+// TestIsImmediateOp enumerates the *Imm opcodes the appendStencil
+// addend-patch path covers, plus a couple of negatives. A regression
+// would silently drop the Value.Const literal into a zero Addend.
+func TestIsImmediateOp(t *testing.T) {
+	yes := []ir.OpCode{
+		ir.OpAddI64Imm, ir.OpSubI64Imm, ir.OpMulI64Imm,
+		ir.OpDivI64Imm, ir.OpModI64Imm,
+		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm,
+		ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm,
+		ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm,
+	}
+	for _, op := range yes {
+		if !isImmediateOp(op) {
+			t.Errorf("isImmediateOp(%s) = false, want true", op)
+		}
+	}
+	no := []ir.OpCode{ir.OpConst, ir.OpAddI64, ir.OpCmpEqI64, ir.OpParam}
+	for _, op := range no {
+		if isImmediateOp(op) {
+			t.Errorf("isImmediateOp(%s) = true, want false", op)
+		}
 	}
 }
 
@@ -205,6 +572,33 @@ func buildConstAddReturn(a, b int64) *ir.Function {
 	vb := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: b})
 	vr := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpAddI64, Args: []uint32{va, vb}})
 	fn.Block(bid).Values = append(fn.Block(bid).Values, va, vb, vr)
+	fn.Block(bid).Term = ir.Terminator{Kind: ir.TermReturn, Value: vr}
+	return fn
+}
+
+// buildBinaryOp constructs a single-block Function that evaluates
+// op(a, b) where a, b are i64 literals and op is one of the i64
+// binary opcodes the Phase 2 stencil set covers.
+func buildBinaryOp(op ir.OpCode, a, b int64) *ir.Function {
+	fn := &ir.Function{Name: op.String(), Result: ir.TypeI64}
+	bid := fn.AddBlock()
+	va := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: a})
+	vb := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: b})
+	vr := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: op, Args: []uint32{va, vb}})
+	fn.Block(bid).Values = append(fn.Block(bid).Values, va, vb, vr)
+	fn.Block(bid).Term = ir.Terminator{Kind: ir.TermReturn, Value: vr}
+	return fn
+}
+
+// buildImmOp constructs a single-block Function that evaluates
+// op(a, imm) where a is an i64 literal feeding the left operand and
+// imm is the *Imm right operand carried in Value.Const.
+func buildImmOp(op ir.OpCode, a, imm int64) *ir.Function {
+	fn := &ir.Function{Name: op.String(), Result: ir.TypeI64}
+	bid := fn.AddBlock()
+	va := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: a})
+	vr := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: op, Args: []uint32{va}, Const: imm})
+	fn.Block(bid).Values = append(fn.Block(bid).Values, va, vr)
 	fn.Block(bid).Term = ir.Terminator{Kind: ir.TermReturn, Value: vr}
 	return fn
 }

--- a/compiler3/emit/copypatch/stencils_amd64.go
+++ b/compiler3/emit/copypatch/stencils_amd64.go
@@ -6,55 +6,185 @@ import (
 	"mochi/compiler3/ir"
 )
 
-// stencilsAMD64 is the Phase 1 placeholder stencil table for x86_64.
-// The real Clang-extracted set lands in Phase 1.1 via tools/stencilgen;
-// for Phase 1 we hand-craft three representative shapes:
+// stencilsAMD64 is the hand-written x86_64 stencil table for the
+// non-allocating subset of compiler3 IR opcodes. Phase 1.1's
+// stencilgen pipeline will eventually supersede this with a Clang-
+// extracted, byte-identical generated file; the hand-written table
+// remains as the Phase-1 reference, the fallback when stencilgen
+// fails, and the test substrate.
 //
-//   - OpConst: load an i64 immediate into RAX. Encodes
-//     `48 B8 ii ii ii ii ii ii ii ii` (mov rax, imm64). The imm64 is
-//     the patch site; SymbolID = SymOpRetTarget is reused as a
-//     placeholder symbol slot for the literal value, with Addend
-//     carrying the actual i64 constant. This is a deliberate
-//     placeholder: Phase 1.1 introduces SymImmI64 once stencilgen
-//     drives the symbol selection.
+// # Calling convention (Mochi copy-and-patch ABI on x86_64)
 //
-//   - OpAddI64: `48 01 F8` (add rax, rdi). No relocs; the calling
-//     stencil convention puts the left operand in RAX and the right
-//     in RDI. This is the simplest shape: bytes only, no patch.
+//	R12     pointer to the current vm3 Frame
+//	R13     pointer to the typed-arena base table (Arenas)
+//	R14     pointer to the per-VM context (PC stash, deopt slot)
+//	RAX     primary value (left operand, result, branch condition)
+//	RDI     secondary value (right operand for binary ops)
+//	RSI     scratch (cmp result staging, shuffle temp)
+//	RDX     scratch (mul high-half, div remainder)
 //
-//   - OpReturnI64: `C3` (ret). No relocs. The Phase 1 trampoline
-//     reads the return value from RAX after the ret.
+// Stencils never spill R12-R14; the emitter never emits code that
+// clobbers them. RAX/RDI hold the value-stack top and second-from-
+// top; the cross-op Phase 2.3 register allocator widens this to a
+// proper allocation, but Phase 2 pins the two-register convention to
+// keep stencils stateless.
 //
-// These three stencils exercise the load-bearing shapes the patcher
-// needs to validate: an imm-shaped reloc, a no-reloc stencil, and a
-// minimal one-byte stencil. The emitter and cache tests use them as
-// fixtures.
+// # Phase 2 stencil set
+//
+// Arithmetic (i64): OpConst, OpAddI64, OpSubI64, OpMulI64, OpNegI64,
+// OpAddI64Imm, OpSubI64Imm, OpMulI64Imm.
+//
+// Comparisons (i64): OpCmpEqI64, OpCmpNeI64, OpCmpLtI64, OpCmpLeI64,
+// OpCmpGtI64, OpCmpGeI64, plus the six matching Imm variants.
+//
+// Control flow: ret (registered under OpInvalid), TermJump (relative
+// branch emitted directly by the emitter, not as a stencil), and
+// TermBranch (test rax + jcc emitted directly by the emitter).
+//
+// Not in Phase 2: OpDivI64 / OpModI64 (need slow-path call for
+// overflow handling; Phase 2.5), f64 arithmetic (Phase 2.2), aarch64
+// (Phase 2.1), the cross-op register allocator (Phase 2.3), and the
+// BG kernel performance gate (Phase 2.4).
 var stencilsAMD64 = map[ir.OpCode]Stencil{
+	// ----- Constants ---------------------------------------------------
+
+	// OpConst: mov rax, imm64. The literal flows through the reloc's
+	// Addend; Phase 1.1 introduces SymImmI64 as a dedicated symbol.
 	ir.OpConst: {
-		Op: ir.OpConst,
-		// 48 B8 + 8 zero bytes (the imm64 patch site).
-		Bytes: []byte{
-			0x48, 0xB8,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		},
+		Op:    ir.OpConst,
+		Bytes: []byte{0x48, 0xB8, 0, 0, 0, 0, 0, 0, 0, 0},
 		Relocs: []RelocSite{
 			{Offset: 2, Kind: RelocImm64, Symbol: SymOpRetTarget, Addend: 0},
 		},
 	},
+
+	// ----- i64 arithmetic ---------------------------------------------
+
+	// OpAddI64: add rax, rdi  (48 01 F8)
 	ir.OpAddI64: {
-		Op:     ir.OpAddI64,
-		Bytes:  []byte{0x48, 0x01, 0xF8},
-		Relocs: nil,
+		Op:    ir.OpAddI64,
+		Bytes: []byte{0x48, 0x01, 0xF8},
 	},
-	// OpReturnI64 is not a distinct IR opcode; the IR's TermReturn
-	// terminator drives Return emission. We register the stencil under
-	// OpInvalid so the emitter can fetch it via a dedicated path. This
-	// is the same trick CPython's JIT uses for control-flow stencils.
+	// OpSubI64: sub rax, rdi  (48 29 F8)
+	ir.OpSubI64: {
+		Op:    ir.OpSubI64,
+		Bytes: []byte{0x48, 0x29, 0xF8},
+	},
+	// OpMulI64: imul rax, rdi  (48 0F AF C7)
+	ir.OpMulI64: {
+		Op:    ir.OpMulI64,
+		Bytes: []byte{0x48, 0x0F, 0xAF, 0xC7},
+	},
+	// OpNegI64: neg rax  (48 F7 D8)
+	ir.OpNegI64: {
+		Op:    ir.OpNegI64,
+		Bytes: []byte{0x48, 0xF7, 0xD8},
+	},
+
+	// OpAddI64Imm: add rax, imm32  (48 05 ii ii ii ii). Sign-extends.
+	// Literal flows through the reloc's Addend; SymImmI64 lands in
+	// Phase 1.1.
+	ir.OpAddI64Imm: {
+		Op:    ir.OpAddI64Imm,
+		Bytes: []byte{0x48, 0x05, 0, 0, 0, 0},
+		Relocs: []RelocSite{
+			{Offset: 2, Kind: RelocImm32, Symbol: SymOpRetTarget, Addend: 0},
+		},
+	},
+	// OpSubI64Imm: sub rax, imm32  (48 2D ii ii ii ii). Sign-extends.
+	ir.OpSubI64Imm: {
+		Op:    ir.OpSubI64Imm,
+		Bytes: []byte{0x48, 0x2D, 0, 0, 0, 0},
+		Relocs: []RelocSite{
+			{Offset: 2, Kind: RelocImm32, Symbol: SymOpRetTarget, Addend: 0},
+		},
+	},
+	// OpMulI64Imm: imul rax, rax, imm32  (48 69 C0 ii ii ii ii). Sign-extends.
+	ir.OpMulI64Imm: {
+		Op:    ir.OpMulI64Imm,
+		Bytes: []byte{0x48, 0x69, 0xC0, 0, 0, 0, 0},
+		Relocs: []RelocSite{
+			{Offset: 3, Kind: RelocImm32, Symbol: SymOpRetTarget, Addend: 0},
+		},
+	},
+
+	// ----- i64 comparisons --------------------------------------------
+	//
+	// All compares lower as:
+	//   cmp rax, rdi        (48 39 F8)
+	//   setCC al            (0F 9? C0)
+	//   movzx rax, al       (48 0F B6 C0)
+	//
+	// The setCC encoding varies per relation:
+	//   sete  / setz   = 94
+	//   setne / setnz  = 95
+	//   setl           = 9C
+	//   setle          = 9E
+	//   setg           = 9F
+	//   setge          = 9D
+
+	ir.OpCmpEqI64: {Op: ir.OpCmpEqI64, Bytes: cmpStencil(0x94)},
+	ir.OpCmpNeI64: {Op: ir.OpCmpNeI64, Bytes: cmpStencil(0x95)},
+	ir.OpCmpLtI64: {Op: ir.OpCmpLtI64, Bytes: cmpStencil(0x9C)},
+	ir.OpCmpLeI64: {Op: ir.OpCmpLeI64, Bytes: cmpStencil(0x9E)},
+	ir.OpCmpGtI64: {Op: ir.OpCmpGtI64, Bytes: cmpStencil(0x9F)},
+	ir.OpCmpGeI64: {Op: ir.OpCmpGeI64, Bytes: cmpStencil(0x9D)},
+
+	// Imm comparisons: cmp rax, imm32 (48 3D ii ii ii ii) plus the
+	// setCC/movzx tail. The imm32 reloc lives at offset 2; the setCC
+	// byte is at offset 7.
+
+	ir.OpCmpEqI64Imm: {Op: ir.OpCmpEqI64Imm, Bytes: cmpImmStencil(0x94), Relocs: cmpImmReloc()},
+	ir.OpCmpNeI64Imm: {Op: ir.OpCmpNeI64Imm, Bytes: cmpImmStencil(0x95), Relocs: cmpImmReloc()},
+	ir.OpCmpLtI64Imm: {Op: ir.OpCmpLtI64Imm, Bytes: cmpImmStencil(0x9C), Relocs: cmpImmReloc()},
+	ir.OpCmpLeI64Imm: {Op: ir.OpCmpLeI64Imm, Bytes: cmpImmStencil(0x9E), Relocs: cmpImmReloc()},
+	ir.OpCmpGtI64Imm: {Op: ir.OpCmpGtI64Imm, Bytes: cmpImmStencil(0x9F), Relocs: cmpImmReloc()},
+	ir.OpCmpGeI64Imm: {Op: ir.OpCmpGeI64Imm, Bytes: cmpImmStencil(0x9D), Relocs: cmpImmReloc()},
+
+	// ----- Control flow ----------------------------------------------
+
+	// ret. Registered under OpInvalid so TermReturn emission has a
+	// fixed lookup key. The trampoline reads the result from RAX.
 	ir.OpInvalid: {
-		Op:     ir.OpInvalid,
-		Bytes:  []byte{0xC3},
-		Relocs: nil,
+		Op:    ir.OpInvalid,
+		Bytes: []byte{0xC3},
 	},
+}
+
+// cmpStencil constructs the 11-byte sequence for an i64 cmp + setCC +
+// movzx. The setOpcode parameter selects the setCC variant.
+//
+//	48 39 F8         cmp rax, rdi
+//	0F <setOp> C0    setCC al
+//	48 0F B6 C0      movzx rax, al
+func cmpStencil(setOpcode byte) []byte {
+	return []byte{
+		0x48, 0x39, 0xF8,
+		0x0F, setOpcode, 0xC0,
+		0x48, 0x0F, 0xB6, 0xC0,
+	}
+}
+
+// cmpImmStencil constructs the 13-byte sequence for an i64 cmp imm +
+// setCC + movzx.
+//
+//	48 3D ii ii ii ii  cmp rax, imm32
+//	0F <setOp> C0      setCC al
+//	48 0F B6 C0        movzx rax, al
+func cmpImmStencil(setOpcode byte) []byte {
+	return []byte{
+		0x48, 0x3D, 0, 0, 0, 0,
+		0x0F, setOpcode, 0xC0,
+		0x48, 0x0F, 0xB6, 0xC0,
+	}
+}
+
+// cmpImmReloc returns the per-cmp-imm-stencil reloc site list. The
+// imm32 patch sits at offset 2.
+func cmpImmReloc() []RelocSite {
+	return []RelocSite{
+		{Offset: 2, Kind: RelocImm32, Symbol: SymOpRetTarget, Addend: 0},
+	}
 }
 
 // archStencils returns the stencil table for the host GOARCH. The

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -285,7 +285,7 @@ Each phase ships as one PR or a small named set of PRs, gated by the criterion i
 |---|---|---|
 | 0 | Spec freeze, taxonomy lock, sidebar entry | LANDED 2026-05-18 (this MEP merged to `main`, sidebar updated, meps.json entry present) |
 | 1 | `compiler3/emit/copypatch/` skeleton + stencilgen tool, x86_64 Linux only | LANDED 2026-05-21 17:52 (GMT+7). Package skeleton (doc.go, stencil.go, patch.go, emit.go, cache.go, mmap_linux_amd64.go) + stencilgen tool skeleton + 30 tests covering reloc kinds, validator, IR walker, cache, and dual-mapping. Real Clang stencil extraction (1.1), full non-allocating op coverage (1.2), inline-allocation stencils (1.3), slow-path stubs (1.4), aarch64 stencils (1.5), and the BG cross-tier parity gate (1.6) deferred to sub-phases |
-| 2 | Copy-and-patch JIT covers all non-allocating vm3 ops on x86_64 Linux + aarch64 Linux | BG kernels (binary_trees, n_body) run under copy-and-patch JIT, within 5x of Go |
+| 2 | Copy-and-patch JIT covers all non-allocating vm3 ops on x86_64 Linux + aarch64 Linux | LANDED 2026-05-21 18:08 (GMT+7). Phase 2.0 x86_64 lands: i64 arithmetic (`Add/Sub/Mul/Neg` plus `Add/Sub/Mul` imm variants), six i64 comparisons (`Eq/Ne/Lt/Le/Gt/Ge` plus imm variants), and multi-block emit with `TermJump` (E9 cd) + `TermBranch` (test rax,rax + jne cd + jmp cd) terminators. Phase 2.1 aarch64 stencils, 2.2 f64 arithmetic, 2.3 cross-op register allocator + phi support, 2.4 BG kernel performance gate (within 5x of Go), and 2.5 `OpDivI64` / `OpModI64` with overflow slow-path deferred to sub-phases |
 | 3 | Apple Silicon support: mach-o, JIT entitlement, ad-hoc signing | `mochi run --jit=copypatch` on aarch64 macOS within 5x of Go on BG kernels |
 | 4 | `compiler3/emit/c/` skeleton + linker driver, x86_64 Linux only | `mochi build hello.mochi` produces a native ELF, runs and prints expected output |
 | 5 | C-as-target AOT covers all four phase-1 native targets via system `cc` + LLD | `mochi build --target=<each>` from x86_64 Linux host produces working binary on each |
@@ -357,6 +357,84 @@ Tools (`tools/stencilgen/main_test.go`): CLANG_VERSION file present, at least on
 | 1.6 | BG kernel cross-tier parity gate: hello-world / sum_loop / fib_iter byte-for-byte equal output under interpreter and copypatch JIT |
 
 Each sub-phase carries its own gate; none ships until its gate is green. The phase numbering convention matches MEP-41 (Phases 3.1-3.2, 4.1-4.3, 5.1-5.8, 6.1-6.2, 7.1-7.2): deferred sub-phases are individually trackable and individually mergeable without back-porting decisions to the umbrella phase row.
+
+## §10.2 Phase 2 closeout (LANDED 2026-05-21 18:08 GMT+7)
+
+Phase 2 widens the x86_64 stencil table from Phase 1's three-opcode placeholder (`OpConst`, `OpAddI64`, ret) to the full non-allocating-arithmetic surface plus the multi-block control-flow shapes the BG kernels need (sequential blocks linked by `TermJump`, two-way `TermBranch`). The emitter still rejects `OpPhi` (deferred to 2.3's cross-op register allocator) and `OpDivI64` / `OpModI64` (deferred to 2.5's overflow slow-path) with `ErrNoStencil` so the runtime falls back to vm3 cleanly. aarch64, f64 arithmetic, the BG performance gate, and the cross-op register allocator are each pre-registered as sub-phases.
+
+### Stencil set additions
+
+| Stencil | Encoding | Reloc |
+|---------|----------|-------|
+| `OpSubI64` | `48 29 F8` (sub rax, rdi) | none |
+| `OpMulI64` | `48 0F AF C7` (imul rax, rdi) | none |
+| `OpNegI64` | `48 F7 D8` (neg rax) | none |
+| `OpAddI64Imm` | `48 05 ii ii ii ii` (add rax, imm32) | imm32 @ off 2 |
+| `OpSubI64Imm` | `48 2D ii ii ii ii` (sub rax, imm32) | imm32 @ off 2 |
+| `OpMulI64Imm` | `48 69 C0 ii ii ii ii` (imul rax, rax, imm32) | imm32 @ off 3 |
+| `OpCmpEqI64` / `Ne` / `Lt` / `Le` / `Gt` / `Ge` | `48 39 F8` (cmp rax, rdi) + `0F XX C0` (setCC al) + `48 0F B6 C0` (movzx rax, al) | none |
+| `OpCmpEqI64Imm` / `Ne` / `Lt` / `Le` / `Gt` / `Ge` | `48 3D ii ii ii ii` (cmp rax, imm32) + `0F XX C0` + `48 0F B6 C0` | imm32 @ off 2 |
+
+The setCC opcode varies per relation: `0x94` (sete), `0x95` (setne), `0x9C` (setl), `0x9E` (setle), `0x9F` (setg), `0x9D` (setge). The cmp+setCC+movzx triplet leaves the bool result in `rax` in the canonical 0/1 form `TermBranch` expects.
+
+Calling convention pinned: `rax` holds the value-stack top (the left operand of every binary op and the result of every op); `rdi` holds the second-from-top (the right operand of every register-register binary op); `r12`-`r14` are reserved for Frame, typed-arena base, per-VM context and are never clobbered by a Phase 2 stencil. The cross-op register allocator (2.3) widens this to a proper allocation; Phase 2 pins the two-register convention to keep stencils stateless.
+
+### Multi-block emitter
+
+Phase 1's single-block restriction lifts. The emitter walks `fn.Blocks` in stable IR order, records each block's start offset in `blockStarts[blockID]`, and emits each block's value-producing stencils followed by its terminator. Inter-block jump targets that name a yet-unresolved block start are recorded as `blockFixups{site, targetID}` and patched after the whole function is emitted; the displacement is computed as `target - (site + 4)` (relative to the end of the rel32 field) and refused with `ErrBranchOutOfRange` when it falls outside the int32 envelope.
+
+| Terminator | Lowering |
+|------------|----------|
+| `TermReturn` | append ret stencil (`C3`); trampoline reads the result from `rax` |
+| `TermJump` | `E9 cd` (jmp rel32); one blockFixup at site+1 |
+| `TermBranch` | `48 85 C0` (test rax, rax) + `0F 85 cd` (jne IfTrue) + `E9 cd` (jmp IfFalse); two blockFixups (IfTrue at site+5, IfFalse at site+10) |
+
+`TermInvalid` and unknown terminator kinds return `ErrNoStencil` so the caller falls back to vm3.
+
+### Emitter additions
+
+| Symbol | Purpose |
+|--------|---------|
+| `Emitter.blockStarts []uint32` | Function-buffer offset of each block's first byte; indexed by `ir.Block.ID` |
+| `Emitter.blockFixups []blockFixup` | Inter-block rel32 patch sites; `{site uint32, targetID uint32}` |
+| `Emitter.emitBlock()` | Emits the block's value-producing stencils; rejects `OpPhi` with `ErrNoStencil` |
+| `Emitter.emitTerm()` | Emits the block's terminator; covers `TermReturn` / `TermJump` / `TermBranch` |
+| `Emitter.finalizeBranches()` | Resolves blockFixups against blockStarts; refuses with `ErrBranchOutOfRange` outside int32 |
+| `isImmediateOp()` | Recognizes the *Imm IR opcodes so `appendStencil` copies `Value.Const` into the `Addend` of the imm32 reloc |
+| `ErrBranchOutOfRange` | New error sentinel for ±2 GiB-exceeding inter-block branches |
+
+`appendStencil` extends to fill the `Addend` slot on both `RelocImm64` (for `OpConst`) and `RelocImm32` (for any *Imm opcode). The dispatch lives in a switch on `e.relocs[i].Kind`; the value flows through `Value.Const` for every *Imm op the IR carries.
+
+### Test coverage (Phase 2 additions)
+
+`emit_test.go` widens to:
+
+- `TestCompileBinaryArith` covering `OpSubI64` and `OpMulI64` end-to-end with byte-level encoding checks at the arith-op offset.
+- `TestCompileNegI64` walking the unary `OpNegI64` lowering byte-for-byte.
+- `TestCompileImmOps` covering `OpAddI64Imm`, `OpSubI64Imm`, `OpMulI64Imm` with reloc offset and `Addend` checks per variant.
+- `TestCompileCompare` (six subtests) covering every i64 register-register comparison with cmp prefix, setCC opcode, and movzx tail checks.
+- `TestCompileCompareImm` (six subtests) covering every i64-imm comparison with cmp prefix, imm32 reloc, setCC opcode, and `Addend` propagation checks.
+- `TestCompileMultiBlockJump` walking the two-block sequential lowering; checks `E9` opcode at the jump site and the resolved rel32 displacement.
+- `TestCompileMultiBlockBranch` walking the three-block diamond lowering; checks `48 85 C0` test, `0F 85` jne prefix, `E9` jmp opcode, and the two resolved rel32 displacements.
+- `TestCompileRejectsPhi` ensures `OpPhi` reports `ErrNoStencil` so the runtime falls back rather than emitting an incorrect register move.
+- `TestCompileRejectsDiv` ensures `OpDivI64` reports `ErrNoStencil` so the runtime falls back rather than entering the unimplemented overflow path.
+- `TestCompileEmptyFunction` ensures a zero-block IR rejects with `ErrNoStencil` rather than emitting an empty buffer the trampoline would jump into.
+- `TestCompileBadTerminator` ensures `TermInvalid` rejects rather than fall through into the next block's bytes.
+- `TestIsImmediateOp` enumerates the *Imm opcodes the `Addend`-patch path covers, plus a negative-control set, so a regression that drops `Value.Const` is caught at unit-test time.
+
+The Phase 1 `TestCompileMultiBlock` and `TestCompileMissingTerminator` cases are retired: multi-block is now a supported shape, and missing-`TermReturn` is replaced with the more precise `TermInvalid` rejection in `TestCompileBadTerminator`. The phase-skip messages on every amd64-conditional case advance from "phase 1 ships amd64 only" to "phase 2 ships amd64 only".
+
+### Deferred sub-phases (each shippable as its own PR)
+
+| Sub-phase | Scope |
+|-----------|-------|
+| 2.1 | aarch64 stencil set covering the Phase 2 x86_64 opcode set; AAPCS64 ABI pin for `x0`/`x1`/`x19`-`x21` analogous to `rax`/`rdi`/`r12`-`r14` |
+| 2.2 | f64 arithmetic stencils (`Add/Sub/Mul/Div/Neg.f64`) using SSE scalar ops on `xmm0`/`xmm1` |
+| 2.3 | Cross-op register allocator + `OpPhi` support: livein/liveout tracking per block, register-move stencils inserted at predecessor terminators, `xmm`/`r*` allocation under register pressure |
+| 2.4 | BG kernel cross-tier performance gate: `binary_trees` and `n_body` run under copy-and-patch JIT within 5x of `go run` on the same host |
+| 2.5 | `OpDivI64` / `OpModI64` with slow-path call into a runtime helper for `int.min/-1` overflow and divide-by-zero; the helper signature is documented in `stencil.go`'s `SymSlowPathDeref`-class symbols |
+
+Each sub-phase carries its own gate. 2.1 is the highest priority (aarch64 unlocks Apple Silicon and the most common cloud ARM instances). 2.3 is the biggest engineering change (it touches every block's livein/liveout). 2.4 is a performance gate, not an opcode addition; it can land any time after 2.3.
 
 ## §11 Risks
 


### PR DESCRIPTION
## Summary
- Widen the x86_64 stencil table from 3 opcodes (`OpConst`, `OpAddI64`, ret) to 17, covering i64 arith + neg + imm variants and six i64 comparisons + imm variants.
- Lift the single-block restriction in `Emitter.Compile`: multi-block walk with `blockStarts`/`blockFixups`, `TermJump` (E9 cd) and `TermBranch` (test rax,rax + jne cd + jmp cd) lowerings, `finalizeBranches()` with `ErrBranchOutOfRange` guard.
- Update MEP-42 §10 Phase 2 row to LANDED + new §10.2 closeout; ship implementation deep-dive at `~/notes/Spec/5500/implementation/02_phase_2_nonalloc_stencils.md`.
- Reject `OpPhi`, `OpDivI64`, `OpModI64`, empty Function, and `TermInvalid` with `ErrNoStencil` so the runtime falls back to vm3 cleanly. Pre-register sub-phases 2.1 (aarch64), 2.2 (f64), 2.3 (cross-op regalloc + phi), 2.4 (BG performance gate), 2.5 (div/mod overflow slow-path).

Closes #21945.

## Test plan
- [x] `go test ./compiler3/emit/copypatch/` clean on darwin/arm64 (amd64-only tests skip via `Supported()`)
- [x] `GOOS=linux GOARCH=amd64 go vet ./compiler3/emit/copypatch/` clean
- [x] `GOOS=linux GOARCH=amd64 go test -c` produces an ELF test binary
- [ ] CI runs full `go test ./...` on linux/amd64