### PR TITLE
mep-0042: Phase 4.2.1 len(str) on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -1347,6 +1347,39 @@ print(a)
 	}
 }
 
+// TestBuildSourceLenStrLiteral pins the Phase 4.2.1 surface: `len`
+// applied to a string literal lowers to OpLenStr and the C emitter
+// emits `(int64_t)strlen(...)`. The runtime <string.h> include is
+// added by the pre-pass when OpLenStr is present in the program.
+func TestBuildSourceLenStrLiteral(t *testing.T) {
+	src := `print(len("hello"))` + "\n"
+	if got, want := runMochiBuild(t, src), "5\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceLenStrEmpty pins the empty-string edge: strlen of
+// "" is 0, which matches Mochi's `len("")` returning int(0).
+func TestBuildSourceLenStrEmpty(t *testing.T) {
+	src := `print(len(""))` + "\n"
+	if got, want := runMochiBuild(t, src), "0\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceLenStrViaLet pins len on a string-typed let binding,
+// exercising the side-table indirection (the literal lives in
+// fn.Strings, OpLenStr reads the carrier variable rather than a
+// freshly emitted literal).
+func TestBuildSourceLenStrViaLet(t *testing.T) {
+	src := `let s = "hello, world!"
+print(len(s))
+`
+	if got, want := runMochiBuild(t, src), "13\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceSpectralNormBgFixture pins the unmodified
 // bench/template/bg/spectral_norm fixture (N=100) on the C target.
 // This is the §10.7 closeout for spectral_norm at the fixture level

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -66,6 +66,7 @@ func Emit(p *Program) ([]byte, error) {
 	usesNow := false
 	usesMapI64I64 := false
 	usesTree := false
+	usesStrH := false
 	for _, fn := range p.Funcs {
 		for _, v := range fn.Values {
 			switch v.Op {
@@ -90,6 +91,8 @@ func Emit(p *Program) ([]byte, error) {
 				usesMapI64I64 = true
 			case ir.OpNewListAny, ir.OpListAnyLen, ir.OpListAnyPushAny, ir.OpListAnyGetAny:
 				usesTree = true
+			case ir.OpLenStr:
+				usesStrH = true
 			case ir.OpNow:
 				usesNow = true
 			}
@@ -118,6 +121,9 @@ func Emit(p *Program) ([]byte, error) {
 	}
 	if usesNow {
 		buf.WriteString("#include \"mochi_time.h\"\n")
+	}
+	if usesStrH {
+		buf.WriteString("#include <string.h>\n")
 	}
 	buf.WriteString("\n")
 
@@ -378,6 +384,12 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    mochi_tree_push(%s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpListAnyGetAny:
 		fmt.Fprintf(w, "    %s = mochi_tree_get(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpLenStr:
+		// `const char*` carriers are NUL-terminated string literals
+		// (Phase 4.2.0), so strlen reads byte length up to but not
+		// including the terminator. Cast to int64_t because Mochi
+		// `len(s)` returns int.
+		fmt.Fprintf(w, "    %s = (int64_t)strlen(%s);\n", name, valueName(v.Args[0]))
 	case ir.OpNow:
 		fmt.Fprintf(w, "    %s = mochi_now_us();\n", name)
 	case ir.OpJsonI64Object:

--- a/compiler3/emit/c/emit_test.go
+++ b/compiler3/emit/c/emit_test.go
@@ -151,16 +151,18 @@ func TestEmitMainF64(t *testing.T) {
 // driver downstream treats this as a clean "AOT cannot lower this
 // program" signal.
 func TestEmitUnsupportedOp(t *testing.T) {
-	fn := &ir.Function{Name: "bad", Result: ir.TypeI64}
+	fn := &ir.Function{Name: "bad", Result: ir.TypeStr}
 	bid := fn.AddBlock()
-	c := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 0})
-	// OpLenStr is out of Phase 4.0 scope.
-	s := fn.AddValue(ir.Value{Type: ir.TypeStr, Op: ir.OpParam})
-	fn.Params = []uint32{s}
-	ln := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpLenStr, Args: []uint32{s}})
+	// OpConcatStr is out of Phase 4.2 scope (Phase 4.2.x widens to
+	// owning mochi_str when string concat lands; until then it is the
+	// canonical unsupported-op probe for the C emitter).
+	a := fn.AddValue(ir.Value{Type: ir.TypeStr, Op: ir.OpParam})
+	b := fn.AddValue(ir.Value{Type: ir.TypeStr, Op: ir.OpParam})
+	fn.Params = []uint32{a, b}
+	cc := fn.AddValue(ir.Value{Type: ir.TypeStr, Op: ir.OpConcatStr, Args: []uint32{a, b}})
 	blk := fn.Block(bid)
-	blk.Values = []uint32{c, ln}
-	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: ln}
+	blk.Values = []uint32{cc}
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: cc}
 	_, err := Emit(&Program{Funcs: []*ir.Function{fn}})
 	if err == nil {
 		t.Fatalf("expected ErrUnsupportedOp, got nil")

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -662,7 +662,8 @@ This is the contract behind the §Top-line objective. Every IR `OpCode` and `Typ
 | `OpCallGo{fmt.Println}` | dispatch on arg type to `mochi_print_*` runtime | LANDED (Phase 4.1 for i64/f64/bool; Phase 4.2.0 adds str) |
 | `OpCallGo{*}` (other) | none | REJECTED by design (no cgo; use `--target=go`) |
 | `OpFnRef` | function-pointer literal | DEFERRED Phase 4.4 |
-| `OpLenStr` / `OpConcatStr` | `mochi_str_len` / `mochi_str_concat` | DEFERRED Phase 4.2 |
+| `OpLenStr` | `(int64_t)strlen(s)` for the `const char*` carrier; auto-includes `<string.h>` | LANDED (Phase 4.2.1) |
+| `OpConcatStr` | `mochi_str_concat` (requires owning `mochi_str`) | DEFERRED Phase 4.2.x |
 | `OpNewList` / `OpListLenI64` / `OpListPushI64` / `OpListGetI64` / `OpListSetI64` | `mochi_list_i64_*` runtime (heap-allocated header, doubling growth) | LANDED (Phase 4.3.1) |
 | `OpListGetF64` / `OpListSetF64` | not lowered by the C target; `list<float>` routes through `OpNewF64Array` instead | N/A (vm3 surface) |
 | `OpNewMap` / `OpMapSet/Get/I64I64` | `mochi_map_*` runtime | DEFERRED Phase 4.3 |
@@ -1834,10 +1835,30 @@ The §Top-line objective is "`mochi build hello.mochi` produces a single native 
 
 ### Limitations
 
-- String literals only. No concat (`a + b`), no `len(s)` on the C side (the IR has `OpLenStr`/`OpConcatStr` but the C emit does not lower them yet), no slicing, no equality, no string-keyed map. A future Phase 4.2.1 wires `OpLenStr` for the literal carrier; Phase 4.2.2+ introduces an owning `mochi_str` runtime once a fixture needs allocation.
+- String literals only. No concat (`a + b`), no slicing, no equality, no string-keyed map. Phase 4.2.1 (below) wires `OpLenStr` for the literal carrier; Phase 4.2.2+ introduces an owning `mochi_str` runtime once a fixture needs allocation.
 - No string formatting. `print(x)` for non-string `x` still goes through the existing scalar dispatch; there is no `mochi_format_*` or `Sprintf` analog. A future Phase 4.2.x lands an interpolation-style format pass when the bench corpus surfaces a need.
 - The `const char*` lowering relies on C99's read-only static storage for string literals. A generated program that captured the literal and tried to mutate through it would invoke undefined behavior, but the frontend does not produce such code: TypeStr Values are immutable in the IR by construction (no `OpStrSetByte` exists).
 - Non-ASCII bytes use octal escapes in the emitted C, which keeps the binary stable across compilers but bloats the source. The size cost is negligible for typical programs; a future cosmetic pass can switch to UTF-8 pass-through with an explicit "encoding: UTF-8" pragma if the bloat ever matters.
+
+## §10.28 Phase 4.2.1 closeout (LANDED 2026-05-22 08:05 GMT+7)
+
+Phase 4.2.1 wires `OpLenStr` on the C target. The frontend already lowered `len(s)` for TypeStr args (Phase 4.3.1's `lowerBuiltinCall` covered the dispatch), but the C emitter rejected `OpLenStr` with `ErrUnsupportedOp`, so `print(len("hello"))` failed at build time with `cgen: unsupported IR op: len.str`. After this sub-phase, the same source compiles and prints `5\n` on `mochi build --target=c`.
+
+### What landed
+
+- `compiler3/emit/c/emit.go`: new `OpLenStr` case lowering to `(int64_t)strlen(s)`. The `const char*` carrier (Phase 4.2.0) is NUL-terminated, so `strlen` is the matching primitive. Result is cast to `int64_t` because Mochi `len` returns int. A `usesStrH` flag in the pre-pass auto-includes `<string.h>` only when the program actually calls `len(str)`, keeping the i64-only programs free of the extra include.
+- `compiler3/emit/c/emit_test.go`: `TestEmitUnsupportedOp` repointed from `OpLenStr` to `OpConcatStr`, which remains the canonical unsupported-op probe until Phase 4.2.x lands owning `mochi_str`.
+- `compiler3/build/c/driver_test.go`: three new tests, `TestBuildSourceLenStrLiteral` (`len("hello")` → 5), `TestBuildSourceLenStrEmpty` (`len("")` → 0), and `TestBuildSourceLenStrViaLet` (`len(s)` where `s` is a let-bound string literal, exercising the side-table indirection).
+- §10.6 `OpLenStr` row moves from DEFERRED to LANDED; `OpConcatStr` is split into its own row, still deferred. §10.27 limitation list is amended.
+
+### Why this closes a goal
+
+The §Top-line objective ties to the canonical user-facing programs. After Phase 4.2.0, `print("hello, world!")` worked but `print(len("hello"))` did not. That gap is the smallest visible failure-mode for any user writing string code on the C target. Wiring `OpLenStr` removes it without introducing new runtime surface (libc's `strlen` is the primitive). The C-target now matches the Go-target for the read-only string operations that do not require allocation.
+
+### Limitations
+
+- Still no concat, slicing, equality, or string-keyed maps. Those require an owning `mochi_str` because the result of concat does not have a literal in the source to point at; Phase 4.2.2 lands that.
+- `strlen` is byte length, not codepoint count. Mochi `len(s)` is documented as byte length so this matches the spec, but a user expecting "characters" on a UTF-8 string with multibyte sequences will be surprised. The Mochi-side spec text covers this; no C-target action required.
 
 ## §11 Risks
 


### PR DESCRIPTION
Closes #21995. Follows #21994 (Phase 4.2.0 string literal + print(str)).

## Summary

- C emitter lowers `OpLenStr` to `(int64_t)strlen(s)` over the `const char*` carrier introduced in Phase 4.2.0.
- Auto-includes `<string.h>` only when `OpLenStr` is present (keeps i64-only programs free of the extra include).
- `TestEmitUnsupportedOp` repointed from `OpLenStr` to `OpConcatStr`.
- Three driver tests: literal, empty, let-bound carrier.
- MEP-42 §10.6 row LANDED; §10.27 limitations amended; §10.28 closeout added.

## Why

After Phase 4.2.0 made `print("hello, world!")` build on the C target, `print(len("hello"))` was the next obvious gap. It errored at `cgen: unsupported IR op: len.str`. This sub-phase removes that error with the matching primitive (libc `strlen`) and no new runtime surface.

## Test plan

- [x] `go test ./compiler3/... -count=1` (green sweep)
- [x] `mochi build --target=c` on `print(len("hello"))` prints `5`
- [x] Three new driver tests pass (`TestBuildSourceLenStrLiteral`, `TestBuildSourceLenStrEmpty`, `TestBuildSourceLenStrViaLet`)
- [x] `TestEmitUnsupportedOp` still passes with the repointed unsupported op