### PR TITLE
mep-0042: Phase 4.2.6 multi-arg print on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -1596,6 +1596,54 @@ func TestBuildSourceWebsiteHomepageHello(t *testing.T) {
 	}
 }
 
+// TestBuildSourceMultiArgPrintLabel pins MEP-42 Phase 4.2.6: the
+// common `print("label", value)` idiom from v0.1 tutorial examples
+// lowers to a single mochi_print_str of the space-joined form. The
+// space separator matches Go's fmt.Println default; the value's
+// string form matches strconv (Phase 4.2.4).
+func TestBuildSourceMultiArgPrintLabel(t *testing.T) {
+	src := `let i = 3
+print("i =", i)
+`
+	if got, want := runMochiBuild(t, src), "i = 3\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceMultiArgPrintThree pins the >2 arg case: each
+// successive arg adds a leading " " separator before its string
+// form (Go's fmt.Println behaviour for space-joined Sprint of args).
+func TestBuildSourceMultiArgPrintThree(t *testing.T) {
+	src := `print("Sum", "=", 55)` + "\n"
+	if got, want := runMochiBuild(t, src), "Sum = 55\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceMultiArgPrintMixed pins the heterogeneous-types
+// case: int, float, bool, and string each lifts through the matching
+// scalar->str op (Phase 4.2.4) before joining.
+func TestBuildSourceMultiArgPrintMixed(t *testing.T) {
+	src := `print("answer", 42, 3.5, true)` + "\n"
+	if got, want := runMochiBuild(t, src), "answer 42 3.5 true\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceMultiArgPrintLoop pins the v0.1/for.mochi tutorial
+// surface: `for i in lo..hi { print("i =", i) }` produces one
+// labeled line per iteration. This is the exact user-facing motivation
+// for Phase 4.2.6.
+func TestBuildSourceMultiArgPrintLoop(t *testing.T) {
+	src := `for i in 0..3 {
+  print("i =", i)
+}
+`
+	if got, want := runMochiBuild(t, src), "i = 0\ni = 1\ni = 2\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceSpectralNormBgFixture pins the unmodified
 // bench/template/bg/spectral_norm fixture (N=100) on the C target.
 // This is the §10.7 closeout for spectral_norm at the fixture level

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1052,7 +1052,17 @@ func (b *builder) lowerForCollection(s *parser.ForStmt) error {
 // expressions are lowered as regular expressions and their value is
 // discarded.
 func (b *builder) lowerExprAsStmt(e *parser.Expr) (uint32, error) {
-	if call := exprAsCall(e); call != nil && call.Func == "print" && len(call.Args) == 1 {
+	if call := exprAsCall(e); call != nil && call.Func == "print" && len(call.Args) >= 1 {
+		// Multi-arg print (`print(a, b, c)`) lowers to single-arg
+		// print of the space-joined string form, matching Go's
+		// fmt.Println default. Each non-string arg is lifted via
+		// the matching OpI64ToStr / OpF64ToStr / OpBoolToStr, then
+		// the parts are joined left-to-right with " " separators
+		// through OpConcatStr. This reuses Phase 4.2.3/4.2.4 ops
+		// without inventing a new variadic call.
+		if len(call.Args) > 1 {
+			return b.lowerMultiArgPrint(call.Args)
+		}
 		arg, err := b.lowerExpr(call.Args[0])
 		if err != nil {
 			return 0, err
@@ -1081,6 +1091,67 @@ func (b *builder) lowerExprAsStmt(e *parser.Expr) (uint32, error) {
 		return 0, fmt.Errorf("frontend: json() requires a map literal argument in MVP")
 	}
 	return b.lowerExpr(e)
+}
+
+// lowerMultiArgPrint lowers `print(a, b, ..., z)` (N >= 2) by lifting
+// each non-string arg through the matching scalar→str op, then
+// left-fold-joining the parts with " " separators via OpConcatStr,
+// and finally calling the single-arg print path on the result. The
+// space-separator + final newline matches Go's `fmt.Println(a, b, ..)`
+// default for the scalar arg set Mochi supports (TypeStr, TypeI64,
+// TypeF64, TypeBool); each scalar's string form matches strconv's
+// FormatInt/FormatFloat/FormatBool, which Go's fmt %v defaults to
+// for these types.
+func (b *builder) lowerMultiArgPrint(args []*parser.Expr) (uint32, error) {
+	sepIdx := int64(len(b.fn.Strings))
+	b.fn.Strings = append(b.fn.Strings, " ")
+	sepID := b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpConst, Const: sepIdx})
+	var acc uint32
+	for i, raw := range args {
+		argID, err := b.lowerExpr(raw)
+		if err != nil {
+			return 0, err
+		}
+		strID, err := b.liftToStr(argID)
+		if err != nil {
+			return 0, err
+		}
+		if i == 0 {
+			acc = strID
+			continue
+		}
+		withSep := b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpConcatStr, Args: []uint32{acc, sepID}})
+		acc = b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpConcatStr, Args: []uint32{withSep, strID}})
+	}
+	bind := ir.GoBinding{
+		Pkg:      "fmt",
+		Alias:    "fmt",
+		Name:     "Println",
+		ArgTypes: []string{"string"},
+		Result:   "",
+	}
+	bindIdx := int64(len(b.fn.GoBindings))
+	b.fn.GoBindings = append(b.fn.GoBindings, bind)
+	id := b.addValue(ir.Value{Type: ir.TypeUnit, Op: ir.OpCallGo, Args: []uint32{acc}, Const: bindIdx})
+	return id, nil
+}
+
+// liftToStr returns argID unchanged when its IR type is TypeStr, or
+// inserts the matching scalar→str op (OpI64ToStr / OpF64ToStr /
+// OpBoolToStr) and returns the new SSA id. Used by lowerMultiArgPrint
+// so each arg can be concatenated into the space-joined output.
+func (b *builder) liftToStr(argID uint32) (uint32, error) {
+	switch b.fn.Values[argID].Type {
+	case ir.TypeStr:
+		return argID, nil
+	case ir.TypeI64:
+		return b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpI64ToStr, Args: []uint32{argID}}), nil
+	case ir.TypeF64:
+		return b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpF64ToStr, Args: []uint32{argID}}), nil
+	case ir.TypeBool:
+		return b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpBoolToStr, Args: []uint32{argID}}), nil
+	}
+	return 0, fmt.Errorf("frontend: print() argument type %s unsupported in MVP", b.fn.Values[argID].Type)
 }
 
 // lowerJsonObject lowers `json({"k1": e1, ..., "kN": eN})` as an

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -1959,6 +1959,24 @@ The §Top-line objective is "the smallest user-facing bootstrap demo". The mochi
 - Still no compound `str()` (list, map, struct). Tracked in §10.31; orthogonal to this sub-phase.
 - Still no string slicing or indexing. Same status.
 - No relational `<`/`<=`/`>`/`>=` on strings. The bench corpus has no user; deferred.
+## §10.33 Phase 4.2.6 closeout (LANDED 2026-05-22 08:46 GMT+7)
+
+Phase 4.2.6 wires multi-argument `print(a, b, ..., z)` on the C target (and equivalently on Go). Before this sub-phase, the frontend's `lowerExprAsStmt` rejected anything but a single argument: `print("i =", i)` errored with `unknown function "print"` (the multi-arg call did not match the `len(args)==1` guard so it fell through to the user-fun lookup). After it, the same source compiles unchanged on both `--target=c` and `--target=go`, closing the v0.1 tutorial idiom (`print("Sum =", sum)`, `print("i =", i)`) that the homepage v0.1 examples rely on.
+
+### What landed
+
+- `compiler3/frontend/lower.go`: `lowerExprAsStmt` now accepts `print(...)` with N >= 1 args. When N >= 2, dispatch goes to a new helper `lowerMultiArgPrint` that lifts each non-string arg through the matching scalar→str op (`OpI64ToStr` / `OpF64ToStr` / `OpBoolToStr`, all from Phase 4.2.4), interleaves a `" "` string literal between consecutive parts, folds left-to-right via `OpConcatStr` (Phase 4.2.3), then calls the existing single-arg print path on the joined `TypeStr` SSA value. A second helper `liftToStr` centralises the scalar-arg-to-string dispatch so future widening (e.g. lifting list element-by-element) has one entry point.
+- `compiler3/build/c/driver_test.go`: four new driver tests, `TestBuildSourceMultiArgPrintLabel` (`print("i =", i)`), `TestBuildSourceMultiArgPrintThree` (three-arg, mixed string/string/int), `TestBuildSourceMultiArgPrintMixed` (four-arg, string/int/float/bool), and `TestBuildSourceMultiArgPrintLoop` (the v0.1 `for i in 0..N { print("i =", i) }` tutorial form).
+
+### Why this closes a goal
+
+The §Top-line objective is "the smallest user-facing bootstrap demo". After Phase 4.2.5 the homepage `hello.mochi` was green; the next-most-canonical Mochi tutorial form is the labeled-print loop (`for i in 0..n { print("i =", i) }`), which lives in `examples/v0.1/for.mochi`. With the multi-arg print plumbing in place, the entire v0.1 hello / let / for / if surface set is expressible on the C target. The implementation is pure frontend (no new IR ops, no new runtime files): the multi-arg form is sugar over the existing string stack, so it inherits every constant-folding and verifier guarantee already proven for `OpConcatStr` / `OpI64ToStr` / etc.
+
+### Limitations
+
+- The space-separator + final-newline matches Go's `fmt.Println` default for the scalar arg types Mochi supports. Compound types (list / map / struct) still error at the lift step with `unsupported in MVP`; they will inherit support once `str()` widens to compound types (orthogonal sub-phase tracked in §10.31).
+- The join allocates O(N) intermediate strings (each `OpConcatStr` is a fresh heap buffer; same leak discipline as Phase 4.2.3). For typical `print("label", value)` callers this is two allocations per call site, dwarfed by the I/O cost.
+- The Go target also routes through the multi-arg lowering rather than passing N args to `fmt.Println` directly. Output byte-matches Go's native `fmt.Println(a, b, c)` for the typical scalar set; if the Mochi surface ever adds custom formatters or types whose `String()` method matters, the Go target's `fmt.Println` would diverge from this lowering and we would need to extend `OpCallGo` to be variadic. No such type exists today.
 
 ## §11 Risks
 


### PR DESCRIPTION
Tracking issue: #22005

## Summary

- Wires multi-argument `print(a, b, ..., z)` on `mochi build --target=c` (and equivalently `--target=go`) by desugaring at the frontend over the existing Phase 4.2.x string stack. No new IR ops, no new runtime files.
- Closes the v0.1 tutorial idiom `print("i =", i)` and the labeled-print loop `for i in 0..n { print("i =", i) }` from `examples/v0.1/for.mochi`.

## What changed

`compiler3/frontend/lower.go`:
- `lowerExprAsStmt` print guard relaxed from `len(args)==1` to `len(args)>=1`; multi-arg case dispatches to a new helper `lowerMultiArgPrint`.
- `lowerMultiArgPrint` lifts each non-string arg through the matching scalar->str op from Phase 4.2.4 (`OpI64ToStr` / `OpF64ToStr` / `OpBoolToStr`), interleaves a `" "` string literal between consecutive parts, folds left-to-right via `OpConcatStr` (Phase 4.2.3), then calls the existing single-arg print path on the joined `TypeStr` value.
- `liftToStr` centralises the scalar-arg-to-string dispatch so future widening has one entry point.

`compiler3/build/c/driver_test.go`:
- `TestBuildSourceMultiArgPrintLabel` (2-arg string+int).
- `TestBuildSourceMultiArgPrintThree` (3-arg string+string+int).
- `TestBuildSourceMultiArgPrintMixed` (4-arg string+int+float+bool).
- `TestBuildSourceMultiArgPrintLoop` (the v0.1 `for i in 0..N { print("i =", i) }` form).

`website/docs/mep/mep-0042.md`:
- §10.33 closeout (LANDED 2026-05-22 08:46 GMT+7).

## Test plan

- [x] `go test ./compiler3/build/c/... -run TestBuildSourceMultiArgPrint -count=1` (all four PASS).
- [x] `go test ./compiler3/build/c/... -run 'TestBuildSourceMultiArgPrint|TestBuildSourceStr|TestBuildSourceWebsiteHomepageHello' -count=1` (all PASS).
- [x] Full `go test ./compiler3/... -count=1` green.