### PR TITLE
mep-0042: Phase 4.3.11 [T] bracketed list-type + spectral kernel

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -648,6 +648,128 @@ print(int(energy * 1e9))
 	}
 }
 
+// TestBuildSourceBracketListTypeFloat pins the Phase 4.3.11
+// bracketed list-type syntax: `[float]` in a fun parameter
+// position is accepted as syntactic sugar for `list<float>` and
+// lowers to the same TypeF64Arr backing. The body fills a 3-slot
+// list with 2.0 and sums it. Output: 6.
+func TestBuildSourceBracketListTypeFloat(t *testing.T) {
+	src := `fun fill(xs: [float], n: int) {
+  for i in 0..n {
+    xs[i] = 2.0
+  }
+}
+
+var u: list<float> = []
+for _ in 0..3 {
+  u = append(u, 0.0)
+}
+fill(u, 3)
+print(int(u[0] + u[1] + u[2]))
+`
+	if got, want := runMochiBuild(t, src), "6\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceBracketListTypeInt pins `[int]` as the i64
+// counterpart: same surface, TypeList backing.
+func TestBuildSourceBracketListTypeInt(t *testing.T) {
+	src := `fun setall(xs: [int], n: int, v: int) {
+  for i in 0..n {
+    xs[i] = v
+  }
+}
+
+var u: list<int> = []
+for _ in 0..4 {
+  u = append(u, 0)
+}
+setall(u, 4, 7)
+print(u[0] + u[1] + u[2] + u[3])
+`
+	if got, want := runMochiBuild(t, src), "28\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceSpectralFullKernel pins the Phase 4.3.11 milestone:
+// the full benchmark-games spectral_norm kernel (N=10, 5 outer power-
+// method iterations, eval_a Hilbert-like matrix entry, mul_av and
+// mul_atv helper funs taking `[float]` parameters, final
+// `int(sqrt(uv/vv) * 1e9) = 1271844019`) now compiles end-to-end
+// through compiler3 to a native binary via `mochi build --target=c`.
+// Output byte-matches the `--target=go` build.
+//
+// Phase 4.3.11 adds the only remaining surface piece (the `[float]`
+// bracketed list-type syntax in mul_av / mul_atv signatures). The
+// `u + [1.0]` list-concatenation pattern from the native source is
+// rewritten here to `u = append(u, 1.0)` because the kernel's
+// growth happens once at the top of the program (the inner kernel
+// loops do not mutate list shape); whether to add list-concat as a
+// later sub-phase depends on whether any benchmark needs it inside
+// a hot loop, which spectral_norm does not.
+func TestBuildSourceSpectralFullKernel(t *testing.T) {
+	src := `import python "math" as math
+extern fun math.sqrt(x: float): float
+
+let N = 10
+
+fun eval_a(i: int, j: int): float {
+  let s = i + j
+  return 1.0 / float(s * (s + 1) / 2 + i + 1)
+}
+
+fun mul_av(src: [float], dst: [float], n: int) {
+  for i in 0..n {
+    var s = 0.0
+    for j in 0..n {
+      s = s + eval_a(i, j) * src[j]
+    }
+    dst[i] = s
+  }
+}
+
+fun mul_atv(src: [float], dst: [float], n: int) {
+  for i in 0..n {
+    var s = 0.0
+    for j in 0..n {
+      s = s + eval_a(j, i) * src[j]
+    }
+    dst[i] = s
+  }
+}
+
+var u: list<float> = []
+var v: list<float> = []
+var tmp: list<float> = []
+for _ in 0..N {
+  u = append(u, 1.0)
+  v = append(v, 0.0)
+  tmp = append(tmp, 0.0)
+}
+
+for _ in 0..5 {
+  mul_av(u, tmp, N)
+  mul_atv(tmp, v, N)
+  mul_av(v, tmp, N)
+  mul_atv(tmp, u, N)
+}
+
+var uv = 0.0
+var vv = 0.0
+for i in 0..N {
+  uv = uv + u[i] * v[i]
+  vv = vv + v[i] * v[i]
+}
+
+print(int(math.sqrt(uv / vv) * 1e9))
+`
+	if got, want := runMochiBuild(t, src), "1271844019\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceMathPiConst pins the Phase 4.3.9 math.pi constant
 // read on the C target: 4*pi*pi truncated = 39.
 func TestBuildSourceMathPiConst(t *testing.T) {

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -36,12 +36,26 @@ func Lower(prog *parser.Program) (*gogen.Program, error) {
 
 	// First pass: collect user fun declarations so call lookups can
 	// resolve before the fun body is lowered (allows mutual recursion
-	// and forward references).
+	// and forward references). The result type is resolved here, not
+	// inside lowerFun, so a call from one fun into another can read
+	// the callee's Result regardless of the (non-deterministic) order
+	// in which bodies are lowered. Without this pre-pass, Go's random
+	// map iteration order would cause flaky lowering errors of the
+	// shape "binop X across types invalid and Y" whenever a caller
+	// happened to be lowered before its callee.
 	userFns := map[string]funEntry{}
 	for _, st := range prog.Statements {
 		if st.Fun != nil {
 			idx := uint32(len(p.Funcs))
 			fn := &ir.Function{Name: st.Fun.Name}
+			fn.Result = ir.TypeI64
+			if st.Fun.Return != nil {
+				t, err := lowerType(st.Fun.Return)
+				if err != nil {
+					return nil, fmt.Errorf("lower fun %s result: %w", st.Fun.Name, err)
+				}
+				fn.Result = t
+			}
 			p.Funcs = append(p.Funcs, fn)
 			userFns[st.Fun.Name] = funEntry{index: idx, stmt: st.Fun}
 		}
@@ -185,17 +199,9 @@ func newBuilder(fn *ir.Function, userFns map[string]funEntry, prog *gogen.Progra
 
 func lowerFun(p *gogen.Program, idx uint32, fs *parser.FunStmt, userFns map[string]funEntry, goImports map[string]*goImport) error {
 	fn := p.Funcs[idx]
-	// Single result type. MVP supports i64 returns only; the absence
-	// of a return type annotation is treated as i64 to keep the most
-	// common fixture shape working without forcing the user to annotate.
-	fn.Result = ir.TypeI64
-	if fs.Return != nil {
-		t, err := lowerType(fs.Return)
-		if err != nil {
-			return err
-		}
-		fn.Result = t
-	}
+	// fn.Result is pre-populated by Lower's first pass so cross-fun
+	// calls can resolve their value type regardless of map iteration
+	// order. lowerFun only fills in Params and Blocks.
 	b := newBuilder(fn, userFns, p, goImports)
 	// Params: every param is an OpParam value of the declared type.
 	for _, param := range fs.Params {
@@ -260,6 +266,23 @@ func lowerType(t *parser.TypeRef) (ir.Type, error) {
 			return ir.TypeInvalid, fmt.Errorf("frontend: list<%s> unsupported in MVP (only list<int> and list<float>)", el)
 		}
 		return ir.TypeInvalid, fmt.Errorf("frontend: generic %s<...> unsupported in MVP", t.Generic.Name)
+	}
+	// `[T]` is syntactic sugar for `list<T>` (MEP-42 Phase 4.3.11).
+	// spectral_norm-style fun signatures (`mul_av(src: [float], dst:
+	// [float], n: int)`) use this surface; it dispatches to the same
+	// TypeList / TypeF64Arr lowering as the generic form.
+	if t.ListElem != nil {
+		el, err := lowerType(t.ListElem)
+		if err != nil {
+			return ir.TypeInvalid, fmt.Errorf("frontend: bracketed list element: %w", err)
+		}
+		switch el {
+		case ir.TypeI64:
+			return ir.TypeList, nil
+		case ir.TypeF64:
+			return ir.TypeF64Arr, nil
+		}
+		return ir.TypeInvalid, fmt.Errorf("frontend: [%s] unsupported in MVP (only [int] and [float])", el)
 	}
 	if t.Simple == nil {
 		return ir.TypeInvalid, fmt.Errorf("frontend: only simple and list<...> type names are supported in the MVP")

--- a/compiler3/frontend/lower_test.go
+++ b/compiler3/frontend/lower_test.go
@@ -15,7 +15,7 @@ import (
 // to a temp dir, and runs `go run`. Returns the program's stdout.
 func runEnd2End(t *testing.T, src string) string {
 	t.Helper()
-	prog, err := parser.Parser.ParseString("test.mochi", src)
+	prog, err := parser.ParseString(src)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -527,6 +527,121 @@ print(int(energy * 1e9))
 	got := runEnd2End(t, src)
 	if got != "-169073021\n" {
 		t.Errorf("got %q, want %q", got, "-169073021\n")
+	}
+}
+
+// TestLowerBracketListTypeFloat pins the Phase 4.3.11 bracketed
+// list-type syntax through the Go target: `[float]` in a fun
+// parameter is accepted as syntactic sugar for `list<float>` and
+// lowers to the same TypeF64Arr backing.
+func TestLowerBracketListTypeFloat(t *testing.T) {
+	src := `fun fill(xs: [float], n: int) {
+  for i in 0..n {
+    xs[i] = 2.0
+  }
+}
+
+var u: list<float> = []
+for _ in 0..3 {
+  u = append(u, 0.0)
+}
+fill(u, 3)
+print(int(u[0] + u[1] + u[2]))
+`
+	got := runEnd2End(t, src)
+	if got != "6\n" {
+		t.Errorf("got %q, want %q", got, "6\n")
+	}
+}
+
+// TestLowerBracketListTypeInt mirrors the bracketed surface for the
+// i64 backing: `[int]` lowers to TypeList.
+func TestLowerBracketListTypeInt(t *testing.T) {
+	src := `fun setall(xs: [int], n: int, v: int) {
+  for i in 0..n {
+    xs[i] = v
+  }
+}
+
+var u: list<int> = []
+for _ in 0..4 {
+  u = append(u, 0)
+}
+setall(u, 4, 7)
+print(u[0] + u[1] + u[2] + u[3])
+`
+	got := runEnd2End(t, src)
+	if got != "28\n" {
+		t.Errorf("got %q, want %q", got, "28\n")
+	}
+}
+
+// TestLowerSpectralFullKernel pins the Phase 4.3.11 milestone: the
+// full benchmark-games spectral_norm kernel (N=10, 5 outer power-
+// method iterations, eval_a Hilbert-like matrix entry, mul_av and
+// mul_atv helper funs taking `[float]` parameters, final
+// `int(sqrt(uv/vv) * 1e9) = 1271844019`) now lowers through
+// compiler3 and emits valid Go. The C-target mirror is
+// `TestBuildSourceSpectralFullKernel`.
+func TestLowerSpectralFullKernel(t *testing.T) {
+	src := `import python "math" as math
+extern fun math.sqrt(x: float): float
+
+let N = 10
+
+fun eval_a(i: int, j: int): float {
+  let s = i + j
+  return 1.0 / float(s * (s + 1) / 2 + i + 1)
+}
+
+fun mul_av(src: [float], dst: [float], n: int) {
+  for i in 0..n {
+    var s = 0.0
+    for j in 0..n {
+      s = s + eval_a(i, j) * src[j]
+    }
+    dst[i] = s
+  }
+}
+
+fun mul_atv(src: [float], dst: [float], n: int) {
+  for i in 0..n {
+    var s = 0.0
+    for j in 0..n {
+      s = s + eval_a(j, i) * src[j]
+    }
+    dst[i] = s
+  }
+}
+
+var u: list<float> = []
+var v: list<float> = []
+var tmp: list<float> = []
+for _ in 0..N {
+  u = append(u, 1.0)
+  v = append(v, 0.0)
+  tmp = append(tmp, 0.0)
+}
+
+for _ in 0..5 {
+  mul_av(u, tmp, N)
+  mul_atv(tmp, v, N)
+  mul_av(v, tmp, N)
+  mul_atv(tmp, u, N)
+}
+
+var uv = 0.0
+var vv = 0.0
+for i in 0..N {
+  uv = uv + u[i] * v[i]
+  vv = vv + v[i] * v[i]
+}
+
+print(int(math.sqrt(uv / vv) * 1e9))
+`
+	got := runEnd2End(t, src)
+	if got != "1271844019\n" {
+		t.Errorf("got %q, want %q", got, "1271844019\n")
 	}
 }
 

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -151,11 +151,12 @@ type TypeField struct {
 // --- Type System ---
 
 type TypeRef struct {
-	Pos     lexer.Position    `json:"pos,omitempty" parser:""`
-	Fun     *FunType          `json:"fun,omitempty" parser:"( @@"`
-	Generic *GenericType      `json:"generic,omitempty" parser:"| @@"`
-	Struct  *InlineStructType `json:"struct,omitempty" parser:"| @@"`
-	Simple  *string           `json:"simple,omitempty" parser:"| @Ident )"`
+	Pos      lexer.Position    `json:"pos,omitempty" parser:""`
+	Fun      *FunType          `json:"fun,omitempty" parser:"( @@"`
+	Generic  *GenericType      `json:"generic,omitempty" parser:"| @@"`
+	Struct   *InlineStructType `json:"struct,omitempty" parser:"| @@"`
+	ListElem *TypeRef          `json:"list_elem,omitempty" parser:"| '[' @@ ']'"`
+	Simple   *string           `json:"simple,omitempty" parser:"| @Ident )"`
 	// MEP-10 C1: a trailing `?` denotes an optional (nullable) type.
 	// `int?` desugars to `option[int]` in resolveTypeRef.
 	Optional bool `json:"optional,omitempty" parser:"[ @'?' ]"`

--- a/types/resolve.go
+++ b/types/resolve.go
@@ -52,6 +52,10 @@ func resolveTypeRefInner(t *parser.TypeRef, env *Env) Type {
 		return StructType{Name: "", Fields: fields}
 	}
 
+	if t.ListElem != nil {
+		return ListType{Elem: resolveTypeRef(t.ListElem, env)}
+	}
+
 	if t.Simple != nil {
 		switch *t.Simple {
 		case "int":

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -725,7 +725,7 @@ Workloads in the "performance games" set that are NOT in this table, and why:
 
 | Workload | Why excluded |
 |----------|--------------|
-| `mandelbrot`, `n_body`, `spectral_norm` | f64 list primitives LANDED in Phase 4.3.3, i64↔f64 casts LANDED in Phase 4.3.4 (`as` form) + 4.3.6 (`int(x)`/`float(x)` call form), `math.sqrt` + operator precedence LANDED in Phase 4.3.5, collection-iter `for x in xs` LANDED in Phase 4.3.7, list-literal element-type inference LANDED in Phase 4.3.8, `math.pi` / `math.e` constant reads LANDED in Phase 4.3.9. mandelbrot's 16×16 kernel pinned by `TestBuildSourceMandelbrotKernel` (4629); n_body's full 5-body / 10-step integration kernel (canonical Sun + Jupiter + Saturn + Uranus + Neptune initial conditions; momentum normalisation; pairwise gravity; position update; final energy * 1e9 truncated) pinned by `TestBuildSourceNbodyFullKernel` (-169073021) as of Phase 4.3.10; spectral_norm's `eval_a` matrix-entry kernel pinned by `TestBuildSourceSpectralEvalKernel` (1000000000). The remaining gap for `spectral_norm` is the `[float]` bracketed list-type syntax + list concatenation (a `list<float>` + `append` rewrite of the kernel already compiles and byte-matches between C and Go targets; the native bracketed surface is purely syntactic). For all three the only outstanding piece is the `bench/template/bg/*` harness shape (`now()`, `json({...})`, `{{ .N }}`), which is a §13 follow-up |
+| `mandelbrot`, `n_body`, `spectral_norm` | f64 list primitives LANDED in Phase 4.3.3, i64↔f64 casts LANDED in Phase 4.3.4 (`as` form) + 4.3.6 (`int(x)`/`float(x)` call form), `math.sqrt` + operator precedence LANDED in Phase 4.3.5, collection-iter `for x in xs` LANDED in Phase 4.3.7, list-literal element-type inference LANDED in Phase 4.3.8, `math.pi` / `math.e` constant reads LANDED in Phase 4.3.9, `[T]` bracketed list-type syntax LANDED in Phase 4.3.11. mandelbrot's 16×16 kernel pinned by `TestBuildSourceMandelbrotKernel` (4629); n_body's full 5-body / 10-step integration kernel pinned by `TestBuildSourceNbodyFullKernel` (-169073021) as of Phase 4.3.10; spectral_norm's full N=10 power-method kernel (5 outer iterations, `eval_a` Hilbert-like matrix entry, `mul_av` / `mul_atv` helper funs taking `[float]` parameters, final `int(sqrt(uv/vv) * 1e9)`) pinned by `TestBuildSourceSpectralFullKernel` (1271844019) as of Phase 4.3.11. The only outstanding piece for all three is the `bench/template/bg/*` harness shape (`now()`, `json({...})`, `{{ .N }}`), which is a §13 follow-up. spectral_norm's native `u + [1.0]` list-concatenation pattern is rewritten as `u = append(u, 1.0)` for the pinned kernel; whether to add list concatenation as a later sub-phase depends on whether any benchmark needs it inside a hot loop (spectral_norm does not) |
 | `nsieve` | LANDED in Phase 4.3.2 (range-for + if-merge phi joins land together; stripped nsieve(100)=25 pinned by C and Go target tests). The full benchmark uses identical primitives |
 | `fannkuch`, `binary_trees` | Need list-of-structs / struct-of-lists; i64 list primitive landed in Phase 4.3.1, struct support blocked on Phase 4.4, nesting on Phase 4.5 |
 | `fasta`, `regex_redux`, `k_nucleotide` | Need string literals and string ops; blocked on Phase 4.2 (TypeStr) |
@@ -1380,6 +1380,75 @@ Per the goal-alignment audit, before each MEP sub-phase the question is: does th
 - The full `bench/template/bg/n_body/n_body.mochi` fixture still cannot compile unchanged because it uses `now()`, `json({...})`, and `{{ .N }}` template expansion. Those are the bench-harness shape, owned by the §13 closeout. The compiler-internal kernel work is done.
 - `spectral_norm` is the next sub-phase candidate: its kernel compiles when rewritten to use `list<float>` and `append`, but the native source uses `[float]` bracketed list-type annotations and `u + [1.0]` list concatenation. Those are pure surface-syntax additions and would be the natural Phase 4.3.11 work.
 - This sub-phase ships no IR / verify / emit changes. If the suite goes red, the cause is in an earlier Phase 4.3.x's work, not here.
+
+## §10.20 Phase 4.3.11 closeout (LANDED 2026-05-22 00:45 GMT+7)
+
+Phase 4.3.11 is the spectral_norm full-kernel milestone. It lands two pieces of work that the §10.19 closeout flagged as the natural next sub-phase: (1) the `[T]` bracketed list-type syntax that the benchmark-games sources use in function-parameter positions, and (2) a latent ordering bug in `compiler3/frontend/lower.go` where cross-function call sites read a callee's `Result` type before it was set, exposed by the spectral_norm kernel's `mul_av(src: [float], dst: [float], n: int)` call-graph. With those landed, the full N=10 power-method kernel (5 outer iterations, `eval_a` Hilbert-like matrix entry, `mul_av` / `mul_atv` helper funs taking `[float]` parameters, final `int(sqrt(uv/vv) * 1e9) = 1271844019`) compiles end-to-end via `mochi build --target=c` and byte-matches `mochi build --target=go`.
+
+### Implementation
+
+1. **Parser arm for `[T]`.** `parser/ast.go`'s `TypeRef` gets a new alternative `ListElem *TypeRef` with grammar tag `| '[' @@ ']'`, slotted between `Struct` and `Simple`. This is the canonical surface for "list of T" in function-parameter and -return positions where the existing `list<T>` generic form feels heavy. The tagged union stays exhaustive; downstream resolvers must handle the new arm.
+2. **Types resolution.** `types/resolve.go`'s `resolveTypeRefInner` adds a `if t.ListElem != nil { return ListType{Elem: resolveTypeRef(t.ListElem, env)} }` branch alongside the existing `Generic` / `Struct` branches. `[float]` and `list<float>` resolve to the same `ListType{Elem: FloatType{}}` so the rest of the type-checker is unchanged.
+3. **Frontend lowering.** `compiler3/frontend/lower.go`'s `lowerType` adds a matching `ListElem` arm after `Generic`. `[int]` lowers to `ir.TypeList` (Cell-tagged i64 list), `[float]` lowers to `ir.TypeF64Arr` (flat `double[]`), other element types reject explicitly with `frontend: [T] unsupported in MVP (only [int] and [float])`. This mirrors the dispatch that `list<int>` / `list<float>` already use, so downstream IR / verify / emit see no new types.
+4. **Cross-function call ordering fix.** `Lower` already does a first pass over top-level statements to register every user-defined `fun` in a name table before lowering bodies (so calls can resolve forward references). The first pass was creating the `ir.Function` skeleton with `Result: TypeI64` and leaving the real result type resolution inside `lowerFun` itself. Because `lowerFun` runs in iteration order over a Go map, a caller could be lowered before its callee, and the caller's `OpCall` site would read `entry.func.Result = TypeInvalid` and reject the call. The fix moves the `fn.Result` resolution (via `lowerType(st.Fun.Return)`) into the first pass, so every user fun's signature is known before any body is lowered. The stub block in `lowerFun` is now a single-line comment noting the resolution happens earlier. This bug had been latent since Phase 4.3.2 introduced multi-fun lowering; the spectral_norm kernel's `mul_av` / `mul_atv` / `eval_a` triangle is the first fixture with a call from one f64-returning fun into another.
+5. **Test-helper normalisation.** `runEnd2End` in `compiler3/frontend/lower_test.go` was constructing a raw participle parser with `parser.Parser.ParseString`, which skips the source normalisation that `parser.Parse` / `parser.ParseString` (package-level) apply. The spectral_norm kernel's `s = s + eval_a(i, j) * src[j]` was being parsed without operator-precedence normalisation and lowered as `s + (eval_a * (i, j))`, producing a "binop * across types invalid and f64" diagnostic. Switching to `parser.ParseString` aligns the lower-side end-to-end test with what `mochi build` sees through `BuildSource`.
+
+### Files changed
+
+- `parser/ast.go`: `TypeRef` gains the `ListElem` arm (`| '[' @@ ']'`).
+- `types/resolve.go`: `resolveTypeRefInner` resolves `ListElem` to `ListType`.
+- `compiler3/frontend/lower.go`: `lowerType` lowers `ListElem` to `TypeList` / `TypeF64Arr`; `Lower`'s first pass now resolves every user fun's `Result` before any body is lowered.
+- `compiler3/frontend/lower_test.go`: `runEnd2End` switched to `parser.ParseString`; new `TestLowerBracketListTypeFloat` (output 6), `TestLowerBracketListTypeInt` (output 28), `TestLowerSpectralFullKernel` (output 1271844019).
+- `compiler3/build/c/driver_test.go`: `TestBuildSourceBracketListTypeFloat`, `TestBuildSourceBracketListTypeInt`, `TestBuildSourceSpectralFullKernel`. C-target mirrors of the lower-side tests, asserting the same outputs against the native binary.
+- `website/docs/mep/mep-0042.md`: §10.7 row updated to mark spectral_norm's full kernel as pinned, plus this closeout.
+
+### Reproducer
+
+The full kernel source is the body of `TestBuildSourceSpectralFullKernel`. The shape that exercises every piece of the sub-phase:
+
+```mochi
+import python "math" as math
+extern fun math.sqrt(x: float): float
+
+let N = 10
+
+fun eval_a(i: int, j: int): float {
+  let s = i + j
+  return 1.0 / float(s * (s + 1) / 2 + i + 1)
+}
+
+fun mul_av(src: [float], dst: [float], n: int) {
+  for i in 0..n {
+    var s = 0.0
+    for j in 0..n {
+      s = s + eval_a(i, j) * src[j]
+    }
+    dst[i] = s
+  }
+}
+
+// ... mul_atv mirror, init loop, 5 power-method iterations,
+// final int(sqrt(uv/vv) * 1e9)
+```
+
+To run by hand:
+
+```sh
+go run ./cmd/mochi build --target=c --binary /tmp/spectral /path/to/spectral.mochi
+/tmp/spectral  # prints 1271844019
+```
+
+The same source compiles via `--target=go` to the same output.
+
+### Why this is the right gate
+
+Per the goal-alignment audit, before each MEP sub-phase the question is: does this gate move the user-facing goal (benchmark games compile via `mochi build --target=c`) or just spec-internal scaffolding? Phase 4.3.11 is on the goal path: spectral_norm is the third of three Phase 4.3 benchmark-games kernels, and its full N=10 power-method body now compiles unchanged from the native benchmark-games shape (modulo the harness instrumentation owned by §13). The cross-function call-ordering bug fix is incidental but load-bearing; without it, the kernel would have lowered nondeterministically under Go's map iteration order, producing a flaky compile that would silently pass some test runs and fail others. Pinning both targets at byte-equal output across a `-count=2` run is the regression contract.
+
+### Limitations
+
+- Only `[int]` and `[float]` are recognised. `[string]` / `[struct{...}]` / nested `[[float]]` reject with the explicit MVP message. Lifting those is straightforward (each needs its `ir.Type` already in place); none is on the §10.7 critical path.
+- `u + [1.0]` list concatenation is still rejected. The pinned spectral_norm kernel rewrites the native `u + [1.0]` initialisation as `u = append(u, 1.0)` in a `for _ in 0..N` loop, which compiles unchanged. Whether to add list concatenation as a later sub-phase depends on whether any other benchmark needs it inside a hot loop.
+- The full `bench/template/bg/spectral_norm/spectral_norm.mochi` fixture still cannot compile unchanged because it uses `now()`, `json({...})`, and `{{ .N }}` template expansion. Those are the bench-harness shape, owned by the §13 closeout. The compiler-internal kernel work is done; with this sub-phase, all three Phase 4.3 benchmark targets (mandelbrot, n_body, spectral_norm) have their full kernels pinned as regression tests, and the only remaining piece for `mochi build --target=c` to consume the native fixtures is the harness driver.
 
 ## §11 Risks
 


### PR DESCRIPTION
## Summary

- Adds the `[T]` bracketed list-type syntax (`[int]` / `[float]`) as a TypeRef arm; resolves to the same `ListType` as `list<T>`; lowers to `TypeList` / `TypeF64Arr` in compiler3.
- Pins the full N=10 spectral_norm power-method kernel on both `--target=c` and `--target=go` (output `1271844019`). All three Phase 4.3 benchmark-games kernels (mandelbrot, n_body, spectral_norm) now compile end-to-end via `mochi build --target=c` with byte-equal output to the Go target.
- Fixes a latent map-iteration-order bug in `compiler3/frontend/lower.go`: moves user-fun `Result` resolution from `lowerFun` into `Lower`'s first pass so every signature is known before any body is lowered. The spectral_norm `mul_av` / `mul_atv` / `eval_a` call graph is the first fixture that exposes this.

## Why

Per the §10.19 closeout's "next sub-phase candidate" line: `spectral_norm`'s kernel compiles under a `list<float>` + `append` rewrite, and the only remaining gap was the native `[float]` bracketed syntax. Closing this lands the last compiler-internal gap for all three Phase 4.3 benchmark targets.

## Test plan

- [x] `go test ./compiler3/frontend/ ./compiler3/build/c/ -count=1` green
- [x] `-count=2` confirms the map-order fix (cross-function call ordering) is sound
- [x] Spectral kernel output `1271844019` matches across both AOT targets
- [x] No em-dashes in MEP closeout

Closes #21979