### PR TITLE
mep-0042: Phase 4.3.7 collection-iter for x in xs

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -540,6 +540,37 @@ print(int(eval_a(0, 0) * 1.0e9))
 	}
 }
 
+// TestBuildSourceForInListI64 pins the Phase 4.3.7 collection-iter
+// surface on the C target for list<int>. Sum of [10,20,30] is 60.
+func TestBuildSourceForInListI64(t *testing.T) {
+	src := `let xs: list<int> = [10, 20, 30]
+var s = 0
+for x in xs {
+  s = s + x
+}
+print(s)
+`
+	if got, want := runMochiBuild(t, src), "60\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceForInListF64 pins the Phase 4.3.7 collection-iter
+// surface on the C target for list<float>. The body sums an f64 list
+// and the truncating Phase 4.3.6 `int(...)` gives 6.
+func TestBuildSourceForInListF64(t *testing.T) {
+	src := `let xs: list<float> = [1.5, 2.0, 2.5]
+var s = 0.0
+for x in xs {
+  s = s + x
+}
+print(int(s))
+`
+	if got, want := runMochiBuild(t, src), "6\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceFibIter is the §10.7 unblock for the iterative Fib
 // benchmark: while loop, mutated `a`/`b`/`i`, and a `let t` inside the
 // body that the phi-at-header must NOT track (it's body-scoped).

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -681,7 +681,7 @@ func (b *builder) lowerWhile(s *parser.WhileStmt) error {
 // loop count.
 func (b *builder) lowerFor(s *parser.ForStmt) error {
 	if s.RangeEnd == nil {
-		return fmt.Errorf("frontend: for-in over a collection unsupported in MVP (only `for x in lo..hi`)")
+		return b.lowerForCollection(s)
 	}
 	lo, err := b.lowerExpr(s.Source)
 	if err != nil {
@@ -794,6 +794,159 @@ func (b *builder) lowerFor(s *parser.ForStmt) error {
 	// loop. Without this, a subsequent reference to `loopName` in the
 	// outer scope would resolve to the header phi, which is wrong if
 	// the user had a same-named outer binding.
+	if hadOld {
+		b.values[loopName] = oldVal
+	} else {
+		delete(b.values, loopName)
+	}
+	return nil
+}
+
+// lowerForCollection lowers `for x in xs { body }` for a list-typed xs.
+// The desugared shape is:
+//
+//	var i = 0
+//	while i < len(xs) {
+//	  let x = xs[i]
+//	  <body>
+//	  i = i + 1
+//	}
+//
+// This is built directly in IR rather than via a synthesized AST so the
+// loop variable scoping matches `for ... in lo..hi`: x is reset on every
+// iteration to the indexed read of xs[i], not phi-tracked across the
+// back-edge. The index counter i and any other pre-loop bindings ARE
+// phi-tracked at the header (same shape as lowerWhile).
+//
+// The list value xs is lowered once in the pre-header and captured in
+// SSA, so a mutation of the binding `xs` inside the body does not change
+// what is iterated over. The same holds for `len(xs)`, which is also
+// computed once in the pre-header.
+//
+// Supported list element types: i64 (TypeList) and f64 (TypeF64Arr).
+// Any other element type rejects.
+func (b *builder) lowerForCollection(s *parser.ForStmt) error {
+	xs, err := b.lowerExpr(s.Source)
+	if err != nil {
+		return err
+	}
+	listType := b.fn.Values[xs].Type
+	var lenOp ir.OpCode
+	var getOp ir.OpCode
+	var elemType ir.Type
+	switch listType {
+	case ir.TypeList:
+		lenOp, getOp, elemType = ir.OpListLenI64, ir.OpListGetI64, ir.TypeI64
+	case ir.TypeF64Arr:
+		lenOp, getOp, elemType = ir.OpF64ArrayLenI64, ir.OpF64ArrayGetF64, ir.TypeF64
+	default:
+		return fmt.Errorf("frontend: for-in over %s unsupported (need list)", listType)
+	}
+	lenID := b.addValue(ir.Value{Type: ir.TypeI64, Op: lenOp, Args: []uint32{xs}})
+	zero := b.addValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 0})
+
+	loopName := s.Name
+	oldVal, hadOld := b.values[loopName]
+	// Reserve an index counter under a fresh internal name. It will be
+	// phi-tracked at the header alongside any other pre-loop bindings.
+	// Using a name that can't collide with user identifiers ($ is not in
+	// the Mochi ident grammar) keeps the env from accidentally exposing
+	// it to inner expressions.
+	idxName := "$for_idx_" + loopName
+	b.values[idxName] = zero
+
+	preID := b.curBlock
+	headID := b.fn.AddBlock()
+	bodyID := b.fn.AddBlock()
+	contID := b.fn.AddBlock()
+
+	names := make([]string, 0, len(b.values))
+	for name := range b.values {
+		if name == loopName {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	preVals := make([]uint32, len(names))
+	for i, name := range names {
+		preVals[i] = b.values[name]
+	}
+
+	b.terminator(ir.Terminator{Kind: ir.TermJump, Target: headID})
+
+	b.curBlock = headID
+	b.terminated = false
+	phis := make([]uint32, len(names))
+	var idxPhi uint32
+	for i, name := range names {
+		preVid := preVals[i]
+		phiVid := b.addValue(ir.Value{
+			Type: b.fn.Values[preVid].Type,
+			Op:   ir.OpPhi,
+			Args: []uint32{preID, preVid, bodyID, 0},
+		})
+		phis[i] = phiVid
+		b.values[name] = phiVid
+		if name == idxName {
+			idxPhi = phiVid
+		}
+	}
+	cond := b.addValue(ir.Value{
+		Type: ir.TypeBool,
+		Op:   ir.OpCmpLtI64,
+		Args: []uint32{idxPhi, lenID},
+	})
+	b.terminator(ir.Terminator{Kind: ir.TermBranch, Value: cond, IfTrue: bodyID, IfFalse: contID})
+
+	b.curBlock = bodyID
+	b.terminated = false
+	// Bind the loop variable to xs[idx] for the duration of the body.
+	elemID := b.addValue(ir.Value{
+		Type:     elemType,
+		ElemType: elemType,
+		Op:       getOp,
+		Args:     []uint32{xs, idxPhi},
+	})
+	b.values[loopName] = elemID
+	for _, st := range s.Body {
+		if err := b.lowerStmt(st); err != nil {
+			return err
+		}
+		if b.terminated {
+			break
+		}
+	}
+	if !b.terminated {
+		// Synthetic `i = i + 1` step. Use the current idx binding from
+		// the env (normally the header phi).
+		cur := b.values[idxName]
+		one := b.addValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 1})
+		next := b.addValue(ir.Value{Type: ir.TypeI64, Op: ir.OpAddI64, Args: []uint32{cur, one}})
+		b.values[idxName] = next
+		endBlock := b.curBlock
+		for i, name := range names {
+			b.fn.Values[phis[i]].Args[2] = endBlock
+			b.fn.Values[phis[i]].Args[3] = b.values[name]
+		}
+		b.terminator(ir.Terminator{Kind: ir.TermJump, Target: headID})
+	} else {
+		head := b.fn.Block(headID)
+		head.Preds = []uint32{preID}
+		for _, phiVid := range phis {
+			phi := &b.fn.Values[phiVid]
+			phi.Args = phi.Args[:2]
+		}
+	}
+
+	b.curBlock = contID
+	b.terminated = false
+	for i, name := range names {
+		b.values[name] = phis[i]
+	}
+	// The idx counter is dead after the loop. Drop the synthetic binding
+	// so a later for-in over the same name does not collide.
+	delete(b.values, idxName)
 	if hadOld {
 		b.values[loopName] = oldVal
 	} else {

--- a/compiler3/frontend/lower_test.go
+++ b/compiler3/frontend/lower_test.go
@@ -429,6 +429,58 @@ print(int(eval_a(0, 0) * 1.0e9))
 	}
 }
 
+// TestLowerForInListI64 pins the Phase 4.3.7 collection-iter surface
+// for list<int>: iterating `for x in xs` over a 3-element list and
+// summing the values produces 60.
+func TestLowerForInListI64(t *testing.T) {
+	src := `let xs: list<int> = [10, 20, 30]
+var s = 0
+for x in xs {
+  s = s + x
+}
+print(s)
+`
+	got := runEnd2End(t, src)
+	if got != "60\n" {
+		t.Errorf("got %q, want %q", got, "60\n")
+	}
+}
+
+// TestLowerForInListF64 pins the Phase 4.3.7 collection-iter surface
+// for list<float>: iterating a 3-element f64 list, summing, then
+// truncating to int via the Phase 4.3.6 `int(...)` builtin gives 6
+// (= 1.5 + 2.0 + 2.5 truncated).
+func TestLowerForInListF64(t *testing.T) {
+	src := `let xs: list<float> = [1.5, 2.0, 2.5]
+var s = 0.0
+for x in xs {
+  s = s + x
+}
+print(int(s))
+`
+	got := runEnd2End(t, src)
+	if got != "6\n" {
+		t.Errorf("got %q, want %q", got, "6\n")
+	}
+}
+
+// TestLowerForInListEmpty pins the zero-iteration shape: a `for x in xs`
+// over an empty list runs the body 0 times, so the accumulator keeps
+// its pre-loop value.
+func TestLowerForInListEmpty(t *testing.T) {
+	src := `var xs: list<int> = []
+var s = 42
+for x in xs {
+  s = s + x
+}
+print(s)
+`
+	got := runEnd2End(t, src)
+	if got != "42\n" {
+		t.Errorf("got %q, want %q", got, "42\n")
+	}
+}
+
 // TestLowerNsieve is the load-bearing Phase 4.3.2 gate: a stripped
 // nsieve(100) returning the prime count (25). It exercises range-for
 // with nested while, indexed reads/writes, len(), and the synthetic

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -725,7 +725,7 @@ Workloads in the "performance games" set that are NOT in this table, and why:
 
 | Workload | Why excluded |
 |----------|--------------|
-| `mandelbrot`, `n_body`, `spectral_norm` | f64 list primitives LANDED in Phase 4.3.3, i64↔f64 casts LANDED in Phase 4.3.4 (`as` form) + 4.3.6 (`int(x)`/`float(x)` call form), `math.sqrt` + operator precedence LANDED in Phase 4.3.5. mandelbrot's 16×16 kernel pinned by `TestBuildSourceMandelbrotKernel` (4629); n_body's softened-distance kernel pinned by `TestBuildSourceNbodyDistanceKernel` (8000000); spectral_norm's `eval_a` matrix-entry kernel pinned by `TestBuildSourceSpectralEvalKernel` (1000000000). The remaining gap for `n_body` is the multi-step time-step integration plus the `extern let math.pi` form; for `spectral_norm` it is the `[float]` bracketed list-type syntax + list concatenation + collection-iter `for x in xs`; for all three it is the `bench/template/bg/*` harness shape (`now()`, `json({...})`, `{{ .N }}`). Those are §13 follow-ups |
+| `mandelbrot`, `n_body`, `spectral_norm` | f64 list primitives LANDED in Phase 4.3.3, i64↔f64 casts LANDED in Phase 4.3.4 (`as` form) + 4.3.6 (`int(x)`/`float(x)` call form), `math.sqrt` + operator precedence LANDED in Phase 4.3.5, collection-iter `for x in xs` LANDED in Phase 4.3.7. mandelbrot's 16×16 kernel pinned by `TestBuildSourceMandelbrotKernel` (4629); n_body's softened-distance kernel pinned by `TestBuildSourceNbodyDistanceKernel` (8000000); spectral_norm's `eval_a` matrix-entry kernel pinned by `TestBuildSourceSpectralEvalKernel` (1000000000). The remaining gap for `n_body` is the multi-step time-step integration plus the `extern let math.pi` form; for `spectral_norm` it is the `[float]` bracketed list-type syntax + list concatenation; for all three it is the `bench/template/bg/*` harness shape (`now()`, `json({...})`, `{{ .N }}`). Those are §13 follow-ups |
 | `nsieve` | LANDED in Phase 4.3.2 (range-for + if-merge phi joins land together; stripped nsieve(100)=25 pinned by C and Go target tests). The full benchmark uses identical primitives |
 | `fannkuch`, `binary_trees` | Need list-of-structs / struct-of-lists; i64 list primitive landed in Phase 4.3.1, struct support blocked on Phase 4.4, nesting on Phase 4.5 |
 | `fasta`, `regex_redux`, `k_nucleotide` | Need string literals and string ops; blocked on Phase 4.2 (TypeStr) |
@@ -1234,6 +1234,46 @@ Compiles via `mochi build --target=c` (and `--target=go`) to a binary that print
 
 - Only `int` and `float` are recognised. `bool(x)`, `str(x)`, `i32(x)`, `u64(x)`, ... extend the same dispatch but each needs a target IR type. None are on the §10.7 critical path.
 - The full spectral_norm fixture still cannot compile because it uses `[float]` (the bracketed list-type syntax, distinct from `list<float>`), list concatenation (`u + [1.0]`), and `for _ in 0..N` driving a `[float]` accumulator. Those are the next sub-phases. The full n_body fixture still needs top-level `var` at module scope, the `extern let math.pi` extern-variable form, and the `now()` + `json({...})` + `{{ .N }}` benchmark harness shape.
+
+## §10.16 Phase 4.3.7 closeout (LANDED 2026-05-22 00:07 GMT+7)
+
+Phase 4.3.7 lands collection-iter: `for x in xs { body }` where xs is `list<int>` or `list<float>`. The desugared CFG is the same phi-at-header shape as the existing range-for, with an internal index counter `$for_idx_<name>` taking the place of the explicit `i in lo..hi` counter. The loop variable `x` is rebound on every iteration to `xs[idx]` via the existing `OpListGetI64` / `OpF64ArrayGetF64` ops; xs itself and `len(xs)` are evaluated once in the pre-header so a mutation of `xs` inside the body does not change what is iterated over.
+
+### Implementation
+
+No IR additions, no verify or emit changes. The work is entirely in `lowerFor`, which now routes `s.RangeEnd == nil` to a new `lowerForCollection(s)` helper. That helper:
+
+- evaluates xs once in the pre-header and dispatches on its IR type. `TypeList` selects `(OpListLenI64, OpListGetI64, TypeI64)`; `TypeF64Arr` selects `(OpF64ArrayLenI64, OpF64ArrayGetF64, TypeF64)`. Any other type rejects with `for-in over %s unsupported (need list)`.
+- creates an internal index counter `$for_idx_<loopName>` initialised to 0 in the pre-header. The leading `$` ensures it cannot collide with a user identifier (the Mochi ident grammar excludes `$`).
+- mirrors `lowerWhile`'s phi-at-header CFG with the counter and any other pre-loop bindings phi-tracked, then patches the back-edge after the body lowers (same arity-fixup discipline as the existing while / range-for paths if the body terminates unconditionally).
+- binds the user-visible loop variable to `OpListGetI64(xs, idx)` (or the f64 equivalent) at the top of the body. The body sees `x` as a fresh SSA value on every iteration, not a phi.
+- restores the shadowed outer binding (if any) at the cont block, matching the existing range-for scoping. The internal counter is deleted from the env at the cont so a later `for ... in xs` over the same loop name does not collide.
+
+### Files changed
+
+- `compiler3/frontend/lower.go`: route `lowerFor` to a new `lowerForCollection` when `RangeEnd == nil` (+150 lines, all in one function).
+- `compiler3/frontend/lower_test.go`: `TestLowerForInListI64`, `TestLowerForInListF64`, `TestLowerForInListEmpty`.
+- `compiler3/build/c/driver_test.go`: matching `TestBuildSourceForInListI64` and `TestBuildSourceForInListF64`.
+- `website/docs/mep/mep-0042.md`: this section. §10.7 spectral_norm row notes collection-iter is no longer a blocker (the bracketed-list-type syntax and list concat remain).
+
+### Reproducer
+
+```mochi
+let xs: list<float> = [1.5, 2.0, 2.5]
+var s = 0.0
+for x in xs {
+  s = s + x
+}
+print(int(s))
+```
+
+Compiles via `mochi build --target=c` (and `--target=go`) to a binary that prints `6\n`. Pinned by `TestBuildSourceForInListF64`.
+
+### Limitations
+
+- Only `list<int>` and `list<float>` are supported. `list<bool>` / `list<string>` / nested-list iteration extend the same dispatch but each needs its own elem-type IR path.
+- The collection-iter desugar evaluates `xs` once and freezes the length. A body that appends to `xs` does NOT extend the iteration count. This matches Mochi's documented semantics (the loop iterates the snapshot taken at entry) and the Go target.
+- Map iteration (`for k in m { ... }` where m is a map) still rejects. Maps are deferred to a later Phase 4.x sub-phase along with `OpNewMap`.
 
 ## §11 Risks
 


### PR DESCRIPTION
Closes #21971

## Summary

- Lower `for x in xs { body }` (list<int> and list<float>) into the same phi-at-header CFG shape as the existing range-for, with an internal `$for_idx_<name>` counter.
- xs and len(xs) are evaluated once in the pre-header so a mutation of xs inside the body does not change what is iterated over.
- No IR / verify / emit additions; everything lives in the new `lowerForCollection` helper called from `lowerFor` when `RangeEnd == nil`.

## Tests

- `TestLowerForInListI64`, `TestLowerForInListF64`, `TestLowerForInListEmpty` (frontend, Go target).
- `TestBuildSourceForInListI64`, `TestBuildSourceForInListF64` (C target).
- Full compiler3 suite green locally.

## Test plan

- [x] `go test ./compiler3/...`
- [x] `for x in xs` over a list<float> compiles via `mochi build --target=c` and byte-matches Go
- [x] §10.16 closeout landed in `website/docs/mep/mep-0042.md`