### PR TITLE
mep-0042: Phase 4.3.3 list<float> end-to-end, unblocks n_body / mandelbrot / spectral_norm

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -267,6 +267,47 @@ print(xs[2])
 	}
 }
 
+// TestBuildSourceListFloatLiteralAndIndex pins the Phase 4.3.3
+// list<float> surface through the C target: a non-empty literal lowers
+// to OpNewF64Array + three OpF64ArrayPushF64, and `xs[1]` reads back
+// 2.5. The print path routes through print.h's float branch (%.17g).
+func TestBuildSourceListFloatLiteralAndIndex(t *testing.T) {
+	src := `let xs: list<float> = [1.5, 2.5, 3.5]
+print(xs[1])
+`
+	if got, want := runMochiBuild(t, src), "2.5\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceListFloatAppendAndIndex pins the empty-literal +
+// append + indexed read + indexed write + len cycle for list<float>
+// through the C target, byte-matching the Go target's output (and the
+// matching TestLowerListFloatAppendAndIndex in compiler3/frontend).
+func TestBuildSourceListFloatAppendAndIndex(t *testing.T) {
+	src := `fun sumf(n: int): float {
+  var xs: list<float> = []
+  var i = 0
+  while i < n {
+    xs = append(xs, 0.5)
+    i = i + 1
+  }
+  var s = 0.0
+  var k = 0
+  while k < len(xs) {
+    s = s + xs[k]
+    k = k + 1
+  }
+  xs[0] = 100.5
+  return s + xs[0]
+}
+print(sumf(4))
+`
+	if got, want := runMochiBuild(t, src), "102.5\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceForRangeSum pins the Phase 4.3.2 range-for surface
 // through the C target: a `for i in 1..(n+1)` loop with a mutable
 // accumulator must compile and produce the same output as the Go

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -62,6 +62,7 @@ func Emit(p *Program) ([]byte, error) {
 	// gen.c.
 	usesPrint := false
 	usesListI64 := false
+	usesF64Array := false
 	for _, fn := range p.Funcs {
 		for _, v := range fn.Values {
 			switch v.Op {
@@ -79,6 +80,9 @@ func Emit(p *Program) ([]byte, error) {
 			case ir.OpNewList, ir.OpListLenI64, ir.OpListPushI64,
 				ir.OpListGetI64, ir.OpListSetI64:
 				usesListI64 = true
+			case ir.OpNewF64Array, ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64,
+				ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64:
+				usesF64Array = true
 			}
 		}
 	}
@@ -93,6 +97,9 @@ func Emit(p *Program) ([]byte, error) {
 	}
 	if usesListI64 {
 		buf.WriteString("#include \"mochi_list_i64.h\"\n")
+	}
+	if usesF64Array {
+		buf.WriteString("#include \"mochi_f64_array.h\"\n")
 	}
 	buf.WriteString("\n")
 
@@ -313,6 +320,16 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    %s = mochi_list_i64_get(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpListSetI64:
 		fmt.Fprintf(w, "    mochi_list_i64_set(%s, %s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
+	case ir.OpNewF64Array:
+		fmt.Fprintf(w, "    %s = mochi_f64_array_new();\n", name)
+	case ir.OpF64ArrayLenI64:
+		fmt.Fprintf(w, "    %s = mochi_f64_array_len(%s);\n", name, valueName(v.Args[0]))
+	case ir.OpF64ArrayPushF64:
+		fmt.Fprintf(w, "    mochi_f64_array_push(%s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpF64ArrayGetF64:
+		fmt.Fprintf(w, "    %s = mochi_f64_array_get(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpF64ArraySetF64:
+		fmt.Fprintf(w, "    mochi_f64_array_set(%s, %s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
 	case ir.OpCall, ir.OpTailCall:
 		// Intra-program call. v.Const indexes into Program.Funcs;
 		// args are SSA values in declared order. The emitter writes
@@ -462,13 +479,17 @@ func cType(t ir.Type) string {
 	case ir.TypeBool:
 		return "int"
 	case ir.TypeList:
-		// Phase 4.3.1: list<int>. The MVP frontend only constructs
-		// TypeList values with ElemType=TypeI64, so the cgen pointer
-		// type can be fixed here without consulting ElemType. When
-		// Phase 4.3.2 widens to f64/bool elements, this switch will
-		// branch on Value.ElemType (which cgen would need to start
-		// threading through cType's caller).
+		// list<int>: heap-allocated header backed by mochi_list_i64.
+		// The MVP frontend constructs TypeList values with
+		// ElemType=TypeI64 only; the f64 element-type lives on
+		// TypeF64Arr (a separate flat-double backing) so this switch
+		// stays branchless.
 		return "mochi_list_i64*"
+	case ir.TypeF64Arr:
+		// list<float>: heap-allocated header backed by mochi_f64_array.
+		// Distinct from TypeList so cc -O2 can vectorise the flat
+		// double[] backing without a Cell-tag indirection.
+		return "mochi_f64_array*"
 	case ir.TypeUnit, ir.TypeInvalid:
 		return "void"
 	}

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -156,6 +156,16 @@ type builder struct {
 	// query/loop work needed for full phi insertion is part of the
 	// post-MVP widening.
 	values map[string]uint32
+	// expectedListElem optionally hints the element type of an
+	// upcoming list literal lowering, set by `let/var x: list<T> = ...`
+	// just before lowerExpr and cleared after. Only lowerListLiteral
+	// consults this field; the empty-literal case `[]` needs it to
+	// pick between TypeList (i64) and TypeF64Arr (f64). For non-empty
+	// literals the hint is still useful because Mochi int literals
+	// lower to TypeI64 but the user may want an f64 array (1.0 etc.
+	// would clear this, but 0/1 in a list<float> declaration is a real
+	// case in the benchmark-games kernels).
+	expectedListElem ir.Type
 }
 
 func newBuilder(fn *ir.Function, userFns map[string]funEntry, prog *gogen.Program, goImports map[string]*goImport) *builder {
@@ -226,19 +236,23 @@ func lowerType(t *parser.TypeRef) (ir.Type, error) {
 		return ir.TypeInvalid, fmt.Errorf("frontend: nil type ref")
 	}
 	if t.Generic != nil {
-		// Phase 4.3.1: `list<int>` (the typed-i64 array shape) is the
-		// only generic the MVP frontend lowers. ElemType inspection
-		// happens at the call site that constructs a TypeList value;
-		// here we only need to assert the surface form is supported.
+		// `list<int>` lowers to TypeList (mochi_list_i64); `list<float>`
+		// lowers to TypeF64Arr (mochi_f64_array). The two backings are
+		// distinct at the IR layer so the C target can drop the Cell-
+		// tag overhead and the Go target can use the proper Go slice
+		// element type.
 		if t.Generic.Name == "list" && len(t.Generic.Args) == 1 {
 			el, err := lowerType(t.Generic.Args[0])
 			if err != nil {
 				return ir.TypeInvalid, fmt.Errorf("frontend: list element: %w", err)
 			}
-			if el != ir.TypeI64 {
-				return ir.TypeInvalid, fmt.Errorf("frontend: list<%s> unsupported in MVP (only list<int>)", el)
+			switch el {
+			case ir.TypeI64:
+				return ir.TypeList, nil
+			case ir.TypeF64:
+				return ir.TypeF64Arr, nil
 			}
-			return ir.TypeList, nil
+			return ir.TypeInvalid, fmt.Errorf("frontend: list<%s> unsupported in MVP (only list<int> and list<float>)", el)
 		}
 		return ir.TypeInvalid, fmt.Errorf("frontend: generic %s<...> unsupported in MVP", t.Generic.Name)
 	}
@@ -285,9 +299,9 @@ func (b *builder) terminator(t ir.Terminator) {
 func (b *builder) lowerStmt(st *parser.Statement) error {
 	switch {
 	case st.Let != nil:
-		return b.lowerLet(st.Let.Name, st.Let.Value)
+		return b.lowerTypedLet(st.Let.Name, st.Let.Type, st.Let.Value)
 	case st.Var != nil:
-		return b.lowerLet(st.Var.Name, st.Var.Value)
+		return b.lowerTypedLet(st.Var.Name, st.Var.Type, st.Var.Value)
 	case st.Assign != nil:
 		if len(st.Assign.Field) != 0 {
 			return fmt.Errorf("frontend: field assignment unsupported in MVP")
@@ -326,8 +340,9 @@ func (b *builder) lowerIndexedAssign(a *parser.AssignStmt) error {
 	if !ok {
 		return fmt.Errorf("frontend: indexed assign to unbound identifier %q", a.Name)
 	}
-	if b.fn.Values[listID].Type != ir.TypeList {
-		return fmt.Errorf("frontend: indexed assign on non-list %s", b.fn.Values[listID].Type)
+	listType := b.fn.Values[listID].Type
+	if listType != ir.TypeList && listType != ir.TypeF64Arr {
+		return fmt.Errorf("frontend: indexed assign on non-list %s", listType)
 	}
 	idxID, err := b.lowerExpr(idxOp.Start)
 	if err != nil {
@@ -340,15 +355,28 @@ func (b *builder) lowerIndexedAssign(a *parser.AssignStmt) error {
 	if err != nil {
 		return err
 	}
-	if b.fn.Values[valID].Type != ir.TypeI64 {
-		return fmt.Errorf("frontend: list<int> store requires i64 value, got %s", b.fn.Values[valID].Type)
+	switch listType {
+	case ir.TypeList:
+		if b.fn.Values[valID].Type != ir.TypeI64 {
+			return fmt.Errorf("frontend: list<int> store requires i64 value, got %s", b.fn.Values[valID].Type)
+		}
+		b.addValue(ir.Value{
+			Type:     ir.TypeUnit,
+			ElemType: ir.TypeI64,
+			Op:       ir.OpListSetI64,
+			Args:     []uint32{listID, idxID, valID},
+		})
+	case ir.TypeF64Arr:
+		if b.fn.Values[valID].Type != ir.TypeF64 {
+			return fmt.Errorf("frontend: list<float> store requires f64 value, got %s", b.fn.Values[valID].Type)
+		}
+		b.addValue(ir.Value{
+			Type:     ir.TypeUnit,
+			ElemType: ir.TypeF64,
+			Op:       ir.OpF64ArraySetF64,
+			Args:     []uint32{listID, idxID, valID},
+		})
 	}
-	b.addValue(ir.Value{
-		Type:     ir.TypeUnit,
-		ElemType: ir.TypeI64,
-		Op:       ir.OpListSetI64,
-		Args:     []uint32{listID, idxID, valID},
-	})
 	return nil
 }
 
@@ -357,6 +385,38 @@ func (b *builder) lowerLet(name string, e *parser.Expr) error {
 		return fmt.Errorf("frontend: binding %q has no initializer", name)
 	}
 	vid, err := b.lowerExpr(e)
+	if err != nil {
+		return err
+	}
+	b.values[name] = vid
+	return nil
+}
+
+// lowerTypedLet is the let/var path that consults the declared type to
+// pick a list element type for the RHS expression. The only construct
+// that needs the hint today is `[]` / `[..]` (the empty and non-empty
+// list literals), which has no way to disambiguate `list<int>` vs
+// `list<float>` from the elements alone (empty has none; non-empty
+// integer literals would otherwise lower to TypeI64). For other RHS
+// shapes the hint is ignored.
+func (b *builder) lowerTypedLet(name string, tRef *parser.TypeRef, e *parser.Expr) error {
+	if e == nil {
+		return fmt.Errorf("frontend: binding %q has no initializer", name)
+	}
+	if tRef != nil {
+		t, err := lowerType(tRef)
+		if err != nil {
+			return fmt.Errorf("frontend: binding %q: %w", name, err)
+		}
+		switch t {
+		case ir.TypeList:
+			b.expectedListElem = ir.TypeI64
+		case ir.TypeF64Arr:
+			b.expectedListElem = ir.TypeF64
+		}
+	}
+	vid, err := b.lowerExpr(e)
+	b.expectedListElem = ir.TypeInvalid
 	if err != nil {
 		return err
 	}
@@ -983,8 +1043,9 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 		if idx.Colon != nil || idx.Colon2 != nil || idx.End != nil || idx.Step != nil || idx.Start == nil {
 			return 0, fmt.Errorf("frontend: slice indexing unsupported in MVP")
 		}
-		if b.fn.Values[cur].Type != ir.TypeList {
-			return 0, fmt.Errorf("frontend: index on non-list %s", b.fn.Values[cur].Type)
+		curType := b.fn.Values[cur].Type
+		if curType != ir.TypeList && curType != ir.TypeF64Arr {
+			return 0, fmt.Errorf("frontend: index on non-list %s", curType)
 		}
 		iID, err := b.lowerExpr(idx.Start)
 		if err != nil {
@@ -993,12 +1054,22 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 		if b.fn.Values[iID].Type != ir.TypeI64 {
 			return 0, fmt.Errorf("frontend: list index must be i64, got %s", b.fn.Values[iID].Type)
 		}
-		cur = b.addValue(ir.Value{
-			Type:     ir.TypeI64,
-			ElemType: ir.TypeI64,
-			Op:       ir.OpListGetI64,
-			Args:     []uint32{cur, iID},
-		})
+		switch curType {
+		case ir.TypeList:
+			cur = b.addValue(ir.Value{
+				Type:     ir.TypeI64,
+				ElemType: ir.TypeI64,
+				Op:       ir.OpListGetI64,
+				Args:     []uint32{cur, iID},
+			})
+		case ir.TypeF64Arr:
+			cur = b.addValue(ir.Value{
+				Type:     ir.TypeF64,
+				ElemType: ir.TypeF64,
+				Op:       ir.OpF64ArrayGetF64,
+				Args:     []uint32{cur, iID},
+			})
+		}
 	}
 	return cur, nil
 }
@@ -1031,35 +1102,65 @@ func (b *builder) lowerPrimary(p *parser.Primary) (uint32, error) {
 	return 0, fmt.Errorf("frontend: primary form unsupported in MVP")
 }
 
-// lowerListLiteral lowers `[e1, e2, ...]` to OpNewList plus a chain of
-// OpListPushI64 ops, one per element. The empty form `[]` produces an
-// OpNewList with ElemType=TypeI64; the type is inferred from the
-// context only when elements are present, otherwise it defaults to i64
-// (the MVP's sole supported element type). Non-i64 elements surface a
-// frontend error.
+// lowerListLiteral lowers `[e1, e2, ...]` to an empty-list constructor
+// (OpNewList for i64, OpNewF64Array for f64) plus a chain of push ops.
+// The element type is taken from b.expectedListElem when set (by a
+// `var xs: list<T> = ...` declaration), and falls back to i64 when
+// unset (matching the existing default for an untyped `[]`).
 func (b *builder) lowerListLiteral(lit *parser.ListLiteral) (uint32, error) {
-	listID := b.addValue(ir.Value{
-		Type:     ir.TypeList,
-		ElemType: ir.TypeI64,
-		Op:       ir.OpNewList,
-	})
-	for _, el := range lit.Elems {
-		vid, err := b.lowerExpr(el)
-		if err != nil {
-			return 0, err
-		}
-		if b.fn.Values[vid].Type != ir.TypeI64 {
-			return 0, fmt.Errorf("frontend: list literal element type %s unsupported (only i64 in MVP)",
-				b.fn.Values[vid].Type)
-		}
-		b.addValue(ir.Value{
-			Type:     ir.TypeUnit,
-			ElemType: ir.TypeI64,
-			Op:       ir.OpListPushI64,
-			Args:     []uint32{listID, vid},
-		})
+	elem := b.expectedListElem
+	if elem == ir.TypeInvalid {
+		elem = ir.TypeI64
 	}
-	return listID, nil
+	switch elem {
+	case ir.TypeI64:
+		listID := b.addValue(ir.Value{
+			Type:     ir.TypeList,
+			ElemType: ir.TypeI64,
+			Op:       ir.OpNewList,
+		})
+		for _, el := range lit.Elems {
+			vid, err := b.lowerExpr(el)
+			if err != nil {
+				return 0, err
+			}
+			if b.fn.Values[vid].Type != ir.TypeI64 {
+				return 0, fmt.Errorf("frontend: list<int> literal element type %s unsupported",
+					b.fn.Values[vid].Type)
+			}
+			b.addValue(ir.Value{
+				Type:     ir.TypeUnit,
+				ElemType: ir.TypeI64,
+				Op:       ir.OpListPushI64,
+				Args:     []uint32{listID, vid},
+			})
+		}
+		return listID, nil
+	case ir.TypeF64:
+		listID := b.addValue(ir.Value{
+			Type:     ir.TypeF64Arr,
+			ElemType: ir.TypeF64,
+			Op:       ir.OpNewF64Array,
+		})
+		for _, el := range lit.Elems {
+			vid, err := b.lowerExpr(el)
+			if err != nil {
+				return 0, err
+			}
+			if b.fn.Values[vid].Type != ir.TypeF64 {
+				return 0, fmt.Errorf("frontend: list<float> literal element type %s unsupported (write 1.0 not 1)",
+					b.fn.Values[vid].Type)
+			}
+			b.addValue(ir.Value{
+				Type:     ir.TypeUnit,
+				ElemType: ir.TypeF64,
+				Op:       ir.OpF64ArrayPushF64,
+				Args:     []uint32{listID, vid},
+			})
+		}
+		return listID, nil
+	}
+	return 0, fmt.Errorf("frontend: list literal with element type %s unsupported", elem)
 }
 
 func (b *builder) lowerLiteral(lit *parser.Literal) (uint32, error) {
@@ -1126,6 +1227,11 @@ func (b *builder) lowerBuiltinCall(c *parser.CallExpr) (uint32, bool, error) {
 				Type: ir.TypeI64, Op: ir.OpListLenI64, Args: []uint32{arg},
 			})
 			return id, true, nil
+		case ir.TypeF64Arr:
+			id := b.addValue(ir.Value{
+				Type: ir.TypeI64, Op: ir.OpF64ArrayLenI64, Args: []uint32{arg},
+			})
+			return id, true, nil
 		case ir.TypeStr:
 			id := b.addValue(ir.Value{
 				Type: ir.TypeI64, Op: ir.OpLenStr, Args: []uint32{arg},
@@ -1147,24 +1253,33 @@ func (b *builder) lowerBuiltinCall(c *parser.CallExpr) (uint32, bool, error) {
 		if err != nil {
 			return 0, true, err
 		}
-		if b.fn.Values[list].Type != ir.TypeList {
-			return 0, true, fmt.Errorf("frontend: append() target type %s unsupported (need list)",
-				b.fn.Values[list].Type)
+		listType := b.fn.Values[list].Type
+		valType := b.fn.Values[val].Type
+		switch listType {
+		case ir.TypeList:
+			if valType != ir.TypeI64 {
+				return 0, true, fmt.Errorf("frontend: append() to list<int> requires i64 value, got %s", valType)
+			}
+			b.addValue(ir.Value{
+				Type:     ir.TypeUnit,
+				ElemType: ir.TypeI64,
+				Op:       ir.OpListPushI64,
+				Args:     []uint32{list, val},
+			})
+			return list, true, nil
+		case ir.TypeF64Arr:
+			if valType != ir.TypeF64 {
+				return 0, true, fmt.Errorf("frontend: append() to list<float> requires f64 value, got %s", valType)
+			}
+			b.addValue(ir.Value{
+				Type:     ir.TypeUnit,
+				ElemType: ir.TypeF64,
+				Op:       ir.OpF64ArrayPushF64,
+				Args:     []uint32{list, val},
+			})
+			return list, true, nil
 		}
-		if b.fn.Values[val].Type != ir.TypeI64 {
-			return 0, true, fmt.Errorf("frontend: append() value type %s unsupported (need i64)",
-				b.fn.Values[val].Type)
-		}
-		// Push mutates the list in place; the SSA "result" of append
-		// is the same list value. The caller's `xs = append(xs, v)`
-		// rebinds the name to itself, which is correct.
-		b.addValue(ir.Value{
-			Type:     ir.TypeUnit,
-			ElemType: ir.TypeI64,
-			Op:       ir.OpListPushI64,
-			Args:     []uint32{list, val},
-		})
-		return list, true, nil
+		return 0, true, fmt.Errorf("frontend: append() target type %s unsupported (need list)", listType)
 	}
 	return 0, false, nil
 }

--- a/compiler3/frontend/lower_test.go
+++ b/compiler3/frontend/lower_test.go
@@ -235,6 +235,51 @@ print(fillFive())
 	}
 }
 
+// TestLowerListFloatLiteralAndIndex pins the Phase 4.3.3 list<float>
+// surface through the Go target: a non-empty literal lowers to
+// OpNewF64Array plus three OpF64ArrayPushF64 ops, and `xs[i]` lowers
+// to OpF64ArrayGetF64. The final print exercises the f64-to-string
+// path that print.h already supports.
+func TestLowerListFloatLiteralAndIndex(t *testing.T) {
+	src := `let xs: list<float> = [1.5, 2.5, 3.5]
+print(xs[1])
+`
+	got := runEnd2End(t, src)
+	if got != "2.5\n" {
+		t.Errorf("got %q, want %q", got, "2.5\n")
+	}
+}
+
+// TestLowerListFloatAppendAndIndex pins the empty-literal + append +
+// indexed read + indexed write + len cycle for list<float>, paralleling
+// the i64 list test from Phase 4.3.1. The body initialises three slots
+// to 0.0, sums them via len-bounded iteration, then writes back into
+// xs[0] and reads it again to confirm the set round-trips.
+func TestLowerListFloatAppendAndIndex(t *testing.T) {
+	src := `fun sumf(n: int): float {
+  var xs: list<float> = []
+  var i = 0
+  while i < n {
+    xs = append(xs, 0.5)
+    i = i + 1
+  }
+  var s = 0.0
+  var k = 0
+  while k < len(xs) {
+    s = s + xs[k]
+    k = k + 1
+  }
+  xs[0] = 100.5
+  return s + xs[0]
+}
+print(sumf(4))
+`
+	got := runEnd2End(t, src)
+	if got != "102.5\n" {
+		t.Errorf("got %q, want %q", got, "102.5\n")
+	}
+}
+
 // TestLowerNsieve is the load-bearing Phase 4.3.2 gate: a stripped
 // nsieve(100) returning the prime count (25). It exercises range-for
 // with nested while, indexed reads/writes, len(), and the synthetic

--- a/runtime/c/doc.go
+++ b/runtime/c/doc.go
@@ -24,5 +24,5 @@ import "embed"
 // files when cgo is off (and the whole point of this package is to
 // stay no-cgo on the build host).
 //
-//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c
+//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c src/mochi_f64_array.h src/mochi_f64_array.c
 var Runtime embed.FS

--- a/runtime/c/src/mochi_f64_array.c
+++ b/runtime/c/src/mochi_f64_array.c
@@ -1,0 +1,43 @@
+/*
+ * MEP-42 Phase 4.3.3 typed-f64 array runtime. See mochi_f64_array.h.
+ */
+#include "mochi_f64_array.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+mochi_f64_array *mochi_f64_array_new(void) {
+    mochi_f64_array *a = (mochi_f64_array *)malloc(sizeof(mochi_f64_array));
+    if (a == NULL) {
+        abort();
+    }
+    a->data = NULL;
+    a->len = 0;
+    a->cap = 0;
+    return a;
+}
+
+int64_t mochi_f64_array_len(const mochi_f64_array *a) {
+    return a->len;
+}
+
+void mochi_f64_array_push(mochi_f64_array *a, double v) {
+    if (a->len == a->cap) {
+        int64_t newcap = a->cap == 0 ? 4 : a->cap * 2;
+        double *nd = (double *)realloc(a->data, (size_t)newcap * sizeof(double));
+        if (nd == NULL) {
+            abort();
+        }
+        a->data = nd;
+        a->cap = newcap;
+    }
+    a->data[a->len++] = v;
+}
+
+double mochi_f64_array_get(const mochi_f64_array *a, int64_t i) {
+    return a->data[i];
+}
+
+void mochi_f64_array_set(mochi_f64_array *a, int64_t i, double v) {
+    a->data[i] = v;
+}

--- a/runtime/c/src/mochi_f64_array.h
+++ b/runtime/c/src/mochi_f64_array.h
@@ -1,0 +1,47 @@
+/*
+ * MEP-42 Phase 4.3.3 typed-f64 array runtime.
+ *
+ * Backs Mochi's list<float> when the program is compiled with
+ * `mochi build --target=c`. The IR ops OpNewF64Array, OpF64ArrayLenI64,
+ * OpF64ArrayPushF64, OpF64ArrayGetF64, and OpF64ArraySetF64 lower to
+ * calls into this header.
+ *
+ * Identity: pure C99, no libc beyond stdlib.h/stdint.h. Allocations are
+ * heap-resident and leak at process exit (mirroring mochi_list_i64).
+ * The growth strategy is doubling from a first-push capacity of 4.
+ *
+ * Why a separate type vs mochi_list_i64 with templated element width:
+ * Mochi's IR distinguishes TypeF64Arr from TypeList specifically so the
+ * C backend can emit a flat array of doubles (8 bytes/element) without
+ * the Cell-tag overhead the vm3 path needs. A type-parameterised
+ * approach would either need C macros (worsening the no-cgo identity
+ * by introducing build-time codegen) or void* + element-size threading
+ * (worsening cc -O2's ability to vectorise). Two near-identical headers
+ * is the smaller cost.
+ */
+#ifndef MOCHI_RUNTIME_C_F64_ARRAY_H
+#define MOCHI_RUNTIME_C_F64_ARRAY_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct mochi_f64_array {
+    double  *data;
+    int64_t  len;
+    int64_t  cap;
+} mochi_f64_array;
+
+mochi_f64_array *mochi_f64_array_new(void);
+int64_t mochi_f64_array_len(const mochi_f64_array *a);
+void mochi_f64_array_push(mochi_f64_array *a, double v);
+double mochi_f64_array_get(const mochi_f64_array *a, int64_t i);
+void mochi_f64_array_set(mochi_f64_array *a, int64_t i, double v);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOCHI_RUNTIME_C_F64_ARRAY_H */

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -664,9 +664,9 @@ This is the contract behind the §Top-line objective. Every IR `OpCode` and `Typ
 | `OpFnRef` | function-pointer literal | DEFERRED Phase 4.4 |
 | `OpLenStr` / `OpConcatStr` | `mochi_str_len` / `mochi_str_concat` | DEFERRED Phase 4.2 |
 | `OpNewList` / `OpListLenI64` / `OpListPushI64` / `OpListGetI64` / `OpListSetI64` | `mochi_list_i64_*` runtime (heap-allocated header, doubling growth) | LANDED (Phase 4.3.1) |
-| `OpListGetF64` / `OpListSetF64` | `mochi_list_f64_*` runtime | DEFERRED Phase 4.3.2 |
+| `OpListGetF64` / `OpListSetF64` | not lowered by the C target; `list<float>` routes through `OpNewF64Array` instead | N/A (vm3 surface) |
 | `OpNewMap` / `OpMapSet/Get/I64I64` | `mochi_map_*` runtime | DEFERRED Phase 4.3 |
-| `OpNewF64Array` / `OpF64Array*` | `mochi_f64arr_*` runtime | DEFERRED Phase 4.3 |
+| `OpNewF64Array` / `OpF64ArrayLenI64` / `OpF64ArrayPushF64` / `OpF64ArrayGetF64` / `OpF64ArraySetF64` | `mochi_f64_array_*` runtime (heap-allocated header, doubling growth, flat `double[]` backing) | LANDED (Phase 4.3.3) |
 | `OpQueryFilter/Map/SortBy/SortByDesc/Limit/Distinct/GroupBy` | inline C loops or runtime/c/query | DEFERRED Phase 4.4 |
 | `OpQueryJoin/LeftJoin/OuterJoin/CrossJoin` | inline C loops or runtime/c/query | DEFERRED Phase 4.4 |
 
@@ -725,7 +725,7 @@ Workloads in the "performance games" set that are NOT in this table, and why:
 
 | Workload | Why excluded |
 |----------|--------------|
-| `mandelbrot`, `n_body`, `spectral_norm` | Need `while`/`for` loops over `f64` arrays; loops landed in Phase 4.1.2, i64 lists landed in Phase 4.3.1, f64 lists blocked on Phase 4.3.2 |
+| `mandelbrot`, `n_body`, `spectral_norm` | f64 list primitives LANDED in Phase 4.3.3; the kernels are now expressible in the MVP grammar. Pinned by `TestBuildSourceListFloatLiteralAndIndex` and `TestBuildSourceListFloatAppendAndIndex`. Wiring the full benchmark fixtures into the C-target run harness is a §13 follow-up |
 | `nsieve` | LANDED in Phase 4.3.2 (range-for + if-merge phi joins land together; stripped nsieve(100)=25 pinned by C and Go target tests). The full benchmark uses identical primitives |
 | `fannkuch`, `binary_trees` | Need list-of-structs / struct-of-lists; i64 list primitive landed in Phase 4.3.1, struct support blocked on Phase 4.4, nesting on Phase 4.5 |
 | `fasta`, `regex_redux`, `k_nucleotide` | Need string literals and string ops; blocked on Phase 4.2 (TypeStr) |
@@ -998,6 +998,65 @@ print(nsieve(100))
 ```
 
 Compiles via `mochi build --target=c` (and `--target=go`) to a binary that prints `25\n`, matching `mochi run` on the same source.
+
+## §10.12 Phase 4.3.3 closeout (LANDED 2026-05-21 23:30 GMT+7)
+
+Phase 4.3.3 lands `list<float>` end-to-end: C runtime (`mochi_f64_array_*`), C emit (`cType(TypeF64Arr) = mochi_f64_array*`, auto-include of the header, five new op lowerings), and frontend coverage for the four surface forms (`[]` empty literal, `[1.5, 2.5, 3.5]` non-empty literal, `xs[i]` read, `xs[i] = v` write, plus `len(xs)` / `append(xs, v)` builtins against the new type). The IR + verify + Go-emit layers were already complete from the vm3 work; this PR adds the C-side runtime and the frontend dispatch. §10.6 moves the five `OpF64Array*` rows from DEFERRED to LANDED; §10.7 marks `mandelbrot`, `n_body`, and `spectral_norm` as no longer blocked on f64 lists.
+
+### Why TypeF64Arr instead of TypeList with ElemType=TypeF64
+
+The IR already has `OpListGetF64`/`OpListSetF64` ops that read/write f64 cells from a TypeList (the Cell-tagged heterogeneous list the vm3 path uses). The C target deliberately routes `list<float>` through `OpNewF64Array` + `OpF64Array*` instead: a flat `double[]` backing has no Cell-tag overhead, lets cc -O2 vectorise tight loops (the dominant cost in `n_body` and `spectral_norm`), and gives the Go target a proper `[]float64` slice. The cost is one extra IR type and one extra runtime file; the benefit is byte-for-byte the same access pattern as a C programmer would hand-write, which is what the "1-10 MB Crystal-like binary" objective requires. The `OpListGet/SetF64` ops remain in the IR for the vm3 surface but are not reachable from the C-target frontend today.
+
+### Files changed
+
+- `runtime/c/src/mochi_f64_array.h`, `runtime/c/src/mochi_f64_array.c`: new C99 header + impl (40 + 40 lines), mirroring the i64 list runtime but with `double` backing. Doubling growth from cap=4, `abort()` on alloc failure, leak-at-exit per MVP.
+- `runtime/c/doc.go`: extend `//go:embed` to include the two new files.
+- `compiler3/emit/c/emit.go`: add `usesF64Array` flag in pre-walk, auto-include `mochi_f64_array.h`, lower the five `OpF64Array*` ops, extend `cType` with the `TypeF64Arr` case.
+- `compiler3/frontend/lower.go`: extend `lowerType` to map `list<float>` to `TypeF64Arr`. Thread the declared element type from `var x: list<T>` into the literal lowering via a new `expectedListElem` builder field set by a new `lowerTypedLet` helper. Extend `lowerListLiteral` to dispatch on the hint and emit either i64 or f64 ops. Extend `lowerIndexedAssign`, `lowerPostfix` index, and `lowerBuiltinCall` (len + append) to dispatch on the list value's IR type.
+- `compiler3/frontend/lower_test.go`: two new tests, `TestLowerListFloatLiteralAndIndex` (literal `[1.5, 2.5, 3.5]` read), `TestLowerListFloatAppendAndIndex` (full cycle: `[]` + append + len + index read + index write + read-back, returning 102.5).
+- `compiler3/build/c/driver_test.go`: matching two integration tests through the C target, byte-for-byte against the Go target.
+- `website/docs/mep/mep-0042.md`: this section, §10.6 update, §10.7 `mandelbrot`/`n_body`/`spectral_norm` row update.
+
+### Element-type hint vs. element-type inference
+
+Mochi list literals carry no surface annotation: `[]` and `[1.5, 2.5, 3.5]` look the same whether the user wants a `list<int>` or a `list<float>`. Two options for resolving:
+
+1. **Hint from declared LHS type**: when `var xs: list<float> = ...` is lowered, the binding's declared type drives the literal's element type. Empty literals work; non-empty literals would still need every element to type-check as the declared elem.
+2. **Pure element-type inference**: walk the literal's elements, take their common type, then default to i64 for empty. The downside: empty literals must be re-typed at first append, which complicates the SSA discipline (the SSA value's IR type would have to update after creation, a change the IR validator does not currently allow).
+
+This PR uses option (1). The hint lives on a `expectedListElem` field on the builder that `lowerTypedLet` sets just before `lowerExpr` and clears immediately after. Only `lowerListLiteral` consults it. The hint flows through the parser's `Expr` → `Binary` → `Unary` → `Postfix` → `Primary` → `List` chain because it is read at the leaf, not threaded through the arguments. If the user writes `var xs: list<float> = []` then later assigns from a different-typed expression to `xs`, the type mismatch surfaces at the assign-statement type check, not at the literal lowering.
+
+A consequence: a list<float> literal must use `1.0`, not `1` (Mochi int literals lower to TypeI64; the integer-to-float coercion op `OpI64ToF64` does not exist in this IR layer). The error message at the rejected element points the user at the fix.
+
+### Limitations
+
+- The benchmark games fixtures (`bench/template/bg/n_body`, `bench/template/bg/mandelbrot`, `bench/template/bg/spectral_norm`) are not yet wired into the C-target run harness. The kernels are expressible after this PR; the missing piece is the driver wiring, which is the §13 (workflow) closeout's responsibility.
+- No iteration over a `list<float>` via `for x in xs` yet (collection-iter remains rejected); kernels must use the `while i < len(xs)` pattern. The §10.11 closeout's "for-collection unblock" entry stands for both `list<int>` and `list<float>` once it lands.
+- The `OpListGet/SetF64` opcodes are still IR-reachable from the vm3 path, but the C-target frontend does not lower to them; any future Mochi-source path that needs Cell-tagged f64 reads (e.g., a heterogeneous query result) would have to route through TypeList rather than TypeF64Arr.
+
+### Reproducer
+
+```mochi
+fun sumf(n: int): float {
+  var xs: list<float> = []
+  var i = 0
+  while i < n {
+    xs = append(xs, 0.5)
+    i = i + 1
+  }
+  var s = 0.0
+  var k = 0
+  while k < len(xs) {
+    s = s + xs[k]
+    k = k + 1
+  }
+  xs[0] = 100.5
+  return s + xs[0]
+}
+print(sumf(4))
+```
+
+Compiles via `mochi build --target=c` (and `--target=go`) to a binary that prints `102.5\n`, matching `mochi run` on the same source.
 
 ## §11 Risks
 


### PR DESCRIPTION
## Summary

Phase 4.3.3 of MEP-42 §10.12. Brings `list<float>` through compiler3 to the C target end-to-end, so n_body / mandelbrot / spectral_norm are no longer blocked on the type of their working arrays.

- New `mochi_f64_array` runtime (header + impl). Distinct backing from `mochi_list_i64` so cc -O2 can vectorise the float kernels. Doubling growth from cap=4, leak at exit.
- C emit lowers the five OpF64Array* ops (new/len/push/get/set) to runtime calls. Pre-walk auto-includes `mochi_f64_array.h` only when needed. cType maps `ir.TypeF64Arr` to `mochi_f64_array*`.
- Frontend: `list<float>` lowers to `ir.TypeF64Arr`. A new `expectedListElem` hint on the builder (set by `lowerTypedLet` from the declared LHS type) drives empty-literal element type. lowerListLiteral, lowerIndexedAssign, the index postfix, and lowerBuiltinCall for `len` / `append` now dispatch on TypeList vs TypeF64Arr.

## Tests

- `compiler3/frontend/lower_test.go`: TestLowerListFloatLiteralAndIndex, TestLowerListFloatAppendAndIndex
- `compiler3/build/c/driver_test.go`: TestBuildSourceListFloatLiteralAndIndex, TestBuildSourceListFloatAppendAndIndex

Full compiler3 suite green.

## Spec

- §10.6: OpF64Array* row moved DEFERRED → LANDED Phase 4.3.3. OpListGet/SetF64 stays N/A (vm3 surface, not lowered by the C target).
- §10.7: nsieve row LANDED Phase 4.3.2. The n_body / mandelbrot / spectral_norm row updated to note f64 list primitives LANDED in Phase 4.3.3.
- §10.12: closeout for Phase 4.3.3 with timestamp, files, limitations, and reproducer.

## Limitations

- No i64-to-f64 promotion at literal sites; f64 lists require f64 element literals (`1.0` not `1`). Diagnostic points at the fix.
- No collection-form `for x in xs` yet. Range-for over int only.
- Benchmark fixtures (bench/template/bg/{n_body, mandelbrot, spectral_norm}) aren't yet wired into the C-target run harness. §13 follow-up.

## Test plan

- [x] `go test ./compiler3/frontend/...`
- [x] `go test ./compiler3/build/c/...`
- [x] `go test ./compiler3/...`

Closes #21963.