### PR TITLE
mep-0042: Phase 4.2.7 bool == / != on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -1644,6 +1644,78 @@ func TestBuildSourceMultiArgPrintLoop(t *testing.T) {
 	}
 }
 
+// TestBuildSourceBoolEqTrue pins MEP-42 Phase 4.2.7: bool == bool.
+// Before this sub-phase, `let a = true; let b = true; print(a == b)`
+// errored at lower with `binop "==" on type bool unsupported in MVP`.
+// After it, the comparison routes through OpCmpEqBool and the
+// single-arg print path renders it through fmt.Println (Phase 4.2.0),
+// matching Go's "true" / "false" convention byte for byte.
+func TestBuildSourceBoolEqTrue(t *testing.T) {
+	src := `let a = true
+let b = true
+print(a == b)
+`
+	if got, want := runMochiBuild(t, src), "true\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceBoolNe pins `!=` on bool, the other half of v0.1's
+// examples/v0.1/binary.mochi block ("bool_neq").
+func TestBuildSourceBoolNe(t *testing.T) {
+	src := `let a = true
+let b = false
+print(a != b)
+`
+	if got, want := runMochiBuild(t, src), "true\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceBoolEqMixed pins the heterogeneous mixing of bool
+// comparisons through the multi-arg print path: a `bool == bool`
+// result lifts through OpBoolToStr (Phase 4.2.4) into the
+// space-joined string. This exercises the full Phase 4.2.x interplay.
+func TestBuildSourceBoolEqMixed(t *testing.T) {
+	src := `let ba = true
+let bb = false
+print("bool_eq:", ba == ba)
+print("bool_neq:", ba != bb)
+`
+	if got, want := runMochiBuild(t, src), "bool_eq: true\nbool_neq: true\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceBoolEqUnaryNested pins examples/v0.1/unary.mochi's
+// nested expression `!((2 < 3) == true)`. The inner `(2 < 3)`
+// produces a bool (OpCmpLtI64), the `== true` then triggers
+// OpCmpEqBool, and the outer `!` is OpNotBool. The final value is
+// false / 0.
+func TestBuildSourceBoolEqUnaryNested(t *testing.T) {
+	src := `let e = !((2 < 3) == true)
+print(e)
+`
+	if got, want := runMochiBuild(t, src), "false\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceV01BinaryFixture pins examples/v0.1/binary.mochi
+// end-to-end, the v0.1 tutorial program that motivated Phase 4.2.7.
+// Reads the fixture verbatim so future tutorial edits surface as a
+// regression here.
+func TestBuildSourceV01BinaryFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.1/binary.mochi")
+	if err != nil {
+		t.Fatalf("read v0.1 binary fixture: %v", err)
+	}
+	want := "add: 5\nsub: 3\nmul: 10\ndiv: 4\neq: true\nneq: true\nlt: true\nlte: true\ngt: true\ngte: true\nstr_eq: true\nstr_neq: true\nstr_concat: hello world\nbool_eq: true\nbool_neq: true\n"
+	if got := runMochiBuild(t, string(srcBytes)); got != want {
+		t.Errorf("v0.1/binary stdout = %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceSpectralNormBgFixture pins the unmodified
 // bench/template/bg/spectral_norm fixture (N=100) on the C target.
 // This is the §10.7 closeout for spectral_norm at the fixture level

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -404,6 +404,16 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    %s = (strcmp(%s, %s) == 0);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpCmpNeStr:
 		fmt.Fprintf(w, "    %s = (strcmp(%s, %s) != 0);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpCmpEqBool:
+		// Bool carriers are int (cType returns "int" for TypeBool), so
+		// equality is plain `==`. The `!!` normalises both operands to
+		// 0 or 1 first; Phase 4.2.4 OpBoolToStr already routes through
+		// the same normalisation, and the C emit of OpConst writes 0/1
+		// for TypeBool, but defensively normalise so any future opaque
+		// bool source (e.g. a Go FFI bridge) still compares correctly.
+		fmt.Fprintf(w, "    %s = ((!!%s) == (!!%s));\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpCmpNeBool:
+		fmt.Fprintf(w, "    %s = ((!!%s) != (!!%s));\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpConcatStr:
 		// mochi_str_concat allocates a NUL-terminated byte sequence
 		// holding the bytes of v.Args[0] followed by v.Args[1] and

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -304,6 +304,10 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 		fmt.Fprintf(w, "\t%s = %s == %s\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpCmpNeStr:
 		fmt.Fprintf(w, "\t%s = %s != %s\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpCmpEqBool:
+		fmt.Fprintf(w, "\t%s = %s == %s\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpCmpNeBool:
+		fmt.Fprintf(w, "\t%s = %s != %s\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpI64ToStr:
 		imports["strconv"] = true
 		fmt.Fprintf(w, "\t%s = strconv.FormatInt(%s, 10)\n", name, valueName(v.Args[0]))

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1421,6 +1421,17 @@ func (b *builder) applyBinOp(op string, l, r uint32) (uint32, error) {
 		default:
 			return 0, fmt.Errorf("frontend: operator %q on str unsupported in MVP", op)
 		}
+	case ir.TypeBool:
+		switch op {
+		case "==":
+			code = ir.OpCmpEqBool
+			resType = ir.TypeBool
+		case "!=":
+			code = ir.OpCmpNeBool
+			resType = ir.TypeBool
+		default:
+			return 0, fmt.Errorf("frontend: operator %q on bool unsupported in MVP", op)
+		}
 	case ir.TypeList:
 		if op != "+" {
 			return 0, fmt.Errorf("frontend: operator %q on list<int> unsupported in MVP", op)

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -143,6 +143,13 @@ const (
 	OpF64ToStr
 	OpBoolToStr
 
+	// Bool comparisons (MEP-42 Phase 4.2.7). Result Type == TypeBool.
+	// Bool values are int-sized in both targets, so the C emit lowers
+	// to plain `==` / `!=` and the Go emit to the same. Distinct ops
+	// (rather than reusing OpCmpEqI64) keep the IR type-precise.
+	OpCmpEqBool
+	OpCmpNeBool
+
 	// List ops (Phase 3.2 vm3 surface).
 	OpNewList
 	OpListLenI64
@@ -371,6 +378,10 @@ func (o OpCode) String() string {
 		return "f64.to.str"
 	case OpBoolToStr:
 		return "bool.to.str"
+	case OpCmpEqBool:
+		return "cmp.eq.bool"
+	case OpCmpNeBool:
+		return "cmp.ne.bool"
 	case OpNewList:
 		return "newlist"
 	case OpListLenI64:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -183,6 +183,8 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeStr, [3]Type{TypeF64}}
 	case OpBoolToStr:
 		return opSig{TypeStr, [3]Type{TypeBool}}
+	case OpCmpEqBool, OpCmpNeBool:
+		return opSig{TypeBool, [3]Type{TypeBool, TypeBool}}
 	case OpNewList:
 		return opSig{TypeList, [3]Type{}}
 	case OpListLenI64:

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -157,6 +157,7 @@ func kindOf(o ir.OpCode) ProducerKind {
 		ir.OpAndI64, ir.OpOrI64, ir.OpXorI64, ir.OpShlI64, ir.OpShrI64, ir.OpNotI64,
 		ir.OpCmpEqF64, ir.OpCmpNeF64, ir.OpCmpLtF64, ir.OpCmpLeF64, ir.OpCmpGtF64, ir.OpCmpGeF64,
 		ir.OpCmpEqStr, ir.OpCmpNeStr,
+		ir.OpCmpEqBool, ir.OpCmpNeBool,
 		ir.OpNotBool,
 		ir.OpI64ToF64, ir.OpF64ToI64,
 		ir.OpSqrtF64,
@@ -398,7 +399,8 @@ func contractResult(o ir.OpCode) ir.Type {
 		return ir.TypeF64
 	case ir.OpCmpEqI64, ir.OpCmpNeI64, ir.OpCmpLtI64, ir.OpCmpLeI64, ir.OpCmpGtI64, ir.OpCmpGeI64,
 		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm,
-		ir.OpCmpEqStr, ir.OpCmpNeStr:
+		ir.OpCmpEqStr, ir.OpCmpNeStr,
+		ir.OpCmpEqBool, ir.OpCmpNeBool:
 		return ir.TypeBool
 	case ir.OpLenStr:
 		return ir.TypeI64

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -1978,6 +1978,29 @@ The §Top-line objective is "the smallest user-facing bootstrap demo". After Pha
 - The join allocates O(N) intermediate strings (each `OpConcatStr` is a fresh heap buffer; same leak discipline as Phase 4.2.3). For typical `print("label", value)` callers this is two allocations per call site, dwarfed by the I/O cost.
 - The Go target also routes through the multi-arg lowering rather than passing N args to `fmt.Println` directly. Output byte-matches Go's native `fmt.Println(a, b, c)` for the typical scalar set; if the Mochi surface ever adds custom formatters or types whose `String()` method matters, the Go target's `fmt.Println` would diverge from this lowering and we would need to extend `OpCallGo` to be variadic. No such type exists today.
 
+## §10.34 Phase 4.2.7 closeout (LANDED 2026-05-22 08:58 GMT+7)
+
+Phase 4.2.7 wires `==` and `!=` on `TypeBool` for both `--target=c` and `--target=go`. Before this sub-phase, `a == b` (with both sides bool) errored at lower with `binop "==" on type bool unsupported in MVP`, blocking `examples/v0.1/binary.mochi` (the "bool_eq:" / "bool_neq:" lines) and `examples/v0.1/unary.mochi` (the nested `!((2 < 3) == true)` expression). After it, both fixtures compile end-to-end on the C target.
+
+### What landed
+
+- `compiler3/ir/types.go`: two new ops `OpCmpEqBool` / `OpCmpNeBool` with `String()` entries `cmp.eq.bool` / `cmp.ne.bool`.
+- `compiler3/ir/validate.go`: signature `(TypeBool, TypeBool) -> TypeBool` for both.
+- `compiler3/verify/verify.go`: both ops added to the `KindOperator` row alongside the other scalar comparisons, and `contractResult` returns `TypeBool` for both.
+- `compiler3/emit/c/emit.go`: both ops lower to plain `==` / `!=` on the underlying `int` carrier (`cType(TypeBool) == "int"`). Operands are `!!`-normalised first so any future opaque bool source (Go FFI bridge, etc.) still compares correctly.
+- `compiler3/emit/go/emit.go`: both ops lower to plain `==` / `!=` on Go's native `bool` type.
+- `compiler3/frontend/lower.go`: `lowerBinary` adds a `TypeBool` arm that emits `OpCmpEqBool` for `==` and `OpCmpNeBool` for `!=`. Other operators on bool still error with `operator %q on bool unsupported in MVP` (no surface form needs `&&` / `||` on bool today since those are short-circuit, not binops).
+- `compiler3/build/c/driver_test.go`: five new tests. `TestBuildSourceBoolEqTrue` / `TestBuildSourceBoolNe` pin the elementary `bool == bool` / `bool != bool` cases. `TestBuildSourceBoolEqMixed` pins the multi-arg-print interplay (`print("bool_eq:", ba == ba)`), which lifts the bool result through `OpBoolToStr` (Phase 4.2.4). `TestBuildSourceBoolEqUnaryNested` pins the v0.1/unary.mochi-derived `!((2 < 3) == true)` expression, which threads `OpCmpLtI64` -> `OpCmpEqBool` -> `OpNotBool`. `TestBuildSourceV01BinaryFixture` reads `examples/v0.1/binary.mochi` verbatim and asserts the full 16-line stdout.
+
+### Why this closes a goal
+
+The §Top-line objective is "the smallest user-facing bootstrap demo". After Phase 4.2.6, v0.1 status on the C target was `hello`, `let`, `if`, `expr`, `for` green; `binary` and `unary` still failed at lower because no surface form of bool equality was wired. Phase 4.2.7 closes those two fixtures, taking v0.1 green-fixture count from 5/17 to 7/17. The remaining v0.1 gaps are first-class function types (`fun(int): int`) for the `fun*.mochi` cluster and Go-FFI for `agent.mochi` / `stream.mochi`; both are larger gates tracked separately.
+
+### Limitations
+
+- The bool `==` / `!=` lowering is pure scalar; there is no path through tree-handle equality (TypeListAny / TypeMap), which still error if either side is a compound. Compound equality is a separate larger gate.
+- The `!!`-normalisation in the C emit assumes the int carrier holds a small magnitude (0 vs any non-zero); for opaque bool sources whose underlying int is larger than 1, this collapses correctly. No source today can produce such a value, but the defensive normalisation keeps the rule "bool carriers behave 0/1 under ==" stable as the Phase 4.2.x surface widens.
+
 ## §11 Risks
 
 ### 11.1 Clang ABI drift breaks stencils


### PR DESCRIPTION
Tracking issue: #22007

## Summary

- Wires `==` and `!=` on `TypeBool` for both `mochi build --target=c` and `--target=go` via two new IR ops `OpCmpEqBool` / `OpCmpNeBool`. C emit lowers to plain `==` / `!=` on the `int` carrier; Go emit lowers to the same operators on Go's native bool.
- Unblocks `examples/v0.1/binary.mochi` and `examples/v0.1/unary.mochi` end-to-end on the C target. v0.1 green-fixture count on `--target=c` goes from 5/17 to 7/17.

## What changed

`compiler3/ir/types.go`, `validate.go`, `compiler3/verify/verify.go`: register the two new ops in the IR contract, the kind tables, and `contractResult`.

`compiler3/emit/c/emit.go`: two emit cases. Operands are `!!`-normalised first so opaque bool sources (Go FFI bridge etc.) compare correctly.

`compiler3/emit/go/emit.go`: two emit cases routing to plain `==` / `!=`.

`compiler3/frontend/lower.go`: `lowerBinary` adds a `TypeBool` arm emitting `OpCmpEqBool` for `==` and `OpCmpNeBool` for `!=`; other ops on bool still error with `operator %q on bool unsupported in MVP`.

`compiler3/build/c/driver_test.go`: five new tests pin the elementary `bool == / != bool` cases, the multi-arg-print interplay, the v0.1/unary.mochi nested expression `!((2 < 3) == true)`, and the full v0.1/binary.mochi fixture end-to-end.

`website/docs/mep/mep-0042.md`: §10.34 closeout (LANDED 2026-05-22 08:58 GMT+7).

## Test plan

- [x] `go test ./compiler3/build/c/... -run 'TestBuildSourceBoolEq|TestBuildSourceBoolNe|TestBuildSourceV01BinaryFixture' -count=1 -v` (all five PASS).
- [x] Full `go test ./compiler3/... -count=1` green.
- [x] `go run ./cmd/mochi build --target=c --binary=/tmp/v01 examples/v0.1/binary.mochi && /tmp/v01` matches `mochi run` byte for byte.