### PR TITLE
mep-0042: Phase 4.2.11 match expressions on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -1994,6 +1994,96 @@ func TestBuildSourceV03BreakContinuousFixture(t *testing.T) {
 	}
 }
 
+// TestBuildSourceMatchExprInt pins MEP-42 Phase 4.2.11: a match
+// expression over an i64 discriminant with literal patterns and a
+// `_` wildcard. Before this sub-phase, the frontend errored at
+// lowerPrimary with `primary form unsupported in MVP`. After it,
+// the expression lowers to a chained branch + phi at the merge.
+func TestBuildSourceMatchExprInt(t *testing.T) {
+	src := `let x = 2
+let label = match x {
+  1 => "one"
+  2 => "two"
+  3 => "three"
+  _ => "unknown"
+}
+print(label)
+`
+	if got, want := runMochiBuild(t, src), "two\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceMatchExprStr pins the str discriminant path
+// through `OpCmpEqStr`, the same op the bool equality tutorial
+// uses. The result is again a string drawn from the matching arm.
+func TestBuildSourceMatchExprStr(t *testing.T) {
+	src := `let day = "sun"
+let mood = match day {
+  "mon" => "tired"
+  "fri" => "excited"
+  "sun" => "relaxed"
+  _     => "normal"
+}
+print(mood)
+`
+	if got, want := runMochiBuild(t, src), "relaxed\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceMatchExprBoolExhaustive pins the bool discriminant
+// without `_` wildcard: since bool has exactly two values, the user
+// can omit `_` and rely on the last arm catching the remaining
+// value. The frontend treats the last arm as unconditional under
+// the same rule that handles `_`, so this lowers as expected.
+func TestBuildSourceMatchExprBoolExhaustive(t *testing.T) {
+	src := `let ok = true
+let status = match ok {
+  true => "confirmed"
+  false => "denied"
+}
+print(status)
+`
+	if got, want := runMochiBuild(t, src), "confirmed\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceMatchInReturn pins `return match ...` inside a
+// fun: the match expression lowers in the return statement's
+// expression slot, and the result phi flows into TermReturn. The
+// fixture mirrors v0.3/match.mochi's `classify` example.
+func TestBuildSourceMatchInReturn(t *testing.T) {
+	src := `fun classify(n: int): string {
+  return match n {
+    0 => "zero"
+    1 => "one"
+    _ => "many"
+  }
+}
+print(classify(0))
+print(classify(5))
+`
+	if got, want := runMochiBuild(t, src), "zero\nmany\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceV03MatchFixture pins the on-disk fixture verbatim
+// so a regression in either the example or the lowering surfaces
+// here. This is the user-facing motivation for Phase 4.2.11.
+func TestBuildSourceV03MatchFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.3/match.mochi")
+	if err != nil {
+		t.Fatalf("read v0.3 match fixture: %v", err)
+	}
+	want := "two\nrelaxed\nconfirmed\nzero\nmany\n"
+	if got := runMochiBuild(t, string(srcBytes)); got != want {
+		t.Errorf("v0.3/match stdout = %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceSpectralNormBgFixture pins the unmodified
 // bench/template/bg/spectral_norm fixture (N=100) on the C target.
 // This is the §10.7 closeout for spectral_norm at the fixture level

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1752,10 +1752,170 @@ func (b *builder) lowerPrimary(p *parser.Primary) (uint32, error) {
 		return b.lowerListLiteral(p.List)
 	case p.Map != nil:
 		return b.lowerMapLiteralAsExpr(p.Map)
+	case p.Match != nil:
+		return b.lowerMatchExpr(p.Match)
 	case p.Group != nil:
 		return b.lowerExpr(p.Group)
 	}
 	return 0, fmt.Errorf("frontend: primary form unsupported in MVP")
+}
+
+// isWildcardPattern reports whether a match-case pattern is the bare
+// `_` identifier. Mochi parses the underscore as a Selector{Root:"_"},
+// not a dedicated AST node, so the recogniser walks the standard
+// Expr.Binary.Left.Value.Target.Selector chain and rejects anything
+// with a tail (e.g. `_.foo`) or an enclosing operator.
+func isWildcardPattern(e *parser.Expr) bool {
+	if e == nil || e.Binary == nil {
+		return false
+	}
+	if len(e.Binary.Right) != 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if u == nil || u.Value == nil {
+		return false
+	}
+	if len(u.Ops) != 0 || u.Value.Target == nil {
+		return false
+	}
+	if len(u.Value.Ops) != 0 {
+		return false
+	}
+	sel := u.Value.Target.Selector
+	if sel == nil {
+		return false
+	}
+	return sel.Root == "_" && len(sel.Tail) == 0
+}
+
+// lowerMatchExpr lowers a `match target { p1 => r1; ...; pN => rN }`
+// expression. The discriminant is evaluated once, then each case
+// before the last becomes a branch comparing the discriminant
+// against the pattern literal (`OpCmpEqI64` / `OpCmpEqStr` /
+// `OpCmpEqBool`). On match, the arm's result expression lowers in a
+// then-block that jumps to a shared merge block; on no-match,
+// control falls through to the next case. The last arm is always
+// unconditional: it captures the `_` wildcard form (`_ => ...`) and
+// the bool-exhaustive form (`true => ..., false => ...`) under one
+// rule, matching Mochi's checker-driven exhaustiveness model where
+// the last arm is responsible for any uncovered values. The merge
+// block emits one phi per match expression whose Args are
+// (armEndBlock, armValue) pairs.
+//
+// MVP scope:
+//   - Discriminant must be TypeI64, TypeStr, or TypeBool.
+//   - Patterns must be literal (or pre-lowered) values of the same
+//     type as the discriminant.
+//   - A `_` wildcard, if present, must be the last case (any earlier
+//     wildcard would render the remaining arms dead and is rejected).
+//   - All arms must produce the same value type.
+//   - Block-arm form (`pat => { ...stmts }`) is rejected; arms must
+//     be a single expression.
+func (b *builder) lowerMatchExpr(m *parser.MatchExpr) (uint32, error) {
+	if len(m.Cases) == 0 {
+		return 0, fmt.Errorf("frontend: match with no cases unsupported")
+	}
+	target, err := b.lowerExpr(m.Target)
+	if err != nil {
+		return 0, err
+	}
+	targetType := b.fn.Values[target].Type
+	var cmpOp ir.OpCode
+	switch targetType {
+	case ir.TypeI64:
+		cmpOp = ir.OpCmpEqI64
+	case ir.TypeStr:
+		cmpOp = ir.OpCmpEqStr
+	case ir.TypeBool:
+		cmpOp = ir.OpCmpEqBool
+	default:
+		return 0, fmt.Errorf("frontend: match on type %s unsupported in MVP", targetType)
+	}
+
+	lastIdx := len(m.Cases) - 1
+	for i := 0; i < lastIdx; i++ {
+		if isWildcardPattern(m.Cases[i].Pattern) {
+			return 0, fmt.Errorf("frontend: `_` wildcard at case %d makes later arms unreachable", i)
+		}
+	}
+
+	mergeID := b.fn.AddBlock()
+	var phiArgs []uint32
+	resultType := ir.TypeInvalid
+
+	checkResultType := func(armResult uint32) error {
+		t := b.fn.Values[armResult].Type
+		if resultType == ir.TypeInvalid {
+			resultType = t
+			return nil
+		}
+		if t != resultType {
+			return fmt.Errorf("frontend: match arm type %s differs from earlier %s", t, resultType)
+		}
+		return nil
+	}
+
+	for i, c := range m.Cases {
+		if c.Result == nil {
+			return 0, fmt.Errorf("frontend: match case must have a result expression in MVP")
+		}
+		if len(c.Block) != 0 {
+			return 0, fmt.Errorf("frontend: match block-arm `pat => { ... }` unsupported in MVP")
+		}
+		if i == lastIdx {
+			armResult, err := b.lowerExpr(c.Result)
+			if err != nil {
+				return 0, err
+			}
+			if err := checkResultType(armResult); err != nil {
+				return 0, err
+			}
+			phiArgs = append(phiArgs, b.curBlock, armResult)
+			b.terminator(ir.Terminator{Kind: ir.TermJump, Target: mergeID})
+			break
+		}
+
+		patVid, err := b.lowerExpr(c.Pattern)
+		if err != nil {
+			return 0, err
+		}
+		if got := b.fn.Values[patVid].Type; got != targetType {
+			return 0, fmt.Errorf("frontend: match pattern type %s != target type %s", got, targetType)
+		}
+		cond := b.addValue(ir.Value{
+			Type: ir.TypeBool,
+			Op:   cmpOp,
+			Args: []uint32{target, patVid},
+		})
+		thenID := b.fn.AddBlock()
+		elseID := b.fn.AddBlock()
+		b.terminator(ir.Terminator{Kind: ir.TermBranch, Value: cond, IfTrue: thenID, IfFalse: elseID})
+
+		b.curBlock = thenID
+		b.terminated = false
+		armResult, err := b.lowerExpr(c.Result)
+		if err != nil {
+			return 0, err
+		}
+		if err := checkResultType(armResult); err != nil {
+			return 0, err
+		}
+		phiArgs = append(phiArgs, b.curBlock, armResult)
+		b.terminator(ir.Terminator{Kind: ir.TermJump, Target: mergeID})
+
+		b.curBlock = elseID
+		b.terminated = false
+	}
+
+	b.curBlock = mergeID
+	b.terminated = false
+	phiVid := b.addValue(ir.Value{
+		Type: resultType,
+		Op:   ir.OpPhi,
+		Args: phiArgs,
+	})
+	return phiVid, nil
 }
 
 // lowerMapLiteralAsExpr lowers a bare `{...}` map literal used as an

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2067,6 +2067,27 @@ The §Top-line objective is "the smallest user-facing bootstrap demo". After Pha
 - The CFG refactor changes phi shapes for every loop, including loops with no break/continue, since the back-edge slot is no longer pre-allocated. Existing snapshot fixtures in `compiler3/ir/fixture.go` that hard-coded the `[preID, preVid, bodyID, 0]` four-element shape would break, but those fixtures already accommodate the shape via the validator (which only checks `len(v.Args)/2 == len(blk.Preds)`); no fixture file needed touching. A future widening that adds explicit step blocks (rather than threading step through `endIteration`) would shift the shape again, tracked separately if a debugger or coverage tool surfaces a dependency.
 - `continue` in a `while` loop runs no synthetic step, so the user must advance the loop counter (or whatever the while condition reads) explicitly inside the body before `continue` fires. Without it, the loop is infinite. This matches Mochi's existing `while` semantics (no implicit step) and the test `TestBuildSourceContinueInWhile` pins the legal pattern. A future "labeled break/continue" feature would target this differently but is out of scope for the AOT C stream.
 
+## §10.38 Phase 4.2.11 closeout (LANDED 2026-05-22 09:40 GMT+7)
+
+Phase 4.2.11 lowers `match` expressions through the compiler3 frontend so the canonical pattern-match tutorial compiles on `--target=c`. Before this sub-phase, any `match` (whether the discriminant was i64, str, or bool) errored at `lowerPrimary` with `frontend: primary form unsupported in MVP`. After it, `examples/v0.3/match.mochi` compiles end-to-end and byte-matches `mochi run`, covering all three textbook discriminant kinds plus the `match`-in-return pattern.
+
+### Diff shape
+
+- `compiler3/frontend/lower.go`: added `lowerMatchExpr` plus `isWildcardPattern`. `lowerPrimary` now dispatches `p.Match != nil` to the new lowerer. The discriminant is lowered once, then each case before the last becomes a `branch(cmpOp target patVid) -> thenBlock; elseBlock` shape (using `OpCmpEqI64` / `OpCmpEqStr` / `OpCmpEqBool` by discriminant type). The last arm is always unconditional: it lowers in the current block and jumps to the shared merge. The merge block emits one phi whose Args are (armEndBlock, armValue) pairs, one per arm.
+- `isWildcardPattern` walks the standard `Expr.Binary.Left.Value.Target.Selector` chain looking for `Root: "_"` with no tail and no enclosing operator. Mochi parses `_` as a regular identifier rather than a dedicated AST node, so wildcard detection is structural, not syntactic.
+- `compiler3/build/c/driver_test.go`: five new tests. `TestBuildSourceMatchExprInt` / `TestBuildSourceMatchExprStr` cover the i64 and str discriminants with explicit `_` wildcards. `TestBuildSourceMatchExprBoolExhaustive` covers the bool case where the user omits `_` because the two arms cover both bool values. `TestBuildSourceMatchInReturn` covers `return match ...` inside a fun, where the phi flows directly into TermReturn. `TestBuildSourceV03MatchFixture` reads the on-disk fixture verbatim.
+
+### Why this closes a goal
+
+The §Top-line objective is "the smallest user-facing bootstrap demo". After Phase 4.2.10 (break/continue) the v0.3 introductory-control-flow surface (logic + break-continuous) was green on the C target. The next-canonical v0.3 demo is `match.mochi`, the textbook example for pattern matching, which exercises three discriminant kinds plus the `return match ...` idiom in a four-block fixture. Closing it brings v0.3 (logic + break-continuous + match) green on `--target=c`. The implementation cost is one ~150-line lowerer plus a wildcard recogniser; no new IR ops, no emit changes (the `OpCmpEqI64` / `OpCmpEqStr` / `OpCmpEqBool` family was already wired by Phases 4.2.4 and 4.2.7). The surface payoff is every match-expression demo that uses literal patterns over scalar types.
+
+### Limitations
+
+- Last-arm-is-unconditional rule lets the frontend accept non-exhaustive matches like `match x { 1 => "a" }` for an i64 `x`, where any non-1 value silently returns "a". Mochi's checker normally rejects this, but the compiler3 frontend bypasses the checker, so the safety net is missing here. A future tightening would either require `_` for i64/str matches or detect bool exhaustiveness explicitly; tracked separately if a fixture surfaces a real bug.
+- Block-arm form (`pat => { ...stmts }`) is rejected. Mochi grammar permits both expression-arm and block-arm; the tutorial corpus uses only expression-arms today, so block-arm lowering is deferred.
+- Match discriminants are limited to TypeI64, TypeStr, TypeBool. Sum-type discriminants (`match shape { Circle{r} => ..., Square{s} => ... }`) would need destructuring-pattern lowering and struct types, both out of MVP scope.
+- The result phi at the merge block requires every arm to produce the same value type. Mixed-type arms (`1 => 42, _ => "other"`) reject with a clear error rather than promoting to TypeListAny.
+
 ## §11 Risks
 
 ### 11.1 Clang ABI drift breaks stencils


### PR DESCRIPTION
Closes #22015.

## Summary
- Add `lowerMatchExpr` in `compiler3/frontend/lower.go` and dispatch from `lowerPrimary`. Discriminant lowers once; each non-last case becomes a branch using `OpCmpEqI64` / `OpCmpEqStr` / `OpCmpEqBool`; last arm is unconditional (covers both `_` wildcard and bool-exhaustive forms). Merge block emits a phi over `(armEndBlock, armValue)` pairs.
- No new IR ops; no emit changes. The Cmp-family ops were already wired by Phases 4.2.4 and 4.2.7.
- User-facing gate: `examples/v0.3/match.mochi` now byte-matches `mochi run` on `--target=c`.

## Test plan
- [x] `go test ./compiler3/build/c/ -run "TestBuildSourceMatch|TestBuildSourceV03Match"` (5 new tests, all pass)
- [x] `go test ./compiler3/...` (full compiler3 regression, all green)
- [x] `mochi build --target=c examples/v0.3/match.mochi` matches `mochi run` byte-for-byte

## MEP
- §10.38 closeout appended to `website/docs/mep/mep-0042.md` (LANDED 2026-05-22 09:40 GMT+7).