### PR TITLE
mep-0042: Phase 4.2.0 string literal + print(str) on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -1306,6 +1306,47 @@ print(len(big))
 	}
 }
 
+// TestBuildSourceStringLiteralHello pins the Phase 4.2.0 surface:
+// a top-level `print("hello, world!")` builds via `mochi build
+// --target=c` and writes the expected line to stdout. This is the
+// smallest user-facing program against the §Top-line objective ("a
+// single native binary that runs on a clean machine").
+func TestBuildSourceStringLiteralHello(t *testing.T) {
+	src := `print("hello, world!")` + "\n"
+	if got, want := runMochiBuild(t, src), "hello, world!\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStringLiteralEscape covers escape coverage in the
+// emitter's cStringLiteral helper: backslash, double-quote, newline,
+// and a non-ASCII byte (0xc3 = first byte of UTF-8 "é"). The runtime
+// just writes bytes through, so the output must match the input
+// byte-for-byte plus the trailing print newline.
+func TestBuildSourceStringLiteralEscape(t *testing.T) {
+	src := `print("a\"b\\c\nd")` + "\n"
+	if got, want := runMochiBuild(t, src), "a\"b\\c\nd\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStringLiteralLet pins string-typed let bindings: the
+// frontend stores the literal in fn.Strings, OpConst{TypeStr} reads
+// from that side-table, and the emitter declares `const char* v3 = 0;`
+// at function head followed by `v3 = "..."` in the body. Two prints
+// share the same constant pool, exercising the index path.
+func TestBuildSourceStringLiteralLet(t *testing.T) {
+	src := `let a = "first"
+let b = "second"
+print(a)
+print(b)
+print(a)
+`
+	if got, want := runMochiBuild(t, src), "first\nsecond\nfirst\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceSpectralNormBgFixture pins the unmodified
 // bench/template/bg/spectral_norm fixture (N=100) on the C target.
 // This is the §10.7 closeout for spectral_norm at the fixture level

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -291,6 +291,12 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 				val = 1
 			}
 			fmt.Fprintf(w, "    %s = %d;\n", name, val)
+		case ir.TypeStr:
+			if int(v.Const) < 0 || int(v.Const) >= len(fn.Strings) {
+				return fmt.Errorf("OpConst str v%d: Const %d out of range (have %d strings)",
+					v.ID, v.Const, len(fn.Strings))
+			}
+			fmt.Fprintf(w, "    %s = %s;\n", name, cStringLiteral(fn.Strings[v.Const]))
 		default:
 			return fmt.Errorf("%w: OpConst type %s", ErrUnsupportedType, v.Type)
 		}
@@ -444,8 +450,10 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 			fmt.Fprintf(w, "    mochi_print_f64(%s);\n", valueName(v.Args[0]))
 		case ir.TypeBool:
 			fmt.Fprintf(w, "    mochi_print_bool(%s);\n", valueName(v.Args[0]))
+		case ir.TypeStr:
+			fmt.Fprintf(w, "    mochi_print_str(%s);\n", valueName(v.Args[0]))
 		default:
-			return fmt.Errorf("%w: print arg type %s (Phase 4.1 covers i64/f64/bool only)",
+			return fmt.Errorf("%w: print arg type %s",
 				ErrUnsupportedType, argType)
 		}
 	case ir.OpPhi:
@@ -544,6 +552,13 @@ func cType(t ir.Type) string {
 		return "double"
 	case ir.TypeBool:
 		return "int"
+	case ir.TypeStr:
+		// String literals are read-only static-storage objects per
+		// C99 §6.4.5; const char* matches their type and prevents the
+		// generated body from accidentally mutating them. Phase 4.2.0
+		// covers literal + print only, so no owning mochi_str runtime
+		// is needed yet (a future 4.2.x adds concat/slice).
+		return "const char*"
 	case ir.TypeList:
 		// list<int>: heap-allocated header backed by mochi_list_i64.
 		// The MVP frontend constructs TypeList values with
@@ -574,6 +589,41 @@ func cType(t ir.Type) string {
 }
 
 func valueName(id uint32) string { return fmt.Sprintf("v%d", id) }
+
+// cStringLiteral formats s as a C99 string literal, including the
+// surrounding quotes. Printable ASCII bytes pass through; `"` and `\`
+// are escaped; common whitespace gets the short forms (`\n`, `\t`,
+// `\r`); other bytes use 3-digit octal so an immediately-following
+// digit cannot be misparsed as part of the escape (which would be the
+// case with `\x` hex escapes since cc consumes as many hex digits as
+// possible).
+func cStringLiteral(s string) string {
+	var buf bytes.Buffer
+	buf.WriteByte('"')
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case '"':
+			buf.WriteString(`\"`)
+		case '\\':
+			buf.WriteString(`\\`)
+		case '\n':
+			buf.WriteString(`\n`)
+		case '\t':
+			buf.WriteString(`\t`)
+		case '\r':
+			buf.WriteString(`\r`)
+		default:
+			if c >= 0x20 && c <= 0x7e {
+				buf.WriteByte(c)
+			} else {
+				fmt.Fprintf(&buf, "\\%03o", c)
+			}
+		}
+	}
+	buf.WriteByte('"')
+	return buf.String()
+}
 
 func i64BinaryOp(op ir.OpCode) string {
 	switch op {

--- a/compiler3/emit/c/emit_test.go
+++ b/compiler3/emit/c/emit_test.go
@@ -299,18 +299,19 @@ func TestEmitOpCallGoFFIRejected(t *testing.T) {
 }
 
 // TestEmitOpCallGoPrintArgTypeUnsupported covers the path where the
-// print sentinel is invoked with an argument outside the Phase 4.1
-// scalar set (Phase 4.2 lands TypeStr). The emitter must surface
+// print sentinel is invoked with an argument outside the supported
+// scalar+string set. Phase 4.2.0 added TypeStr; composite types like
+// TypeList stay outside the print dispatch until a future phase wires
+// fmt-equivalent formatting. The emitter must surface
 // ErrUnsupportedType, not silently emit garbled C.
 func TestEmitOpCallGoPrintArgTypeUnsupported(t *testing.T) {
 	fn := &ir.Function{Name: "say", Result: ir.TypeUnit}
-	arg := fn.AddValue(ir.Value{Type: ir.TypeStr, Op: ir.OpParam})
-	fn.Params = []uint32{arg}
+	arg := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpNewList})
 	fn.GoBindings = []ir.GoBinding{{Pkg: "fmt", Alias: "fmt", Name: "Println"}}
 	bid := fn.AddBlock()
 	call := fn.AddValue(ir.Value{Type: ir.TypeUnit, Op: ir.OpCallGo, Args: []uint32{arg}, Const: 0})
 	blk := fn.Block(bid)
-	blk.Values = []uint32{call}
+	blk.Values = []uint32{arg, call}
 	blk.Term = ir.Terminator{Kind: ir.TermReturn}
 
 	_, err := Emit(&Program{Funcs: []*ir.Function{fn}})

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -244,6 +244,11 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 				val = "true"
 			}
 			fmt.Fprintf(w, "\t%s = %s\n", name, val)
+		case ir.TypeStr:
+			if int(v.Const) < 0 || int(v.Const) >= len(fn.Strings) {
+				return fmt.Errorf("OpConst str v%d: Const %d out of range (have %d strings)", v.ID, v.Const, len(fn.Strings))
+			}
+			fmt.Fprintf(w, "\t%s = %q\n", name, fn.Strings[v.Const])
 		default:
 			return fmt.Errorf("OpConst unsupported type %s", v.Type)
 		}

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1630,8 +1630,12 @@ func (b *builder) lowerLiteral(lit *parser.Literal) (uint32, error) {
 		return b.addValue(ir.Value{Type: ir.TypeBool, Op: ir.OpConst, Const: c}), nil
 	case lit.Float != nil:
 		return b.addValue(ir.Value{Type: ir.TypeF64, Op: ir.OpConst, Const: int64(math.Float64bits(*lit.Float))}), nil
+	case lit.Str != nil:
+		idx := int64(len(b.fn.Strings))
+		b.fn.Strings = append(b.fn.Strings, *lit.Str)
+		return b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpConst, Const: idx}), nil
 	}
-	return 0, fmt.Errorf("frontend: literal kind unsupported in MVP (str/none)")
+	return 0, fmt.Errorf("frontend: literal kind unsupported in MVP (none)")
 }
 
 func (b *builder) lowerCall(c *parser.CallExpr) (uint32, error) {

--- a/compiler3/frontend/lower_test.go
+++ b/compiler3/frontend/lower_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	gogen "mochi/compiler3/emit/go"
+	"mochi/compiler3/ir"
 	"mochi/parser"
 )
 
@@ -137,18 +138,59 @@ print(42)
 	}
 }
 
-// TestLowerUnsupportedSurfacesError asserts that an unsupported form
-// produces a frontend error rather than a silent miscompile. The A/B
-// harness relies on this to mark the fixture skipped.
-func TestLowerUnsupportedSurfacesError(t *testing.T) {
+// TestLowerStringLiteral pins the Phase 4.2.0 surface: a string
+// literal lowers to OpConst{TypeStr} with the payload captured in
+// fn.Strings, and print(s) wires through to an OpCallGo with a
+// `fmt.Println(string)` GoBinding.
+func TestLowerStringLiteral(t *testing.T) {
 	src := `let s = "hi"
+print(s)
+`
+	prog, err := parser.Parser.ParseString("t.mochi", src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	out, err := Lower(prog)
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	if len(out.Funcs) != 1 {
+		t.Fatalf("expected 1 function, got %d", len(out.Funcs))
+	}
+	fn := out.Funcs[0]
+	if len(fn.Strings) != 1 || fn.Strings[0] != "hi" {
+		t.Fatalf("Strings table: got %v, want [\"hi\"]", fn.Strings)
+	}
+	var sawConst, sawCall bool
+	for _, v := range fn.Values {
+		if v.Op == ir.OpConst && v.Type == ir.TypeStr {
+			sawConst = true
+		}
+		if v.Op == ir.OpCallGo {
+			sawCall = true
+		}
+	}
+	if !sawConst {
+		t.Errorf("expected an OpConst{TypeStr} value, none found")
+	}
+	if !sawCall {
+		t.Errorf("expected an OpCallGo value for print, none found")
+	}
+}
+
+// TestLowerNoneLiteralError asserts that the `none` literal, which
+// has no MVP type lowering yet, still produces a frontend error rather
+// than a silent miscompile. Phase 4.2.0 lifted the string-literal
+// restriction but `none` remains unsupported.
+func TestLowerNoneLiteralError(t *testing.T) {
+	src := `let s = none
 `
 	prog, err := parser.Parser.ParseString("t.mochi", src)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
 	if _, err := Lower(prog); err == nil {
-		t.Fatal("expected error for unsupported string literal in MVP, got nil")
+		t.Fatal("expected error for unsupported none literal in MVP, got nil")
 	}
 }
 

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -586,6 +586,11 @@ type Function struct {
 	Values     []Value
 	GoBindings  []GoBinding
 	JsonObjects []JsonObject
+	// Strings is the side-table of constant string payloads referenced
+	// by OpConst Values of Type TypeStr. The Value's Const field is the
+	// index into this slice. Side-table form mirrors GoBindings and
+	// JsonObjects so the Const field stays int64-shaped.
+	Strings    []string
 	SourceFile  string
 
 	// RefModes records the MEP-41 §6.9 reference-mode tag for the

--- a/compiler3/migrate/frontend_test.go
+++ b/compiler3/migrate/frontend_test.go
@@ -38,10 +38,12 @@ func TestFrontendRunnerEndToEnd(t *testing.T) {
 
 // TestFrontendRunnerPendingForUnsupportedSurface asserts FrontendRunner
 // surfaces MVP-unsupported sources as ErrNewPathPending so the A/B
-// harness records a skip rather than a regression.
+// harness records a skip rather than a regression. Phase 4.2.0 lifted
+// the string-literal restriction, so the durable unsupported surface
+// is now the `none` literal.
 func TestFrontendRunnerPendingForUnsupportedSurface(t *testing.T) {
 	dir := t.TempDir()
-	src := `let s = "hello"` + "\n"
+	src := `let s = none` + "\n"
 	mochiPath := filepath.Join(dir, "demo.mochi")
 	if err := os.WriteFile(mochiPath, []byte(src), 0o644); err != nil {
 		t.Fatalf("write mochi: %v", err)

--- a/runtime/c/src/print.c
+++ b/runtime/c/src/print.c
@@ -19,6 +19,11 @@ void mochi_print_bool(int x) {
     fputs(x ? "true\n" : "false\n", stdout);
 }
 
+void mochi_print_str(const char *s) {
+    fputs(s, stdout);
+    fputc('\n', stdout);
+}
+
 void mochi_print_f64(double x) {
     /*
      * Shortest round-trip: try precision 1..17 and pick the first

--- a/runtime/c/src/print.h
+++ b/runtime/c/src/print.h
@@ -32,6 +32,14 @@ void mochi_print_i64(int64_t x);
 void mochi_print_bool(int x);
 
 /*
+ * mochi_print_str writes the bytes of s (NUL-terminated) followed by
+ * a single '\n', matching Go's `fmt.Println(s)` for plain-string args.
+ * Phase 4.2.0 covers literal strings only; later 4.2.x sub-phases
+ * widen to owning mochi_str values when concat/slice lands.
+ */
+void mochi_print_str(const char *s);
+
+/*
  * mochi_print_f64 writes x using the shortest representation that
  * round-trips through strtod, followed by '\n'. The output matches
  * Go's `fmt.Println(float64)` for normal finite values where Go's

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -635,7 +635,7 @@ This is the contract behind the §Top-line objective. Every IR `OpCode` and `Typ
 | `TypeF64` | `double` | LANDED (Phase 4.0) |
 | `TypeBool` | `int` (canonical 0/1) | LANDED (Phase 4.0) |
 | `TypeUnit` | function-result `void` | LANDED (Phase 4.0) |
-| `TypeStr` | `mochi_str` (UTF-8 owning slice) | DEFERRED Phase 4.2 |
+| `TypeStr` | `const char*` for string literals (Phase 4.2.0); `mochi_str` (UTF-8 owning slice) for concat/slice later in Phase 4.2.x | PARTIAL (Phase 4.2.0: literal-only) |
 | `TypeList[T]` | `mochi_list_<T>*` | DEFERRED Phase 4.3 |
 | `TypeMap[K,V]` | `mochi_map_<K>_<V>*` | DEFERRED Phase 4.3 |
 | `TypeF64Array` | `mochi_f64arr*` (typed slice) | DEFERRED Phase 4.3 |
@@ -650,7 +650,7 @@ This is the contract behind the §Top-line objective. Every IR `OpCode` and `Typ
 | `OpConst` (i64) | integer literal with LLONG_MIN edge | LANDED (Phase 4.0) |
 | `OpConst` (f64) | bit-cast via anonymous union | LANDED (Phase 4.0) |
 | `OpConst` (bool) | `0` / `1` | LANDED (Phase 4.0) |
-| `OpConst` (str) | `mochi_str` literal | DEFERRED Phase 4.2 |
+| `OpConst` (str) | `const char*` to a C string literal; payload stored in `fn.Strings`, indexed by `Value.Const` | LANDED (Phase 4.2.0) |
 | `OpPhi` | predecessor-side assignment in terminator | LANDED (Phase 4.0) |
 | `OpAddI64`/`OpSubI64`/`OpMulI64`/`OpDivI64`/`OpModI64`/`OpNegI64` + *Imm | direct C operator | LANDED (Phase 4.0) |
 | `OpAddF64`/`OpSubF64`/`OpMulF64`/`OpDivF64`/`OpNegF64` | direct C operator | LANDED (Phase 4.0) |
@@ -659,7 +659,7 @@ This is the contract behind the §Top-line objective. Every IR `OpCode` and `Typ
 | `OpCmpEqF64`..`OpCmpGeF64` | `(a op b) ? 1 : 0` over `double` | LANDED (Phase 4.1.1) |
 | `OpNotBool` | `v ? 0 : 1` (canonical bool form) | LANDED (Phase 4.1.1) |
 | `OpCall` / `OpTailCall` | direct C call via `Program.Funcs[v.Const]` | LANDED (Phase 4.1) |
-| `OpCallGo{fmt.Println}` | dispatch on arg type to `mochi_print_*` runtime | LANDED (Phase 4.1, i64/f64/bool only) |
+| `OpCallGo{fmt.Println}` | dispatch on arg type to `mochi_print_*` runtime | LANDED (Phase 4.1 for i64/f64/bool; Phase 4.2.0 adds str) |
 | `OpCallGo{*}` (other) | none | REJECTED by design (no cgo; use `--target=go`) |
 | `OpFnRef` | function-pointer literal | DEFERRED Phase 4.4 |
 | `OpLenStr` / `OpConcatStr` | `mochi_str_len` / `mochi_str_concat` | DEFERRED Phase 4.2 |
@@ -1789,6 +1789,55 @@ The Phase 4.3 stream's user-facing goal is "all bench-template benchmark games p
 - The C runtime leaks tree nodes at process exit (same convention as `mochi_list_i64`). For benchmark workloads that complete in under a few seconds this is fine; a long-running tree-heavy workload would need an arena allocator or a deinit hook.
 - No iteration over `list<any>` (`for x in t`). The check_tree kernel walks the two known children explicitly (`t[0]`, `t[1]`), so iteration is not on the critical path.
 - No deep equality, no print of `list<any>`. The kernel reduces trees to an i64 count before any print; the `_MochiAny` Go type has no `String()` override either. Adding it is straightforward but deferred until a fixture surfaces.
+
+## §10.27 Phase 4.2.0 closeout (LANDED 2026-05-22 07:55 GMT+7)
+
+Phase 4.2.0 lands the minimum slice of Phase 4.2: string literal lowering plus `print(str)`. Before this sub-phase, the simplest user-facing program against the §Top-line objective, `print("hello, world!")`, errored at the frontend with `literal kind unsupported in MVP (str/none)` on both `--target=c` and `--target=go`. After it, the same source compiles unchanged on both targets and the C-target binary writes the line to stdout via a new `mochi_print_str` runtime entry.
+
+### Implementation
+
+1. `compiler3/ir/types.go`: added `Strings []string` side-table to `ir.Function`. `OpConst` with `Type: TypeStr` uses `Value.Const` as an index into this slice. Side-table form mirrors `GoBindings` and `JsonObjects`, so the existing IR-load/save shape and the `Const` field's `int64` carrier stay unchanged.
+2. `compiler3/frontend/lower.go`: `lowerLiteral` now handles `lit.Str`: appends the string to `b.fn.Strings` and emits an `OpConst{Type: TypeStr, Const: <index>}` Value. The remaining unsupported literal kind is `none`; the error message was narrowed accordingly.
+3. `compiler3/emit/go/emit.go`: `OpConst` switch adds a `TypeStr` arm that bounds-checks the index against `fn.Strings` and emits a `%q`-quoted Go string literal. No other Go-emit changes were needed; the existing OpCallGo dispatch already routes `fmt.Println` with a `string` arg type unchanged.
+4. `compiler3/emit/c/emit.go`: `cType(TypeStr)` returns `const char*`; the `OpConst` switch adds a `TypeStr` arm that bounds-checks the index and writes `v3 = "<escaped>";` via a new `cStringLiteral` helper. The helper escapes `"`, `\`, `\n`, `\t`, `\r` to their C short forms, passes printable ASCII through, and emits other bytes as 3-digit octal so an immediately-following digit cannot be misparsed (which would happen with `\x` hex escapes per C99 §6.4.4.4). The OpCallGo print dispatch adds `TypeStr → mochi_print_str(...)`.
+5. `runtime/c/src/print.{h,c}`: added `mochi_print_str(const char *s)`. The body is `fputs(s, stdout); fputc('\n', stdout);` -- one allocation-free write of the literal bytes plus a trailing newline, byte-equivalent to Go's `fmt.Println(string)` for plain ASCII/UTF-8 strings without `%` formatting.
+
+### Files changed
+
+- `compiler3/ir/types.go` (+5 lines: `Strings` field + doc)
+- `compiler3/frontend/lower.go` (+5 lines: `lit.Str` arm in `lowerLiteral`)
+- `compiler3/emit/go/emit.go` (+5 lines: `TypeStr` OpConst arm)
+- `compiler3/emit/c/emit.go` (+8 lines `cType` + OpConst + dispatch, +33 lines `cStringLiteral` helper)
+- `runtime/c/src/print.h` (+8 lines: `mochi_print_str` decl + doc)
+- `runtime/c/src/print.c` (+5 lines: implementation)
+- `compiler3/build/c/driver_test.go` (3 new tests: Hello, Escape, Let)
+- `compiler3/frontend/lower_test.go` (split: positive `TestLowerStringLiteral` + negative `TestLowerNoneLiteralError`)
+- `compiler3/emit/c/emit_test.go` (`TestEmitOpCallGoPrintArgTypeUnsupported` repointed at `TypeList`, since `TypeStr` is now supported)
+- `compiler3/migrate/frontend_test.go` (`TestFrontendRunnerPendingForUnsupportedSurface` repointed at the `none` literal)
+
+### Reproducer
+
+```
+$ cat /tmp/hello.mochi
+print("hello, world!")
+$ mochi build --target=c --binary=/tmp/hello /tmp/hello.mochi
+binary /tmp/hello
+$ /tmp/hello
+hello, world!
+```
+
+The same source under `mochi build --target=go` produces a Go program whose `go run` output byte-matches.
+
+### Why this closes the goal
+
+The §Top-line objective is "`mochi build hello.mochi` produces a single native binary that runs on a clean machine". Before Phase 4.2.0, the canonical hello-world string variant did not build at all through compiler3; the goal-state demo had to use `print(42)` to dodge the frontend gap. After Phase 4.2.0, the literal program every newcomer types as their first Mochi source compiles and runs unchanged. That is the floor of the §Top-line objective for the AOT-C target.
+
+### Limitations
+
+- String literals only. No concat (`a + b`), no `len(s)` on the C side (the IR has `OpLenStr`/`OpConcatStr` but the C emit does not lower them yet), no slicing, no equality, no string-keyed map. A future Phase 4.2.1 wires `OpLenStr` for the literal carrier; Phase 4.2.2+ introduces an owning `mochi_str` runtime once a fixture needs allocation.
+- No string formatting. `print(x)` for non-string `x` still goes through the existing scalar dispatch; there is no `mochi_format_*` or `Sprintf` analog. A future Phase 4.2.x lands an interpolation-style format pass when the bench corpus surfaces a need.
+- The `const char*` lowering relies on C99's read-only static storage for string literals. A generated program that captured the literal and tried to mutate through it would invoke undefined behavior, but the frontend does not produce such code: TypeStr Values are immutable in the IR by construction (no `OpStrSetByte` exists).
+- Non-ASCII bytes use octal escapes in the emitted C, which keeps the binary stable across compilers but bloats the source. The size cost is negligible for typical programs; a future cosmetic pass can switch to UTF-8 pass-through with an explicit "encoding: UTF-8" pragma if the bloat ever matters.
 
 ## §11 Risks
 


### PR DESCRIPTION
Closes #21993. Part of MEP-42 Phase 4.2.

## Summary

- Frontend lowers `lit.Str` into a new `ir.Function.Strings` side-table; emits `OpConst{TypeStr, Const=<index>}`.
- C emit maps `TypeStr` to `const char*`, emits the literal with C99-safe escapes (3-digit octal for non-printable bytes), and routes `print(str)` through a new `mochi_print_str(const char *s)` entry in `runtime/c/src/print.{h,c}`.
- Go emit adds the matching `OpConst{TypeStr}` arm (`%q`-quoted literal); the existing OpCallGo dispatch already handled `fmt.Println(string)` once the value exists.

## Why this closes the §Top-line goal

Before this PR, `print(\"hello, world!\")` errored at the frontend on both targets. After this PR, the canonical first-Mochi-program builds via `mochi build --target=c` and writes the expected line. That is the floor of the §Top-line objective for the AOT-C target.

## Test plan

- [x] `go test ./compiler3/build/c/... -run 'StringLiteral'` (3 new driver tests pass)
- [x] `go test ./compiler3/...` (full sweep green)
- [x] Manual: `print(\"hello, world!\")` builds & runs on `--target=c`
- [x] MEP-42 §10.27 closeout added; §10.6 matrix updated