### PR TITLE
mep-0042: Phase 4.2.3 string concat on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -1436,6 +1436,73 @@ func TestBuildSourceStrNeLiteral(t *testing.T) {
 	}
 }
 
+// TestBuildSourceStrConcatLiteral pins the Phase 4.2.3 surface: `+`
+// on two string literals lowers to OpConcatStr, the C emitter calls
+// mochi_str_concat (auto-included via mochi_str.h), and the runtime
+// allocates a NUL-terminated heap buffer that the existing
+// mochi_print_str writes to stdout.
+func TestBuildSourceStrConcatLiteral(t *testing.T) {
+	src := `print("hello, " + "world")` + "\n"
+	if got, want := runMochiBuild(t, src), "hello, world\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStrConcatLet pins concat over let-bound carriers:
+// the side-table holds each literal; OpConcatStr reads the carrier
+// variables and the heap result re-binds to a fresh carrier.
+func TestBuildSourceStrConcatLet(t *testing.T) {
+	src := `let a = "foo"
+let b = "bar"
+print(a + b)
+`
+	if got, want := runMochiBuild(t, src), "foobar\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStrConcatChain pins left-associative chaining: the
+// frontend's Shunting-Yard lowering produces a left-leaning tree, so
+// "[" + a + "-" + b + "]" lowers to four nested OpConcatStr calls
+// each receiving the previous heap pointer as left arg.
+func TestBuildSourceStrConcatChain(t *testing.T) {
+	src := `let a = "foo"
+let b = "bar"
+print("[" + a + "-" + b + "]")
+`
+	if got, want := runMochiBuild(t, src), "[foo-bar]\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStrConcatLenComposes pins len applied to a concat
+// result, exercising that the heap carrier is NUL-terminated so
+// strlen reads the joined byte length.
+func TestBuildSourceStrConcatLenComposes(t *testing.T) {
+	src := `let a = "abc"
+let b = "defgh"
+print(len(a + b))
+`
+	if got, want := runMochiBuild(t, src), "8\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStrConcatEqComposes pins equality on a concat
+// result: strcmp reads through the heap carrier as it would through
+// a literal. Mochi's `==` is byte equality on the joined sequence.
+func TestBuildSourceStrConcatEqComposes(t *testing.T) {
+	src := `let a = "hel"
+let b = "lo"
+if a + b == "hello" {
+  print("matched")
+}
+`
+	if got, want := runMochiBuild(t, src), "matched\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceSpectralNormBgFixture pins the unmodified
 // bench/template/bg/spectral_norm fixture (N=100) on the C target.
 // This is the §10.7 closeout for spectral_norm at the fixture level

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -67,6 +67,7 @@ func Emit(p *Program) ([]byte, error) {
 	usesMapI64I64 := false
 	usesTree := false
 	usesStrH := false
+	usesStrRuntime := false
 	for _, fn := range p.Funcs {
 		for _, v := range fn.Values {
 			switch v.Op {
@@ -93,6 +94,8 @@ func Emit(p *Program) ([]byte, error) {
 				usesTree = true
 			case ir.OpLenStr, ir.OpCmpEqStr, ir.OpCmpNeStr:
 				usesStrH = true
+			case ir.OpConcatStr:
+				usesStrRuntime = true
 			case ir.OpNow:
 				usesNow = true
 			}
@@ -124,6 +127,9 @@ func Emit(p *Program) ([]byte, error) {
 	}
 	if usesStrH {
 		buf.WriteString("#include <string.h>\n")
+	}
+	if usesStrRuntime {
+		buf.WriteString("#include \"mochi_str.h\"\n")
 	}
 	buf.WriteString("\n")
 
@@ -398,6 +404,14 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    %s = (strcmp(%s, %s) == 0);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpCmpNeStr:
 		fmt.Fprintf(w, "    %s = (strcmp(%s, %s) != 0);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpConcatStr:
+		// mochi_str_concat allocates a NUL-terminated byte sequence
+		// holding the bytes of v.Args[0] followed by v.Args[1] and
+		// returns a `const char*` carrier the rest of the Phase 4.2.x
+		// string ops accept without distinguishing literal from heap.
+		// The buffer leaks; see runtime/c/src/mochi_str.h for the
+		// ownership note.
+		fmt.Fprintf(w, "    %s = mochi_str_concat(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpNow:
 		fmt.Fprintf(w, "    %s = mochi_now_us();\n", name)
 	case ir.OpJsonI64Object:

--- a/compiler3/emit/c/emit_test.go
+++ b/compiler3/emit/c/emit_test.go
@@ -151,18 +151,21 @@ func TestEmitMainF64(t *testing.T) {
 // driver downstream treats this as a clean "AOT cannot lower this
 // program" signal.
 func TestEmitUnsupportedOp(t *testing.T) {
-	fn := &ir.Function{Name: "bad", Result: ir.TypeStr}
+	fn := &ir.Function{Name: "bad", Result: ir.TypeF64}
 	bid := fn.AddBlock()
-	// OpConcatStr is out of Phase 4.2 scope (Phase 4.2.x widens to
-	// owning mochi_str when string concat lands; until then it is the
-	// canonical unsupported-op probe for the C emitter).
-	a := fn.AddValue(ir.Value{Type: ir.TypeStr, Op: ir.OpParam})
-	b := fn.AddValue(ir.Value{Type: ir.TypeStr, Op: ir.OpParam})
-	fn.Params = []uint32{a, b}
-	cc := fn.AddValue(ir.Value{Type: ir.TypeStr, Op: ir.OpConcatStr, Args: []uint32{a, b}})
+	// OpListGetF64 is the C-target's canonical unsupported-op probe:
+	// the C emitter routes `list<float>` through OpNewF64Array (a
+	// flat double[] backing) rather than the vm3 Cell-tagged list,
+	// so OpListGetF64 never appears in code the frontend produces.
+	// A hand-crafted IR value with this op is the cleanest way to
+	// exercise the default unsupported-op error.
+	xs := fn.AddValue(ir.Value{Type: ir.TypeList, Op: ir.OpParam})
+	i := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpParam})
+	fn.Params = []uint32{xs, i}
+	g := fn.AddValue(ir.Value{Type: ir.TypeF64, Op: ir.OpListGetF64, Args: []uint32{xs, i}})
 	blk := fn.Block(bid)
-	blk.Values = []uint32{cc}
-	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: cc}
+	blk.Values = []uint32{g}
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: g}
 	_, err := Emit(&Program{Funcs: []*ir.Function{fn}})
 	if err == nil {
 		t.Fatalf("expected ErrUnsupportedOp, got nil")

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1339,6 +1339,8 @@ func (b *builder) applyBinOp(op string, l, r uint32) (uint32, error) {
 		}
 	case ir.TypeStr:
 		switch op {
+		case "+":
+			code = ir.OpConcatStr
 		case "==":
 			code = ir.OpCmpEqStr
 			resType = ir.TypeBool

--- a/runtime/c/doc.go
+++ b/runtime/c/doc.go
@@ -24,5 +24,5 @@ import "embed"
 // files when cgo is off (and the whole point of this package is to
 // stay no-cgo on the build host).
 //
-//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c src/mochi_f64_array.h src/mochi_f64_array.c src/mochi_time.h src/mochi_time.c src/mochi_map_i64_i64.h src/mochi_map_i64_i64.c src/mochi_tree.h src/mochi_tree.c
+//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c src/mochi_f64_array.h src/mochi_f64_array.c src/mochi_time.h src/mochi_time.c src/mochi_map_i64_i64.h src/mochi_map_i64_i64.c src/mochi_tree.h src/mochi_tree.c src/mochi_str.h src/mochi_str.c
 var Runtime embed.FS

--- a/runtime/c/src/mochi_str.c
+++ b/runtime/c/src/mochi_str.c
@@ -1,0 +1,24 @@
+/*
+ * MEP-42 Phase 4.2.3 C-target string runtime. See mochi_str.h for
+ * the contract.
+ */
+#include "mochi_str.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+const char *mochi_str_concat(const char *a, const char *b) {
+    size_t la = strlen(a);
+    size_t lb = strlen(b);
+    /*
+     * The +1 reserves room for the NUL terminator so the result
+     * remains a valid C string for downstream strlen / strcmp /
+     * fputs calls (the Phase 4.2.0-4.2.2 string ops all read
+     * through the NUL-terminated path).
+     */
+    char *out = (char *)malloc(la + lb + 1);
+    memcpy(out, a, la);
+    memcpy(out + la, b, lb);
+    out[la + lb] = '\0';
+    return out;
+}

--- a/runtime/c/src/mochi_str.h
+++ b/runtime/c/src/mochi_str.h
@@ -1,0 +1,43 @@
+/*
+ * MEP-42 Phase 4.2.3 C-target string runtime.
+ *
+ * Backs Mochi's `+` operator on TypeStr when the program is
+ * compiled with `mochi build --target=c`. Phase 4.2.0-4.2.2 used
+ * `const char*` carriers pointing at C99 read-only string-literal
+ * storage; that aliasing model worked for literals, print, len,
+ * and strcmp because none of them allocated. Concat is the first
+ * op whose result has no source-pointed literal to alias, so the
+ * runtime allocates a NUL-terminated heap buffer and hands back
+ * a pointer the caller treats as `const char*`.
+ *
+ * Identity: pure C99, no libc beyond stdlib.h/string.h. The
+ * runtime is dropped next to gen.c by the build driver and
+ * compiled in the same cc invocation; no separate library.
+ *
+ * Ownership: the returned buffer is heap-resident and currently
+ * leaks at process exit. Mochi-on-C MVP programs run to completion
+ * in seconds (the bench corpus), so a leak in a tight concat loop
+ * is documented as a known limitation; a later 4.2.x sub-phase
+ * adds an arena once a long-running fixture surfaces.
+ */
+#ifndef MOCHI_RUNTIME_C_STR_H
+#define MOCHI_RUNTIME_C_STR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * mochi_str_concat returns a freshly allocated NUL-terminated byte
+ * sequence containing the bytes of a followed by the bytes of b.
+ * The result is owned by the runtime (currently leaked); callers
+ * must not free() it. Both inputs are NUL-terminated `const char*`
+ * carriers from the Phase 4.2.0 lowering of string literals.
+ */
+const char *mochi_str_concat(const char *a, const char *b);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOCHI_RUNTIME_C_STR_H */

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -664,7 +664,7 @@ This is the contract behind the §Top-line objective. Every IR `OpCode` and `Typ
 | `OpFnRef` | function-pointer literal | DEFERRED Phase 4.4 |
 | `OpLenStr` | `(int64_t)strlen(s)` for the `const char*` carrier; auto-includes `<string.h>` | LANDED (Phase 4.2.1) |
 | `OpCmpEqStr` / `OpCmpNeStr` | `(strcmp(a, b) == 0)` / `!= 0` over the `const char*` carriers | LANDED (Phase 4.2.2) |
-| `OpConcatStr` | `mochi_str_concat` (requires owning `mochi_str`) | DEFERRED Phase 4.2.x |
+| `OpConcatStr` | `mochi_str_concat(a, b)` allocates a NUL-terminated heap buffer and returns a `const char*` carrier (leaks at process exit; arena lands in a later 4.2.x) | LANDED (Phase 4.2.3) |
 | `OpNewList` / `OpListLenI64` / `OpListPushI64` / `OpListGetI64` / `OpListSetI64` | `mochi_list_i64_*` runtime (heap-allocated header, doubling growth) | LANDED (Phase 4.3.1) |
 | `OpListGetF64` / `OpListSetF64` | not lowered by the C target; `list<float>` routes through `OpNewF64Array` instead | N/A (vm3 surface) |
 | `OpNewMap` / `OpMapSet/Get/I64I64` | `mochi_map_*` runtime | DEFERRED Phase 4.3 |
@@ -1880,8 +1880,30 @@ After Phase 4.2.1, a user could write a literal, print it, and ask for its lengt
 
 ### Limitations
 
-- Still no concat (`+`) or relational comparisons (`<`, `<=`, `>`, `>=`). Concat needs an owning `mochi_str`; relational comparisons could be added today with a single `strcmp(a, b) <op> 0` lowering but the bench corpus has no user yet, so they are deferred until one surfaces.
+- Still no relational comparisons (`<`, `<=`, `>`, `>=`). They could be added today with a single `strcmp(a, b) <op> 0` lowering but the bench corpus has no user yet, so they are deferred until one surfaces. Concat (`+`) is wired in Phase 4.2.3 (below).
 - Equality is byte-level. Two strings encoding the same logical character via different UTF-8 normalisations would compare unequal. That matches Go's `==` behaviour and the Mochi spec.
+
+## §10.30 Phase 4.2.3 closeout (LANDED 2026-05-22 08:23 GMT+7)
+
+Phase 4.2.3 wires string concat (`+`) on the C target. Before this sub-phase, `print("hello, " + name)` errored at the frontend with `binop "+" on type str unsupported in MVP`. After it, the same source compiles unchanged on both `--target=c` and `--target=go`, and the user-visible single-tool-bootstrap story finally covers the canonical hello-name pattern.
+
+### What landed
+
+- `runtime/c/src/mochi_str.{h,c}` (new): `mochi_str_concat(const char *a, const char *b)` returns a freshly allocated NUL-terminated `const char*` containing the bytes of `a` followed by the bytes of `b`. Pure C99, no libc beyond `stdlib.h` / `string.h`. Embedded via `runtime/c/doc.go` so the build driver writes it next to `gen.c`.
+- `compiler3/emit/c/emit.go`: new `OpConcatStr` case lowers to `mochi_str_concat(a, b)`. Pre-pass adds a `usesStrRuntime` flag that fires when `OpConcatStr` is present, auto-including `mochi_str.h` and (via the driver's existing embed walk) compiling `mochi_str.c` alongside `gen.c`.
+- `compiler3/frontend/lower.go`: `lowerBinary`'s TypeStr arm gains a `+` branch that lowers to `OpConcatStr` (result type stays TypeStr).
+- `compiler3/emit/c/emit_test.go`: `TestEmitUnsupportedOp` repointed from `OpConcatStr` to `OpListGetF64`, the new canonical unsupported-op probe (the C target routes `list<float>` through `OpNewF64Array` instead, so `OpListGetF64` is unreachable from the frontend).
+- `compiler3/build/c/driver_test.go`: five new tests covering literal concat, let-bound concat, three-way chain, `len()` composed on a concat result, and `==` composed on a concat result.
+
+### Why this closes a goal
+
+The §Top-line objective is the smallest user-facing bootstrap demo. Phase 4.2.0 made `print("hello, world!")` build; Phase 4.2.1 added `len(s)`; Phase 4.2.2 added equality. Concat is the next-most-natural primitive a Mochi newcomer reaches for, and was the last allocation-free-no-more gate. After this sub-phase, a program like `let name = "world"; print("hello, " + name)` produces a single native binary that prints `hello, world` byte-identical to `mochi run`.
+
+### Limitations
+
+- Heap result leaks at process exit. The MVP target is short-running batch programs (the bench corpus all run in seconds); a long-running concat-in-hot-loop fixture would leak unboundedly. A later 4.2.x sub-phase adds a per-program arena that frees on `mochi_main` return, once a long-running fixture surfaces the gap.
+- Concat result is NUL-terminated. An embedded `\0` in either input would truncate downstream `strlen` / `strcmp` reads. The literal lowering in Phase 4.2.0 uses octal escapes that can encode a `\0` byte, but the bench corpus has no such fixture. A future widening that introduces an owning `mochi_str` with explicit length retires this corner.
+- No string slicing, indexing, or formatted construction (e.g. `str(42)`). Those are independent gates handled by later sub-phases.
 
 ## §11 Risks
 


### PR DESCRIPTION
Closes #21999. Follows #21998 (Phase 4.2.2 string equality).

## Summary

- New `runtime/c/src/mochi_str.{h,c}` with `mochi_str_concat(a, b)`; embedded via `runtime/c/doc.go`.
- C emit lowers `OpConcatStr` to `mochi_str_concat(a, b)` and auto-includes the new header.
- Frontend `lowerBinary` TypeStr arm gains `+`.
- `TestEmitUnsupportedOp` repointed to `OpListGetF64` (C target routes `list<float>` through `OpNewF64Array`).
- 5 new driver tests; MEP-42 §10.6 row LANDED; §10.30 closeout.

## Why

Last alloc-free-no-more string gate. After this, the canonical newcomer demo `print("hello, " + name)` produces a single native binary on the C target, byte-identical to `mochi run`.

## Known limitation

Heap result leaks at process exit. Acceptable for the MVP's short-running batch programs; arena lands in a later 4.2.x sub-phase when a long-running fixture surfaces.

## Test plan

- [x] `go test ./compiler3/... -count=1` (green sweep)
- [x] `print("hello, " + "world")` builds and prints `hello, world`
- [x] `len("foo" + "bar")` returns `6`
- [x] `"hel" + "lo" == "hello"` is true
- [x] 5 new driver tests pass