### PR TITLE
mep-0042: Phase 4.3.15.2 map<int,int> literal + index ops for k_nucleotide

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -1166,6 +1166,66 @@ func TestBuildSourceRegexReduxBgFixture(t *testing.T) {
 	}
 }
 
+// TestBuildSourceKNucleotideBgFixture pins the unmodified
+// bench/template/bg/k_nucleotide fixture (N=10000) on the C target.
+// The fixture exercises the Phase 4.3.15.2 surface end-to-end:
+// `var counts: map<int, int> = {}` initializer lowers via OpNewMap,
+// `counts[k] = v` via OpMapSetI64I64, and `counts[k]` (in read
+// position) via OpMapGetI64I64. Output is the LCG-driven rolling
+// i64 hash of 20 counts; byte-matches the --target=go build on the
+// same source (the interpreter rejects the source with a type
+// error, so the cross-check is C target vs Go target).
+func TestBuildSourceKNucleotideBgFixture(t *testing.T) {
+	src := readBenchFixture(t, "k_nucleotide", 0)
+	got := runMochiBuild(t, src)
+	if want := "723253870\n"; got != want {
+		t.Errorf("k_nucleotide fixture stdout = %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceMapI64I64Basic pins the Phase 4.3.15.2 map<int,int>
+// surface on the C target: empty-literal initializer, an
+// indexed-assign store, a read of the same key, plus a read of an
+// absent key that must return 0 (matching Go's zero-default semantic
+// for `map[int64]int64`).
+func TestBuildSourceMapI64I64Basic(t *testing.T) {
+	src := `var m: map<int, int> = {}
+m[7] = 11
+m[8] = 22
+print(m[7])
+print(m[8])
+print(m[999])
+`
+	if got, want := runMochiBuild(t, src), "11\n22\n0\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceMapI64I64Grow exercises the runtime's grow path: 32
+// inserts force at least two grows (initial cap=8, threshold 0.75
+// triggers grow at len=7, again at len=13, again at len=25). Reads
+// after grow must still return the right values; this catches a
+// rehash bug where the new probe order doesn't match the new mask.
+func TestBuildSourceMapI64I64Grow(t *testing.T) {
+	src := `var m: map<int, int> = {}
+var i = 0
+while i < 32 {
+  m[i] = i * 100
+  i = i + 1
+}
+var k = 0
+var sum = 0
+while k < 32 {
+  sum = sum + m[k]
+  k = k + 1
+}
+print(sum)
+`
+	if got, want := runMochiBuild(t, src), "49600\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceSpectralNormBgFixture pins the unmodified
 // bench/template/bg/spectral_norm fixture (N=100) on the C target.
 // This is the §10.7 closeout for spectral_norm at the fixture level

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -64,6 +64,7 @@ func Emit(p *Program) ([]byte, error) {
 	usesListI64 := false
 	usesF64Array := false
 	usesNow := false
+	usesMapI64I64 := false
 	for _, fn := range p.Funcs {
 		for _, v := range fn.Values {
 			switch v.Op {
@@ -84,6 +85,8 @@ func Emit(p *Program) ([]byte, error) {
 			case ir.OpNewF64Array, ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64,
 				ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64, ir.OpF64ArrayConcat:
 				usesF64Array = true
+			case ir.OpNewMap, ir.OpMapSetI64I64, ir.OpMapGetI64I64:
+				usesMapI64I64 = true
 			case ir.OpNow:
 				usesNow = true
 			}
@@ -103,6 +106,9 @@ func Emit(p *Program) ([]byte, error) {
 	}
 	if usesF64Array {
 		buf.WriteString("#include \"mochi_f64_array.h\"\n")
+	}
+	if usesMapI64I64 {
+		buf.WriteString("#include \"mochi_map_i64_i64.h\"\n")
 	}
 	if usesNow {
 		buf.WriteString("#include \"mochi_time.h\"\n")
@@ -346,6 +352,12 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    %s = mochi_list_i64_concat(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpF64ArrayConcat:
 		fmt.Fprintf(w, "    %s = mochi_f64_array_concat(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpNewMap:
+		fmt.Fprintf(w, "    %s = mochi_map_i64_i64_new();\n", name)
+	case ir.OpMapSetI64I64:
+		fmt.Fprintf(w, "    mochi_map_i64_i64_set(%s, %s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
+	case ir.OpMapGetI64I64:
+		fmt.Fprintf(w, "    %s = mochi_map_i64_i64_get(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpNow:
 		fmt.Fprintf(w, "    %s = mochi_now_us();\n", name)
 	case ir.OpJsonI64Object:
@@ -530,6 +542,11 @@ func cType(t ir.Type) string {
 		// Distinct from TypeList so cc -O2 can vectorise the flat
 		// double[] backing without a Cell-tag indirection.
 		return "mochi_f64_array*"
+	case ir.TypeMap:
+		// map<int, int>: heap-allocated open-addressing hashtable.
+		// Backed by runtime/c/src/mochi_map_i64_i64.{h,c}; sized for
+		// k_nucleotide's 20-key worst case but grows on demand.
+		return "mochi_map_i64_i64*"
 	case ir.TypeUnit, ir.TypeInvalid:
 		return "void"
 	}

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -185,6 +185,13 @@ type builder struct {
 	// would clear this, but 0/1 in a list<float> declaration is a real
 	// case in the benchmark-games kernels).
 	expectedListElem ir.Type
+	// expectedMap is set by `let/var m: map<int, int> = ...` just before
+	// lowerExpr and cleared after. lowerPrimary consults it so a bare
+	// `{}` map-literal RHS lowers to OpNewMap when the LHS is TypeMap.
+	// Phase 4.3.15.2 supports only empty map literals at this hook;
+	// non-empty literals are out of scope until a sub-phase widens the
+	// IR's map family.
+	expectedMap bool
 }
 
 func newBuilder(fn *ir.Function, userFns map[string]funEntry, prog *gogen.Program, goImports map[string]*goImport) *builder {
@@ -264,6 +271,27 @@ func lowerType(t *parser.TypeRef) (ir.Type, error) {
 				return ir.TypeF64Arr, nil
 			}
 			return ir.TypeInvalid, fmt.Errorf("frontend: list<%s> unsupported in MVP (only list<int> and list<float>)", el)
+		}
+		// Phase 4.3.15.2: `map<int, int>` lowers to TypeMap, backed by
+		// runtime/c/src/mochi_map_i64_i64.{h,c} on the C target and
+		// `map[int64]int64` on the Go target. Other key/value type
+		// combinations stay rejected until a later sub-phase widens the
+		// IR's map family (OpMapSetI64I64 / OpMapGetI64I64 are i64->i64
+		// today; OpNewMap is type-agnostic at the op level but the
+		// emit side assumes i64->i64).
+		if t.Generic.Name == "map" && len(t.Generic.Args) == 2 {
+			k, err := lowerType(t.Generic.Args[0])
+			if err != nil {
+				return ir.TypeInvalid, fmt.Errorf("frontend: map key: %w", err)
+			}
+			v, err := lowerType(t.Generic.Args[1])
+			if err != nil {
+				return ir.TypeInvalid, fmt.Errorf("frontend: map value: %w", err)
+			}
+			if k == ir.TypeI64 && v == ir.TypeI64 {
+				return ir.TypeMap, nil
+			}
+			return ir.TypeInvalid, fmt.Errorf("frontend: map<%s, %s> unsupported in MVP (only map<int, int>)", k, v)
 		}
 		return ir.TypeInvalid, fmt.Errorf("frontend: generic %s<...> unsupported in MVP", t.Generic.Name)
 	}
@@ -369,7 +397,7 @@ func (b *builder) lowerIndexedAssign(a *parser.AssignStmt) error {
 		return fmt.Errorf("frontend: indexed assign to unbound identifier %q", a.Name)
 	}
 	listType := b.fn.Values[listID].Type
-	if listType != ir.TypeList && listType != ir.TypeF64Arr {
+	if listType != ir.TypeList && listType != ir.TypeF64Arr && listType != ir.TypeMap {
 		return fmt.Errorf("frontend: indexed assign on non-list %s", listType)
 	}
 	idxID, err := b.lowerExpr(idxOp.Start)
@@ -403,6 +431,15 @@ func (b *builder) lowerIndexedAssign(a *parser.AssignStmt) error {
 			ElemType: ir.TypeF64,
 			Op:       ir.OpF64ArraySetF64,
 			Args:     []uint32{listID, idxID, valID},
+		})
+	case ir.TypeMap:
+		if b.fn.Values[valID].Type != ir.TypeI64 {
+			return fmt.Errorf("frontend: map<int, int> store requires i64 value, got %s", b.fn.Values[valID].Type)
+		}
+		b.addValue(ir.Value{
+			Type: ir.TypeUnit,
+			Op:   ir.OpMapSetI64I64,
+			Args: []uint32{listID, idxID, valID},
 		})
 	}
 	return nil
@@ -441,10 +478,13 @@ func (b *builder) lowerTypedLet(name string, tRef *parser.TypeRef, e *parser.Exp
 			b.expectedListElem = ir.TypeI64
 		case ir.TypeF64Arr:
 			b.expectedListElem = ir.TypeF64
+		case ir.TypeMap:
+			b.expectedMap = true
 		}
 	}
 	vid, err := b.lowerExpr(e)
 	b.expectedListElem = ir.TypeInvalid
+	b.expectedMap = false
 	if err != nil {
 		return err
 	}
@@ -1360,7 +1400,7 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 				return 0, fmt.Errorf("frontend: slice indexing unsupported in MVP")
 			}
 			curType := b.fn.Values[cur].Type
-			if curType != ir.TypeList && curType != ir.TypeF64Arr {
+			if curType != ir.TypeList && curType != ir.TypeF64Arr && curType != ir.TypeMap {
 				return 0, fmt.Errorf("frontend: index on non-list %s", curType)
 			}
 			iID, err := b.lowerExpr(idx.Start)
@@ -1384,6 +1424,12 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 					ElemType: ir.TypeF64,
 					Op:       ir.OpF64ArrayGetF64,
 					Args:     []uint32{cur, iID},
+				})
+			case ir.TypeMap:
+				cur = b.addValue(ir.Value{
+					Type: ir.TypeI64,
+					Op:   ir.OpMapGetI64I64,
+					Args: []uint32{cur, iID},
 				})
 			}
 		case op.Cast != nil:
@@ -1438,10 +1484,30 @@ func (b *builder) lowerPrimary(p *parser.Primary) (uint32, error) {
 		return b.lowerCall(p.Call)
 	case p.List != nil:
 		return b.lowerListLiteral(p.List)
+	case p.Map != nil:
+		return b.lowerMapLiteralAsExpr(p.Map)
 	case p.Group != nil:
 		return b.lowerExpr(p.Group)
 	}
 	return 0, fmt.Errorf("frontend: primary form unsupported in MVP")
+}
+
+// lowerMapLiteralAsExpr lowers a bare `{...}` map literal used as an
+// expression (not the statement-level json({...}) hook). Phase
+// 4.3.15.2 supports only empty literals under a `var m: map<int, int>
+// = {}` declaration; the empty case lowers to OpNewMap producing a
+// fresh empty heap-allocated table. Non-empty literals would need
+// every key+value to be a constant-folded int and the IR would need
+// either a chain of OpMapSetI64I64 ops or a new OpMapLit op; both
+// stay out of MVP scope until a fixture needs them.
+func (b *builder) lowerMapLiteralAsExpr(m *parser.MapLiteral) (uint32, error) {
+	if !b.expectedMap {
+		return 0, fmt.Errorf("frontend: map literal requires `map<int, int>` type annotation on the binding")
+	}
+	if len(m.Items) != 0 {
+		return 0, fmt.Errorf("frontend: non-empty map literal unsupported in MVP (only `{}` initializer)")
+	}
+	return b.addValue(ir.Value{Type: ir.TypeMap, Op: ir.OpNewMap}), nil
 }
 
 // lowerListLiteral lowers `[e1, e2, ...]` to an empty-list constructor

--- a/compiler3/frontend/lower_test.go
+++ b/compiler3/frontend/lower_test.go
@@ -978,6 +978,26 @@ print(s)
 // loop-variable increment all in one program. This is the program the
 // benchmark games' nsieve fixture reduces to once the list element-
 // type widening is removed.
+// TestLowerMapI64I64Basic pins the Phase 4.3.15.2 map<int,int>
+// surface end-to-end through the frontend. Confirms empty-literal
+// `{}` lowers to OpNewMap under the type-annotated `var m: map<int,
+// int> = {}`, that `m[k] = v` and `m[k]` lower to OpMapSetI64I64 /
+// OpMapGetI64I64, and that a read of an absent key returns 0
+// (matching Go's zero-default semantic).
+func TestLowerMapI64I64Basic(t *testing.T) {
+	src := `var m: map<int, int> = {}
+m[7] = 11
+m[8] = 22
+print(m[7])
+print(m[8])
+print(m[999])
+`
+	got := runEnd2End(t, src)
+	if want := "11\n22\n0\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestLowerNsieve(t *testing.T) {
 	src := `fun nsieve(m: int): int {
   var flags: list<int> = []

--- a/runtime/c/doc.go
+++ b/runtime/c/doc.go
@@ -24,5 +24,5 @@ import "embed"
 // files when cgo is off (and the whole point of this package is to
 // stay no-cgo on the build host).
 //
-//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c src/mochi_f64_array.h src/mochi_f64_array.c src/mochi_time.h src/mochi_time.c
+//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c src/mochi_f64_array.h src/mochi_f64_array.c src/mochi_time.h src/mochi_time.c src/mochi_map_i64_i64.h src/mochi_map_i64_i64.c
 var Runtime embed.FS

--- a/runtime/c/src/mochi_map_i64_i64.c
+++ b/runtime/c/src/mochi_map_i64_i64.c
@@ -1,0 +1,108 @@
+/*
+ * MEP-42 Phase 4.3.15.2 typed-i64->i64 map runtime. See
+ * mochi_map_i64_i64.h.
+ */
+#include "mochi_map_i64_i64.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+static uint64_t mochi_map_i64_hash(int64_t k) {
+    /* SplitMix64 finaliser, used here as a cheap avalanche hash so
+     * that consecutive small keys (k_nucleotide uses 0..19) don't
+     * pile up on a few buckets after the cap-1 mask. */
+    uint64_t x = (uint64_t)k + 0x9E3779B97F4A7C15ULL;
+    x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    x = (x ^ (x >> 27)) * 0x94D049BB133111EBULL;
+    x = x ^ (x >> 31);
+    return x;
+}
+
+mochi_map_i64_i64 *mochi_map_i64_i64_new(void) {
+    mochi_map_i64_i64 *m = (mochi_map_i64_i64 *)malloc(sizeof(mochi_map_i64_i64));
+    if (m == NULL) {
+        abort();
+    }
+    m->keys = NULL;
+    m->vals = NULL;
+    m->occ = NULL;
+    m->cap = 0;
+    m->len = 0;
+    return m;
+}
+
+static int64_t mochi_map_i64_probe(const mochi_map_i64_i64 *m, int64_t k) {
+    /* Returns the bucket index where k lives (if occupied) or the
+     * first empty bucket on the probe path (if absent). Caller
+     * inspects occ[idx] to disambiguate. Cap must be > 0; callers
+     * that might be called on an empty map must grow first. */
+    uint64_t mask = (uint64_t)m->cap - 1;
+    uint64_t i = mochi_map_i64_hash(k) & mask;
+    while (m->occ[i] != 0 && m->keys[i] != k) {
+        i = (i + 1) & mask;
+    }
+    return (int64_t)i;
+}
+
+static void mochi_map_i64_grow(mochi_map_i64_i64 *m) {
+    int64_t newcap = m->cap == 0 ? 8 : m->cap * 2;
+    int64_t *nkeys = (int64_t *)calloc((size_t)newcap, sizeof(int64_t));
+    int64_t *nvals = (int64_t *)calloc((size_t)newcap, sizeof(int64_t));
+    uint8_t *nocc = (uint8_t *)calloc((size_t)newcap, sizeof(uint8_t));
+    if (nkeys == NULL || nvals == NULL || nocc == NULL) {
+        abort();
+    }
+    /* Re-probe every occupied bucket into the new arrays. */
+    int64_t oldcap = m->cap;
+    int64_t *okeys = m->keys;
+    int64_t *ovals = m->vals;
+    uint8_t *oocc = m->occ;
+    m->keys = nkeys;
+    m->vals = nvals;
+    m->occ = nocc;
+    m->cap = newcap;
+    m->len = 0;
+    uint64_t mask = (uint64_t)newcap - 1;
+    for (int64_t b = 0; b < oldcap; b++) {
+        if (oocc[b] == 0) {
+            continue;
+        }
+        int64_t k = okeys[b];
+        uint64_t i = mochi_map_i64_hash(k) & mask;
+        while (m->occ[i] != 0) {
+            i = (i + 1) & mask;
+        }
+        m->keys[i] = k;
+        m->vals[i] = ovals[b];
+        m->occ[i] = 1;
+        m->len++;
+    }
+    free(okeys);
+    free(ovals);
+    free(oocc);
+}
+
+int64_t mochi_map_i64_i64_get(const mochi_map_i64_i64 *m, int64_t k) {
+    if (m->cap == 0) {
+        return 0;
+    }
+    int64_t i = mochi_map_i64_probe(m, k);
+    if (m->occ[i] == 0) {
+        return 0;
+    }
+    return m->vals[i];
+}
+
+void mochi_map_i64_i64_set(mochi_map_i64_i64 *m, int64_t k, int64_t v) {
+    if (m->cap == 0 || (m->len + 1) * 4 > m->cap * 3) {
+        mochi_map_i64_grow(m);
+    }
+    int64_t i = mochi_map_i64_probe(m, k);
+    if (m->occ[i] == 0) {
+        m->occ[i] = 1;
+        m->keys[i] = k;
+        m->len++;
+    }
+    m->vals[i] = v;
+}

--- a/runtime/c/src/mochi_map_i64_i64.h
+++ b/runtime/c/src/mochi_map_i64_i64.h
@@ -1,0 +1,69 @@
+/*
+ * MEP-42 Phase 4.3.15.2 typed-i64->i64 map runtime.
+ *
+ * Backs Mochi's `map<int, int>` when the program is compiled with
+ * `mochi build --target=c`. The IR ops OpNewMap, OpMapSetI64I64, and
+ * OpMapGetI64I64 lower to calls into this header.
+ *
+ * Semantics mirror Go's `map[int64]int64{}`: a get on an absent key
+ * returns 0 (matches Go's zero-value default for the int64 value
+ * type). Set overwrites any prior value for the same key. The
+ * iteration order is not defined; the generated code never iterates
+ * the map directly (k_nucleotide walks an explicit 0..20 key range
+ * with `for k in 0..20 { let c = counts[k] }`).
+ *
+ * Identity: pure C99, no libc beyond stdlib.h/string.h/stdint.h.
+ * Allocations are heap-resident and leak at process exit; the AOT
+ * target's MVP does not run finalisers between builds. The growth
+ * strategy doubles the bucket array when the load factor exceeds
+ * 0.75, matching the shape Go's runtime map uses, so cc -O2 inlines
+ * the lookup hot loop competitively with Go's map probe on the
+ * k_nucleotide hot path.
+ */
+#ifndef MOCHI_RUNTIME_C_MAP_I64_I64_H
+#define MOCHI_RUNTIME_C_MAP_I64_I64_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * mochi_map_i64_i64 is an open-addressing linear-probing hashtable.
+ * `keys` and `vals` are parallel arrays of size `cap`; `occ` marks
+ * each bucket as occupied (1) or empty (0). `len` is the number of
+ * occupied buckets. cap is always a power of two when nonzero so the
+ * probe step can use `(h + i) & (cap - 1)` instead of a modulo.
+ */
+typedef struct mochi_map_i64_i64 {
+    int64_t *keys;
+    int64_t *vals;
+    uint8_t *occ;
+    int64_t  cap;
+    int64_t  len;
+} mochi_map_i64_i64;
+
+/* mochi_map_i64_i64_new returns a fresh empty map (cap=0, len=0). */
+mochi_map_i64_i64 *mochi_map_i64_i64_new(void);
+
+/*
+ * mochi_map_i64_i64_get returns m[k], or 0 if k is not present.
+ * Matches Go's `m[k]` zero-default semantics for the int64 value
+ * type, which is what compiler3 emits when lowering a TypeMap read.
+ */
+int64_t mochi_map_i64_i64_get(const mochi_map_i64_i64 *m, int64_t k);
+
+/*
+ * mochi_map_i64_i64_set writes v to m[k]. If k already maps to a
+ * value, that value is overwritten. If the table is more than 75%
+ * full after the insert, the backing arrays double and every key is
+ * re-probed.
+ */
+void mochi_map_i64_i64_set(mochi_map_i64_i64 *m, int64_t k, int64_t v);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOCHI_RUNTIME_C_MAP_I64_I64_H */

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -733,11 +733,11 @@ Workloads in the "performance games" set that are NOT in this micro-benchmark ta
 | `fasta` | **LANDED.** Native fixture (N=10000) compiles unchanged and produces a deterministic LCG rolling-hash `1072663717`. The fixture uses bare `print(h)` rather than `json({...})` because the cross-lang reference compares a single integer hash. The previous "needs string literals" rationale was wrong; the cross-lang harness already replaced strings with the integer hash. | `TestBuildSourceFastaBgFixture` |
 | `regex_redux` | **LANDED.** Native fixture (N=10000) compiles unchanged and produces `69`. The cross-lang reference uses an LCG-driven state machine over a bit-packed window rather than actual regex, so no `TypeStr` is needed. | `TestBuildSourceRegexReduxBgFixture` |
 | `reverse_complement` | **LANDED.** Native fixture (N=4096) compiles unchanged and produces `293888` = `(N/4)*287`. The previous "needs file I/O + strings" rationale was wrong; the cross-lang fixture uses a synthesised i64 ACGT cycle and prints a checksum. | `TestBuildSourceReverseComplementBgFixture` |
+| `k_nucleotide` | **LANDED** (Phase 4.3.15.2). Native fixture (N=10000) compiles unchanged and produces `723253870` (LCG-driven 20-key rolling i64 hash), byte-matches `--target=go` on the same source. Gating sub-phase wires `map<int, int>` type, `{}` empty-literal initializer, `m[k]` read, and `m[k] = v` indexed-assign through the existing `OpNewMap` / `OpMapGetI64I64` / `OpMapSetI64I64` IR ops, plus a new `runtime/c/src/mochi_map_i64_i64.{h,c}` open-addressing hashtable. | `TestBuildSourceKNucleotideBgFixture` |
 | `binary_trees` | **BLOCKED.** Needs heterogeneous `list<any>` cells (the canonical CLBG kernel encodes tree nodes as `[left, right, value]` lists) and a `t[0] as list<any>` element cast. Tracked as a candidate Phase 4.3.15.1 follow-up. |  |
-| `k_nucleotide` | **BLOCKED.** Needs general `map<int, int>` (insert, get, iteration) which compiler3 does not lower yet (the IR has `OpMapSetI64I64`/`OpMapGetI64I64` but the frontend never produces map-literal expressions outside the `json({...})` statement-level hook). Tracked as a candidate Phase 4.3.15.2 follow-up. |  |
 | `pidigits` | **OUT OF SCOPE.** Needs arbitrary-precision integers; not on MEP-42 scope. |  |
 
-The Phase 4.3 stream's user-facing goal "all bench-template benchmark games programs compile via `mochi build --target=c`" is satisfied for 8 of 11 fixtures (9 of 11 if `pidigits` is excluded as out-of-scope). The two remaining gaps (`binary_trees`, `k_nucleotide`) are concrete feature requests with named blockers, not open-ended research.
+The Phase 4.3 stream's user-facing goal "all bench-template benchmark games programs compile via `mochi build --target=c`" is satisfied for 9 of 11 fixtures (10 of 11 if `pidigits` is excluded as out-of-scope). The one remaining gap (`binary_trees`) is a concrete feature request with a named blocker, not open-ended research.
 
 Reproducer scripts and sources are at `/tmp/mep42bench/` on the recording machine; the Mochi sources are:
 
@@ -1689,6 +1689,50 @@ The user's standing directive for Phase 4 is "make sure all benchmark games prog
 
 - The `duration_us` field varies run-to-run because it is wall-clock; the regression tests assert the full `{"duration_us":0,"output":N}\n` line, which holds because every audited workload completes in under 1 ms on the recording machine. If CI runs on a much slower machine the duration could round up to 1 µs and break the strict-equality assertion. A follow-up that switches to a substring-only assertion (`strings.Contains(got, "output":N}")`) is a 2-line change if this becomes flaky.
 - The fasta and reverse_complement fixtures are rejected by the Mochi interpreter (type/index errors that the C target's lower-then-trust pipeline tolerates), so the cross-check against `mochi run` is not available for those two; the pinning is against the audit-recorded output only, which is deterministic because both kernels are LCG-driven with seed=42 and a fixed sequence of i64 operations.
+
+## §10.25 Phase 4.3.15.2 closeout (LANDED 2026-05-22 07:15 GMT+7)
+
+Phase 4.3.15.2 closes the `k_nucleotide` blocker called out by the §10.24 audit. The bench-template `bench/template/bg/k_nucleotide/k_nucleotide.mochi` now compiles unchanged via `mochi build --target=c` and produces `723253870` (byte-matches `--target=go`). With this sub-phase landed, 9 of 11 bench-games fixtures are LANDED on the C target.
+
+### Implementation
+
+The IR already had every map op the kernel needs (`OpNewMap`, `OpMapSetI64I64`, `OpMapGetI64I64`) and the Go emit had handled them since Phase 3. Phase 4.3.15.2 wires four missing pieces:
+
+1. **Type lowering.** `compiler3/frontend/lower.go`'s `lowerType` now recognises `map<int, int>` and returns `ir.TypeMap`. Other key/value combinations stay rejected with a clean "unsupported in MVP" error so the A/B harness skips the fixture instead of miscompiling. The check is two `lowerType` calls + an i64/i64 equality test, not a generalised polymorphic table.
+2. **Empty-literal lowering.** A new builder field `expectedMap` (set by `lowerTypedLet` when the LHS type is `TypeMap`, cleared after `lowerExpr` returns) tells `lowerPrimary` to accept a bare `{}` map literal and emit `OpNewMap`. Non-empty literals are rejected because their lowering needs either a chain of `OpMapSetI64I64` ops or a new variadic `OpMapLit` op, and the current bench fixtures do not need them.
+3. **Index ops dispatch.** `lowerIndexedAssign` and the `lowerPostfix` index-read loop both gained a `case ir.TypeMap` arm that emits `OpMapSetI64I64` / `OpMapGetI64I64` with the same i64-only constraint the existing list arms use. The dispatch chooses by the receiver's `Type` field, so a binding declared `map<int, int>` automatically routes to the map ops without any explicit syntax distinction from `list<int>` indexing.
+4. **C emit + runtime.** A new `runtime/c/src/mochi_map_i64_i64.{h,c}` ships an open-addressing linear-probing hashtable with the SplitMix64 finaliser as the bucket hash and a 0.75 load-factor grow trigger. The C emit case for `OpNewMap` calls `mochi_map_i64_i64_new()`; `OpMapSetI64I64` calls `_set(m, k, v)`; `OpMapGetI64I64` calls `_get(m, k)` which returns 0 on absent keys (matching Go's `map[int64]int64` zero-default for the value type). `cType(ir.TypeMap)` returns `mochi_map_i64_i64*` so the function-head var-declaration loop emits the right pointer type. The driver's existing `writeRuntime` walks the embed.FS so the new files ship automatically.
+
+### Files changed
+
+- `runtime/c/src/mochi_map_i64_i64.h`, `runtime/c/src/mochi_map_i64_i64.c`: new open-addressing hashtable (i64 keys, i64 values, 0.75 load factor, SplitMix64 hash).
+- `runtime/c/doc.go`: `//go:embed` directive widened to include the two new files.
+- `compiler3/frontend/lower.go`: `lowerType` accepts `map<int, int>` → `TypeMap`; `builder.expectedMap` field; `lowerTypedLet` sets/clears it; `lowerPrimary` dispatches `p.Map`; new `lowerMapLiteralAsExpr` helper rejects non-empty literals; `lowerIndexedAssign` and `lowerPostfix` index-read gained `case ir.TypeMap` arms.
+- `compiler3/emit/c/emit.go`: `usesMapI64I64` detection + include; emit cases for `OpNewMap` / `OpMapSetI64I64` / `OpMapGetI64I64`; `cType(ir.TypeMap)` returns `mochi_map_i64_i64*`.
+- `compiler3/frontend/lower_test.go`: `TestLowerMapI64I64Basic` (frontend round-trip).
+- `compiler3/build/c/driver_test.go`: `TestBuildSourceKNucleotideBgFixture` (k_nucleotide fixture pin), `TestBuildSourceMapI64I64Basic` (insert + get + absent-key default), `TestBuildSourceMapI64I64Grow` (32-key insert/read to exercise the runtime's grow + rehash path).
+- `website/docs/mep/mep-0042.md`: §10.7 k_nucleotide row flipped to LANDED with the new pinning test name; this closeout (§10.25).
+
+### Reproducer
+
+```sh
+go run ./cmd/mochi build --target=c --binary=/tmp/knuc_c bench/template/bg/k_nucleotide/k_nucleotide.mochi
+/tmp/knuc_c
+# 723253870
+```
+
+The Go target on the same source produces `723253870`, byte-equivalent. The Mochi interpreter rejects this fixture (the LCG arithmetic mixes float and int via `float(seed)` and the interpreter's stricter type checker objects to `c1 + 1` where `c1` is inferred any), so the cross-check is C target versus Go target only.
+
+### Why this closes the goal
+
+The Phase 4.3 stream's user-facing goal is "all bench-template benchmark games programs compile via `mochi build --target=c`". Before this sub-phase, k_nucleotide was the only remaining bench fixture whose blocker was a missing IR-supported feature (the IR already had the map ops; only the frontend dispatch and the C runtime were missing). With Phase 4.3.15.2 landed, the C target compiles 9 of the 11 fixtures unchanged (10 of 11 excluding `pidigits` per §11). The remaining gap is `binary_trees`, whose blocker is the more invasive `list<any>` polymorphic type that the IR does not yet support.
+
+### Limitations
+
+- Map literals must be empty (`{}`). A non-empty literal like `{1: 10, 2: 20}` requires either a chain of `OpMapSetI64I64` ops after `OpNewMap` (straightforward, but no fixture needs it yet) or a variadic `OpMapLit` op (cleaner emit but doubles the IR ops table). Deferred to a follow-up sub-phase if a fixture surfaces.
+- Map iteration (`for k, v in m`) is not supported. k_nucleotide walks an explicit `0..20` key range and indexes through the map, which is why no iteration support is needed. Adding iteration would need an `OpMapIter` opcode plus the corresponding range-for hook in the frontend.
+- Only `map<int, int>` is accepted. `map<int, float>`, `map<int, list<int>>`, `map<str, int>`, etc. all hit a clean frontend error. The IR has no generic-map representation; adding one would need a typed `OpMap[K,V]` family with explicit element-type tags.
+- The map runtime does not support deletion. The k_nucleotide kernel only inserts and updates, never removes. Adding `mochi_map_i64_i64_del` would need a tombstone marker in `occ[]` (currently 0/1, would become 0/1/2 with 2=tombstone) and grow-skip-tombstones in the rehash loop; deferred until a fixture needs it.
 
 ## §11 Risks
 


### PR DESCRIPTION
## Summary

- Add C runtime hashtable (open-addressing, SplitMix64) and wire `map<int, int>` through frontend + emitter so the k_nucleotide bench-games fixture compiles via `mochi build --target=c`.
- Pin TestBuildSourceKNucleotideBgFixture against fixed output `723253870`; add TestBuildSourceMapI64I64Basic and TestBuildSourceMapI64I64Grow to exercise the runtime.
- bench-games AOT C coverage now 9 of 11 (10 of 11 excluding pidigits).

## Test plan
- [x] `go test ./compiler3/...` green
- [x] `mochi build --target=c bench/template/bg/k_nucleotide.mochi` produces `723253870`, deterministic across 3 runs
- [x] Output byte-matches `--target=go` build of the same fixture
- [x] Map runtime exercised by grow test (32 inserts)

## Limitations
- Only `map<int, int>` accepted; only empty literal `{}` supported; no iteration or delete.

Tracking issue: #21989