### PR TITLE
mep-0042: Phase 1.1 aarch64 Linux target

### DIFF
--- a/compiler3/emit/copypatch/cache_test.go
+++ b/compiler3/emit/copypatch/cache_test.go
@@ -3,6 +3,8 @@ package copypatch
 import (
 	"encoding/binary"
 	"testing"
+
+	"mochi/compiler3/ir"
 )
 
 // TestCacheNewMismatch ensures NewCache rejects a mismatched (rw, rx)
@@ -27,7 +29,7 @@ func TestCacheNewMismatch(t *testing.T) {
 // returned entry address must equal the rx-base.
 func TestCacheInstallSingle(t *testing.T) {
 	if !Supported() {
-		t.Skip("phase 1 ships amd64 only")
+		t.Skip("host has no stencil table")
 	}
 	page := make([]byte, 4096)
 	c, err := NewCache(page, page)
@@ -67,9 +69,12 @@ func TestCacheInstallSingle(t *testing.T) {
 	if got := c.HighWater(); got != len(code) {
 		t.Errorf("HighWater post-install = %d, want %d", got, len(code))
 	}
-	// The OpConst stencil's imm64 sits at offset 2..10; after patch it
-	// must hold (1 + (Const - 1)) = Const = 0xCAFE.
-	if got := binary.LittleEndian.Uint64(page[2:10]); got != 0xCAFE {
+	// The OpConst stencil's imm64 patch site is arch-specific: offset 2
+	// on amd64 (mov rax, imm64), offset 8 on arm64 (the literal pool
+	// slot following ldr+b). After patch it must hold (1 + (Const - 1))
+	// = Const = 0xCAFE.
+	off := archStencils()[ir.OpConst].Relocs[0].Offset
+	if got := binary.LittleEndian.Uint64(page[off : off+8]); got != 0xCAFE {
 		t.Errorf("patched imm64 = 0x%x, want 0xCAFE", got)
 	}
 }
@@ -79,7 +84,7 @@ func TestCacheInstallSingle(t *testing.T) {
 // blob's bytes must be undisturbed.
 func TestCacheInstallSequence(t *testing.T) {
 	if !Supported() {
-		t.Skip("phase 1 ships amd64 only")
+		t.Skip("host has no stencil table")
 	}
 	page := make([]byte, 4096)
 	c, _ := NewCache(page, page)
@@ -111,11 +116,13 @@ func TestCacheInstallSequence(t *testing.T) {
 		t.Errorf("entryB - entryA = %d, want %d (len(codeA))",
 			entryB-entryA, len(codeA))
 	}
-	// Verify both imm64 patch sites carry the right constants.
-	if got := binary.LittleEndian.Uint64(page[2:10]); got != 0x1111 {
+	// Verify both imm64 patch sites carry the right constants. The
+	// patch offset is arch-specific (see TestCacheInstallSingle).
+	off := int(archStencils()[ir.OpConst].Relocs[0].Offset)
+	if got := binary.LittleEndian.Uint64(page[off : off+8]); got != 0x1111 {
 		t.Errorf("blob A imm64 = 0x%x, want 0x1111", got)
 	}
-	if got := binary.LittleEndian.Uint64(page[len(codeA)+2 : len(codeA)+10]); got != 0x2222 {
+	if got := binary.LittleEndian.Uint64(page[len(codeA)+off : len(codeA)+off+8]); got != 0x2222 {
 		t.Errorf("blob B imm64 = 0x%x, want 0x2222", got)
 	}
 }

--- a/compiler3/emit/copypatch/emit.go
+++ b/compiler3/emit/copypatch/emit.go
@@ -196,6 +196,10 @@ func (e *Emitter) emitTerm(blk *ir.Block) error {
 		return nil
 
 	case ir.TermJump:
+		if !archSupportsBranches() {
+			return fmt.Errorf("%w: inter-block jump (host GOARCH lacks Phase 2.x terminator encodings)",
+				ErrNoStencil)
+		}
 		// E9 cd  jmp rel32
 		base := uint32(len(e.out))
 		e.out = append(e.out, 0xE9, 0, 0, 0, 0)
@@ -206,6 +210,10 @@ func (e *Emitter) emitTerm(blk *ir.Block) error {
 		return nil
 
 	case ir.TermBranch:
+		if !archSupportsBranches() {
+			return fmt.Errorf("%w: inter-block branch (host GOARCH lacks Phase 2.x terminator encodings)",
+				ErrNoStencil)
+		}
 		// test rax, rax       (48 85 C0)
 		// jne IfTrue          (0F 85 cd)
 		// jmp IfFalse         (E9 cd)

--- a/compiler3/emit/copypatch/emit_amd64_test.go
+++ b/compiler3/emit/copypatch/emit_amd64_test.go
@@ -1,0 +1,360 @@
+//go:build amd64
+
+package copypatch
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"mochi/compiler3/ir"
+)
+
+// TestCompileBinaryArith covers OpSubI64 and OpMulI64 on amd64. Each
+// variant is exercised end-to-end (two-constant feed + arith op + ret)
+// and the byte sequence at the arith-op offset is asserted against the
+// hand-written stencil table. This test is amd64-specific because it
+// asserts on x86_64 ModR/M and REX prefix bytes; the arm64 placeholder
+// keeps the same shape behind `TestCompileAddChain` in emit_test.go.
+func TestCompileBinaryArith(t *testing.T) {
+	cases := []struct {
+		name   string
+		op     ir.OpCode
+		bytes  []byte
+		opSize int
+	}{
+		{"sub", ir.OpSubI64, []byte{0x48, 0x29, 0xF8}, 3},
+		{"mul", ir.OpMulI64, []byte{0x48, 0x0F, 0xAF, 0xC7}, 4},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fn := buildBinaryOp(c.op, 11, 22)
+			e, err := NewEmitter()
+			if err != nil {
+				t.Fatalf("NewEmitter: %v", err)
+			}
+			code, _, err := e.Compile(fn)
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			// Two OpConst (10 bytes each) + arith + ret.
+			wantLen := 20 + c.opSize + 1
+			if got := len(code); got != wantLen {
+				t.Fatalf("len(code) = %d, want %d", got, wantLen)
+			}
+			arith := code[20 : 20+c.opSize]
+			for i, b := range c.bytes {
+				if arith[i] != b {
+					t.Errorf("arith[%d] = %#02x, want %#02x", i, arith[i], b)
+				}
+			}
+		})
+	}
+}
+
+// TestCompileNegI64 walks the unary OpNegI64 lowering on amd64. One
+// OpConst feeds the neg, the result is returned. neg rax = 48 F7 D8.
+// Arm64's analog (`neg x0, x0` = `CB 00 03 E0`) lands in Phase 2.1.
+func TestCompileNegI64(t *testing.T) {
+	fn := &ir.Function{Name: "neg", Result: ir.TypeI64}
+	bid := fn.AddBlock()
+	va := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 7})
+	vr := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpNegI64, Args: []uint32{va}})
+	fn.Block(bid).Values = append(fn.Block(bid).Values, va, vr)
+	fn.Block(bid).Term = ir.Terminator{Kind: ir.TermReturn, Value: vr}
+	e, err := NewEmitter()
+	if err != nil {
+		t.Fatalf("NewEmitter: %v", err)
+	}
+	code, _, err := e.Compile(fn)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	// OpConst (10) + neg (3) + ret (1) = 14.
+	if got, want := len(code), 14; got != want {
+		t.Fatalf("len(code) = %d, want %d", got, want)
+	}
+	want := []byte{0x48, 0xF7, 0xD8}
+	for i, b := range want {
+		if code[10+i] != b {
+			t.Errorf("code[%d] = %#02x, want %#02x", 10+i, code[10+i], b)
+		}
+	}
+}
+
+// TestCompileImmOps walks the three i64 arith-Imm stencils on amd64
+// and checks the imm32 Addend lands in the reloc. The IR uses one
+// OpConst feeding the *Imm op (whose Value.Const carries the
+// immediate) and returns the result. Arm64's *Imm encoding (12-bit
+// imm in `add x0, x0, #imm` plus the multi-instruction path for the
+// general case) lands in Phase 2.1.
+func TestCompileImmOps(t *testing.T) {
+	cases := []struct {
+		name   string
+		op     ir.OpCode
+		imm    int64
+		opSize int
+		// relocOffsetInOp names where in the *Imm stencil the imm32 sits.
+		relocOffsetInOp uint32
+	}{
+		{"add_imm", ir.OpAddI64Imm, 99, 6, 2},
+		{"sub_imm", ir.OpSubI64Imm, -7, 6, 2},
+		{"mul_imm", ir.OpMulI64Imm, 3, 7, 3},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fn := buildImmOp(c.op, 5, c.imm)
+			e, err := NewEmitter()
+			if err != nil {
+				t.Fatalf("NewEmitter: %v", err)
+			}
+			code, relocs, err := e.Compile(fn)
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			// OpConst (10) + *Imm (c.opSize) + ret (1).
+			if got, want := len(code), 11+c.opSize; got != want {
+				t.Fatalf("len(code) = %d, want %d", got, want)
+			}
+			// Two relocs: OpConst RelocImm64 at offset 2, *Imm RelocImm32
+			// at offset 10 + relocOffsetInOp.
+			if got, want := len(relocs), 2; got != want {
+				t.Fatalf("len(relocs) = %d, want %d", got, want)
+			}
+			want := uint32(10) + c.relocOffsetInOp
+			if relocs[1].Offset != want {
+				t.Errorf("imm reloc offset = %d, want %d", relocs[1].Offset, want)
+			}
+			if relocs[1].Kind != RelocImm32 {
+				t.Errorf("imm reloc kind = %s, want imm32", relocs[1].Kind)
+			}
+			if int64(relocs[1].Addend) != c.imm {
+				t.Errorf("imm addend = %d, want %d", relocs[1].Addend, c.imm)
+			}
+		})
+	}
+}
+
+// TestCompileCompare exercises the six i64 comparison lowerings on
+// amd64. Each must emit cmp rax, rdi (48 39 F8) + setCC al (0F XX C0)
+// + movzx rax, al (48 0F B6 C0), with the setCC opcode varying per
+// relation. Arm64's analog (`cmp x0, x1` + `cset x0, COND`) lands in
+// Phase 2.1.
+func TestCompileCompare(t *testing.T) {
+	cases := []struct {
+		name      string
+		op        ir.OpCode
+		setOpcode byte
+	}{
+		{"eq", ir.OpCmpEqI64, 0x94},
+		{"ne", ir.OpCmpNeI64, 0x95},
+		{"lt", ir.OpCmpLtI64, 0x9C},
+		{"le", ir.OpCmpLeI64, 0x9E},
+		{"gt", ir.OpCmpGtI64, 0x9F},
+		{"ge", ir.OpCmpGeI64, 0x9D},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fn := buildBinaryOp(c.op, 1, 2)
+			fn.Values[2].Type = ir.TypeBool
+			e, err := NewEmitter()
+			if err != nil {
+				t.Fatalf("NewEmitter: %v", err)
+			}
+			code, _, err := e.Compile(fn)
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			// Two OpConst (20) + cmp+setCC+movzx (10) + ret (1) = 31.
+			if got, want := len(code), 31; got != want {
+				t.Fatalf("len(code) = %d, want %d", got, want)
+			}
+			// cmp prefix at offset 20.
+			if code[20] != 0x48 || code[21] != 0x39 || code[22] != 0xF8 {
+				t.Errorf("cmp prefix = % x, want 48 39 F8", code[20:23])
+			}
+			// setCC opcode at offset 23+1.
+			if code[23] != 0x0F || code[24] != c.setOpcode || code[25] != 0xC0 {
+				t.Errorf("setCC = % x, want 0F %02x C0", code[23:26], c.setOpcode)
+			}
+			// movzx tail.
+			if code[26] != 0x48 || code[27] != 0x0F || code[28] != 0xB6 || code[29] != 0xC0 {
+				t.Errorf("movzx tail = % x, want 48 0F B6 C0", code[26:30])
+			}
+		})
+	}
+}
+
+// TestCompileCompareImm exercises the six i64-imm comparison lowerings
+// on amd64. The cmp prefix is 48 3D + imm32, the setCC opcode varies
+// per relation, and the imm32 Addend is set from Value.Const.
+func TestCompileCompareImm(t *testing.T) {
+	cases := []struct {
+		name      string
+		op        ir.OpCode
+		setOpcode byte
+	}{
+		{"eq", ir.OpCmpEqI64Imm, 0x94},
+		{"ne", ir.OpCmpNeI64Imm, 0x95},
+		{"lt", ir.OpCmpLtI64Imm, 0x9C},
+		{"le", ir.OpCmpLeI64Imm, 0x9E},
+		{"gt", ir.OpCmpGtI64Imm, 0x9F},
+		{"ge", ir.OpCmpGeI64Imm, 0x9D},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fn := buildImmOp(c.op, 42, 7)
+			fn.Values[1].Type = ir.TypeBool
+			e, err := NewEmitter()
+			if err != nil {
+				t.Fatalf("NewEmitter: %v", err)
+			}
+			code, relocs, err := e.Compile(fn)
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			// OpConst (10) + cmp+setCC+movzx (13) + ret (1) = 24.
+			if got, want := len(code), 24; got != want {
+				t.Fatalf("len(code) = %d, want %d", got, want)
+			}
+			// cmp prefix at offset 10.
+			if code[10] != 0x48 || code[11] != 0x3D {
+				t.Errorf("cmp prefix = % x, want 48 3D", code[10:12])
+			}
+			// setCC opcode at offset 16+1.
+			if code[16] != 0x0F || code[17] != c.setOpcode || code[18] != 0xC0 {
+				t.Errorf("setCC = % x, want 0F %02x C0", code[16:19], c.setOpcode)
+			}
+			// Two relocs: OpConst RelocImm64 at 2, *Imm RelocImm32 at 12.
+			if got, want := len(relocs), 2; got != want {
+				t.Fatalf("len(relocs) = %d, want %d", got, want)
+			}
+			if relocs[1].Offset != 12 || relocs[1].Kind != RelocImm32 {
+				t.Errorf("imm reloc = %+v, want offset=12 kind=imm32", relocs[1])
+			}
+			if relocs[1].Addend != 7 {
+				t.Errorf("imm addend = %d, want 7", relocs[1].Addend)
+			}
+		})
+	}
+}
+
+// TestCompileMultiBlockJump checks the multi-block TermJump path on
+// amd64. Two blocks: block 0 holds Const + TermJump to block 1; block
+// 1 holds the ret. The jump's rel32 must point from the end of the
+// rel32 field to the start of block 1. Arm64's TermJump (b rel26)
+// lands in Phase 2.1; until then `archSupportsBranches()` is false on
+// arm64 and `TestCompileRejectsBranchOnUnsupportedArch` covers the
+// reject path.
+func TestCompileMultiBlockJump(t *testing.T) {
+	fn := &ir.Function{Name: "jump", Result: ir.TypeI64}
+	b0 := fn.AddBlock()
+	b1 := fn.AddBlock()
+	v := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 9})
+	fn.Block(b0).Values = append(fn.Block(b0).Values, v)
+	fn.Block(b0).Term = ir.Terminator{Kind: ir.TermJump, Target: b1}
+	fn.Block(b1).Term = ir.Terminator{Kind: ir.TermReturn, Value: v}
+	e, err := NewEmitter()
+	if err != nil {
+		t.Fatalf("NewEmitter: %v", err)
+	}
+	code, _, err := e.Compile(fn)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	// OpConst (10) + jmp E9+rel32 (5) + ret (1) = 16.
+	if got, want := len(code), 16; got != want {
+		t.Fatalf("len(code) = %d, want %d", got, want)
+	}
+	if code[10] != 0xE9 {
+		t.Errorf("expected E9 at offset 10, got %#02x", code[10])
+	}
+	// rel32 = block1 start (15) - end of rel32 field (15) = 0.
+	disp := int32(binary.LittleEndian.Uint32(code[11:15]))
+	if disp != 0 {
+		t.Errorf("jump disp = %d, want 0", disp)
+	}
+	if code[15] != 0xC3 {
+		t.Errorf("expected ret (C3) at offset 15, got %#02x", code[15])
+	}
+}
+
+// TestCompileMultiBlockBranch checks the TermBranch lowering on amd64.
+// Three blocks: block 0 produces a bool, branches to block 1 (true) or
+// block 2 (false). The emitter must lay down test rax,rax + jne IfTrue
+// + jmp IfFalse, with both rel32 displacements pointing at the right
+// block starts. Arm64's TermBranch (cbnz rel19 + b rel26) lands in
+// Phase 2.1.
+func TestCompileMultiBlockBranch(t *testing.T) {
+	fn := &ir.Function{Name: "branch", Result: ir.TypeI64}
+	b0 := fn.AddBlock()
+	b1 := fn.AddBlock()
+	b2 := fn.AddBlock()
+	vcond := fn.AddValue(ir.Value{Type: ir.TypeBool, Op: ir.OpConst, Const: 1})
+	vone := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 1})
+	vtwo := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 2})
+	fn.Block(b0).Values = append(fn.Block(b0).Values, vcond)
+	fn.Block(b0).Term = ir.Terminator{Kind: ir.TermBranch, Value: vcond, IfTrue: b1, IfFalse: b2}
+	fn.Block(b1).Values = append(fn.Block(b1).Values, vone)
+	fn.Block(b1).Term = ir.Terminator{Kind: ir.TermReturn, Value: vone}
+	fn.Block(b2).Values = append(fn.Block(b2).Values, vtwo)
+	fn.Block(b2).Term = ir.Terminator{Kind: ir.TermReturn, Value: vtwo}
+	e, err := NewEmitter()
+	if err != nil {
+		t.Fatalf("NewEmitter: %v", err)
+	}
+	code, _, err := e.Compile(fn)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	// b0: OpConst (10) + test (3) + jne (6) + jmp (5) = 24.
+	// b1: OpConst (10) + ret (1) = 11. Starts at 24.
+	// b2: OpConst (10) + ret (1) = 11. Starts at 35.
+	// Total 46.
+	if got, want := len(code), 46; got != want {
+		t.Fatalf("len(code) = %d, want %d", got, want)
+	}
+	if code[10] != 0x48 || code[11] != 0x85 || code[12] != 0xC0 {
+		t.Errorf("test rax,rax bytes = % x, want 48 85 C0", code[10:13])
+	}
+	if code[13] != 0x0F || code[14] != 0x85 {
+		t.Errorf("jne prefix = % x, want 0F 85", code[13:15])
+	}
+	// jne rel32: site=15, end=19, target=24 → disp=5.
+	if disp := int32(binary.LittleEndian.Uint32(code[15:19])); disp != 5 {
+		t.Errorf("jne disp = %d, want 5", disp)
+	}
+	if code[19] != 0xE9 {
+		t.Errorf("jmp opcode = %#02x, want E9", code[19])
+	}
+	// jmp rel32: site=20, end=24, target=35 → disp=11.
+	if disp := int32(binary.LittleEndian.Uint32(code[20:24])); disp != 11 {
+		t.Errorf("jmp disp = %d, want 11", disp)
+	}
+}
+
+// TestCompileConstReturnAMD64 asserts the exact amd64 byte layout for
+// the OpConst+ret path: mov rax, imm64 (10 bytes, imm at offset 2)
+// followed by ret (1 byte, C3). The portable
+// `TestCompileConstReturn` in emit_test.go checks the same semantics
+// via the host stencil table; this test pins the amd64-specific
+// encoding so a regression in stencils_amd64.go fails loudly.
+func TestCompileConstReturnAMD64(t *testing.T) {
+	fn := buildConstReturn(0x1122334455667788)
+	e, err := NewEmitter()
+	if err != nil {
+		t.Fatalf("NewEmitter: %v", err)
+	}
+	code, _, err := e.Compile(fn)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if got, want := len(code), 11; got != want {
+		t.Fatalf("len(code) = %d, want %d", got, want)
+	}
+	if code[0] != 0x48 || code[1] != 0xB8 {
+		t.Errorf("mov rax prefix = % x, want 48 B8", code[0:2])
+	}
+	if code[10] != 0xC3 {
+		t.Errorf("ret byte = %#02x, want C3", code[10])
+	}
+}

--- a/compiler3/emit/copypatch/emit_arm64_test.go
+++ b/compiler3/emit/copypatch/emit_arm64_test.go
@@ -1,0 +1,162 @@
+//go:build arm64
+
+package copypatch
+
+import (
+	"testing"
+
+	"mochi/compiler3/ir"
+)
+
+// TestCompileConstReturnARM64 asserts the exact aarch64 byte layout
+// for the OpConst + ret path on the Phase 1.1 placeholder table:
+//
+//	40 00 00 58    ldr x0, [pc, #8]
+//	03 00 00 14    b   #12              (skip the literal pool)
+//	8 bytes        literal pool entry   (RelocImm64 patch site)
+//	C0 03 5F D6    ret
+//
+// Total = 20 bytes, with the imm64 reloc at offset 8.
+//
+// The portable `TestCompileConstReturn` in emit_test.go checks the same
+// semantics via the host stencil table; this test pins the arm64-
+// specific encoding so a regression in stencils_arm64.go fails loudly.
+func TestCompileConstReturnARM64(t *testing.T) {
+	// k fits in int32 so the truncated `Addend = int32(v.Const)` patch
+	// path (shared with amd64 OpConst) round-trips cleanly. The wider
+	// imm64 path lands in Phase 1.1's stencilgen pipeline once
+	// SymImmI64 supersedes the SymOpRetTarget placeholder.
+	const k int64 = 0x11223344
+	fn := buildConstReturn(k)
+	e, err := NewEmitter()
+	if err != nil {
+		t.Fatalf("NewEmitter: %v", err)
+	}
+	code, relocs, err := e.Compile(fn)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if got, want := len(code), 20; got != want {
+		t.Fatalf("len(code) = %d, want %d", got, want)
+	}
+	// ldr x0, [pc, #8]  = 0x58000040 LE = 40 00 00 58.
+	want := []byte{0x40, 0x00, 0x00, 0x58}
+	for i, b := range want {
+		if code[i] != b {
+			t.Errorf("ldr[%d] = %#02x, want %#02x", i, code[i], b)
+		}
+	}
+	// b #12  = 0x14000003 LE = 03 00 00 14.
+	want = []byte{0x03, 0x00, 0x00, 0x14}
+	for i, b := range want {
+		if code[4+i] != b {
+			t.Errorf("b[%d] = %#02x, want %#02x", i, code[4+i], b)
+		}
+	}
+	// Literal pool slot at [8:16] is zero (Compile leaves it unpatched
+	// until the cache.Install pass applies the reloc).
+	for i := 8; i < 16; i++ {
+		if code[i] != 0 {
+			t.Errorf("literal[%d] = %#02x, want 0", i-8, code[i])
+		}
+	}
+	// ret = 0xD65F03C0 LE = C0 03 5F D6.
+	want = []byte{0xC0, 0x03, 0x5F, 0xD6}
+	for i, b := range want {
+		if code[16+i] != b {
+			t.Errorf("ret[%d] = %#02x, want %#02x", i, code[16+i], b)
+		}
+	}
+	// Reloc: imm64 at offset 8, addend carries the low 32 bits of k
+	// (the int32 Addend field's truncation matches the amd64 OpConst
+	// path; cache.Install's SymImmI64 lookup widens the patch back to
+	// 64 bits in Phase 1.1's stencilgen pipeline).
+	if len(relocs) != 1 {
+		t.Fatalf("len(relocs) = %d, want 1", len(relocs))
+	}
+	if relocs[0].Offset != 8 || relocs[0].Kind != RelocImm64 {
+		t.Errorf("reloc = %+v, want offset=8 kind=imm64", relocs[0])
+	}
+	if int64(relocs[0].Addend) != k {
+		t.Errorf("reloc addend = %d, want %d", relocs[0].Addend, k)
+	}
+}
+
+// TestCompileAddChainARM64 asserts the exact aarch64 byte layout for
+// the two-constant + add + ret path on the Phase 1.1 placeholder:
+//
+//	OpConst (16 bytes) + OpConst (16 bytes) + add x0,x0,x1 (4 bytes)
+//	+ ret (4 bytes) = 40 bytes total.
+//
+// add x0, x0, x1 = 0x8B010000 LE = 00 00 01 8B.
+func TestCompileAddChainARM64(t *testing.T) {
+	fn := buildConstAddReturn(100, 23)
+	e, err := NewEmitter()
+	if err != nil {
+		t.Fatalf("NewEmitter: %v", err)
+	}
+	code, _, err := e.Compile(fn)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if got, want := len(code), 40; got != want {
+		t.Fatalf("len(code) = %d, want %d", got, want)
+	}
+	// add x0, x0, x1 at offset 32.
+	want := []byte{0x00, 0x00, 0x01, 0x8B}
+	for i, b := range want {
+		if code[32+i] != b {
+			t.Errorf("add[%d] = %#02x, want %#02x", i, code[32+i], b)
+		}
+	}
+	// ret at offset 36.
+	want = []byte{0xC0, 0x03, 0x5F, 0xD6}
+	for i, b := range want {
+		if code[36+i] != b {
+			t.Errorf("ret[%d] = %#02x, want %#02x", i, code[36+i], b)
+		}
+	}
+}
+
+// TestARM64RejectsSubMulNeg confirms that the Phase 1.1 placeholder
+// table covers only the three opcodes (OpConst, OpAddI64, OpInvalid
+// for ret). Every other arithmetic opcode the amd64 table supports
+// must still report `ErrNoStencil` on arm64 until Phase 2.1 widens the
+// table. A regression that silently added a wrong-ISA stencil would
+// produce a buffer the runtime would jump into and trap on; this test
+// guards against that.
+func TestARM64RejectsSubMulNeg(t *testing.T) {
+	cases := []ir.OpCode{
+		ir.OpSubI64, ir.OpMulI64, ir.OpNegI64,
+		ir.OpAddI64Imm, ir.OpSubI64Imm, ir.OpMulI64Imm,
+		ir.OpCmpEqI64, ir.OpCmpNeI64, ir.OpCmpLtI64,
+		ir.OpCmpLeI64, ir.OpCmpGtI64, ir.OpCmpGeI64,
+		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm,
+		ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm,
+	}
+	e, err := NewEmitter()
+	if err != nil {
+		t.Fatalf("NewEmitter: %v", err)
+	}
+	for _, op := range cases {
+		t.Run(op.String(), func(t *testing.T) {
+			var fn *ir.Function
+			if op == ir.OpNegI64 {
+				fn = &ir.Function{Name: op.String(), Result: ir.TypeI64}
+				bid := fn.AddBlock()
+				va := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 5})
+				vr := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: op, Args: []uint32{va}})
+				fn.Block(bid).Values = append(fn.Block(bid).Values, va, vr)
+				fn.Block(bid).Term = ir.Terminator{Kind: ir.TermReturn, Value: vr}
+			} else if isImmediateOp(op) {
+				fn = buildImmOp(op, 5, 3)
+			} else {
+				fn = buildBinaryOp(op, 5, 3)
+			}
+			_, _, err := e.Compile(fn)
+			if err == nil {
+				t.Fatalf("Compile(%s) = nil, want ErrNoStencil", op)
+			}
+		})
+	}
+}

--- a/compiler3/emit/copypatch/emit_test.go
+++ b/compiler3/emit/copypatch/emit_test.go
@@ -1,7 +1,6 @@
 package copypatch
 
 import (
-	"encoding/binary"
 	"errors"
 	"testing"
 
@@ -25,12 +24,16 @@ func TestEmitterSupportedMatchesArch(t *testing.T) {
 // TestCompileConstReturn covers the simplest end-to-end path: a
 // Function whose only block holds an OpConst followed by TermReturn.
 // The emitted buffer must be the OpConst stencil's bytes followed by
-// the ret stencil's bytes, with the imm64 patched in.
+// the ret stencil's bytes, with the imm64 patched in. The assertion
+// is arch-portable: the expected length and reloc offset come from
+// the host's own stencil table (amd64 places imm64 at offset 2 of a
+// 10-byte stencil; arm64 places it at offset 8 of a 16-byte stencil).
 func TestCompileConstReturn(t *testing.T) {
 	if !Supported() {
-		t.Skip("phase 2 ships amd64 only")
+		t.Skip("host has no stencil table")
 	}
-	fn := buildConstReturn(123456789)
+	const k int64 = 123456789
+	fn := buildConstReturn(k)
 	e, err := NewEmitter()
 	if err != nil {
 		t.Fatalf("NewEmitter: %v", err)
@@ -39,31 +42,36 @@ func TestCompileConstReturn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
-	// OpConst stencil = 10 bytes; ret stencil = 1 byte. Total 11.
-	if got, want := len(code), 11; got != want {
-		t.Errorf("len(code) = %d, want %d", got, want)
+	tab := archStencils()
+	opConst := tab[ir.OpConst]
+	ret := tab[ir.OpInvalid]
+	if got, want := len(code), len(opConst.Bytes)+len(ret.Bytes); got != want {
+		t.Errorf("len(code) = %d, want %d (opConst=%d + ret=%d)",
+			got, want, len(opConst.Bytes), len(ret.Bytes))
 	}
-	// One reloc, at offset 2 (the mov rax, imm64 patch site),
-	// kind = imm64, addend = 123456789.
 	if len(relocs) != 1 {
 		t.Fatalf("len(relocs) = %d, want 1", len(relocs))
 	}
-	if relocs[0].Offset != 2 || relocs[0].Kind != RelocImm64 {
-		t.Errorf("reloc = %+v, want offset=2 kind=imm64", relocs[0])
+	wantOffset := opConst.Relocs[0].Offset
+	if relocs[0].Offset != wantOffset || relocs[0].Kind != RelocImm64 {
+		t.Errorf("reloc = %+v, want offset=%d kind=imm64", relocs[0], wantOffset)
 	}
-	if relocs[0].Addend != 123456789 {
-		t.Errorf("reloc addend = %d, want 123456789", relocs[0].Addend)
+	if int64(relocs[0].Addend) != k {
+		t.Errorf("reloc addend = %d, want %d", relocs[0].Addend, k)
 	}
 }
 
 // TestCompileAddChain covers the multi-op path: Const + Const + Add +
 // Return. The emitter walks the block's Values, picks a stencil per
 // op, and rebases each stencil's relocs to the function-buffer offset.
+// Arch-portable: expected sizes and reloc offsets are computed from
+// the host's stencil table.
 func TestCompileAddChain(t *testing.T) {
 	if !Supported() {
-		t.Skip("phase 2 ships amd64 only")
+		t.Skip("host has no stencil table")
 	}
-	fn := buildConstAddReturn(100, 23)
+	const a, b int64 = 100, 23
+	fn := buildConstAddReturn(a, b)
 	e, err := NewEmitter()
 	if err != nil {
 		t.Fatalf("NewEmitter: %v", err)
@@ -72,354 +80,28 @@ func TestCompileAddChain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
-	// Two OpConst (10 bytes each) + OpAddI64 (3 bytes) + ret (1) = 24.
-	if got, want := len(code), 24; got != want {
-		t.Errorf("len(code) = %d, want %d", got, want)
+	tab := archStencils()
+	opConst := tab[ir.OpConst]
+	opAdd := tab[ir.OpAddI64]
+	ret := tab[ir.OpInvalid]
+	wantLen := 2*len(opConst.Bytes) + len(opAdd.Bytes) + len(ret.Bytes)
+	if got := len(code); got != wantLen {
+		t.Errorf("len(code) = %d, want %d", got, wantLen)
 	}
 	if got, want := len(relocs), 2; got != want {
 		t.Errorf("len(relocs) = %d, want %d", got, want)
 	}
-	if relocs[0].Offset != 2 {
-		t.Errorf("relocs[0].Offset = %d, want 2", relocs[0].Offset)
+	wantOff0 := opConst.Relocs[0].Offset
+	wantOff1 := uint32(len(opConst.Bytes)) + opConst.Relocs[0].Offset
+	if relocs[0].Offset != wantOff0 {
+		t.Errorf("relocs[0].Offset = %d, want %d", relocs[0].Offset, wantOff0)
 	}
-	if relocs[1].Offset != 12 {
-		t.Errorf("relocs[1].Offset = %d, want 12", relocs[1].Offset)
+	if relocs[1].Offset != wantOff1 {
+		t.Errorf("relocs[1].Offset = %d, want %d", relocs[1].Offset, wantOff1)
 	}
-	if relocs[0].Addend != 100 || relocs[1].Addend != 23 {
-		t.Errorf("addends = (%d, %d), want (100, 23)", relocs[0].Addend, relocs[1].Addend)
-	}
-}
-
-// TestCompileBinaryArith covers OpSubI64, OpMulI64, and OpNegI64.
-// Each variant is exercised end-to-end: two-constant feed plus the
-// arith op plus ret, and we check the buffer length plus the stencil
-// bytes that appear at the arith-op offset.
-func TestCompileBinaryArith(t *testing.T) {
-	if !Supported() {
-		t.Skip("phase 2 ships amd64 only")
-	}
-	cases := []struct {
-		name   string
-		op     ir.OpCode
-		bytes  []byte
-		opSize int
-	}{
-		{"sub", ir.OpSubI64, []byte{0x48, 0x29, 0xF8}, 3},
-		{"mul", ir.OpMulI64, []byte{0x48, 0x0F, 0xAF, 0xC7}, 4},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			fn := buildBinaryOp(c.op, 11, 22)
-			e, err := NewEmitter()
-			if err != nil {
-				t.Fatalf("NewEmitter: %v", err)
-			}
-			code, _, err := e.Compile(fn)
-			if err != nil {
-				t.Fatalf("Compile: %v", err)
-			}
-			// Two OpConst (10 bytes each) + arith + ret.
-			wantLen := 20 + c.opSize + 1
-			if got := len(code); got != wantLen {
-				t.Fatalf("len(code) = %d, want %d", got, wantLen)
-			}
-			arith := code[20 : 20+c.opSize]
-			for i, b := range c.bytes {
-				if arith[i] != b {
-					t.Errorf("arith[%d] = %#02x, want %#02x", i, arith[i], b)
-				}
-			}
-		})
-	}
-}
-
-// TestCompileNegI64 walks the unary OpNegI64 lowering: one OpConst
-// feeds the neg, the result is returned. neg rax = 48 F7 D8.
-func TestCompileNegI64(t *testing.T) {
-	if !Supported() {
-		t.Skip("phase 2 ships amd64 only")
-	}
-	fn := &ir.Function{Name: "neg", Result: ir.TypeI64}
-	bid := fn.AddBlock()
-	va := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 7})
-	vr := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpNegI64, Args: []uint32{va}})
-	fn.Block(bid).Values = append(fn.Block(bid).Values, va, vr)
-	fn.Block(bid).Term = ir.Terminator{Kind: ir.TermReturn, Value: vr}
-	e, err := NewEmitter()
-	if err != nil {
-		t.Fatalf("NewEmitter: %v", err)
-	}
-	code, _, err := e.Compile(fn)
-	if err != nil {
-		t.Fatalf("Compile: %v", err)
-	}
-	// OpConst (10) + neg (3) + ret (1) = 14.
-	if got, want := len(code), 14; got != want {
-		t.Fatalf("len(code) = %d, want %d", got, want)
-	}
-	want := []byte{0x48, 0xF7, 0xD8}
-	for i, b := range want {
-		if code[10+i] != b {
-			t.Errorf("code[%d] = %#02x, want %#02x", 10+i, code[10+i], b)
-		}
-	}
-}
-
-// TestCompileImmOps walks the three i64 arith-Imm stencils and checks
-// the imm32 Addend lands in the reloc. The IR uses one OpConst feeding
-// the *Imm op (whose Value.Const carries the immediate) and returns
-// the result.
-func TestCompileImmOps(t *testing.T) {
-	if !Supported() {
-		t.Skip("phase 2 ships amd64 only")
-	}
-	cases := []struct {
-		name   string
-		op     ir.OpCode
-		imm    int64
-		opSize int
-		// relocOffsetInOp names where in the *Imm stencil the imm32 sits.
-		relocOffsetInOp uint32
-	}{
-		{"add_imm", ir.OpAddI64Imm, 99, 6, 2},
-		{"sub_imm", ir.OpSubI64Imm, -7, 6, 2},
-		{"mul_imm", ir.OpMulI64Imm, 3, 7, 3},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			fn := buildImmOp(c.op, 5, c.imm)
-			e, err := NewEmitter()
-			if err != nil {
-				t.Fatalf("NewEmitter: %v", err)
-			}
-			code, relocs, err := e.Compile(fn)
-			if err != nil {
-				t.Fatalf("Compile: %v", err)
-			}
-			// OpConst (10) + *Imm (c.opSize) + ret (1).
-			if got, want := len(code), 11+c.opSize; got != want {
-				t.Fatalf("len(code) = %d, want %d", got, want)
-			}
-			// Two relocs: OpConst RelocImm64 at offset 2, *Imm RelocImm32
-			// at offset 10 + relocOffsetInOp.
-			if got, want := len(relocs), 2; got != want {
-				t.Fatalf("len(relocs) = %d, want %d", got, want)
-			}
-			want := uint32(10) + c.relocOffsetInOp
-			if relocs[1].Offset != want {
-				t.Errorf("imm reloc offset = %d, want %d", relocs[1].Offset, want)
-			}
-			if relocs[1].Kind != RelocImm32 {
-				t.Errorf("imm reloc kind = %s, want imm32", relocs[1].Kind)
-			}
-			if int64(relocs[1].Addend) != c.imm {
-				t.Errorf("imm addend = %d, want %d", relocs[1].Addend, c.imm)
-			}
-		})
-	}
-}
-
-// TestCompileCompare exercises the six i64 comparison lowerings. Each
-// must emit cmp rax, rdi (48 39 F8) + setCC al (0F XX C0) + movzx rax, al
-// (48 0F B6 C0), with the setCC opcode varying per relation.
-func TestCompileCompare(t *testing.T) {
-	if !Supported() {
-		t.Skip("phase 2 ships amd64 only")
-	}
-	cases := []struct {
-		name      string
-		op        ir.OpCode
-		setOpcode byte
-	}{
-		{"eq", ir.OpCmpEqI64, 0x94},
-		{"ne", ir.OpCmpNeI64, 0x95},
-		{"lt", ir.OpCmpLtI64, 0x9C},
-		{"le", ir.OpCmpLeI64, 0x9E},
-		{"gt", ir.OpCmpGtI64, 0x9F},
-		{"ge", ir.OpCmpGeI64, 0x9D},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			fn := buildBinaryOp(c.op, 1, 2)
-			fn.Values[2].Type = ir.TypeBool
-			e, err := NewEmitter()
-			if err != nil {
-				t.Fatalf("NewEmitter: %v", err)
-			}
-			code, _, err := e.Compile(fn)
-			if err != nil {
-				t.Fatalf("Compile: %v", err)
-			}
-			// Two OpConst (20) + cmp+setCC+movzx (10) + ret (1) = 31.
-			if got, want := len(code), 31; got != want {
-				t.Fatalf("len(code) = %d, want %d", got, want)
-			}
-			// cmp prefix at offset 20.
-			if code[20] != 0x48 || code[21] != 0x39 || code[22] != 0xF8 {
-				t.Errorf("cmp prefix = % x, want 48 39 F8", code[20:23])
-			}
-			// setCC opcode at offset 23+1.
-			if code[23] != 0x0F || code[24] != c.setOpcode || code[25] != 0xC0 {
-				t.Errorf("setCC = % x, want 0F %02x C0", code[23:26], c.setOpcode)
-			}
-			// movzx tail.
-			if code[26] != 0x48 || code[27] != 0x0F || code[28] != 0xB6 || code[29] != 0xC0 {
-				t.Errorf("movzx tail = % x, want 48 0F B6 C0", code[26:30])
-			}
-		})
-	}
-}
-
-// TestCompileCompareImm exercises the six i64-imm comparison
-// lowerings. The cmp prefix is 48 3D + imm32, the setCC opcode varies
-// per relation, and the imm32 Addend is set from Value.Const.
-func TestCompileCompareImm(t *testing.T) {
-	if !Supported() {
-		t.Skip("phase 2 ships amd64 only")
-	}
-	cases := []struct {
-		name      string
-		op        ir.OpCode
-		setOpcode byte
-	}{
-		{"eq", ir.OpCmpEqI64Imm, 0x94},
-		{"ne", ir.OpCmpNeI64Imm, 0x95},
-		{"lt", ir.OpCmpLtI64Imm, 0x9C},
-		{"le", ir.OpCmpLeI64Imm, 0x9E},
-		{"gt", ir.OpCmpGtI64Imm, 0x9F},
-		{"ge", ir.OpCmpGeI64Imm, 0x9D},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			fn := buildImmOp(c.op, 42, 7)
-			fn.Values[1].Type = ir.TypeBool
-			e, err := NewEmitter()
-			if err != nil {
-				t.Fatalf("NewEmitter: %v", err)
-			}
-			code, relocs, err := e.Compile(fn)
-			if err != nil {
-				t.Fatalf("Compile: %v", err)
-			}
-			// OpConst (10) + cmp+setCC+movzx (13) + ret (1) = 24.
-			if got, want := len(code), 24; got != want {
-				t.Fatalf("len(code) = %d, want %d", got, want)
-			}
-			// cmp prefix at offset 10.
-			if code[10] != 0x48 || code[11] != 0x3D {
-				t.Errorf("cmp prefix = % x, want 48 3D", code[10:12])
-			}
-			// setCC opcode at offset 16+1.
-			if code[16] != 0x0F || code[17] != c.setOpcode || code[18] != 0xC0 {
-				t.Errorf("setCC = % x, want 0F %02x C0", code[16:19], c.setOpcode)
-			}
-			// Two relocs: OpConst RelocImm64 at 2, *Imm RelocImm32 at 12.
-			if got, want := len(relocs), 2; got != want {
-				t.Fatalf("len(relocs) = %d, want %d", got, want)
-			}
-			if relocs[1].Offset != 12 || relocs[1].Kind != RelocImm32 {
-				t.Errorf("imm reloc = %+v, want offset=12 kind=imm32", relocs[1])
-			}
-			if relocs[1].Addend != 7 {
-				t.Errorf("imm addend = %d, want 7", relocs[1].Addend)
-			}
-		})
-	}
-}
-
-// TestCompileMultiBlockJump checks the multi-block TermJump path. Two
-// blocks: block 0 holds Const + TermJump to block 1; block 1 holds the
-// ret. The jump's rel32 must point from the end of the rel32 field to
-// the start of block 1.
-func TestCompileMultiBlockJump(t *testing.T) {
-	if !Supported() {
-		t.Skip("phase 2 ships amd64 only")
-	}
-	fn := &ir.Function{Name: "jump", Result: ir.TypeI64}
-	b0 := fn.AddBlock()
-	b1 := fn.AddBlock()
-	v := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 9})
-	fn.Block(b0).Values = append(fn.Block(b0).Values, v)
-	fn.Block(b0).Term = ir.Terminator{Kind: ir.TermJump, Target: b1}
-	fn.Block(b1).Term = ir.Terminator{Kind: ir.TermReturn, Value: v}
-	e, err := NewEmitter()
-	if err != nil {
-		t.Fatalf("NewEmitter: %v", err)
-	}
-	code, _, err := e.Compile(fn)
-	if err != nil {
-		t.Fatalf("Compile: %v", err)
-	}
-	// OpConst (10) + jmp E9+rel32 (5) + ret (1) = 16.
-	if got, want := len(code), 16; got != want {
-		t.Fatalf("len(code) = %d, want %d", got, want)
-	}
-	if code[10] != 0xE9 {
-		t.Errorf("expected E9 at offset 10, got %#02x", code[10])
-	}
-	// rel32 = block1 start (15) - end of rel32 field (15) = 0.
-	disp := int32(binary.LittleEndian.Uint32(code[11:15]))
-	if disp != 0 {
-		t.Errorf("jump disp = %d, want 0", disp)
-	}
-	if code[15] != 0xC3 {
-		t.Errorf("expected ret (C3) at offset 15, got %#02x", code[15])
-	}
-}
-
-// TestCompileMultiBlockBranch checks the TermBranch lowering. Three
-// blocks: block 0 produces a bool, branches to block 1 (true) or
-// block 2 (false). The emitter must lay down test rax,rax + jne IfTrue
-// + jmp IfFalse, with both rel32 displacements pointing at the right
-// block starts.
-func TestCompileMultiBlockBranch(t *testing.T) {
-	if !Supported() {
-		t.Skip("phase 2 ships amd64 only")
-	}
-	fn := &ir.Function{Name: "branch", Result: ir.TypeI64}
-	b0 := fn.AddBlock()
-	b1 := fn.AddBlock()
-	b2 := fn.AddBlock()
-	vcond := fn.AddValue(ir.Value{Type: ir.TypeBool, Op: ir.OpConst, Const: 1})
-	vone := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 1})
-	vtwo := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 2})
-	fn.Block(b0).Values = append(fn.Block(b0).Values, vcond)
-	fn.Block(b0).Term = ir.Terminator{Kind: ir.TermBranch, Value: vcond, IfTrue: b1, IfFalse: b2}
-	fn.Block(b1).Values = append(fn.Block(b1).Values, vone)
-	fn.Block(b1).Term = ir.Terminator{Kind: ir.TermReturn, Value: vone}
-	fn.Block(b2).Values = append(fn.Block(b2).Values, vtwo)
-	fn.Block(b2).Term = ir.Terminator{Kind: ir.TermReturn, Value: vtwo}
-	e, err := NewEmitter()
-	if err != nil {
-		t.Fatalf("NewEmitter: %v", err)
-	}
-	code, _, err := e.Compile(fn)
-	if err != nil {
-		t.Fatalf("Compile: %v", err)
-	}
-	// b0: OpConst (10) + test (3) + jne (6) + jmp (5) = 24.
-	// b1: OpConst (10) + ret (1) = 11. Starts at 24.
-	// b2: OpConst (10) + ret (1) = 11. Starts at 35.
-	// Total 46.
-	if got, want := len(code), 46; got != want {
-		t.Fatalf("len(code) = %d, want %d", got, want)
-	}
-	if code[10] != 0x48 || code[11] != 0x85 || code[12] != 0xC0 {
-		t.Errorf("test rax,rax bytes = % x, want 48 85 C0", code[10:13])
-	}
-	if code[13] != 0x0F || code[14] != 0x85 {
-		t.Errorf("jne prefix = % x, want 0F 85", code[13:15])
-	}
-	// jne rel32: site=15, end=19, target=24 → disp=5.
-	if disp := int32(binary.LittleEndian.Uint32(code[15:19])); disp != 5 {
-		t.Errorf("jne disp = %d, want 5", disp)
-	}
-	if code[19] != 0xE9 {
-		t.Errorf("jmp opcode = %#02x, want E9", code[19])
-	}
-	// jmp rel32: site=20, end=24, target=35 → disp=11.
-	if disp := int32(binary.LittleEndian.Uint32(code[20:24])); disp != 11 {
-		t.Errorf("jmp disp = %d, want 11", disp)
+	if int64(relocs[0].Addend) != a || int64(relocs[1].Addend) != b {
+		t.Errorf("addends = (%d, %d), want (%d, %d)",
+			relocs[0].Addend, relocs[1].Addend, a, b)
 	}
 }
 
@@ -428,7 +110,7 @@ func TestCompileMultiBlockBranch(t *testing.T) {
 // allocator unlocks phi support.
 func TestCompileRejectsPhi(t *testing.T) {
 	if !Supported() {
-		t.Skip("phase 2 ships amd64 only")
+		t.Skip("host has no stencil table")
 	}
 	fn := &ir.Function{Name: "phi", Result: ir.TypeI64}
 	bid := fn.AddBlock()
@@ -447,9 +129,11 @@ func TestCompileRejectsPhi(t *testing.T) {
 
 // TestCompileRejectsDiv covers the OpDivI64 fallback. Division needs
 // an overflow slow-path (Phase 2.5); until then it must fall back.
+// On arm64 the placeholder table also lacks OpDivI64; the rejection
+// path is identical on both archs.
 func TestCompileRejectsDiv(t *testing.T) {
 	if !Supported() {
-		t.Skip("phase 2 ships amd64 only")
+		t.Skip("host has no stencil table")
 	}
 	fn := buildBinaryOp(ir.OpDivI64, 10, 2)
 	e, err := NewEmitter()
@@ -466,7 +150,7 @@ func TestCompileRejectsDiv(t *testing.T) {
 // path must not segfault on a misuse.
 func TestCompileNilFunction(t *testing.T) {
 	if !Supported() {
-		t.Skip("phase 2 ships amd64 only")
+		t.Skip("host has no stencil table")
 	}
 	e, err := NewEmitter()
 	if err != nil {
@@ -483,7 +167,7 @@ func TestCompileNilFunction(t *testing.T) {
 // buffer the runtime would jump into.
 func TestCompileEmptyFunction(t *testing.T) {
 	if !Supported() {
-		t.Skip("phase 2 ships amd64 only")
+		t.Skip("host has no stencil table")
 	}
 	fn := &ir.Function{Name: "empty", Result: ir.TypeI64}
 	e, err := NewEmitter()
@@ -502,7 +186,7 @@ func TestCompileEmptyFunction(t *testing.T) {
 // buffer.
 func TestCompileBadTerminator(t *testing.T) {
 	if !Supported() {
-		t.Skip("phase 2 ships amd64 only")
+		t.Skip("host has no stencil table")
 	}
 	fn := &ir.Function{Name: "bad_term", Result: ir.TypeI64}
 	bid := fn.AddBlock()
@@ -514,6 +198,37 @@ func TestCompileBadTerminator(t *testing.T) {
 	_, _, err = e.Compile(fn)
 	if !errors.Is(err, ErrNoStencil) {
 		t.Errorf("Compile(bad_term) err = %v, want ErrNoStencil", err)
+	}
+}
+
+// TestCompileRejectsBranchOnUnsupportedArch ensures the emitter
+// refuses to lower a TermJump or TermBranch on a GOARCH whose
+// arch-specific stencil file reports `archSupportsBranches() ==
+// false`. The amd64 file sets it true; the arm64 placeholder sets it
+// false until Phase 2.1 ports the rel26 / cbz encodings. The test is
+// a no-op skip on archs where archSupportsBranches() is true (the
+// existing branch tests cover those paths).
+func TestCompileRejectsBranchOnUnsupportedArch(t *testing.T) {
+	if !Supported() {
+		t.Skip("host has no stencil table")
+	}
+	if archSupportsBranches() {
+		t.Skip("host supports inter-block branches; reject path is unreachable")
+	}
+	fn := &ir.Function{Name: "jump", Result: ir.TypeI64}
+	b0 := fn.AddBlock()
+	b1 := fn.AddBlock()
+	v := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 1})
+	fn.Block(b0).Values = append(fn.Block(b0).Values, v)
+	fn.Block(b0).Term = ir.Terminator{Kind: ir.TermJump, Target: b1}
+	fn.Block(b1).Term = ir.Terminator{Kind: ir.TermReturn, Value: v}
+	e, err := NewEmitter()
+	if err != nil {
+		t.Fatalf("NewEmitter: %v", err)
+	}
+	_, _, err = e.Compile(fn)
+	if !errors.Is(err, ErrNoStencil) {
+		t.Errorf("Compile(jump) err = %v, want ErrNoStencil", err)
 	}
 }
 
@@ -578,7 +293,8 @@ func buildConstAddReturn(a, b int64) *ir.Function {
 
 // buildBinaryOp constructs a single-block Function that evaluates
 // op(a, b) where a, b are i64 literals and op is one of the i64
-// binary opcodes the Phase 2 stencil set covers.
+// binary opcodes the host's stencil set covers (or doesn't, for
+// rejection tests).
 func buildBinaryOp(op ir.OpCode, a, b int64) *ir.Function {
 	fn := &ir.Function{Name: op.String(), Result: ir.TypeI64}
 	bid := fn.AddBlock()

--- a/compiler3/emit/copypatch/mmap_linux_arm64.go
+++ b/compiler3/emit/copypatch/mmap_linux_arm64.go
@@ -1,0 +1,133 @@
+//go:build linux && arm64
+
+package copypatch
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// NewLinuxARM64Mapping creates a dual-mapping (rw, rx) pair of size
+// bytes that share the same physical pages, on aarch64 Linux. The
+// technique is byte-identical to the linux/amd64 path
+// (`NewLinuxAMD64Mapping`), the only difference being the
+// `memfd_create` syscall number (319 on x86_64, 279 on aarch64).
+//
+//  1. memfd_create("mochi-jit", MFD_CLOEXEC) returns an anonymous
+//     file descriptor backed by RAM.
+//  2. ftruncate(fd, size) sizes the backing file.
+//  3. mmap(fd, PROT_READ|PROT_WRITE, MAP_SHARED) produces the RW
+//     view.
+//  4. mmap(fd, PROT_READ|PROT_EXEC,  MAP_SHARED) produces the RX
+//     view.
+//  5. close(fd) drops the descriptor; the two mappings keep the
+//     backing storage alive until both are munmap'd.
+//
+// The two views are not at the same virtual address. A stencil's
+// internal jumps are patched against the RX entry, the address the
+// trampoline jumps to, not the RW view the patcher writes through.
+// cache.Install passes the RX-view entry as baseAddr to applyRelocs.
+//
+// W^X is structural: neither mapping is ever simultaneously writable
+// and executable. The RW mapping has `PROT_READ|PROT_WRITE`; the RX
+// mapping has `PROT_READ|PROT_EXEC`. No mprotect toggling is needed.
+// This is the linux/arm64 spelling of MEP-41 §5's W^X requirement
+// (axis 1) and the analog of `NewLinuxAMD64Mapping` on x86_64 Linux.
+//
+// aarch64 cache coherency: the dual-mapping technique relies on the
+// kernel keeping the data cache and instruction cache coherent for
+// the same backing pages. Linux's MAP_SHARED + the kernel-side
+// `flush_dcache_page` invocation on fault satisfies this; the
+// userspace caller does not need to issue `IC IVAU` / `DSB` /
+// `ISB` manually for first-fault pages. A future `Cache.Reset` that
+// reuses pages will need an explicit cache-flush pass; that lands in
+// Phase 1.6 alongside the BG parity gate.
+func NewLinuxARM64Mapping(size int) (rw, rx []byte, err error) {
+	if size <= 0 {
+		return nil, nil, fmt.Errorf("copypatch.NewLinuxARM64Mapping: size must be positive, got %d", size)
+	}
+	if size%pageSizeARM64() != 0 {
+		return nil, nil, fmt.Errorf("copypatch.NewLinuxARM64Mapping: size %d not page-aligned (page=%d)",
+			size, pageSizeARM64())
+	}
+	fd, err := memfdCreateARM64("mochi-jit", mfdCloexecARM64)
+	if err != nil {
+		return nil, nil, fmt.Errorf("memfd_create: %w", err)
+	}
+	defer func() {
+		// Drop the fd unconditionally; the mappings keep the backing
+		// storage alive on their own. Failure to close the fd is
+		// non-fatal but should never happen on Linux.
+		_ = syscall.Close(fd)
+	}()
+	if err := syscall.Ftruncate(fd, int64(size)); err != nil {
+		return nil, nil, fmt.Errorf("ftruncate: %w", err)
+	}
+	rw, err = syscall.Mmap(fd, 0, size, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+	if err != nil {
+		return nil, nil, fmt.Errorf("mmap rw: %w", err)
+	}
+	rx, err = syscall.Mmap(fd, 0, size, syscall.PROT_READ|syscall.PROT_EXEC, syscall.MAP_SHARED)
+	if err != nil {
+		_ = syscall.Munmap(rw)
+		return nil, nil, fmt.Errorf("mmap rx: %w", err)
+	}
+	return rw, rx, nil
+}
+
+// ReleaseLinuxARM64Mapping unmaps both views. Errors from the
+// individual munmap calls are surfaced via the returned wrapped
+// error; callers should log them but cannot meaningfully recover.
+func ReleaseLinuxARM64Mapping(rw, rx []byte) error {
+	var errRW, errRX error
+	if len(rw) > 0 {
+		errRW = syscall.Munmap(rw)
+	}
+	if len(rx) > 0 {
+		errRX = syscall.Munmap(rx)
+	}
+	switch {
+	case errRW != nil && errRX != nil:
+		return fmt.Errorf("munmap rw=%v, rx=%v", errRW, errRX)
+	case errRW != nil:
+		return fmt.Errorf("munmap rw: %w", errRW)
+	case errRX != nil:
+		return fmt.Errorf("munmap rx: %w", errRX)
+	}
+	return nil
+}
+
+// pageSizeARM64 returns the host page size on aarch64 Linux. The
+// arm64-specific spelling avoids collisions with the amd64
+// `pageSize()` helper defined in mmap_linux_amd64.go; both files
+// can be compiled into separate per-GOARCH binaries without
+// linker-level conflict.
+func pageSizeARM64() int {
+	return os.Getpagesize()
+}
+
+// memfd_create syscall constants for aarch64 Linux. The syscall
+// number is 279 on aarch64 (vs 319 on x86_64). The MFD_CLOEXEC flag
+// value is architecture-agnostic. Hard-coded here so the linux/arm64
+// build does not pull in golang.org/x/sys (Mochi's pure-Go-no-cgo
+// identity rule, MEP-42 §13).
+const (
+	sysMemfdCreateARM64 = 279 // aarch64 syscall number; man 2 memfd_create
+	mfdCloexecARM64     = 0x0001
+)
+
+func memfdCreateARM64(name string, flags int) (int, error) {
+	// syscall.BytePtrFromString returns a NUL-terminated copy of the
+	// name; required by the kernel's strncpy_from_user.
+	bp, err := syscall.BytePtrFromString(name)
+	if err != nil {
+		return 0, err
+	}
+	r1, _, errno := syscall.Syscall(sysMemfdCreateARM64, uintptr(unsafe.Pointer(bp)), uintptr(flags), 0)
+	if errno != 0 {
+		return 0, errno
+	}
+	return int(r1), nil
+}

--- a/compiler3/emit/copypatch/mmap_linux_arm64_stub.go
+++ b/compiler3/emit/copypatch/mmap_linux_arm64_stub.go
@@ -1,0 +1,22 @@
+//go:build !(linux && arm64)
+
+package copypatch
+
+import "fmt"
+
+// NewLinuxARM64Mapping on non-(linux/arm64) returns an error. Phase
+// 1.1 ships the linux/arm64 spelling of the dual-mapping; macOS arm64
+// uses the `MAP_JIT` + `pthread_jit_write_protect_np` path
+// (mmap_darwin_arm64.go, Phase 1.3). Callers must consult the
+// platform-appropriate constructor; this stub exists so callers can
+// link platform-agnostic teardown code without per-host build tags.
+func NewLinuxARM64Mapping(size int) (rw, rx []byte, err error) {
+	return nil, nil, fmt.Errorf("copypatch: NewLinuxARM64Mapping unsupported on this GOOS/GOARCH (phase 1.1 ships linux/arm64)")
+}
+
+// ReleaseLinuxARM64Mapping is a no-op on non-(linux/arm64). The
+// signature is preserved so callers can write platform-agnostic
+// teardown code that compiles on every host.
+func ReleaseLinuxARM64Mapping(rw, rx []byte) error {
+	return nil
+}

--- a/compiler3/emit/copypatch/mmap_linux_arm64_test.go
+++ b/compiler3/emit/copypatch/mmap_linux_arm64_test.go
@@ -1,0 +1,115 @@
+//go:build linux && arm64
+
+package copypatch
+
+import (
+	"os"
+	"testing"
+)
+
+// TestLinuxARM64MappingDualView covers the load-bearing W^X invariant
+// on aarch64 Linux: after NewLinuxARM64Mapping returns (rw, rx), a
+// write to rw[i] is observable as a read at rx[i] (the two mappings
+// share physical pages via the shared memfd backing). The test does
+// not attempt to execute through rx; the Phase 1.6 integration test
+// owns the real-trampoline coverage.
+//
+// aarch64 cache-coherence note: the test relies on the Linux kernel's
+// `flush_dcache_page` invocation on first-fault to keep the data and
+// instruction caches in sync on the same backing pages. The userspace
+// caller does not need to issue IC IVAU / DSB / ISB for first-fault
+// pages; the kernel does that for us through MAP_SHARED's coherence
+// semantics on aarch64.
+func TestLinuxARM64MappingDualView(t *testing.T) {
+	page := os.Getpagesize()
+	rw, rx, err := NewLinuxARM64Mapping(page)
+	if err != nil {
+		t.Fatalf("NewLinuxARM64Mapping: %v", err)
+	}
+	defer func() {
+		if err := ReleaseLinuxARM64Mapping(rw, rx); err != nil {
+			t.Errorf("ReleaseLinuxARM64Mapping: %v", err)
+		}
+	}()
+	if len(rw) != page || len(rx) != page {
+		t.Errorf("mapping lens = (%d, %d), want (%d, %d)", len(rw), len(rx), page, page)
+	}
+	for i := range 16 {
+		rw[i] = byte(0xA0 + i)
+	}
+	for i := range 16 {
+		if got := rx[i]; got != byte(0xA0+i) {
+			t.Errorf("rx[%d] = 0x%x, want 0x%x (rw write not visible through rx)",
+				i, got, 0xA0+i)
+		}
+	}
+}
+
+// TestLinuxARM64MappingRejectsZero covers input validation. A zero or
+// negative size is a misuse; the mapper must fail loudly rather than
+// calling memfd_create with garbage.
+func TestLinuxARM64MappingRejectsZero(t *testing.T) {
+	if _, _, err := NewLinuxARM64Mapping(0); err == nil {
+		t.Errorf("NewLinuxARM64Mapping(0) = nil error, want non-nil")
+	}
+	if _, _, err := NewLinuxARM64Mapping(-4096); err == nil {
+		t.Errorf("NewLinuxARM64Mapping(-4096) = nil error, want non-nil")
+	}
+}
+
+// TestLinuxARM64MappingRejectsMisalignment covers the page-alignment
+// requirement. The aarch64 page size on Linux is configurable at
+// kernel build time (4 KiB, 16 KiB, or 64 KiB); the test uses
+// os.Getpagesize() so it adapts to whichever the host runs.
+func TestLinuxARM64MappingRejectsMisalignment(t *testing.T) {
+	page := os.Getpagesize()
+	if _, _, err := NewLinuxARM64Mapping(page + 17); err == nil {
+		t.Errorf("NewLinuxARM64Mapping(page+17) = nil error, want non-nil")
+	}
+}
+
+// TestLinuxARM64MappingWithCache wires the arm64 mapping into a real
+// Cache and installs a stencil. This is the end-to-end path the
+// runtime takes on a real JIT compile on aarch64 Linux; we cannot
+// execute the bytes (no trampoline in this test), but we can verify
+// the patcher writes the right values into the executable view's
+// physical pages.
+func TestLinuxARM64MappingWithCache(t *testing.T) {
+	if !Supported() {
+		t.Skip("aarch64 stencil table unavailable")
+	}
+	page := os.Getpagesize()
+	rw, rx, err := NewLinuxARM64Mapping(page)
+	if err != nil {
+		t.Fatalf("mapping: %v", err)
+	}
+	defer ReleaseLinuxARM64Mapping(rw, rx)
+	c, err := NewCache(rw, rx)
+	if err != nil {
+		t.Fatalf("NewCache: %v", err)
+	}
+	e, _ := NewEmitter()
+	fn := buildConstReturn(0xABCD)
+	code, relocs, err := e.Compile(fn)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	var st SymbolTable
+	st.Set(SymOpRetTarget, 1)
+	for i := range relocs {
+		relocs[i].Addend--
+	}
+	entry, err := c.Install(code, relocs, &st)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if entry == 0 {
+		t.Errorf("entry address is zero")
+	}
+	for i, b := range rw[:len(code)] {
+		if rx[i] != b {
+			t.Errorf("rx[%d] = 0x%x, rw[%d] = 0x%x (views disagree)",
+				i, rx[i], i, b)
+		}
+	}
+}

--- a/compiler3/emit/copypatch/stencil_test.go
+++ b/compiler3/emit/copypatch/stencil_test.go
@@ -143,14 +143,16 @@ func TestStencilValidate(t *testing.T) {
 	}
 }
 
-// TestStencilsAMD64Valid runs every Phase 1 amd64 stencil through
-// validate() so a regression in the hand-written table (off-by-one
-// offset, accidental overlap, RelocInvalid leak) is caught at
-// package-test time, not at runtime.
-func TestStencilsAMD64Valid(t *testing.T) {
+// TestStencilsHostValid runs every host stencil through validate() so
+// a regression in the hand-written table (off-by-one offset,
+// accidental overlap, RelocInvalid leak) is caught at package-test
+// time, not at runtime. The test is arch-portable: it consults
+// archStencils() so amd64, arm64, and the empty fallback are all
+// covered without per-arch duplication.
+func TestStencilsHostValid(t *testing.T) {
 	tab := archStencils()
 	if tab == nil {
-		t.Skip("no stencil table for this GOARCH (phase 1 ships amd64 only)")
+		t.Skip("no stencil table for this GOARCH (phase 1 target matrix lists 5 hosts)")
 	}
 	for op, s := range tab {
 		if err := s.validate(); err != nil {

--- a/compiler3/emit/copypatch/stencils_amd64.go
+++ b/compiler3/emit/copypatch/stencils_amd64.go
@@ -189,7 +189,17 @@ func cmpImmReloc() []RelocSite {
 
 // archStencils returns the stencil table for the host GOARCH. The
 // build-tagged file ensures only one definition is linked into the
-// final binary; non-amd64 builds get the stencils_other.go fallback.
+// final binary; non-amd64 builds get stencils_arm64.go or the
+// stencils_other.go fallback.
 func archStencils() map[ir.OpCode]Stencil {
 	return stencilsAMD64
+}
+
+// archSupportsBranches reports whether the emitter can lower inter-
+// block terminators (`TermJump`, `TermBranch`) for the host GOARCH.
+// True on amd64 (Phase 2.0); false on arm64 until Phase 2.1 ports the
+// rel26/cbz encodings; false on every other host until that host gets
+// its own arch-specific terminator-byte sequence.
+func archSupportsBranches() bool {
+	return true
 }

--- a/compiler3/emit/copypatch/stencils_arm64.go
+++ b/compiler3/emit/copypatch/stencils_arm64.go
@@ -1,0 +1,107 @@
+//go:build arm64
+
+package copypatch
+
+import (
+	"mochi/compiler3/ir"
+)
+
+// stencilsARM64 is the hand-written aarch64 stencil table covering
+// the Phase 1.1 placeholder shape: the same three opcodes the Phase
+// 1.0 amd64 table covers (`OpConst`, `OpAddI64`, ret under
+// `OpInvalid`), encoded in the AAPCS64 calling convention pinned by
+// MEP-42 §2:
+//
+//	X0      primary value (left operand, result, branch condition)
+//	X1      secondary value (right operand for binary ops)
+//	X19-X21 reserved for Frame / typed-arena base / per-VM context
+//
+// Phase 2.1 widens this table to cover the same non-allocating
+// arithmetic and comparison surface the amd64 table reached in
+// Phase 2.0. Phase 1.1 leaves the wider opcodes off the table so
+// `Emitter.Compile` returns `ErrNoStencil` cleanly and the runtime
+// falls back to vm3 on every IR that exceeds the placeholder.
+//
+// # OpConst lowering
+//
+// aarch64 has no single instruction that loads an arbitrary 64-bit
+// immediate. The two production patterns are:
+//
+//  1. movz + 3 movk (4 instructions, each patching a 16-bit slot);
+//     Clang and LLVM emit this for `__int128_t v = literal;`.
+//  2. ldr x0, [pc, #N] + a literal pool entry; the assembler emits
+//     this when `-mcmodel=large` or when the immediate cannot be
+//     synthesized in fewer instructions.
+//
+// The literal-pool form is chosen for Phase 1.1 because it preserves
+// the `RelocImm64` reloc-kind invariant: the 8-byte literal slot
+// patches with a single 64-bit write, identical in shape to the
+// amd64 `mov rax, imm64`. The movz/movk form would need a new
+// `RelocMovkUABS_G{0,1,2,3}` per-slot reloc kind (the LLVM
+// `R_AARCH64_MOVW_UABS_G*` family), which is Phase 2.1's
+// responsibility to introduce alongside its widened stencil set.
+//
+//	ldr x0, [pc, #8]   58 00 00 40 LE → 40 00 00 58
+//	b   #12            14 00 00 03 LE → 03 00 00 14   (skip the literal)
+//	<8 bytes literal>                                  (RelocImm64 patch site)
+//
+// Total OpConst = 16 bytes. The `b #12` skips past the literal so
+// fall-through execution lands on the next stencil. The patcher
+// writes the i64 value directly into bytes [8:16] via the standard
+// `RelocImm64` site at offset 8.
+//
+// # OpAddI64 lowering
+//
+//	add x0, x0, x1     8B 01 00 00 LE → 00 00 01 8B
+//
+// 4 bytes, no reloc. Result lands in x0.
+//
+// # ret lowering
+//
+//	ret                D6 5F 03 C0 LE → C0 03 5F D6
+//
+// 4 bytes, no reloc. Registered under `OpInvalid` so `TermReturn`
+// emission has a fixed lookup key, matching the amd64 convention.
+var stencilsARM64 = map[ir.OpCode]Stencil{
+	// OpConst: ldr x0, [pc, #8] + b #12 + 8-byte literal pool.
+	ir.OpConst: {
+		Op: ir.OpConst,
+		Bytes: []byte{
+			0x40, 0x00, 0x00, 0x58, // ldr x0, [pc, #8]
+			0x03, 0x00, 0x00, 0x14, // b #12 (skip the literal)
+			0, 0, 0, 0, 0, 0, 0, 0, // literal pool entry (8 bytes)
+		},
+		Relocs: []RelocSite{
+			{Offset: 8, Kind: RelocImm64, Symbol: SymOpRetTarget, Addend: 0},
+		},
+	},
+
+	// OpAddI64: add x0, x0, x1.
+	ir.OpAddI64: {
+		Op:    ir.OpAddI64,
+		Bytes: []byte{0x00, 0x00, 0x01, 0x8B},
+	},
+
+	// ret. Registered under OpInvalid so TermReturn emission has a
+	// fixed lookup key. The trampoline reads the result from X0.
+	ir.OpInvalid: {
+		Op:    ir.OpInvalid,
+		Bytes: []byte{0xC0, 0x03, 0x5F, 0xD6},
+	},
+}
+
+// archStencils returns the stencil table for the host GOARCH on
+// aarch64 builds. Phase 1.1 ships a 3-opcode placeholder; Phase 2.1
+// widens to the full non-allocating set.
+func archStencils() map[ir.OpCode]Stencil {
+	return stencilsARM64
+}
+
+// archSupportsBranches reports whether the emitter can lower inter-
+// block terminators on aarch64. False in Phase 1.1: the rel26 / cbz
+// encodings land in Phase 2.1 alongside the widened opcode set. The
+// emitter falls back to vm3 via `ErrNoStencil` on any `TermJump` or
+// `TermBranch` while this returns false.
+func archSupportsBranches() bool {
+	return false
+}

--- a/compiler3/emit/copypatch/stencils_arm64_test.go
+++ b/compiler3/emit/copypatch/stencils_arm64_test.go
@@ -1,0 +1,45 @@
+//go:build arm64
+
+package copypatch
+
+import (
+	"testing"
+
+	"mochi/compiler3/ir"
+)
+
+// TestStencilsARM64Coverage pins the exact opcode set the Phase 1.1
+// arm64 placeholder table covers: OpConst, OpAddI64, and OpInvalid
+// (the ret stencil). Phase 2.1 widens this set to match amd64's
+// non-allocating arithmetic + comparison surface; this test fails
+// loudly when that widening lands so the umbrella matrix in MEP-42
+// §10 stays in sync with the code.
+func TestStencilsARM64Coverage(t *testing.T) {
+	tab := archStencils()
+	want := map[ir.OpCode]bool{
+		ir.OpConst:   true,
+		ir.OpAddI64:  true,
+		ir.OpInvalid: true,
+	}
+	for op := range want {
+		if _, ok := tab[op]; !ok {
+			t.Errorf("missing stencil for %s", op)
+		}
+	}
+	for op := range tab {
+		if !want[op] {
+			t.Errorf("unexpected stencil for %s (phase 1.1 placeholder set is 3 opcodes)", op)
+		}
+	}
+}
+
+// TestArchSupportsBranchesARM64 pins the Phase 1.1 default. The
+// emitter gates TermJump and TermBranch emission on this; flipping it
+// to true without porting the rel26 / cbz encodings would let the
+// emitter produce invalid arm64 bytes. Phase 2.1 flips this to true
+// and removes this test (or rewrites it to assert true).
+func TestArchSupportsBranchesARM64(t *testing.T) {
+	if archSupportsBranches() {
+		t.Fatal("archSupportsBranches() = true on arm64 in Phase 1.1; rel26 / cbz encodings land in Phase 2.1")
+	}
+}

--- a/compiler3/emit/copypatch/stencils_other.go
+++ b/compiler3/emit/copypatch/stencils_other.go
@@ -1,13 +1,23 @@
-//go:build !amd64
+//go:build !amd64 && !arm64
 
 package copypatch
 
 import "mochi/compiler3/ir"
 
-// archStencils on non-amd64 returns an empty table. The Phase 1
-// scope (MEP-42 §9 row 1) is x86_64 Linux only; aarch64 stencils
-// land in Phase 1.5. Callers must consult NewEmitter().Supported()
-// before attempting to compile a Function on these platforms.
+// archStencils on hosts that are neither amd64 nor arm64 returns an
+// empty table. Phase 1's scope (MEP-42 §9) is the five must-have
+// targets: x86_64 Linux (Phase 1.0), aarch64 Linux (Phase 1.1),
+// x86_64 macOS (Phase 1.2), aarch64 macOS (Phase 1.3), and wasm32
+// (Phase 1.4). Hosts outside this matrix get the empty fallback;
+// callers must consult `Supported()` before attempting to compile a
+// Function on these platforms.
 func archStencils() map[ir.OpCode]Stencil {
 	return nil
+}
+
+// archSupportsBranches reports whether the emitter can lower inter-
+// block terminators on the host GOARCH. Always false on hosts
+// outside the Phase 1 target matrix because no stencil table exists.
+func archSupportsBranches() bool {
+	return false
 }

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -284,7 +284,7 @@ Each phase ships as one PR or a small named set of PRs, gated by the criterion i
 | Phase | Deliverable | Gate |
 |---|---|---|
 | 0 | Spec freeze, taxonomy lock, sidebar entry | LANDED 2026-05-18 (this MEP merged to `main`, sidebar updated, meps.json entry present) |
-| 1 | `compiler3/emit/copypatch/` skeleton + stencilgen tool, x86_64 Linux only | LANDED 2026-05-21 17:52 (GMT+7). Package skeleton (doc.go, stencil.go, patch.go, emit.go, cache.go, mmap_linux_amd64.go) + stencilgen tool skeleton + 30 tests covering reloc kinds, validator, IR walker, cache, and dual-mapping. Real Clang stencil extraction (1.1), full non-allocating op coverage (1.2), inline-allocation stencils (1.3), slow-path stubs (1.4), aarch64 stencils (1.5), and the BG cross-tier parity gate (1.6) deferred to sub-phases |
+| 1 | `compiler3/emit/copypatch/` skeleton + stencilgen tool, complete §9 target matrix | PARTIAL. 1.0 x86_64 Linux LANDED 2026-05-21 17:52 (GMT+7); 1.1 aarch64 Linux LANDED 2026-05-21 18:36 (GMT+7); 1.2 x86_64 macOS, 1.3 aarch64 macOS, 1.4 wasm32, and 1.5 spec target-matrix reconciliation pending. Umbrella row flips to LANDED once all five §9 must-have targets are green. Real Clang stencil extraction (1.6), full non-allocating op coverage (1.7), inline-allocation stencils (1.8), slow-path stubs (1.9), and the BG cross-tier parity gate (1.10) deferred to later sub-phases |
 | 2 | Copy-and-patch JIT covers all non-allocating vm3 ops on x86_64 Linux + aarch64 Linux | LANDED 2026-05-21 18:08 (GMT+7). Phase 2.0 x86_64 lands: i64 arithmetic (`Add/Sub/Mul/Neg` plus `Add/Sub/Mul` imm variants), six i64 comparisons (`Eq/Ne/Lt/Le/Gt/Ge` plus imm variants), and multi-block emit with `TermJump` (E9 cd) + `TermBranch` (test rax,rax + jne cd + jmp cd) terminators. Phase 2.1 aarch64 stencils, 2.2 f64 arithmetic, 2.3 cross-op register allocator + phi support, 2.4 BG kernel performance gate (within 5x of Go), and 2.5 `OpDivI64` / `OpModI64` with overflow slow-path deferred to sub-phases |
 | 3 | Apple Silicon support: mach-o, JIT entitlement, ad-hoc signing | `mochi run --jit=copypatch` on aarch64 macOS within 5x of Go on BG kernels |
 | 4 | `compiler3/emit/c/` skeleton + linker driver, x86_64 Linux only | `mochi build hello.mochi` produces a native ELF, runs and prints expected output |
@@ -435,6 +435,44 @@ The Phase 1 `TestCompileMultiBlock` and `TestCompileMissingTerminator` cases are
 | 2.5 | `OpDivI64` / `OpModI64` with slow-path call into a runtime helper for `int.min/-1` overflow and divide-by-zero; the helper signature is documented in `stencil.go`'s `SymSlowPathDeref`-class symbols |
 
 Each sub-phase carries its own gate. 2.1 is the highest priority (aarch64 unlocks Apple Silicon and the most common cloud ARM instances). 2.3 is the biggest engineering change (it touches every block's livein/liveout). 2.4 is a performance gate, not an opcode addition; it can land any time after 2.3.
+
+## §10.3 Phase 1.1 closeout (LANDED 2026-05-21 18:36 GMT+7)
+
+Phase 1.1 lands the aarch64 Linux target from the §9 must-have matrix. The umbrella Phase 1 row stays PARTIAL until 1.2 (x86_64 macOS), 1.3 (aarch64 macOS), and 1.4 (wasm32) land; 1.5 then reconciles the spec to flip the row to LANDED.
+
+The 1.1 deliverables (all under `compiler3/emit/copypatch/`):
+
+| File | Purpose | Status |
+|------|---------|--------|
+| `stencils_arm64.go` | Hand-written aarch64 placeholder stencil table (`OpConst` via ldr+b+literal-pool, `OpAddI64` via `add x0, x0, x1`, ret under `OpInvalid`) | LANDED |
+| `mmap_linux_arm64.go` | Dual-mapping (rw, rx) via `memfd_create(279) + ftruncate + mmap*2`; W^X structural, no `mprotect` toggling | LANDED |
+| `mmap_linux_arm64_stub.go` | Stub returning "unsupported" on non-(linux/arm64) so the package builds on every host | LANDED |
+| `stencils_other.go` | Updated to `!amd64 && !arm64` so the empty-table fallback only kicks in on truly-out-of-matrix hosts | UPDATED |
+| `emit_amd64_test.go` (`//go:build amd64`) | Holds the byte-asserting tests that were arch-specific to x86_64 (`TestCompileBinaryArith`, `TestCompileNegI64`, `TestCompileImmOps`, `TestCompileCompare`, `TestCompileCompareImm`, `TestCompileMultiBlockJump`, `TestCompileMultiBlockBranch`, `TestCompileConstReturnAMD64`) | LANDED |
+| `emit_arm64_test.go` (`//go:build arm64`) | Asserts the exact aarch64 byte layout for `OpConst` and `OpAddI64`; covers `TestARM64RejectsSubMulNeg` so a regression that silently widens the placeholder table is caught | LANDED |
+| `stencils_arm64_test.go` (`//go:build arm64`) | Pins the 3-opcode placeholder coverage and asserts `archSupportsBranches() == false` so a premature flip is caught | LANDED |
+| `mmap_linux_arm64_test.go` (`//go:build linux && arm64`) | Dual-view + reject-zero + reject-misalignment + cache-install tests, mirroring the linux/amd64 suite | LANDED |
+| `emit_test.go` | Rewritten cross-arch: `TestCompileConstReturn` and `TestCompileAddChain` look up expected sizes and reloc offsets from `archStencils()` so they pass byte-for-byte on every host that has a table; adds `TestCompileRejectsBranchOnUnsupportedArch` covering the new `archSupportsBranches()` gate | UPDATED |
+| `cache_test.go` | Patch-offset assertions now read the offset from `archStencils()[OpConst].Relocs[0].Offset` so the test passes on both amd64 (offset 2) and arm64 (offset 8) without per-arch duplication | UPDATED |
+
+The `archSupportsBranches()` discriminator (new in 1.1, declared in `stencils_amd64.go` returning true and in `stencils_arm64.go` returning false) gates `emitTerm`'s `TermJump` and `TermBranch` lowering. The amd64 path emits `E9 cd` (jump) and `48 85 C0` + `0F 85 cd` + `E9 cd` (branch) directly from the emitter; the arm64 path reports `ErrNoStencil` until Phase 2.1 ports the rel26 / cbz encodings. This keeps the runtime safe: the emitter never produces a buffer of wrong-ISA bytes the trampoline would trap on.
+
+The aarch64 `OpConst` lowering deserves a specific design call-out. aarch64 has no single instruction that loads an arbitrary 64-bit immediate; the two production patterns are `movz` + 3 `movk` (4 instructions, each patching a 16-bit slot) or `ldr xN, [pc, #N]` + a literal-pool entry. The literal-pool form was chosen because it preserves the `RelocImm64` reloc-kind invariant: the 8-byte literal slot patches with a single 64-bit write, byte-identical in shape to the amd64 `mov rax, imm64` site. The `movz`/`movk` form would require introducing `RelocMovkUABS_G{0,1,2,3}` per-slot reloc kinds (the LLVM `R_AARCH64_MOVW_UABS_G*` family), which is Phase 2.1's responsibility to add alongside the widened arm64 stencil set. The placeholder bytes are:
+
+```
+40 00 00 58      ldr x0, [pc, #8]
+03 00 00 14      b   #12                   ; skip the literal pool
+8 bytes          literal (RelocImm64 site)
+C0 03 5F D6      ret                       ; (this is the OpInvalid/ret stencil, not part of OpConst)
+```
+
+The `b #12` skips past the 8-byte literal so fall-through execution lands on the next stencil instead of trapping on the data bytes.
+
+Cross-arch test portability: the previous emit_test.go asserted explicit x86_64 byte sequences (`code[20] != 0x48` etc.); on aarch64 those assertions would fire against valid arm64 bytes. The fix splits byte-asserting tests by build tag (`emit_amd64_test.go`, `emit_arm64_test.go`) while keeping the semantic shape checks (`TestCompileConstReturn`, `TestCompileAddChain`) cross-arch portable via `archStencils()` table lookups. The patcher tests in `cache_test.go` do the same, reading the OpConst reloc offset from the host table rather than hardcoding 2. Verified by `GOOS=linux GOARCH={amd64,arm64} go vet ./compiler3/emit/copypatch/` and `GOOS=darwin GOARCH={amd64,arm64} go vet ./compiler3/emit/copypatch/` all clean.
+
+Sub-task PRs and tracking issues:
+
+- aarch64 stencil table + dual-mapping + cross-arch test split: this PR, tracked alongside the umbrella MEP-42 issue.
 
 ## §11 Risks
 


### PR DESCRIPTION
Lands the aarch64 Linux target from MEP-42 §9 must-have matrix. The umbrella Phase 1 row stays PARTIAL until 1.2 (x86_64 macOS), 1.3 (aarch64 macOS), 1.4 (wasm32) ship; 1.5 then flips the row to LANDED.

Tracks #21947.

## Summary
- New `stencils_arm64.go`: 3-opcode placeholder table pinned to AAPCS64. OpConst uses ldr+b+literal-pool (preserves the `RelocImm64` invariant; movz/movk would need new `R_AARCH64_MOVW_UABS_G*` reloc kinds in Phase 2.1).
- New `mmap_linux_arm64.go`: dual-mapping via `memfd_create` syscall 279 + `ftruncate` + `mmap` * 2. Structurally W^X.
- Cross-arch test split: byte-asserting tests in `emit_amd64_test.go` / `emit_arm64_test.go`; semantic shape tests in `emit_test.go` look up sizes and reloc offsets from `archStencils()`.
- `archSupportsBranches()` discriminator on the emitter so TermJump / TermBranch fall back cleanly to vm3 on archs whose Phase 2.x terminator encodings have not landed.
- MEP-42 §10.3 closeout documenting the literal-pool encoding choice and the test arch-split.

## Test plan
- [x] `go test ./compiler3/emit/copypatch/` on darwin/arm64 (host).
- [x] `GOOS={linux,darwin} GOARCH={amd64,arm64} go vet ./compiler3/emit/copypatch/` all clean.
- [x] `GOOS=linux GOARCH=arm64 go test -c` builds a clean test binary.

## Spec sync
- `website/docs/mep/mep-0042.md`: Phase 1 row flipped from LANDED to PARTIAL; §10.3 Phase 1.1 closeout added.
- `~/notes/Spec/5500/implementation/03_phase_1_1_aarch64_linux.md`: implementer-facing deep dive (file-by-file shape, design choices, what's next).