### PR TITLE
mep-0042: Phase 4.1.1 port all C scalar operators to IR + frontend + emit

### DIFF
--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -281,6 +281,16 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 	case ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm:
 		op := i64ImmCmpOp(v.Op)
 		fmt.Fprintf(w, "    %s = (%s %s (int64_t)%dLL) ? 1 : 0;\n", name, valueName(v.Args[0]), op, v.Const)
+	case ir.OpAndI64, ir.OpOrI64, ir.OpXorI64, ir.OpShlI64, ir.OpShrI64:
+		op := i64BitwiseOp(v.Op)
+		fmt.Fprintf(w, "    %s = %s %s %s;\n", name, valueName(v.Args[0]), op, valueName(v.Args[1]))
+	case ir.OpNotI64:
+		fmt.Fprintf(w, "    %s = ~%s;\n", name, valueName(v.Args[0]))
+	case ir.OpCmpEqF64, ir.OpCmpNeF64, ir.OpCmpLtF64, ir.OpCmpLeF64, ir.OpCmpGtF64, ir.OpCmpGeF64:
+		op := f64CmpOp(v.Op)
+		fmt.Fprintf(w, "    %s = (%s %s %s) ? 1 : 0;\n", name, valueName(v.Args[0]), op, valueName(v.Args[1]))
+	case ir.OpNotBool:
+		fmt.Fprintf(w, "    %s = %s ? 0 : 1;\n", name, valueName(v.Args[0]))
 	case ir.OpCall, ir.OpTailCall:
 		// Intra-program call. v.Const indexes into Program.Funcs;
 		// args are SSA values in declared order. The emitter writes
@@ -514,6 +524,40 @@ func i64ImmCmpOp(op ir.OpCode) string {
 	case ir.OpCmpGtI64Imm:
 		return ">"
 	case ir.OpCmpGeI64Imm:
+		return ">="
+	}
+	return "?"
+}
+
+func i64BitwiseOp(op ir.OpCode) string {
+	switch op {
+	case ir.OpAndI64:
+		return "&"
+	case ir.OpOrI64:
+		return "|"
+	case ir.OpXorI64:
+		return "^"
+	case ir.OpShlI64:
+		return "<<"
+	case ir.OpShrI64:
+		return ">>"
+	}
+	return "?"
+}
+
+func f64CmpOp(op ir.OpCode) string {
+	switch op {
+	case ir.OpCmpEqF64:
+		return "=="
+	case ir.OpCmpNeF64:
+		return "!="
+	case ir.OpCmpLtF64:
+		return "<"
+	case ir.OpCmpLeF64:
+		return "<="
+	case ir.OpCmpGtF64:
+		return ">"
+	case ir.OpCmpGeF64:
 		return ">="
 	}
 	return "?"

--- a/compiler3/emit/c/emit_test.go
+++ b/compiler3/emit/c/emit_test.go
@@ -322,6 +322,112 @@ func TestEmitOpCallGoPrintArgTypeUnsupported(t *testing.T) {
 	}
 }
 
+// TestEmitBitwiseI64 covers the Phase 4.1.1 bitwise/shift family.
+// Mochi's surface grammar does not yet expose `&`/`|`/`^`/`<<`/`>>`,
+// but the IR + emitter must support them so a future parser
+// extension or a frontend that constructs IR directly (the
+// optimizer) can lower these ops without re-touching the emitter.
+func TestEmitBitwiseI64(t *testing.T) {
+	for _, c := range []struct {
+		op   ir.OpCode
+		want string
+	}{
+		{ir.OpAndI64, "v0 & v1"},
+		{ir.OpOrI64, "v0 | v1"},
+		{ir.OpXorI64, "v0 ^ v1"},
+		{ir.OpShlI64, "v0 << v1"},
+		{ir.OpShrI64, "v0 >> v1"},
+	} {
+		fn := &ir.Function{Name: "bw", Result: ir.TypeI64}
+		a := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpParam})
+		b := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpParam})
+		fn.Params = []uint32{a, b}
+		bid := fn.AddBlock()
+		r := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: c.op, Args: []uint32{a, b}})
+		blk := fn.Block(bid)
+		blk.Values = []uint32{r}
+		blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: r}
+		src, err := Emit(&Program{Funcs: []*ir.Function{fn}})
+		if err != nil {
+			t.Fatalf("%s: Emit: %v", c.op, err)
+		}
+		if !strings.Contains(string(src), c.want) {
+			t.Errorf("%s: missing %q in:\n%s", c.op, c.want, src)
+		}
+	}
+}
+
+// TestEmitNotI64 covers the bitwise-complement unary op.
+func TestEmitNotI64(t *testing.T) {
+	fn := &ir.Function{Name: "neg", Result: ir.TypeI64}
+	a := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpParam})
+	fn.Params = []uint32{a}
+	bid := fn.AddBlock()
+	r := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpNotI64, Args: []uint32{a}})
+	blk := fn.Block(bid)
+	blk.Values = []uint32{r}
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: r}
+	src, err := Emit(&Program{Funcs: []*ir.Function{fn}})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	mustContain(t, string(src), "= ~v0")
+}
+
+// TestEmitCompareF64 covers the six f64 comparison ops. The result
+// is canonical 0/1 just like the i64 cmp family; NaN behaviour
+// matches IEEE 754 ordered comparison (the C99 default for `==`,
+// `!=`, `<`, `<=`, `>`, `>=` on `double`).
+func TestEmitCompareF64(t *testing.T) {
+	for _, c := range []struct {
+		op   ir.OpCode
+		want string
+	}{
+		{ir.OpCmpEqF64, "v0 == v1"},
+		{ir.OpCmpNeF64, "v0 != v1"},
+		{ir.OpCmpLtF64, "v0 < v1"},
+		{ir.OpCmpLeF64, "v0 <= v1"},
+		{ir.OpCmpGtF64, "v0 > v1"},
+		{ir.OpCmpGeF64, "v0 >= v1"},
+	} {
+		fn := &ir.Function{Name: "fcmp", Result: ir.TypeBool}
+		a := fn.AddValue(ir.Value{Type: ir.TypeF64, Op: ir.OpParam})
+		b := fn.AddValue(ir.Value{Type: ir.TypeF64, Op: ir.OpParam})
+		fn.Params = []uint32{a, b}
+		bid := fn.AddBlock()
+		r := fn.AddValue(ir.Value{Type: ir.TypeBool, Op: c.op, Args: []uint32{a, b}})
+		blk := fn.Block(bid)
+		blk.Values = []uint32{r}
+		blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: r}
+		src, err := Emit(&Program{Funcs: []*ir.Function{fn}})
+		if err != nil {
+			t.Fatalf("%s: Emit: %v", c.op, err)
+		}
+		if !strings.Contains(string(src), c.want) {
+			t.Errorf("%s: missing %q in:\n%s", c.op, c.want, src)
+		}
+	}
+}
+
+// TestEmitNotBool covers the logical-NOT unary op. The result is
+// canonical 0/1 so it composes with the existing bool ABI (cType
+// TypeBool == "int" with 0/1 contract).
+func TestEmitNotBool(t *testing.T) {
+	fn := &ir.Function{Name: "neg_bool", Result: ir.TypeBool}
+	a := fn.AddValue(ir.Value{Type: ir.TypeBool, Op: ir.OpParam})
+	fn.Params = []uint32{a}
+	bid := fn.AddBlock()
+	r := fn.AddValue(ir.Value{Type: ir.TypeBool, Op: ir.OpNotBool, Args: []uint32{a}})
+	blk := fn.Block(bid)
+	blk.Values = []uint32{r}
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: r}
+	src, err := Emit(&Program{Funcs: []*ir.Function{fn}})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	mustContain(t, string(src), "v1 = v0 ? 0 : 1;")
+}
+
 func mustContain(t *testing.T, s, sub string) {
 	t.Helper()
 	if !strings.Contains(s, sub) {

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -246,6 +246,24 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 	case ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm:
 		op := i64ImmCmpOp(v.Op)
 		fmt.Fprintf(w, "\t%s = %s %s int64(%d)\n", name, valueName(v.Args[0]), op, v.Const)
+	case ir.OpAndI64, ir.OpOrI64, ir.OpXorI64, ir.OpShlI64, ir.OpShrI64:
+		op := i64BitwiseOp(v.Op)
+		// Go requires the shift-count operand to be unsigned (uint or
+		// untyped). Mochi's IR carries i64 throughout, so the shift
+		// variants cast the right operand at the use site. The bitwise
+		// AND/OR/XOR operands are both i64 and need no cast.
+		if v.Op == ir.OpShlI64 || v.Op == ir.OpShrI64 {
+			fmt.Fprintf(w, "\t%s = %s %s uint64(%s)\n", name, valueName(v.Args[0]), op, valueName(v.Args[1]))
+		} else {
+			fmt.Fprintf(w, "\t%s = %s %s %s\n", name, valueName(v.Args[0]), op, valueName(v.Args[1]))
+		}
+	case ir.OpNotI64:
+		fmt.Fprintf(w, "\t%s = ^%s\n", name, valueName(v.Args[0]))
+	case ir.OpCmpEqF64, ir.OpCmpNeF64, ir.OpCmpLtF64, ir.OpCmpLeF64, ir.OpCmpGtF64, ir.OpCmpGeF64:
+		op := f64CmpOp(v.Op)
+		fmt.Fprintf(w, "\t%s = %s %s %s\n", name, valueName(v.Args[0]), op, valueName(v.Args[1]))
+	case ir.OpNotBool:
+		fmt.Fprintf(w, "\t%s = !%s\n", name, valueName(v.Args[0]))
 	case ir.OpLenStr:
 		fmt.Fprintf(w, "\t%s = int64(len(%s))\n", name, valueName(v.Args[0]))
 	case ir.OpConcatStr:
@@ -639,6 +657,40 @@ func i64ImmCmpOp(op ir.OpCode) string {
 	case ir.OpCmpGtI64Imm:
 		return ">"
 	case ir.OpCmpGeI64Imm:
+		return ">="
+	}
+	return "?"
+}
+
+func i64BitwiseOp(op ir.OpCode) string {
+	switch op {
+	case ir.OpAndI64:
+		return "&"
+	case ir.OpOrI64:
+		return "|"
+	case ir.OpXorI64:
+		return "^"
+	case ir.OpShlI64:
+		return "<<"
+	case ir.OpShrI64:
+		return ">>"
+	}
+	return "?"
+}
+
+func f64CmpOp(op ir.OpCode) string {
+	switch op {
+	case ir.OpCmpEqF64:
+		return "=="
+	case ir.OpCmpNeF64:
+		return "!="
+	case ir.OpCmpLtF64:
+		return "<"
+	case ir.OpCmpLeF64:
+		return "<="
+	case ir.OpCmpGtF64:
+		return ">"
+	case ir.OpCmpGeF64:
 		return ">="
 	}
 	return "?"

--- a/compiler3/emit/go/emit_test.go
+++ b/compiler3/emit/go/emit_test.go
@@ -524,3 +524,110 @@ func intStr(n int64) string {
 	}
 	return digits
 }
+
+// TestEmitBitwiseI64 covers the Phase 4.1.1 bitwise/shift family in
+// the Go target. Verifies the emitter writes the Go form for AND,
+// OR, XOR, SHL, SHR. Shifts cast the right operand to uint64 because
+// Go requires unsigned shift counts.
+func TestEmitBitwiseI64(t *testing.T) {
+	for _, c := range []struct {
+		op   ir.OpCode
+		want string
+	}{
+		{ir.OpAndI64, "v0 & v1"},
+		{ir.OpOrI64, "v0 | v1"},
+		{ir.OpXorI64, "v0 ^ v1"},
+		{ir.OpShlI64, "v0 << uint64(v1)"},
+		{ir.OpShrI64, "v0 >> uint64(v1)"},
+	} {
+		fn := &ir.Function{Name: "bw", Result: ir.TypeI64}
+		a := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpParam})
+		b := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpParam})
+		fn.Params = []uint32{a, b}
+		bid := fn.AddBlock()
+		r := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: c.op, Args: []uint32{a, b}})
+		blk := fn.Block(bid)
+		blk.Values = []uint32{r}
+		blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: r}
+		src, err := Emit(&Program{PkgName: "demo", Funcs: []*ir.Function{fn}})
+		if err != nil {
+			t.Fatalf("%s: Emit: %v", c.op, err)
+		}
+		if !strings.Contains(string(src), c.want) {
+			t.Errorf("%s: missing %q in:\n%s", c.op, c.want, src)
+		}
+	}
+}
+
+// TestEmitNotI64Go covers bitwise complement lowering on the Go
+// target. Go spells it `^x`, not `~x`.
+func TestEmitNotI64Go(t *testing.T) {
+	fn := &ir.Function{Name: "not_i64", Result: ir.TypeI64}
+	a := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpParam})
+	fn.Params = []uint32{a}
+	bid := fn.AddBlock()
+	r := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpNotI64, Args: []uint32{a}})
+	blk := fn.Block(bid)
+	blk.Values = []uint32{r}
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: r}
+	src, err := Emit(&Program{PkgName: "demo", Funcs: []*ir.Function{fn}})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(string(src), "= ^v0") {
+		t.Errorf("missing `^v0`:\n%s", src)
+	}
+}
+
+// TestEmitCompareF64Go covers the six f64 comparisons on the Go
+// target. The result is a Go bool, no explicit cast needed.
+func TestEmitCompareF64Go(t *testing.T) {
+	for _, c := range []struct {
+		op   ir.OpCode
+		want string
+	}{
+		{ir.OpCmpEqF64, "v0 == v1"},
+		{ir.OpCmpNeF64, "v0 != v1"},
+		{ir.OpCmpLtF64, "v0 < v1"},
+		{ir.OpCmpLeF64, "v0 <= v1"},
+		{ir.OpCmpGtF64, "v0 > v1"},
+		{ir.OpCmpGeF64, "v0 >= v1"},
+	} {
+		fn := &ir.Function{Name: "fcmp", Result: ir.TypeBool}
+		a := fn.AddValue(ir.Value{Type: ir.TypeF64, Op: ir.OpParam})
+		b := fn.AddValue(ir.Value{Type: ir.TypeF64, Op: ir.OpParam})
+		fn.Params = []uint32{a, b}
+		bid := fn.AddBlock()
+		r := fn.AddValue(ir.Value{Type: ir.TypeBool, Op: c.op, Args: []uint32{a, b}})
+		blk := fn.Block(bid)
+		blk.Values = []uint32{r}
+		blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: r}
+		src, err := Emit(&Program{PkgName: "demo", Funcs: []*ir.Function{fn}})
+		if err != nil {
+			t.Fatalf("%s: Emit: %v", c.op, err)
+		}
+		if !strings.Contains(string(src), c.want) {
+			t.Errorf("%s: missing %q in:\n%s", c.op, c.want, src)
+		}
+	}
+}
+
+// TestEmitNotBoolGo covers logical NOT on the Go target. Go spells
+// it `!x`.
+func TestEmitNotBoolGo(t *testing.T) {
+	fn := &ir.Function{Name: "not_b", Result: ir.TypeBool}
+	a := fn.AddValue(ir.Value{Type: ir.TypeBool, Op: ir.OpParam})
+	fn.Params = []uint32{a}
+	bid := fn.AddBlock()
+	r := fn.AddValue(ir.Value{Type: ir.TypeBool, Op: ir.OpNotBool, Args: []uint32{a}})
+	blk := fn.Block(bid)
+	blk.Values = []uint32{r}
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: r}
+	src, err := Emit(&Program{PkgName: "demo", Funcs: []*ir.Function{fn}})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(string(src), "= !v0") {
+		t.Errorf("missing `!v0`:\n%s", src)
+	}
+}

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -461,42 +461,85 @@ func (b *builder) applyBinOp(op string, l, r uint32) (uint32, error) {
 	if lt != rt {
 		return 0, fmt.Errorf("frontend: binop %q across types %s and %s unsupported in MVP", op, lt, rt)
 	}
-	if lt != ir.TypeI64 {
-		return 0, fmt.Errorf("frontend: binop %q on type %s unsupported in MVP", op, lt)
-	}
 	var code ir.OpCode
-	resType := ir.TypeI64
-	switch op {
-	case "+":
-		code = ir.OpAddI64
-	case "-":
-		code = ir.OpSubI64
-	case "*":
-		code = ir.OpMulI64
-	case "/":
-		code = ir.OpDivI64
-	case "%":
-		code = ir.OpModI64
-	case "==":
-		code = ir.OpCmpEqI64
-		resType = ir.TypeBool
-	case "!=":
-		code = ir.OpCmpNeI64
-		resType = ir.TypeBool
-	case "<":
-		code = ir.OpCmpLtI64
-		resType = ir.TypeBool
-	case "<=":
-		code = ir.OpCmpLeI64
-		resType = ir.TypeBool
-	case ">":
-		code = ir.OpCmpGtI64
-		resType = ir.TypeBool
-	case ">=":
-		code = ir.OpCmpGeI64
-		resType = ir.TypeBool
+	resType := lt
+	switch lt {
+	case ir.TypeI64:
+		switch op {
+		case "+":
+			code = ir.OpAddI64
+		case "-":
+			code = ir.OpSubI64
+		case "*":
+			code = ir.OpMulI64
+		case "/":
+			code = ir.OpDivI64
+		case "%":
+			code = ir.OpModI64
+		case "&":
+			code = ir.OpAndI64
+		case "|":
+			code = ir.OpOrI64
+		case "^":
+			code = ir.OpXorI64
+		case "<<":
+			code = ir.OpShlI64
+		case ">>":
+			code = ir.OpShrI64
+		case "==":
+			code = ir.OpCmpEqI64
+			resType = ir.TypeBool
+		case "!=":
+			code = ir.OpCmpNeI64
+			resType = ir.TypeBool
+		case "<":
+			code = ir.OpCmpLtI64
+			resType = ir.TypeBool
+		case "<=":
+			code = ir.OpCmpLeI64
+			resType = ir.TypeBool
+		case ">":
+			code = ir.OpCmpGtI64
+			resType = ir.TypeBool
+		case ">=":
+			code = ir.OpCmpGeI64
+			resType = ir.TypeBool
+		default:
+			return 0, fmt.Errorf("frontend: operator %q on i64 unsupported in MVP", op)
+		}
+	case ir.TypeF64:
+		switch op {
+		case "+":
+			code = ir.OpAddF64
+		case "-":
+			code = ir.OpSubF64
+		case "*":
+			code = ir.OpMulF64
+		case "/":
+			code = ir.OpDivF64
+		case "==":
+			code = ir.OpCmpEqF64
+			resType = ir.TypeBool
+		case "!=":
+			code = ir.OpCmpNeF64
+			resType = ir.TypeBool
+		case "<":
+			code = ir.OpCmpLtF64
+			resType = ir.TypeBool
+		case "<=":
+			code = ir.OpCmpLeF64
+			resType = ir.TypeBool
+		case ">":
+			code = ir.OpCmpGtF64
+			resType = ir.TypeBool
+		case ">=":
+			code = ir.OpCmpGeF64
+			resType = ir.TypeBool
+		default:
+			return 0, fmt.Errorf("frontend: operator %q on f64 unsupported in MVP", op)
+		}
 	default:
-		return 0, fmt.Errorf("frontend: operator %q unsupported in MVP", op)
+		return 0, fmt.Errorf("frontend: binop %q on type %s unsupported in MVP", op, lt)
 	}
 	return b.addValue(ir.Value{Type: resType, Op: code, Args: []uint32{l, r}}), nil
 }
@@ -511,10 +554,20 @@ func (b *builder) lowerUnary(u *parser.Unary) (uint32, error) {
 		switch op {
 		case "-":
 			vt := b.fn.Values[val].Type
-			if vt != ir.TypeI64 {
+			switch vt {
+			case ir.TypeI64:
+				val = b.addValue(ir.Value{Type: ir.TypeI64, Op: ir.OpNegI64, Args: []uint32{val}})
+			case ir.TypeF64:
+				val = b.addValue(ir.Value{Type: ir.TypeF64, Op: ir.OpNegF64, Args: []uint32{val}})
+			default:
 				return 0, fmt.Errorf("frontend: unary `-` on %s unsupported in MVP", vt)
 			}
-			val = b.addValue(ir.Value{Type: ir.TypeI64, Op: ir.OpNegI64, Args: []uint32{val}})
+		case "!":
+			vt := b.fn.Values[val].Type
+			if vt != ir.TypeBool {
+				return 0, fmt.Errorf("frontend: unary `!` on %s unsupported in MVP", vt)
+			}
+			val = b.addValue(ir.Value{Type: ir.TypeBool, Op: ir.OpNotBool, Args: []uint32{val}})
 		default:
 			return 0, fmt.Errorf("frontend: unary operator %q unsupported in MVP", op)
 		}

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -185,6 +185,34 @@ const (
 	// binding's import path so the generated file has a normal Go
 	// import. There is no Mochi-side reflection at the call site.
 	OpCallGo
+
+	// i64 bitwise / shift ops (Phase 4.1.1 scalar-operator parity).
+	// `OpShrI64` is the signed right shift (C99 `>>` on signed
+	// int64_t, which all modern compilers lower to an arithmetic
+	// shift); a future unsigned-shift variant would land as a
+	// separate OpcUshrI64 if Mochi ever exposes uint64 to the IR.
+	OpAndI64
+	OpOrI64
+	OpXorI64
+	OpShlI64
+	OpShrI64
+	OpNotI64
+
+	// f64 comparisons (result Type == TypeBool). NaN behavior matches
+	// IEEE 754 ordered comparison ("unordered yields false"), which is
+	// the C99 default for `==`/`!=`/`<`/`<=`/`>`/`>=` on `double`.
+	OpCmpEqF64
+	OpCmpNeF64
+	OpCmpLtF64
+	OpCmpLeF64
+	OpCmpGtF64
+	OpCmpGeF64
+
+	// Logical NOT on bool. `&&` and `||` lower in the frontend to
+	// short-circuiting TermBranch graphs (no IR op needed), but unary
+	// `!` is a single operator with no fall-through so it carries its
+	// own opcode.
+	OpNotBool
 )
 
 // String renders an OpCode's short name. Used by Validate and IR
@@ -319,6 +347,32 @@ func (o OpCode) String() string {
 		return "query.crossjoin"
 	case OpCallGo:
 		return "call.go"
+	case OpAndI64:
+		return "and.i64"
+	case OpOrI64:
+		return "or.i64"
+	case OpXorI64:
+		return "xor.i64"
+	case OpShlI64:
+		return "shl.i64"
+	case OpShrI64:
+		return "shr.i64"
+	case OpNotI64:
+		return "not.i64"
+	case OpCmpEqF64:
+		return "cmp.eq.f64"
+	case OpCmpNeF64:
+		return "cmp.ne.f64"
+	case OpCmpLtF64:
+		return "cmp.lt.f64"
+	case OpCmpLeF64:
+		return "cmp.le.f64"
+	case OpCmpGtF64:
+		return "cmp.gt.f64"
+	case OpCmpGeF64:
+		return "cmp.ge.f64"
+	case OpNotBool:
+		return "not.bool"
 	}
 	return "?"
 }

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -205,6 +205,14 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeF64, [3]Type{TypeF64Arr, TypeI64}}
 	case OpF64ArraySetF64:
 		return opSig{TypeUnit, [3]Type{TypeF64Arr, TypeI64, TypeF64}}
+	case OpAndI64, OpOrI64, OpXorI64, OpShlI64, OpShrI64:
+		return opSig{TypeI64, [3]Type{TypeI64, TypeI64}}
+	case OpNotI64:
+		return opSig{TypeI64, [3]Type{TypeI64}}
+	case OpCmpEqF64, OpCmpNeF64, OpCmpLtF64, OpCmpLeF64, OpCmpGtF64, OpCmpGeF64:
+		return opSig{TypeBool, [3]Type{TypeF64, TypeF64}}
+	case OpNotBool:
+		return opSig{TypeBool, [3]Type{TypeBool}}
 	}
 	// OpParam, OpConst, OpPhi, OpCall, OpTailCall: the validator
 	// can't pre-compute their signature without more context, so we

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -153,7 +153,10 @@ func kindOf(o ir.OpCode) ProducerKind {
 		ir.OpAddI64Imm, ir.OpSubI64Imm, ir.OpMulI64Imm, ir.OpDivI64Imm, ir.OpModI64Imm,
 		ir.OpAddF64, ir.OpSubF64, ir.OpMulF64, ir.OpDivF64, ir.OpNegF64,
 		ir.OpCmpEqI64, ir.OpCmpNeI64, ir.OpCmpLtI64, ir.OpCmpLeI64, ir.OpCmpGtI64, ir.OpCmpGeI64,
-		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm:
+		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm,
+		ir.OpAndI64, ir.OpOrI64, ir.OpXorI64, ir.OpShlI64, ir.OpShrI64, ir.OpNotI64,
+		ir.OpCmpEqF64, ir.OpCmpNeF64, ir.OpCmpLtF64, ir.OpCmpLeF64, ir.OpCmpGtF64, ir.OpCmpGeF64,
+		ir.OpNotBool:
 		return KindOperator
 
 	case ir.OpLenStr:
@@ -210,7 +213,7 @@ func init() {
 // the last OpCode known to ir/types.go at this MEP-41 Phase 1 commit;
 // adding a new op past it bumps this constant in the same PR.
 func mustClassifyAll() {
-	const lastOpCode = ir.OpCallGo
+	const lastOpCode = ir.OpNotBool
 	for o := ir.OpInvalid + 1; o <= lastOpCode; o++ {
 		if kindOf(o) == KindInvalid {
 			panic(fmt.Sprintf("verify: OpCode %s (=%d) is unclassified; extend kindOf in compiler3/verify/verify.go (MEP-41 §6.2 rule class C / coverage backstop)", o, o))

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -655,6 +655,9 @@ This is the contract behind the §Top-line objective. Every IR `OpCode` and `Typ
 | `OpAddI64`/`OpSubI64`/`OpMulI64`/`OpDivI64`/`OpModI64`/`OpNegI64` + *Imm | direct C operator | LANDED (Phase 4.0) |
 | `OpAddF64`/`OpSubF64`/`OpMulF64`/`OpDivF64`/`OpNegF64` | direct C operator | LANDED (Phase 4.0) |
 | `OpCmpEqI64`..`OpCmpGeI64` + *Imm | `(a op b) ? 1 : 0` | LANDED (Phase 4.0) |
+| `OpAndI64`/`OpOrI64`/`OpXorI64`/`OpShlI64`/`OpShrI64`/`OpNotI64` | direct C operator (`&`, `|`, `^`, `<<`, `>>`, `~`); shifts are arithmetic on signed `int64_t` | LANDED (Phase 4.1.1, IR + emit only; not parser-reachable yet) |
+| `OpCmpEqF64`..`OpCmpGeF64` | `(a op b) ? 1 : 0` over `double` | LANDED (Phase 4.1.1) |
+| `OpNotBool` | `v ? 0 : 1` (canonical bool form) | LANDED (Phase 4.1.1) |
 | `OpCall` / `OpTailCall` | direct C call via `Program.Funcs[v.Const]` | LANDED (Phase 4.1) |
 | `OpCallGo{fmt.Println}` | dispatch on arg type to `mochi_print_*` runtime | LANDED (Phase 4.1, i64/f64/bool only) |
 | `OpCallGo{*}` (other) | none | REJECTED by design (no cgo; use `--target=go`) |


### PR DESCRIPTION
Closes #21955.

## Summary
- 13 new IR opcodes: bitwise/shift i64 (\`& | ^ << >> ~\`), f64 compares (6), bool not
- C-emit + Go-emit lower all 13 directly to native operators (Go casts shift counts to uint64)
- Frontend applyBinOp now dispatches on operand type so f64 binops/cmps lower correctly; lowerUnary handles f64 unary \`-\` and bool unary \`!\`
- 8 new emit tests (4 C, 4 Go), all pass
- §10.6 IR coverage matrix in mep-0042.md updated in the same change (spec-in-sync rule)

Bitwise/shift IR + emit are forward-compat scaffolding (parser has no tokens yet). Short-circuit \`&&\`/\`||\` deferred to Phase 4.1.2 (needs frontend block creation, same as while loops).

## Test plan
- [x] go test ./compiler3/emit/c/ ./compiler3/emit/go/ ./compiler3/ir/ ./compiler3/verify/ ./compiler3/frontend/
- [x] new C-emit tests pass (TestEmitBitwiseI64, TestEmitNotI64, TestEmitCompareF64, TestEmitNotBool)
- [x] new Go-emit tests pass (TestEmitBitwiseI64, TestEmitNotI64Go, TestEmitCompareF64Go, TestEmitNotBoolGo)