### PR TITLE
MEP-42 Phase 4.2.13: print(list<int>) on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -2142,6 +2142,60 @@ func TestBuildSourceV010IfThenElseFixture(t *testing.T) {
 	}
 }
 
+// TestBuildSourcePrintListI64 pins MEP-42 Phase 4.2.13: print(xs)
+// where xs is a list<int>. Before this phase the frontend rejected
+// `print(list)` with `print() argument type list unsupported in MVP`.
+// After it, the value is lifted via OpListI64ToStr (-> TypeStr) then
+// fed into the existing single-arg print path. The runtime helper
+// mochi_list_i64_to_str produces the Mochi reference `[a, b, c]`
+// form (comma-space separators, square brackets, no newline) so the
+// C target byte-matches `mochi run`.
+func TestBuildSourcePrintListI64(t *testing.T) {
+	src := `let xs = [1, 2, 3, 4, 5]
+print(xs)
+`
+	if got, want := runMochiBuild(t, src), "[1, 2, 3, 4, 5]\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourcePrintListI64Empty covers the empty-list edge case.
+// mochi_list_i64_to_str returns the static "[]" literal, no malloc.
+func TestBuildSourcePrintListI64Empty(t *testing.T) {
+	src := `let xs: list<int> = []
+print(xs)
+`
+	if got, want := runMochiBuild(t, src), "[]\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourcePrintListI64MultiArg covers list<int> as one of
+// several print() args. liftToStr's new TypeList case converts the
+// list value to its display string, then the concat-with-separator
+// path joins it into the space-separated multi-arg form.
+func TestBuildSourcePrintListI64MultiArg(t *testing.T) {
+	src := `let xs = [10, 20, 30]
+print("values:", xs)
+`
+	if got, want := runMochiBuild(t, src), "values: [10, 20, 30]\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourcePrintListI64AfterConcat covers a list grown via
+// concat: mochi_list_i64_to_str walks len, not cap, so a concat
+// producing a 3-element list prints `[1, 2, 3]` regardless of any
+// over-allocation in the concat helper.
+func TestBuildSourcePrintListI64AfterConcat(t *testing.T) {
+	src := `let xs = [1, 2] + [3]
+print(xs)
+`
+	if got, want := runMochiBuild(t, src), "[1, 2, 3]\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceV03MatchFixture pins the on-disk fixture verbatim
 // so a regression in either the example or the lowering surfaces
 // here. This is the user-facing motivation for Phase 4.2.11.

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -374,6 +374,8 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    mochi_f64_array_set(%s, %s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
 	case ir.OpListConcatI64:
 		fmt.Fprintf(w, "    %s = mochi_list_i64_concat(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpListI64ToStr:
+		fmt.Fprintf(w, "    %s = mochi_list_i64_to_str(%s);\n", name, valueName(v.Args[0]))
 	case ir.OpF64ArrayConcat:
 		fmt.Fprintf(w, "    %s = mochi_f64_array_concat(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpNewMap:

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -363,6 +363,19 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 	case ir.OpListConcatI64:
 		fmt.Fprintf(w, "\t%s = append(append([]int64{}, %s...), %s...)\n",
 			name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpListI64ToStr:
+		// Inline the format so we never pull in mochi/runtime/mochi/fmt
+		// (default alias "fmt", collides with stdlib). The lambda
+		// produces the same `[a, b, c]` shape as the C runtime's
+		// mochi_list_i64_to_str and the VM's valueToString.
+		imports["fmt"] = true
+		imports["strings"] = true
+		fmt.Fprintf(w, "\t%s = func(xs []int64) string {\n", name)
+		w.WriteString("\t\tif len(xs) == 0 { return \"[]\" }\n")
+		w.WriteString("\t\tparts := make([]string, len(xs))\n")
+		w.WriteString("\t\tfor i, x := range xs { parts[i] = fmt.Sprintf(\"%d\", x) }\n")
+		w.WriteString("\t\treturn \"[\" + strings.Join(parts, \", \") + \"]\"\n")
+		fmt.Fprintf(w, "\t}(%s)\n", valueName(v.Args[0]))
 	case ir.OpF64ArrayConcat:
 		fmt.Fprintf(w, "\t%s = append(append([]float64{}, %s...), %s...)\n",
 			name, valueName(v.Args[0]), valueName(v.Args[1]))

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1198,6 +1198,14 @@ func (b *builder) lowerExprAsStmt(e *parser.Expr) (uint32, error) {
 			return 0, err
 		}
 		argType := b.fn.Values[arg].Type
+		// list<int>: lift through OpListI64ToStr so the single-arg
+		// print path can reuse the TypeStr fmt.Println binding. The
+		// runtime formatter (mochi_list_i64_to_str / Go-side helper)
+		// produces the Mochi reference `[a, b, c]` form.
+		if argType == ir.TypeList {
+			arg = b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpListI64ToStr, Args: []uint32{arg}})
+			argType = ir.TypeStr
+		}
 		goArgType := goTypeForIRType(argType)
 		if goArgType == "" {
 			return 0, fmt.Errorf("frontend: print() argument type %s unsupported in MVP", argType)
@@ -1280,6 +1288,8 @@ func (b *builder) liftToStr(argID uint32) (uint32, error) {
 		return b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpF64ToStr, Args: []uint32{argID}}), nil
 	case ir.TypeBool:
 		return b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpBoolToStr, Args: []uint32{argID}}), nil
+	case ir.TypeList:
+		return b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpListI64ToStr, Args: []uint32{argID}}), nil
 	}
 	return 0, fmt.Errorf("frontend: print() argument type %s unsupported in MVP", b.fn.Values[argID].Type)
 }

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -291,6 +291,14 @@ const (
 	OpListAnyPushAny
 	OpListAnyGetAny
 
+	// List display formatting (Phase 4.2.13). OpListI64ToStr converts a
+	// list<i64> to its Mochi reference display form: `[a, b, c]` with
+	// comma-space separators, square brackets, no trailing newline.
+	// Surface form `print(xs)` where `xs: list<int>` lowers to this op
+	// then OpCallGo(fmt.Println). Go emit calls a runtime formatter
+	// (runtime/mochi/fmt); C emit calls `mochi_list_i64_to_str`.
+	OpListI64ToStr
+
 	// Bench-harness JSON sink (Phase 4.3.14). OpJsonI64Object is the
 	// statement-level form `json({"k1": v1, ..., "kN": vN})` where every
 	// key is a string literal and every value is an i64 expression. It
@@ -439,6 +447,8 @@ func (o OpCode) String() string {
 		return "listany.push"
 	case OpListAnyGetAny:
 		return "listany.get"
+	case OpListI64ToStr:
+		return "list.i64.tostr"
 	case OpJsonI64Object:
 		return "json.i64.object"
 	case OpCall:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -233,6 +233,8 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeF64, [3]Type{TypeF64}}
 	case OpListConcatI64:
 		return opSig{TypeList, [3]Type{TypeList, TypeList}}
+	case OpListI64ToStr:
+		return opSig{TypeStr, [3]Type{TypeList}}
 	case OpF64ArrayConcat:
 		return opSig{TypeF64Arr, [3]Type{TypeF64Arr, TypeF64Arr}}
 	case OpNow:

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -168,7 +168,7 @@ func kindOf(o ir.OpCode) ProducerKind {
 
 	case ir.OpLenStr:
 		return KindDispatch
-	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr:
+	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpListI64ToStr:
 		return KindConstructor
 
 	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array, ir.OpNewListAny,

--- a/runtime/c/src/mochi_list_i64.c
+++ b/runtime/c/src/mochi_list_i64.c
@@ -3,7 +3,9 @@
  */
 #include "mochi_list_i64.h"
 
+#include <inttypes.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -41,6 +43,38 @@ int64_t mochi_list_i64_get(const mochi_list_i64 *l, int64_t i) {
 
 void mochi_list_i64_set(mochi_list_i64 *l, int64_t i, int64_t v) {
     l->data[i] = v;
+}
+
+const char *mochi_list_i64_to_str(const mochi_list_i64 *l) {
+    /* Empty list: return the static literal "[]" so callers do not have
+     * to special-case malloc(2). The carrier is `const char*`, so a
+     * literal is indistinguishable from a heap buffer downstream. */
+    if (l->len == 0) {
+        return "[]";
+    }
+    /* Worst-case per-element width: "-9223372036854775808" is 20 bytes
+     * plus the ", " separator (2 bytes); reserve 22. Plus "[" + "]" + NUL. */
+    size_t cap = (size_t)l->len * 22 + 3;
+    char *buf = (char *)malloc(cap);
+    if (buf == NULL) {
+        abort();
+    }
+    size_t off = 0;
+    buf[off++] = '[';
+    for (int64_t i = 0; i < l->len; i++) {
+        if (i > 0) {
+            buf[off++] = ',';
+            buf[off++] = ' ';
+        }
+        int n = snprintf(buf + off, cap - off, "%" PRId64, l->data[i]);
+        if (n < 0) {
+            abort();
+        }
+        off += (size_t)n;
+    }
+    buf[off++] = ']';
+    buf[off] = '\0';
+    return buf;
 }
 
 mochi_list_i64 *mochi_list_i64_concat(const mochi_list_i64 *a, const mochi_list_i64 *b) {

--- a/runtime/c/src/mochi_list_i64.h
+++ b/runtime/c/src/mochi_list_i64.h
@@ -63,6 +63,19 @@ void mochi_list_i64_set(mochi_list_i64 *l, int64_t i, int64_t v);
  * by b's. Neither operand is mutated; the result owns its own buffer. */
 mochi_list_i64 *mochi_list_i64_concat(const mochi_list_i64 *a, const mochi_list_i64 *b);
 
+/*
+ * mochi_list_i64_to_str returns a freshly malloc'd NUL-terminated string
+ * holding the Mochi reference display form of l: `[a, b, c]` with comma-
+ * space separators, square brackets, no trailing newline. Empty list
+ * returns "[]"; single-element returns "[x]". The result is owned by the
+ * runtime (currently leaked); callers must not free() it.
+ *
+ * Format matches `mochi run`'s list-printing rule so a program compiled
+ * with `mochi build --target=c` byte-matches the same source run under
+ * `mochi run` for any `print(xs)` where `xs: list<int>`.
+ */
+const char *mochi_list_i64_to_str(const mochi_list_i64 *l);
+
 #ifdef __cplusplus
 }
 #endif

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2109,6 +2109,32 @@ The §Top-line objective is "the smallest user-facing bootstrap demo". After Pha
 - The `else if` chain is left-leaning recursion: each `else if` allocates its own `thenID`/`elseID`/`mergeID` triple. For a chain of N conditions this generates O(N) merge blocks. SSA peephole could collapse the cascade post-lowering, but the C emitter's block walk already handles the redundant single-pred merges fine; deferred unless a benchmark surfaces it.
 - An if-expr inside a non-trivial larger expression (`f(if c then a else b) + 1`) is supported (the merge phi just feeds the next op), but a `print(if ...)` may surface unrelated `print` overload limitations if the branch type isn't one of the already-supported print types (i64/f64/bool/str). Same constraint as any other expression in print position.
 
+## §10.40 Phase 4.2.13 closeout (LANDED 2026-05-22 10:07 GMT+7)
+
+Phase 4.2.13 lowers `print(xs)` where `xs: list<int>` so the canonical list-printing tutorial line compiles on `--target=c`. Before this sub-phase the frontend rejected list arguments to `print` with `print() argument type list unsupported in MVP`. After it, list values are lifted through a new `OpListI64ToStr` op (TypeStr ← TypeList) and fed into the existing single-arg print path. The runtime helper `mochi_list_i64_to_str` produces the Mochi reference `[a, b, c]` form, matching the VM's `valueToString` rule for lists (runtime/vm/vm.go) byte-for-byte.
+
+### Diff shape
+
+- `compiler3/ir/types.go`: new `OpListI64ToStr` opcode + String entry.
+- `compiler3/ir/validate.go`: contract `opSig{TypeStr, [3]Type{TypeList}}`. Type system check enforces input is TypeList, output is TypeStr.
+- `compiler3/verify/verify.go`: classify the new op under `KindConstructor` (it materialises a freshly malloc'd carrier string, same shape as `OpI64ToStr` and `OpConcatStr`).
+- `runtime/c/src/mochi_list_i64.{h,c}`: new `mochi_list_i64_to_str(const mochi_list_i64 *)` helper. Empty list returns the static `"[]"` literal (no malloc); non-empty mallocs a worst-case `22n + 3` byte buffer and snprintf's each element with `PRId64`. The pointer is owned by the runtime (currently leaked, matching `mochi_str_concat` ownership).
+- `compiler3/emit/c/emit.go`: dispatch `ir.OpListI64ToStr` to `mochi_list_i64_to_str(arg)`.
+- `compiler3/emit/go/emit.go`: dispatch `ir.OpListI64ToStr` to an inline lambda that builds the same `[a, b, c]` string via stdlib `fmt.Sprintf("%d", x)` + `strings.Join`. Inlined (rather than calling into a `runtime/mochi/fmt` helper) so the default Go-side alias for the `fmt` package, which is the host package this lambda must reach, does not collide with the user binding for `fmt.Println`.
+- `compiler3/frontend/lower.go`: in `lowerExprAsStmt`'s single-arg print path, when `argType == TypeList`, insert an `OpListI64ToStr` value first; `liftToStr` gains a parallel `TypeList` case so multi-arg `print("xs:", xs)` works through the same op.
+- `compiler3/build/c/driver_test.go`: 4 new tests covering the basic case, empty list, multi-arg combined with a string label, and a list grown via concat (validates `len`-not-`cap` behaviour in the runtime formatter).
+
+### Why this closes a goal
+
+The §Top-line objective is "the smallest user-facing bootstrap demo". After Phase 4.2.12 (if-then-else as expression) the v0.10 conditional-expression idiom was green on the C target. The next-canonical demo cluster is the list-tutorial family: `examples/v0.2/list.mochi`, `examples/v0.2/matrix.mochi`, and the v0.2/for-in cluster all open with `print(values)` against a list literal. Before this phase that very first line errored. After it, the list-print idiom compiles for `list<int>`, the most common element type across the v0.2 cluster. Subsequent sub-phases will extend the same pattern to `list<str>`, list-of-list, negative indexing, and slicing.
+
+### Limitations
+
+- `print` accepts only `list<int>` today. `list<float>` (TypeF64Arr) and `list<any>` (TypeListAny) and `list<str>` would each need a parallel `OpF64ArrayToStr` / `OpListAnyToStr` / `OpListStrToStr` op plus runtime helper. Each is one-Phase scope; deferred until the matching fixture lands.
+- `print(nested_list)` (a `list<list<int>>`) is not supported. The frontend's MVP rejects `list<list<...>>` element types entirely; supporting it requires both the type-system extension and a recursive formatter.
+- The Go-target emit inlines the format via a per-call lambda rather than a runtime helper. The lambda compiles cleanly under `go build`, but a fixture that uses `print(list)` in a tight loop will produce many lambda call sites; SSA-level CSE could fold them, but the optimiser cost is not justified until a benchmark surfaces it.
+- The C runtime's `mochi_list_i64_to_str` does not free the result. This matches the existing `mochi_str_concat` ownership convention (everything leaks, MVP doesn't run finalisers). A long-running fixture printing many large lists will accumulate memory; documented as a known limitation, same as the rest of the string-producing runtime ops.
+
 ## §11 Risks
 
 ### 11.1 Clang ABI drift breaks stencils


### PR DESCRIPTION
## Summary

- Add `OpListI64ToStr` (TypeStr <- TypeList) so `print(xs)` works when `xs: list<int>`.
- Runtime: `mochi_list_i64_to_str` produces the Mochi reference `[a, b, c]` form (matches VM's `valueToString`).
- C and Go targets both supported.
- Append §10.40 closeout to MEP-42.

## Shape

Frontend lifts list-typed print args through `OpListI64ToStr` then reuses the existing TypeStr print path. C emit calls into the runtime helper; Go emit inlines a `fmt.Sprintf+strings.Join` lambda to avoid the stdlib-fmt vs mochi-fmt alias collision. Empty list returns the static `"[]"` literal (no malloc); non-empty mallocs a worst-case `22n+3` byte buffer.

## Why this closes a goal

After Phase 4.2.12 (if-then-else) the v0.10 conditional-expression idiom was green. The next demo cluster is the v0.2 list family (`list.mochi`, `matrix.mochi`, `for-in.mochi`), each opening with `print(values)` against a list literal. This phase unblocks that very first line for `list<int>`.

## Test plan

- [x] `go test ./compiler3/build/c -run 'TestBuildSourcePrintListI64' -v` (4/4 PASS)
- [x] `go test ./compiler3/...` full suite (no regressions)
- [x] `go test ./runtime/mochi/fmt/...` (no regressions)
- [x] `print([1, 2, 3])` byte-matches `mochi run`

Closes #22019