### PR TITLE
MEP-42 Phase 4.2.12: if-then-else as expression on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -2070,6 +2070,78 @@ print(classify(5))
 	}
 }
 
+// TestBuildSourceIfExprStr pins MEP-42 Phase 4.2.12: `if cond then T
+// else E` as an expression in a binding position. Before this phase
+// the frontend rejected `let r = if ...` with `primary form
+// unsupported in MVP`; after it, the expression lowers to a 2-way
+// branch + phi at the merge block, with both arms required to share
+// a value type.
+func TestBuildSourceIfExprStr(t *testing.T) {
+	src := `let x = 12
+let result = if x > 10 then "yes" else "no"
+print(result)
+`
+	if got, want := runMochiBuild(t, src), "yes\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceIfExprInt pins the i64 result path: both branches
+// produce TypeI64, the merge phi infers TypeI64, and the bound name
+// flows into print as i64.
+func TestBuildSourceIfExprInt(t *testing.T) {
+	src := `let n = 3
+let abs = if n < 0 then 0 - n else n
+print(abs)
+`
+	if got, want := runMochiBuild(t, src), "3\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceIfExprElseIfChain pins the `else if` recursion
+// inside lowerIfExpr: the else branch becomes a nested if-expr that
+// itself produces a merge phi flowed into the outer phi.
+func TestBuildSourceIfExprElseIfChain(t *testing.T) {
+	src := `let n = 2
+let label = if n == 1 then "one" else if n == 2 then "two" else if n == 3 then "three" else "other"
+print(label)
+`
+	if got, want := runMochiBuild(t, src), "two\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceIfExprInReturn pins `return if ...` inside a fun:
+// the if-expr lowers in the return statement's expression slot, and
+// the merge phi flows into TermReturn.
+func TestBuildSourceIfExprInReturn(t *testing.T) {
+	src := `fun classify(n: int): string {
+  return if n < 0 then "negative" else if n == 0 then "zero" else "positive"
+}
+print(classify(-5))
+print(classify(0))
+print(classify(7))
+`
+	if got, want := runMochiBuild(t, src), "negative\nzero\npositive\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceV010IfThenElseFixture pins the on-disk fixture
+// verbatim so the v0.10/if_then_else.mochi tutorial example
+// regression-tests if-expr lowering at the fixture level.
+func TestBuildSourceV010IfThenElseFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.10/if_then_else.mochi")
+	if err != nil {
+		t.Fatalf("read v0.10 if_then_else fixture: %v", err)
+	}
+	want := "yes\n"
+	if got := runMochiBuild(t, string(srcBytes)); got != want {
+		t.Errorf("v0.10/if_then_else stdout = %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceV03MatchFixture pins the on-disk fixture verbatim
 // so a regression in either the example or the lowering surfaces
 // here. This is the user-facing motivation for Phase 4.2.11.

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1754,6 +1754,8 @@ func (b *builder) lowerPrimary(p *parser.Primary) (uint32, error) {
 		return b.lowerMapLiteralAsExpr(p.Map)
 	case p.Match != nil:
 		return b.lowerMatchExpr(p.Match)
+	case p.If != nil:
+		return b.lowerIfExpr(p.If)
 	case p.Group != nil:
 		return b.lowerExpr(p.Group)
 	}
@@ -1916,6 +1918,69 @@ func (b *builder) lowerMatchExpr(m *parser.MatchExpr) (uint32, error) {
 		Args: phiArgs,
 	})
 	return phiVid, nil
+}
+
+// lowerIfExpr lowers `if cond then T else E` (or its `else if ...` chain)
+// as an expression. The condition lowers in the current block, then two
+// fresh successor blocks evaluate each branch. Both branches must produce
+// the same value type; the merge block phi-joins (thenEnd, thenVal) and
+// (elseEnd, elseVal). Unlike lowerIf (the statement form), an if-expr
+// requires an else branch (an expression must always produce a value)
+// and does not snapshot/restore the variable env, since branch
+// expressions are pure subterms that introduce no bindings.
+func (b *builder) lowerIfExpr(e *parser.IfExpr) (uint32, error) {
+	cond, err := b.lowerExpr(e.Cond)
+	if err != nil {
+		return 0, err
+	}
+	if got := b.fn.Values[cond].Type; got != ir.TypeBool {
+		return 0, fmt.Errorf("frontend: if-expr cond has Type %s, want bool", got)
+	}
+	if e.ElseIf == nil && e.Else == nil {
+		return 0, fmt.Errorf("frontend: if-expr must have an else branch")
+	}
+
+	thenID := b.fn.AddBlock()
+	elseID := b.fn.AddBlock()
+	mergeID := b.fn.AddBlock()
+	b.terminator(ir.Terminator{Kind: ir.TermBranch, Value: cond, IfTrue: thenID, IfFalse: elseID})
+
+	b.curBlock = thenID
+	b.terminated = false
+	thenVal, err := b.lowerExpr(e.Then)
+	if err != nil {
+		return 0, err
+	}
+	thenEnd := b.curBlock
+	b.terminator(ir.Terminator{Kind: ir.TermJump, Target: mergeID})
+
+	b.curBlock = elseID
+	b.terminated = false
+	var elseVal uint32
+	if e.ElseIf != nil {
+		elseVal, err = b.lowerIfExpr(e.ElseIf)
+	} else {
+		elseVal, err = b.lowerExpr(e.Else)
+	}
+	if err != nil {
+		return 0, err
+	}
+	elseEnd := b.curBlock
+	b.terminator(ir.Terminator{Kind: ir.TermJump, Target: mergeID})
+
+	thenType := b.fn.Values[thenVal].Type
+	elseType := b.fn.Values[elseVal].Type
+	if thenType != elseType {
+		return 0, fmt.Errorf("frontend: if-expr branches differ in type: then %s vs else %s", thenType, elseType)
+	}
+
+	b.curBlock = mergeID
+	b.terminated = false
+	return b.addValue(ir.Value{
+		Type: thenType,
+		Op:   ir.OpPhi,
+		Args: []uint32{thenEnd, thenVal, elseEnd, elseVal},
+	}), nil
 }
 
 // lowerMapLiteralAsExpr lowers a bare `{...}` map literal used as an

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2088,6 +2088,27 @@ The §Top-line objective is "the smallest user-facing bootstrap demo". After Pha
 - Match discriminants are limited to TypeI64, TypeStr, TypeBool. Sum-type discriminants (`match shape { Circle{r} => ..., Square{s} => ... }`) would need destructuring-pattern lowering and struct types, both out of MVP scope.
 - The result phi at the merge block requires every arm to produce the same value type. Mixed-type arms (`1 => 42, _ => "other"`) reject with a clear error rather than promoting to TypeListAny.
 
+## §10.39 Phase 4.2.12 closeout (LANDED 2026-05-22 09:48 GMT+7)
+
+Phase 4.2.12 lowers `if cond then T else E` (and its `else if` chain) as an expression form so the canonical if-then-else tutorial compiles on `--target=c`. Before this sub-phase the frontend dispatched only `if` as a statement; any binding-position `let r = if ...` errored at `lowerPrimary` with `frontend: primary form unsupported in MVP`. After it, `examples/v0.10/if_then_else.mochi` compiles end-to-end and byte-matches `mochi run`, and the `else if ... else if ... else` chain lowers as a left-leaning recursion of merge phis.
+
+### Diff shape
+
+- `compiler3/frontend/lower.go`: added `lowerIfExpr(*parser.IfExpr) (uint32, error)`. `lowerPrimary` now dispatches `p.If != nil` to the new lowerer. Shape: lower `cond` in the current block, allocate `thenID`, `elseID`, `mergeID`, branch on `cond`. Each branch lowers its expression, captures the block where lowering finished (so a nested if-expr's merge block is what feeds the outer phi), jumps to the merge. The merge block emits a single 2-arg phi `(thenEnd, thenVal, elseEnd, elseVal)`. `e.ElseIf != nil` recurses into `lowerIfExpr`; an else-less if-expr rejects (an expression must produce a value on every path).
+- Type unification: both branches must produce the same value type; a mismatch (`then i64 vs else str`) errors with a clear message rather than producing an ill-typed phi that would crash `ir.Validate`.
+- `compiler3/build/c/driver_test.go`: five new tests. `TestBuildSourceIfExprStr` is the literal v0.10 fixture inline. `TestBuildSourceIfExprInt` covers the i64 result path. `TestBuildSourceIfExprElseIfChain` exercises the `else if` recursion across three conditions plus an else-tail. `TestBuildSourceIfExprInReturn` covers `return if ...` inside a fun, where the merge phi flows directly into TermReturn. `TestBuildSourceV010IfThenElseFixture` reads the on-disk fixture verbatim.
+
+### Why this closes a goal
+
+The §Top-line objective is "the smallest user-facing bootstrap demo". After Phase 4.2.11 (match) the v0.3 introductory-control-flow surface was green on the C target. The next-canonical demo is v0.10's `if_then_else.mochi`, the textbook example for if-as-expression, which is the Mochi idiom used pervasively in larger fixtures (e.g. the v0.2/π Leibniz-sign alternation, the v0.5 string-tutorial branching, every classifier in the v0.3 tutorial cluster). Closing it unblocks every binding-position if-expression in the downstream fixtures. The implementation cost is one ~50-line lowerer plus a dispatch arm; no new IR ops, no emit changes (the phi+branch path was already wired by every existing if-statement lowering). The surface payoff is the universal Mochi conditional-expression idiom.
+
+### Limitations
+
+- An if-expr without `else` is rejected. The statement form (`if c { ... } else { ... }`) still allows the else to be omitted (control-flow only), but a binding-position expression must produce a value on every path.
+- Both branches must produce the same value type. Mixed-type branches (`if c then 42 else "no"`) reject; there is no implicit any-promotion.
+- The `else if` chain is left-leaning recursion: each `else if` allocates its own `thenID`/`elseID`/`mergeID` triple. For a chain of N conditions this generates O(N) merge blocks. SSA peephole could collapse the cascade post-lowering, but the C emitter's block walk already handles the redundant single-pred merges fine; deferred unless a benchmark surfaces it.
+- An if-expr inside a non-trivial larger expression (`f(if c then a else b) + 1`) is supported (the merge phi just feeds the next op), but a `print(if ...)` may surface unrelated `print` overload limitations if the branch type isn't one of the already-supported print types (i64/f64/bool/str). Same constraint as any other expression in print position.
+
 ## §11 Risks
 
 ### 11.1 Clang ABI drift breaks stencils


### PR DESCRIPTION
## Summary

- Add `lowerIfExpr` to the compiler3 frontend so `if cond then T else E` (and its `else if` chain) lowers as a primary expression on `--target=c`.
- `let r = if ...` and `return if ...` now compile end-to-end; `examples/v0.10/if_then_else.mochi` byte-matches `mochi run`.
- Append §10.39 closeout to MEP-42.

## Shape

Lower `cond`, branch to fresh `thenID`/`elseID`, lower each branch's expression, jump to a `mergeID` that emits one 2-arg phi `(thenEnd, thenVal, elseEnd, elseVal)`. `e.ElseIf` recurses into `lowerIfExpr` (the nested merge block feeds the outer phi). Both branches must produce the same value type; an else-less if-expr is rejected since an expression must produce a value on every path.

## Why this closes a goal

After Phase 4.2.11 the v0.3 introductory-control-flow surface was green. v0.10/if_then_else is the textbook example for if-as-expression, the Mochi idiom used pervasively in v0.2/π (Leibniz sign alternation), v0.5 string tutorials, and every classifier across v0.3. Closing it unblocks every binding-position if-expression in downstream fixtures with one ~50-line lowerer and zero new IR ops.

## Test plan

- [x] `go test ./compiler3/build/c -run 'TestBuildSourceIfExpr|TestBuildSourceV010IfThenElse' -v` (5/5 PASS)
- [x] `go test ./compiler3/...` full suite (no regressions)
- [x] `examples/v0.10/if_then_else.mochi` compiles end-to-end and byte-matches expected output

Closes #22017