### PR TITLE
mep-0042: Phase 4.2.5 homepage hello fixture green on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -1577,6 +1577,25 @@ func TestBuildSourceStrConcatWithBool(t *testing.T) {
 	}
 }
 
+// TestBuildSourceWebsiteHomepageHello pins MEP-42 Phase 4.2.5: the
+// canonical hello program from `examples/website/hello.mochi`, the
+// homepage demo on mochi-lang.dev. It is the smallest end-to-end
+// user-facing program that exercises the full Phase 4.2.x string
+// stack (let-bound string, concat with `+`, `str(int)` lift, two
+// `print` calls back-to-back). Reads the file verbatim so a future
+// rewrite of the homepage demo is caught as a regression here.
+func TestBuildSourceWebsiteHomepageHello(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/website/hello.mochi")
+	if err != nil {
+		t.Fatalf("read homepage hello fixture: %v", err)
+	}
+	src := string(srcBytes)
+	want := "Hello, Mochi!\nthe answer is 42\n"
+	if got := runMochiBuild(t, src); got != want {
+		t.Errorf("homepage hello stdout = %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceSpectralNormBgFixture pins the unmodified
 // bench/template/bg/spectral_norm fixture (N=100) on the C target.
 // This is the §10.7 closeout for spectral_norm at the fixture level

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -1932,6 +1932,34 @@ The §Top-line objective is the smallest user-facing bootstrap demo. Phase 4.2.0
 - `str(x)` on `bool` returns a static literal pointer (no allocation). A future widening that distinguishes owning from borrowed string carriers would need a uniform handle; today the `const char*` carrier discipline makes the literal-vs-heap split invisible to the Mochi level.
 - No `str()` on lists, maps, structs, or any other compound type. The Mochi surface form `str([1,2,3])` errors with `frontend: str(list) unsupported in MVP`. Compound formatting is a separate larger gate (it implies recursive descent and a structural-equality story for nested fields).
 
+## §10.32 Phase 4.2.5 closeout (LANDED 2026-05-22 08:39 GMT+7)
+
+Phase 4.2.5 is a "discovered green" sub-phase: pinning the canonical homepage Mochi program from `examples/website/hello.mochi` as a C-target regression test. The fixture is the program the mochi-lang.dev landing page shows new users; it exercises the full Phase 4.2.x string stack in two short lines:
+
+```
+let name = "Mochi"
+print("Hello, " + name + "!")
+
+let answer = 42
+print("the answer is " + str(answer))
+```
+
+After Phases 4.2.0 (literal + print) → 4.2.1 (len) → 4.2.2 (==/!=) → 4.2.3 (concat) → 4.2.4 (str(i64/f64/bool)), the program compiles end-to-end via `mochi build --target=c` with no remaining surface gaps. The new test reads `examples/website/hello.mochi` verbatim and asserts the produced binary's stdout is `Hello, Mochi!\nthe answer is 42\n`, byte-matching `mochi run` on the same source.
+
+### What landed
+
+- `compiler3/build/c/driver_test.go`: new `TestBuildSourceWebsiteHomepageHello` reads the homepage fixture from `examples/website/hello.mochi` (no string copy, so a future homepage edit is caught as a test failure) and asserts the two-line stdout. No new emit or runtime code; the entire string stack is already wired.
+
+### Why this closes a goal
+
+The §Top-line objective is "the smallest user-facing bootstrap demo". The mochi-lang.dev homepage program is the canonical instance of that demo, and it has been the load-bearing motivation for the entire Phase 4.2.x stream. Pinning it as a regression test turns "the homepage program compiles" from an ad-hoc property into a CI-enforced one: any future refactor of `OpConcatStr`, `OpI64ToStr`, `OpCallGo{print}`, the `const char*` carrier discipline, or the `mochi_str` runtime that breaks the homepage demo fails CI before it merges.
+
+### Limitations
+
+- Still no compound `str()` (list, map, struct). Tracked in §10.31; orthogonal to this sub-phase.
+- Still no string slicing or indexing. Same status.
+- No relational `<`/`<=`/`>`/`>=` on strings. The bench corpus has no user; deferred.
+
 ## §11 Risks
 
 ### 11.1 Clang ABI drift breaks stencils


### PR DESCRIPTION
Closes #22003. Sub-phase of MEP-42 §10 Phase 4.2.x.

## Summary

- Discovered-green: after Phases 4.2.0-4.2.4 (literal+print, len, ==/!=, concat, str), the canonical homepage program at `examples/website/hello.mochi` compiles via `mochi build --target=c`.
- Pinned as a regression test reading the fixture verbatim, so a future refactor of the string stack can't silently break the homepage demo.
- No new emit, runtime, or IR code; this sub-phase is purely a test plus the MEP closeout.

See `website/docs/mep/mep-0042.md` §10.32 for the full closeout.

## Test plan

- [x] `go test ./compiler3/build/c/... -run TestBuildSourceWebsiteHomepageHello -count=1`