### PR TITLE
mep-0042: Phase 4.3.14 json({...}) builtin lowering

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -920,6 +920,44 @@ if duration >= 0 {
 	}
 }
 
+// TestBuildSourceJsonI64Object pins the Phase 4.3.14 `json({...})`
+// builtin on the C target: lowers to a single printf with `%lld` per
+// i64 value and a constant key list. This is the closing C-target
+// piece for `bench/template/bg/mandelbrot.mochi` running through
+// `mochi build --target=c` without source modification.
+func TestBuildSourceJsonI64Object(t *testing.T) {
+	src := `let duration = 42
+let total = 17
+json({
+  "duration_us": duration,
+  "output": total,
+})
+`
+	if got, want := runMochiBuild(t, src), "{\"duration_us\":42,\"output\":17}\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceJsonI64ObjectFromArith pins that the JSON values may
+// be arbitrary i64 expressions on the C target (sum reduction here),
+// matching the Go target's TestLowerJsonI64ObjectFromArith.
+func TestBuildSourceJsonI64ObjectFromArith(t *testing.T) {
+	src := `var sum = 0
+var i = 0
+while i < 10 {
+  sum = sum + i
+  i = i + 1
+}
+json({
+  "duration_us": sum * 2,
+  "output": sum,
+})
+`
+	if got, want := runMochiBuild(t, src), "{\"duration_us\":90,\"output\":45}\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceMathPiConst pins the Phase 4.3.9 math.pi constant
 // read on the C target: 4*pi*pi truncated = 39.
 func TestBuildSourceMathPiConst(t *testing.T) {

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -348,6 +348,28 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    %s = mochi_f64_array_concat(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpNow:
 		fmt.Fprintf(w, "    %s = mochi_now_us();\n", name)
+	case ir.OpJsonI64Object:
+		if int(v.Const) < 0 || int(v.Const) >= len(fn.JsonObjects) {
+			return fmt.Errorf("OpJsonI64Object v%d: Const %d out of range (have %d JsonObjects)",
+				v.ID, v.Const, len(fn.JsonObjects))
+		}
+		obj := fn.JsonObjects[v.Const]
+		if len(obj.Keys) != len(v.Args) {
+			return fmt.Errorf("OpJsonI64Object v%d: %d keys but %d args",
+				v.ID, len(obj.Keys), len(v.Args))
+		}
+		w.WriteString(`    printf("{`)
+		for i, k := range obj.Keys {
+			if i > 0 {
+				w.WriteString(",")
+			}
+			fmt.Fprintf(w, `\"%s\":%%lld`, k)
+		}
+		w.WriteString(`}\n"`)
+		for _, aid := range v.Args {
+			fmt.Fprintf(w, ", (long long)%s", valueName(aid))
+		}
+		w.WriteString(");\n")
 	case ir.OpCall, ir.OpTailCall:
 		// Intra-program call. v.Const indexes into Program.Funcs;
 		// args are SSA values in declared order. The emitter writes

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -315,6 +315,30 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 	case ir.OpNow:
 		imports["time"] = true
 		fmt.Fprintf(w, "\t%s = time.Now().UnixMicro()\n", name)
+	case ir.OpJsonI64Object:
+		if int(v.Const) < 0 || int(v.Const) >= len(fn.JsonObjects) {
+			return fmt.Errorf("OpJsonI64Object v%d: Const %d out of range (have %d JsonObjects)", v.ID, v.Const, len(fn.JsonObjects))
+		}
+		obj := fn.JsonObjects[v.Const]
+		if len(obj.Keys) != len(v.Args) {
+			return fmt.Errorf("OpJsonI64Object v%d: %d keys but %d args", v.ID, len(obj.Keys), len(v.Args))
+		}
+		imports["fmt"] = true
+		var fb bytes.Buffer
+		fb.WriteString(`"{`)
+		for i, k := range obj.Keys {
+			if i > 0 {
+				fb.WriteString(",")
+			}
+			fmt.Fprintf(&fb, `\"%s\":%%d`, k)
+		}
+		fb.WriteString(`}\n"`)
+		fmt.Fprintf(w, "\tfmt.Printf(%s", fb.String())
+		for _, aid := range v.Args {
+			fmt.Fprintf(w, ", %s", valueName(aid))
+		}
+		w.WriteString(")\n")
+		_ = name
 	case ir.OpCall, ir.OpTailCall:
 		callee := all[v.Const]
 		fmt.Fprintf(w, "\t%s = %s(", name, callee.Name)

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1005,7 +1005,80 @@ func (b *builder) lowerExprAsStmt(e *parser.Expr) (uint32, error) {
 		id := b.addValue(ir.Value{Type: ir.TypeUnit, Op: ir.OpCallGo, Args: []uint32{arg}, Const: bindIdx})
 		return id, nil
 	}
+	if call := exprAsCall(e); call != nil && call.Func == "json" && len(call.Args) == 1 {
+		if m := exprAsMapLit(call.Args[0]); m != nil {
+			return b.lowerJsonObject(m)
+		}
+		return 0, fmt.Errorf("frontend: json() requires a map literal argument in MVP")
+	}
 	return b.lowerExpr(e)
+}
+
+// lowerJsonObject lowers `json({"k1": e1, ..., "kN": eN})` as an
+// OpJsonI64Object statement. Phase 4.3.14 restricts the value type to
+// i64 (the `bench/template/bg/*.mochi` fixtures only need
+// `duration_us` and `output`, both i64). The keys are captured into
+// a fn.JsonObjects entry the emitter indexes via Value.Const; the
+// values lower to N i64 SSA IDs in Args.
+func (b *builder) lowerJsonObject(m *parser.MapLiteral) (uint32, error) {
+	if len(m.Items) == 0 {
+		return 0, fmt.Errorf("frontend: json({}) with no keys unsupported in MVP")
+	}
+	keys := make([]string, 0, len(m.Items))
+	args := make([]uint32, 0, len(m.Items))
+	for _, item := range m.Items {
+		k, ok := exprAsStrLit(item.Key)
+		if !ok {
+			return 0, fmt.Errorf("frontend: json() keys must be string literals in MVP")
+		}
+		valID, err := b.lowerExpr(item.Value)
+		if err != nil {
+			return 0, err
+		}
+		if got := b.fn.Values[valID].Type; got != ir.TypeI64 {
+			return 0, fmt.Errorf("frontend: json() value for key %q has type %s, MVP requires i64", k, got)
+		}
+		keys = append(keys, k)
+		args = append(args, valID)
+	}
+	idx := int64(len(b.fn.JsonObjects))
+	b.fn.JsonObjects = append(b.fn.JsonObjects, ir.JsonObject{Keys: keys})
+	id := b.addValue(ir.Value{Type: ir.TypeUnit, Op: ir.OpJsonI64Object, Args: args, Const: idx})
+	return id, nil
+}
+
+// exprAsMapLit returns the underlying MapLiteral if e is a bare
+// `{k:v, ...}` primary, else nil. Used by json({...}) recognition.
+func exprAsMapLit(e *parser.Expr) *parser.MapLiteral {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) != 0 {
+		return nil
+	}
+	u := e.Binary.Left
+	if u == nil || len(u.Ops) != 0 || u.Value == nil || len(u.Value.Ops) != 0 {
+		return nil
+	}
+	p := u.Value.Target
+	if p == nil {
+		return nil
+	}
+	return p.Map
+}
+
+// exprAsStrLit returns the string payload + true if e is a bare
+// string-literal primary, else "", false.
+func exprAsStrLit(e *parser.Expr) (string, bool) {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) != 0 {
+		return "", false
+	}
+	u := e.Binary.Left
+	if u == nil || len(u.Ops) != 0 || u.Value == nil || len(u.Value.Ops) != 0 {
+		return "", false
+	}
+	p := u.Value.Target
+	if p == nil || p.Lit == nil || p.Lit.Str == nil {
+		return "", false
+	}
+	return *p.Lit.Str, true
 }
 
 func goTypeForIRType(t ir.Type) string {

--- a/compiler3/frontend/lower_test.go
+++ b/compiler3/frontend/lower_test.go
@@ -798,6 +798,49 @@ if duration >= 0 {
 	}
 }
 
+// TestLowerJsonI64Object pins the Phase 4.3.14 `json({...})` builtin:
+// a string-keyed map literal with i64 values lowers to OpJsonI64Object
+// and prints a single-line JSON object. This is the closing piece for
+// `bench/template/bg/mandelbrot.mochi` running through the compiler3
+// frontend without source modification.
+func TestLowerJsonI64Object(t *testing.T) {
+	src := `let duration = 42
+let total = 17
+json({
+  "duration_us": duration,
+  "output": total,
+})
+`
+	got := runEnd2End(t, src)
+	want := "{\"duration_us\":42,\"output\":17}\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestLowerJsonI64ObjectFromArith pins that the JSON values may be
+// arbitrary i64 expressions (not just identifiers): the map values are
+// SSA placeholders fed through OpJsonI64Object.Args, so `(now()-now())`
+// + arithmetic + cast composition all reach the printer.
+func TestLowerJsonI64ObjectFromArith(t *testing.T) {
+	src := `var sum = 0
+var i = 0
+while i < 10 {
+  sum = sum + i
+  i = i + 1
+}
+json({
+  "duration_us": sum * 2,
+  "output": sum,
+})
+`
+	got := runEnd2End(t, src)
+	want := "{\"duration_us\":90,\"output\":45}\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestLowerMathPiConst pins the Phase 4.3.9 `math.pi` constant read:
 // `extern let math.pi: float` is accepted as a no-op binding; the
 // selector read lowers to OpConst of TypeF64 with the math.Pi value.

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -243,6 +243,19 @@ const (
 	// which wraps POSIX `gettimeofday` to produce the same microsecond
 	// granularity. The op takes no SSA args.
 	OpNow
+
+	// Bench-harness JSON sink (Phase 4.3.14). OpJsonI64Object is the
+	// statement-level form `json({"k1": v1, ..., "kN": vN})` where every
+	// key is a string literal and every value is an i64 expression. It
+	// prints a single-line JSON object plus newline. Args carries the
+	// N value SSA IDs in declared order; Const indexes into
+	// fn.JsonObjects for the matching key list. Result is TypeUnit.
+	// Go emit: `fmt.Printf("{\"k1\":%d,...}\n", v1, ...)`. C emit:
+	// `printf("{\"k1\":%lld,...}\n", v1, ...);`. The whole-object form
+	// (not per-key) keeps the emit a single I/O call so the bench
+	// harness reads one atomic line per program run, matching the
+	// `bench/template/bg/*.mochi` fixture contract.
+	OpJsonI64Object
 )
 
 // String renders an OpCode's short name. Used by Validate and IR
@@ -353,6 +366,8 @@ func (o OpCode) String() string {
 		return "f64arr.concat"
 	case OpNow:
 		return "now"
+	case OpJsonI64Object:
+		return "json.i64.object"
 	case OpCall:
 		return "call"
 	case OpTailCall:
@@ -457,6 +472,15 @@ type GoBinding struct {
 	IsValue bool
 }
 
+// JsonObject names the key list for one OpJsonI64Object call site.
+// Keys is the declared-order list of JSON object keys; the matching
+// OpJsonI64Object Value carries the values via Args (one i64 SSA ID
+// per key). The frontend constructs one JsonObject per `json({...})`
+// expression-statement and indexes it from OpJsonI64Object.Const.
+type JsonObject struct {
+	Keys []string
+}
+
 // Value is one SSA-form IR node. Type is mandatory; the type checker
 // proves it before compiler3 sees the value. Const carries:
 //   - the literal payload for OpConst (sign-extended i64, bit-cast
@@ -531,8 +555,9 @@ type Function struct {
 	Result     Type
 	Blocks     []Block
 	Values     []Value
-	GoBindings []GoBinding
-	SourceFile string
+	GoBindings  []GoBinding
+	JsonObjects []JsonObject
+	SourceFile  string
 
 	// RefModes records the MEP-41 §6.9 reference-mode tag for the
 	// Values whose Mochi-surface binding carried one. Nil for any

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -225,6 +225,12 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeF64Arr, [3]Type{TypeF64Arr, TypeF64Arr}}
 	case OpNow:
 		return opSig{TypeI64, [3]Type{}}
+	case OpJsonI64Object:
+		// Variadic in Args (N i64 values, N >= 1); per-arg shape is
+		// enforced by the frontend at lower time. opContract returns
+		// only the result Type; checkOperandTypes skips inTypes when
+		// they are TypeInvalid.
+		return opSig{TypeUnit, [3]Type{}}
 	}
 	// OpParam, OpConst, OpPhi, OpCall, OpTailCall: the validator
 	// can't pre-compute their signature without more context, so we

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -159,7 +159,8 @@ func kindOf(o ir.OpCode) ProducerKind {
 		ir.OpNotBool,
 		ir.OpI64ToF64, ir.OpF64ToI64,
 		ir.OpSqrtF64,
-		ir.OpNow:
+		ir.OpNow,
+		ir.OpJsonI64Object:
 		return KindOperator
 
 	case ir.OpLenStr:
@@ -217,7 +218,7 @@ func init() {
 // the last OpCode known to ir/types.go at this MEP-41 Phase 1 commit;
 // adding a new op past it bumps this constant in the same PR.
 func mustClassifyAll() {
-	const lastOpCode = ir.OpNow
+	const lastOpCode = ir.OpJsonI64Object
 	for o := ir.OpInvalid + 1; o <= lastOpCode; o++ {
 		if kindOf(o) == KindInvalid {
 			panic(fmt.Sprintf("verify: OpCode %s (=%d) is unclassified; extend kindOf in compiler3/verify/verify.go (MEP-41 §6.2 rule class C / coverage backstop)", o, o))
@@ -423,6 +424,8 @@ func contractResult(o ir.OpCode) ir.Type {
 		return ir.TypeF64Arr
 	case ir.OpNow:
 		return ir.TypeI64
+	case ir.OpJsonI64Object:
+		return ir.TypeUnit
 	}
 	return ir.TypeInvalid
 }

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -1574,6 +1574,63 @@ Per the goal-alignment audit: `now()` alone does not unblock any benchmark fixtu
 - The C runtime uses `gettimeofday` rather than `clock_gettime(CLOCK_REALTIME)` because the latter is missing on older Darwin SDKs and Mochi targets POSIX baseline. The microsecond truncation in `gettimeofday` is the limiting factor in either case.
 - No timezone awareness: `now()` returns a Unix-epoch microsecond count, not a local-time wall clock. Mochi's higher-level time API (formatting, parsing) is a separate concern outside Phase 4.
 
+## §10.23 Phase 4.3.14 closeout (LANDED 2026-05-22 01:23 GMT+7)
+
+Phase 4.3.14 lands the `json({"k": v, ...})` builtin on both AOT targets. This is the closing piece for the bench-harness output contract: `bench/template/bg/mandelbrot.mochi` and `bench/template/bg/n_body.mochi` both compile unchanged through `mochi build --target=c` and produce `{"duration_us":...,"output":...}\n` byte-equivalent to the Go target.
+
+### Implementation
+
+1. **IR.** `compiler3/ir/types.go` gains `OpJsonI64Object` (variadic i64 Args, TypeUnit result, no handle production) and a sibling `JsonObject{Keys []string}` side-table on `ir.Function`. Each call site reserves one entry in `fn.JsonObjects` and references it via `Value.Const`. The validator returns `opSig{TypeUnit, ...}` with the inTypes left blank because the variadic shape is enforced at lowering time; the verifier classifies the op `KindOperator` (produces non-handle TypeUnit, never a fresh arena).
+2. **Frontend.** `compiler3/frontend/lower.go`'s `lowerExprAsStmt` already special-cased `print(x)`; the same hook now also recognises `json(<MapLit>)`. The new `lowerJsonObject` walks `MapLiteral.Items`, asserts each key is a string-literal Primary and each value lowers to a TypeI64 SSA value, then emits a single `OpJsonI64Object`. Phase 4.3.14 is i64-only by design; mixed-type bodies fall to a clean error rather than a silent miscompile, leaving room for a follow-up sub-phase if a benchmark fixture needs strings or floats inside the object.
+3. **Go emit.** Auto-imports `"fmt"` and emits `fmt.Printf("{\"k1\":%d,...}\n", v1, ...)` with one `%d` per key. The `_ = name` suppression is omitted because TypeUnit values are never declared as Go locals (`goTypeForValue` returns `""`); the emit writes only the `fmt.Printf` line.
+4. **C emit.** Emits `printf("{\"k1\":%lld,...}\n", (long long)v1, ...);`. The cast keeps the format directive portable across LP64 platforms where `int64_t` is sometimes `long` and sometimes `long long`. No new runtime files are needed because `stdio.h` is already in the prologue.
+
+### Files changed
+
+- `compiler3/ir/types.go`: `OpJsonI64Object` opcode + `JsonObject` struct + `JsonObjects []JsonObject` field on `Function`.
+- `compiler3/ir/validate.go`: opSig for `OpJsonI64Object` (TypeUnit result, variadic args).
+- `compiler3/verify/verify.go`: kindOf + opResultType cases; `lastOpCode` bumped to `OpJsonI64Object`.
+- `compiler3/frontend/lower.go`: `lowerExprAsStmt` recognises `json(MapLit)`; helpers `lowerJsonObject`, `exprAsMapLit`, `exprAsStrLit`.
+- `compiler3/emit/go/emit.go`: emit case (`fmt.Printf` with `%d` per key).
+- `compiler3/emit/c/emit.go`: emit case (`printf` with `%lld` per key).
+- `compiler3/frontend/lower_test.go`: `TestLowerJsonI64Object`, `TestLowerJsonI64ObjectFromArith`.
+- `compiler3/build/c/driver_test.go`: `TestBuildSourceJsonI64Object`, `TestBuildSourceJsonI64ObjectFromArith`.
+- `website/docs/mep/mep-0042.md`: this closeout.
+
+### Reproducer (mandelbrot.mochi)
+
+The bench fixture compiles unchanged once `{{ .N }}` is template-substituted by the bench harness (or hand-substituted for a local probe). With `side = 16`:
+
+```sh
+go run ./cmd/mochi build --target=c --binary /tmp/mandel_c /path/to/mandelbrot.mochi
+/tmp/mandel_c
+# {"duration_us":0,"output":4629}
+```
+
+The Go interpreter and `--target=go` both produce the same `output` field (the `duration_us` field is wall-clock and runtime-dependent by design).
+
+### Reproducer (n_body.mochi)
+
+n_body needs Phase 4.3.5's `math.sqrt`, Phase 4.3.9's `math.pi`, Phase 4.3.10's f64-list indexing, Phase 4.3.12's list concat (for `vel_x[0] = ...` assignments under the centering pass which the IR builder still expresses as concat-then-store), Phase 4.3.13's `now()`, and Phase 4.3.14's `json({...})` all working together. With `steps = 50`:
+
+```sh
+go run ./cmd/mochi build --target=c --binary /tmp/nbody_c /path/to/n_body.mochi
+/tmp/nbody_c
+# {"duration_us":0,"output":-169063617}
+```
+
+The interpreter on the same source produces `{"duration_us":...,"output":-169063617}`, byte-equivalent on `output`.
+
+### Why this closes the goal
+
+The user-facing objective for the §10 Phase 4.3 stream is "all bench-template benchmark games programs compile via `mochi build --target=c`". The harness output contract (`{"duration_us":X,"output":Y}\n`) is the only piece that requires JSON support; every other bench fixture uses the same shape. With Phase 4.3.14 landed, the remaining gates are kernel-specific (binary trees, fasta, regex_redux, etc.) rather than harness-shaped, and those are §10's matrix entries.
+
+### Limitations
+
+- Values are i64-only. A fixture that wants to emit a float (`{"score": 0.001}`) hits a clean frontend error. None of the §10.7 fixtures need this in their current form; adding f64 support is a 30-line follow-up if needed (`%g` for Go, `%.17g` for C; the IR side already supports variadic Args of arbitrary type).
+- The emitted JSON has no whitespace inside the object. The bench harness parses with `encoding/json` which accepts both pretty and compact forms, so this is invisible to the user. The interpreter produces the pretty form; the AOT-emitted form is compact; both decode equivalently.
+- Object-of-object and array-of-object shapes are not supported. The bench harness's flat `{duration_us, output}` shape covers every fixture in `bench/template/bg/`.
+
 ## §11 Risks
 
 ### 11.1 Clang ABI drift breaks stencils


### PR DESCRIPTION
## Summary
- Add `OpJsonI64Object` IR opcode (variadic i64 args, TypeUnit result) plus `JsonObject{Keys []string}` side-table on `ir.Function` so the emitter can build the format string at emit time.
- Frontend recognises `json(<MapLit>)` at statement position, validates keys are string literals + values are i64, lowers to a single `OpJsonI64Object`.
- Go emit lowers to `fmt.Printf("{\"k1\":%d,...}\n", v1, ...)`; C emit lowers to `printf("{\"k1\":%lld,...}\n", (long long)v1, ...);`.

## Why
Closes the bench-harness output contract for the C target. `bench/template/bg/mandelbrot.mochi` and `bench/template/bg/n_body.mochi` now compile unchanged through `mochi build --target=c` and produce `{"duration_us":X,"output":Y}\n` byte-equivalent to the Go target (the `output` field matches; `duration_us` is wall-clock and runtime-dependent by design).

## Test plan
- [x] `go test ./compiler3/frontend/... -run TestLowerJson -count=1`
- [x] `go test ./compiler3/build/c/... -run TestBuildSourceJson -count=1`
- [x] Full compiler3 suite green (one pre-existing `GOPROXY=off` failure unrelated)
- [x] Hand probe: `mochi build --target=c` on mandelbrot.mochi (side=16) -> `{"duration_us":0,"output":4629}`, matches interpreter `output`
- [x] Hand probe: `mochi build --target=c` on n_body.mochi (steps=50) -> `{"duration_us":0,"output":-169063617}`, matches interpreter `output`
- [x] `website/docs/mep/mep-0042.md` §10.23 closeout added

Closes #21985