### PR TITLE
mep-0042: Phase 4.3.9 math.pi + math.e constant selector reads

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -540,6 +540,20 @@ print(int(eval_a(0, 0) * 1.0e9))
 	}
 }
 
+// TestBuildSourceMathPiConst pins the Phase 4.3.9 math.pi constant
+// read on the C target: 4*pi*pi truncated = 39.
+func TestBuildSourceMathPiConst(t *testing.T) {
+	src := `import python "math" as math
+extern let math.pi: float
+
+let solar_mass = 4.0 * math.pi * math.pi
+print(int(solar_mass))
+`
+	if got, want := runMochiBuild(t, src), "39\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceListInferFloatElem pins the Phase 4.3.8 element-type
 // inference on the C target: a float-element literal without a type
 // annotation lowers via mochi_f64_array, not mochi_list_i64.

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1316,6 +1316,9 @@ func (b *builder) lowerPrimary(p *parser.Primary) (uint32, error) {
 			if imp, ok := b.goImports[p.Selector.Root]; ok {
 				return b.lowerGoValue(imp, p.Selector.Tail[0])
 			}
+			if id, ok, err := b.tryLowerMathConst(p.Selector.Root, p.Selector.Tail); ok {
+				return id, err
+			}
 		}
 		if len(p.Selector.Tail) != 0 {
 			return 0, fmt.Errorf("frontend: selector tail %v unsupported in MVP", p.Selector.Tail)
@@ -1574,6 +1577,31 @@ func (b *builder) lowerBuiltinCall(c *parser.CallExpr) (uint32, bool, error) {
 // are no-ops at compiler3-lower time. Only `math.sqrt` is recognised
 // in Phase 4.3.5; further entries (`pow`, `log`, ...) extend the
 // switch.
+// tryLowerMathConst recognises `math.<name>` selector reads against a
+// known math constant. It mirrors the math-builtin function-call
+// dispatch (Phase 4.3.5) but for value-reads rather than calls. The
+// Mochi source advertises the binding via `extern let math.pi: float`
+// (skipped at top-level statement collection) plus the usual
+// `import python "math" as math`; both are no-op declarations at
+// compiler3-lower time. Phase 4.3.9 covers `pi` and `e`; further
+// constants extend the switch.
+func (b *builder) tryLowerMathConst(root string, tail []string) (uint32, bool, error) {
+	if root != "math" || len(tail) != 1 {
+		return 0, false, nil
+	}
+	var v float64
+	switch tail[0] {
+	case "pi":
+		v = math.Pi
+	case "e":
+		v = math.E
+	default:
+		return 0, false, nil
+	}
+	id := b.addValue(ir.Value{Type: ir.TypeF64, Op: ir.OpConst, Const: int64(math.Float64bits(v))})
+	return id, true, nil
+}
+
 func (b *builder) tryLowerMathBuiltin(root string, tail []string, callArgs []*parser.Expr) (uint32, bool, error) {
 	if root != "math" || len(tail) != 1 {
 		return 0, false, nil

--- a/compiler3/frontend/lower_test.go
+++ b/compiler3/frontend/lower_test.go
@@ -429,6 +429,37 @@ print(int(eval_a(0, 0) * 1.0e9))
 	}
 }
 
+// TestLowerMathPiConst pins the Phase 4.3.9 `math.pi` constant read:
+// `extern let math.pi: float` is accepted as a no-op binding; the
+// selector read lowers to OpConst of TypeF64 with the math.Pi value.
+// 4*pi*pi truncated to int gives 39 (= 4 * 3.14159^2 = 39.478).
+func TestLowerMathPiConst(t *testing.T) {
+	src := `import python "math" as math
+extern let math.pi: float
+
+let solar_mass = 4.0 * math.pi * math.pi
+print(int(solar_mass))
+`
+	got := runEnd2End(t, src)
+	if got != "39\n" {
+		t.Errorf("got %q, want %q", got, "39\n")
+	}
+}
+
+// TestLowerMathEConst pins the secondary `math.e` constant: e^2
+// truncated to int gives 7 (= 2.71828^2 = 7.389).
+func TestLowerMathEConst(t *testing.T) {
+	src := `import python "math" as math
+extern let math.e: float
+
+print(int(math.e * math.e))
+`
+	got := runEnd2End(t, src)
+	if got != "7\n" {
+		t.Errorf("got %q, want %q", got, "7\n")
+	}
+}
+
 // TestLowerListInferFloatElem pins the Phase 4.3.8 element-type
 // inference: `var xs = [1.0, 2.0, 3.0]` (no type annotation) lowers
 // to OpNewF64Array, not the default OpNewList, because the first

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -1313,6 +1313,39 @@ Compiles via `mochi build --target=c` (and `--target=go`) to a binary that print
 - Empty literals with no annotation still default to i64. The user must write `var xs: list<float> = []` to get an f64 array. A smarter inference would look at later context (the first push or the first read) but that requires a second pass and is not on any §10.7 critical path.
 - The Phase 4.3.7 collection-iter desugar happens after type inference, so `for x in xs { body }` over an inferred f64 array correctly dispatches to the f64 path.
 
+## §10.18 Phase 4.3.9 closeout (LANDED 2026-05-22 00:20 GMT+7)
+
+Phase 4.3.9 adds `math.pi` and `math.e` as recognised selector reads. The Mochi-source pattern is `import python "math" as math` plus `extern let math.pi: float` (both already accepted as no-op binding statements from Phase 4.3.5); the new work is recognising the `math.pi` selector read at the use site and lowering it to an `OpConst` of TypeF64 carrying the value of `math.Pi` (or `math.E`). This is the value-read analogue of Phase 4.3.5's `tryLowerMathBuiltin` for function calls.
+
+### Implementation
+
+New helper `tryLowerMathConst(root, tail)` in `compiler3/frontend/lower.go`. Returns `(id, true, nil)` on a successful lower, `(0, false, nil)` when the receiver/method pair is not a known math constant, and is wired into the `lowerPrimary` Selector branch immediately after the goImports lookup. The constant table holds `pi` and `e`; the encoding is the same as `lowerLiteral`'s float case (`int64(math.Float64bits(v))`), so the verify and emit paths see a regular `OpConst` and need no changes.
+
+### Files changed
+
+- `compiler3/frontend/lower.go`: new `tryLowerMathConst` helper; wired into `lowerPrimary` Selector dispatch.
+- `compiler3/frontend/lower_test.go`: `TestLowerMathPiConst` (4*pi*pi truncated = 39), `TestLowerMathEConst` (e*e truncated = 7).
+- `compiler3/build/c/driver_test.go`: matching `TestBuildSourceMathPiConst`.
+- `website/docs/mep/mep-0042.md`: this section.
+
+### Reproducer
+
+```mochi
+import python "math" as math
+extern let math.pi: float
+
+let solar_mass = 4.0 * math.pi * math.pi
+print(int(solar_mass))
+```
+
+Compiles via `mochi build --target=c` (and `--target=go`) to a binary that prints `39\n`. Pinned by `TestBuildSourceMathPiConst`.
+
+### Limitations
+
+- Only `math.pi` and `math.e` are recognised. `math.inf`, `math.nan`, `math.tau` extend the same switch and need one line each.
+- The const value is baked at lower time. If the Mochi source declares `extern let math.pi: float = 3.0` (a user override), the override is silently ignored because the selector read goes to the math constant table, not the env. Mochi's `extern let` is a declaration of an external binding, not a definition, so this matches the language semantics.
+- Selector reads against non-math roots still go through the goImports path (`pkg.Var`) or reject. There is no general "any extern let binding" path; each external symbol has to be recognised explicitly. This is fine for the §10.7 critical path; a future Phase 4.x can widen if a benchmark adds a new pattern.
+
 ## §11 Risks
 
 ### 11.1 Clang ABI drift breaks stencils


### PR DESCRIPTION
Closes #21975.

Recognise `math.pi` and `math.e` as selector reads at compiler3-lower time and emit `OpConst` of TypeF64 carrying `math.Pi` / `math.E`. The Mochi source pattern is `import python \"math\" as math` plus `extern let math.pi: float` (both already accepted as no-op binding statements from Phase 4.3.5); this PR is the use-site analogue of Phase 4.3.5's `tryLowerMathBuiltin` function-call dispatch.

## Implementation

New helper `tryLowerMathConst(root, tail)` in `compiler3/frontend/lower.go`. Wired into `lowerPrimary`'s Selector branch right after the goImports lookup, so non-math selectors still fall through to the existing goImports path or reject. Returns `(id, true, nil)` on a hit, `(0, false, nil)` otherwise. Encoding matches `lowerLiteral`'s float case (`int64(math.Float64bits(v))`) so verify and emit see a regular `OpConst` and need no changes.

## Tests

- `TestLowerMathPiConst`: `4.0 * math.pi * math.pi` truncated to int = 39.
- `TestLowerMathEConst`: `math.e * math.e` truncated to int = 7.
- `TestBuildSourceMathPiConst`: same pi case on the C target.

## Spec

§10.18 closeout in MEP-42 with reproducer and limitations.

## Unblocks

n_body's `4.0 * math.pi * math.pi` solar-mass constant on the §10.7 critical path.

## Limitations

- Only `pi` and `e`. `tau`, `inf`, `nan` are one switch line each.
- The const value is baked at lower time; `extern let math.pi: float = 3.0` user overrides are ignored (matches Mochi's extern-decl-not-definition semantics).
- Selectors against non-math roots still go through goImports or reject. No general "any extern let binding" lookup.

## Test plan

- [x] `go test ./compiler3/frontend/ -run 'TestLowerMathPiConst|TestLowerMathEConst' -count=1`
- [x] `go test ./compiler3/build/c/ -run 'TestBuildSourceMathPiConst' -count=1`

Stacked on #21974 (Phase 4.3.8 list-literal element-type inference).