### PR TITLE
mep-0042: Phase 4.3.10 pin n_body full integration kernel

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -540,6 +540,114 @@ print(int(eval_a(0, 0) * 1.0e9))
 	}
 }
 
+// TestBuildSourceNbodyFullKernel pins the Phase 4.3.10 milestone: the
+// full benchmark-games n_body integration kernel (5 bodies, 10 steps,
+// canonical Sun + Jupiter + Saturn + Uranus + Neptune initial
+// conditions; momentum normalisation; pairwise gravity inner loop;
+// position update outer loop; final energy * 1e9 truncated to int)
+// now compiles end-to-end through compiler3 to a native binary via
+// `mochi build --target=c`. Output -169073021 byte-matches the
+// `--target=go` build.
+//
+// This is the load-bearing regression test for the entire n_body
+// kernel surface. With Phase 4.3.9's math.pi constant read, every
+// arithmetic expression and indexed array assignment the kernel
+// needs is now lowerable. The remaining gap before the
+// bench/template/bg/n_body fixture compiles unchanged is the bench
+// harness shape (`now()`, `json({...})`, `{{ .N }}`), which is a
+// §13 follow-up and out of Phase 4.3's scope.
+func TestBuildSourceNbodyFullKernel(t *testing.T) {
+	src := `import python "math" as math
+extern let math.pi: float
+extern fun math.sqrt(x: float): float
+
+let DAYS_PER_YEAR = 365.24
+let SOLAR_MASS = 4.0 * math.pi * math.pi
+let DT = 0.01
+
+var pos_x = [0.0, 4.84143144246472090, 8.34336671824457987, 1.28943695621391310e+01, 1.53796971148509165e+01]
+var pos_y = [0.0, -1.16032004402742839, 4.12479856412430479, -1.51111514016986312e+01, -2.59193146099879641e+01]
+var pos_z = [0.0, -1.03622044471123109e-01, -4.03523417114321381e-01, -2.23307578892655734e-01, 1.79258772950371181e-01]
+var vel_x = [0.0, 1.66007664274403694e-03 * DAYS_PER_YEAR, -2.76742510726862411e-03 * DAYS_PER_YEAR, 2.96460137564761618e-03 * DAYS_PER_YEAR, 2.68067772490389322e-03 * DAYS_PER_YEAR]
+var vel_y = [0.0, 7.69901118419740425e-03 * DAYS_PER_YEAR, 4.99852801234917238e-03 * DAYS_PER_YEAR, 2.37847173959480950e-03 * DAYS_PER_YEAR, 1.62824170038242295e-03 * DAYS_PER_YEAR]
+var vel_z = [0.0, -6.90460016972063023e-05 * DAYS_PER_YEAR, 2.30417297573763929e-05 * DAYS_PER_YEAR, -2.96589568540237556e-05 * DAYS_PER_YEAR, -9.51592254519715870e-05 * DAYS_PER_YEAR]
+var mass = [SOLAR_MASS, 9.54791938424326609e-04 * SOLAR_MASS, 2.85885980666130812e-04 * SOLAR_MASS, 4.36624404335156298e-05 * SOLAR_MASS, 5.15138902046611451e-05 * SOLAR_MASS]
+
+let N_BODIES = 5
+let steps = 10
+
+var px = 0.0
+var py = 0.0
+var pz = 0.0
+var k = 1
+while k < N_BODIES {
+  px = px - vel_x[k] * mass[k]
+  py = py - vel_y[k] * mass[k]
+  pz = pz - vel_z[k] * mass[k]
+  k = k + 1
+}
+vel_x[0] = px / SOLAR_MASS
+vel_y[0] = py / SOLAR_MASS
+vel_z[0] = pz / SOLAR_MASS
+
+var s = 0
+while s < steps {
+  var i = 0
+  while i < N_BODIES {
+    var j = i + 1
+    while j < N_BODIES {
+      let dx = pos_x[i] - pos_x[j]
+      let dy = pos_y[i] - pos_y[j]
+      let dz = pos_z[i] - pos_z[j]
+      let d2 = dx * dx + dy * dy + dz * dz
+      let mag = DT / (d2 * math.sqrt(d2))
+      let mi_mag = mass[i] * mag
+      let mj_mag = mass[j] * mag
+      vel_x[i] = vel_x[i] - dx * mj_mag
+      vel_y[i] = vel_y[i] - dy * mj_mag
+      vel_z[i] = vel_z[i] - dz * mj_mag
+      vel_x[j] = vel_x[j] + dx * mi_mag
+      vel_y[j] = vel_y[j] + dy * mi_mag
+      vel_z[j] = vel_z[j] + dz * mi_mag
+      j = j + 1
+    }
+    i = i + 1
+  }
+  var p = 0
+  while p < N_BODIES {
+    pos_x[p] = pos_x[p] + vel_x[p] * DT
+    pos_y[p] = pos_y[p] + vel_y[p] * DT
+    pos_z[p] = pos_z[p] + vel_z[p] * DT
+    p = p + 1
+  }
+  s = s + 1
+}
+
+var energy = 0.0
+var bi = 0
+while bi < N_BODIES {
+  let kin = 0.5 * mass[bi] * (vel_x[bi] * vel_x[bi] + vel_y[bi] * vel_y[bi] + vel_z[bi] * vel_z[bi])
+  var pot = 0.0
+  var bj = bi + 1
+  while bj < N_BODIES {
+    let dx = pos_x[bi] - pos_x[bj]
+    let dy = pos_y[bi] - pos_y[bj]
+    let dz = pos_z[bi] - pos_z[bj]
+    let r = math.sqrt(dx * dx + dy * dy + dz * dz)
+    pot = pot + mass[bi] * mass[bj] / r
+    bj = bj + 1
+  }
+  energy = energy + kin - pot
+  bi = bi + 1
+}
+
+print(int(energy * 1e9))
+`
+	if got, want := runMochiBuild(t, src), "-169073021\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceMathPiConst pins the Phase 4.3.9 math.pi constant
 // read on the C target: 4*pi*pi truncated = 39.
 func TestBuildSourceMathPiConst(t *testing.T) {

--- a/compiler3/frontend/lower_test.go
+++ b/compiler3/frontend/lower_test.go
@@ -429,6 +429,107 @@ print(int(eval_a(0, 0) * 1.0e9))
 	}
 }
 
+// TestLowerNbodyFullKernel pins the Phase 4.3.10 milestone: the full
+// benchmark-games n_body integration kernel (5 bodies, 10 steps,
+// canonical Sun + Jupiter + Saturn + Uranus + Neptune initial
+// conditions; momentum normalisation; pairwise gravity inner loop;
+// position update outer loop; final energy * 1e9 truncated to int)
+// now lowers through compiler3 and emits valid Go. The C-target
+// mirror is `TestBuildSourceNbodyFullKernel` in
+// compiler3/build/c/driver_test.go; both produce -169073021.
+func TestLowerNbodyFullKernel(t *testing.T) {
+	src := `import python "math" as math
+extern let math.pi: float
+extern fun math.sqrt(x: float): float
+
+let DAYS_PER_YEAR = 365.24
+let SOLAR_MASS = 4.0 * math.pi * math.pi
+let DT = 0.01
+
+var pos_x = [0.0, 4.84143144246472090, 8.34336671824457987, 1.28943695621391310e+01, 1.53796971148509165e+01]
+var pos_y = [0.0, -1.16032004402742839, 4.12479856412430479, -1.51111514016986312e+01, -2.59193146099879641e+01]
+var pos_z = [0.0, -1.03622044471123109e-01, -4.03523417114321381e-01, -2.23307578892655734e-01, 1.79258772950371181e-01]
+var vel_x = [0.0, 1.66007664274403694e-03 * DAYS_PER_YEAR, -2.76742510726862411e-03 * DAYS_PER_YEAR, 2.96460137564761618e-03 * DAYS_PER_YEAR, 2.68067772490389322e-03 * DAYS_PER_YEAR]
+var vel_y = [0.0, 7.69901118419740425e-03 * DAYS_PER_YEAR, 4.99852801234917238e-03 * DAYS_PER_YEAR, 2.37847173959480950e-03 * DAYS_PER_YEAR, 1.62824170038242295e-03 * DAYS_PER_YEAR]
+var vel_z = [0.0, -6.90460016972063023e-05 * DAYS_PER_YEAR, 2.30417297573763929e-05 * DAYS_PER_YEAR, -2.96589568540237556e-05 * DAYS_PER_YEAR, -9.51592254519715870e-05 * DAYS_PER_YEAR]
+var mass = [SOLAR_MASS, 9.54791938424326609e-04 * SOLAR_MASS, 2.85885980666130812e-04 * SOLAR_MASS, 4.36624404335156298e-05 * SOLAR_MASS, 5.15138902046611451e-05 * SOLAR_MASS]
+
+let N_BODIES = 5
+let steps = 10
+
+var px = 0.0
+var py = 0.0
+var pz = 0.0
+var k = 1
+while k < N_BODIES {
+  px = px - vel_x[k] * mass[k]
+  py = py - vel_y[k] * mass[k]
+  pz = pz - vel_z[k] * mass[k]
+  k = k + 1
+}
+vel_x[0] = px / SOLAR_MASS
+vel_y[0] = py / SOLAR_MASS
+vel_z[0] = pz / SOLAR_MASS
+
+var s = 0
+while s < steps {
+  var i = 0
+  while i < N_BODIES {
+    var j = i + 1
+    while j < N_BODIES {
+      let dx = pos_x[i] - pos_x[j]
+      let dy = pos_y[i] - pos_y[j]
+      let dz = pos_z[i] - pos_z[j]
+      let d2 = dx * dx + dy * dy + dz * dz
+      let mag = DT / (d2 * math.sqrt(d2))
+      let mi_mag = mass[i] * mag
+      let mj_mag = mass[j] * mag
+      vel_x[i] = vel_x[i] - dx * mj_mag
+      vel_y[i] = vel_y[i] - dy * mj_mag
+      vel_z[i] = vel_z[i] - dz * mj_mag
+      vel_x[j] = vel_x[j] + dx * mi_mag
+      vel_y[j] = vel_y[j] + dy * mi_mag
+      vel_z[j] = vel_z[j] + dz * mi_mag
+      j = j + 1
+    }
+    i = i + 1
+  }
+  var p = 0
+  while p < N_BODIES {
+    pos_x[p] = pos_x[p] + vel_x[p] * DT
+    pos_y[p] = pos_y[p] + vel_y[p] * DT
+    pos_z[p] = pos_z[p] + vel_z[p] * DT
+    p = p + 1
+  }
+  s = s + 1
+}
+
+var energy = 0.0
+var bi = 0
+while bi < N_BODIES {
+  let kin = 0.5 * mass[bi] * (vel_x[bi] * vel_x[bi] + vel_y[bi] * vel_y[bi] + vel_z[bi] * vel_z[bi])
+  var pot = 0.0
+  var bj = bi + 1
+  while bj < N_BODIES {
+    let dx = pos_x[bi] - pos_x[bj]
+    let dy = pos_y[bi] - pos_y[bj]
+    let dz = pos_z[bi] - pos_z[bj]
+    let r = math.sqrt(dx * dx + dy * dy + dz * dz)
+    pot = pot + mass[bi] * mass[bj] / r
+    bj = bj + 1
+  }
+  energy = energy + kin - pot
+  bi = bi + 1
+}
+
+print(int(energy * 1e9))
+`
+	got := runEnd2End(t, src)
+	if got != "-169073021\n" {
+		t.Errorf("got %q, want %q", got, "-169073021\n")
+	}
+}
+
 // TestLowerMathPiConst pins the Phase 4.3.9 `math.pi` constant read:
 // `extern let math.pi: float` is accepted as a no-op binding; the
 // selector read lowers to OpConst of TypeF64 with the math.Pi value.

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -725,7 +725,7 @@ Workloads in the "performance games" set that are NOT in this table, and why:
 
 | Workload | Why excluded |
 |----------|--------------|
-| `mandelbrot`, `n_body`, `spectral_norm` | f64 list primitives LANDED in Phase 4.3.3, i64↔f64 casts LANDED in Phase 4.3.4 (`as` form) + 4.3.6 (`int(x)`/`float(x)` call form), `math.sqrt` + operator precedence LANDED in Phase 4.3.5, collection-iter `for x in xs` LANDED in Phase 4.3.7. mandelbrot's 16×16 kernel pinned by `TestBuildSourceMandelbrotKernel` (4629); n_body's softened-distance kernel pinned by `TestBuildSourceNbodyDistanceKernel` (8000000); spectral_norm's `eval_a` matrix-entry kernel pinned by `TestBuildSourceSpectralEvalKernel` (1000000000). The remaining gap for `n_body` is the multi-step time-step integration plus the `extern let math.pi` form; for `spectral_norm` it is the `[float]` bracketed list-type syntax + list concatenation; for all three it is the `bench/template/bg/*` harness shape (`now()`, `json({...})`, `{{ .N }}`). Those are §13 follow-ups |
+| `mandelbrot`, `n_body`, `spectral_norm` | f64 list primitives LANDED in Phase 4.3.3, i64↔f64 casts LANDED in Phase 4.3.4 (`as` form) + 4.3.6 (`int(x)`/`float(x)` call form), `math.sqrt` + operator precedence LANDED in Phase 4.3.5, collection-iter `for x in xs` LANDED in Phase 4.3.7, list-literal element-type inference LANDED in Phase 4.3.8, `math.pi` / `math.e` constant reads LANDED in Phase 4.3.9. mandelbrot's 16×16 kernel pinned by `TestBuildSourceMandelbrotKernel` (4629); n_body's full 5-body / 10-step integration kernel (canonical Sun + Jupiter + Saturn + Uranus + Neptune initial conditions; momentum normalisation; pairwise gravity; position update; final energy * 1e9 truncated) pinned by `TestBuildSourceNbodyFullKernel` (-169073021) as of Phase 4.3.10; spectral_norm's `eval_a` matrix-entry kernel pinned by `TestBuildSourceSpectralEvalKernel` (1000000000). The remaining gap for `spectral_norm` is the `[float]` bracketed list-type syntax + list concatenation (a `list<float>` + `append` rewrite of the kernel already compiles and byte-matches between C and Go targets; the native bracketed surface is purely syntactic). For all three the only outstanding piece is the `bench/template/bg/*` harness shape (`now()`, `json({...})`, `{{ .N }}`), which is a §13 follow-up |
 | `nsieve` | LANDED in Phase 4.3.2 (range-for + if-merge phi joins land together; stripped nsieve(100)=25 pinned by C and Go target tests). The full benchmark uses identical primitives |
 | `fannkuch`, `binary_trees` | Need list-of-structs / struct-of-lists; i64 list primitive landed in Phase 4.3.1, struct support blocked on Phase 4.4, nesting on Phase 4.5 |
 | `fasta`, `regex_redux`, `k_nucleotide` | Need string literals and string ops; blocked on Phase 4.2 (TypeStr) |
@@ -1345,6 +1345,41 @@ Compiles via `mochi build --target=c` (and `--target=go`) to a binary that print
 - Only `math.pi` and `math.e` are recognised. `math.inf`, `math.nan`, `math.tau` extend the same switch and need one line each.
 - The const value is baked at lower time. If the Mochi source declares `extern let math.pi: float = 3.0` (a user override), the override is silently ignored because the selector read goes to the math constant table, not the env. Mochi's `extern let` is a declaration of an external binding, not a definition, so this matches the language semantics.
 - Selector reads against non-math roots still go through the goImports path (`pkg.Var`) or reject. There is no general "any extern let binding" path; each external symbol has to be recognised explicitly. This is fine for the §10.7 critical path; a future Phase 4.x can widen if a benchmark adds a new pattern.
+
+## §10.19 Phase 4.3.10 closeout (LANDED 2026-05-22 00:28 GMT+7)
+
+Phase 4.3.10 is the n_body full-integration-kernel milestone. Phase 4.3.9's `math.pi` constant read was the last syntactic gap; this sub-phase verifies that result by pinning the canonical benchmark-games n_body integration kernel (5 bodies, 10 steps, Sun + Jupiter + Saturn + Uranus + Neptune initial conditions, momentum normalisation, pairwise gravity inner loop, position update outer loop, final `int(energy * 1e9) = -169073021`) as a load-bearing regression test. The kernel compiles end-to-end through compiler3 to a native binary via `mochi build --target=c`, and the output byte-matches `mochi build --target=go` (which goes through compiler3 + the Go emitter). No new lowering work was needed; this is a "discovered green" sub-phase where the cumulative effect of Phases 4.3.3 - 4.3.9 turns out to cover the entire n_body kernel surface.
+
+### Implementation
+
+No code changes. The work is two new tests and §10.7 row + this closeout in the MEP.
+
+### Files changed
+
+- `compiler3/build/c/driver_test.go`: `TestBuildSourceNbodyFullKernel`. Runs the full kernel through `mochi build --target=c` and asserts the stdout against `-169073021\n`.
+- `compiler3/frontend/lower_test.go`: `TestLowerNbodyFullKernel`. Mirror against the Go target via compiler3 + gogen.
+- `website/docs/mep/mep-0042.md`: §10.7 row updated to mark n_body's kernel as no longer blocked; this section added.
+
+### Reproducer
+
+The full kernel source is the body of `TestBuildSourceNbodyFullKernel`. To run by hand:
+
+```sh
+go run ./cmd/mochi build --target=c --binary /tmp/nbody /path/to/kernel.mochi
+/tmp/nbody  # prints -169073021
+```
+
+The same source compiles via `--target=go` to the same output.
+
+### Why this is the right gate
+
+Per the goal-alignment audit, before each MEP sub-phase the question is: does this gate move the user-facing goal (benchmark games compile via `mochi build --target=c`) or just spec-internal scaffolding? Phase 4.3.10 directly verifies that one of the three Phase 4.3 benchmark targets (n_body) has its entire arithmetic / control-flow / array surface compilable, with byte-matching output across both AOT targets. That is the load-bearing claim the §10.7 row makes; pinning it as a regression test means a future refactor of any of the Phase 4.3.x building blocks (list inference, math constants, sqrt, casts, collection-iter, list ops) cannot silently regress the n_body kernel.
+
+### Limitations
+
+- The full `bench/template/bg/n_body/n_body.mochi` fixture still cannot compile unchanged because it uses `now()`, `json({...})`, and `{{ .N }}` template expansion. Those are the bench-harness shape, owned by the §13 closeout. The compiler-internal kernel work is done.
+- `spectral_norm` is the next sub-phase candidate: its kernel compiles when rewritten to use `list<float>` and `append`, but the native source uses `[float]` bracketed list-type annotations and `u + [1.0]` list concatenation. Those are pure surface-syntax additions and would be the natural Phase 4.3.11 work.
+- This sub-phase ships no IR / verify / emit changes. If the suite goes red, the cause is in an earlier Phase 4.3.x's work, not here.
 
 ## §11 Risks
 


### PR DESCRIPTION
Closes #21977.

Pins the full benchmark-games n_body integration kernel (5 bodies, 10 steps, canonical Sun + Jupiter + Saturn + Uranus + Neptune initial conditions, momentum normalisation, pairwise gravity inner loop, position update outer loop, energy * 1e9 truncated = -169073021) as a load-bearing regression test. The kernel compiles end-to-end through compiler3 to a native binary via `mochi build --target=c`, byte-matching the `--target=go` build.

## Why

Phase 4.3.9's math.pi constant read was the last syntactic gap. This is a "discovered green" sub-phase: no new lowering work is needed. The cumulative effect of Phases 4.3.3 - 4.3.9 covers the entire n_body kernel surface, and pinning it as a regression test means a future refactor of any of the Phase 4.3.x building blocks (list-element-type inference, math constants, sqrt, i64<->f64 casts, collection-iter, list ops) cannot silently regress the n_body kernel.

## Tests

- `TestBuildSourceNbodyFullKernel`: full kernel via `mochi build --target=c`. Asserts `-169073021\n`.
- `TestLowerNbodyFullKernel`: same kernel via compiler3 + gogen. Asserts `-169073021\n`.

## Spec

§10.7 row updated: n_body's kernel is no longer a syntactic blocker. §10.19 closeout added with reproducer and the audit reasoning.

## What still blocks the full fixture

Only the bench-harness shape (`now()`, `json({...})`, `{{ .N }}`). That is owned by the §13 closeout and not a compiler-internal concern.

## Next sub-phase

spectral_norm syntax: the `[float]` bracketed list-type annotation in fun signatures and `u + [1.0]` list concatenation. The kernel logic already compiles when rewritten to `list<float>` + `append` (verified locally; byte-matches between C and Go targets). The remaining work is purely surface-syntactic.

## Test plan

- [x] `go test ./compiler3/build/c/ -count=1`
- [x] `go test ./compiler3/frontend/ -count=1`