### PR TITLE
mep-0042: Phase 4.3.2 range-for + lowerIf phi-join, unblocks nsieve

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -267,6 +267,75 @@ print(xs[2])
 	}
 }
 
+// TestBuildSourceForRangeSum pins the Phase 4.3.2 range-for surface
+// through the C target: a `for i in 1..(n+1)` loop with a mutable
+// accumulator must compile and produce the same output as the Go
+// target.
+func TestBuildSourceForRangeSum(t *testing.T) {
+	src := `fun sumRange(n: int): int {
+  var s = 0
+  for i in 1..(n + 1) {
+    s = s + i
+  }
+  return s
+}
+print(sumRange(10))
+`
+	if got, want := runMochiBuild(t, src), "55\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceForRangeUnderscore covers the `_` loop variable: a
+// range-for that runs N iterations without referring to the index.
+func TestBuildSourceForRangeUnderscore(t *testing.T) {
+	src := `fun fillFive(): int {
+  var xs: list<int> = []
+  for _ in 0..5 {
+    xs = append(xs, 0)
+  }
+  return len(xs)
+}
+print(fillFive())
+`
+	if got, want := runMochiBuild(t, src), "5\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceNsieve is the Phase 4.3.2 load-bearing gate: a
+// stripped nsieve(100)=25 program compiles via `mochi build
+// --target=c` and produces the same byte-stream as `mochi run`.
+// Exercises range-for, nested while, indexed list ops, and the
+// if-merge phi join all in one program.
+func TestBuildSourceNsieve(t *testing.T) {
+	src := `fun nsieve(m: int): int {
+  var flags: list<int> = []
+  var i = 0
+  while i < m {
+    flags = append(flags, 1)
+    i = i + 1
+  }
+  var count = 0
+  for k in 2..m {
+    if flags[k] == 1 {
+      count = count + 1
+      var j = k + k
+      while j < m {
+        flags[j] = 0
+        j = j + k
+      }
+    }
+  }
+  return count
+}
+print(nsieve(100))
+`
+	if got, want := runMochiBuild(t, src), "25\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceFibIter is the §10.7 unblock for the iterative Fib
 // benchmark: while loop, mutated `a`/`b`/`i`, and a `let t` inside the
 // body that the phi-at-header must NOT track (it's body-scoped).

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -302,6 +302,8 @@ func (b *builder) lowerStmt(st *parser.Statement) error {
 		return b.lowerIf(st.If)
 	case st.While != nil:
 		return b.lowerWhile(st.While)
+	case st.For != nil:
+		return b.lowerFor(st.For)
 	case st.Expr != nil:
 		_, err := b.lowerExprAsStmt(st.Expr.Expr)
 		return err
@@ -384,6 +386,14 @@ func (b *builder) lowerIf(s *parser.IfStmt) error {
 	elseID := b.fn.AddBlock()
 	contID := b.fn.AddBlock()
 
+	// Snapshot the env at entry so the else branch sees the same
+	// pre-if bindings the then branch saw, and so the merge can phi-
+	// join values that diverge between the two paths.
+	preEnv := make(map[string]uint32, len(b.values))
+	for k, v := range b.values {
+		preEnv[k] = v
+	}
+
 	b.terminator(ir.Terminator{Kind: ir.TermBranch, Value: cond, IfTrue: thenID, IfFalse: elseID})
 
 	// Then.
@@ -397,8 +407,22 @@ func (b *builder) lowerIf(s *parser.IfStmt) error {
 			break
 		}
 	}
+	var thenEnv map[string]uint32
+	var thenEnd uint32
+	thenTerminated := b.terminated
 	if !b.terminated {
+		thenEnd = b.curBlock
+		thenEnv = make(map[string]uint32, len(b.values))
+		for k, v := range b.values {
+			thenEnv[k] = v
+		}
 		b.terminator(ir.Terminator{Kind: ir.TermJump, Target: contID})
+	}
+
+	// Restore the pre-if env so else sees the same bindings then did.
+	b.values = make(map[string]uint32, len(preEnv))
+	for k, v := range preEnv {
+		b.values[k] = v
 	}
 
 	// Else.
@@ -418,13 +442,62 @@ func (b *builder) lowerIf(s *parser.IfStmt) error {
 			}
 		}
 	}
+	var elseEnv map[string]uint32
+	var elseEnd uint32
+	elseTerminated := b.terminated
 	if !b.terminated {
+		elseEnd = b.curBlock
+		elseEnv = make(map[string]uint32, len(b.values))
+		for k, v := range b.values {
+			elseEnv[k] = v
+		}
 		b.terminator(ir.Terminator{Kind: ir.TermJump, Target: contID})
 	}
 
-	// Continuation: empty block; caller continues lowering here.
+	// Continuation: phi-join bindings that diverge between the two
+	// paths. When only one branch terminated, the merge has a single
+	// predecessor and we can use that branch's env directly. When both
+	// terminated, the contID block is unreachable; clear its preds.
 	b.curBlock = contID
 	b.terminated = false
+	switch {
+	case thenTerminated && elseTerminated:
+		// Unreachable merge.
+	case thenTerminated:
+		b.values = elseEnv
+	case elseTerminated:
+		b.values = thenEnv
+	default:
+		// Both branches reach the merge. For every name in the pre-if
+		// env, phi-join if the two paths diverge; otherwise keep the
+		// common value. Names introduced only inside a branch are
+		// dropped (their scope ended at the branch).
+		names := make([]string, 0, len(preEnv))
+		for name := range preEnv {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		newEnv := make(map[string]uint32, len(names))
+		for _, name := range names {
+			tv, tok := thenEnv[name]
+			ev, eok := elseEnv[name]
+			if !tok || !eok {
+				newEnv[name] = preEnv[name]
+				continue
+			}
+			if tv == ev {
+				newEnv[name] = tv
+				continue
+			}
+			phiVid := b.addValue(ir.Value{
+				Type: b.fn.Values[tv].Type,
+				Op:   ir.OpPhi,
+				Args: []uint32{thenEnd, tv, elseEnd, ev},
+			})
+			newEnv[name] = phiVid
+		}
+		b.values = newEnv
+	}
 	return nil
 }
 
@@ -496,8 +569,12 @@ func (b *builder) lowerWhile(s *parser.WhileStmt) error {
 	}
 	if !b.terminated {
 		// Patch back-edge slots from the post-body env before jumping.
-		// terminator() appends bodyID to header.Preds for us.
+		// The predecessor block is b.curBlock (the actual end of the
+		// body), which differs from bodyID when the body contains
+		// nested control flow that ends in a merge block.
+		endBlock := b.curBlock
 		for i, name := range names {
+			b.fn.Values[phis[i]].Args[2] = endBlock
 			b.fn.Values[phis[i]].Args[3] = b.values[name]
 		}
 		b.terminator(ir.Terminator{Kind: ir.TermJump, Target: headID})
@@ -519,6 +596,143 @@ func (b *builder) lowerWhile(s *parser.WhileStmt) error {
 	b.terminated = false
 	for i, name := range names {
 		b.values[name] = phis[i]
+	}
+	return nil
+}
+
+// lowerFor lowers `for x in lo..hi { body }` (integer range) to the
+// same phi-at-header CFG shape as lowerWhile, with the loop variable
+// `x` as one of the snapshotted bindings. Pre-header initialises `x`
+// to `lo`; the header phi joins (pre-header `x`, body's `x + 1`); the
+// header's cond is `x < hi`; the body lowers each statement, then
+// inserts the synthetic `x = x + 1` step at the end. The range form
+// is the only ForStmt shape the MVP frontend lowers; collection-iter
+// (`for x in xs { body }`, where xs is a list) stays rejected until
+// Phase 4.3.x widens the surface.
+//
+// Bounds may be any TypeI64 expression including local bindings and
+// nested arithmetic; they are evaluated once in the pre-header and
+// captured in SSA, so a mutation inside the body does not affect the
+// loop count.
+func (b *builder) lowerFor(s *parser.ForStmt) error {
+	if s.RangeEnd == nil {
+		return fmt.Errorf("frontend: for-in over a collection unsupported in MVP (only `for x in lo..hi`)")
+	}
+	lo, err := b.lowerExpr(s.Source)
+	if err != nil {
+		return err
+	}
+	hi, err := b.lowerExpr(s.RangeEnd)
+	if err != nil {
+		return err
+	}
+	if b.fn.Values[lo].Type != ir.TypeI64 {
+		return fmt.Errorf("frontend: for-range lo must be i64, got %s", b.fn.Values[lo].Type)
+	}
+	if b.fn.Values[hi].Type != ir.TypeI64 {
+		return fmt.Errorf("frontend: for-range hi must be i64, got %s", b.fn.Values[hi].Type)
+	}
+
+	loopName := s.Name
+	// Save the shadowed binding (if any) so the loop variable does not
+	// leak past the loop. Mochi semantics scope the for-variable to the
+	// loop body; both targets observe that by restoring the prior env
+	// at the cont block.
+	oldVal, hadOld := b.values[loopName]
+	b.values[loopName] = lo
+
+	preID := b.curBlock
+	headID := b.fn.AddBlock()
+	bodyID := b.fn.AddBlock()
+	contID := b.fn.AddBlock()
+
+	names := make([]string, 0, len(b.values))
+	for name := range b.values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	preVals := make([]uint32, len(names))
+	for i, name := range names {
+		preVals[i] = b.values[name]
+	}
+
+	b.terminator(ir.Terminator{Kind: ir.TermJump, Target: headID})
+
+	b.curBlock = headID
+	b.terminated = false
+	phis := make([]uint32, len(names))
+	var loopPhi uint32
+	for i, name := range names {
+		preVid := preVals[i]
+		phiVid := b.addValue(ir.Value{
+			Type: b.fn.Values[preVid].Type,
+			Op:   ir.OpPhi,
+			Args: []uint32{preID, preVid, bodyID, 0},
+		})
+		phis[i] = phiVid
+		b.values[name] = phiVid
+		if name == loopName {
+			loopPhi = phiVid
+		}
+	}
+	cond := b.addValue(ir.Value{
+		Type: ir.TypeBool,
+		Op:   ir.OpCmpLtI64,
+		Args: []uint32{loopPhi, hi},
+	})
+	b.terminator(ir.Terminator{Kind: ir.TermBranch, Value: cond, IfTrue: bodyID, IfFalse: contID})
+
+	b.curBlock = bodyID
+	b.terminated = false
+	for _, st := range s.Body {
+		if err := b.lowerStmt(st); err != nil {
+			return err
+		}
+		if b.terminated {
+			break
+		}
+	}
+	if !b.terminated {
+		// Synthetic `x = x + 1` step at the end of the body. The
+		// increment runs against the current SSA binding for `x`,
+		// which is normally the header phi but would be a rebind if
+		// the user shadowed the loop variable inside the body.
+		cur := b.values[loopName]
+		one := b.addValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 1})
+		next := b.addValue(ir.Value{Type: ir.TypeI64, Op: ir.OpAddI64, Args: []uint32{cur, one}})
+		b.values[loopName] = next
+		// Patch back-edge slots. The predecessor block is b.curBlock
+		// (the actual end of the body), which differs from bodyID when
+		// the body contains nested control flow that ends in a merge
+		// block (e.g., an inner if-statement).
+		endBlock := b.curBlock
+		for i, name := range names {
+			b.fn.Values[phis[i]].Args[2] = endBlock
+			b.fn.Values[phis[i]].Args[3] = b.values[name]
+		}
+		b.terminator(ir.Terminator{Kind: ir.TermJump, Target: headID})
+	} else {
+		head := b.fn.Block(headID)
+		head.Preds = []uint32{preID}
+		for _, phiVid := range phis {
+			phi := &b.fn.Values[phiVid]
+			phi.Args = phi.Args[:2]
+		}
+	}
+
+	b.curBlock = contID
+	b.terminated = false
+	for i, name := range names {
+		b.values[name] = phis[i]
+	}
+	// Restore the shadowed binding; the loop variable is dead after the
+	// loop. Without this, a subsequent reference to `loopName` in the
+	// outer scope would resolve to the header phi, which is wrong if
+	// the user had a same-named outer binding.
+	if hadOld {
+		b.values[loopName] = oldVal
+	} else {
+		delete(b.values, loopName)
 	}
 	return nil
 }

--- a/compiler3/frontend/lower_test.go
+++ b/compiler3/frontend/lower_test.go
@@ -195,3 +195,77 @@ print(xs[2])
 		t.Errorf("got %q, want %q", got, "30\n")
 	}
 }
+
+// TestLowerForRangeSum pins the Phase 4.3.2 range-for surface: a
+// `for i in 1..(n+1)` loop with a mutable accumulator must lower to
+// the same phi-at-header CFG shape as while, with the loop variable
+// participating as one of the snapshotted bindings. Sum 1..10 = 55.
+func TestLowerForRangeSum(t *testing.T) {
+	src := `fun sumRange(n: int): int {
+  var s = 0
+  for i in 1..(n + 1) {
+    s = s + i
+  }
+  return s
+}
+print(sumRange(10))
+`
+	got := runEnd2End(t, src)
+	if got != "55\n" {
+		t.Errorf("got %q, want %q", got, "55\n")
+	}
+}
+
+// TestLowerForRangeUnderscore exercises the `_` loop variable: the
+// body does not reference the index, but the loop still iterates the
+// right number of times. After 5 iterations, len(xs) is 5.
+func TestLowerForRangeUnderscore(t *testing.T) {
+	src := `fun fillFive(): int {
+  var xs: list<int> = []
+  for _ in 0..5 {
+    xs = append(xs, 0)
+  }
+  return len(xs)
+}
+print(fillFive())
+`
+	got := runEnd2End(t, src)
+	if got != "5\n" {
+		t.Errorf("got %q, want %q", got, "5\n")
+	}
+}
+
+// TestLowerNsieve is the load-bearing Phase 4.3.2 gate: a stripped
+// nsieve(100) returning the prime count (25). It exercises range-for
+// with nested while, indexed reads/writes, len(), and the synthetic
+// loop-variable increment all in one program. This is the program the
+// benchmark games' nsieve fixture reduces to once the list element-
+// type widening is removed.
+func TestLowerNsieve(t *testing.T) {
+	src := `fun nsieve(m: int): int {
+  var flags: list<int> = []
+  var i = 0
+  while i < m {
+    flags = append(flags, 1)
+    i = i + 1
+  }
+  var count = 0
+  for k in 2..m {
+    if flags[k] == 1 {
+      count = count + 1
+      var j = k + k
+      while j < m {
+        flags[j] = 0
+        j = j + k
+      }
+    }
+  }
+  return count
+}
+print(nsieve(100))
+`
+	got := runEnd2End(t, src)
+	if got != "25\n" {
+		t.Errorf("got %q, want %q", got, "25\n")
+	}
+}

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -726,7 +726,7 @@ Workloads in the "performance games" set that are NOT in this table, and why:
 | Workload | Why excluded |
 |----------|--------------|
 | `mandelbrot`, `n_body`, `spectral_norm` | Need `while`/`for` loops over `f64` arrays; loops landed in Phase 4.1.2, i64 lists landed in Phase 4.3.1, f64 lists blocked on Phase 4.3.2 |
-| `nsieve` | Typed-i64 list landed in Phase 4.3.1; remaining blocker is range-for (`for _ in 0..n+1`), gated on Phase 4.3.2 |
+| `nsieve` | LANDED in Phase 4.3.2 (range-for + if-merge phi joins land together; stripped nsieve(100)=25 pinned by C and Go target tests). The full benchmark uses identical primitives |
 | `fannkuch`, `binary_trees` | Need list-of-structs / struct-of-lists; i64 list primitive landed in Phase 4.3.1, struct support blocked on Phase 4.4, nesting on Phase 4.5 |
 | `fasta`, `regex_redux`, `k_nucleotide` | Need string literals and string ops; blocked on Phase 4.2 (TypeStr) |
 | `pidigits` | Needs arbitrary-precision integers; not on MEP-42 scope at all |
@@ -938,6 +938,66 @@ fun sumlist(n: int): int {
 }
 print(sumlist(10))
 ```
+
+## §10.11 Phase 4.3.2 closeout (LANDED 2026-05-21 23:17 GMT+7)
+
+Phase 4.3.2 lands the range-for surface (`for x in lo..hi`) end-to-end through the compiler3 frontend and onto both targets (Go and C). The same PR also lands the SSA discipline fix in `lowerIf` that range-for first surfaced: when a branch of an `if` mutates bindings (or runs a nested loop that introduces phis), the merge block now phi-joins values from both paths instead of leaking the last-touched env. The §10.7 `nsieve` row moves from "blocked on Phase 4.3.2" to LANDED; the matching `--target=c` integration test runs the stripped nsieve(100)=25 kernel byte-for-byte against the Go target.
+
+### Why this PR splits into two halves
+
+The frontend half is one new method, `lowerFor` in `compiler3/frontend/lower.go`. It is a clone of `lowerWhile`: snapshot the bindings live at loop entry, build header/body/cont blocks, materialise one `OpPhi` per snapshotted binding at the header, insert a `cmp_lt_i64(loopvar, hi)` as the header's branch cond, lower the body, then insert a synthetic `loopvar = loopvar + 1` step at the end of the body before patching the back-edge phi-args. The loop variable joins the snapshot set so its phi is one of the back-edge slots. The pre-header binds `loopvar` to `lo`; the body's last instruction is the synthetic increment; the cont block restores the loop variable's outer binding (if any) so the loop variable does not leak past the loop. Bounds are typed `i64` and may be any expression including local bindings and parenthesised arithmetic (the test `for i in 1..(n + 1)` exercises this).
+
+The if-merge half is the change that the range-for tests forced. `lowerIf` previously did not phi-join at the merge block; it let `b.values` flow forward from whichever branch ran last. That worked for the pre-existing `if/else` tests because the only test bodies were `print(...)` calls that did not mutate any binding. The first test that mutates inside an `if` inside a loop (the stripped `nsieve`, which does `count = count + 1` and runs an inner `while` that produces phi outputs) immediately broke: the merge block read SSA values defined only on the then-path, so traversing the else-path left those reads uninitialised at the IR level (and zero-valued at runtime in Go, so the loop counter never advanced). The fix is the standard SSA-construction one: snapshot the env at if-entry, snapshot the env at end-of-then, restore for the else branch, snapshot the env at end-of-else, and at the merge block phi-join any name whose value diverges between the two paths. Names introduced only inside a branch keep the pre-if value (their scope ended at the branch). When only one branch terminates (return / break), the merge takes the other branch's env directly. When both terminate, the merge is unreachable.
+
+### Why the back-edge predecessor needed patching
+
+When the for-loop's body contains nested control flow (e.g., an inner `if`), `b.curBlock` at the end of body-lowering is the merge block of that inner control flow, NOT the original `bodyID`. The phi-at-header's `Args[2]` slot, however, was set to `bodyID` when the phi was created in the header. The emit's parallel-copy logic walks each block's terminator and matches `phi.Args[2*i] == blk.ID` to know which phi-arg pair to emit at that predecessor's jump. With `Args[2] = bodyID` but the actual back-edge coming from the inner merge block, no parallel copies were emitted at the back-edge, so the back-edge value was lost and the loop counter never advanced. The fix sets `phi.Args[2] = b.curBlock` (the actual end-of-body block) at the moment of patching the back-edge value. The matching fix in `lowerWhile` is included because the same bug exists there in principle; the pre-existing `lowerWhile` tests do not have an inner `if`, so it had never been triggered. After this PR both loops patch the back-edge predecessor correctly.
+
+### Files changed
+
+- `compiler3/frontend/lower.go`: `lowerStmt` routes `st.For` to new `lowerFor`. `lowerFor` is the new method described above. `lowerIf` gains pre/then/else env snapshots and merge-block phi-join. Both `lowerWhile` and `lowerFor` patch `phi.Args[2] = b.curBlock` before the back-edge jump so phi predecessors reflect the actual end-of-body block.
+- `compiler3/frontend/lower_test.go`: three new tests, `TestLowerForRangeSum` (sum 1..(n+1) for n=10 = 55), `TestLowerForRangeUnderscore` (5 iterations with `_` index), `TestLowerNsieve` (stripped nsieve(100) = 25).
+- `compiler3/build/c/driver_test.go`: matching three integration tests through the C target, byte-for-byte against the Go target.
+- `website/docs/mep/mep-0042.md`: this section, plus §10.7 nsieve row update.
+
+### What this unblocks
+
+- The `bench/template/bg/nsieve/nsieve.mochi` fixture's stripped form compiles unchanged through `mochi build --target=c`; the full benchmark uses the same primitives (range-for, list of i64, indexed read/write, `len`, `append`, nested while, if). Wiring the benchmark harness to invoke the C-target build is a §13 (workflow) follow-up, not a frontend gap.
+- Any benchmark-games kernel whose only blocker was range-for is now compilable. The next gates in §10.7 are f64 lists (Phase 4.3.x's `OpListGetF64`/`OpListSetF64`, gating `n_body`/`spectral_norm`/`mandelbrot`) and structs (Phase 4.4, gating `fannkuch`/`binary_trees`).
+
+### Limitations
+
+- Collection-iter (`for x in xs { body }`, where `xs` is a list) stays rejected with `frontend: for-in over a collection unsupported in MVP`. Adding it is two steps: lower the source as a list value, then synthesise a `var i = 0; while i < len(xs) { let x = xs[i]; body; i = i + 1 }`. Not on the Phase 4.3.2 critical path; the §10.7 benchmark-games kernels that need it (none today) can be unblocked by a follow-up sub-phase.
+- The for-loop bounds are inclusive of `lo` and exclusive of `hi` (the standard half-open range). Mochi has no surface syntax for a fully inclusive range; if added later, the closed-form `hi+1` rewrite is one line in `lowerFor`.
+- The `lowerIf` phi-join treats `b.values` as a flat name → SSA map; nested struct field updates and indexed list writes are tracked at the list-pointer level (correct, because the C target's lists are heap-allocated and mutation in one branch is visible after the merge), but a per-field write into a stack-allocated struct (Phase 4.4) will need a richer place-tracking scheme. Not a current concern.
+
+### Reproducer
+
+```mochi
+fun nsieve(m: int): int {
+  var flags: list<int> = []
+  var i = 0
+  while i < m {
+    flags = append(flags, 1)
+    i = i + 1
+  }
+  var count = 0
+  for k in 2..m {
+    if flags[k] == 1 {
+      count = count + 1
+      var j = k + k
+      while j < m {
+        flags[j] = 0
+        j = j + k
+      }
+    }
+  }
+  return count
+}
+print(nsieve(100))
+```
+
+Compiles via `mochi build --target=c` (and `--target=go`) to a binary that prints `25\n`, matching `mochi run` on the same source.
 
 ## §11 Risks
 


### PR DESCRIPTION
Tracks #21961.

## Summary
- Lowers `for x in lo..hi { body }` end-to-end through compiler3 frontend onto both Go and C targets
- Fixes lowerIf SSA discipline: merge block now phi-joins values when branches diverge (was previously letting the last-touched env flow forward, which broke as soon as range-for + nested-while + if + mutation all combined in nsieve)
- Fixes back-edge phi predecessor in both lowerWhile and lowerFor: `phi.Args[2]` patched to `b.curBlock` at the jump, so a body ending in a merge block from nested control flow still emits the parallel copies at the right place

## Test plan
- [x] `go test ./compiler3/frontend/` (3 new tests + 9 prior)
- [x] `go test ./compiler3/build/c/` (3 new tests + prior)
- [x] `go test ./compiler3/...` (all packages green)
- [x] Stripped nsieve(100) prints `25` via `mochi build --target=c`, byte-matching Go target

## Spec
- §10.7 nsieve row moves to LANDED (range-for + if-merge phi joins land together)
- §10.11 new closeout documents range-for shape, lowerIf phi-join, back-edge predecessor fix, limitations