### PR TITLE
mep-0042: Phase 4.3.1 typed-i64 list end-to-end (runtime + emit + frontend)

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -224,6 +224,49 @@ while n > 0 {
 	}
 }
 
+// TestBuildSourceListAppendAndIndex is the Phase 4.3.1 integration
+// gate: a Mochi script using the typed-i64 list surface (empty list
+// literal, append, indexed read, len, indexed write) compiles via
+// `mochi build --target=c` to a binary whose stdout byte-matches the
+// Go target's output for the same source. This exercises every list
+// op the IR declares: OpNewList, OpListPushI64, OpListGetI64,
+// OpListLenI64, OpListSetI64.
+func TestBuildSourceListAppendAndIndex(t *testing.T) {
+	src := `fun sumlist(n: int): int {
+  var xs: list<int> = []
+  var i = 0
+  while i < n {
+    xs = append(xs, i + 1)
+    i = i + 1
+  }
+  var s = 0
+  var k = 0
+  while k < len(xs) {
+    s = s + xs[k]
+    k = k + 1
+  }
+  xs[0] = 100
+  return s + xs[0]
+}
+print(sumlist(10))
+`
+	if got, want := runMochiBuild(t, src), "155\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceListLiteralRead pins the non-empty list-literal
+// shape through the C target: `[10, 20, 30]` lowers to OpNewList +
+// three OpListPushI64, and `xs[2]` reads back 30.
+func TestBuildSourceListLiteralRead(t *testing.T) {
+	src := `let xs: list<int> = [10, 20, 30]
+print(xs[2])
+`
+	if got, want := runMochiBuild(t, src), "30\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceFibIter is the §10.7 unblock for the iterative Fib
 // benchmark: while loop, mutated `a`/`b`/`i`, and a `let t` inside the
 // body that the phi-at-header must NOT track (it's body-scoped).

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -61,21 +61,25 @@ func Emit(p *Program) ([]byte, error) {
 	// and lets the driver decide what runtime files to drop next to
 	// gen.c.
 	usesPrint := false
+	usesListI64 := false
 	for _, fn := range p.Funcs {
 		for _, v := range fn.Values {
-			if v.Op != ir.OpCallGo {
-				continue
+			switch v.Op {
+			case ir.OpCallGo:
+				if int(v.Const) < 0 || int(v.Const) >= len(fn.GoBindings) {
+					return nil, fmt.Errorf("emit %s: OpCallGo v%d: Const %d out of range (have %d bindings)",
+						fn.Name, v.ID, v.Const, len(fn.GoBindings))
+				}
+				b := fn.GoBindings[v.Const]
+				if isPrintBinding(b) {
+					usesPrint = true
+					continue
+				}
+				return nil, fmt.Errorf("emit %s: OpCallGo to %s.%s: %w", fn.Name, b.Pkg, b.Name, ErrUnsupportedFFI)
+			case ir.OpNewList, ir.OpListLenI64, ir.OpListPushI64,
+				ir.OpListGetI64, ir.OpListSetI64:
+				usesListI64 = true
 			}
-			if int(v.Const) < 0 || int(v.Const) >= len(fn.GoBindings) {
-				return nil, fmt.Errorf("emit %s: OpCallGo v%d: Const %d out of range (have %d bindings)",
-					fn.Name, v.ID, v.Const, len(fn.GoBindings))
-			}
-			b := fn.GoBindings[v.Const]
-			if isPrintBinding(b) {
-				usesPrint = true
-				continue
-			}
-			return nil, fmt.Errorf("emit %s: OpCallGo to %s.%s: %w", fn.Name, b.Pkg, b.Name, ErrUnsupportedFFI)
 		}
 	}
 
@@ -86,6 +90,9 @@ func Emit(p *Program) ([]byte, error) {
 	buf.WriteString("#include <math.h>\n")
 	if usesPrint {
 		buf.WriteString("#include \"print.h\"\n")
+	}
+	if usesListI64 {
+		buf.WriteString("#include \"mochi_list_i64.h\"\n")
 	}
 	buf.WriteString("\n")
 
@@ -291,6 +298,21 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    %s = (%s %s %s) ? 1 : 0;\n", name, valueName(v.Args[0]), op, valueName(v.Args[1]))
 	case ir.OpNotBool:
 		fmt.Fprintf(w, "    %s = %s ? 0 : 1;\n", name, valueName(v.Args[0]))
+	case ir.OpNewList:
+		// New empty list: allocates a header on the heap with NULL data.
+		// The first push lazily reserves capacity; this matches the
+		// Go target's `[]int64{}` shape (nil slice grown by append).
+		fmt.Fprintf(w, "    %s = mochi_list_i64_new();\n", name)
+	case ir.OpListLenI64:
+		fmt.Fprintf(w, "    %s = mochi_list_i64_len(%s);\n", name, valueName(v.Args[0]))
+	case ir.OpListPushI64:
+		// Mutates the heap struct in place; the C pointer in Args[0]
+		// stays valid. The op produces a TypeUnit value with no LHS.
+		fmt.Fprintf(w, "    mochi_list_i64_push(%s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpListGetI64:
+		fmt.Fprintf(w, "    %s = mochi_list_i64_get(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpListSetI64:
+		fmt.Fprintf(w, "    mochi_list_i64_set(%s, %s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
 	case ir.OpCall, ir.OpTailCall:
 		// Intra-program call. v.Const indexes into Program.Funcs;
 		// args are SSA values in declared order. The emitter writes
@@ -439,6 +461,14 @@ func cType(t ir.Type) string {
 		return "double"
 	case ir.TypeBool:
 		return "int"
+	case ir.TypeList:
+		// Phase 4.3.1: list<int>. The MVP frontend only constructs
+		// TypeList values with ElemType=TypeI64, so the cgen pointer
+		// type can be fixed here without consulting ElemType. When
+		// Phase 4.3.2 widens to f64/bool elements, this switch will
+		// branch on Value.ElemType (which cgen would need to start
+		// threading through cType's caller).
+		return "mochi_list_i64*"
 	case ir.TypeUnit, ir.TypeInvalid:
 		return "void"
 	}

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -222,8 +222,28 @@ func lowerFun(p *gogen.Program, idx uint32, fs *parser.FunStmt, userFns map[stri
 }
 
 func lowerType(t *parser.TypeRef) (ir.Type, error) {
-	if t == nil || t.Simple == nil {
-		return ir.TypeInvalid, fmt.Errorf("frontend: only simple type names are supported in the MVP")
+	if t == nil {
+		return ir.TypeInvalid, fmt.Errorf("frontend: nil type ref")
+	}
+	if t.Generic != nil {
+		// Phase 4.3.1: `list<int>` (the typed-i64 array shape) is the
+		// only generic the MVP frontend lowers. ElemType inspection
+		// happens at the call site that constructs a TypeList value;
+		// here we only need to assert the surface form is supported.
+		if t.Generic.Name == "list" && len(t.Generic.Args) == 1 {
+			el, err := lowerType(t.Generic.Args[0])
+			if err != nil {
+				return ir.TypeInvalid, fmt.Errorf("frontend: list element: %w", err)
+			}
+			if el != ir.TypeI64 {
+				return ir.TypeInvalid, fmt.Errorf("frontend: list<%s> unsupported in MVP (only list<int>)", el)
+			}
+			return ir.TypeList, nil
+		}
+		return ir.TypeInvalid, fmt.Errorf("frontend: generic %s<...> unsupported in MVP", t.Generic.Name)
+	}
+	if t.Simple == nil {
+		return ir.TypeInvalid, fmt.Errorf("frontend: only simple and list<...> type names are supported in the MVP")
 	}
 	switch *t.Simple {
 	case "int":
@@ -269,9 +289,11 @@ func (b *builder) lowerStmt(st *parser.Statement) error {
 	case st.Var != nil:
 		return b.lowerLet(st.Var.Name, st.Var.Value)
 	case st.Assign != nil:
-		// MVP: only plain `name = expr` (no index/field assignment).
-		if len(st.Assign.Index) != 0 || len(st.Assign.Field) != 0 {
-			return fmt.Errorf("frontend: indexed/field assignment unsupported in MVP")
+		if len(st.Assign.Field) != 0 {
+			return fmt.Errorf("frontend: field assignment unsupported in MVP")
+		}
+		if len(st.Assign.Index) != 0 {
+			return b.lowerIndexedAssign(st.Assign)
 		}
 		return b.lowerLet(st.Assign.Name, st.Assign.Value)
 	case st.Return != nil:
@@ -285,6 +307,47 @@ func (b *builder) lowerStmt(st *parser.Statement) error {
 		return err
 	}
 	return fmt.Errorf("frontend: statement kind unsupported in MVP")
+}
+
+// lowerIndexedAssign handles `xs[i] = v`. MVP scope is a single-level
+// IndexOp on a TypeList(elem=i64) binding. Multi-level indices (xs[i][j])
+// and field-then-index chains stay rejected until a later phase.
+func (b *builder) lowerIndexedAssign(a *parser.AssignStmt) error {
+	if len(a.Index) != 1 {
+		return fmt.Errorf("frontend: multi-level indexed assignment unsupported in MVP")
+	}
+	idxOp := a.Index[0]
+	if idxOp.Colon != nil || idxOp.Colon2 != nil || idxOp.End != nil || idxOp.Step != nil || idxOp.Start == nil {
+		return fmt.Errorf("frontend: slice assignment unsupported in MVP")
+	}
+	listID, ok := b.values[a.Name]
+	if !ok {
+		return fmt.Errorf("frontend: indexed assign to unbound identifier %q", a.Name)
+	}
+	if b.fn.Values[listID].Type != ir.TypeList {
+		return fmt.Errorf("frontend: indexed assign on non-list %s", b.fn.Values[listID].Type)
+	}
+	idxID, err := b.lowerExpr(idxOp.Start)
+	if err != nil {
+		return err
+	}
+	if b.fn.Values[idxID].Type != ir.TypeI64 {
+		return fmt.Errorf("frontend: list index must be i64, got %s", b.fn.Values[idxID].Type)
+	}
+	valID, err := b.lowerExpr(a.Value)
+	if err != nil {
+		return err
+	}
+	if b.fn.Values[valID].Type != ir.TypeI64 {
+		return fmt.Errorf("frontend: list<int> store requires i64 value, got %s", b.fn.Values[valID].Type)
+	}
+	b.addValue(ir.Value{
+		Type:     ir.TypeUnit,
+		ElemType: ir.TypeI64,
+		Op:       ir.OpListSetI64,
+		Args:     []uint32{listID, idxID, valID},
+	})
+	return nil
 }
 
 func (b *builder) lowerLet(name string, e *parser.Expr) error {
@@ -687,10 +750,43 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 			return b.lowerGoCall(imp, sel.Tail[0], pe.Ops[0].Call.Args)
 		}
 	}
-	if len(pe.Ops) != 0 {
-		return 0, fmt.Errorf("frontend: postfix ops unsupported in MVP")
+	if len(pe.Ops) == 0 {
+		return b.lowerPrimary(pe.Target)
 	}
-	return b.lowerPrimary(pe.Target)
+	// Phase 4.3.1: a chain of IndexOp postfixes on a Primary lowers
+	// to OpListGetI64. Only single-level i64 indexing is supported in
+	// the MVP; ranges and multi-level chains stay rejected so the A/B
+	// harness skips the fixture rather than miscompiling.
+	cur, err := b.lowerPrimary(pe.Target)
+	if err != nil {
+		return 0, err
+	}
+	for _, op := range pe.Ops {
+		if op.Index == nil {
+			return 0, fmt.Errorf("frontend: non-index postfix unsupported in MVP")
+		}
+		idx := op.Index
+		if idx.Colon != nil || idx.Colon2 != nil || idx.End != nil || idx.Step != nil || idx.Start == nil {
+			return 0, fmt.Errorf("frontend: slice indexing unsupported in MVP")
+		}
+		if b.fn.Values[cur].Type != ir.TypeList {
+			return 0, fmt.Errorf("frontend: index on non-list %s", b.fn.Values[cur].Type)
+		}
+		iID, err := b.lowerExpr(idx.Start)
+		if err != nil {
+			return 0, err
+		}
+		if b.fn.Values[iID].Type != ir.TypeI64 {
+			return 0, fmt.Errorf("frontend: list index must be i64, got %s", b.fn.Values[iID].Type)
+		}
+		cur = b.addValue(ir.Value{
+			Type:     ir.TypeI64,
+			ElemType: ir.TypeI64,
+			Op:       ir.OpListGetI64,
+			Args:     []uint32{cur, iID},
+		})
+	}
+	return cur, nil
 }
 
 func (b *builder) lowerPrimary(p *parser.Primary) (uint32, error) {
@@ -713,10 +809,43 @@ func (b *builder) lowerPrimary(p *parser.Primary) (uint32, error) {
 		return id, nil
 	case p.Call != nil:
 		return b.lowerCall(p.Call)
+	case p.List != nil:
+		return b.lowerListLiteral(p.List)
 	case p.Group != nil:
 		return b.lowerExpr(p.Group)
 	}
 	return 0, fmt.Errorf("frontend: primary form unsupported in MVP")
+}
+
+// lowerListLiteral lowers `[e1, e2, ...]` to OpNewList plus a chain of
+// OpListPushI64 ops, one per element. The empty form `[]` produces an
+// OpNewList with ElemType=TypeI64; the type is inferred from the
+// context only when elements are present, otherwise it defaults to i64
+// (the MVP's sole supported element type). Non-i64 elements surface a
+// frontend error.
+func (b *builder) lowerListLiteral(lit *parser.ListLiteral) (uint32, error) {
+	listID := b.addValue(ir.Value{
+		Type:     ir.TypeList,
+		ElemType: ir.TypeI64,
+		Op:       ir.OpNewList,
+	})
+	for _, el := range lit.Elems {
+		vid, err := b.lowerExpr(el)
+		if err != nil {
+			return 0, err
+		}
+		if b.fn.Values[vid].Type != ir.TypeI64 {
+			return 0, fmt.Errorf("frontend: list literal element type %s unsupported (only i64 in MVP)",
+				b.fn.Values[vid].Type)
+		}
+		b.addValue(ir.Value{
+			Type:     ir.TypeUnit,
+			ElemType: ir.TypeI64,
+			Op:       ir.OpListPushI64,
+			Args:     []uint32{listID, vid},
+		})
+	}
+	return listID, nil
 }
 
 func (b *builder) lowerLiteral(lit *parser.Literal) (uint32, error) {
@@ -736,6 +865,12 @@ func (b *builder) lowerLiteral(lit *parser.Literal) (uint32, error) {
 }
 
 func (b *builder) lowerCall(c *parser.CallExpr) (uint32, error) {
+	// Builtins: `len(xs)` and `append(xs, v)` map to dedicated IR ops
+	// rather than a user-declared `fun`. They're checked before the
+	// user-fun lookup so a Mochi program cannot shadow them.
+	if id, ok, err := b.lowerBuiltinCall(c); ok {
+		return id, err
+	}
 	entry, ok := b.userFns[c.Func]
 	if !ok {
 		return 0, fmt.Errorf("frontend: unknown function %q (only user-declared funs callable in MVP)", c.Func)
@@ -751,6 +886,73 @@ func (b *builder) lowerCall(c *parser.CallExpr) (uint32, error) {
 	callee := b.prog.Funcs[entry.index]
 	id := b.addValue(ir.Value{Type: callee.Result, Op: ir.OpCall, Args: args, Const: int64(entry.index)})
 	return id, nil
+}
+
+// lowerBuiltinCall recognises the small set of builtin function names
+// that lower to dedicated IR ops. Returns (id, true, nil) on match,
+// (0, false, nil) when the name is not a builtin, and (_, true, err)
+// when the name matches but the argument shape is wrong.
+//
+// Phase 4.3.1 covers `len(xs)` and `append(xs, v)` against list<int>;
+// `len("s")` against TypeStr is wired through OpLenStr in the same
+// case for free since the IR op already exists.
+func (b *builder) lowerBuiltinCall(c *parser.CallExpr) (uint32, bool, error) {
+	switch c.Func {
+	case "len":
+		if len(c.Args) != 1 {
+			return 0, true, fmt.Errorf("frontend: len() takes 1 argument, got %d", len(c.Args))
+		}
+		arg, err := b.lowerExpr(c.Args[0])
+		if err != nil {
+			return 0, true, err
+		}
+		switch b.fn.Values[arg].Type {
+		case ir.TypeList:
+			id := b.addValue(ir.Value{
+				Type: ir.TypeI64, Op: ir.OpListLenI64, Args: []uint32{arg},
+			})
+			return id, true, nil
+		case ir.TypeStr:
+			id := b.addValue(ir.Value{
+				Type: ir.TypeI64, Op: ir.OpLenStr, Args: []uint32{arg},
+			})
+			return id, true, nil
+		default:
+			return 0, true, fmt.Errorf("frontend: len() on %s unsupported in MVP",
+				b.fn.Values[arg].Type)
+		}
+	case "append":
+		if len(c.Args) != 2 {
+			return 0, true, fmt.Errorf("frontend: append() takes 2 arguments, got %d", len(c.Args))
+		}
+		list, err := b.lowerExpr(c.Args[0])
+		if err != nil {
+			return 0, true, err
+		}
+		val, err := b.lowerExpr(c.Args[1])
+		if err != nil {
+			return 0, true, err
+		}
+		if b.fn.Values[list].Type != ir.TypeList {
+			return 0, true, fmt.Errorf("frontend: append() target type %s unsupported (need list)",
+				b.fn.Values[list].Type)
+		}
+		if b.fn.Values[val].Type != ir.TypeI64 {
+			return 0, true, fmt.Errorf("frontend: append() value type %s unsupported (need i64)",
+				b.fn.Values[val].Type)
+		}
+		// Push mutates the list in place; the SSA "result" of append
+		// is the same list value. The caller's `xs = append(xs, v)`
+		// rebinds the name to itself, which is correct.
+		b.addValue(ir.Value{
+			Type:     ir.TypeUnit,
+			ElemType: ir.TypeI64,
+			Op:       ir.OpListPushI64,
+			Args:     []uint32{list, val},
+		})
+		return list, true, nil
+	}
+	return 0, false, nil
 }
 
 // lowerGoCall handles a `pkg.Func(args)` call against a resolved

--- a/compiler3/frontend/lower_test.go
+++ b/compiler3/frontend/lower_test.go
@@ -151,3 +151,47 @@ func TestLowerUnsupportedSurfacesError(t *testing.T) {
 		t.Fatal("expected error for unsupported string literal in MVP, got nil")
 	}
 }
+
+// TestLowerListAppendAndIndex pins the Phase 4.3.1 typed-i64-array
+// surface: empty list literal, append, indexed read, len, and indexed
+// write must all lower and produce the same output under both
+// emitters. This test verifies the Go path; the C path is pinned by
+// the matching TestBuildSourceListAppendAndIndex in build/c.
+func TestLowerListAppendAndIndex(t *testing.T) {
+	src := `fun sumlist(n: int): int {
+  var xs: list<int> = []
+  var i = 0
+  while i < n {
+    xs = append(xs, i + 1)
+    i = i + 1
+  }
+  var s = 0
+  var k = 0
+  while k < len(xs) {
+    s = s + xs[k]
+    k = k + 1
+  }
+  xs[0] = 100
+  return s + xs[0]
+}
+print(sumlist(10))
+`
+	got := runEnd2End(t, src)
+	if got != "155\n" {
+		t.Errorf("got %q, want %q", got, "155\n")
+	}
+}
+
+// TestLowerListLiteralWithElems exercises the non-empty list literal
+// shape: `[1, 2, 3]` lowers to OpNewList followed by three pushes. The
+// program reads back the third element to confirm push-then-get is a
+// round trip.
+func TestLowerListLiteralWithElems(t *testing.T) {
+	src := `let xs: list<int> = [10, 20, 30]
+print(xs[2])
+`
+	got := runEnd2End(t, src)
+	if got != "30\n" {
+		t.Errorf("got %q, want %q", got, "30\n")
+	}
+}

--- a/runtime/c/doc.go
+++ b/runtime/c/doc.go
@@ -24,5 +24,5 @@ import "embed"
 // files when cgo is off (and the whole point of this package is to
 // stay no-cgo on the build host).
 //
-//go:embed src/print.h src/print.c
+//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c
 var Runtime embed.FS

--- a/runtime/c/src/mochi_list_i64.c
+++ b/runtime/c/src/mochi_list_i64.c
@@ -1,0 +1,44 @@
+/*
+ * MEP-42 Phase 4.3.1 typed-i64 list runtime. See mochi_list_i64.h.
+ */
+#include "mochi_list_i64.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+mochi_list_i64 *mochi_list_i64_new(void) {
+    mochi_list_i64 *l = (mochi_list_i64 *)malloc(sizeof(mochi_list_i64));
+    if (l == NULL) {
+        abort();
+    }
+    l->data = NULL;
+    l->len = 0;
+    l->cap = 0;
+    return l;
+}
+
+int64_t mochi_list_i64_len(const mochi_list_i64 *l) {
+    return l->len;
+}
+
+void mochi_list_i64_push(mochi_list_i64 *l, int64_t v) {
+    if (l->len == l->cap) {
+        int64_t newcap = l->cap == 0 ? 4 : l->cap * 2;
+        int64_t *nd = (int64_t *)realloc(l->data, (size_t)newcap * sizeof(int64_t));
+        if (nd == NULL) {
+            abort();
+        }
+        l->data = nd;
+        l->cap = newcap;
+    }
+    l->data[l->len++] = v;
+}
+
+int64_t mochi_list_i64_get(const mochi_list_i64 *l, int64_t i) {
+    return l->data[i];
+}
+
+void mochi_list_i64_set(mochi_list_i64 *l, int64_t i, int64_t v) {
+    l->data[i] = v;
+}

--- a/runtime/c/src/mochi_list_i64.h
+++ b/runtime/c/src/mochi_list_i64.h
@@ -1,0 +1,66 @@
+/*
+ * MEP-42 Phase 4.3.1 typed-i64 list runtime.
+ *
+ * Backs Mochi's list<int> when the program is compiled with
+ * `mochi build --target=c`. The IR ops OpNewList, OpListLenI64,
+ * OpListPushI64, OpListGetI64, and OpListSetI64 lower to calls into
+ * this header.
+ *
+ * Identity: pure C99, no libc beyond stdlib.h/string.h/stdint.h.
+ * Allocations are heap-resident and leak at process exit; the AOT
+ * target's MVP does not run finalisers between builds. The growth
+ * strategy mirrors Go's slice (double-on-overflow), so a Mochi loop
+ * that pushes N values amortises to O(N) memory traffic, byte-for-
+ * byte matching the Go target's `append` performance shape under cc
+ * -O2.
+ */
+#ifndef MOCHI_RUNTIME_C_LIST_I64_H
+#define MOCHI_RUNTIME_C_LIST_I64_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * mochi_list_i64 is the heap-allocated header for a growable i64 array.
+ * `data` is malloc'd; `len` is the current element count; `cap` is the
+ * allocated capacity in elements (not bytes). The struct is exposed so
+ * the generated source can inline length reads without a function call,
+ * but `data` must only be mutated through the helpers below.
+ */
+typedef struct mochi_list_i64 {
+    int64_t *data;
+    int64_t  len;
+    int64_t  cap;
+} mochi_list_i64;
+
+/* mochi_list_i64_new returns a fresh empty list (len=0, cap=0). */
+mochi_list_i64 *mochi_list_i64_new(void);
+
+/* mochi_list_i64_len returns l->len. Provided as a function for parity
+ * with the other helpers; the generated source uses it for readability. */
+int64_t mochi_list_i64_len(const mochi_list_i64 *l);
+
+/*
+ * mochi_list_i64_push appends v to l, growing the backing storage by
+ * doubling when l->cap is exhausted. The first push allocates a
+ * capacity-4 buffer to avoid a chain of tiny reallocs for the typical
+ * append-in-a-loop pattern.
+ */
+void mochi_list_i64_push(mochi_list_i64 *l, int64_t v);
+
+/* mochi_list_i64_get returns l->data[i]. No bounds check in the MVP;
+ * the IR validates indices upstream. */
+int64_t mochi_list_i64_get(const mochi_list_i64 *l, int64_t i);
+
+/* mochi_list_i64_set writes v to l->data[i]. No bounds check in the
+ * MVP, same rationale as get. */
+void mochi_list_i64_set(mochi_list_i64 *l, int64_t i, int64_t v);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOCHI_RUNTIME_C_LIST_I64_H */

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -663,7 +663,8 @@ This is the contract behind the §Top-line objective. Every IR `OpCode` and `Typ
 | `OpCallGo{*}` (other) | none | REJECTED by design (no cgo; use `--target=go`) |
 | `OpFnRef` | function-pointer literal | DEFERRED Phase 4.4 |
 | `OpLenStr` / `OpConcatStr` | `mochi_str_len` / `mochi_str_concat` | DEFERRED Phase 4.2 |
-| `OpNewList` / `OpListLen/Push/Get/Set/I64/F64` | `mochi_list_*` runtime | DEFERRED Phase 4.3 |
+| `OpNewList` / `OpListLenI64` / `OpListPushI64` / `OpListGetI64` / `OpListSetI64` | `mochi_list_i64_*` runtime (heap-allocated header, doubling growth) | LANDED (Phase 4.3.1) |
+| `OpListGetF64` / `OpListSetF64` | `mochi_list_f64_*` runtime | DEFERRED Phase 4.3.2 |
 | `OpNewMap` / `OpMapSet/Get/I64I64` | `mochi_map_*` runtime | DEFERRED Phase 4.3 |
 | `OpNewF64Array` / `OpF64Array*` | `mochi_f64arr_*` runtime | DEFERRED Phase 4.3 |
 | `OpQueryFilter/Map/SortBy/SortByDesc/Limit/Distinct/GroupBy` | inline C loops or runtime/c/query | DEFERRED Phase 4.4 |
@@ -724,8 +725,9 @@ Workloads in the "performance games" set that are NOT in this table, and why:
 
 | Workload | Why excluded |
 |----------|--------------|
-| `mandelbrot`, `n_body`, `spectral_norm` | Need `while`/`for` loops over `f64` arrays; loops landed in Phase 4.1.2, arrays blocked on Phase 4.3 |
-| `fannkuch`, `binary_trees` | Need `while`/`for` loops over lists; loops landed in Phase 4.1.2, lists blocked on Phase 4.3 |
+| `mandelbrot`, `n_body`, `spectral_norm` | Need `while`/`for` loops over `f64` arrays; loops landed in Phase 4.1.2, i64 lists landed in Phase 4.3.1, f64 lists blocked on Phase 4.3.2 |
+| `nsieve` | Typed-i64 list landed in Phase 4.3.1; remaining blocker is range-for (`for _ in 0..n+1`), gated on Phase 4.3.2 |
+| `fannkuch`, `binary_trees` | Need list-of-structs / struct-of-lists; i64 list primitive landed in Phase 4.3.1, struct support blocked on Phase 4.4, nesting on Phase 4.5 |
 | `fasta`, `regex_redux`, `k_nucleotide` | Need string literals and string ops; blocked on Phase 4.2 (TypeStr) |
 | `pidigits` | Needs arbitrary-precision integers; not on MEP-42 scope at all |
 | `reverse_complement` | Needs file I/O + strings; blocked on Phase 4.2 + a file-IO sentinel |
@@ -859,6 +861,82 @@ fun sum_to(n: int): int {
   return s
 }
 print(sum_to(100000000))
+```
+
+## §10.10 Phase 4.3.1 closeout (LANDED 2026-05-21 22:48 GMT+7)
+
+Phase 4.3.1 lands the typed-`i64` list surface end-to-end: IR opcodes (already declared), C runtime, both target emitters, and frontend support for the four Mochi-surface forms (`[]` empty literal, `[1, 2, 3]` non-empty literal, `xs[i]` read, `xs[i] = v` write, plus the `len(xs)` / `append(xs, v)` builtins). After this PR, every benchmark-games kernel whose only missing operator was "growable i64 array" compiles through `mochi build --target=c`. The closing-out gates in §10.6 move the five `OpList*I64` rows from DEFERRED to LANDED; the matching f64 rows stay deferred for Phase 4.3.2.
+
+### Why this PR is small
+
+The IR layer was complete before Phase 4.3.1 started. `compiler3/ir/types.go` already declared `OpNewList`, `OpListLenI64`, `OpListPushI64`, `OpListGetI64`, `OpListSetI64` with `String()` coverage; `compiler3/ir/validate.go` carried their `opSig` entries (return type and arg-type vector); `compiler3/verify/verify.go` covered the kindOf table and the read/write dispatch classifications. The Go target emit was also complete (lines 271-285 of `emit/go/emit.go` lower all five ops to `[]int64{}` / `append` / indexed get/set / `int64(len(...))`). The unmet work was the C-side runtime + emit and the frontend forms. The IR-layer pre-work meant Phase 4.3.1 reduced to two new C files, ~25 lines of C-emit changes, and ~120 lines of frontend changes.
+
+### C runtime
+
+`runtime/c/src/mochi_list_i64.{h,c}` adds a heap-allocated growable i64 array. The struct (`{ int64_t *data, int64_t len, int64_t cap }`) is exposed in the header so the generated C source could in principle inline length reads without a function call, but the generated source today routes through `mochi_list_i64_len()` for uniformity with the other ops. Growth is doubling from an initial 4-element capacity on first push, matching the amortised-O(N) shape of Go's slice append. The MVP leaks at exit (no free); a future Phase 4.3.x can add a finaliser hook if a benchmark surfaces pressure. The runtime is C99 with only `stdint.h`, `stdlib.h`, and `string.h`, preserving the MEP-42 "no libc beyond ANSI" identity.
+
+The driver-side wiring: `runtime/c/doc.go` extends its `//go:embed` pattern to include the two new files, and the existing `writeRuntime` walk in `compiler3/build/c/driver.go` picks them up unchanged. The cc invocation already links every `.c` it finds in the runtime tree, so a Mochi program that uses a list links `mochi_list_i64.o` for free; programs that do not reference any list op still get the object linked but the linker dead-strips it, costing ~200 bytes of binary size on darwin/arm64.
+
+### C-emit lowering
+
+`compiler3/emit/c/emit.go` grows a `usesListI64` flag computed in the pre-walk over `fn.Values`. When set, the prologue includes `mochi_list_i64.h`. The five list opcodes lower as one-line C statements each: `mochi_list_i64_new()` for OpNewList, `mochi_list_i64_push(l, v)` for OpListPushI64, `mochi_list_i64_get(l, i)` for OpListGetI64, `mochi_list_i64_set(l, i, v)` for OpListSetI64, `mochi_list_i64_len(l)` for OpListLenI64. The mutating ops (push, set) emit no LHS because their IR type is TypeUnit; the read ops (new, get, len) emit `<lhs> = <rhs>;`. The function-head declaration block already declares every non-param value via `cType(v.Type)` with a zero initialiser, so `cType(ir.TypeList) = "mochi_list_i64*"` (added in this PR) makes the list values self-declaring as nullable pointers. The first OpNewList overwrites the NULL with a real heap pointer.
+
+### Frontend lowering
+
+`compiler3/frontend/lower.go`:
+
+1. `lowerType` grows a `t.Generic != nil` branch handling `list<int>` → `ir.TypeList`. Non-i64 element types (`list<float>`, `list<bool>`) surface an explicit error so the A/B harness skips the fixture rather than miscompiling.
+2. `lowerStmt`'s AssignStmt case splits on `len(st.Assign.Index)`: zero indices route to `lowerLet` (the previous behaviour); one index routes to a new `lowerIndexedAssign` that emits OpListSetI64. Multi-level indices and slice forms stay rejected.
+3. `lowerPostfix` previously rejected any postfix ops; it now lowers a chain of `IndexOp` postfixes to OpListGetI64 values, type-checking that the operand is a TypeList and the index is TypeI64. Slice forms (`xs[lo:hi]`) stay rejected.
+4. `lowerPrimary` grows a `p.List != nil` branch that calls `lowerListLiteral`, which emits OpNewList plus one OpListPushI64 per element. Non-i64 element types in the literal surface an error.
+5. `lowerCall` consults a new `lowerBuiltinCall` helper before the user-fun lookup. The helper recognises `len(xs)` (lowering to OpListLenI64 for TypeList args or OpLenStr for TypeStr args) and `append(xs, v)` (lowering to OpListPushI64 plus returning the same SSA value, so `xs = append(xs, v)` rebinds the name to itself — the C-target's pointer-aliasing model means the underlying list mutates in place, which is what the user expects).
+
+The `lowerWhile` phi-at-header construction needed no changes: TypeList values flow through phi nodes the same way every other type does, with the C-emit's pointer assignment in the predecessor-side phi-assignment serialising correctly because a list value is a single pointer (no parallel-copy issue).
+
+### Integration tests
+
+Two new gate tests in `compiler3/build/c/driver_test.go`:
+
+- `TestBuildSourceListAppendAndIndex`: the load-bearing gate. A Mochi script that uses `var xs: list<int> = []`, `append`, `len`, indexed read, and indexed write inside nested `while` loops, computing `sumlist(10) = 55 + 100 = 155` (sum of 1..10 plus an indexed write of 100 to xs[0]). Builds via `mochi build --target=c` and prints `155\n`.
+- `TestBuildSourceListLiteralRead`: pins the non-empty list literal shape; `let xs: list<int> = [10, 20, 30]; print(xs[2])` builds to a binary that prints `30\n`.
+
+Matching Go-target tests in `compiler3/frontend/lower_test.go` (`TestLowerListAppendAndIndex`, `TestLowerListLiteralWithElems`) byte-match the same outputs, confirming both backends agree on the typed-array surface semantics.
+
+### What this unblocks
+
+`nsieve`: this remains gated on adding range-for support (Phase 4.3.2 covers `for _ in 0..n+1` and `for i in lo..hi`); once that lands, the existing `bench/template/bg/nsieve/nsieve.mochi` compiles unchanged to a C binary. `fannkuch` (permutation enumeration with index moves) and `binary_trees` (tree construction over heap-typed nodes) both need list-of-structs or struct-of-lists; those land in later sub-phases (Phase 4.4 covers structs, Phase 4.5 covers nested lists). The two benchmark-games rows that move closest to green from Phase 4.3.1 alone are `nsieve` (one phase away) and `n_body` / `spectral_norm` (which need `list<float>`, i.e. Phase 4.3.2's `OpListGetF64`/`OpListSetF64` lowering).
+
+The §10.7 exclusion table's "lists blocked on Phase 4.3" entries (`fannkuch`, `binary_trees`) move from "blocked on Phase 4.3" to "blocked on Phase 4.4 + 4.5"; the typed-`i64` list primitive is no longer the gating concern for any of them.
+
+### Limitations and follow-ups
+
+The frontend forms an aggressive minimum:
+
+- Slice ops (`xs[lo:hi]`), multi-level indices (`xs[i][j]`), and field+index chains are still rejected. Lifting them requires either widening `lowerPostfix` to track the SSA value through every op (straightforward) or threading a small intermediate "place" type through the postfix walker (cleaner). Neither is on the Phase 4.3.1 critical path because none of the §10.7 benchmark-games kernels need them.
+- `len(xs)` was wired into `lowerBuiltinCall`. The frontend has no other builtin recogniser today (`print` is special-cased in `lowerExprAsStmt`, `append` is handled in the same builtin helper). A future PR may consolidate them into a single dispatch table, but two cases do not yet justify the indirection.
+- The C runtime leaks lists at process exit. For long-running compiled binaries this is undesirable; a future Phase 4.3.x can add a deinit hook or an arena allocator that wraps every `mochi_list_i64_new()` allocation. The benchmark-games suite runs to completion before the leak matters.
+- ElemType-aware `cType` is hard-coded to assume `TypeI64` for any TypeList. When Phase 4.3.2 widens the surface to `list<float>` and `list<bool>`, `cType` will need to consult `Value.ElemType`, which means the `cType` caller (`emitFunc`'s declaration loop) needs to start passing the full Value rather than just the type. This is a small refactor scoped into Phase 4.3.2.
+
+The reproducer script:
+
+```
+fun sumlist(n: int): int {
+  var xs: list<int> = []
+  var i = 0
+  while i < n {
+    xs = append(xs, i + 1)
+    i = i + 1
+  }
+  var s = 0
+  var k = 0
+  while k < len(xs) {
+    s = s + xs[k]
+    k = k + 1
+  }
+  xs[0] = 100
+  return s + xs[0]
+}
+print(sumlist(10))
 ```
 
 ## §11 Risks


### PR DESCRIPTION
Tracks #21959.

## Summary

- C runtime `mochi_list_i64.{h,c}`: heap-allocated growable header, doubling growth from cap=4, no libc beyond `stdint.h`/`stdlib.h`/`string.h`. Leaks at exit (MVP); a finaliser hook is a Phase 4.3.x follow-up.
- C-emit: lowers `OpNewList`, `OpListLenI64`, `OpListPushI64`, `OpListGetI64`, `OpListSetI64` to one-line `mochi_list_i64_*` calls; `cType(TypeList) = "mochi_list_i64*"`; auto-includes the header when any list op is present.
- Frontend: `list<int>` generic type ref; `[]` and `[1, 2, 3]` literals (OpNewList plus per-element OpListPushI64); `xs[i]` postfix lowering to OpListGetI64; `xs[i] = v` AssignStmt-with-Index lowering to OpListSetI64; `len(xs)` and `append(xs, v)` builtin recognisers in `lowerBuiltinCall`.
- Tests: `TestBuildSourceListAppendAndIndex` and `TestBuildSourceListLiteralRead` (C target gates); matching `TestLowerListAppendAndIndex` and `TestLowerListLiteralWithElems` (Go target). All four green; full `./compiler3/...` suite green.
- Spec: §10.6 moves five list-i64 rows from DEFERRED to LANDED; §10.7 exclusion table updates `nsieve` (one phase away: range-for), `fannkuch`, `binary_trees`; §10.10 closeout documents runtime, emit, frontend, and follow-up scope.

## Test plan

- [x] `go test ./compiler3/...` green (build/c, frontend, emit/c)
- [x] Phase 4.3.1 gate tests pass on both targets
- [x] No regressions in Phase 4.0 / 4.1 / 4.1.1 / 4.1.2 fixtures (the existing tests in lower_test.go and driver_test.go all pass)
- [x] MEP-42 §10.6, §10.7, §10.10 in sync with code (spec-in-sync rule)

## What this does NOT do

- `nsieve` does not yet compile end-to-end via `--target=c` because the source uses `for _ in 0..n+1`. Range-for lands in Phase 4.3.2.
- `list<float>` / `list<bool>` element types stay deferred. Phase 4.3.2 widens.
- Slice / multi-level indices stay rejected with a clean frontend error.