### PR TITLE
mep-0042: Phase 4.3.5 math.sqrt + operator precedence fix

### DIFF
--- a/compiler3/build/c/driver.go
+++ b/compiler3/build/c/driver.go
@@ -105,6 +105,12 @@ func Build(p *cgen.Program, opts Options) (Result, error) {
 	args = append(args, opts.CCFlags...)
 	args = append(args, "-o", binPath, srcPath)
 	args = append(args, runtimeSources...)
+	// Always link with libm. The C target's emit.go unconditionally
+	// includes <math.h>, and Phase 4.3.5 onward emits real math
+	// builtins (sqrt and friends). On glibc/musl Linux libm is a
+	// separate archive; on macOS / *BSD the symbols live in libSystem
+	// so -lm is a no-op there. Either way it is harmless.
+	args = append(args, "-lm")
 
 	cmd := exec.Command(cc, args...)
 	out, err := cmd.CombinedOutput()

--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -441,6 +441,63 @@ print(total)
 	}
 }
 
+// TestBuildSourceMathSqrtBuiltin pins the Phase 4.3.5 math.sqrt
+// builtin through the C target: the `import python "math"` plus
+// `extern fun math.sqrt(x: float): float` declarations are accepted
+// as no-op bindings, and the call site lowers to OpSqrtF64 which
+// the C emitter renders as `sqrt(v)` and the driver links with -lm.
+// sqrt(2) * sqrt(2) round-trips through f64 to 2 cast to int.
+func TestBuildSourceMathSqrtBuiltin(t *testing.T) {
+	src := `import python "math" as math
+extern fun math.sqrt(x: float): float
+
+let r = math.sqrt(2.0) * math.sqrt(2.0)
+print(r as int)
+`
+	if got, want := runMochiBuild(t, src), "2\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceNbodyDistanceKernel pins the n_body softened-distance
+// expression `1 / (d2 * sqrt(d2))` through the C target for a 3-4-5
+// right triangle: d2 = 25, sqrt(25) = 5, 1/(25*5) = 0.008. Scaled by
+// 1e9 and cast to int, the result is 8000000. This is the load-bearing
+// Phase 4.3.5 gate for the n_body kernel: math.sqrt + the precedence-
+// climbing fix (without precedence, `dx*dx + dy*dy + dz*dz` evaluated
+// left-to-right gave a wrong d2 and the test would fail with INT64_MAX
+// from NaN-to-int).
+func TestBuildSourceNbodyDistanceKernel(t *testing.T) {
+	src := `import python "math" as math
+extern fun math.sqrt(x: float): float
+
+let dx = 3.0
+let dy = 4.0
+let dz = 0.0
+let d2 = dx * dx + dy * dy + dz * dz
+let factor = 1.0 / (d2 * math.sqrt(d2))
+print((factor * 1.0e9) as int)
+`
+	if got, want := runMochiBuild(t, src), "8000000\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourcePrecedenceClimbing pins the Phase 4.3.5 precedence-
+// climbing reducer in lowerBinary: `1 + 2 * 3` must be `1 + (2*3)` = 7,
+// not the previous left-assoc shape `((1+2)*3)` = 9. Without this,
+// every multi-operator non-parenthesised expression in the benchmark
+// games would silently miscompile.
+func TestBuildSourcePrecedenceClimbing(t *testing.T) {
+	src := `print(1 + 2 * 3)
+print(2 * 3 + 4)
+print(1 + 2 * 3 + 4 * 5)
+`
+	if got, want := runMochiBuild(t, src), "7\n10\n27\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceFibIter is the §10.7 unblock for the iterative Fib
 // benchmark: while loop, mutated `a`/`b`/`i`, and a `let t` inside the
 // body that the phi-at-header must NOT track (it's body-scoped).

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -309,6 +309,8 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    %s = (double)%s;\n", name, valueName(v.Args[0]))
 	case ir.OpF64ToI64:
 		fmt.Fprintf(w, "    %s = (int64_t)%s;\n", name, valueName(v.Args[0]))
+	case ir.OpSqrtF64:
+		fmt.Fprintf(w, "    %s = sqrt(%s);\n", name, valueName(v.Args[0]))
 	case ir.OpNewList:
 		// New empty list: allocates a header on the heap with NULL data.
 		// The first push lazily reserves capacity; this matches the

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -268,6 +268,9 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 		fmt.Fprintf(w, "\t%s = float64(%s)\n", name, valueName(v.Args[0]))
 	case ir.OpF64ToI64:
 		fmt.Fprintf(w, "\t%s = int64(%s)\n", name, valueName(v.Args[0]))
+	case ir.OpSqrtF64:
+		imports["math"] = true
+		fmt.Fprintf(w, "\t%s = math.Sqrt(%s)\n", name, valueName(v.Args[0]))
 	case ir.OpLenStr:
 		fmt.Fprintf(w, "\t%s = int64(len(%s))\n", name, valueName(v.Args[0]))
 	case ir.OpConcatStr:

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -86,10 +86,15 @@ func Lower(prog *parser.Program) (*gogen.Program, error) {
 	}
 
 	// Wrap top-level (non-fun) statements in a synthetic `main`. If
-	// there are no top-level statements, no main is emitted.
+	// there are no top-level statements, no main is emitted. Import
+	// and ExternFun declarations are recognised here as binding-only
+	// statements: they advertise a name (e.g. `math.sqrt`) that the
+	// frontend resolves through a builtin path rather than as a real
+	// call into a Mochi function, so no IR is emitted for them.
 	var topLevel []*parser.Statement
 	for _, st := range prog.Statements {
-		if st.Fun != nil || st.Import != nil {
+		if st.Fun != nil || st.Import != nil || st.ExternFun != nil ||
+			st.ExternVar != nil || st.ExternType != nil || st.ExternObject != nil {
 			continue
 		}
 		topLevel = append(topLevel, st)
@@ -873,21 +878,62 @@ func (b *builder) lowerBinary(be *parser.BinaryExpr) (uint32, error) {
 	if len(be.Right) == 0 {
 		return left, nil
 	}
-	// MVP: left-associative without precedence; sufficient for the
-	// numeric fixtures because most have only one operator or
-	// fully-parenthesised expressions.
-	cur := left
+	// Phase 4.3.5: lower with standard operator precedence (Shunting-
+	// Yard reduction). The parser yields a flat sequence Left, [Op,
+	// Right]*; we fold pairs from highest precedence down so that
+	// `a * b + c * d` becomes `(a*b) + (c*d)`, not `((a*b)+c)*d`.
+	// Without this, mandelbrot's fully-parenthesised expressions still
+	// happen to be correct (`2.0 * zr * zi + cy` is left-assoc-
+	// friendly), but n_body and spectral_norm's `dx*dx + dy*dy`
+	// shapes silently miscompile.
+	values := []uint32{left}
+	ops := make([]string, 0, len(be.Right))
 	for _, op := range be.Right {
 		rhs, err := b.lowerUnary(op.Right)
 		if err != nil {
 			return 0, err
 		}
-		cur, err = b.applyBinOp(op.Op, cur, rhs)
-		if err != nil {
-			return 0, err
+		values = append(values, rhs)
+		ops = append(ops, op.Op)
+	}
+	// Reduce pairs left-to-right, sweeping precedence levels from
+	// highest to lowest. Each sweep collapses adjacent operands joined
+	// by an operator at the current level into one combined value.
+	for _, level := range binaryPrecedenceLevels {
+		i := 0
+		for i < len(ops) {
+			if !level[ops[i]] {
+				i++
+				continue
+			}
+			combined, err := b.applyBinOp(ops[i], values[i], values[i+1])
+			if err != nil {
+				return 0, err
+			}
+			values[i] = combined
+			values = append(values[:i+1], values[i+2:]...)
+			ops = append(ops[:i], ops[i+1:]...)
 		}
 	}
-	return cur, nil
+	if len(values) != 1 || len(ops) != 0 {
+		return 0, fmt.Errorf("frontend: binary precedence reduce left %d values, %d ops (operators present that have no precedence level)", len(values), len(ops))
+	}
+	return values[0], nil
+}
+
+// binaryPrecedenceLevels lists operator precedence buckets from
+// highest to lowest. Each bucket is left-associative; sweep order
+// gives the natural math reading of `a * b + c` -> `(a*b) + c`.
+// `in`, set ops (`union` / `except` / `intersect`), and `??` are
+// listed even though the MVP frontend doesn't yet implement them,
+// so the precedence shape lands once they do.
+var binaryPrecedenceLevels = []map[string]bool{
+	{"*": true, "/": true, "%": true},
+	{"+": true, "-": true, "union": true, "except": true, "intersect": true},
+	{"==": true, "!=": true, "<": true, "<=": true, ">": true, ">=": true, "in": true},
+	{"&&": true},
+	{"||": true},
+	{"??": true},
 }
 
 func (b *builder) applyBinOp(op string, l, r uint32) (uint32, error) {
@@ -1022,6 +1068,18 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 		sel := pe.Target.Selector
 		if imp, ok := b.goImports[sel.Root]; ok && len(sel.Tail) == 1 {
 			return b.lowerGoCall(imp, sel.Tail[0], pe.Ops[0].Call.Args)
+		}
+		// Phase 4.3.5: `math.sqrt(x)` is recognised as a builtin
+		// regardless of the import language (python or go) or whether
+		// the import statement is present at all. The Mochi source
+		// declares the binding via `import python "math" as math` plus
+		// `extern fun math.sqrt(x: float): float`; both statements are
+		// no-ops at compiler3-lower time, and the call site lowers
+		// directly to OpSqrtF64. This keeps the IR target-agnostic
+		// while letting the Go emitter route to `math.Sqrt` and the
+		// C emitter to `sqrt` (linked with -lm).
+		if id, ok, err := b.tryLowerMathBuiltin(sel.Root, sel.Tail, pe.Ops[0].Call.Args); ok {
+			return id, err
 		}
 	}
 	if len(pe.Ops) == 0 {
@@ -1302,6 +1360,40 @@ func (b *builder) lowerBuiltinCall(c *parser.CallExpr) (uint32, bool, error) {
 			return list, true, nil
 		}
 		return 0, true, fmt.Errorf("frontend: append() target type %s unsupported (need list)", listType)
+	}
+	return 0, false, nil
+}
+
+// tryLowerMathBuiltin recognises `math.<name>(args)` selector-call
+// shapes and lowers them to one of the OpMath* opcodes. Returns
+// (id, true, nil) on a successful lower; (0, false, nil) when the
+// receiver/method pair is not a known math builtin (so the caller can
+// fall through to other dispatch paths); (0, true, err) when the name
+// is a builtin but the arguments are malformed.
+//
+// The Mochi source advertises the binding via `import python "math" as
+// math` plus `extern fun math.sqrt(x: float): float`; both statements
+// are no-ops at compiler3-lower time. Only `math.sqrt` is recognised
+// in Phase 4.3.5; further entries (`pow`, `log`, ...) extend the
+// switch.
+func (b *builder) tryLowerMathBuiltin(root string, tail []string, callArgs []*parser.Expr) (uint32, bool, error) {
+	if root != "math" || len(tail) != 1 {
+		return 0, false, nil
+	}
+	switch tail[0] {
+	case "sqrt":
+		if len(callArgs) != 1 {
+			return 0, true, fmt.Errorf("frontend: math.sqrt expects 1 arg, got %d", len(callArgs))
+		}
+		argID, err := b.lowerExpr(callArgs[0])
+		if err != nil {
+			return 0, true, err
+		}
+		if b.fn.Values[argID].Type != ir.TypeF64 {
+			return 0, true, fmt.Errorf("frontend: math.sqrt requires float arg, got %s", b.fn.Values[argID].Type)
+		}
+		id := b.addValue(ir.Value{Type: ir.TypeF64, Op: ir.OpSqrtF64, Args: []uint32{argID}})
+		return id, true, nil
 	}
 	return 0, false, nil
 }

--- a/compiler3/frontend/lower_test.go
+++ b/compiler3/frontend/lower_test.go
@@ -343,6 +343,47 @@ print(total)
 	}
 }
 
+// TestLowerMathSqrtBuiltin pins the Phase 4.3.5 `math.sqrt(x)` builtin:
+// an `import python "math" as math` + `extern fun math.sqrt(x: float):
+// float` pair must be accepted as no-op declarations, and the call site
+// must lower to OpSqrtF64. The expression `math.sqrt(2.0) * math.sqrt(2.0)`
+// returns 2.0 (within FP rounding) cast to int 2.
+func TestLowerMathSqrtBuiltin(t *testing.T) {
+	src := `import python "math" as math
+extern fun math.sqrt(x: float): float
+
+let r = math.sqrt(2.0) * math.sqrt(2.0)
+print(r as int)
+`
+	got := runEnd2End(t, src)
+	if got != "2\n" {
+		t.Errorf("got %q, want %q", got, "2\n")
+	}
+}
+
+// TestLowerNbodyDistanceKernel pins a focused fragment of the n_body
+// inner loop: compute the gravitational softening factor `1 / (d2 *
+// sqrt(d2))` for a known 3-4-5 right triangle (d2 = 25, sqrt(25) = 5,
+// 1/(25*5) = 1/125 = 0.008). Scaled by 1e9 and cast to int, the
+// result is 8000000. This exercises the OpSqrtF64 op inside the same
+// expression shape n_body uses to compute its softened distance.
+func TestLowerNbodyDistanceKernel(t *testing.T) {
+	src := `import python "math" as math
+extern fun math.sqrt(x: float): float
+
+let dx = 3.0
+let dy = 4.0
+let dz = 0.0
+let d2 = dx * dx + dy * dy + dz * dz
+let factor = 1.0 / (d2 * math.sqrt(d2))
+print((factor * 1.0e9) as int)
+`
+	got := runEnd2End(t, src)
+	if got != "8000000\n" {
+		t.Errorf("got %q, want %q", got, "8000000\n")
+	}
+}
+
 // TestLowerNsieve is the load-bearing Phase 4.3.2 gate: a stripped
 // nsieve(100) returning the prime count (25). It exercises range-for
 // with nested while, indexed reads/writes, len(), and the synthetic

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -220,6 +220,13 @@ const (
 	// Go target's `int64(f64)` semantics).
 	OpI64ToF64
 	OpF64ToI64
+
+	// Math builtins (Phase 4.3.5). OpSqrtF64 is the f64 square root,
+	// lowered from `math.sqrt(x)` after the python-import + extern
+	// declarations are accepted as no-op binding statements. The Go
+	// target emits `math.Sqrt(v)` (auto-imports "math"); the C target
+	// emits `sqrt(v)` (auto-includes <math.h> and links with -lm).
+	OpSqrtF64
 )
 
 // String renders an OpCode's short name. Used by Validate and IR
@@ -384,6 +391,8 @@ func (o OpCode) String() string {
 		return "i64.to.f64"
 	case OpF64ToI64:
 		return "f64.to.i64"
+	case OpSqrtF64:
+		return "sqrt.f64"
 	}
 	return "?"
 }

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -217,6 +217,8 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeF64, [3]Type{TypeI64}}
 	case OpF64ToI64:
 		return opSig{TypeI64, [3]Type{TypeF64}}
+	case OpSqrtF64:
+		return opSig{TypeF64, [3]Type{TypeF64}}
 	}
 	// OpParam, OpConst, OpPhi, OpCall, OpTailCall: the validator
 	// can't pre-compute their signature without more context, so we

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -157,7 +157,8 @@ func kindOf(o ir.OpCode) ProducerKind {
 		ir.OpAndI64, ir.OpOrI64, ir.OpXorI64, ir.OpShlI64, ir.OpShrI64, ir.OpNotI64,
 		ir.OpCmpEqF64, ir.OpCmpNeF64, ir.OpCmpLtF64, ir.OpCmpLeF64, ir.OpCmpGtF64, ir.OpCmpGeF64,
 		ir.OpNotBool,
-		ir.OpI64ToF64, ir.OpF64ToI64:
+		ir.OpI64ToF64, ir.OpF64ToI64,
+		ir.OpSqrtF64:
 		return KindOperator
 
 	case ir.OpLenStr:
@@ -214,7 +215,7 @@ func init() {
 // the last OpCode known to ir/types.go at this MEP-41 Phase 1 commit;
 // adding a new op past it bumps this constant in the same PR.
 func mustClassifyAll() {
-	const lastOpCode = ir.OpF64ToI64
+	const lastOpCode = ir.OpSqrtF64
 	for o := ir.OpInvalid + 1; o <= lastOpCode; o++ {
 		if kindOf(o) == KindInvalid {
 			panic(fmt.Sprintf("verify: OpCode %s (=%d) is unclassified; extend kindOf in compiler3/verify/verify.go (MEP-41 §6.2 rule class C / coverage backstop)", o, o))

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -725,7 +725,7 @@ Workloads in the "performance games" set that are NOT in this table, and why:
 
 | Workload | Why excluded |
 |----------|--------------|
-| `mandelbrot`, `n_body`, `spectral_norm` | f64 list primitives LANDED in Phase 4.3.3 and i64↔f64 casts LANDED in Phase 4.3.4; `mandelbrot`'s 16×16 kernel pinned end-to-end through the C target by `TestBuildSourceMandelbrotKernel` (output `4629`). `n_body` and `spectral_norm` still need top-level `var` at module scope (n_body), `int(...)` / `float(...)` function-call cast form (spectral_norm), and the `bench/template/bg/*` harness shape (`now()`, `json({...})`, `{{ .N }}`). Wiring those is a §13 follow-up |
+| `mandelbrot`, `n_body`, `spectral_norm` | f64 list primitives LANDED in Phase 4.3.3, i64↔f64 casts LANDED in Phase 4.3.4, and `math.sqrt` + operator precedence LANDED in Phase 4.3.5. `mandelbrot`'s 16×16 kernel pinned by `TestBuildSourceMandelbrotKernel` (4629). The `n_body` softened-distance kernel pinned by `TestBuildSourceNbodyDistanceKernel` (8000000). The remaining gap for `n_body` is wiring the multi-step time-step integration; for `spectral_norm` it is the `int(...)` / `float(...)` function-call cast form plus collection-iter `for x in xs`; for all three it is the `bench/template/bg/*` harness shape (`now()`, `json({...})`, `{{ .N }}`). Those are §13 follow-ups |
 | `nsieve` | LANDED in Phase 4.3.2 (range-for + if-merge phi joins land together; stripped nsieve(100)=25 pinned by C and Go target tests). The full benchmark uses identical primitives |
 | `fannkuch`, `binary_trees` | Need list-of-structs / struct-of-lists; i64 list primitive landed in Phase 4.3.1, struct support blocked on Phase 4.4, nesting on Phase 4.5 |
 | `fasta`, `regex_redux`, `k_nucleotide` | Need string literals and string ops; blocked on Phase 4.2 (TypeStr) |
@@ -1141,6 +1141,60 @@ Compiles via `mochi build --target=c` (and `--target=go`) to a binary that print
 - No `int(x)` / `float(x)` function-call cast form yet (used by `spectral_norm.mochi`); the postfix `as` form is the only supported surface in this sub-phase. Adding the function-call form is mostly parser routing and would be a fast follow.
 - No widening between f32 and f64 (Mochi has no `f32` surface; f64 is the only float type).
 - The benchmark-games mandelbrot fixture itself still needs `now()`, `json({...})`, and `{{ .N }}` template expansion before it runs as-shipped from `bench/template/bg/mandelbrot/`. The §13 (workflow) closeout owns wiring those harness pieces.
+
+## §10.14 Phase 4.3.5 closeout (LANDED 2026-05-21 23:55 GMT+7)
+
+Phase 4.3.5 lands `math.sqrt(x)` end-to-end and fixes a foundational operator-precedence bug in `lowerBinary` that was silently miscompiling every multi-operator non-parenthesised expression. The n_body softened-distance kernel (`1/(d2 * sqrt(d2))` for a 3-4-5 triangle, scaled by 1e9, cast to int = 8000000) now compiles end-to-end via `mochi build --target=c` and byte-matches the Go target. With this in place, the n_body inner loop is expressible in the MVP grammar.
+
+### IR + verify additions
+
+One new opcode: `OpSqrtF64` with signature `(TypeF64) -> TypeF64`, classified `KindOperator`. `lastOpCode` advances to `OpSqrtF64`.
+
+### Frontend wiring
+
+- `Lower` now skips `Import`, `ExternFun`, `ExternVar`, `ExternType`, and `ExternObject` declarations at top level (treats them as binding-only statements that do not produce IR). This is what makes `import python "math" as math` + `extern fun math.sqrt(x: float): float` valid statements that contribute nothing to the synthetic `main`.
+- `lowerPostfix` gains a `tryLowerMathBuiltin(root, tail, args)` helper alongside the existing `lowerGoCall` selector-call path. The helper recognises `math.sqrt` and emits `OpSqrtF64`; the surface for additional builtins (`pow`, `log`, ...) is the same switch.
+- `lowerBinary` switches from "left-associative without precedence" to Shunting-Yard reduction. A single flat list `[v0, op0, v1, op1, v2, ...]` is collapsed level-by-level from highest precedence (`* / %`) down through `+ - union except intersect`, comparisons, `&&`, `||`, `??`. Each sweep collapses left-to-right, so the resulting tree is left-associative within each level, matching the canonical math reading. The bug it fixes: `dx*dx + dy*dy + dz*dz` previously evaluated as `((((dx*dx)+dy)*dy)+dz)*dz` (a wrong scalar) which made d2 a nonsense value, sqrt(d2) NaN, and `(factor*1e9) as int` undefined-behavior int64_max. The mandelbrot kernel from Phase 4.3.4 was incidentally correct because its expressions are written as `2.0*zr*zi + cy` (left-assoc-friendly) and `(r2 - i2) + cx`.
+
+### Emit
+
+- Go target: `math.Sqrt(v)` plus an auto-added `"math"` import (the existing `imports["math"] = true` mechanism handles this; it was already set for `OpConst` of a TypeF64 via `math.Float64frombits`).
+- C target: `sqrt(v)` from `<math.h>` (already unconditionally included). The driver appends `-lm` to the cc command unconditionally; on macOS / *BSD where the math symbols live in libSystem this is a no-op, on glibc/musl Linux it is required for the link.
+
+### Files changed
+
+- `compiler3/ir/types.go`: add `OpSqrtF64` constant + `String()` case.
+- `compiler3/ir/validate.go`: add op signature.
+- `compiler3/verify/verify.go`: classify `OpSqrtF64` as `KindOperator`; advance `lastOpCode`.
+- `compiler3/emit/go/emit.go`: emit `math.Sqrt(v)` (auto-imports `"math"`).
+- `compiler3/emit/c/emit.go`: emit `sqrt(v)`.
+- `compiler3/build/c/driver.go`: append `-lm` to the cc command.
+- `compiler3/frontend/lower.go`: skip Import/ExternFun/ExternVar/ExternType/ExternObject at top level; add `tryLowerMathBuiltin`; replace `lowerBinary`'s left-assoc fold with a precedence-climbing reducer; add `binaryPrecedenceLevels` table.
+- `compiler3/frontend/lower_test.go`: `TestLowerMathSqrtBuiltin` (sqrt(2)*sqrt(2) = 2), `TestLowerNbodyDistanceKernel` (the load-bearing 8000000 case).
+- `compiler3/build/c/driver_test.go`: matching three C-target tests including `TestBuildSourcePrecedenceClimbing` which pins the precedence regression directly.
+- `website/docs/mep/mep-0042.md`: this section; §10.7 n_body row updated to drop the math.sqrt + precedence blockers.
+
+### Reproducer
+
+```mochi
+import python "math" as math
+extern fun math.sqrt(x: float): float
+
+let dx = 3.0
+let dy = 4.0
+let dz = 0.0
+let d2 = dx * dx + dy * dy + dz * dz
+let factor = 1.0 / (d2 * math.sqrt(d2))
+print((factor * 1.0e9) as int)
+```
+
+Compiles via `mochi build --target=c` (and `--target=go`) to a binary that prints `8000000\n`, matching `mochi run` on the same source. Pinned by `TestBuildSourceNbodyDistanceKernel`.
+
+### Limitations
+
+- Only `math.sqrt` is recognised in this sub-phase. `pow`, `log`, `sin`, `cos`, etc. extend the same `tryLowerMathBuiltin` switch and need one new OpCode each (or one generic `OpMathBuiltin` with a sub-tag) plus the matching Go and C emit lines. spectral_norm currently uses only sqrt so the n_body / spectral_norm goal is met by this sub-phase alone.
+- `import go "..."`-style FFI imports still require the typebridge resolver. Only the python-import-plus-extern pattern is recognised as a no-op binding statement.
+- The precedence reducer is set to standard math precedence. `&` `|` `^` `<<` `>>` (bitwise) are NOT in the parser's BinaryOp set today; if they are added later they will need to land in `binaryPrecedenceLevels` at the right level so existing code does not silently change meaning.
 
 ## §11 Risks
 


### PR DESCRIPTION
Closes #21967

## Summary

- New IR op `OpSqrtF64` plumbed end-to-end (ir/types, ir/validate, verify/kindOf + lastOpCode advance, Go emit `math.Sqrt`, C emit `sqrt`, driver `-lm`).
- Frontend accepts `import python "math" as math` and `extern fun math.sqrt(x: float): float` as no-op binding decls; `math.sqrt(x)` selector calls lower to `OpSqrtF64`.
- **Operator precedence fix**: replaced lowerBinary's left-assoc fold with Shunting-Yard precedence reduction (mul/div before add/sub before compare before && before || before ??). The prior code was silently miscompiling expressions like `dx*dx + dy*dy`; old tests happened to be left-assoc friendly.

## Tests

- `TestLowerMathSqrtBuiltin`, `TestLowerNbodyDistanceKernel` (frontend, Go target).
- `TestBuildSourceMathSqrtBuiltin`, `TestBuildSourceNbodyDistanceKernel`, `TestBuildSourcePrecedenceClimbing` (C target).
- Full compiler3 suite green locally.

## Test plan

- [x] `go test ./compiler3/...`
- [x] `mochi build --target=c` produces a runnable n_body softened-distance kernel that byte-matches Go
- [x] §10.14 closeout landed in `website/docs/mep/mep-0042.md`