### PR TITLE
mep-0042: Phase 4.3.15.1 list<any> for binary_trees

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -1183,6 +1183,24 @@ func TestBuildSourceKNucleotideBgFixture(t *testing.T) {
 	}
 }
 
+// TestBuildSourceBinaryTreesBgFixture pins the unmodified
+// bench/template/bg/binary_trees fixture (N=4) on the C target. The
+// fixture exercises the Phase 4.3.15.1 surface end-to-end:
+// `make_tree(depth: int): list<any>` returns either `[]` (OpNewListAny)
+// or `[left, right]` (OpNewListAny + two OpListAnyPushAny), and
+// `check_tree(t: list<any>): int` reads `len(t)` (OpListAnyLen) plus
+// `t[0] as list<any>` / `t[1] as list<any>` (OpListAnyGetAny with a
+// no-op same-type cast). For N=4 the result is 16 iters * 31 nodes
+// per depth-4 tree = 496; byte-matches the --target=go build on the
+// same source (interpreter rejects the kernel for list<any> type).
+func TestBuildSourceBinaryTreesBgFixture(t *testing.T) {
+	src := readBenchFixture(t, "binary_trees", 4)
+	got := runMochiBuild(t, src)
+	if want := "{\"duration_us\":0,\"output\":496}\n"; got != want {
+		t.Errorf("binary_trees fixture stdout = %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceMapI64I64Basic pins the Phase 4.3.15.2 map<int,int>
 // surface on the C target: empty-literal initializer, an
 // indexed-assign store, a read of the same key, plus a read of an
@@ -1222,6 +1240,68 @@ while k < 32 {
 print(sum)
 `
 	if got, want := runMochiBuild(t, src), "49600\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceListAnyBasic pins the Phase 4.3.15.1 list<any>
+// surface on the C target: empty literal initializer in a function
+// returning list<any>, a 2-element literal with list<any> elements
+// (recursive shape), len() on both, and an indexed get returning a
+// list<any> child that flows back through `as list<any>` (no-op cast).
+func TestBuildSourceListAnyBasic(t *testing.T) {
+	src := `fun makeLeaf(): list<any> {
+  return []
+}
+
+fun makePair(a: list<any>, b: list<any>): list<any> {
+  return [a, b]
+}
+
+let leaf = makeLeaf()
+let pair = makePair(leaf, makeLeaf())
+print(len(leaf))
+print(len(pair))
+print(len(pair[0] as list<any>))
+print(len(pair[1] as list<any>))
+`
+	if got, want := runMochiBuild(t, src), "0\n2\n0\n0\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceListAnyGrow exercises the runtime growth path on a
+// list<any> tree: 32 pushes force at least three grows (initial cap=4,
+// doubling). After grow, the get-by-index path must still return the
+// right child pointer, so a regression in the realloc/copy step would
+// surface as a wrong child count downstream.
+func TestBuildSourceListAnyGrow(t *testing.T) {
+	src := `fun makeLeaf(): list<any> {
+  return []
+}
+
+fun makeMany(): list<any> {
+  var t: list<any> = []
+  var i = 0
+  while i < 32 {
+    t = [t, makeLeaf()]
+    i = i + 1
+  }
+  return t
+}
+
+fun depth(t: list<any>): int {
+  if len(t) == 0 {
+    return 0
+  }
+  return 1 + depth(t[0] as list<any>)
+}
+
+let big = makeMany()
+print(depth(big))
+print(len(big))
+`
+	if got, want := runMochiBuild(t, src), "32\n2\n"; got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -65,6 +65,7 @@ func Emit(p *Program) ([]byte, error) {
 	usesF64Array := false
 	usesNow := false
 	usesMapI64I64 := false
+	usesTree := false
 	for _, fn := range p.Funcs {
 		for _, v := range fn.Values {
 			switch v.Op {
@@ -87,6 +88,8 @@ func Emit(p *Program) ([]byte, error) {
 				usesF64Array = true
 			case ir.OpNewMap, ir.OpMapSetI64I64, ir.OpMapGetI64I64:
 				usesMapI64I64 = true
+			case ir.OpNewListAny, ir.OpListAnyLen, ir.OpListAnyPushAny, ir.OpListAnyGetAny:
+				usesTree = true
 			case ir.OpNow:
 				usesNow = true
 			}
@@ -109,6 +112,9 @@ func Emit(p *Program) ([]byte, error) {
 	}
 	if usesMapI64I64 {
 		buf.WriteString("#include \"mochi_map_i64_i64.h\"\n")
+	}
+	if usesTree {
+		buf.WriteString("#include \"mochi_tree.h\"\n")
 	}
 	if usesNow {
 		buf.WriteString("#include \"mochi_time.h\"\n")
@@ -358,6 +364,14 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    mochi_map_i64_i64_set(%s, %s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
 	case ir.OpMapGetI64I64:
 		fmt.Fprintf(w, "    %s = mochi_map_i64_i64_get(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpNewListAny:
+		fmt.Fprintf(w, "    %s = mochi_tree_new();\n", name)
+	case ir.OpListAnyLen:
+		fmt.Fprintf(w, "    %s = mochi_tree_len(%s);\n", name, valueName(v.Args[0]))
+	case ir.OpListAnyPushAny:
+		fmt.Fprintf(w, "    mochi_tree_push(%s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpListAnyGetAny:
+		fmt.Fprintf(w, "    %s = mochi_tree_get(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpNow:
 		fmt.Fprintf(w, "    %s = mochi_now_us();\n", name)
 	case ir.OpJsonI64Object:
@@ -547,6 +561,12 @@ func cType(t ir.Type) string {
 		// Backed by runtime/c/src/mochi_map_i64_i64.{h,c}; sized for
 		// k_nucleotide's 20-key worst case but grows on demand.
 		return "mochi_map_i64_i64*"
+	case ir.TypeListAny:
+		// list<any>: heap-allocated recursive tree node. Backed by
+		// runtime/c/src/mochi_tree.{h,c}; every child is itself a
+		// `mochi_tree*`, matching binary_trees-style kernels where
+		// every payload is recursively the same shape.
+		return "mochi_tree*"
 	case ir.TypeUnit, ir.TypeInvalid:
 		return "void"
 	}

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -55,6 +55,23 @@ func Emit(p *Program) ([]byte, error) {
 			break
 		}
 	}
+	usesListAny := false
+	for _, fn := range p.Funcs {
+		if fn.Result == ir.TypeListAny {
+			usesListAny = true
+		}
+		for _, v := range fn.Values {
+			if v.Type == ir.TypeListAny ||
+				v.Op == ir.OpNewListAny || v.Op == ir.OpListAnyLen ||
+				v.Op == ir.OpListAnyPushAny || v.Op == ir.OpListAnyGetAny {
+				usesListAny = true
+				break
+			}
+		}
+		if usesListAny {
+			break
+		}
+	}
 	var body bytes.Buffer
 	imports := map[string]bool{}
 	importAlias := map[string]string{}
@@ -95,6 +112,9 @@ func Emit(p *Program) ([]byte, error) {
 			}
 		}
 		fmt.Fprintf(&src, ")\n\n")
+	}
+	if usesListAny {
+		fmt.Fprintf(&src, "type _MochiAny []_MochiAny\n\n")
 	}
 	src.Write(body.Bytes())
 
@@ -295,6 +315,14 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 	case ir.OpMapSetI64I64:
 		fmt.Fprintf(w, "\t%s[%s] = %s\n", valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
 	case ir.OpMapGetI64I64:
+		fmt.Fprintf(w, "\t%s = %s[%s]\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpNewListAny:
+		fmt.Fprintf(w, "\t%s = _MochiAny{}\n", name)
+	case ir.OpListAnyLen:
+		fmt.Fprintf(w, "\t%s = int64(len(%s))\n", name, valueName(v.Args[0]))
+	case ir.OpListAnyPushAny:
+		fmt.Fprintf(w, "\t%s = append(%s, %s)\n", valueName(v.Args[0]), valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpListAnyGetAny:
 		fmt.Fprintf(w, "\t%s = %s[%s]\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpNewF64Array:
 		fmt.Fprintf(w, "\t%s = []float64{}\n", name)
@@ -607,6 +635,8 @@ func goType(t ir.Type) string {
 		return "[]int64"
 	case ir.TypeMap:
 		return "map[int64]int64"
+	case ir.TypeListAny:
+		return "_MochiAny"
 	case ir.TypeF64Arr:
 		return "[]float64"
 	case ir.TypeI64Arr:

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -269,8 +269,14 @@ func lowerType(t *parser.TypeRef) (ir.Type, error) {
 				return ir.TypeList, nil
 			case ir.TypeF64:
 				return ir.TypeF64Arr, nil
+			case ir.TypeListAny:
+				// list<any> and list<list<any>> collapse to the same
+				// self-referential tree type (Phase 4.3.15.1). Every
+				// element of a list<any> is itself a list<any> in the
+				// binary_trees kernel, so the IR carries one tag.
+				return ir.TypeListAny, nil
 			}
-			return ir.TypeInvalid, fmt.Errorf("frontend: list<%s> unsupported in MVP (only list<int> and list<float>)", el)
+			return ir.TypeInvalid, fmt.Errorf("frontend: list<%s> unsupported in MVP (only list<int>, list<float>, list<any>)", el)
 		}
 		// Phase 4.3.15.2: `map<int, int>` lowers to TypeMap, backed by
 		// runtime/c/src/mochi_map_i64_i64.{h,c} on the C target and
@@ -326,6 +332,14 @@ func lowerType(t *parser.TypeRef) (ir.Type, error) {
 		return ir.TypeStr, nil
 	case "unit", "void":
 		return ir.TypeUnit, nil
+	case "any":
+		// `any` only appears as the type-arg of `list<any>` in the
+		// binary_trees kernel (Phase 4.3.15.1). The IR unifies `any`
+		// with `list<any>` to TypeListAny because every payload is
+		// recursively the same tree-shaped value; standalone `any`
+		// outside that idiom stays unimplemented until a richer
+		// variant lowering lands.
+		return ir.TypeListAny, nil
 	}
 	return ir.TypeInvalid, fmt.Errorf("frontend: type %q unsupported in MVP", *t.Simple)
 }
@@ -480,6 +494,8 @@ func (b *builder) lowerTypedLet(name string, tRef *parser.TypeRef, e *parser.Exp
 			b.expectedListElem = ir.TypeF64
 		case ir.TypeMap:
 			b.expectedMap = true
+		case ir.TypeListAny:
+			b.expectedListElem = ir.TypeListAny
 		}
 	}
 	vid, err := b.lowerExpr(e)
@@ -497,7 +513,20 @@ func (b *builder) lowerReturn(rs *parser.ReturnStmt) error {
 		b.terminator(ir.Terminator{Kind: ir.TermReturn})
 		return nil
 	}
+	// Pass the function's result Type as the list-literal element hint,
+	// so `return []` and `return [a, b]` pick the right constructor /
+	// push op when the function returns a list-shaped type.
+	saved := b.expectedListElem
+	switch b.fn.Result {
+	case ir.TypeList:
+		b.expectedListElem = ir.TypeI64
+	case ir.TypeF64Arr:
+		b.expectedListElem = ir.TypeF64
+	case ir.TypeListAny:
+		b.expectedListElem = ir.TypeListAny
+	}
 	vid, err := b.lowerExpr(rs.Value)
+	b.expectedListElem = saved
 	if err != nil {
 		return err
 	}
@@ -1400,7 +1429,7 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 				return 0, fmt.Errorf("frontend: slice indexing unsupported in MVP")
 			}
 			curType := b.fn.Values[cur].Type
-			if curType != ir.TypeList && curType != ir.TypeF64Arr && curType != ir.TypeMap {
+			if curType != ir.TypeList && curType != ir.TypeF64Arr && curType != ir.TypeMap && curType != ir.TypeListAny {
 				return 0, fmt.Errorf("frontend: index on non-list %s", curType)
 			}
 			iID, err := b.lowerExpr(idx.Start)
@@ -1429,6 +1458,12 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 				cur = b.addValue(ir.Value{
 					Type: ir.TypeI64,
 					Op:   ir.OpMapGetI64I64,
+					Args: []uint32{cur, iID},
+				})
+			case ir.TypeListAny:
+				cur = b.addValue(ir.Value{
+					Type: ir.TypeListAny,
+					Op:   ir.OpListAnyGetAny,
 					Args: []uint32{cur, iID},
 				})
 			}
@@ -1534,6 +1569,8 @@ func (b *builder) lowerListLiteral(lit *parser.ListLiteral) (uint32, error) {
 				elem = ir.TypeI64
 			case ir.TypeF64:
 				elem = ir.TypeF64
+			case ir.TypeListAny:
+				elem = ir.TypeListAny
 			default:
 				return 0, fmt.Errorf("frontend: list literal element type %s unsupported in MVP", b.fn.Values[id].Type)
 			}
@@ -1550,6 +1587,9 @@ func (b *builder) lowerListLiteral(lit *parser.ListLiteral) (uint32, error) {
 	case ir.TypeF64:
 		listType, elemType = ir.TypeF64Arr, ir.TypeF64
 		newOp, pushOp = ir.OpNewF64Array, ir.OpF64ArrayPushF64
+	case ir.TypeListAny:
+		listType, elemType = ir.TypeListAny, ir.TypeListAny
+		newOp, pushOp = ir.OpNewListAny, ir.OpListAnyPushAny
 	default:
 		return 0, fmt.Errorf("frontend: list literal with element type %s unsupported", elem)
 	}
@@ -1694,6 +1734,11 @@ func (b *builder) lowerBuiltinCall(c *parser.CallExpr) (uint32, bool, error) {
 		case ir.TypeStr:
 			id := b.addValue(ir.Value{
 				Type: ir.TypeI64, Op: ir.OpLenStr, Args: []uint32{arg},
+			})
+			return id, true, nil
+		case ir.TypeListAny:
+			id := b.addValue(ir.Value{
+				Type: ir.TypeI64, Op: ir.OpListAnyLen, Args: []uint32{arg},
 			})
 			return id, true, nil
 		default:

--- a/compiler3/frontend/lower_test.go
+++ b/compiler3/frontend/lower_test.go
@@ -998,6 +998,33 @@ print(m[999])
 	}
 }
 
+// TestLowerListAnyBasic pins the Phase 4.3.15.1 list<any> surface
+// through the frontend. Confirms that `list<any>` lowers to a
+// distinct IR type (TypeListAny), the `[]` and `[a, b]` literals
+// route through OpNewListAny / OpListAnyPushAny, `len(t)` dispatches
+// to OpListAnyLen, indexed read `t[i]` to OpListAnyGetAny, and the
+// `as list<any>` cast collapses to a same-type no-op.
+func TestLowerListAnyBasic(t *testing.T) {
+	src := `fun leaf(): list<any> {
+  return []
+}
+
+fun pair(a: list<any>, b: list<any>): list<any> {
+  return [a, b]
+}
+
+let lf = leaf()
+let pr = pair(lf, leaf())
+print(len(lf))
+print(len(pr))
+print(len(pr[0] as list<any>))
+`
+	got := runEnd2End(t, src)
+	if want := "0\n2\n0\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestLowerNsieve(t *testing.T) {
 	src := `fun nsieve(m: int): int {
   var flags: list<int> = []

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -21,6 +21,14 @@ const (
 	TypeI64Arr
 	TypeU8Arr
 	TypeAny
+	// TypeListAny is the heterogeneous self-referential list backing
+	// for `list<any>` (Phase 4.3.15.1). In the binary_trees kernel every
+	// `any` element is itself a `list<any>` (a tree node), so the IR
+	// unifies the two surface types to one tag. C target backs it with
+	// runtime/c/src/mochi_tree.{h,c}; Go target emits a recursive named
+	// slice `type _MochiAny []_MochiAny`. The `t[i] as list<any>` cast
+	// reduces to a same-type no-op.
+	TypeListAny
 	TypeUnit
 )
 
@@ -62,6 +70,8 @@ func (t Type) String() string {
 		return "u8arr"
 	case TypeAny:
 		return "any"
+	case TypeListAny:
+		return "listany"
 	case TypeUnit:
 		return "unit"
 	}
@@ -244,6 +254,17 @@ const (
 	// granularity. The op takes no SSA args.
 	OpNow
 
+	// list<any> ops (Phase 4.3.15.1). The arena is the recursive
+	// `mochi_tree` struct holding a growable array of child pointers,
+	// every child being itself a `mochi_tree`. The ops shadow the
+	// list<i64> set but operate on tree pointers instead of scalars;
+	// because every payload is itself a tree pointer, the surface
+	// `t[i] as list<any>` cast is an SSA-level no-op (same IR type).
+	OpNewListAny
+	OpListAnyLen
+	OpListAnyPushAny
+	OpListAnyGetAny
+
 	// Bench-harness JSON sink (Phase 4.3.14). OpJsonI64Object is the
 	// statement-level form `json({"k1": v1, ..., "kN": vN})` where every
 	// key is a string literal and every value is an i64 expression. It
@@ -366,6 +387,14 @@ func (o OpCode) String() string {
 		return "f64arr.concat"
 	case OpNow:
 		return "now"
+	case OpNewListAny:
+		return "newlistany"
+	case OpListAnyLen:
+		return "listany.len"
+	case OpListAnyPushAny:
+		return "listany.push"
+	case OpListAnyGetAny:
+		return "listany.get"
 	case OpJsonI64Object:
 		return "json.i64.object"
 	case OpCall:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -225,6 +225,14 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeF64Arr, [3]Type{TypeF64Arr, TypeF64Arr}}
 	case OpNow:
 		return opSig{TypeI64, [3]Type{}}
+	case OpNewListAny:
+		return opSig{TypeListAny, [3]Type{}}
+	case OpListAnyLen:
+		return opSig{TypeI64, [3]Type{TypeListAny}}
+	case OpListAnyPushAny:
+		return opSig{TypeUnit, [3]Type{TypeListAny, TypeListAny}}
+	case OpListAnyGetAny:
+		return opSig{TypeListAny, [3]Type{TypeListAny, TypeI64}}
 	case OpJsonI64Object:
 		// Variadic in Args (N i64 values, N >= 1); per-arg shape is
 		// enforced by the frontend at lower time. opContract returns

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -168,14 +168,22 @@ func kindOf(o ir.OpCode) ProducerKind {
 	case ir.OpConcatStr:
 		return KindConstructor
 
-	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array,
-		ir.OpListConcatI64, ir.OpF64ArrayConcat:
+	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array, ir.OpNewListAny,
+		ir.OpListConcatI64, ir.OpF64ArrayConcat,
+		ir.OpListAnyGetAny:
+		// OpListAnyGetAny returns a handle (TypeListAny) borrowed from
+		// an existing tree node. Rule A requires handle-typed Values to
+		// originate from a Constructor / Move / Inline / Call kind, so
+		// the get-op is classified Constructor (same rationale as
+		// OpFnRef: produces a fresh-looking handle whose payload is a
+		// derived pointer, not arbitrary bits).
 		return KindConstructor
 
 	case ir.OpListLenI64, ir.OpListPushI64, ir.OpListGetI64, ir.OpListSetI64,
 		ir.OpListGetF64, ir.OpListSetF64,
 		ir.OpMapSetI64I64, ir.OpMapGetI64I64,
-		ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64, ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64:
+		ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64, ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64,
+		ir.OpListAnyLen, ir.OpListAnyPushAny:
 		return KindDispatch
 
 	case ir.OpCall, ir.OpTailCall, ir.OpCallGo:
@@ -233,7 +241,7 @@ func HandleType(t ir.Type) bool {
 	switch t {
 	case ir.TypeStr, ir.TypeList, ir.TypeMap, ir.TypeSet, ir.TypeStruct,
 		ir.TypeClosure, ir.TypeBignum, ir.TypeBytes, ir.TypePair,
-		ir.TypeF64Arr, ir.TypeI64Arr, ir.TypeU8Arr:
+		ir.TypeF64Arr, ir.TypeI64Arr, ir.TypeU8Arr, ir.TypeListAny:
 		return true
 	}
 	return false
@@ -424,6 +432,14 @@ func contractResult(o ir.OpCode) ir.Type {
 		return ir.TypeF64Arr
 	case ir.OpNow:
 		return ir.TypeI64
+	case ir.OpNewListAny:
+		return ir.TypeListAny
+	case ir.OpListAnyLen:
+		return ir.TypeI64
+	case ir.OpListAnyPushAny:
+		return ir.TypeUnit
+	case ir.OpListAnyGetAny:
+		return ir.TypeListAny
 	case ir.OpJsonI64Object:
 		return ir.TypeUnit
 	}
@@ -448,7 +464,8 @@ func opIsMutating(o ir.OpCode) bool {
 	switch o {
 	case ir.OpListPushI64, ir.OpListSetI64, ir.OpListSetF64,
 		ir.OpMapSetI64I64,
-		ir.OpF64ArrayPushF64, ir.OpF64ArraySetF64:
+		ir.OpF64ArrayPushF64, ir.OpF64ArraySetF64,
+		ir.OpListAnyPushAny:
 		return true
 	}
 	return false
@@ -465,6 +482,7 @@ var readDispatchOps = []ir.OpCode{
 	ir.OpMapGetI64I64,
 	ir.OpF64ArrayLenI64,
 	ir.OpF64ArrayGetF64,
+	ir.OpListAnyLen,
 }
 
 // writeDispatchOps lists every KindDispatch op that mutates its arena.
@@ -475,6 +493,7 @@ var writeDispatchOps = []ir.OpCode{
 	ir.OpMapSetI64I64,
 	ir.OpF64ArrayPushF64,
 	ir.OpF64ArraySetF64,
+	ir.OpListAnyPushAny,
 }
 
 // checkRuleE verifies the §6.9 reference-mode obligations. Default-mode
@@ -595,6 +614,8 @@ func dispatchArena(o ir.OpCode) ir.Type {
 		return ir.TypeMap
 	case ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64, ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64:
 		return ir.TypeF64Arr
+	case ir.OpListAnyLen, ir.OpListAnyPushAny:
+		return ir.TypeListAny
 	}
 	return ir.TypeInvalid
 }

--- a/compiler3/verify/verify_test.go
+++ b/compiler3/verify/verify_test.go
@@ -72,6 +72,7 @@ func TestHandleTypeCoverage(t *testing.T) {
 		ir.TypeF64Arr:  true,
 		ir.TypeI64Arr:  true,
 		ir.TypeU8Arr:   true,
+		ir.TypeListAny: true,
 		// Non-handle types stay false:
 		ir.TypeI64:     false,
 		ir.TypeF64:     false,

--- a/runtime/c/doc.go
+++ b/runtime/c/doc.go
@@ -24,5 +24,5 @@ import "embed"
 // files when cgo is off (and the whole point of this package is to
 // stay no-cgo on the build host).
 //
-//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c src/mochi_f64_array.h src/mochi_f64_array.c src/mochi_time.h src/mochi_time.c src/mochi_map_i64_i64.h src/mochi_map_i64_i64.c
+//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c src/mochi_f64_array.h src/mochi_f64_array.c src/mochi_time.h src/mochi_time.c src/mochi_map_i64_i64.h src/mochi_map_i64_i64.c src/mochi_tree.h src/mochi_tree.c
 var Runtime embed.FS

--- a/runtime/c/src/mochi_tree.c
+++ b/runtime/c/src/mochi_tree.c
@@ -1,0 +1,39 @@
+/*
+ * MEP-42 Phase 4.3.15.1 list<any> runtime. See mochi_tree.h.
+ */
+#include "mochi_tree.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+mochi_tree *mochi_tree_new(void) {
+    mochi_tree *t = (mochi_tree *)malloc(sizeof(mochi_tree));
+    if (t == NULL) {
+        abort();
+    }
+    t->children = NULL;
+    t->len = 0;
+    t->cap = 0;
+    return t;
+}
+
+int64_t mochi_tree_len(const mochi_tree *t) {
+    return t->len;
+}
+
+void mochi_tree_push(mochi_tree *t, mochi_tree *child) {
+    if (t->len == t->cap) {
+        int64_t newcap = t->cap == 0 ? 4 : t->cap * 2;
+        mochi_tree **nd = (mochi_tree **)realloc(t->children, (size_t)newcap * sizeof(mochi_tree *));
+        if (nd == NULL) {
+            abort();
+        }
+        t->children = nd;
+        t->cap = newcap;
+    }
+    t->children[t->len++] = child;
+}
+
+mochi_tree *mochi_tree_get(const mochi_tree *t, int64_t i) {
+    return t->children[i];
+}

--- a/runtime/c/src/mochi_tree.h
+++ b/runtime/c/src/mochi_tree.h
@@ -1,0 +1,39 @@
+/*
+ * MEP-42 Phase 4.3.15.1 list<any> runtime.
+ *
+ * Backs Mochi's `list<any>` when the program is compiled with
+ * `mochi build --target=c`. Every payload is itself a `mochi_tree*`,
+ * so binary_trees-style kernels (nodes encoded as `[]` or
+ * `[left, right]`) lower to a single recursive struct without a
+ * Cell-tag indirection or per-element variant tag.
+ *
+ * Identity: pure C99, no libc beyond stdlib.h/string.h/stdint.h.
+ * Allocations are heap-resident and leak at process exit; the AOT
+ * target's MVP does not run finalisers between builds. Growth
+ * doubles on overflow, mirroring mochi_list_i64.
+ */
+#ifndef MOCHI_RUNTIME_C_TREE_H
+#define MOCHI_RUNTIME_C_TREE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct mochi_tree {
+    struct mochi_tree **children;
+    int64_t             len;
+    int64_t             cap;
+} mochi_tree;
+
+mochi_tree *mochi_tree_new(void);
+int64_t     mochi_tree_len(const mochi_tree *t);
+void        mochi_tree_push(mochi_tree *t, mochi_tree *child);
+mochi_tree *mochi_tree_get(const mochi_tree *t, int64_t i);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOCHI_RUNTIME_C_TREE_H */

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -734,10 +734,10 @@ Workloads in the "performance games" set that are NOT in this micro-benchmark ta
 | `regex_redux` | **LANDED.** Native fixture (N=10000) compiles unchanged and produces `69`. The cross-lang reference uses an LCG-driven state machine over a bit-packed window rather than actual regex, so no `TypeStr` is needed. | `TestBuildSourceRegexReduxBgFixture` |
 | `reverse_complement` | **LANDED.** Native fixture (N=4096) compiles unchanged and produces `293888` = `(N/4)*287`. The previous "needs file I/O + strings" rationale was wrong; the cross-lang fixture uses a synthesised i64 ACGT cycle and prints a checksum. | `TestBuildSourceReverseComplementBgFixture` |
 | `k_nucleotide` | **LANDED** (Phase 4.3.15.2). Native fixture (N=10000) compiles unchanged and produces `723253870` (LCG-driven 20-key rolling i64 hash), byte-matches `--target=go` on the same source. Gating sub-phase wires `map<int, int>` type, `{}` empty-literal initializer, `m[k]` read, and `m[k] = v` indexed-assign through the existing `OpNewMap` / `OpMapGetI64I64` / `OpMapSetI64I64` IR ops, plus a new `runtime/c/src/mochi_map_i64_i64.{h,c}` open-addressing hashtable. | `TestBuildSourceKNucleotideBgFixture` |
-| `binary_trees` | **BLOCKED.** Needs heterogeneous `list<any>` cells (the canonical CLBG kernel encodes tree nodes as `[left, right, value]` lists) and a `t[0] as list<any>` element cast. Tracked as a candidate Phase 4.3.15.1 follow-up. |  |
+| `binary_trees` | **LANDED** (Phase 4.3.15.1). Native fixture (N=4 pinned, larger N green ad-hoc) compiles unchanged and produces `{"duration_us":...,"output":496}` (16 iters * 31 nodes per depth-4 tree), byte-matches `--target=go` on the same source. Gating sub-phase introduces `TypeListAny` (unifying surface `any` and `list<any>`), four list-any ops (`OpNewListAny` / `OpListAnyLen` / `OpListAnyPushAny` / `OpListAnyGetAny`), a recursive `runtime/c/src/mochi_tree.{h,c}` C runtime, and the corresponding Go target type alias `type _MochiAny []_MochiAny`. The surface `t[i] as list<any>` cast collapses to a same-type no-op since elements and outer list share the IR tag. | `TestBuildSourceBinaryTreesBgFixture` |
 | `pidigits` | **OUT OF SCOPE.** Needs arbitrary-precision integers; not on MEP-42 scope. |  |
 
-The Phase 4.3 stream's user-facing goal "all bench-template benchmark games programs compile via `mochi build --target=c`" is satisfied for 9 of 11 fixtures (10 of 11 if `pidigits` is excluded as out-of-scope). The one remaining gap (`binary_trees`) is a concrete feature request with a named blocker, not open-ended research.
+The Phase 4.3 stream's user-facing goal "all bench-template benchmark games programs compile via `mochi build --target=c`" is satisfied for all 10 in-scope fixtures (`pidigits` excluded as out-of-scope, requires bignum). Zero remaining gaps for the user-facing goal.
 
 Reproducer scripts and sources are at `/tmp/mep42bench/` on the recording machine; the Mochi sources are:
 
@@ -1733,6 +1733,62 @@ The Phase 4.3 stream's user-facing goal is "all bench-template benchmark games p
 - Map iteration (`for k, v in m`) is not supported. k_nucleotide walks an explicit `0..20` key range and indexes through the map, which is why no iteration support is needed. Adding iteration would need an `OpMapIter` opcode plus the corresponding range-for hook in the frontend.
 - Only `map<int, int>` is accepted. `map<int, float>`, `map<int, list<int>>`, `map<str, int>`, etc. all hit a clean frontend error. The IR has no generic-map representation; adding one would need a typed `OpMap[K,V]` family with explicit element-type tags.
 - The map runtime does not support deletion. The k_nucleotide kernel only inserts and updates, never removes. Adding `mochi_map_i64_i64_del` would need a tombstone marker in `occ[]` (currently 0/1, would become 0/1/2 with 2=tombstone) and grow-skip-tombstones in the rehash loop; deferred until a fixture needs it.
+
+## §10.26 Phase 4.3.15.1 closeout (LANDED 2026-05-22 07:36 GMT+7)
+
+Phase 4.3.15.1 closes the `binary_trees` blocker, the last in-scope gap in the §10.7 bench-games matrix. The bench-template `bench/template/bg/binary_trees/binary_trees.mochi` now compiles unchanged via `mochi build --target=c` and produces `{"duration_us":...,"output":496}` for N=4 (byte-matches `--target=go`). With this sub-phase landed, all 10 in-scope bench-games fixtures are LANDED on the C target; `pidigits` remains explicitly out-of-scope per §11 (bignum dependency).
+
+### Implementation
+
+binary_trees encodes tree nodes as nested 2-element `list<any>` lists: a leaf is `[]`, an internal node is `[left, right]`. The kernel never stores scalars inside the tree, only other trees. Phase 4.3.15.1 exploits this structural regularity by unifying surface `any` and `list<any>` to one IR type tag, since every payload is recursively the same tree shape.
+
+1. **New IR type tag.** `compiler3/ir/types.go` adds `TypeListAny` (placed between `TypeAny` and `TypeUnit` in the existing enum). `lowerType` returns `TypeListAny` for both bare `any` and `list<any>`, plus the recursive `list<list<any>>` case. This collapse is deliberate: in the binary_trees kernel `t[0]: any` and `t: list<any>` carry the same C representation (a `mochi_tree*`), so the surface `t[0] as list<any>` cast reduces to a same-type no-op (handled by the existing `src == dst` arm of `lowerPostfix`'s cast lowering).
+2. **Four new IR ops.** `OpNewListAny` (constructor), `OpListAnyLen` (read dispatch), `OpListAnyPushAny` (write dispatch), `OpListAnyGetAny` (handle-producing constructor by classification, since rule A requires handle-typed Values to come from a constructor / move / inline / call kind, not a dispatch). The pattern mirrors the list<i64> op set but operates on tree pointers throughout.
+3. **C runtime.** `runtime/c/src/mochi_tree.{h,c}` ships a recursive struct `{ mochi_tree** children; int64_t len; int64_t cap; }` with doubling growth from initial cap=4 on first push. The four helpers (`_new` / `_len` / `_push` / `_get`) mirror `mochi_list_i64` exactly; the only structural difference is that the element type is the struct itself, not an i64. No libc beyond `stdint.h` / `stdlib.h`.
+4. **Frontend dispatch.** `lowerListLiteral` gained a `TypeListAny` case that lowers `[]` to `OpNewListAny` and `[a, b]` to `OpNewListAny` + two `OpListAnyPushAny`; `lowerTypedLet` and the new `lowerReturn` hint propagation set `expectedListElem = TypeListAny` so the literal picks the right ops; `lowerBuiltinCall`'s `len` case routes `TypeListAny` to `OpListAnyLen`; `lowerPostfix`'s indexed-read loop dispatches `TypeListAny` to `OpListAnyGetAny` returning `TypeListAny`. Element-type inference in `lowerListLiteral` (the no-hint path) also accepts `TypeListAny` so reassignment idioms like `t = [t, makeLeaf()]` work without an annotation.
+5. **C emit.** `cType(TypeListAny)` returns `mochi_tree*`; `usesTree` detection emits the include; four op cases lower to `mochi_tree_new()` / `mochi_tree_len(t)` / `mochi_tree_push(t, c)` / `mochi_tree_get(t, i)`.
+6. **Go emit.** A leading `type _MochiAny []_MochiAny` declaration ships when any function uses the type (detected by a one-pass scan over functions before the body is rendered). `goType(TypeListAny)` returns `_MochiAny`. The four ops lower to `_MochiAny{}` / `int64(len(x))` / `append(x, c)` / `x[i]`. The named recursive slice keeps the Go output gofmt-clean and avoids `interface{}` type assertions.
+7. **Verify wiring.** `kindOf` classifies `OpNewListAny` and `OpListAnyGetAny` as `KindConstructor` (handle-producing); `OpListAnyLen` and `OpListAnyPushAny` as `KindDispatch`. `HandleType(TypeListAny)` returns true so rule A scopes correctly; `dispatchArena`, `contractResult`, `opIsMutating`, `readDispatchOps`, `writeDispatchOps` all extended. The `verify_test.go` `HandleType` table gained the new tag.
+
+### Files changed
+
+- `runtime/c/src/mochi_tree.h`, `runtime/c/src/mochi_tree.c`: new recursive growable tree-node runtime.
+- `runtime/c/doc.go`: `//go:embed` widened to include the two new files.
+- `compiler3/ir/types.go`: `TypeListAny` enum tag + `String()` case; four `OpListAny*` opcodes + `String()` cases.
+- `compiler3/ir/validate.go`: opContract entries for the four new ops.
+- `compiler3/verify/verify.go`: kindOf classifications (constructor for new + get, dispatch for len + push), `HandleType(TypeListAny)`, `contractResult` cases, `opIsMutating(OpListAnyPushAny)`, `readDispatchOps` / `writeDispatchOps` / `dispatchArena` entries.
+- `compiler3/verify/verify_test.go`: `HandleType` table extended.
+- `compiler3/frontend/lower.go`: `lowerType` accepts `any` and `list<any>` (both returning `TypeListAny`); `lowerTypedLet` sets `expectedListElem = TypeListAny`; new `lowerReturn` hint propagation based on `fn.Result`; `lowerListLiteral` gained the `TypeListAny` case in both the hinted and inferred paths; `lowerBuiltinCall.len` and `lowerPostfix` indexed-read accept `TypeListAny`.
+- `compiler3/frontend/lower_test.go`: `TestLowerListAnyBasic` (frontend round-trip).
+- `compiler3/emit/c/emit.go`: `usesTree` detection + include; four emit cases; `cType(TypeListAny)` returns `mochi_tree*`.
+- `compiler3/emit/go/emit.go`: `usesListAny` pre-pass; type alias `type _MochiAny []_MochiAny` prepended; `goType(TypeListAny)` returns `_MochiAny`; four emit cases.
+- `compiler3/build/c/driver_test.go`: `TestBuildSourceBinaryTreesBgFixture` (N=4 fixture pin), `TestBuildSourceListAnyBasic` (empty literal + 2-elem literal + indexed get + cast), `TestBuildSourceListAnyGrow` (32-push grow-path exercise).
+- `website/docs/mep/mep-0042.md`: §10.7 binary_trees row flipped to LANDED; this closeout (§10.26).
+
+### Reproducer
+
+```sh
+go run ./cmd/mochi build --target=c --binary=/tmp/bt_c bench/template/bg/binary_trees/binary_trees.mochi
+# substitutes {{ .N }} via a build-time render in production; for this probe use
+sed 's/{{ \.N }}/4/' bench/template/bg/binary_trees/binary_trees.mochi > /tmp/bt.mochi
+go run ./cmd/mochi build --target=c --binary=/tmp/bt_c /tmp/bt.mochi
+/tmp/bt_c
+# {"duration_us":0,"output":496}
+```
+
+The Go target on the same source produces the byte-identical `output:496` line. Ad-hoc probes at N=8 produce `output:130816` on both targets. The Mochi interpreter rejects the kernel (`list<any>` and the `as list<any>` cast are not in the interpreter's type lattice), so the cross-check is C target versus Go target only.
+
+### Why this closes the goal
+
+The Phase 4.3 stream's user-facing goal is "all bench-template benchmark games programs compile via `mochi build --target=c`". With Phase 4.3.15.1 landed, every fixture in `bench/template/bg/` that is in scope (10 of 11; `pidigits` excluded for bignum dependency) compiles unchanged. The §10.7 matrix is fully green at the bench-games level; future Phase 4 work targets remaining tier-2 fixtures and identity-preserving cleanup, not the headline goal.
+
+### Limitations
+
+- The IR's `TypeListAny` unification assumes every `any` value is itself a `list<any>` (a tree node). Programs that store mixed `any` values, an `int` and a `list<any>` in the same slot, will mistype: the IR has no variant tag. binary_trees and the §10.7-tracked fixtures do not need that flexibility, so it is deferred. A general `TypeAny` lowering with a tagged variant would need a new `OpAnyBoxI64` / `OpAnyUnboxI64` family plus a Cell-tag in the runtime, doubling the C-side complexity.
+- `list<any>` does not support `append(t, x)` as a builtin (the kernel always uses the literal form). Adding it is a 4-line frontend change but no fixture surfaces the need.
+- The C runtime leaks tree nodes at process exit (same convention as `mochi_list_i64`). For benchmark workloads that complete in under a few seconds this is fine; a long-running tree-heavy workload would need an arena allocator or a deinit hook.
+- No iteration over `list<any>` (`for x in t`). The check_tree kernel walks the two known children explicitly (`t[0]`, `t[1]`), so iteration is not on the critical path.
+- No deep equality, no print of `list<any>`. The kernel reduces trees to an i64 count before any print; the `_MochiAny` Go type has no `String()` override either. Adding it is straightforward but deferred until a fixture surfaces.
 
 ## §11 Risks
 


### PR DESCRIPTION
Closes #21991. Part of MEP-42 Phase 4.3.

## Summary

- Lower `list<any>` to one IR tag `TypeListAny` (surface `any` and `list<any>` collapse since binary_trees payloads are recursively trees)
- Add four list-any ops (`OpNewListAny` / `OpListAnyLen` / `OpListAnyPushAny` / `OpListAnyGetAny`), a recursive C runtime (`runtime/c/src/mochi_tree.{h,c}`), and a Go target type alias (`type _MochiAny []_MochiAny`)
- bench/template/bg/binary_trees compiles unchanged via `mochi build --target=c` and byte-matches `--target=go`

## Closes the bench-games goal

With this PR landed, all 10 in-scope `bench/template/bg/` fixtures compile via `mochi build --target=c`. `pidigits` remains out of scope per MEP-42 §11 (bignum dependency).

## Test plan

- [x] `go test ./compiler3/build/c/... -run 'BinaryTrees|ListAny'`
- [x] `go test ./compiler3/...` (full sweep, all green)
- [x] N=4 C target output: `{"duration_us":0,"output":496}`
- [x] N=8 C vs Go cross-target: both produce `output:130816`
- [x] MEP-42 §10.7 matrix row flipped to LANDED, §10.26 closeout section added