### PR TITLE
mep-0042: Phase 4.2.9 bool && / || on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -1792,6 +1792,79 @@ func TestBuildSourceV01ExprFixture(t *testing.T) {
 	}
 }
 
+// TestBuildSourceBoolAndBasic pins MEP-42 Phase 4.2.9: bool && bool.
+// Before this sub-phase, the v0.3/logic.mochi tutorial errored at
+// lower with `operator "||" on bool unsupported in MVP`. After it,
+// the elementary `let a = true && false; print(a)` lowers through
+// OpAndBool, emits C99 `&&`, and prints "false" (matching Go's
+// fmt.Println).
+func TestBuildSourceBoolAndBasic(t *testing.T) {
+	src := `let r = true && false
+print(r)
+`
+	if got, want := runMochiBuild(t, src), "false\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceBoolOrBasic pins the OR symmetric case.
+func TestBuildSourceBoolOrBasic(t *testing.T) {
+	src := `let r = false || true
+print(r)
+`
+	if got, want := runMochiBuild(t, src), "true\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceBoolAndOrChain pins v0.3/logic.mochi's mixed
+// expression `x > 0 && y > 2 || x == 0`, which threads
+// OpCmpGtI64 -> OpAndBool -> OpCmpEqI64 -> OpOrBool. Precedence
+// follows Mochi parser; the result is the if-condition's truth.
+func TestBuildSourceBoolAndOrChain(t *testing.T) {
+	src := `let x = 3
+let y = 5
+if x > 0 && y > 2 || x == 0 {
+  print("yes")
+} else {
+  print("no")
+}
+`
+	if got, want := runMochiBuild(t, src), "yes\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceBoolAndOrLeftRightPure pins the eager-evaluation
+// limitation: both operands are evaluated regardless of the
+// left-hand result, matching Go's `a && b` behaviour for
+// side-effect-free operands. This is a deliberate scope of Phase
+// 4.2.9 (true short-circuit at the IR level is a separate gate).
+func TestBuildSourceBoolAndOrLeftRightPure(t *testing.T) {
+	src := `let a = true
+let b = false
+print("and:", a && b)
+print("or:", a || b)
+`
+	if got, want := runMochiBuild(t, src), "and: false\nor: true\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceV03LogicFixture pins examples/v0.3/logic.mochi
+// end-to-end, the user-facing motivation for Phase 4.2.9. Reads the
+// fixture verbatim so future edits surface as a regression here.
+func TestBuildSourceV03LogicFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.3/logic.mochi")
+	if err != nil {
+		t.Fatalf("read v0.3 logic fixture: %v", err)
+	}
+	want := "true || false = true\nfalse || false = false\nx > 0 || y < 0 = true\ntrue && false = false\ntrue && true = true\nx < 10 && y > 2 = true\nCondition matched!\n"
+	if got := runMochiBuild(t, string(srcBytes)); got != want {
+		t.Errorf("v0.3/logic stdout = %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceSpectralNormBgFixture pins the unmodified
 // bench/template/bg/spectral_norm fixture (N=100) on the C target.
 // This is the §10.7 closeout for spectral_norm at the fixture level

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -414,6 +414,15 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    %s = ((!!%s) == (!!%s));\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpCmpNeBool:
 		fmt.Fprintf(w, "    %s = ((!!%s) != (!!%s));\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpAndBool:
+		// Both args are already-evaluated bool carriers. C99 `&&` is
+		// short-circuit at the AST level, but the IR pre-lowered the
+		// right operand into a separate SSA value, so the emitted op
+		// only performs the logical reduction (no actual short-
+		// circuit, which would require control-flow lowering).
+		fmt.Fprintf(w, "    %s = (%s && %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpOrBool:
+		fmt.Fprintf(w, "    %s = (%s || %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpConcatStr:
 		// mochi_str_concat allocates a NUL-terminated byte sequence
 		// holding the bytes of v.Args[0] followed by v.Args[1] and

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -308,6 +308,10 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 		fmt.Fprintf(w, "\t%s = %s == %s\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpCmpNeBool:
 		fmt.Fprintf(w, "\t%s = %s != %s\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpAndBool:
+		fmt.Fprintf(w, "\t%s = %s && %s\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpOrBool:
+		fmt.Fprintf(w, "\t%s = %s || %s\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpI64ToStr:
 		imports["strconv"] = true
 		fmt.Fprintf(w, "\t%s = strconv.FormatInt(%s, 10)\n", name, valueName(v.Args[0]))

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1429,6 +1429,12 @@ func (b *builder) applyBinOp(op string, l, r uint32) (uint32, error) {
 		case "!=":
 			code = ir.OpCmpNeBool
 			resType = ir.TypeBool
+		case "&&":
+			code = ir.OpAndBool
+			resType = ir.TypeBool
+		case "||":
+			code = ir.OpOrBool
+			resType = ir.TypeBool
 		default:
 			return 0, fmt.Errorf("frontend: operator %q on bool unsupported in MVP", op)
 		}

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -150,6 +150,15 @@ const (
 	OpCmpEqBool
 	OpCmpNeBool
 
+	// Bool logical AND / OR (MEP-42 Phase 4.2.9). Result == TypeBool.
+	// Both targets emit C99 `&&` / `||` (and Go's `&&` / `||`); these
+	// ARE short-circuit operators in both languages, but the IR
+	// already pre-evaluates both args, so the emitted operator only
+	// performs the logical reduction. Side-effect-bearing operands
+	// would observe eager evaluation; tracked as a known limitation.
+	OpAndBool
+	OpOrBool
+
 	// List ops (Phase 3.2 vm3 surface).
 	OpNewList
 	OpListLenI64
@@ -382,6 +391,10 @@ func (o OpCode) String() string {
 		return "cmp.eq.bool"
 	case OpCmpNeBool:
 		return "cmp.ne.bool"
+	case OpAndBool:
+		return "and.bool"
+	case OpOrBool:
+		return "or.bool"
 	case OpNewList:
 		return "newlist"
 	case OpListLenI64:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -185,6 +185,8 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeStr, [3]Type{TypeBool}}
 	case OpCmpEqBool, OpCmpNeBool:
 		return opSig{TypeBool, [3]Type{TypeBool, TypeBool}}
+	case OpAndBool, OpOrBool:
+		return opSig{TypeBool, [3]Type{TypeBool, TypeBool}}
 	case OpNewList:
 		return opSig{TypeList, [3]Type{}}
 	case OpListLenI64:

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -158,6 +158,7 @@ func kindOf(o ir.OpCode) ProducerKind {
 		ir.OpCmpEqF64, ir.OpCmpNeF64, ir.OpCmpLtF64, ir.OpCmpLeF64, ir.OpCmpGtF64, ir.OpCmpGeF64,
 		ir.OpCmpEqStr, ir.OpCmpNeStr,
 		ir.OpCmpEqBool, ir.OpCmpNeBool,
+		ir.OpAndBool, ir.OpOrBool,
 		ir.OpNotBool,
 		ir.OpI64ToF64, ir.OpF64ToI64,
 		ir.OpSqrtF64,
@@ -400,7 +401,8 @@ func contractResult(o ir.OpCode) ir.Type {
 	case ir.OpCmpEqI64, ir.OpCmpNeI64, ir.OpCmpLtI64, ir.OpCmpLeI64, ir.OpCmpGtI64, ir.OpCmpGeI64,
 		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm,
 		ir.OpCmpEqStr, ir.OpCmpNeStr,
-		ir.OpCmpEqBool, ir.OpCmpNeBool:
+		ir.OpCmpEqBool, ir.OpCmpNeBool,
+		ir.OpAndBool, ir.OpOrBool:
 		return ir.TypeBool
 	case ir.OpLenStr:
 		return ir.TypeI64

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2024,6 +2024,29 @@ The §Top-line objective is "`mochi build hello.mochi` produces a single native 
 - Trailing-zero stripping in reformatted exponent form is byte-true for the common cases (single-leading-digit mantissas) but has not been audited for every 17-significant-digit subnormal; a fixture exposing the gap would be Phase 4.2.x ammunition.
 - `mochi_print_f64` now requires `mochi_str.c` at link time (it `#include`s `mochi_str.h` and calls `mochi_f64_format`). The build driver's `writeRuntime` writes both unconditionally, so no driver change is needed; if a future minified-runtime mode lands, it must keep `mochi_str.c` whenever it keeps `print.c`.
 
+## §10.36 Phase 4.2.9 closeout (LANDED 2026-05-22 09:15 GMT+7)
+
+Phase 4.2.9 wires `&&` and `||` on `TypeBool` for both `--target=c` and `--target=go`. Before this sub-phase, `examples/v0.3/logic.mochi` (the canonical "boolean logic" tutorial) errored at lower with `operator "||" on bool unsupported in MVP`. After it, the entire file compiles end-to-end and byte-matches `mochi run`.
+
+### What landed
+
+- `compiler3/ir/types.go`: two new ops `OpAndBool` / `OpOrBool` with `String()` entries `and.bool` / `or.bool`.
+- `compiler3/ir/validate.go`: signature `(TypeBool, TypeBool) -> TypeBool` for both.
+- `compiler3/verify/verify.go`: both ops added to the `KindOperator` row alongside the bool comparisons, and `contractResult` returns `TypeBool` for both.
+- `compiler3/emit/c/emit.go`: both ops lower to plain `&&` / `||` on the underlying `int` carriers. C99's `&&` / `||` are short-circuit operators at the AST level, but the IR pre-evaluated both operands into separate SSA values before the op runs, so the emitted operator only performs the logical reduction (no actual short-circuit, which would require control-flow lowering with branches). For the v0.3 surface where operands are pure value comparisons or boolean variables, this matches Go's `mochi run` byte for byte.
+- `compiler3/emit/go/emit.go`: both ops lower to plain `&&` / `||` on Go's native bool type.
+- `compiler3/frontend/lower.go`: `lowerBinary`'s `TypeBool` arm adds `case "&&"` -> `OpAndBool` and `case "||"` -> `OpOrBool`.
+- `compiler3/build/c/driver_test.go`: five new tests. `TestBuildSourceBoolAndBasic` / `TestBuildSourceBoolOrBasic` pin the elementary cases. `TestBuildSourceBoolAndOrChain` pins the v0.3-derived `x > 0 && y > 2 || x == 0`, exercising precedence and mixed comparison/logic operators. `TestBuildSourceBoolAndOrLeftRightPure` pins the eager-evaluation behaviour explicitly. `TestBuildSourceV03LogicFixture` reads `examples/v0.3/logic.mochi` verbatim and asserts the full 7-line stdout.
+
+### Why this closes a goal
+
+The §Top-line objective is "the smallest user-facing bootstrap demo". After Phase 4.2.7 (bool ==/!=) the v0.1 green-fixture count on `--target=c` reached 7/17; the next-most-canonical Mochi tutorial program to unblock was `v0.3/logic.mochi`, which is the textbook example for boolean operators. Closing this fixture brings the tutorial corpus on `--target=c` to v0.1 + v0.3/logic, the entire "introductory expressions" surface a new user is most likely to type. The implementation cost is two IR ops and two emit cases; the surface payoff is the canonical boolean-logic demo working end-to-end.
+
+### Limitations
+
+- Eager evaluation, not short-circuit. The IR lowers both operands of `a && b` into separate SSA values before the op runs, so `f() && g()` (where `f()` is false and `g()` has side effects) still evaluates `g()`. This matches Go's value-level `&&` for pure operands, which is sufficient for the tutorial corpus today, but a side-effect-bearing right operand would observe the divergence. True short-circuit would require lowering `&&` / `||` into a branching control-flow shape; tracked as a separate sub-phase if a user program surfaces the gap.
+- The C emit relies on C99's int-carrier truthiness (`0` vs non-zero). The same `!!`-normalisation rationale from Phase 4.2.7 applies: future opaque bool sources (Go FFI bridges, etc.) would need the carrier discipline preserved. The current emit does not `!!`-normalise the operands of `&&` / `||` because C99 already does that as part of the operator's semantics; only `==` / `!=` needed the explicit normalisation (since those compare bit patterns).
+
 ## §11 Risks
 
 ### 11.1 Clang ABI drift breaks stencils


### PR DESCRIPTION
Tracking issue: #22011

## Summary

- Wires logical AND and OR on `TypeBool` via two new IR ops `OpAndBool` / `OpOrBool`. C emit lowers to plain `&&` / `||` on the int carrier; Go emit lowers to the same on native bool.
- Unblocks `examples/v0.3/logic.mochi` end-to-end on `--target=c`. Output byte-matches `mochi run`.

## What changed

`compiler3/ir/types.go`, `validate.go`, `compiler3/verify/verify.go`: register the two new ops in the IR contract, the kind tables, and `contractResult`.

`compiler3/emit/c/emit.go`: two emit cases. C99 `&&` / `||` on the int carriers.

`compiler3/emit/go/emit.go`: two emit cases on Go's native bool.

`compiler3/frontend/lower.go`: `lowerBinary`'s `TypeBool` arm adds `case \"&&\"` -> `OpAndBool` and `case \"||\"` -> `OpOrBool`.

`compiler3/build/c/driver_test.go`: five new tests pin the elementary cases, the v0.3-derived precedence chain, the eager-evaluation behaviour, and the full v0.3/logic.mochi fixture.

`website/docs/mep/mep-0042.md`: §10.36 closeout (LANDED 2026-05-22 09:15 GMT+7).

## Test plan

- [x] `go test ./compiler3/build/c/... -run 'TestBuildSourceBoolAnd|TestBuildSourceBoolOr|TestBuildSourceV03LogicFixture' -count=1 -v` (all five PASS).
- [x] Full `go test ./compiler3/... -count=1` green.
- [x] `mochi build --target=c examples/v0.3/logic.mochi` byte-matches `mochi run`.