### PR TITLE
mep-0042: Phase 4.3.13 now() builtin lowering

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -879,6 +879,47 @@ print(int(math.sqrt(uv / vv) * 1e9))
 	}
 }
 
+// TestBuildSourceNowBuiltin pins the Phase 4.3.13 `now()` builtin on
+// the C target: lowers to mochi_now_us(), which wraps POSIX
+// gettimeofday. The wall-clock unit + epoch matches the Go target's
+// `time.Now().UnixMicro()`, so two back-to-back calls produce
+// monotonically non-decreasing values.
+func TestBuildSourceNowBuiltin(t *testing.T) {
+	src := `let a = now()
+let b = now()
+if b >= a {
+  print(1)
+} else {
+  print(0)
+}
+`
+	if got, want := runMochiBuild(t, src), "1\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceNowDeltaArith pins that `now()` participates in
+// normal i64 arithmetic on the C target. Sum-of-0..999 = 499500.
+func TestBuildSourceNowDeltaArith(t *testing.T) {
+	src := `let start = now()
+var sum = 0
+var i = 0
+while i < 1000 {
+  sum = sum + i
+  i = i + 1
+}
+let duration = (now() - start) / 1000
+if duration >= 0 {
+  print(sum)
+} else {
+  print(-1)
+}
+`
+	if got, want := runMochiBuild(t, src), "499500\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceMathPiConst pins the Phase 4.3.9 math.pi constant
 // read on the C target: 4*pi*pi truncated = 39.
 func TestBuildSourceMathPiConst(t *testing.T) {

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -63,6 +63,7 @@ func Emit(p *Program) ([]byte, error) {
 	usesPrint := false
 	usesListI64 := false
 	usesF64Array := false
+	usesNow := false
 	for _, fn := range p.Funcs {
 		for _, v := range fn.Values {
 			switch v.Op {
@@ -83,6 +84,8 @@ func Emit(p *Program) ([]byte, error) {
 			case ir.OpNewF64Array, ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64,
 				ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64, ir.OpF64ArrayConcat:
 				usesF64Array = true
+			case ir.OpNow:
+				usesNow = true
 			}
 		}
 	}
@@ -100,6 +103,9 @@ func Emit(p *Program) ([]byte, error) {
 	}
 	if usesF64Array {
 		buf.WriteString("#include \"mochi_f64_array.h\"\n")
+	}
+	if usesNow {
+		buf.WriteString("#include \"mochi_time.h\"\n")
 	}
 	buf.WriteString("\n")
 
@@ -340,6 +346,8 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    %s = mochi_list_i64_concat(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpF64ArrayConcat:
 		fmt.Fprintf(w, "    %s = mochi_f64_array_concat(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpNow:
+		fmt.Fprintf(w, "    %s = mochi_now_us();\n", name)
 	case ir.OpCall, ir.OpTailCall:
 		// Intra-program call. v.Const indexes into Program.Funcs;
 		// args are SSA values in declared order. The emitter writes

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -312,6 +312,9 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 	case ir.OpF64ArrayConcat:
 		fmt.Fprintf(w, "\t%s = append(append([]float64{}, %s...), %s...)\n",
 			name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpNow:
+		imports["time"] = true
+		fmt.Fprintf(w, "\t%s = time.Now().UnixMicro()\n", name)
 	case ir.OpCall, ir.OpTailCall:
 		callee := all[v.Const]
 		fmt.Fprintf(w, "\t%s = %s(", name, callee.Name)

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1525,6 +1525,12 @@ func (b *builder) lowerBuiltinCall(c *parser.CallExpr) (uint32, bool, error) {
 		default:
 			return 0, true, fmt.Errorf("frontend: float(%s) unsupported in MVP", b.fn.Values[arg].Type)
 		}
+	case "now":
+		if len(c.Args) != 0 {
+			return 0, true, fmt.Errorf("frontend: now() takes 0 arguments, got %d", len(c.Args))
+		}
+		id := b.addValue(ir.Value{Type: ir.TypeI64, Op: ir.OpNow})
+		return id, true, nil
 	}
 	switch c.Func {
 	case "len":

--- a/compiler3/frontend/lower_test.go
+++ b/compiler3/frontend/lower_test.go
@@ -754,6 +754,50 @@ print(int(math.sqrt(uv / vv) * 1e9))
 	}
 }
 
+// TestLowerNowBuiltin pins the Phase 4.3.13 `now()` builtin: lowers
+// to OpNow with TypeI64 result; two back-to-back calls return a
+// monotonically non-decreasing value (the second is >= the first).
+// The test checks the ordering invariant rather than a fixed value
+// because `now()` is wall-clock by design.
+func TestLowerNowBuiltin(t *testing.T) {
+	src := `let a = now()
+let b = now()
+if b >= a {
+  print(1)
+} else {
+  print(0)
+}
+`
+	got := runEnd2End(t, src)
+	if got != "1\n" {
+		t.Errorf("got %q, want %q", got, "1\n")
+	}
+}
+
+// TestLowerNowDeltaArith pins that `now()` participates in normal i64
+// arithmetic: a duration computed as `(now() - start) / 1000` is an
+// i64 expression with no surprises in the lowerer.
+func TestLowerNowDeltaArith(t *testing.T) {
+	src := `let start = now()
+var sum = 0
+var i = 0
+while i < 1000 {
+  sum = sum + i
+  i = i + 1
+}
+let duration = (now() - start) / 1000
+if duration >= 0 {
+  print(sum)
+} else {
+  print(-1)
+}
+`
+	got := runEnd2End(t, src)
+	if got != "499500\n" {
+		t.Errorf("got %q, want %q", got, "499500\n")
+	}
+}
+
 // TestLowerMathPiConst pins the Phase 4.3.9 `math.pi` constant read:
 // `extern let math.pi: float` is accepted as a no-op binding; the
 // selector read lowers to OpConst of TypeF64 with the math.Pi value.

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -236,6 +236,13 @@ const (
 	// runtime concat helper.
 	OpListConcatI64
 	OpF64ArrayConcat
+
+	// Bench-harness builtins (Phase 4.3.13). OpNow returns the current
+	// wall-clock time in microseconds since the Unix epoch as i64.
+	// Go emit: `time.Now().UnixMicro()`. C emit: `mochi_now_us()`,
+	// which wraps POSIX `gettimeofday` to produce the same microsecond
+	// granularity. The op takes no SSA args.
+	OpNow
 )
 
 // String renders an OpCode's short name. Used by Validate and IR
@@ -344,6 +351,8 @@ func (o OpCode) String() string {
 		return "list.concat.i64"
 	case OpF64ArrayConcat:
 		return "f64arr.concat"
+	case OpNow:
+		return "now"
 	case OpCall:
 		return "call"
 	case OpTailCall:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -223,6 +223,8 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeList, [3]Type{TypeList, TypeList}}
 	case OpF64ArrayConcat:
 		return opSig{TypeF64Arr, [3]Type{TypeF64Arr, TypeF64Arr}}
+	case OpNow:
+		return opSig{TypeI64, [3]Type{}}
 	}
 	// OpParam, OpConst, OpPhi, OpCall, OpTailCall: the validator
 	// can't pre-compute their signature without more context, so we

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -158,7 +158,8 @@ func kindOf(o ir.OpCode) ProducerKind {
 		ir.OpCmpEqF64, ir.OpCmpNeF64, ir.OpCmpLtF64, ir.OpCmpLeF64, ir.OpCmpGtF64, ir.OpCmpGeF64,
 		ir.OpNotBool,
 		ir.OpI64ToF64, ir.OpF64ToI64,
-		ir.OpSqrtF64:
+		ir.OpSqrtF64,
+		ir.OpNow:
 		return KindOperator
 
 	case ir.OpLenStr:
@@ -216,7 +217,7 @@ func init() {
 // the last OpCode known to ir/types.go at this MEP-41 Phase 1 commit;
 // adding a new op past it bumps this constant in the same PR.
 func mustClassifyAll() {
-	const lastOpCode = ir.OpF64ArrayConcat
+	const lastOpCode = ir.OpNow
 	for o := ir.OpInvalid + 1; o <= lastOpCode; o++ {
 		if kindOf(o) == KindInvalid {
 			panic(fmt.Sprintf("verify: OpCode %s (=%d) is unclassified; extend kindOf in compiler3/verify/verify.go (MEP-41 §6.2 rule class C / coverage backstop)", o, o))
@@ -420,6 +421,8 @@ func contractResult(o ir.OpCode) ir.Type {
 		return ir.TypeList
 	case ir.OpF64ArrayConcat:
 		return ir.TypeF64Arr
+	case ir.OpNow:
+		return ir.TypeI64
 	}
 	return ir.TypeInvalid
 }

--- a/runtime/c/doc.go
+++ b/runtime/c/doc.go
@@ -24,5 +24,5 @@ import "embed"
 // files when cgo is off (and the whole point of this package is to
 // stay no-cgo on the build host).
 //
-//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c src/mochi_f64_array.h src/mochi_f64_array.c
+//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c src/mochi_f64_array.h src/mochi_f64_array.c src/mochi_time.h src/mochi_time.c
 var Runtime embed.FS

--- a/runtime/c/src/mochi_time.c
+++ b/runtime/c/src/mochi_time.c
@@ -1,0 +1,13 @@
+/*
+ * MEP-42 Phase 4.3.13 wall-clock builtin runtime. See mochi_time.h.
+ */
+#include "mochi_time.h"
+
+#include <stdint.h>
+#include <sys/time.h>
+
+int64_t mochi_now_us(void) {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (int64_t)tv.tv_sec * 1000000 + (int64_t)tv.tv_usec;
+}

--- a/runtime/c/src/mochi_time.h
+++ b/runtime/c/src/mochi_time.h
@@ -1,0 +1,32 @@
+/*
+ * MEP-42 Phase 4.3.13 wall-clock builtin runtime.
+ *
+ * Backs Mochi's `now()` builtin when the program is compiled with
+ * `mochi build --target=c`. The IR op OpNow lowers to a call into
+ * mochi_now_us().
+ *
+ * mochi_now_us returns the current wall-clock time in microseconds
+ * since the Unix epoch as int64_t. The unit and reference epoch match
+ * the Go target's `time.Now().UnixMicro()` so cross-target outputs
+ * that take deltas of two calls agree on the magnitude.
+ *
+ * Implementation note: POSIX gettimeofday is used directly. clock_gettime
+ * (CLOCK_REALTIME) would give nanosecond precision but Mochi's `now()`
+ * contract is microsecond, so the cheaper call is sufficient.
+ */
+#ifndef MOCHI_RUNTIME_C_TIME_H
+#define MOCHI_RUNTIME_C_TIME_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int64_t mochi_now_us(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOCHI_RUNTIME_C_TIME_H */

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -1514,6 +1514,66 @@ Per the goal-alignment audit: this sub-phase closes the last compiler-internal g
 - The concat result is freshly allocated on each call (no aliasing, no in-place reuse). Used inside a hot loop this is O(N) per concat plus a malloc; for spectral_norm's init loop (called N times, not in the inner kernel) this is fine. If a future benchmark needs concat in a tight loop, the IR can grow an `append`-style in-place variant without touching the surface syntax.
 - The `[T]` bracketed list-type arm still only supports `[int]` and `[float]`; widening to `[bool]` / `[string]` / nested `[[float]]` is a follow-up sub-phase that touches lowerType and the C-runtime headers but not this concat surface.
 
+## §10.22 Phase 4.3.13 closeout (LANDED 2026-05-22 01:08 GMT+7)
+
+Phase 4.3.13 lands the `now()` builtin end-to-end through compiler3 to both AOT targets. `now()` returns the current wall-clock time in microseconds since the Unix epoch as i64; the unit and reference epoch match the Go target's `time.Now().UnixMicro()` so cross-target deltas agree. This is the first of two bench-harness instrumentation sub-phases; Phase 4.3.14 will land `json({...})` and close the goal-state line for `mandelbrot.mochi` and `n_body.mochi` native fixtures.
+
+### Implementation
+
+1. **IR.** `compiler3/ir/types.go` gains `OpNow` (0 args, TypeI64 result). Validator (`compiler3/ir/validate.go`) and verifier (`compiler3/verify/verify.go`) get matching signatures; `OpNow` is classified `KindOperator` alongside `OpSqrtF64` (both are unary-ish runtime calls with no side effects from the IR's tag-stability point of view).
+2. **Frontend.** `compiler3/frontend/lower.go`'s `lowerBuiltinCall` adds a `now` arm that asserts 0 args and emits a single `OpNow` value.
+3. **Go emit.** `compiler3/emit/go/emit.go` adds an `OpNow` case that auto-imports `"time"` and emits `<lhs> = time.Now().UnixMicro()`.
+4. **C emit + runtime.** `compiler3/emit/c/emit.go` flags `OpNow` to auto-include `mochi_time.h` and emits `<lhs> = mochi_now_us()`. The new `runtime/c/src/mochi_time.{h,c}` defines `mochi_now_us()` as a thin wrapper over POSIX `gettimeofday`. The embed list in `runtime/c/doc.go` is extended so the build driver ships the new files alongside `gen.c`.
+
+### Files changed
+
+- `compiler3/ir/types.go`: `OpNow` opcode + String case.
+- `compiler3/ir/validate.go`: opSig for `OpNow`.
+- `compiler3/verify/verify.go`: kindOf + opResultType cases; `lastOpCode` bumped to `OpNow`.
+- `compiler3/frontend/lower.go`: `lowerBuiltinCall` arm for `now`.
+- `compiler3/emit/go/emit.go`: emit case (`time.Now().UnixMicro()`).
+- `compiler3/emit/c/emit.go`: emit case + auto-include flag.
+- `runtime/c/src/mochi_time.{h,c}`: new runtime files.
+- `runtime/c/doc.go`: embed list extended.
+- `compiler3/frontend/lower_test.go`: `TestLowerNowBuiltin`, `TestLowerNowDeltaArith`.
+- `compiler3/build/c/driver_test.go`: `TestBuildSourceNowBuiltin`, `TestBuildSourceNowDeltaArith`.
+- `website/docs/mep/mep-0042.md`: this closeout.
+
+### Reproducer
+
+```mochi
+let start = now()
+var sum = 0
+var i = 0
+while i < 1000 {
+  sum = sum + i
+  i = i + 1
+}
+let duration = (now() - start) / 1000
+if duration >= 0 {
+  print(sum)
+} else {
+  print(-1)
+}
+```
+
+```sh
+go run ./cmd/mochi build --target=c --binary /tmp/now /path/to/now.mochi
+/tmp/now  # prints 499500
+```
+
+The same source compiles via `--target=go` to the same output.
+
+### Why this is the right gate
+
+Per the goal-alignment audit: `now()` alone does not unblock any benchmark fixture (mandelbrot and n_body need both `now()` and `json({...})` to compile their native shapes). This sub-phase is scaffolding for Phase 4.3.14 (`json({...})`) which closes the goal. The split is the same pattern Phases 4.3.4 (`as` cast) and 4.3.6 (`int(x)`/`float(x)` call form) used: separate but tightly related surfaces ship as adjacent N.x sub-phases, each individually small and reviewable.
+
+### Limitations
+
+- `now()` is wall-clock, not monotonic. Two calls a few microseconds apart can return identical values (the test treats `b >= a` as the invariant, not strict `>`). For long-running benchmarks the microsecond unit is plenty of resolution; for sub-microsecond timing the IR would need an `OpNowNs` variant. None of the §10.7 benchmark games need that.
+- The C runtime uses `gettimeofday` rather than `clock_gettime(CLOCK_REALTIME)` because the latter is missing on older Darwin SDKs and Mochi targets POSIX baseline. The microsecond truncation in `gettimeofday` is the limiting factor in either case.
+- No timezone awareness: `now()` returns a Unix-epoch microsecond count, not a local-time wall clock. Mochi's higher-level time API (formatting, parsing) is a separate concern outside Phase 4.
+
 ## §11 Risks
 
 ### 11.1 Clang ABI drift breaks stencils


### PR DESCRIPTION
## Summary
- Add `OpNow` IR opcode (no args, returns i64 microseconds since Unix epoch) wired through frontend, verify, Go emit, and C emit.
- Go target lowers `now()` to `time.Now().UnixMicro()`; C target lowers to `mochi_now_us()` which wraps POSIX `gettimeofday` for microsecond granularity.
- New runtime sources `runtime/c/src/mochi_time.{h,c}` plus an `//go:embed` line in `runtime/c/doc.go` so the build driver copies them next to `gen.c`.

## Why
Scaffolding for Phase 4.3.14 (`json({...})`), after which `mandelbrot.mochi` and `n_body.mochi` compile unchanged via `mochi build --target=c`. `now()` is a prerequisite of every bench-harness fixture in `bench/template/bg/`.

## Test plan
- [x] `go test ./compiler3/frontend/... -run TestLowerNow -count=1`
- [x] `go test ./compiler3/build/c/... -run TestBuildSourceNow -count=1`
- [x] Full compiler3 verify suite green
- [x] `website/docs/mep/mep-0042.md` §10.22 closeout added

Closes #21983