### PR TITLE
mep-0042: Phase 4.3.4 i64<->f64 casts, unblocks mandelbrot kernel

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -377,6 +377,70 @@ print(nsieve(100))
 	}
 }
 
+// TestBuildSourceCastIntToFloatRoundTrip pins the Phase 4.3.4 cast
+// surface through the C target: `n as float` lowers to OpI64ToF64
+// (emits `(double)n`), and `f as int` to OpF64ToI64 (`(int64_t)f`).
+// The constant 7 round-trips through f64 arithmetic without loss.
+func TestBuildSourceCastIntToFloatRoundTrip(t *testing.T) {
+	src := `let n = 7
+let f = (n as float) / 2.0
+let back = (f * 2.0) as int
+print(back + n)
+`
+	if got, want := runMochiBuild(t, src), "14\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceMandelbrotKernel is the Phase 4.3.4 load-bearing
+// gate: a stripped mandelbrot kernel that compiles via
+// `mochi build --target=c` and produces 4629 for a 16x16 grid with
+// max_iter=50. The program exercises int<->float casts inside nested
+// while loops with early return inside if. This is the program the
+// benchmark games' mandelbrot fixture reduces to once the harness's
+// `now()` / `json({...})` instrumentation is removed.
+func TestBuildSourceMandelbrotKernel(t *testing.T) {
+	src := `fun escape_count(cx: float, cy: float, max_iter: int): int {
+  var zr = 0.0
+  var zi = 0.0
+  var n = 0
+  while n < max_iter {
+    let r2 = zr * zr
+    let i2 = zi * zi
+    if r2 + i2 > 4.0 {
+      return n
+    }
+    let nzi = 2.0 * zr * zi + cy
+    let nzr = (r2 - i2) + cx
+    zr = nzr
+    zi = nzi
+    n = n + 1
+  }
+  return max_iter
+}
+
+let side = 16
+let max_iter = 50
+let side_f = side as float
+var total = 0
+var row = 0
+while row < side {
+  let cy = (row as float) / side_f * 2.0 - 1.0
+  var col = 0
+  while col < side {
+    let cx = (col as float) / side_f * 3.0 - 2.0
+    total = total + escape_count(cx, cy, max_iter)
+    col = col + 1
+  }
+  row = row + 1
+}
+print(total)
+`
+	if got, want := runMochiBuild(t, src), "4629\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceFibIter is the §10.7 unblock for the iterative Fib
 // benchmark: while loop, mutated `a`/`b`/`i`, and a `let t` inside the
 // body that the phi-at-header must NOT track (it's body-scoped).

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -305,6 +305,10 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    %s = (%s %s %s) ? 1 : 0;\n", name, valueName(v.Args[0]), op, valueName(v.Args[1]))
 	case ir.OpNotBool:
 		fmt.Fprintf(w, "    %s = %s ? 0 : 1;\n", name, valueName(v.Args[0]))
+	case ir.OpI64ToF64:
+		fmt.Fprintf(w, "    %s = (double)%s;\n", name, valueName(v.Args[0]))
+	case ir.OpF64ToI64:
+		fmt.Fprintf(w, "    %s = (int64_t)%s;\n", name, valueName(v.Args[0]))
 	case ir.OpNewList:
 		// New empty list: allocates a header on the heap with NULL data.
 		// The first push lazily reserves capacity; this matches the

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -264,6 +264,10 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 		fmt.Fprintf(w, "\t%s = %s %s %s\n", name, valueName(v.Args[0]), op, valueName(v.Args[1]))
 	case ir.OpNotBool:
 		fmt.Fprintf(w, "\t%s = !%s\n", name, valueName(v.Args[0]))
+	case ir.OpI64ToF64:
+		fmt.Fprintf(w, "\t%s = float64(%s)\n", name, valueName(v.Args[0]))
+	case ir.OpF64ToI64:
+		fmt.Fprintf(w, "\t%s = int64(%s)\n", name, valueName(v.Args[0]))
 	case ir.OpLenStr:
 		fmt.Fprintf(w, "\t%s = int64(len(%s))\n", name, valueName(v.Args[0]))
 	case ir.OpConcatStr:

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1036,39 +1036,61 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 		return 0, err
 	}
 	for _, op := range pe.Ops {
-		if op.Index == nil {
-			return 0, fmt.Errorf("frontend: non-index postfix unsupported in MVP")
-		}
-		idx := op.Index
-		if idx.Colon != nil || idx.Colon2 != nil || idx.End != nil || idx.Step != nil || idx.Start == nil {
-			return 0, fmt.Errorf("frontend: slice indexing unsupported in MVP")
-		}
-		curType := b.fn.Values[cur].Type
-		if curType != ir.TypeList && curType != ir.TypeF64Arr {
-			return 0, fmt.Errorf("frontend: index on non-list %s", curType)
-		}
-		iID, err := b.lowerExpr(idx.Start)
-		if err != nil {
-			return 0, err
-		}
-		if b.fn.Values[iID].Type != ir.TypeI64 {
-			return 0, fmt.Errorf("frontend: list index must be i64, got %s", b.fn.Values[iID].Type)
-		}
-		switch curType {
-		case ir.TypeList:
-			cur = b.addValue(ir.Value{
-				Type:     ir.TypeI64,
-				ElemType: ir.TypeI64,
-				Op:       ir.OpListGetI64,
-				Args:     []uint32{cur, iID},
-			})
-		case ir.TypeF64Arr:
-			cur = b.addValue(ir.Value{
-				Type:     ir.TypeF64,
-				ElemType: ir.TypeF64,
-				Op:       ir.OpF64ArrayGetF64,
-				Args:     []uint32{cur, iID},
-			})
+		switch {
+		case op.Index != nil:
+			idx := op.Index
+			if idx.Colon != nil || idx.Colon2 != nil || idx.End != nil || idx.Step != nil || idx.Start == nil {
+				return 0, fmt.Errorf("frontend: slice indexing unsupported in MVP")
+			}
+			curType := b.fn.Values[cur].Type
+			if curType != ir.TypeList && curType != ir.TypeF64Arr {
+				return 0, fmt.Errorf("frontend: index on non-list %s", curType)
+			}
+			iID, err := b.lowerExpr(idx.Start)
+			if err != nil {
+				return 0, err
+			}
+			if b.fn.Values[iID].Type != ir.TypeI64 {
+				return 0, fmt.Errorf("frontend: list index must be i64, got %s", b.fn.Values[iID].Type)
+			}
+			switch curType {
+			case ir.TypeList:
+				cur = b.addValue(ir.Value{
+					Type:     ir.TypeI64,
+					ElemType: ir.TypeI64,
+					Op:       ir.OpListGetI64,
+					Args:     []uint32{cur, iID},
+				})
+			case ir.TypeF64Arr:
+				cur = b.addValue(ir.Value{
+					Type:     ir.TypeF64,
+					ElemType: ir.TypeF64,
+					Op:       ir.OpF64ArrayGetF64,
+					Args:     []uint32{cur, iID},
+				})
+			}
+		case op.Cast != nil:
+			// Phase 4.3.4: `x as float` / `x as int` for the i64<->f64
+			// pair. Other numeric widenings and any non-numeric cast
+			// stay rejected so the harness skips the fixture rather
+			// than miscompiling.
+			dst, err := lowerType(op.Cast.Type)
+			if err != nil {
+				return 0, fmt.Errorf("frontend: cast target: %w", err)
+			}
+			src := b.fn.Values[cur].Type
+			switch {
+			case src == dst:
+				// no-op cast; preserve SSA shape.
+			case src == ir.TypeI64 && dst == ir.TypeF64:
+				cur = b.addValue(ir.Value{Type: ir.TypeF64, Op: ir.OpI64ToF64, Args: []uint32{cur}})
+			case src == ir.TypeF64 && dst == ir.TypeI64:
+				cur = b.addValue(ir.Value{Type: ir.TypeI64, Op: ir.OpF64ToI64, Args: []uint32{cur}})
+			default:
+				return 0, fmt.Errorf("frontend: cast %s -> %s unsupported in MVP", src, dst)
+			}
+		default:
+			return 0, fmt.Errorf("frontend: non-index/non-cast postfix unsupported in MVP")
 		}
 	}
 	return cur, nil

--- a/compiler3/frontend/lower_test.go
+++ b/compiler3/frontend/lower_test.go
@@ -280,6 +280,69 @@ print(sumf(4))
 	}
 }
 
+// TestLowerCastIntToFloatRoundTrip pins the Phase 4.3.4 `as` cast
+// surface: an i64 widened to f64 and the result floored back through
+// `as int`. The constant 7 round-trips through f64 arithmetic without
+// loss, so the program prints 7 plus the original sum.
+func TestLowerCastIntToFloatRoundTrip(t *testing.T) {
+	src := `let n = 7
+let f = (n as float) / 2.0
+let back = (f * 2.0) as int
+print(back + n)
+`
+	got := runEnd2End(t, src)
+	if got != "14\n" {
+		t.Errorf("got %q, want %q", got, "14\n")
+	}
+}
+
+// TestLowerMandelbrotKernel is the load-bearing Phase 4.3.4 gate: a
+// stripped mandelbrot kernel that exercises int<->float casts inside
+// nested while loops with early return inside if. The Go and C targets
+// both produce 4629 for a 16x16 grid with max_iter=50.
+func TestLowerMandelbrotKernel(t *testing.T) {
+	src := `fun escape_count(cx: float, cy: float, max_iter: int): int {
+  var zr = 0.0
+  var zi = 0.0
+  var n = 0
+  while n < max_iter {
+    let r2 = zr * zr
+    let i2 = zi * zi
+    if r2 + i2 > 4.0 {
+      return n
+    }
+    let nzi = 2.0 * zr * zi + cy
+    let nzr = (r2 - i2) + cx
+    zr = nzr
+    zi = nzi
+    n = n + 1
+  }
+  return max_iter
+}
+
+let side = 16
+let max_iter = 50
+let side_f = side as float
+var total = 0
+var row = 0
+while row < side {
+  let cy = (row as float) / side_f * 2.0 - 1.0
+  var col = 0
+  while col < side {
+    let cx = (col as float) / side_f * 3.0 - 2.0
+    total = total + escape_count(cx, cy, max_iter)
+    col = col + 1
+  }
+  row = row + 1
+}
+print(total)
+`
+	got := runEnd2End(t, src)
+	if got != "4629\n" {
+		t.Errorf("got %q, want %q", got, "4629\n")
+	}
+}
+
 // TestLowerNsieve is the load-bearing Phase 4.3.2 gate: a stripped
 // nsieve(100) returning the prime count (25). It exercises range-for
 // with nested while, indexed reads/writes, len(), and the synthetic

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -213,6 +213,13 @@ const (
 	// `!` is a single operator with no fall-through so it carries its
 	// own opcode.
 	OpNotBool
+
+	// Numeric type conversions (Phase 4.3.4). OpI64ToF64 is the Mochi
+	// `x as float` cast on an i64 value (lossless on the int64 range);
+	// OpF64ToI64 is `x as int` (C99 truncation toward zero, matching the
+	// Go target's `int64(f64)` semantics).
+	OpI64ToF64
+	OpF64ToI64
 )
 
 // String renders an OpCode's short name. Used by Validate and IR
@@ -373,6 +380,10 @@ func (o OpCode) String() string {
 		return "cmp.ge.f64"
 	case OpNotBool:
 		return "not.bool"
+	case OpI64ToF64:
+		return "i64.to.f64"
+	case OpF64ToI64:
+		return "f64.to.i64"
 	}
 	return "?"
 }

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -213,6 +213,10 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeBool, [3]Type{TypeF64, TypeF64}}
 	case OpNotBool:
 		return opSig{TypeBool, [3]Type{TypeBool}}
+	case OpI64ToF64:
+		return opSig{TypeF64, [3]Type{TypeI64}}
+	case OpF64ToI64:
+		return opSig{TypeI64, [3]Type{TypeF64}}
 	}
 	// OpParam, OpConst, OpPhi, OpCall, OpTailCall: the validator
 	// can't pre-compute their signature without more context, so we

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -156,7 +156,8 @@ func kindOf(o ir.OpCode) ProducerKind {
 		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm,
 		ir.OpAndI64, ir.OpOrI64, ir.OpXorI64, ir.OpShlI64, ir.OpShrI64, ir.OpNotI64,
 		ir.OpCmpEqF64, ir.OpCmpNeF64, ir.OpCmpLtF64, ir.OpCmpLeF64, ir.OpCmpGtF64, ir.OpCmpGeF64,
-		ir.OpNotBool:
+		ir.OpNotBool,
+		ir.OpI64ToF64, ir.OpF64ToI64:
 		return KindOperator
 
 	case ir.OpLenStr:
@@ -213,7 +214,7 @@ func init() {
 // the last OpCode known to ir/types.go at this MEP-41 Phase 1 commit;
 // adding a new op past it bumps this constant in the same PR.
 func mustClassifyAll() {
-	const lastOpCode = ir.OpNotBool
+	const lastOpCode = ir.OpF64ToI64
 	for o := ir.OpInvalid + 1; o <= lastOpCode; o++ {
 		if kindOf(o) == KindInvalid {
 			panic(fmt.Sprintf("verify: OpCode %s (=%d) is unclassified; extend kindOf in compiler3/verify/verify.go (MEP-41 §6.2 rule class C / coverage backstop)", o, o))

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -725,7 +725,7 @@ Workloads in the "performance games" set that are NOT in this table, and why:
 
 | Workload | Why excluded |
 |----------|--------------|
-| `mandelbrot`, `n_body`, `spectral_norm` | f64 list primitives LANDED in Phase 4.3.3; the kernels are now expressible in the MVP grammar. Pinned by `TestBuildSourceListFloatLiteralAndIndex` and `TestBuildSourceListFloatAppendAndIndex`. Wiring the full benchmark fixtures into the C-target run harness is a §13 follow-up |
+| `mandelbrot`, `n_body`, `spectral_norm` | f64 list primitives LANDED in Phase 4.3.3 and i64↔f64 casts LANDED in Phase 4.3.4; `mandelbrot`'s 16×16 kernel pinned end-to-end through the C target by `TestBuildSourceMandelbrotKernel` (output `4629`). `n_body` and `spectral_norm` still need top-level `var` at module scope (n_body), `int(...)` / `float(...)` function-call cast form (spectral_norm), and the `bench/template/bg/*` harness shape (`now()`, `json({...})`, `{{ .N }}`). Wiring those is a §13 follow-up |
 | `nsieve` | LANDED in Phase 4.3.2 (range-for + if-merge phi joins land together; stripped nsieve(100)=25 pinned by C and Go target tests). The full benchmark uses identical primitives |
 | `fannkuch`, `binary_trees` | Need list-of-structs / struct-of-lists; i64 list primitive landed in Phase 4.3.1, struct support blocked on Phase 4.4, nesting on Phase 4.5 |
 | `fasta`, `regex_redux`, `k_nucleotide` | Need string literals and string ops; blocked on Phase 4.2 (TypeStr) |
@@ -1057,6 +1057,90 @@ print(sumf(4))
 ```
 
 Compiles via `mochi build --target=c` (and `--target=go`) to a binary that prints `102.5\n`, matching `mochi run` on the same source.
+
+## §10.13 Phase 4.3.4 closeout (LANDED 2026-05-21 23:50 GMT+7)
+
+Phase 4.3.4 lands the i64↔f64 `as` cast through compiler3 to both targets. The stripped mandelbrot kernel (16×16 grid, max_iter=50) now compiles end-to-end via `mochi build --target=c` and produces `4629`, byte-matching the Go target. This was the last surface gap blocking the mandelbrot kernel before harness instrumentation (`now()`, `json({...})`, `{{ .N }}` template expansion); the §10.7 mandelbrot row moves from "loops + f64 arithmetic" to "blocked only on benchmark harness shape".
+
+### IR additions
+
+Two new opcodes: `OpI64ToF64` (i64 → f64, lossless on the int64 range) and `OpF64ToI64` (f64 → i64, C99 truncation toward zero, matching the Go target's `int64(f64)`). Both are nullary-arity producers (one Arg, one result). Validate gives them `(TypeI64) → TypeF64` and `(TypeF64) → TypeI64` signatures respectively. verify/kindOf classifies them as `KindOperator` and `lastOpCode` advances to `OpF64ToI64`.
+
+### Frontend wiring
+
+The CastOp branch in `lowerPostfix` is now a real case, not the catch-all reject. It lowers `op.Cast.Type` via the existing `lowerType` and dispatches on the source/target IR-type pair:
+
+- `src == dst`: no-op (preserves SSA shape; useful for `x as int` on an already-i64 value, which costs nothing).
+- `i64 → f64`: emit `OpI64ToF64`.
+- `f64 → i64`: emit `OpF64ToI64`.
+- anything else: rejected with `cast %s -> %s unsupported in MVP`, so the A/B harness skips the fixture rather than miscompiling.
+
+The CastOp loop sits inside the existing per-Op walk in `lowerPostfix`, so casts compose with indexing (`xs[i] as float`) and chain with other casts (`(x as float) as int`).
+
+### Emit
+
+- Go target: `float64(v)` and `int64(v)` casts at the use site (no helper).
+- C target: `(double)v` and `(int64_t)v` casts at the use site (no helper). cc -O2 folds these into the surrounding fp/int register move when used as an operand to an arithmetic op, which is the path the mandelbrot inner loop relies on.
+
+### Files changed
+
+- `compiler3/ir/types.go`: add `OpI64ToF64`/`OpF64ToI64` constants and `String()` cases.
+- `compiler3/ir/validate.go`: add op signatures.
+- `compiler3/verify/verify.go`: classify both ops as `KindOperator`; advance `lastOpCode`.
+- `compiler3/emit/go/emit.go`: emit Go-side casts.
+- `compiler3/emit/c/emit.go`: emit C-side casts.
+- `compiler3/frontend/lower.go`: real CastOp branch in `lowerPostfix` with source/target pair dispatch.
+- `compiler3/frontend/lower_test.go`: `TestLowerCastIntToFloatRoundTrip` (7 round-trips through f64 arithmetic) and `TestLowerMandelbrotKernel` (the load-bearing 16×16 mandelbrot kernel returning 4629).
+- `compiler3/build/c/driver_test.go`: matching two integration tests through the C target.
+- `website/docs/mep/mep-0042.md`: this section; §10.7 mandelbrot/n_body/spectral_norm row updated to drop the cast blocker.
+
+### Reproducer
+
+```mochi
+fun escape_count(cx: float, cy: float, max_iter: int): int {
+  var zr = 0.0
+  var zi = 0.0
+  var n = 0
+  while n < max_iter {
+    let r2 = zr * zr
+    let i2 = zi * zi
+    if r2 + i2 > 4.0 {
+      return n
+    }
+    let nzi = 2.0 * zr * zi + cy
+    let nzr = (r2 - i2) + cx
+    zr = nzr
+    zi = nzi
+    n = n + 1
+  }
+  return max_iter
+}
+
+let side = 16
+let max_iter = 50
+let side_f = side as float
+var total = 0
+var row = 0
+while row < side {
+  let cy = (row as float) / side_f * 2.0 - 1.0
+  var col = 0
+  while col < side {
+    let cx = (col as float) / side_f * 3.0 - 2.0
+    total = total + escape_count(cx, cy, max_iter)
+    col = col + 1
+  }
+  row = row + 1
+}
+print(total)
+```
+
+Compiles via `mochi build --target=c` (and `--target=go`) to a binary that prints `4629\n`, matching `mochi run` on the same source. Pinned by `TestBuildSourceMandelbrotKernel`.
+
+### Limitations
+
+- No `int(x)` / `float(x)` function-call cast form yet (used by `spectral_norm.mochi`); the postfix `as` form is the only supported surface in this sub-phase. Adding the function-call form is mostly parser routing and would be a fast follow.
+- No widening between f32 and f64 (Mochi has no `f32` surface; f64 is the only float type).
+- The benchmark-games mandelbrot fixture itself still needs `now()`, `json({...})`, and `{{ .N }}` template expansion before it runs as-shipped from `bench/template/bg/mandelbrot/`. The §13 (workflow) closeout owns wiring those harness pieces.
 
 ## §11 Risks
 


### PR DESCRIPTION
## Summary

Phase 4.3.4 of MEP-42 §10.13. Adds the i64<->f64 `as` cast through compiler3, so the stripped mandelbrot kernel (16x16 grid, max_iter=50) now compiles end-to-end via `mochi build --target=c` and prints `4629`, byte-matching the Go target.

- IR: new opcodes `OpI64ToF64` / `OpF64ToI64`, validated, classified `KindOperator` by verify/kindOf, `lastOpCode` advanced to `OpF64ToI64`.
- Frontend: the CastOp branch in `lowerPostfix` is now a real case. It dispatches on the source/target IR-type pair (same: no-op; i64->f64: `OpI64ToF64`; f64->i64: `OpF64ToI64`; anything else: rejected so the A/B harness skips rather than miscompiles).
- Emit: Go target lowers to `float64(v)` / `int64(v)`; C target lowers to `(double)v` / `(int64_t)v`. cc -O2 folds these into surrounding fp/int register moves, which is the path the mandelbrot inner loop relies on.

## Tests

- `compiler3/frontend/lower_test.go`: TestLowerCastIntToFloatRoundTrip, TestLowerMandelbrotKernel
- `compiler3/build/c/driver_test.go`: TestBuildSourceCastIntToFloatRoundTrip, TestBuildSourceMandelbrotKernel

Full `go test ./compiler3/...` is green.

## Spec

- §10.13: closeout for Phase 4.3.4 with timestamp, IR additions, frontend wiring, emit shape, limitations, and the reproducer.
- §10.7: mandelbrot / n_body / spectral_norm row updated to drop the cast blocker and call out the remaining n_body / spectral_norm gaps (top-level `var`, function-call cast form, benchmark-harness shape).

## Limitations

- No `int(x)` / `float(x)` function-call cast form yet (used by spectral_norm.mochi). Postfix `as` only.
- No f32 (Mochi has no f32 surface).
- The benchmark-games mandelbrot fixture itself still needs `now()`, `json({...})`, and `{{ .N }}` template expansion before it runs as-shipped from `bench/template/bg/mandelbrot/`. §13 follow-up.

## Test plan

- [x] `go test ./compiler3/frontend/...`
- [x] `go test ./compiler3/build/c/...`
- [x] `go test ./compiler3/...`

Closes #21965.