### PR TITLE
mep-0042: Phase 4.3.6 int(x)/float(x) call-cast form

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -498,6 +498,48 @@ print(1 + 2 * 3 + 4 * 5)
 	}
 }
 
+// TestBuildSourceIntCallCastFromFloat pins the Phase 4.3.6 `int(x)`
+// builtin against an f64 argument: emits `(int64_t)x`, truncating
+// toward zero (1.7 -> 1). This is the surface spectral_norm uses to
+// produce the final printable integer.
+func TestBuildSourceIntCallCastFromFloat(t *testing.T) {
+	src := `let x = 1.7
+print(int(x))
+`
+	if got, want := runMochiBuild(t, src), "1\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceFloatCallCastFromInt pins the Phase 4.3.6 `float(x)`
+// builtin against an i64 argument: emits `(double)x`, then divides as
+// f64. 7 widened to 7.0, halved to 3.5, cast back to int 3.
+func TestBuildSourceFloatCallCastFromInt(t *testing.T) {
+	src := `let n = 7
+let half = float(n) / 2.0
+print(int(half))
+`
+	if got, want := runMochiBuild(t, src), "3\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceSpectralEvalKernel is the load-bearing Phase 4.3.6
+// gate on the C target: a single eval of spectral_norm's `eval_a(i,j)
+// = 1 / float(s*(s+1)/2 + i + 1)` matrix entry at i=0, j=0. The
+// expected value is 1/1 = 1.0; scaled by 1e9 and truncated, 1000000000.
+func TestBuildSourceSpectralEvalKernel(t *testing.T) {
+	src := `fun eval_a(i: int, j: int): float {
+  let s = i + j
+  return 1.0 / float(s * (s + 1) / 2 + i + 1)
+}
+print(int(eval_a(0, 0) * 1.0e9))
+`
+	if got, want := runMochiBuild(t, src), "1000000000\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceFibIter is the §10.7 unblock for the iterative Fib
 // benchmark: while loop, mutated `a`/`b`/`i`, and a `let t` inside the
 // body that the phi-at-header must NOT track (it's body-scoped).

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1290,8 +1290,46 @@ func (b *builder) lowerCall(c *parser.CallExpr) (uint32, error) {
 //
 // Phase 4.3.1 covers `len(xs)` and `append(xs, v)` against list<int>;
 // `len("s")` against TypeStr is wired through OpLenStr in the same
-// case for free since the IR op already exists.
+// case for free since the IR op already exists. Phase 4.3.6 adds
+// `int(x)` and `float(x)` as the function-call surface of the
+// i64<->f64 cast pair landed in Phase 4.3.4.
 func (b *builder) lowerBuiltinCall(c *parser.CallExpr) (uint32, bool, error) {
+	switch c.Func {
+	case "int":
+		if len(c.Args) != 1 {
+			return 0, true, fmt.Errorf("frontend: int() takes 1 argument, got %d", len(c.Args))
+		}
+		arg, err := b.lowerExpr(c.Args[0])
+		if err != nil {
+			return 0, true, err
+		}
+		switch b.fn.Values[arg].Type {
+		case ir.TypeI64:
+			return arg, true, nil
+		case ir.TypeF64:
+			id := b.addValue(ir.Value{Type: ir.TypeI64, Op: ir.OpF64ToI64, Args: []uint32{arg}})
+			return id, true, nil
+		default:
+			return 0, true, fmt.Errorf("frontend: int(%s) unsupported in MVP", b.fn.Values[arg].Type)
+		}
+	case "float":
+		if len(c.Args) != 1 {
+			return 0, true, fmt.Errorf("frontend: float() takes 1 argument, got %d", len(c.Args))
+		}
+		arg, err := b.lowerExpr(c.Args[0])
+		if err != nil {
+			return 0, true, err
+		}
+		switch b.fn.Values[arg].Type {
+		case ir.TypeF64:
+			return arg, true, nil
+		case ir.TypeI64:
+			id := b.addValue(ir.Value{Type: ir.TypeF64, Op: ir.OpI64ToF64, Args: []uint32{arg}})
+			return id, true, nil
+		default:
+			return 0, true, fmt.Errorf("frontend: float(%s) unsupported in MVP", b.fn.Values[arg].Type)
+		}
+	}
 	switch c.Func {
 	case "len":
 		if len(c.Args) != 1 {

--- a/compiler3/frontend/lower_test.go
+++ b/compiler3/frontend/lower_test.go
@@ -384,6 +384,51 @@ print((factor * 1.0e9) as int)
 	}
 }
 
+// TestLowerIntCallCastFromFloat pins the Phase 4.3.6 `int(x)` builtin
+// against an f64 argument: 1.7 truncates to 1, byte-matching the C
+// target's `(int64_t)1.7`. This is the surface spectral_norm uses
+// (`int(math.sqrt(uv / vv) * 1e9)`).
+func TestLowerIntCallCastFromFloat(t *testing.T) {
+	src := `let x = 1.7
+print(int(x))
+`
+	got := runEnd2End(t, src)
+	if got != "1\n" {
+		t.Errorf("got %q, want %q", got, "1\n")
+	}
+}
+
+// TestLowerFloatCallCastFromInt pins the Phase 4.3.6 `float(x)` builtin
+// against an i64 argument: 7 widens to 7.0, the f64 divide produces
+// 3.5, and the result casts back to int 3.
+func TestLowerFloatCallCastFromInt(t *testing.T) {
+	src := `let n = 7
+let half = float(n) / 2.0
+print(int(half))
+`
+	got := runEnd2End(t, src)
+	if got != "3\n" {
+		t.Errorf("got %q, want %q", got, "3\n")
+	}
+}
+
+// TestLowerSpectralEvalKernel is the load-bearing Phase 4.3.6 gate: a
+// single eval of spectral_norm's `eval_a(i, j) = 1 / float(s*(s+1)/2 +
+// i + 1)` matrix entry for i=0, j=0. The expected value is 1/1=1.0,
+// scaled by 1e9 and cast back to int is 1000000000.
+func TestLowerSpectralEvalKernel(t *testing.T) {
+	src := `fun eval_a(i: int, j: int): float {
+  let s = i + j
+  return 1.0 / float(s * (s + 1) / 2 + i + 1)
+}
+print(int(eval_a(0, 0) * 1.0e9))
+`
+	got := runEnd2End(t, src)
+	if got != "1000000000\n" {
+		t.Errorf("got %q, want %q", got, "1000000000\n")
+	}
+}
+
 // TestLowerNsieve is the load-bearing Phase 4.3.2 gate: a stripped
 // nsieve(100) returning the prime count (25). It exercises range-for
 // with nested while, indexed reads/writes, len(), and the synthetic

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -725,7 +725,7 @@ Workloads in the "performance games" set that are NOT in this table, and why:
 
 | Workload | Why excluded |
 |----------|--------------|
-| `mandelbrot`, `n_body`, `spectral_norm` | f64 list primitives LANDED in Phase 4.3.3, i64↔f64 casts LANDED in Phase 4.3.4, and `math.sqrt` + operator precedence LANDED in Phase 4.3.5. `mandelbrot`'s 16×16 kernel pinned by `TestBuildSourceMandelbrotKernel` (4629). The `n_body` softened-distance kernel pinned by `TestBuildSourceNbodyDistanceKernel` (8000000). The remaining gap for `n_body` is wiring the multi-step time-step integration; for `spectral_norm` it is the `int(...)` / `float(...)` function-call cast form plus collection-iter `for x in xs`; for all three it is the `bench/template/bg/*` harness shape (`now()`, `json({...})`, `{{ .N }}`). Those are §13 follow-ups |
+| `mandelbrot`, `n_body`, `spectral_norm` | f64 list primitives LANDED in Phase 4.3.3, i64↔f64 casts LANDED in Phase 4.3.4 (`as` form) + 4.3.6 (`int(x)`/`float(x)` call form), `math.sqrt` + operator precedence LANDED in Phase 4.3.5. mandelbrot's 16×16 kernel pinned by `TestBuildSourceMandelbrotKernel` (4629); n_body's softened-distance kernel pinned by `TestBuildSourceNbodyDistanceKernel` (8000000); spectral_norm's `eval_a` matrix-entry kernel pinned by `TestBuildSourceSpectralEvalKernel` (1000000000). The remaining gap for `n_body` is the multi-step time-step integration plus the `extern let math.pi` form; for `spectral_norm` it is the `[float]` bracketed list-type syntax + list concatenation + collection-iter `for x in xs`; for all three it is the `bench/template/bg/*` harness shape (`now()`, `json({...})`, `{{ .N }}`). Those are §13 follow-ups |
 | `nsieve` | LANDED in Phase 4.3.2 (range-for + if-merge phi joins land together; stripped nsieve(100)=25 pinned by C and Go target tests). The full benchmark uses identical primitives |
 | `fannkuch`, `binary_trees` | Need list-of-structs / struct-of-lists; i64 list primitive landed in Phase 4.3.1, struct support blocked on Phase 4.4, nesting on Phase 4.5 |
 | `fasta`, `regex_redux`, `k_nucleotide` | Need string literals and string ops; blocked on Phase 4.2 (TypeStr) |
@@ -1195,6 +1195,45 @@ Compiles via `mochi build --target=c` (and `--target=go`) to a binary that print
 - Only `math.sqrt` is recognised in this sub-phase. `pow`, `log`, `sin`, `cos`, etc. extend the same `tryLowerMathBuiltin` switch and need one new OpCode each (or one generic `OpMathBuiltin` with a sub-tag) plus the matching Go and C emit lines. spectral_norm currently uses only sqrt so the n_body / spectral_norm goal is met by this sub-phase alone.
 - `import go "..."`-style FFI imports still require the typebridge resolver. Only the python-import-plus-extern pattern is recognised as a no-op binding statement.
 - The precedence reducer is set to standard math precedence. `&` `|` `^` `<<` `>>` (bitwise) are NOT in the parser's BinaryOp set today; if they are added later they will need to land in `binaryPrecedenceLevels` at the right level so existing code does not silently change meaning.
+
+## §10.15 Phase 4.3.6 closeout (LANDED 2026-05-22 00:01 GMT+7)
+
+Phase 4.3.6 lands `int(x)` and `float(x)` as the function-call surface of the i64<->f64 cast pair that Phase 4.3.4 already wired as the `as` postfix. The two surfaces are interchangeable; benchmark-games kernels prefer the call form (`int(math.sqrt(uv/vv) * 1e9)` in spectral_norm, `1.0 / float(s*(s+1)/2 + i + 1)` in the same fixture's `eval_a`) because it sits inside a larger expression more naturally than a trailing `as int`. A stripped spectral_norm `eval_a(0, 0)` kernel now compiles end-to-end via `mochi build --target=c`, producing 1000000000 (= 1.0 * 1e9 truncated), byte-matching the Go target.
+
+### Implementation
+
+No new IR opcodes, no new emit lines, no new verify entries. The cast ops (`OpI64ToF64`, `OpF64ToI64`) and their Go and C lowerings already exist from Phase 4.3.4. The only change is in `lowerBuiltinCall`: two new `case "int"` and `case "float"` arms that:
+
+- accept exactly 1 argument, lower it via `lowerExpr`, and inspect the result type.
+- if the argument type already matches the target, return the argument unchanged (no-op cast preserves SSA shape; `int(x)` on an i64 value or `float(x)` on an f64 value costs nothing).
+- if the argument crosses the i64<->f64 boundary, emit the matching cast op.
+- if the argument is anything else (bool, str, list, ...), reject with `int(%s) unsupported in MVP`. The harness treats this as a skipped fixture rather than a miscompile.
+
+The early-return placement matters: the two arms sit before the rest of the builtin switch so `int(...)` and `float(...)` are not shadowable by a user-declared `fun int(x)` (the existing `lowerBuiltinCall` is checked before `userFns`, so a user fun named `int` was already unreachable, but the new arms keep the same invariant).
+
+### Files changed
+
+- `compiler3/frontend/lower.go`: add `int` and `float` arms to `lowerBuiltinCall` (28 net lines).
+- `compiler3/frontend/lower_test.go`: `TestLowerIntCallCastFromFloat` (1.7 -> 1), `TestLowerFloatCallCastFromInt` (7 -> 7.0 / 2.0 -> 3), `TestLowerSpectralEvalKernel` (the load-bearing 1000000000 case).
+- `compiler3/build/c/driver_test.go`: matching three C-target tests.
+- `website/docs/mep/mep-0042.md`: this section; §10.7 spectral_norm row updated to drop the int/float call-cast blocker.
+
+### Reproducer
+
+```mochi
+fun eval_a(i: int, j: int): float {
+  let s = i + j
+  return 1.0 / float(s * (s + 1) / 2 + i + 1)
+}
+print(int(eval_a(0, 0) * 1.0e9))
+```
+
+Compiles via `mochi build --target=c` (and `--target=go`) to a binary that prints `1000000000\n`, matching `mochi run` on the same source. Pinned by `TestBuildSourceSpectralEvalKernel`.
+
+### Limitations
+
+- Only `int` and `float` are recognised. `bool(x)`, `str(x)`, `i32(x)`, `u64(x)`, ... extend the same dispatch but each needs a target IR type. None are on the §10.7 critical path.
+- The full spectral_norm fixture still cannot compile because it uses `[float]` (the bracketed list-type syntax, distinct from `list<float>`), list concatenation (`u + [1.0]`), and `for _ in 0..N` driving a `[float]` accumulator. Those are the next sub-phases. The full n_body fixture still needs top-level `var` at module scope, the `extern let math.pi` extern-variable form, and the `now()` + `json({...})` + `{{ .N }}` benchmark harness shape.
 
 ## §11 Risks
 


### PR DESCRIPTION
Closes #21969

## Summary

- Add `int(x)` and `float(x)` arms to `lowerBuiltinCall`. Routes through existing `OpF64ToI64` / `OpI64ToF64` ops (no new IR / emit / verify changes).
- Same-type calls (`int(i)` on i64, `float(f)` on f64) return the argument unchanged so SSA shape stays the same.
- Anything other than i64/f64 surfaces a frontend error so the A/B harness marks the fixture skipped rather than miscompiling.

## Tests

- `TestLowerIntCallCastFromFloat`, `TestLowerFloatCallCastFromInt`, `TestLowerSpectralEvalKernel` (frontend, Go target).
- `TestBuildSourceIntCallCastFromFloat`, `TestBuildSourceFloatCallCastFromInt`, `TestBuildSourceSpectralEvalKernel` (C target).
- Full compiler3 suite green locally.

## Test plan

- [x] `go test ./compiler3/...`
- [x] `mochi build --target=c` produces a runnable spectral_norm `eval_a` kernel that byte-matches Go
- [x] §10.15 closeout landed in `website/docs/mep/mep-0042.md`