### PR TITLE
mep-0042: Phase 4.2.2 string equality on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -1380,6 +1380,62 @@ print(len(s))
 	}
 }
 
+// TestBuildSourceStrEqLiteralTrue pins the Phase 4.2.2 surface for
+// the equal-literals case: `"hi" == "hi"` lowers to OpCmpEqStr,
+// strcmp returns 0, the boolean is true, and the if-branch fires.
+func TestBuildSourceStrEqLiteralTrue(t *testing.T) {
+	src := `if "hi" == "hi" {
+  print("yes")
+} else {
+  print("no")
+}
+`
+	if got, want := runMochiBuild(t, src), "yes\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStrEqLiteralFalse pins the unequal-literals case:
+// strcmp returns non-zero so the boolean is false and the else
+// branch fires.
+func TestBuildSourceStrEqLiteralFalse(t *testing.T) {
+	src := `if "hi" == "bye" {
+  print("yes")
+} else {
+  print("no")
+}
+`
+	if got, want := runMochiBuild(t, src), "no\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStrEqViaLet pins string equality on a let-bound
+// carrier: the side-table holds the literal, OpCmpEqStr reads the
+// `const char*` variable on both sides.
+func TestBuildSourceStrEqViaLet(t *testing.T) {
+	src := `let answer = "yes"
+if answer == "yes" {
+  print("matched")
+}
+`
+	if got, want := runMochiBuild(t, src), "matched\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStrNeLiteral pins the `!=` arm: same surface, with
+// the result inverted by OpCmpNeStr's `!= 0` test.
+func TestBuildSourceStrNeLiteral(t *testing.T) {
+	src := `if "a" != "b" {
+  print("differ")
+}
+`
+	if got, want := runMochiBuild(t, src), "differ\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceSpectralNormBgFixture pins the unmodified
 // bench/template/bg/spectral_norm fixture (N=100) on the C target.
 // This is the §10.7 closeout for spectral_norm at the fixture level

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -91,7 +91,7 @@ func Emit(p *Program) ([]byte, error) {
 				usesMapI64I64 = true
 			case ir.OpNewListAny, ir.OpListAnyLen, ir.OpListAnyPushAny, ir.OpListAnyGetAny:
 				usesTree = true
-			case ir.OpLenStr:
+			case ir.OpLenStr, ir.OpCmpEqStr, ir.OpCmpNeStr:
 				usesStrH = true
 			case ir.OpNow:
 				usesNow = true
@@ -390,6 +390,14 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		// including the terminator. Cast to int64_t because Mochi
 		// `len(s)` returns int.
 		fmt.Fprintf(w, "    %s = (int64_t)strlen(%s);\n", name, valueName(v.Args[0]))
+	case ir.OpCmpEqStr:
+		// Byte equality on the NUL-terminated `const char*` carriers.
+		// strcmp returns 0 iff the byte sequences match; the boolean
+		// result is `(strcmp(a, b) == 0)`. Mochi `==` matches Go's
+		// string `==` (byte equality) for Phase 4.2.x literals.
+		fmt.Fprintf(w, "    %s = (strcmp(%s, %s) == 0);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpCmpNeStr:
+		fmt.Fprintf(w, "    %s = (strcmp(%s, %s) != 0);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpNow:
 		fmt.Fprintf(w, "    %s = mochi_now_us();\n", name)
 	case ir.OpJsonI64Object:

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -300,6 +300,10 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 		fmt.Fprintf(w, "\t%s = int64(len(%s))\n", name, valueName(v.Args[0]))
 	case ir.OpConcatStr:
 		fmt.Fprintf(w, "\t%s = %s + %s\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpCmpEqStr:
+		fmt.Fprintf(w, "\t%s = %s == %s\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpCmpNeStr:
+		fmt.Fprintf(w, "\t%s = %s != %s\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpNewList:
 		fmt.Fprintf(w, "\t%s = []int64{}\n", name)
 	case ir.OpListLenI64:

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1337,6 +1337,17 @@ func (b *builder) applyBinOp(op string, l, r uint32) (uint32, error) {
 		default:
 			return 0, fmt.Errorf("frontend: operator %q on f64 unsupported in MVP", op)
 		}
+	case ir.TypeStr:
+		switch op {
+		case "==":
+			code = ir.OpCmpEqStr
+			resType = ir.TypeBool
+		case "!=":
+			code = ir.OpCmpNeStr
+			resType = ir.TypeBool
+		default:
+			return 0, fmt.Errorf("frontend: operator %q on str unsupported in MVP", op)
+		}
 	case ir.TypeList:
 		if op != "+" {
 			return 0, fmt.Errorf("frontend: operator %q on list<int> unsupported in MVP", op)

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -132,6 +132,8 @@ const (
 	// String ops (Phase 3.1 vm3 surface).
 	OpLenStr
 	OpConcatStr
+	OpCmpEqStr
+	OpCmpNeStr
 
 	// List ops (Phase 3.2 vm3 surface).
 	OpNewList
@@ -351,6 +353,10 @@ func (o OpCode) String() string {
 		return "len.str"
 	case OpConcatStr:
 		return "concat.str"
+	case OpCmpEqStr:
+		return "cmp.eq.str"
+	case OpCmpNeStr:
+		return "cmp.ne.str"
 	case OpNewList:
 		return "newlist"
 	case OpListLenI64:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -175,6 +175,8 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeI64, [3]Type{TypeStr}}
 	case OpConcatStr:
 		return opSig{TypeStr, [3]Type{TypeStr, TypeStr}}
+	case OpCmpEqStr, OpCmpNeStr:
+		return opSig{TypeBool, [3]Type{TypeStr, TypeStr}}
 	case OpNewList:
 		return opSig{TypeList, [3]Type{}}
 	case OpListLenI64:

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -156,6 +156,7 @@ func kindOf(o ir.OpCode) ProducerKind {
 		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm,
 		ir.OpAndI64, ir.OpOrI64, ir.OpXorI64, ir.OpShlI64, ir.OpShrI64, ir.OpNotI64,
 		ir.OpCmpEqF64, ir.OpCmpNeF64, ir.OpCmpLtF64, ir.OpCmpLeF64, ir.OpCmpGtF64, ir.OpCmpGeF64,
+		ir.OpCmpEqStr, ir.OpCmpNeStr,
 		ir.OpNotBool,
 		ir.OpI64ToF64, ir.OpF64ToI64,
 		ir.OpSqrtF64,
@@ -396,7 +397,8 @@ func contractResult(o ir.OpCode) ir.Type {
 	case ir.OpAddF64, ir.OpSubF64, ir.OpMulF64, ir.OpDivF64, ir.OpNegF64:
 		return ir.TypeF64
 	case ir.OpCmpEqI64, ir.OpCmpNeI64, ir.OpCmpLtI64, ir.OpCmpLeI64, ir.OpCmpGtI64, ir.OpCmpGeI64,
-		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm:
+		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm,
+		ir.OpCmpEqStr, ir.OpCmpNeStr:
 		return ir.TypeBool
 	case ir.OpLenStr:
 		return ir.TypeI64

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -663,6 +663,7 @@ This is the contract behind the §Top-line objective. Every IR `OpCode` and `Typ
 | `OpCallGo{*}` (other) | none | REJECTED by design (no cgo; use `--target=go`) |
 | `OpFnRef` | function-pointer literal | DEFERRED Phase 4.4 |
 | `OpLenStr` | `(int64_t)strlen(s)` for the `const char*` carrier; auto-includes `<string.h>` | LANDED (Phase 4.2.1) |
+| `OpCmpEqStr` / `OpCmpNeStr` | `(strcmp(a, b) == 0)` / `!= 0` over the `const char*` carriers | LANDED (Phase 4.2.2) |
 | `OpConcatStr` | `mochi_str_concat` (requires owning `mochi_str`) | DEFERRED Phase 4.2.x |
 | `OpNewList` / `OpListLenI64` / `OpListPushI64` / `OpListGetI64` / `OpListSetI64` | `mochi_list_i64_*` runtime (heap-allocated header, doubling growth) | LANDED (Phase 4.3.1) |
 | `OpListGetF64` / `OpListSetF64` | not lowered by the C target; `list<float>` routes through `OpNewF64Array` instead | N/A (vm3 surface) |
@@ -1857,8 +1858,30 @@ The §Top-line objective ties to the canonical user-facing programs. After Phase
 
 ### Limitations
 
-- Still no concat, slicing, equality, or string-keyed maps. Those require an owning `mochi_str` because the result of concat does not have a literal in the source to point at; Phase 4.2.2 lands that.
+- Still no concat, slicing, equality, or string-keyed maps. The first three are widened in Phase 4.2.2 (equality) and a later 4.2.x (concat + slicing, gated on an owning `mochi_str` runtime).
 - `strlen` is byte length, not codepoint count. Mochi `len(s)` is documented as byte length so this matches the spec, but a user expecting "characters" on a UTF-8 string with multibyte sequences will be surprised. The Mochi-side spec text covers this; no C-target action required.
+
+## §10.29 Phase 4.2.2 closeout (LANDED 2026-05-22 08:14 GMT+7)
+
+Phase 4.2.2 wires string equality (`==` and `!=`) on the C target. Before this sub-phase, `if s == "yes" { ... }` errored at the frontend with `binop "==" on type str unsupported in MVP`. After it, the same source compiles and runs unchanged on both `--target=c` and `--target=go`.
+
+### What landed
+
+- `compiler3/ir/types.go` + `validate.go`: two new ops, `OpCmpEqStr` and `OpCmpNeStr`. Result is `TypeBool`, args are two `TypeStr`. Signature mirrors the i64 / f64 compare families.
+- `compiler3/verify/verify.go`: classified as `KindOperator` (pure functions of two value args), and the contract-result table maps both to `TypeBool`.
+- `compiler3/emit/go/emit.go`: lowers to Go's built-in string `==` and `!=` (Go strings are comparable by value).
+- `compiler3/emit/c/emit.go`: lowers to `(strcmp(a, b) == 0)` and `!= 0` over the `const char*` carriers introduced in Phase 4.2.0; the `usesStrH` flag also fires on these ops so `<string.h>` is auto-included.
+- `compiler3/frontend/lower.go`: `lowerBinary` learns a `TypeStr` arm dispatching `==` / `!=` to the new ops; other operators on TypeStr still error explicitly (`+`, `<`, etc.).
+- `compiler3/build/c/driver_test.go`: four new tests: `TestBuildSourceStrEqLiteralTrue` (true branch fires), `TestBuildSourceStrEqLiteralFalse` (false branch fires), `TestBuildSourceStrEqViaLet` (carrier-bound comparison), `TestBuildSourceStrNeLiteral` (`!=` arm).
+
+### Why this closes a goal
+
+After Phase 4.2.1, a user could write a literal, print it, and ask for its length, but could not branch on its value. Equality is the smallest contained primitive that unlocks branching on string state: it requires no allocation (the result is a bool, the inputs are pointer-compared via `strcmp`) and no new runtime surface beyond the libc `<string.h>` header already auto-included for `strlen`. After Phase 4.2.2, the pattern `if user_input == "yes" { ... }` compiles to a native binary that prints the same bytes on both AOT targets.
+
+### Limitations
+
+- Still no concat (`+`) or relational comparisons (`<`, `<=`, `>`, `>=`). Concat needs an owning `mochi_str`; relational comparisons could be added today with a single `strcmp(a, b) <op> 0` lowering but the bench corpus has no user yet, so they are deferred until one surfaces.
+- Equality is byte-level. Two strings encoding the same logical character via different UTF-8 normalisations would compare unequal. That matches Go's `==` behaviour and the Mochi spec.
 
 ## §11 Risks
 


### PR DESCRIPTION
Closes #21997. Follows #21996 (Phase 4.2.1 len(str)).

## Summary

- IR adds `OpCmpEqStr` / `OpCmpNeStr`, both `(TypeStr, TypeStr) -> TypeBool`.
- Verify classifies as `KindOperator` and pins the result type.
- Go emit: native `==` / `!=` on string values.
- C emit: `(strcmp(a, b) == 0)` / `!= 0`; reuses the existing `usesStrH` auto-include path.
- Frontend `lowerBinary` learns a `TypeStr` arm dispatching `==` / `!=`; other operators still error explicitly.
- MEP-42 §10.6 row LANDED; §10.29 closeout added.

## Why

Branching on a string's value is the next-most-common user pattern after `print(s)` and `len(s)`, both already wired by earlier 4.2.x sub-phases. Equality needs no new runtime surface (libc `strcmp`), no allocation, and result is a plain `bool`, so the slice stays minimal.

## Test plan

- [x] `go test ./compiler3/... -count=1` (green sweep)
- [x] `if s == "yes" { print("matched") }` builds and prints `matched`
- [x] 4 new driver tests pass (`TestBuildSourceStrEq*`, `TestBuildSourceStrNeLiteral`)
- [x] Existing `TestEmitUnsupportedOp` (probing `OpConcatStr`) still passes