### PR TITLE
mep-0042: Phase 4.2.14 print(list<float>) on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -2196,6 +2196,76 @@ print(xs)
 	}
 }
 
+// TestBuildSourcePrintListF64 pins MEP-42 Phase 4.2.14: print(xs)
+// where xs is a list<float>. Lifted via OpF64ArrayToStr to TypeStr
+// then fed through the single-arg print path. The runtime helper
+// mochi_f64_array_to_str renders integral floats with the ".0"
+// suffix (matching FormatFloat 'f' -1 64 + ".0"), so the C target
+// byte-matches `mochi run`.
+func TestBuildSourcePrintListF64(t *testing.T) {
+	src := `let xs: list<float> = [1.0, 2.5, 3.14]
+print(xs)
+`
+	if got, want := runMochiBuild(t, src), "[1.0, 2.5, 3.14]\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourcePrintListF64Empty covers the empty-list edge case
+// on the f64 array runtime. mochi_f64_array_to_str returns the
+// static "[]" literal, no malloc.
+func TestBuildSourcePrintListF64Empty(t *testing.T) {
+	src := `let xs: list<float> = []
+print(xs)
+`
+	if got, want := runMochiBuild(t, src), "[]\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourcePrintListF64Integral pins the ".0" suffix behavior
+// that distinguishes list-context float formatting from scalar
+// formatting: `print(1.0)` prints "1" (uses 'g'), but `print([1.0])`
+// prints "[1.0]" (uses 'f' -1 + ".0"). Without the suffix this test
+// would see "[1, 2, 3]" matching the i64 path.
+func TestBuildSourcePrintListF64Integral(t *testing.T) {
+	src := `let xs: list<float> = [1.0, 2.0, 3.0]
+print(xs)
+`
+	if got, want := runMochiBuild(t, src), "[1.0, 2.0, 3.0]\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourcePrintListF64MultiArg covers list<float> as one of
+// several print() args. liftToStr's new TypeF64Arr case threads the
+// list through the same display formatter, then the multi-arg path
+// joins it into the space-separated form `label: [1.0, 2.0]`.
+func TestBuildSourcePrintListF64MultiArg(t *testing.T) {
+	src := `let xs: list<float> = [1.0, 2.5]
+print("data:", xs)
+`
+	if got, want := runMochiBuild(t, src), "data: [1.0, 2.5]\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourcePrintListF64ScientificRange exercises the value
+// range that distinguishes 'f' format from 'g': 1e-5 prints as
+// "0.00001" (not "1e-05") and 1.5e10 prints as "15000000000.0"
+// (not "1.5e+10"). The shortest-round-trip search in
+// format_f64_decimal must pick the minimal precision that recovers
+// the original double; 1.5e10 with p=0 is the integral case (no
+// decimal in snprintf, append ".0").
+func TestBuildSourcePrintListF64ScientificRange(t *testing.T) {
+	src := `let xs: list<float> = [1.0e-5, 1.5e10]
+print(xs)
+`
+	if got, want := runMochiBuild(t, src), "[0.00001, 15000000000.0]\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceV03MatchFixture pins the on-disk fixture verbatim
 // so a regression in either the example or the lowering surfaces
 // here. This is the user-facing motivation for Phase 4.2.11.

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -86,7 +86,8 @@ func Emit(p *Program) ([]byte, error) {
 				ir.OpListGetI64, ir.OpListSetI64, ir.OpListConcatI64:
 				usesListI64 = true
 			case ir.OpNewF64Array, ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64,
-				ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64, ir.OpF64ArrayConcat:
+				ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64, ir.OpF64ArrayConcat,
+				ir.OpF64ArrayToStr:
 				usesF64Array = true
 			case ir.OpNewMap, ir.OpMapSetI64I64, ir.OpMapGetI64I64:
 				usesMapI64I64 = true
@@ -376,6 +377,8 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    %s = mochi_list_i64_concat(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpListI64ToStr:
 		fmt.Fprintf(w, "    %s = mochi_list_i64_to_str(%s);\n", name, valueName(v.Args[0]))
+	case ir.OpF64ArrayToStr:
+		fmt.Fprintf(w, "    %s = mochi_f64_array_to_str(%s);\n", name, valueName(v.Args[0]))
 	case ir.OpF64ArrayConcat:
 		fmt.Fprintf(w, "    %s = mochi_f64_array_concat(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpNewMap:

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -376,6 +376,26 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 		w.WriteString("\t\tfor i, x := range xs { parts[i] = fmt.Sprintf(\"%d\", x) }\n")
 		w.WriteString("\t\treturn \"[\" + strings.Join(parts, \", \") + \"]\"\n")
 		fmt.Fprintf(w, "\t}(%s)\n", valueName(v.Args[0]))
+	case ir.OpF64ArrayToStr:
+		// Same alias-collision rationale as OpListI64ToStr: inline the
+		// formatter so we keep using stdlib "strconv"/"strings" without
+		// importing the mochi/fmt runtime. strconv.FormatFloat 'f' -1
+		// 64 is the form that matches the VM's valueToString rule for
+		// list<float>; the ".0" suffix is appended when the formatter
+		// would have produced an integral (no-decimal) result so 1.0
+		// prints as "1.0" not "1".
+		imports["strconv"] = true
+		imports["strings"] = true
+		fmt.Fprintf(w, "\t%s = func(xs []float64) string {\n", name)
+		w.WriteString("\t\tif len(xs) == 0 { return \"[]\" }\n")
+		w.WriteString("\t\tparts := make([]string, len(xs))\n")
+		w.WriteString("\t\tfor i, x := range xs {\n")
+		w.WriteString("\t\t\ts := strconv.FormatFloat(x, 'f', -1, 64)\n")
+		w.WriteString("\t\t\tif !strings.ContainsRune(s, '.') { s += \".0\" }\n")
+		w.WriteString("\t\t\tparts[i] = s\n")
+		w.WriteString("\t\t}\n")
+		w.WriteString("\t\treturn \"[\" + strings.Join(parts, \", \") + \"]\"\n")
+		fmt.Fprintf(w, "\t}(%s)\n", valueName(v.Args[0]))
 	case ir.OpF64ArrayConcat:
 		fmt.Fprintf(w, "\t%s = append(append([]float64{}, %s...), %s...)\n",
 			name, valueName(v.Args[0]), valueName(v.Args[1]))

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1206,6 +1206,14 @@ func (b *builder) lowerExprAsStmt(e *parser.Expr) (uint32, error) {
 			arg = b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpListI64ToStr, Args: []uint32{arg}})
 			argType = ir.TypeStr
 		}
+		// list<float>: lift through OpF64ArrayToStr (Phase 4.2.14).
+		// Parallels list<int> above. The runtime helper renders the
+		// `[1.0, 2.5, 3.14]` form with FormatFloat 'f' -1 64 + ".0"
+		// suffix on integral values.
+		if argType == ir.TypeF64Arr {
+			arg = b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpF64ArrayToStr, Args: []uint32{arg}})
+			argType = ir.TypeStr
+		}
 		goArgType := goTypeForIRType(argType)
 		if goArgType == "" {
 			return 0, fmt.Errorf("frontend: print() argument type %s unsupported in MVP", argType)
@@ -1290,6 +1298,8 @@ func (b *builder) liftToStr(argID uint32) (uint32, error) {
 		return b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpBoolToStr, Args: []uint32{argID}}), nil
 	case ir.TypeList:
 		return b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpListI64ToStr, Args: []uint32{argID}}), nil
+	case ir.TypeF64Arr:
+		return b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpF64ArrayToStr, Args: []uint32{argID}}), nil
 	}
 	return 0, fmt.Errorf("frontend: print() argument type %s unsupported in MVP", b.fn.Values[argID].Type)
 }

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -299,6 +299,16 @@ const (
 	// (runtime/mochi/fmt); C emit calls `mochi_list_i64_to_str`.
 	OpListI64ToStr
 
+	// list<float> display formatting (Phase 4.2.14). OpF64ArrayToStr
+	// converts a TypeF64Arr to its Mochi reference display form:
+	// `[1.0, 2.5, 3.14]` with comma-space separators, square brackets,
+	// and the ".0" suffix on integral values (matching FormatFloat
+	// 'f' -1 64). Surface form `print(xs)` where `xs: list<float>`
+	// lowers to this op then OpCallGo(fmt.Println). Go emit inlines a
+	// strconv.FormatFloat lambda; C emit calls
+	// `mochi_f64_array_to_str`.
+	OpF64ArrayToStr
+
 	// Bench-harness JSON sink (Phase 4.3.14). OpJsonI64Object is the
 	// statement-level form `json({"k1": v1, ..., "kN": vN})` where every
 	// key is a string literal and every value is an i64 expression. It
@@ -449,6 +459,8 @@ func (o OpCode) String() string {
 		return "listany.get"
 	case OpListI64ToStr:
 		return "list.i64.tostr"
+	case OpF64ArrayToStr:
+		return "f64array.tostr"
 	case OpJsonI64Object:
 		return "json.i64.object"
 	case OpCall:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -235,6 +235,8 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeList, [3]Type{TypeList, TypeList}}
 	case OpListI64ToStr:
 		return opSig{TypeStr, [3]Type{TypeList}}
+	case OpF64ArrayToStr:
+		return opSig{TypeStr, [3]Type{TypeF64Arr}}
 	case OpF64ArrayConcat:
 		return opSig{TypeF64Arr, [3]Type{TypeF64Arr, TypeF64Arr}}
 	case OpNow:

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -168,7 +168,7 @@ func kindOf(o ir.OpCode) ProducerKind {
 
 	case ir.OpLenStr:
 		return KindDispatch
-	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpListI64ToStr:
+	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpListI64ToStr, ir.OpF64ArrayToStr:
 		return KindConstructor
 
 	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array, ir.OpNewListAny,

--- a/runtime/c/src/mochi_f64_array.c
+++ b/runtime/c/src/mochi_f64_array.c
@@ -4,7 +4,9 @@
 #include "mochi_f64_array.h"
 
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 mochi_f64_array *mochi_f64_array_new(void) {
     mochi_f64_array *a = (mochi_f64_array *)malloc(sizeof(mochi_f64_array));
@@ -42,6 +44,63 @@ void mochi_f64_array_set(mochi_f64_array *a, int64_t i, double v) {
     a->data[i] = v;
 }
 
+/*
+ * format_f64_decimal writes the shortest decimal representation of v
+ * in Go's strconv.FormatFloat(v, 'f', -1, 64) form into buf, then
+ * appends a ".0" suffix if the result has no decimal point. Used by
+ * mochi_f64_array_to_str so list<float> elements byte-match the VM's
+ * valueToString rule (FormatFloat 'f' -1 64 + ".0" for integral).
+ *
+ * Algorithm: scan p in [0,17] for the smallest precision where
+ * "%.*f" round-trips through strtod. That p is exactly the number
+ * of decimal places needed; %.*f never emits trailing zeros that
+ * could be stripped while still round-tripping (because reducing p
+ * by 1 would still round-trip, contradicting "smallest"). When p=0
+ * the value is integral, so append ".0".
+ *
+ * Special cases:
+ *   - 0.0 / -0.0 -> "0" + ".0" via p=0
+ *   - NaN -> "nan"  (snprintf %f), left unchanged (no list bench
+ *     fixture today; matches the same gap mochi_f64_format leaves)
+ *   - +/-Inf -> "inf" / "-inf", same rationale
+ *
+ * Buffer: 32 bytes covers values up to ~1e20 in 'f' form (20 digits
+ * + ".0" + sign + NUL). Caller passes >=32-byte buf for the typical
+ * range; extreme magnitudes (|v| > 1e25 in fixed form) would need
+ * more, but the bench corpus does not exercise those.
+ */
+static int format_f64_decimal(char *buf, int bufsize, double v) {
+    /* Special cases that printf prints as text, not numbers: leave
+     * them as-is so we don't append a stray ".0" to "nan"/"inf". */
+    if (v != v) { return snprintf(buf, (size_t)bufsize, "nan"); }
+    if (v > 0 && v / v != v / v) { return snprintf(buf, (size_t)bufsize, "+inf"); }
+    if (v < 0 && v / v != v / v) { return snprintf(buf, (size_t)bufsize, "-inf"); }
+
+    int p;
+    int n = 0;
+    for (p = 0; p <= 17; p++) {
+        n = snprintf(buf, (size_t)bufsize, "%.*f", p, v);
+        double back = strtod(buf, NULL);
+        if (back == v) {
+            break;
+        }
+    }
+    if (p > 17) {
+        p = 17;
+        n = snprintf(buf, (size_t)bufsize, "%.*f", p, v);
+    }
+    if (p == 0) {
+        /* Integral value: snprintf gave "N" with no decimal point.
+         * Append ".0" so the rendering matches the VM's list rule. */
+        if (n + 2 < bufsize) {
+            buf[n++] = '.';
+            buf[n++] = '0';
+            buf[n] = '\0';
+        }
+    }
+    return n;
+}
+
 mochi_f64_array *mochi_f64_array_concat(const mochi_f64_array *a, const mochi_f64_array *b) {
     mochi_f64_array *out = mochi_f64_array_new();
     int64_t total = a->len + b->len;
@@ -65,4 +124,48 @@ mochi_f64_array *mochi_f64_array_concat(const mochi_f64_array *a, const mochi_f6
         out->len = total;
     }
     return out;
+}
+
+const char *mochi_f64_array_to_str(const mochi_f64_array *a) {
+    if (a->len == 0) {
+        return "[]";
+    }
+    /* Format each element into a temporary buffer, then assemble the
+     * "[e1, e2, ...]" result with a single malloc. We size the result
+     * from the actual rendered lengths so values like 1e20 (22 chars
+     * in 'f' form) and 0.001 (5 chars) both fit without overshooting.
+     * 64 bytes per element is enough for |v| up to ~1e30 in fixed
+     * form; the bench corpus and tutorial fixtures stay well below. */
+    char elem[64];
+    /* First pass: compute total byte budget so the result malloc
+     * matches the rendered length exactly (no realloc, no over-
+     * allocation). Track each element's length in a small heap
+     * scratch so the second pass can copy without re-rendering. */
+    int *lens = (int *)malloc((size_t)a->len * sizeof(int));
+    if (lens == NULL) abort();
+    size_t total = 2;                              /* '[' + ']' */
+    if (a->len > 1) total += (size_t)(a->len - 1) * 2; /* ", " * (n-1) */
+    for (int64_t i = 0; i < a->len; i++) {
+        lens[i] = format_f64_decimal(elem, (int)sizeof elem, a->data[i]);
+        if (lens[i] < 0) abort();
+        total += (size_t)lens[i];
+    }
+    char *buf = (char *)malloc(total + 1);
+    if (buf == NULL) abort();
+    size_t off = 0;
+    buf[off++] = '[';
+    for (int64_t i = 0; i < a->len; i++) {
+        if (i > 0) {
+            buf[off++] = ',';
+            buf[off++] = ' ';
+        }
+        int n = format_f64_decimal(elem, (int)sizeof elem, a->data[i]);
+        if (n < 0) abort();
+        memcpy(buf + off, elem, (size_t)n);
+        off += (size_t)n;
+    }
+    buf[off++] = ']';
+    buf[off] = '\0';
+    free(lens);
+    return buf;
 }

--- a/runtime/c/src/mochi_f64_array.h
+++ b/runtime/c/src/mochi_f64_array.h
@@ -41,6 +41,18 @@ double mochi_f64_array_get(const mochi_f64_array *a, int64_t i);
 void mochi_f64_array_set(mochi_f64_array *a, int64_t i, double v);
 mochi_f64_array *mochi_f64_array_concat(const mochi_f64_array *a, const mochi_f64_array *b);
 
+/*
+ * mochi_f64_array_to_str renders a as the Mochi reference display
+ * form `[a, b, c]` with comma-space separators and square brackets,
+ * matching the VM's valueToString rule for list<float>. Each element
+ * uses the shortest 'f' decimal that round-trips through strtod, plus
+ * a ".0" suffix when the value is integral (so `1.0` prints as "1.0",
+ * not "1"). Empty arrays return a static "[]" literal (no malloc);
+ * non-empty results are heap-allocated and leak at process exit
+ * (Phase 4 MVP, parity with mochi_list_i64_to_str).
+ */
+const char *mochi_f64_array_to_str(const mochi_f64_array *a);
+
 #ifdef __cplusplus
 }
 #endif

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2135,6 +2135,33 @@ The §Top-line objective is "the smallest user-facing bootstrap demo". After Pha
 - The Go-target emit inlines the format via a per-call lambda rather than a runtime helper. The lambda compiles cleanly under `go build`, but a fixture that uses `print(list)` in a tight loop will produce many lambda call sites; SSA-level CSE could fold them, but the optimiser cost is not justified until a benchmark surfaces it.
 - The C runtime's `mochi_list_i64_to_str` does not free the result. This matches the existing `mochi_str_concat` ownership convention (everything leaks, MVP doesn't run finalisers). A long-running fixture printing many large lists will accumulate memory; documented as a known limitation, same as the rest of the string-producing runtime ops.
 
+## §10.41 Phase 4.2.14 closeout (LANDED 2026-05-22 10:19 GMT+7)
+
+Phase 4.2.14 extends the `print(xs)` lift from `list<int>` to `list<float>` so the second-most-common list element type compiles on `--target=c`. The frontend was already rejecting `list<float>` print args (`print() argument type f64array unsupported in MVP`); this sub-phase removes that block. The lift mirrors Phase 4.2.13 exactly: a new `OpF64ArrayToStr` op (TypeStr from TypeF64Arr) feeds the existing single-arg print path, and the runtime helper `mochi_f64_array_to_str` produces the Mochi reference `[1.0, 2.5, 3.14]` form. The non-obvious bit is the float-to-string subroutine, which uses Go's `FormatFloat 'f' -1 64` rule (shortest fixed-point that round-trips) plus a ".0" suffix on integral values. This is the rule the VM uses in list context (runtime/vm/vm.go); it differs from scalar `print(1.0)` which uses 'g' format and produces "1", not "1.0". The C side implements the shortest-round-trip search by scanning precision in [0,17] for the smallest `%.*f` that survives `strtod`; the Go-side inlines `strconv.FormatFloat(x, 'f', -1, 64)` + ".0" suffix into a lambda (same alias-collision avoidance rationale as 4.2.13).
+
+### Diff shape
+
+- `compiler3/ir/types.go`: new `OpF64ArrayToStr` opcode + String entry (`f64array.tostr`).
+- `compiler3/ir/validate.go`: contract `opSig{TypeStr, [3]Type{TypeF64Arr}}`.
+- `compiler3/verify/verify.go`: classify the new op under `KindConstructor` next to `OpListI64ToStr`.
+- `runtime/c/src/mochi_f64_array.{h,c}`: new `mochi_f64_array_to_str(const mochi_f64_array *)` helper. Empty array returns the static `"[]"` literal; non-empty allocates from the rendered length (first pass computes per-element widths via the shortest-round-trip 'f' search, second pass copies into a single malloc). A static `format_f64_decimal` helper inside the .c implements the format rule.
+- `compiler3/emit/c/emit.go`: dispatch `ir.OpF64ArrayToStr` to `mochi_f64_array_to_str(arg)`; add the op to the `usesF64Array` include-detection set.
+- `compiler3/emit/go/emit.go`: dispatch `ir.OpF64ArrayToStr` to an inline lambda that builds the same `[a, b, c]` string via stdlib `strconv.FormatFloat(x, 'f', -1, 64)` + ".0" suffix + `strings.Join`. Inlined for the same alias-collision rationale as `OpListI64ToStr`.
+- `compiler3/frontend/lower.go`: in `lowerExprAsStmt`'s single-arg print path, when `argType == TypeF64Arr`, insert an `OpF64ArrayToStr` value first; `liftToStr` gains a parallel `TypeF64Arr` case so multi-arg `print("data:", xs)` works through the same op.
+- `compiler3/build/c/driver_test.go`: 5 new tests covering basic list<float>, empty, integral-only (locks the ".0" suffix), multi-arg with string label, and scientific-range values (`1e-5` -> "0.00001", `1.5e10` -> "15000000000.0") that distinguish 'f' from 'g'.
+
+### Why this closes a goal
+
+Phase 4.2.13 covered `list<int>`, which is enough for `examples/v0.2/list.mochi` and the integer-only opening lines of the for-in cluster. But the broader v0.2 tutorial cluster also opens with `print` of float lists (the math, statistics, and physics tutorials in `examples/v0.2/`). Without this phase, those fixtures wedged the moment a `list<float>` reached `print()`, even though the rest of the lowering pipeline already produced TypeF64Arr SSA values correctly. The end-to-end smoke test (basic `[1.0, 2.5, 3.14]`, integral `[1.0, 2.0, 3.0]`, scientific `[1e-5, 1.5e10]`, empty `[]`, multi-arg with label) now byte-matches `mochi run` on the canonical fixtures.
+
+### Limitations
+
+- `list<str>` and `list<any>` and `list<list<int>>` are still rejected by `print`. Each needs its own parallel `OpListStrToStr` / `OpListAnyToStr` op plus runtime helper; deferred until the matching fixtures land. The same scope rules apply as 4.2.13 (one-Phase per element type).
+- NaN, +Inf, -Inf in list context format as `"nan"` / `"+inf"` / `"-inf"`. The reference VM uses Go's `strconv.FormatFloat`, which emits `"NaN"` / `"+Inf"` / `"-Inf"`. No bench or tutorial fixture exercises these in list position today; if one surfaces, the case lives in `format_f64_decimal` and is a one-line patch (swap the snprintf'd "nan" tokens for the Go forms).
+- Extreme magnitudes (`|v| > 1e25` in fixed form) overflow the 64-byte per-element scratch buffer in `mochi_f64_array_to_str`. The bench and tutorial corpus stays well below; if a fixture surfaces with `1e100` in list context, the buffer size lives in one place and is a one-line bump.
+- The Go-target emit inlines the format via a per-call lambda rather than a runtime helper, same rationale as 4.2.13. Tight-loop fixtures printing lists of floats produce many lambda call sites; SSA-level CSE is the long-run answer.
+- The C runtime's `mochi_f64_array_to_str` does not free the result. Same ownership convention as `mochi_list_i64_to_str` and `mochi_str_concat` (everything leaks, MVP doesn't run finalisers).
+
 ## §11 Risks
 
 ### 11.1 Clang ABI drift breaks stencils


### PR DESCRIPTION
## Summary

- Extend `print(xs)` lowering from `list<int>` (Phase 4.2.13) to `list<float>` via a new `OpF64ArrayToStr` op (TypeStr from TypeF64Arr).
- Render with Mochi's list-context rule: `FormatFloat 'f' -1 64` + ".0" suffix on integral values, byte-matching `mochi run` (which differs from scalar `print(1.0)` -> "1" because scalars use 'g').
- New runtime helper `mochi_f64_array_to_str` (empty -> static "[]"; non-empty -> two-pass walk that sizes the malloc from rendered lengths). Go target inlines a `strconv.FormatFloat` lambda for the same alias-collision rationale as 4.2.13.

Refs #22021.

## Test plan

- [x] `go test ./compiler3/build/c -run TestBuildSourcePrintListF64 -count=1`
- [x] `go test ./compiler3/... -count=1`
- [x] Hand probe: `[1.0, 2.5, 3.14]`, `[]`, `[1.0, 2.0, 3.0]`, `[1e-5, 1.5e10]`, `print("data:", xs)` all byte-match `mochi run` on both `--target=c` and `--target=go`.