### PR TITLE
mep-0042: Phase 4.2.4 str(int/float/bool) on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -1503,6 +1503,80 @@ if a + b == "hello" {
 	}
 }
 
+// TestBuildSourceStrIntLiteral pins MEP-42 Phase 4.2.4: `str(42)`
+// on an int literal lowers to OpI64ToStr, the C emitter calls
+// mochi_str_from_i64, the runtime allocates a decimal carrier and
+// mochi_print_str writes it to stdout. The numeric value matches
+// PRId64 byte-for-byte.
+func TestBuildSourceStrIntLiteral(t *testing.T) {
+	src := `print(str(42))` + "\n"
+	if got, want := runMochiBuild(t, src), "42\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStrIntNegative pins the sign-preserving shape of
+// mochi_str_from_i64: PRId64 prints a leading '-' for negative
+// values, so the carrier round-trips through Mochi's i64 range.
+func TestBuildSourceStrIntNegative(t *testing.T) {
+	src := `print(str(-7))` + "\n"
+	if got, want := runMochiBuild(t, src), "-7\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStrFloatLiteral pins `str(3.5)` on an f64 literal:
+// mochi_str_from_f64 runs the shortest-round-trip search shared
+// with print.c, so str(x) and print(x) agree on the digits printed.
+func TestBuildSourceStrFloatLiteral(t *testing.T) {
+	src := `print(str(3.5))` + "\n"
+	if got, want := runMochiBuild(t, src), "3.5\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStrBoolTrue / False pin the static-literal return
+// of mochi_str_from_bool: no heap allocation, just one of two C99
+// literals. The bool carrier is interchangeable with a literal at
+// every downstream string op (concat, print, len, strcmp).
+func TestBuildSourceStrBoolTrue(t *testing.T) {
+	src := `print(str(true))` + "\n"
+	if got, want := runMochiBuild(t, src), "true\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildSourceStrBoolFalse(t *testing.T) {
+	src := `print(str(false))` + "\n"
+	if got, want := runMochiBuild(t, src), "false\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStrConcatWithInt pins composition with OpConcatStr:
+// `"answer: " + str(x)` lowers to mochi_str_from_i64 followed by
+// mochi_str_concat. This is the user-facing motivation for Phase
+// 4.2.4 (formatted print without multi-line value-only print calls).
+func TestBuildSourceStrConcatWithInt(t *testing.T) {
+	src := `let x = 42
+print("answer: " + str(x))
+`
+	if got, want := runMochiBuild(t, src), "answer: 42\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStrConcatWithBool pins composition of the static
+// "true"/"false" literal with mochi_str_concat: the static buffer is
+// a valid `const char*` carrier, so strcmp/strlen/concat treat it
+// identically to a heap-allocated carrier.
+func TestBuildSourceStrConcatWithBool(t *testing.T) {
+	src := `print("ok=" + str(true))` + "\n"
+	if got, want := runMochiBuild(t, src), "ok=true\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceSpectralNormBgFixture pins the unmodified
 // bench/template/bg/spectral_norm fixture (N=100) on the C target.
 // This is the §10.7 closeout for spectral_norm at the fixture level

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -94,7 +94,7 @@ func Emit(p *Program) ([]byte, error) {
 				usesTree = true
 			case ir.OpLenStr, ir.OpCmpEqStr, ir.OpCmpNeStr:
 				usesStrH = true
-			case ir.OpConcatStr:
+			case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr:
 				usesStrRuntime = true
 			case ir.OpNow:
 				usesNow = true
@@ -412,6 +412,19 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		// The buffer leaks; see runtime/c/src/mochi_str.h for the
 		// ownership note.
 		fmt.Fprintf(w, "    %s = mochi_str_concat(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpI64ToStr:
+		// Decimal i64 via snprintf("%lld"). The runtime returns a
+		// freshly allocated `const char*` carrier (see mochi_str.h).
+		fmt.Fprintf(w, "    %s = mochi_str_from_i64((long long)%s);\n", name, valueName(v.Args[0]))
+	case ir.OpF64ToStr:
+		// Shortest round-trip f64 via the same search used by
+		// runtime/c/src/print.c mochi_print_f64.
+		fmt.Fprintf(w, "    %s = mochi_str_from_f64(%s);\n", name, valueName(v.Args[0]))
+	case ir.OpBoolToStr:
+		// Returns one of two static literals "true"/"false"; no
+		// allocation. The literal type matches every other Phase 4.2.x
+		// string carrier so downstream concat/print/len/strcmp work.
+		fmt.Fprintf(w, "    %s = mochi_str_from_bool(%s);\n", name, valueName(v.Args[0]))
 	case ir.OpNow:
 		fmt.Fprintf(w, "    %s = mochi_now_us();\n", name)
 	case ir.OpJsonI64Object:

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -304,6 +304,15 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 		fmt.Fprintf(w, "\t%s = %s == %s\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpCmpNeStr:
 		fmt.Fprintf(w, "\t%s = %s != %s\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpI64ToStr:
+		imports["strconv"] = true
+		fmt.Fprintf(w, "\t%s = strconv.FormatInt(%s, 10)\n", name, valueName(v.Args[0]))
+	case ir.OpF64ToStr:
+		imports["strconv"] = true
+		fmt.Fprintf(w, "\t%s = strconv.FormatFloat(%s, 'g', -1, 64)\n", name, valueName(v.Args[0]))
+	case ir.OpBoolToStr:
+		imports["strconv"] = true
+		fmt.Fprintf(w, "\t%s = strconv.FormatBool(%s)\n", name, valueName(v.Args[0]))
 	case ir.OpNewList:
 		fmt.Fprintf(w, "\t%s = []int64{}\n", name)
 	case ir.OpListLenI64:

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1727,6 +1727,29 @@ func (b *builder) lowerBuiltinCall(c *parser.CallExpr) (uint32, bool, error) {
 		}
 		id := b.addValue(ir.Value{Type: ir.TypeI64, Op: ir.OpNow})
 		return id, true, nil
+	case "str":
+		if len(c.Args) != 1 {
+			return 0, true, fmt.Errorf("frontend: str() takes 1 argument, got %d", len(c.Args))
+		}
+		arg, err := b.lowerExpr(c.Args[0])
+		if err != nil {
+			return 0, true, err
+		}
+		switch b.fn.Values[arg].Type {
+		case ir.TypeStr:
+			return arg, true, nil
+		case ir.TypeI64:
+			id := b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpI64ToStr, Args: []uint32{arg}})
+			return id, true, nil
+		case ir.TypeF64:
+			id := b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpF64ToStr, Args: []uint32{arg}})
+			return id, true, nil
+		case ir.TypeBool:
+			id := b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpBoolToStr, Args: []uint32{arg}})
+			return id, true, nil
+		default:
+			return 0, true, fmt.Errorf("frontend: str(%s) unsupported in MVP", b.fn.Values[arg].Type)
+		}
 	}
 	switch c.Func {
 	case "len":

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -134,6 +134,14 @@ const (
 	OpConcatStr
 	OpCmpEqStr
 	OpCmpNeStr
+	// Scalar→str conversions (MEP-42 Phase 4.2.4). Surface form
+	// `str(x)` where x is i64/f64/bool. Result owns a freshly
+	// allocated string; the bool form returns a static "true"/"false"
+	// literal so it does not allocate. Go emit calls strconv.FormatInt
+	// / FormatFloat / FormatBool; C emit calls into mochi_str.h.
+	OpI64ToStr
+	OpF64ToStr
+	OpBoolToStr
 
 	// List ops (Phase 3.2 vm3 surface).
 	OpNewList
@@ -357,6 +365,12 @@ func (o OpCode) String() string {
 		return "cmp.eq.str"
 	case OpCmpNeStr:
 		return "cmp.ne.str"
+	case OpI64ToStr:
+		return "i64.to.str"
+	case OpF64ToStr:
+		return "f64.to.str"
+	case OpBoolToStr:
+		return "bool.to.str"
 	case OpNewList:
 		return "newlist"
 	case OpListLenI64:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -177,6 +177,12 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeStr, [3]Type{TypeStr, TypeStr}}
 	case OpCmpEqStr, OpCmpNeStr:
 		return opSig{TypeBool, [3]Type{TypeStr, TypeStr}}
+	case OpI64ToStr:
+		return opSig{TypeStr, [3]Type{TypeI64}}
+	case OpF64ToStr:
+		return opSig{TypeStr, [3]Type{TypeF64}}
+	case OpBoolToStr:
+		return opSig{TypeStr, [3]Type{TypeBool}}
 	case OpNewList:
 		return opSig{TypeList, [3]Type{}}
 	case OpListLenI64:

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -166,7 +166,7 @@ func kindOf(o ir.OpCode) ProducerKind {
 
 	case ir.OpLenStr:
 		return KindDispatch
-	case ir.OpConcatStr:
+	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr:
 		return KindConstructor
 
 	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array, ir.OpNewListAny,
@@ -402,7 +402,7 @@ func contractResult(o ir.OpCode) ir.Type {
 		return ir.TypeBool
 	case ir.OpLenStr:
 		return ir.TypeI64
-	case ir.OpConcatStr:
+	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr:
 		return ir.TypeStr
 	case ir.OpNewList:
 		return ir.TypeList

--- a/runtime/c/src/mochi_str.c
+++ b/runtime/c/src/mochi_str.c
@@ -4,6 +4,8 @@
  */
 #include "mochi_str.h"
 
+#include <inttypes.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -21,4 +23,50 @@ const char *mochi_str_concat(const char *a, const char *b) {
     memcpy(out + la, b, lb);
     out[la + lb] = '\0';
     return out;
+}
+
+const char *mochi_str_from_i64(long long v) {
+    /*
+     * INT64_MIN renders as "-9223372036854775808" (20 chars + NUL),
+     * so a 24-byte buffer covers every i64 with margin.
+     */
+    char buf[24];
+    int n = snprintf(buf, sizeof buf, "%" PRId64, (int64_t)v);
+    char *out = (char *)malloc((size_t)n + 1);
+    memcpy(out, buf, (size_t)n + 1);
+    return out;
+}
+
+const char *mochi_str_from_f64(double v) {
+    /*
+     * Shortest round-trip: mirror runtime/c/src/print.c mochi_print_f64
+     * so str(x) and print(x) produce the same digits for the same
+     * double, matching Go's strconv.FormatFloat(v, 'g', -1, 64).
+     */
+    char buf[64];
+    int p;
+    int n = 0;
+    for (p = 1; p <= 17; p++) {
+        n = snprintf(buf, sizeof buf, "%.*g", p, v);
+        double back = strtod(buf, NULL);
+        if (back == v) {
+            break;
+        }
+    }
+    if (p > 17) {
+        n = snprintf(buf, sizeof buf, "%.17g", v);
+    }
+    char *out = (char *)malloc((size_t)n + 1);
+    memcpy(out, buf, (size_t)n + 1);
+    return out;
+}
+
+const char *mochi_str_from_bool(int v) {
+    /*
+     * Returns one of two static C99 string literals. No allocation:
+     * the carrier discipline (everywhere a `const char*` is treated
+     * as borrowed) makes the static-literal-vs-heap distinction
+     * invisible to the Mochi level.
+     */
+    return v ? "true" : "false";
 }

--- a/runtime/c/src/mochi_str.h
+++ b/runtime/c/src/mochi_str.h
@@ -36,6 +36,23 @@ extern "C" {
  */
 const char *mochi_str_concat(const char *a, const char *b);
 
+/*
+ * mochi_str_from_i64 / mochi_str_from_f64 return freshly allocated
+ * NUL-terminated decimal representations (the int form is %lld via
+ * PRId64; the float form is a shortest round-trip representation
+ * matching the Go target's strconv.FormatFloat('g', -1, 64)). The
+ * result is owned by the runtime (currently leaked); callers must
+ * not free() it.
+ *
+ * mochi_str_from_bool returns one of two static C99 string literals,
+ * "true" or "false". The result is not heap-allocated, but callers
+ * treat all three the same way (as `const char*` carriers) because
+ * no Mochi operation distinguishes a literal from an allocation.
+ */
+const char *mochi_str_from_i64(long long v);
+const char *mochi_str_from_f64(double v);
+const char *mochi_str_from_bool(int v);
+
 #ifdef __cplusplus
 }
 #endif

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -665,6 +665,9 @@ This is the contract behind the §Top-line objective. Every IR `OpCode` and `Typ
 | `OpLenStr` | `(int64_t)strlen(s)` for the `const char*` carrier; auto-includes `<string.h>` | LANDED (Phase 4.2.1) |
 | `OpCmpEqStr` / `OpCmpNeStr` | `(strcmp(a, b) == 0)` / `!= 0` over the `const char*` carriers | LANDED (Phase 4.2.2) |
 | `OpConcatStr` | `mochi_str_concat(a, b)` allocates a NUL-terminated heap buffer and returns a `const char*` carrier (leaks at process exit; arena lands in a later 4.2.x) | LANDED (Phase 4.2.3) |
+| `OpI64ToStr` | `mochi_str_from_i64((long long)v)` formats via `snprintf("%lld")` into a fresh heap buffer (24-byte max for i64 + NUL) | LANDED (Phase 4.2.4) |
+| `OpF64ToStr` | `mochi_str_from_f64(v)` runs the shortest-round-trip search shared with `mochi_print_f64`, so `str(x)` and `print(x)` agree on digits | LANDED (Phase 4.2.4) |
+| `OpBoolToStr` | `mochi_str_from_bool(v)` returns one of two static C99 literals `"true"` / `"false"`; no allocation | LANDED (Phase 4.2.4) |
 | `OpNewList` / `OpListLenI64` / `OpListPushI64` / `OpListGetI64` / `OpListSetI64` | `mochi_list_i64_*` runtime (heap-allocated header, doubling growth) | LANDED (Phase 4.3.1) |
 | `OpListGetF64` / `OpListSetF64` | not lowered by the C target; `list<float>` routes through `OpNewF64Array` instead | N/A (vm3 surface) |
 | `OpNewMap` / `OpMapSet/Get/I64I64` | `mochi_map_*` runtime | DEFERRED Phase 4.3 |
@@ -1904,6 +1907,30 @@ The §Top-line objective is the smallest user-facing bootstrap demo. Phase 4.2.0
 - Heap result leaks at process exit. The MVP target is short-running batch programs (the bench corpus all run in seconds); a long-running concat-in-hot-loop fixture would leak unboundedly. A later 4.2.x sub-phase adds a per-program arena that frees on `mochi_main` return, once a long-running fixture surfaces the gap.
 - Concat result is NUL-terminated. An embedded `\0` in either input would truncate downstream `strlen` / `strcmp` reads. The literal lowering in Phase 4.2.0 uses octal escapes that can encode a `\0` byte, but the bench corpus has no such fixture. A future widening that introduces an owning `mochi_str` with explicit length retires this corner.
 - No string slicing, indexing, or formatted construction (e.g. `str(42)`). Those are independent gates handled by later sub-phases.
+
+## §10.31 Phase 4.2.4 closeout (LANDED 2026-05-22 08:28 GMT+7)
+
+Phase 4.2.4 wires scalar→string conversion (`str(x)`) on the C target for `int`, `float`, and `bool` arguments. Before this sub-phase, the frontend's `lowerBuiltinCall` did not recognise `str` as a builtin, so `print("answer: " + str(x))` errored at parse time with `unknown function "str"`. After it, the same source compiles unchanged on both `--target=c` and `--target=go`, closing the most common formatted-print pattern a Mochi user reaches for (one-line `print` instead of two `print` statements: a label, then the value).
+
+### What landed
+
+- `compiler3/ir/types.go` + `validate.go`: three new ops, `OpI64ToStr`, `OpF64ToStr`, `OpBoolToStr`. Each takes a single arg of the matching scalar type and returns `TypeStr`. Signature added to `opContract`.
+- `compiler3/verify/verify.go`: all three classified as `KindConstructor` (they produce a freshly-shaped `TypeStr` handle, matching `OpConcatStr`'s discipline). `contractResult` adds the new ops to the `TypeStr`-returning row.
+- `runtime/c/src/mochi_str.{h,c}`: extended with `mochi_str_from_i64` (snprintf via `PRId64` into a 24-byte buffer, malloc + memcpy out), `mochi_str_from_f64` (shortest-round-trip search mirroring `mochi_print_f64` so `str(x)` and `print(x)` produce identical digits), and `mochi_str_from_bool` (returns one of two static C99 literals, no allocation).
+- `compiler3/emit/c/emit.go`: pre-pass extends `usesStrRuntime` to fire for `OpI64ToStr`/`OpF64ToStr`/`OpBoolToStr`, ensuring `mochi_str.h` is included whenever any scalar conversion is present. Three new emit cases lower to the matching runtime call.
+- `compiler3/emit/go/emit.go`: three cases route to `strconv.FormatInt(v, 10)`, `strconv.FormatFloat(v, 'g', -1, 64)`, and `strconv.FormatBool(v)` respectively, auto-importing `strconv`.
+- `compiler3/frontend/lower.go`: `lowerBuiltinCall` adds a `str` case in the first switch (next to `int`, `float`, `now`). It dispatches by arg type: `TypeStr` → identity, `TypeI64`/`TypeF64`/`TypeBool` → matching IR op, anything else → `frontend: str(X) unsupported in MVP`.
+- `compiler3/build/c/driver_test.go`: seven new tests covering `str(42)`, `str(-7)`, `str(3.5)`, `str(true)`, `str(false)`, `"answer: " + str(x)`, and `"ok=" + str(true)`. The last two pin the composition with `OpConcatStr` that motivated the sub-phase.
+
+### Why this closes a goal
+
+The §Top-line objective is the smallest user-facing bootstrap demo. Phase 4.2.0-4.2.3 covered string literals, `print`, `len`, equality, and concat. The missing piece for the typical "print a labeled value" idiom was a way to lift a scalar into a string before concatenating. With `str()` wired, `let x = 42; print("answer: " + str(x))` produces a single native binary that prints `answer: 42` byte-identical to `mochi run`, without falling back to two `print` statements.
+
+### Limitations
+
+- `str(x)` on `i64` and `f64` allocates a heap buffer that leaks at process exit, same model as `OpConcatStr`. A per-program arena would retire this; deferred until a fixture exposes the leak.
+- `str(x)` on `bool` returns a static literal pointer (no allocation). A future widening that distinguishes owning from borrowed string carriers would need a uniform handle; today the `const char*` carrier discipline makes the literal-vs-heap split invisible to the Mochi level.
+- No `str()` on lists, maps, structs, or any other compound type. The Mochi surface form `str([1,2,3])` errors with `frontend: str(list) unsupported in MVP`. Compound formatting is a separate larger gate (it implies recursive descent and a structural-equality story for nested fields).
 
 ## §11 Risks
 


### PR DESCRIPTION
Closes #22001. Sub-phase of MEP-42 §10 Phase 4.2.x.

## Summary

- Wires `str(x)` scalar→string conversion on the C target for `i64`, `f64`, and `bool`.
- New IR ops: `OpI64ToStr`, `OpF64ToStr`, `OpBoolToStr` (each returns `TypeStr`).
- C runtime: `mochi_str_from_i64` / `_f64` / `_bool` in `runtime/c/src/mochi_str.{h,c}`.
- Go target: `strconv.FormatInt` / `FormatFloat` / `FormatBool`.
- Frontend: `lowerBuiltinCall` recognises `str(x)` and dispatches by arg type.
- Closes the formatted-print gap: `print("answer: " + str(x))` now compiles on `--target=c` and `--target=go`.

See `website/docs/mep/mep-0042.md` §10.31 for the full closeout.

## Test plan

- [x] `go test ./compiler3/ir/... ./compiler3/verify/... ./compiler3/emit/go/... ./compiler3/emit/c/...`
- [x] `go test ./compiler3/build/c/... -run 'TestBuildSourceStr(Int|Float|Bool|ConcatWith)'`
- [x] `go test ./compiler3/...`