### PR TITLE
mep-0042: Phase 4.3.12 list concatenation + native spectral_norm

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -770,6 +770,115 @@ print(int(math.sqrt(uv / vv) * 1e9))
 	}
 }
 
+// TestBuildSourceListConcatI64 pins the Phase 4.3.12 i64 list
+// concatenation surface on the C target: `xs + ys` calls into
+// mochi_list_i64_concat.
+func TestBuildSourceListConcatI64(t *testing.T) {
+	src := `var a: list<int> = []
+a = append(a, 1)
+a = append(a, 2)
+var b: list<int> = []
+b = append(b, 10)
+b = append(b, 20)
+b = append(b, 30)
+let c = a + b
+print(c[0] + c[1] + c[2] + c[3] + c[4])
+`
+	if got, want := runMochiBuild(t, src), "63\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceF64ArrayConcat pins the Phase 4.3.12 f64 list
+// concatenation surface on the C target: `[float] + [float]` calls
+// into mochi_f64_array_concat.
+func TestBuildSourceF64ArrayConcat(t *testing.T) {
+	src := `var u: [float] = []
+u = u + [1.0]
+u = u + [2.0]
+u = u + [3.0]
+var v: [float] = []
+v = v + [4.0]
+v = v + [5.0]
+v = v + [6.0]
+let w = u + v
+print(int(w[0] + w[1] + w[2] + w[3] + w[4] + w[5]))
+`
+	if got, want := runMochiBuild(t, src), "21\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceSpectralNativeKernel pins the Phase 4.3.12 milestone:
+// the native `bench/template/bg/spectral_norm/spectral_norm.mochi`
+// fixture compiles unchanged via `mochi build --target=c` and produces
+// `1274219991` (N=100 full power-method), byte-matching the Go target.
+// This closes the compiler-internal kernel work for spectral_norm; the
+// only remaining gap to consuming the native fixture is the bench
+// harness shape (`now()`, `json({...})`, `{{ .N }}`), and the native
+// spectral_norm source happens to not use any of those (its outer
+// driver hardcodes N=100 and prints the integer directly).
+func TestBuildSourceSpectralNativeKernel(t *testing.T) {
+	src := `import python "math" as math
+extern fun math.sqrt(x: float): float
+
+let N = 100
+
+fun eval_a(i: int, j: int): float {
+  let s = i + j
+  return 1.0 / float(s * (s + 1) / 2 + i + 1)
+}
+
+fun mul_av(src: [float], dst: [float], n: int) {
+  for i in 0..n {
+    var s = 0.0
+    for j in 0..n {
+      s = s + eval_a(i, j) * src[j]
+    }
+    dst[i] = s
+  }
+}
+
+fun mul_atv(src: [float], dst: [float], n: int) {
+  for i in 0..n {
+    var s = 0.0
+    for j in 0..n {
+      s = s + eval_a(j, i) * src[j]
+    }
+    dst[i] = s
+  }
+}
+
+var u: [float] = []
+var v: [float] = []
+var tmp: [float] = []
+for _ in 0..N {
+  u = u + [1.0]
+  v = v + [0.0]
+  tmp = tmp + [0.0]
+}
+
+for _ in 0..5 {
+  mul_av(u, tmp, N)
+  mul_atv(tmp, v, N)
+  mul_av(v, tmp, N)
+  mul_atv(tmp, u, N)
+}
+
+var uv = 0.0
+var vv = 0.0
+for i in 0..N {
+  uv = uv + u[i] * v[i]
+  vv = vv + v[i] * v[i]
+}
+
+print(int(math.sqrt(uv / vv) * 1e9))
+`
+	if got, want := runMochiBuild(t, src), "1274219991\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceMathPiConst pins the Phase 4.3.9 math.pi constant
 // read on the C target: 4*pi*pi truncated = 39.
 func TestBuildSourceMathPiConst(t *testing.T) {

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -78,10 +78,10 @@ func Emit(p *Program) ([]byte, error) {
 				}
 				return nil, fmt.Errorf("emit %s: OpCallGo to %s.%s: %w", fn.Name, b.Pkg, b.Name, ErrUnsupportedFFI)
 			case ir.OpNewList, ir.OpListLenI64, ir.OpListPushI64,
-				ir.OpListGetI64, ir.OpListSetI64:
+				ir.OpListGetI64, ir.OpListSetI64, ir.OpListConcatI64:
 				usesListI64 = true
 			case ir.OpNewF64Array, ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64,
-				ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64:
+				ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64, ir.OpF64ArrayConcat:
 				usesF64Array = true
 			}
 		}
@@ -336,6 +336,10 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    %s = mochi_f64_array_get(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpF64ArraySetF64:
 		fmt.Fprintf(w, "    mochi_f64_array_set(%s, %s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
+	case ir.OpListConcatI64:
+		fmt.Fprintf(w, "    %s = mochi_list_i64_concat(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpF64ArrayConcat:
+		fmt.Fprintf(w, "    %s = mochi_f64_array_concat(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpCall, ir.OpTailCall:
 		// Intra-program call. v.Const indexes into Program.Funcs;
 		// args are SSA values in declared order. The emitter writes

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -306,6 +306,12 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 		fmt.Fprintf(w, "\t%s = %s[%s]\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpF64ArraySetF64:
 		fmt.Fprintf(w, "\t%s[%s] = %s\n", valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
+	case ir.OpListConcatI64:
+		fmt.Fprintf(w, "\t%s = append(append([]int64{}, %s...), %s...)\n",
+			name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpF64ArrayConcat:
+		fmt.Fprintf(w, "\t%s = append(append([]float64{}, %s...), %s...)\n",
+			name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpCall, ir.OpTailCall:
 		callee := all[v.Const]
 		fmt.Fprintf(w, "\t%s = %s(", name, callee.Name)

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1195,6 +1195,16 @@ func (b *builder) applyBinOp(op string, l, r uint32) (uint32, error) {
 		default:
 			return 0, fmt.Errorf("frontend: operator %q on f64 unsupported in MVP", op)
 		}
+	case ir.TypeList:
+		if op != "+" {
+			return 0, fmt.Errorf("frontend: operator %q on list<int> unsupported in MVP", op)
+		}
+		code = ir.OpListConcatI64
+	case ir.TypeF64Arr:
+		if op != "+" {
+			return 0, fmt.Errorf("frontend: operator %q on list<float> unsupported in MVP", op)
+		}
+		code = ir.OpF64ArrayConcat
 	default:
 		return 0, fmt.Errorf("frontend: binop %q on type %s unsupported in MVP", op, lt)
 	}

--- a/compiler3/frontend/lower_test.go
+++ b/compiler3/frontend/lower_test.go
@@ -645,6 +645,115 @@ print(int(math.sqrt(uv / vv) * 1e9))
 	}
 }
 
+// TestLowerListConcatI64 pins the Phase 4.3.12 i64 list concatenation
+// surface: `xs + ys` on two `list<int>` operands returns a fresh
+// list of i64 with the operands' elements in order.
+func TestLowerListConcatI64(t *testing.T) {
+	src := `var a: list<int> = []
+a = append(a, 1)
+a = append(a, 2)
+var b: list<int> = []
+b = append(b, 10)
+b = append(b, 20)
+b = append(b, 30)
+let c = a + b
+print(c[0] + c[1] + c[2] + c[3] + c[4])
+`
+	got := runEnd2End(t, src)
+	if got != "63\n" {
+		t.Errorf("got %q, want %q", got, "63\n")
+	}
+}
+
+// TestLowerF64ArrayConcat pins the Phase 4.3.12 f64 list concatenation
+// surface: `xs + ys` on two `[float]` operands. Output is the truncated
+// sum 1+2+3+4+5+6 = 21.
+func TestLowerF64ArrayConcat(t *testing.T) {
+	src := `var u: [float] = []
+u = u + [1.0]
+u = u + [2.0]
+u = u + [3.0]
+var v: [float] = []
+v = v + [4.0]
+v = v + [5.0]
+v = v + [6.0]
+let w = u + v
+print(int(w[0] + w[1] + w[2] + w[3] + w[4] + w[5]))
+`
+	got := runEnd2End(t, src)
+	if got != "21\n" {
+		t.Errorf("got %q, want %q", got, "21\n")
+	}
+}
+
+// TestLowerSpectralNativeKernel pins the Phase 4.3.12 milestone: the
+// native `bench/template/bg/spectral_norm/spectral_norm.mochi` shape
+// (N=100, `[float]` parameters, `u + [1.0]` list-concat initialisation,
+// final `int(sqrt(uv/vv) * 1e9) = 1274219991`) now lowers through
+// compiler3 and emits valid Go. The C-target mirror is
+// `TestBuildSourceSpectralNativeKernel`.
+func TestLowerSpectralNativeKernel(t *testing.T) {
+	src := `import python "math" as math
+extern fun math.sqrt(x: float): float
+
+let N = 100
+
+fun eval_a(i: int, j: int): float {
+  let s = i + j
+  return 1.0 / float(s * (s + 1) / 2 + i + 1)
+}
+
+fun mul_av(src: [float], dst: [float], n: int) {
+  for i in 0..n {
+    var s = 0.0
+    for j in 0..n {
+      s = s + eval_a(i, j) * src[j]
+    }
+    dst[i] = s
+  }
+}
+
+fun mul_atv(src: [float], dst: [float], n: int) {
+  for i in 0..n {
+    var s = 0.0
+    for j in 0..n {
+      s = s + eval_a(j, i) * src[j]
+    }
+    dst[i] = s
+  }
+}
+
+var u: [float] = []
+var v: [float] = []
+var tmp: [float] = []
+for _ in 0..N {
+  u = u + [1.0]
+  v = v + [0.0]
+  tmp = tmp + [0.0]
+}
+
+for _ in 0..5 {
+  mul_av(u, tmp, N)
+  mul_atv(tmp, v, N)
+  mul_av(v, tmp, N)
+  mul_atv(tmp, u, N)
+}
+
+var uv = 0.0
+var vv = 0.0
+for i in 0..N {
+  uv = uv + u[i] * v[i]
+  vv = vv + v[i] * v[i]
+}
+
+print(int(math.sqrt(uv / vv) * 1e9))
+`
+	got := runEnd2End(t, src)
+	if got != "1274219991\n" {
+		t.Errorf("got %q, want %q", got, "1274219991\n")
+	}
+}
+
 // TestLowerMathPiConst pins the Phase 4.3.9 `math.pi` constant read:
 // `extern let math.pi: float` is accepted as a no-op binding; the
 // selector read lowers to OpConst of TypeF64 with the math.Pi value.

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -227,6 +227,15 @@ const (
 	// target emits `math.Sqrt(v)` (auto-imports "math"); the C target
 	// emits `sqrt(v)` (auto-includes <math.h> and links with -lm).
 	OpSqrtF64
+
+	// List / array concatenation (Phase 4.3.12). Surface form `xs + ys`
+	// where both operands are the same list-shaped type. Returns a
+	// fresh list (no aliasing with the operands). OpListConcatI64 is
+	// the i64-cell list pair; OpF64ArrayConcat is the flat f64 array
+	// pair. Go emit copies via append + spread; C emit calls into a
+	// runtime concat helper.
+	OpListConcatI64
+	OpF64ArrayConcat
 )
 
 // String renders an OpCode's short name. Used by Validate and IR
@@ -331,6 +340,10 @@ func (o OpCode) String() string {
 		return "f64arr.get.f64"
 	case OpF64ArraySetF64:
 		return "f64arr.set.f64"
+	case OpListConcatI64:
+		return "list.concat.i64"
+	case OpF64ArrayConcat:
+		return "f64arr.concat"
 	case OpCall:
 		return "call"
 	case OpTailCall:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -219,6 +219,10 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeI64, [3]Type{TypeF64}}
 	case OpSqrtF64:
 		return opSig{TypeF64, [3]Type{TypeF64}}
+	case OpListConcatI64:
+		return opSig{TypeList, [3]Type{TypeList, TypeList}}
+	case OpF64ArrayConcat:
+		return opSig{TypeF64Arr, [3]Type{TypeF64Arr, TypeF64Arr}}
 	}
 	// OpParam, OpConst, OpPhi, OpCall, OpTailCall: the validator
 	// can't pre-compute their signature without more context, so we

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -166,7 +166,8 @@ func kindOf(o ir.OpCode) ProducerKind {
 	case ir.OpConcatStr:
 		return KindConstructor
 
-	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array:
+	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array,
+		ir.OpListConcatI64, ir.OpF64ArrayConcat:
 		return KindConstructor
 
 	case ir.OpListLenI64, ir.OpListPushI64, ir.OpListGetI64, ir.OpListSetI64,
@@ -215,7 +216,7 @@ func init() {
 // the last OpCode known to ir/types.go at this MEP-41 Phase 1 commit;
 // adding a new op past it bumps this constant in the same PR.
 func mustClassifyAll() {
-	const lastOpCode = ir.OpSqrtF64
+	const lastOpCode = ir.OpF64ArrayConcat
 	for o := ir.OpInvalid + 1; o <= lastOpCode; o++ {
 		if kindOf(o) == KindInvalid {
 			panic(fmt.Sprintf("verify: OpCode %s (=%d) is unclassified; extend kindOf in compiler3/verify/verify.go (MEP-41 §6.2 rule class C / coverage backstop)", o, o))
@@ -415,6 +416,10 @@ func contractResult(o ir.OpCode) ir.Type {
 		return ir.TypeUnit
 	case ir.OpF64ArrayGetF64:
 		return ir.TypeF64
+	case ir.OpListConcatI64:
+		return ir.TypeList
+	case ir.OpF64ArrayConcat:
+		return ir.TypeF64Arr
 	}
 	return ir.TypeInvalid
 }

--- a/parser/invariants.go
+++ b/parser/invariants.go
@@ -230,10 +230,10 @@ func assertTypeRef(t *TypeRef, pos lexer.Position) error {
 		return invariant(pos, "type reference is nil")
 	}
 	arms := [...]bool{
-		t.Fun != nil, t.Generic != nil, t.Struct != nil, t.Simple != nil,
+		t.Fun != nil, t.Generic != nil, t.Struct != nil, t.ListElem != nil, t.Simple != nil,
 	}
 	if n := countTrue(arms[:]); n != 1 {
-		return invariant(pos, fmt.Sprintf("type reference has %d arms set, expected exactly 1 of {fun, generic, struct, simple}", n))
+		return invariant(pos, fmt.Sprintf("type reference has %d arms set, expected exactly 1 of {fun, generic, struct, list_elem, simple}", n))
 	}
 	return nil
 }

--- a/runtime/c/src/mochi_f64_array.c
+++ b/runtime/c/src/mochi_f64_array.c
@@ -41,3 +41,28 @@ double mochi_f64_array_get(const mochi_f64_array *a, int64_t i) {
 void mochi_f64_array_set(mochi_f64_array *a, int64_t i, double v) {
     a->data[i] = v;
 }
+
+mochi_f64_array *mochi_f64_array_concat(const mochi_f64_array *a, const mochi_f64_array *b) {
+    mochi_f64_array *out = mochi_f64_array_new();
+    int64_t total = a->len + b->len;
+    if (total > 0) {
+        double *nd = (double *)malloc((size_t)total * sizeof(double));
+        if (nd == NULL) {
+            abort();
+        }
+        if (a->len > 0) {
+            for (int64_t i = 0; i < a->len; i++) {
+                nd[i] = a->data[i];
+            }
+        }
+        if (b->len > 0) {
+            for (int64_t i = 0; i < b->len; i++) {
+                nd[a->len + i] = b->data[i];
+            }
+        }
+        out->data = nd;
+        out->cap = total;
+        out->len = total;
+    }
+    return out;
+}

--- a/runtime/c/src/mochi_f64_array.h
+++ b/runtime/c/src/mochi_f64_array.h
@@ -39,6 +39,7 @@ int64_t mochi_f64_array_len(const mochi_f64_array *a);
 void mochi_f64_array_push(mochi_f64_array *a, double v);
 double mochi_f64_array_get(const mochi_f64_array *a, int64_t i);
 void mochi_f64_array_set(mochi_f64_array *a, int64_t i, double v);
+mochi_f64_array *mochi_f64_array_concat(const mochi_f64_array *a, const mochi_f64_array *b);
 
 #ifdef __cplusplus
 }

--- a/runtime/c/src/mochi_list_i64.c
+++ b/runtime/c/src/mochi_list_i64.c
@@ -42,3 +42,24 @@ int64_t mochi_list_i64_get(const mochi_list_i64 *l, int64_t i) {
 void mochi_list_i64_set(mochi_list_i64 *l, int64_t i, int64_t v) {
     l->data[i] = v;
 }
+
+mochi_list_i64 *mochi_list_i64_concat(const mochi_list_i64 *a, const mochi_list_i64 *b) {
+    mochi_list_i64 *out = mochi_list_i64_new();
+    int64_t total = a->len + b->len;
+    if (total > 0) {
+        int64_t *nd = (int64_t *)malloc((size_t)total * sizeof(int64_t));
+        if (nd == NULL) {
+            abort();
+        }
+        if (a->len > 0) {
+            memcpy(nd, a->data, (size_t)a->len * sizeof(int64_t));
+        }
+        if (b->len > 0) {
+            memcpy(nd + a->len, b->data, (size_t)b->len * sizeof(int64_t));
+        }
+        out->data = nd;
+        out->cap = total;
+        out->len = total;
+    }
+    return out;
+}

--- a/runtime/c/src/mochi_list_i64.h
+++ b/runtime/c/src/mochi_list_i64.h
@@ -59,6 +59,10 @@ int64_t mochi_list_i64_get(const mochi_list_i64 *l, int64_t i);
  * MVP, same rationale as get. */
 void mochi_list_i64_set(mochi_list_i64 *l, int64_t i, int64_t v);
 
+/* mochi_list_i64_concat returns a fresh list with a's elements followed
+ * by b's. Neither operand is mutated; the result owns its own buffer. */
+mochi_list_i64 *mochi_list_i64_concat(const mochi_list_i64 *a, const mochi_list_i64 *b);
+
 #ifdef __cplusplus
 }
 #endif

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -725,7 +725,7 @@ Workloads in the "performance games" set that are NOT in this table, and why:
 
 | Workload | Why excluded |
 |----------|--------------|
-| `mandelbrot`, `n_body`, `spectral_norm` | f64 list primitives LANDED in Phase 4.3.3, i64↔f64 casts LANDED in Phase 4.3.4 (`as` form) + 4.3.6 (`int(x)`/`float(x)` call form), `math.sqrt` + operator precedence LANDED in Phase 4.3.5, collection-iter `for x in xs` LANDED in Phase 4.3.7, list-literal element-type inference LANDED in Phase 4.3.8, `math.pi` / `math.e` constant reads LANDED in Phase 4.3.9, `[T]` bracketed list-type syntax LANDED in Phase 4.3.11. mandelbrot's 16×16 kernel pinned by `TestBuildSourceMandelbrotKernel` (4629); n_body's full 5-body / 10-step integration kernel pinned by `TestBuildSourceNbodyFullKernel` (-169073021) as of Phase 4.3.10; spectral_norm's full N=10 power-method kernel (5 outer iterations, `eval_a` Hilbert-like matrix entry, `mul_av` / `mul_atv` helper funs taking `[float]` parameters, final `int(sqrt(uv/vv) * 1e9)`) pinned by `TestBuildSourceSpectralFullKernel` (1271844019) as of Phase 4.3.11. The only outstanding piece for all three is the `bench/template/bg/*` harness shape (`now()`, `json({...})`, `{{ .N }}`), which is a §13 follow-up. spectral_norm's native `u + [1.0]` list-concatenation pattern is rewritten as `u = append(u, 1.0)` for the pinned kernel; whether to add list concatenation as a later sub-phase depends on whether any benchmark needs it inside a hot loop (spectral_norm does not) |
+| `mandelbrot`, `n_body`, `spectral_norm` | f64 list primitives LANDED in Phase 4.3.3, i64↔f64 casts LANDED in Phase 4.3.4 (`as` form) + 4.3.6 (`int(x)`/`float(x)` call form), `math.sqrt` + operator precedence LANDED in Phase 4.3.5, collection-iter `for x in xs` LANDED in Phase 4.3.7, list-literal element-type inference LANDED in Phase 4.3.8, `math.pi` / `math.e` constant reads LANDED in Phase 4.3.9, `[T]` bracketed list-type syntax LANDED in Phase 4.3.11, list concatenation `xs + ys` LANDED in Phase 4.3.12. mandelbrot's 16×16 kernel pinned by `TestBuildSourceMandelbrotKernel` (4629); n_body's full 5-body / 10-step integration kernel pinned by `TestBuildSourceNbodyFullKernel` (-169073021) as of Phase 4.3.10; spectral_norm's full kernel is pinned at two scales: the N=10 reduced kernel by `TestBuildSourceSpectralFullKernel` (1271844019) as of Phase 4.3.11, and the **native unchanged** `bench/template/bg/spectral_norm/spectral_norm.mochi` (N=100, `[float]` params, `u + [1.0]` concat init) by `TestBuildSourceSpectralNativeKernel` (1274219991) as of Phase 4.3.12. The only outstanding piece for `mandelbrot` and `n_body` is the `bench/template/bg/*` harness shape (`now()`, `json({...})`, `{{ .N }}`), which is a §13 follow-up; spectral_norm's native fixture happens not to use any of those, so as of Phase 4.3.12 it compiles unchanged via `mochi build --target=c` |
 | `nsieve` | LANDED in Phase 4.3.2 (range-for + if-merge phi joins land together; stripped nsieve(100)=25 pinned by C and Go target tests). The full benchmark uses identical primitives |
 | `fannkuch`, `binary_trees` | Need list-of-structs / struct-of-lists; i64 list primitive landed in Phase 4.3.1, struct support blocked on Phase 4.4, nesting on Phase 4.5 |
 | `fasta`, `regex_redux`, `k_nucleotide` | Need string literals and string ops; blocked on Phase 4.2 (TypeStr) |
@@ -1448,7 +1448,71 @@ Per the goal-alignment audit, before each MEP sub-phase the question is: does th
 
 - Only `[int]` and `[float]` are recognised. `[string]` / `[struct{...}]` / nested `[[float]]` reject with the explicit MVP message. Lifting those is straightforward (each needs its `ir.Type` already in place); none is on the §10.7 critical path.
 - `u + [1.0]` list concatenation is still rejected. The pinned spectral_norm kernel rewrites the native `u + [1.0]` initialisation as `u = append(u, 1.0)` in a `for _ in 0..N` loop, which compiles unchanged. Whether to add list concatenation as a later sub-phase depends on whether any other benchmark needs it inside a hot loop.
-- The full `bench/template/bg/spectral_norm/spectral_norm.mochi` fixture still cannot compile unchanged because it uses `now()`, `json({...})`, and `{{ .N }}` template expansion. Those are the bench-harness shape, owned by the §13 closeout. The compiler-internal kernel work is done; with this sub-phase, all three Phase 4.3 benchmark targets (mandelbrot, n_body, spectral_norm) have their full kernels pinned as regression tests, and the only remaining piece for `mochi build --target=c` to consume the native fixtures is the harness driver.
+- The full `bench/template/bg/spectral_norm/spectral_norm.mochi` fixture still cannot compile unchanged because it uses `u + [1.0]` list concatenation in its init loop. That is the natural Phase 4.3.12 work, alongside the `[float]` bracketed surface this sub-phase introduces; the only reason it is split off is that the spectral_norm kernel itself compiles without concat (with the loop rewritten as `u = append(u, 1.0)`), and pinning the surface here keeps the diff focused. mandelbrot and n_body still need the bench-harness shape (`now()`, `json({...})`, `{{ .N }}`) for the full native fixtures, owned by the §13 closeout.
+
+## §10.21 Phase 4.3.12 closeout (LANDED 2026-05-22 00:56 GMT+7)
+
+Phase 4.3.12 is the spectral_norm native-fixture milestone. It lands list concatenation (`xs + ys`) for both i64 and f64 lists end-to-end through compiler3 to both AOT targets, plus an invariants-check fix that was masking the `[T]` bracketed list-type arm under `mochi build` (the `parser.Parse` path runs assertions that `parser.Parser.ParseString` skips). With those two pieces in place, the native `bench/template/bg/spectral_norm/spectral_norm.mochi` fixture (N=100, `[float]` parameters in `mul_av` / `mul_atv`, `u + [1.0]` list-concat initialisation) compiles unchanged via `mochi build --target=c` and produces `1274219991`, byte-matching `mochi build --target=go`.
+
+### Implementation
+
+1. **Parser invariants.** `parser/invariants.go`'s `assertTypeRef` previously listed only `{fun, generic, struct, simple}` as legal arms; Phase 4.3.11 added the `ListElem` arm but did not extend the assertion. The lower-side end-to-end test passed because `runEnd2End` calls `parser.ParseString` after the helper switched in Phase 4.3.11, but `parser.Parse` (called by `BuildSource`) runs the invariants. The fix adds `ListElem` to the arm set so any `[T]` surface in a `mochi build` flow passes the assertion.
+2. **IR opcodes.** `compiler3/ir/types.go` gains two constructor opcodes: `OpListConcatI64` (TypeList × TypeList → TypeList) and `OpF64ArrayConcat` (TypeF64Arr × TypeF64Arr → TypeF64Arr). The validator (`compiler3/ir/validate.go`) gets matching signatures. The verifier (`compiler3/verify/verify.go`) classifies both as KindConstructor and bumps `lastOpCode` to `OpF64ArrayConcat`.
+3. **Frontend lowering.** `compiler3/frontend/lower.go`'s `applyBinOp` adds `+` arms for `TypeList` and `TypeF64Arr`, dispatching to the new opcodes. Other operators on lists still reject with the per-type "operator unsupported in MVP" message.
+4. **Go emit.** Both new opcodes lower to `append(append([]T{}, a...), b...)`. The double-append pattern is the idiomatic Go form that returns a fresh slice (no aliasing with the operands); cc -O2's equivalent doesn't apply here because Go's compiler already amortises the two allocations to one.
+5. **C emit + runtime.** Both new opcodes lower to call sites: `mochi_list_i64_concat(a, b)` and `mochi_f64_array_concat(a, b)`. The runtime helpers (`runtime/c/src/mochi_list_i64.{h,c}` and `runtime/c/src/mochi_f64_array.{h,c}`) allocate a fresh header, malloc a single contiguous buffer of size `a.len + b.len`, and memcpy / element-copy both operands in. The result owns its buffer; neither operand is mutated.
+
+### Files changed
+
+- `parser/invariants.go`: `assertTypeRef` extends the legal arm set to include `ListElem`.
+- `compiler3/ir/types.go`: `OpListConcatI64` and `OpF64ArrayConcat` opcodes + String cases.
+- `compiler3/ir/validate.go`: opSig entries for both new opcodes.
+- `compiler3/verify/verify.go`: kindOf + opResultType cases; `lastOpCode` bumped to `OpF64ArrayConcat`.
+- `compiler3/frontend/lower.go`: `applyBinOp` arms for `TypeList` and `TypeF64Arr`.
+- `compiler3/emit/go/emit.go`: emit cases for both opcodes (idiomatic double-append).
+- `compiler3/emit/c/emit.go`: emit cases + auto-include flagging.
+- `runtime/c/src/mochi_list_i64.{h,c}`: `mochi_list_i64_concat`.
+- `runtime/c/src/mochi_f64_array.{h,c}`: `mochi_f64_array_concat`.
+- `compiler3/frontend/lower_test.go`: `TestLowerListConcatI64`, `TestLowerF64ArrayConcat`, `TestLowerSpectralNativeKernel`.
+- `compiler3/build/c/driver_test.go`: `TestBuildSourceListConcatI64`, `TestBuildSourceF64ArrayConcat`, `TestBuildSourceSpectralNativeKernel`.
+- `website/docs/mep/mep-0042.md`: §10.7 row updated; §10.20 limitations note updated; this closeout.
+
+### Reproducer
+
+The native fixture compiles unchanged:
+
+```sh
+go run ./cmd/mochi build --target=c --binary /tmp/spectral bench/template/bg/spectral_norm/spectral_norm.mochi
+/tmp/spectral  # prints 1274219991
+```
+
+The minimal concat surfaces:
+
+```mochi
+var u: [float] = []
+u = u + [1.0]
+u = u + [2.0]
+u = u + [3.0]
+print(int(u[0] + u[1] + u[2]))  // 6
+```
+
+```mochi
+var a: list<int> = []
+a = append(a, 1)
+a = append(a, 2)
+let b = a + a
+print(b[0] + b[1] + b[2] + b[3])  // 6
+```
+
+### Why this is the right gate
+
+Per the goal-alignment audit: this sub-phase closes the last compiler-internal gap for one of three Phase 4.3 benchmark-games fixtures, and is the **first** native benchmark-games source that compiles unchanged via `mochi build --target=c` with no kernel rewrite. spectral_norm is the cleanest of the three for this milestone because its native source does not happen to use `now()` / `json()` / `{{ .N }}`, so it crosses the finish line without waiting on the §13 harness work. mandelbrot and n_body still need that harness shape; they remain pinned by their respective kernel-only regression tests until §13 lands.
+
+### Limitations
+
+- Only same-type concat: `[int] + [int]` and `[float] + [float]`. Mixed-element concat (e.g. `list<int> + list<float>`) rejects with the standard `binop "+" across types invalid and f64` diagnostic from `applyBinOp`'s type-mismatch check. Adding a coercion would mean defining the result element type, which is a Mochi-spec decision, not a §10.21 mechanical extension.
+- The concat result is freshly allocated on each call (no aliasing, no in-place reuse). Used inside a hot loop this is O(N) per concat plus a malloc; for spectral_norm's init loop (called N times, not in the inner kernel) this is fine. If a future benchmark needs concat in a tight loop, the IR can grow an `append`-style in-place variant without touching the surface syntax.
+- The `[T]` bracketed list-type arm still only supports `[int]` and `[float]`; widening to `[bool]` / `[string]` / nested `[[float]]` is a follow-up sub-phase that touches lowerType and the C-runtime headers but not this concat surface.
 
 ## §11 Risks
 


### PR DESCRIPTION
## Summary

- Adds `xs + ys` list concatenation for i64 (`OpListConcatI64` → `mochi_list_i64_concat`) and f64 (`OpF64ArrayConcat` → `mochi_f64_array_concat`) lists end-to-end through compiler3 to both AOT targets. New IR opcodes (both KindConstructor, fresh-list semantics), Go emit (idiomatic double-append), C emit + runtime helpers.
- Fixes a Phase 4.3.11 follow-on: `parser/invariants.go`'s `assertTypeRef` was rejecting the new `ListElem` arm with a P070 violation. The 4.3.11 tests didn't catch this because `runEnd2End` uses `parser.ParseString` (post-normalise), but `mochi build` calls `parser.Parse` (which runs invariants).
- Pins the **native unchanged** `bench/template/bg/spectral_norm/spectral_norm.mochi` fixture (N=100, `[float]` params, `u + [1.0]` init concat, output `1274219991`) on both AOT targets. This is the first native benchmark-games source that compiles via `mochi build --target=c` with no kernel rewrite.

## Why

spectral_norm's native source happens not to use `now()` / `json({...})` / `{{ .N }}`, so once `[T]` + list-concat are in place, it crosses the goal-state line without waiting on the §13 bench-harness work. mandelbrot and n_body still need that harness shape.

## Test plan

- [x] `go test ./compiler3/frontend/ ./compiler3/build/c/ ./compiler3/verify/ ./compiler3/ir/ -count=1` green
- [x] `-count=2` confirms no map-iteration-order flakiness
- [x] `go run ./cmd/mochi build --target=c bench/template/bg/spectral_norm/spectral_norm.mochi` produces a binary that prints `1274219991`
- [x] Same source via `--target=go` matches byte-for-byte
- [x] No em-dashes in MEP closeout

Closes #21981