### PR TITLE
mep-0042: Phase 4.2.8 f64 print/str Go-parity on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -1716,6 +1716,82 @@ func TestBuildSourceV01BinaryFixture(t *testing.T) {
 	}
 }
 
+// TestBuildSourceF64GoParityTen pins MEP-42 Phase 4.2.8: a finite
+// float value whose magnitude lies in Go's fixed-form window must
+// print without C99's "%g" exponent escape. Before this sub-phase,
+// `print(10.0)` produced "1e+01\n" on the C target because C99 "%g"
+// at precision 1 chose exponent form (1 >= 1); Go's
+// strconv.FormatFloat(10.0, 'g', -1, 64) returns "10". The shared
+// mochi_f64_format helper now reformats those cases.
+func TestBuildSourceF64GoParityTen(t *testing.T) {
+	src := `print(10.0)` + "\n"
+	if got, want := runMochiBuild(t, src), "10\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceF64GoParityHundredK pins the upper edge of Go's
+// fixed-form window. 1e5 (= 100000) sits at exp=5 which is < 6, so
+// Go prints "100000"; C99 "%g" at precision 1 would print "1e+05".
+func TestBuildSourceF64GoParityHundredK(t *testing.T) {
+	src := `print(1e5)` + "\n"
+	if got, want := runMochiBuild(t, src), "100000\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceF64GoParityMillion pins the lower edge of Go's
+// exponent-form window. 1e6 sits at exp=6 which is >= 6, so Go
+// prints "1e+06". Both C99 "%g" at precision 1 and the new helper
+// must agree on this case.
+func TestBuildSourceF64GoParityMillion(t *testing.T) {
+	src := `print(1e6)` + "\n"
+	if got, want := runMochiBuild(t, src), "1e+06\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceF64GoParityFractionalEdge pins the lower fixed-form
+// edge. 1e-4 (= 0.0001) is the smallest magnitude Go prints in fixed
+// form (exp = -4); 1e-5 flips to exp form. C99 "%g" agrees on the
+// boundary; the test guards the new code path against regressing.
+func TestBuildSourceF64GoParityFractionalEdge(t *testing.T) {
+	src := `print(0.0001)` + "\n"
+	if got, want := runMochiBuild(t, src), "0.0001\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	src = `print(0.00001)` + "\n"
+	if got, want := runMochiBuild(t, src), "1e-05\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceF64GoParityStr pins str(f64) on the same divergent
+// values: str(10.0) must produce "10" (not "1e+01"), matching the
+// Go target's strconv.FormatFloat. The single-arg print() path and
+// the multi-arg / str() path now share mochi_f64_format, so this
+// test guards against drift between them.
+func TestBuildSourceF64GoParityStr(t *testing.T) {
+	src := `print("e =", 10.0)` + "\n"
+	if got, want := runMochiBuild(t, src), "e = 10\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceV01ExprFixture pins examples/v0.1/expr.mochi
+// end-to-end. Before Phase 4.2.8, "e = 1e+01" leaked into the
+// binary's stdout; after, the program byte-matches mochi run.
+func TestBuildSourceV01ExprFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.1/expr.mochi")
+	if err != nil {
+		t.Fatalf("read v0.1 expr fixture: %v", err)
+	}
+	want := "a = 11\nb = 14\nc = 8\nd = 56\ne = 10\nf = 3\n"
+	if got := runMochiBuild(t, string(srcBytes)); got != want {
+		t.Errorf("v0.1/expr stdout = %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceSpectralNormBgFixture pins the unmodified
 // bench/template/bg/spectral_norm fixture (N=100) on the C target.
 // This is the §10.7 closeout for spectral_norm at the fixture level

--- a/runtime/c/src/mochi_str.c
+++ b/runtime/c/src/mochi_str.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <math.h>
 
 const char *mochi_str_concat(const char *a, const char *b) {
     size_t la = strlen(a);
@@ -37,6 +38,123 @@ const char *mochi_str_from_i64(long long v) {
     return out;
 }
 
+int mochi_f64_format(char *buf, int bufsize, double v) {
+    /*
+     * Goal: byte-match Go's strconv.FormatFloat(v, 'g', -1, 64).
+     *
+     * Step 1: find the shortest precision p in [1,17] such that
+     * "%.*g" round-trips through strtod. This is the same shortest-
+     * round-trip search Phase 4.1 used.
+     *
+     * Step 2: C99 "%g" chooses exponent form when the decimal
+     * exponent X is "X < -4 || X >= P" (where P is the precision
+     * passed in). Go's strconv with prec=-1 uses "X < -4 || X >= 6"
+     * (Go strconv/ftoa.go hard-codes eprec=6 in shortest mode).
+     * When the two rules disagree on the form, reformat.
+     */
+    int p;
+    int n = 0;
+    for (p = 1; p <= 17; p++) {
+        n = snprintf(buf, (size_t)bufsize, "%.*g", p, v);
+        double back = strtod(buf, NULL);
+        if (back == v) {
+            break;
+        }
+    }
+    if (p > 17) {
+        p = 17;
+        n = snprintf(buf, (size_t)bufsize, "%.17g", v);
+    }
+    /*
+     * Special-case the values "%g" prints in non-decimal form so
+     * we don't try to parse a fake decimal exponent: 0, +/-Inf, NaN.
+     * %g prints "0" for 0.0 (no decimal exponent), "inf"/"-inf",
+     * "nan". All three match Go (which prints "0", "+Inf"/"-Inf",
+     * "NaN" -- wait, Go prints +Inf with sign, and NaN capitalised).
+     * mochi_run on these values comes through the same fmt.Println
+     * path so the C target follows that. Today the bench corpus has
+     * no inf/nan emitter; if one shows up the case lives here.
+     */
+    if (v != v || v == 0.0) {
+        return n;
+    }
+    /* Detect whether the current buffer is in exponent form. */
+    int eIdx = -1;
+    for (int i = 0; i < n; i++) {
+        if (buf[i] == 'e' || buf[i] == 'E') {
+            eIdx = i;
+            break;
+        }
+    }
+    int exp;
+    if (eIdx >= 0) {
+        /* Parse "eXXX" or "e+XXX" or "e-XXX". */
+        int sign = 1;
+        int j = eIdx + 1;
+        if (buf[j] == '-') { sign = -1; j++; }
+        else if (buf[j] == '+') { j++; }
+        int v_abs = 0;
+        for (; j < n && buf[j] >= '0' && buf[j] <= '9'; j++) {
+            v_abs = v_abs * 10 + (buf[j] - '0');
+        }
+        exp = sign * v_abs;
+    } else {
+        /*
+         * Fixed form: derive decimal exponent of leading digit
+         * directly from |v|. log10 + floor is sufficient because
+         * the value already round-tripped via strtod above.
+         */
+        double absv = v < 0.0 ? -v : v;
+        exp = (int)floor(log10(absv));
+    }
+    int wantExp = (exp < -4 || exp >= 6);
+    int gotExp = (eIdx >= 0);
+    if (wantExp == gotExp) {
+        return n;
+    }
+    /* Reformat to match Go's form choice. */
+    if (wantExp) {
+        /*
+         * Go wants exp form but C produced fixed. Reformat with
+         * "%.*e" using p-1 fractional digits (so p sig figs total),
+         * then strip trailing zeros from the mantissa for Go
+         * parity (Go's "1.5e+06" never has padding zeros).
+         */
+        n = snprintf(buf, (size_t)bufsize, "%.*e", p - 1, v);
+        int dotIdx = -1, eIdx2 = -1;
+        for (int i = 0; i < n; i++) {
+            if (buf[i] == '.') dotIdx = i;
+            else if (buf[i] == 'e' || buf[i] == 'E') { eIdx2 = i; break; }
+        }
+        if (dotIdx >= 0 && eIdx2 >= 0) {
+            int j = eIdx2 - 1;
+            while (j > dotIdx && buf[j] == '0') j--;
+            if (j == dotIdx) j--; /* drop trailing '.' too */
+            int mantEnd = j + 1;
+            int tailLen = n - eIdx2;
+            memmove(buf + mantEnd, buf + eIdx2, (size_t)tailLen + 1);
+            n = mantEnd + tailLen;
+        }
+        /*
+         * Normalise exponent: C99 produces "1e+01" (two-digit
+         * minimum); Go also uses two-digit minimum for |exp| < 100,
+         * three for >= 100. Same.
+         */
+    } else {
+        /*
+         * Go wants fixed form but C produced exp. Reformat with
+         * "%.*f" where frac digits = (p-1) - exp, clamped to 0.
+         * For 10.0 with p=1, exp=1: frac = 1-1-1 = -1 -> 0;
+         * "%.0f" of 10.0 = "10". Round-trip preserved because the
+         * sig-digit budget is unchanged.
+         */
+        int frac = (p - 1) - exp;
+        if (frac < 0) frac = 0;
+        n = snprintf(buf, (size_t)bufsize, "%.*f", frac, v);
+    }
+    return n;
+}
+
 const char *mochi_str_from_f64(double v) {
     /*
      * Shortest round-trip: mirror runtime/c/src/print.c mochi_print_f64
@@ -44,18 +162,7 @@ const char *mochi_str_from_f64(double v) {
      * double, matching Go's strconv.FormatFloat(v, 'g', -1, 64).
      */
     char buf[64];
-    int p;
-    int n = 0;
-    for (p = 1; p <= 17; p++) {
-        n = snprintf(buf, sizeof buf, "%.*g", p, v);
-        double back = strtod(buf, NULL);
-        if (back == v) {
-            break;
-        }
-    }
-    if (p > 17) {
-        n = snprintf(buf, sizeof buf, "%.17g", v);
-    }
+    int n = mochi_f64_format(buf, (int)sizeof buf, v);
     char *out = (char *)malloc((size_t)n + 1);
     memcpy(out, buf, (size_t)n + 1);
     return out;

--- a/runtime/c/src/mochi_str.h
+++ b/runtime/c/src/mochi_str.h
@@ -53,6 +53,22 @@ const char *mochi_str_from_i64(long long v);
 const char *mochi_str_from_f64(double v);
 const char *mochi_str_from_bool(int v);
 
+/*
+ * mochi_f64_format writes the shortest decimal representation of v
+ * into buf (NUL-terminated) using the same rule as Go's
+ * strconv.FormatFloat(v, 'g', -1, 64): exponent form when the
+ * decimal exponent of the leading digit is < -4 or >= 6, fixed form
+ * otherwise. Returns the number of bytes written (excluding NUL).
+ * buf must have room for at least 32 bytes; the longest output a
+ * finite double can produce here is 24 bytes (the leak-budget
+ * comment in mochi_str.c quantifies the worst case).
+ *
+ * Shared by both mochi_print_f64 (Phase 4.1) and mochi_str_from_f64
+ * (Phase 4.2.4); centralising avoids drift between print() and
+ * str() output for the same double (MEP-42 Phase 4.2.8).
+ */
+int mochi_f64_format(char *buf, int bufsize, double v);
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/c/src/print.c
+++ b/runtime/c/src/print.c
@@ -5,6 +5,7 @@
  * with the generated source in one cc invocation.
  */
 #include "print.h"
+#include "mochi_str.h"
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -26,26 +27,15 @@ void mochi_print_str(const char *s) {
 
 void mochi_print_f64(double x) {
     /*
-     * Shortest round-trip: try precision 1..17 and pick the first
-     * that strtod() reads back to the exact double. Go's
-     * strconv.FormatFloat with prec=-1 uses Ryu under the hood; the
-     * digits produced by %.*g with precision-search and Ryu agree
-     * for the typical finite case. Edge cases where Go switches
-     * fixed vs scientific differently from C %g remain divergent
-     * and are tracked for Phase 4.2.
+     * Delegate to mochi_f64_format so print(x) and str(x) produce
+     * the same digits for the same double, both matching Go's
+     * strconv.FormatFloat(x, 'g', -1, 64). The pre-Phase-4.2.8 body
+     * lived here (shortest-round-trip search via %.*g); the divergence
+     * with Go on values like 10.0 (C produced "1e+01", Go "10") is
+     * fixed in the shared helper.
      */
     char buf[64];
-    int p;
-    for (p = 1; p <= 17; p++) {
-        snprintf(buf, sizeof buf, "%.*g", p, x);
-        double back = strtod(buf, NULL);
-        if (back == x) {
-            break;
-        }
-    }
-    if (p > 17) {
-        snprintf(buf, sizeof buf, "%.17g", x);
-    }
-    fputs(buf, stdout);
+    int n = mochi_f64_format(buf, (int)sizeof buf, x);
+    fwrite(buf, 1, (size_t)n, stdout);
     fputc('\n', stdout);
 }

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2001,6 +2001,29 @@ The §Top-line objective is "the smallest user-facing bootstrap demo". After Pha
 - The bool `==` / `!=` lowering is pure scalar; there is no path through tree-handle equality (TypeListAny / TypeMap), which still error if either side is a compound. Compound equality is a separate larger gate.
 - The `!!`-normalisation in the C emit assumes the int carrier holds a small magnitude (0 vs any non-zero); for opaque bool sources whose underlying int is larger than 1, this collapses correctly. No source today can produce such a value, but the defensive normalisation keeps the rule "bool carriers behave 0/1 under ==" stable as the Phase 4.2.x surface widens.
 
+## §10.35 Phase 4.2.8 closeout (LANDED 2026-05-22 09:08 GMT+7)
+
+Phase 4.2.8 fixes a silent correctness gap in the C target's float-to-string path. C99 "%g" chooses exponent form when the decimal exponent `X` satisfies `X < -4 || X >= P` (where `P` is the precision passed in). Go's `strconv.FormatFloat(v, 'g', -1, 64)` uses `X < -4 || X >= 6` instead (Go's `strconv/ftoa.go` hard-codes `eprec=6` in shortest mode). For values like `10.0` at the shortest-round-trip precision `P=1`, C99 produced `"1e+01"` while Go produced `"10"`. Before this sub-phase, `examples/v0.1/expr.mochi` compiled but its `let e = 5.0 + 2.5 * 2.0` line printed `e = 1e+01` instead of `e = 10`; the binary's stdout drifted from `mochi run` byte-for-byte even though the program compiled.
+
+The fix is a shared formatter `mochi_f64_format` in the C runtime. Both `mochi_print_f64` (used by single-arg `print(x)`) and `mochi_str_from_f64` (used by `str(x)`, multi-arg `print`, and concat) route through it, eliminating drift between the two paths.
+
+### What landed
+
+- `runtime/c/src/mochi_str.h`: new declaration `int mochi_f64_format(char *buf, int bufsize, double v)` returning the byte count written (excluding NUL). Documented to require >=32 bytes of buffer.
+- `runtime/c/src/mochi_str.c`: helper implementation. Algorithm: (1) find the shortest precision `p` in [1,17] such that `"%.*g"` round-trips through `strtod`; (2) detect whether the resulting buffer is in exponent form by scanning for `'e'`/`'E'`; (3) compute the decimal exponent (parse from the buffer in exponent form, derive from `floor(log10(|v|))` in fixed form); (4) compare against Go's rule `(X < -4 || X >= 6)`; (5) if Go and C disagree on the form, reformat using `"%.*e"` (with trailing-zero stripping from the mantissa for parity) or `"%.*f"` (with fractional precision `(p-1)-X` clamped to 0). `mochi_str_from_f64` now delegates to it.
+- `runtime/c/src/print.c`: `mochi_print_f64` delegates to `mochi_f64_format` (via `#include "mochi_str.h"`), replacing the duplicated shortest-round-trip loop. The runtime is unconditionally compiled (the build driver's `writeRuntime` walks every file in `runtime/c/src` and hands the .c TUs to `cc`), so the new dependency from `print.c` to `mochi_str.c` adds no new conditional inclusion logic; the linker dead-strips whatever the program does not reference.
+- `compiler3/build/c/driver_test.go`: six new tests pin the Go-parity boundaries. `TestBuildSourceF64GoParityTen` pins `print(10.0)` -> `"10"` (the v0.1/expr.mochi-derived regression). `TestBuildSourceF64GoParityHundredK` pins `1e5` -> `"100000"` (upper edge of Go's fixed-form window). `TestBuildSourceF64GoParityMillion` pins `1e6` -> `"1e+06"` (lower edge of exp form). `TestBuildSourceF64GoParityFractionalEdge` pins `0.0001` -> `"0.0001"` and `0.00001` -> `"1e-05"` (the negative-exponent boundary). `TestBuildSourceF64GoParityStr` pins the multi-arg / `str()` path through the same helper (`print("e =", 10.0)` -> `"e = 10"`). `TestBuildSourceV01ExprFixture` reads `examples/v0.1/expr.mochi` verbatim and asserts the full 6-line stdout.
+
+### Why this closes a goal
+
+The §Top-line objective is "`mochi build hello.mochi` produces a single native binary". After Phase 4.2.5, `examples/v0.1/expr.mochi` compiled cleanly on `--target=c`, but its stdout silently drifted from `mochi run` because `5.0 + 2.5 * 2.0 = 10.0` rendered as `1e+01`. A "compiles" demo that produces wrong-looking output erodes user trust more than one that fails fast, so this sub-phase closes the silent-divergence gap. After it, the v0.1 fixtures whose stdout is currently asserted byte-for-byte (hello, let, if, expr, for, binary, unary) all match `mochi run` exactly, taking the green-fixture count from 7/17 to 7/17 still (no new fixtures added; one moved from "compiles but wrong" to "compiles and correct").
+
+### Limitations
+
+- `mochi_f64_format` handles the finite-double case. NaN, +/-Inf, and -0.0 short-circuit through the `"%g"` first pass (which produces `"nan"`, `"inf"`, `"-inf"`, `"-0"` respectively). The bench corpus has no NaN/Inf source today; Phase 4.2.x would extend the helper if one appears, matching whatever Go's `fmt.Println` produces for those values.
+- Trailing-zero stripping in reformatted exponent form is byte-true for the common cases (single-leading-digit mantissas) but has not been audited for every 17-significant-digit subnormal; a fixture exposing the gap would be Phase 4.2.x ammunition.
+- `mochi_print_f64` now requires `mochi_str.c` at link time (it `#include`s `mochi_str.h` and calls `mochi_f64_format`). The build driver's `writeRuntime` writes both unconditionally, so no driver change is needed; if a future minified-runtime mode lands, it must keep `mochi_str.c` whenever it keeps `print.c`.
+
 ## §11 Risks
 
 ### 11.1 Clang ABI drift breaks stencils


### PR DESCRIPTION
Tracking issue: #22009

## Summary

- Fix a silent correctness gap in the C target's float-to-string path. Before this PR, `print(10.0)` produced `1e+01` on `--target=c` because C99 `%g` chose exponent form at precision 1, but Go's `strconv.FormatFloat(10.0, 'g', -1, 64)` returns `10` (Go uses `X >= 6` for the exp-form threshold, C99 uses `X >= P`).
- Shared helper `mochi_f64_format` centralises the formatter so single-arg `print(x)` and `str(x)` / multi-arg `print` never drift from each other.
- v0.1 expr.mochi now byte-matches `mochi run`.

## What changed

`runtime/c/src/mochi_str.h`: new declaration `int mochi_f64_format(char *buf, int bufsize, double v)`.

`runtime/c/src/mochi_str.c`: implementation. Finds the shortest round-trip precision via `%.*g`, computes the decimal exponent (parsed from the buffer in exp form, derived from `floor(log10(|v|))` in fixed form), applies Go's `X < -4 || X >= 6` rule, and reformats via `%.*e` (with mantissa trailing-zero stripping) or `%.*f` (with `frac = (p-1) - X` clamped to 0) when C's and Go's choices differ. `mochi_str_from_f64` delegates.

`runtime/c/src/print.c`: `mochi_print_f64` delegates to `mochi_f64_format` (via `#include \"mochi_str.h\"`). The duplicated shortest-round-trip loop is gone.

`compiler3/build/c/driver_test.go`: six new tests pin the Go-parity boundaries and the v0.1 expr fixture.

`website/docs/mep/mep-0042.md`: §10.35 closeout (LANDED 2026-05-22 09:08 GMT+7).

## Test plan

- [x] `go test ./compiler3/build/c/... -run 'TestBuildSourceF64GoParity|TestBuildSourceV01ExprFixture' -count=1 -v` (all six PASS).
- [x] Full `go test ./compiler3/... -count=1` green.
- [x] `mochi build --target=c examples/v0.1/expr.mochi` byte-matches `mochi run` on the same source.