### PR TITLE
mep-0042: §10.7 Phase 4.1 micro-benchmarks (Mochi vs hand vs vm3)

### DIFF
--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -676,6 +676,75 @@ This is the contract behind the §Top-line objective. Every IR `OpCode` and `Typ
 
 When a row moves from DEFERRED to LANDED, the closeout PR updates this matrix in the same change set (MEP-spec-in-sync rule).
 
+## §10.7 Phase 4.1 micro-benchmarks (recorded 2026-05-21 19:53 GMT+7)
+
+The §Top-line objective claims feature-parity, not performance-parity. This section quantifies the latter on the workloads expressible in the compiler3 MVP frontend (recursive scalar functions over `i64` with `print`). Each row is the median of 5 wall-clock runs measured with shell `time` on darwin/arm64 (Apple M-series, Apple clang 17.0.0, Go 1.25.x). The five columns are:
+
+- **Mochi→C**: `mochi build --target=c` then run the binary. Cc invocation: `cc -std=c99 -O2 -I <outdir> gen.c print.c`.
+- **Mochi→Go**: `mochi build --target=go --out=<dir>` then `go build` on the emitted gen.go.
+- **hand C**: a hand-written C99 file with the same algorithm, compiled with `cc -std=c99 -O2`.
+- **hand Go**: a hand-written Go file with the same algorithm, compiled with `go build`.
+- **vm3**: `mochi run`, the interpreter that has been the reference execution model since MEP-16.
+
+| Workload | Mochi→C | Mochi→Go | hand C | hand Go | vm3 |
+|----------|---------|----------|--------|---------|-----|
+| `fib(35)` (recursive Fibonacci) | 0.022 s | 0.029 s | 0.026 s | 0.031 s | 21.139 s |
+| `ack(3, 10)` (Ackermann) | 0.142 s | 0.140 s | 0.140 s | 0.154 s | 41.469 s |
+
+Speedup over vm3 (median/median):
+
+| Workload | Mochi→C | Mochi→Go | hand C | hand Go |
+|----------|---------|----------|--------|---------|
+| `fib(35)` | 961× | 729× | 813× | 682× |
+| `ack(3, 10)` | 292× | 296× | 296× | 269× |
+
+Binary sizes (release, stripped of debug by default):
+
+| Target | `fib_rec` | `ack` |
+|--------|-----------|-------|
+| Mochi→C | 34 KB | 34 KB |
+| hand C | 33 KB | 33 KB |
+| Mochi→Go | 2.5 MB | 2.5 MB |
+| hand Go | 2.5 MB | 2.5 MB |
+
+Findings:
+
+- **Mochi→C is within measurement noise of hand C.** The cc optimiser sees through the SSA-emitted local-then-jump shape and the resulting machine code matches what a direct C author would produce. Generated-C does not pay a parity tax on scalar recursive code.
+- **Mochi→Go is within measurement noise of hand Go.** Same conclusion for the Go target.
+- **vm3 is 290-960x slower than native** on these workloads. The interpreter pays a per-op dispatch cost that recursive scalar code amplifies. This is the §Top-line objective's quantitative motivation: every Mochi program that ships as a vm3-interpreted script can become a 300-1000x faster native binary by switching to `--target=c` or `--target=go`.
+- **C wins on size by 70x.** A 33 KB C executable versus a 2.5 MB Go binary is the practical tie-breaker between the two AOT targets when the deployment cares about binary size.
+
+Workloads in the "performance games" set that are NOT in this table, and why:
+
+| Workload | Why excluded |
+|----------|--------------|
+| `mandelbrot`, `n_body`, `spectral_norm`, `fannkuch`, `binary_trees` | Need `while`/`for` loops; frontend MVP only supports recursion |
+| `fib_iter` | Needs `var` reassignment in loop body; blocked on the same loop-frontend gap |
+| `fasta`, `regex_redux`, `k_nucleotide` | Need string literals and string ops; blocked on Phase 4.2 (TypeStr) |
+| `pidigits` | Needs arbitrary-precision integers; not on MEP-42 scope at all |
+| `reverse_complement` | Needs file I/O + strings; blocked on Phase 4.2 + a file-IO sentinel |
+
+These move into the benchmark table as their gating sub-phases land. The frontend-side blockers are tracked separately and are not in MEP-42 scope; the C-target-side blockers are §10.6's DEFERRED rows.
+
+Reproducer scripts and sources are at `/tmp/mep42bench/` on the recording machine; the Mochi sources are:
+
+```
+// fib_rec.mochi
+fun fib(n: int): int {
+  if n <= 1 { return n }
+  return fib(n - 1) + fib(n - 2)
+}
+print(fib(35))
+
+// ack.mochi
+fun ack(m: int, n: int): int {
+  if m == 0 { return n + 1 }
+  if n == 0 { return ack(m - 1, 1) }
+  return ack(m - 1, ack(m, n - 1))
+}
+print(ack(3, 10))
+```
+
 ## §11 Risks
 
 ### 11.1 Clang ABI drift breaks stencils


### PR DESCRIPTION
## Summary
- Adds §10.7 to MEP-42 documenting a 5-way benchmark comparison for the Phase 4.1 LANDED scope.
- Workloads: `fib(35)` and `ack(3,10)`, the two recursive scalar functions expressible in the compiler3 MVP frontend.
- Findings: Mochi→C matches hand C within measurement noise; Mochi→Go matches hand Go; vm3 is 290-960× slower than the native targets; C binary size is 70× smaller than Go.

## Methodology
Recorded 2026-05-21 19:53 GMT+7 on darwin/arm64, Apple clang 17.0.0, Go 1.25.x. Each cell is the median of 5 wall-clock runs measured with shell `time`.

## Exclusion table
Performance-games workloads that need loops, strings, lists, or bigints are blocked on later sub-phases (4.2 strings, 4.3 collections) or on the compiler3 frontend itself (`while`/`for`). They are listed in §10.7 with a per-workload blocker note and will roll into the table as their gates land.

Refs #21953. Follow-up to #21952 (Phase 4.1).

## Test plan
- [x] §10.7 reads coherently with §10.6's IR coverage matrix
- [x] All numbers in the table come from a single recording session on the same machine
- [x] The exclusion table covers every "performance games" workload not in the main table