### PR TITLE
mep-0042: Phase 4.2.15 literal-negative list indexing on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -2266,6 +2266,70 @@ print(xs)
 	}
 }
 
+// TestBuildSourceNegIndexI64 pins MEP-42 Phase 4.2.15: literal-negative
+// list indexing on the C target. `xs[-1]` is folded at lower time to
+// `xs[len + -1]` so the v0.2/list.mochi `values[-1]` line returns the
+// last element instead of reading past the start of the buffer. Before
+// this phase the C target returned 0 (or some other garbage from
+// stack-adjacent memory) instead of 50.
+func TestBuildSourceNegIndexI64(t *testing.T) {
+	src := `let xs = [10, 20, 30, 40, 50]
+print(xs[-1])
+print(xs[-2])
+print(xs[0])
+`
+	if got, want := runMochiBuild(t, src), "50\n40\n10\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceNegIndexF64 pins the same fold for list<float>: the
+// f64-array path picks OpF64ArrayLenI64 + OpAddI64Imm and feeds the
+// wrapped index to OpF64ArrayGetF64. Verifies the curType switch in
+// the fold picks the right LenOp for the element type.
+func TestBuildSourceNegIndexF64(t *testing.T) {
+	src := `let xs: list<float> = [1.0, 2.5, 3.14]
+print(xs[-1])
+print(xs[-2])
+`
+	if got, want := runMochiBuild(t, src), "3.14\n2.5\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceNegIndexAssign pins the indexed-assign mirror of the
+// fold: `xs[-1] = v` rewrites to `xs[len + -1] = v` so the store
+// targets the actual last element. Reads the slot back after the
+// store to confirm the write landed in the right place.
+func TestBuildSourceNegIndexAssign(t *testing.T) {
+	src := `var xs = [1, 2, 3, 4, 5]
+xs[-1] = 99
+print(xs[-1])
+print(xs[0])
+print(xs[3])
+`
+	if got, want := runMochiBuild(t, src), "99\n1\n4\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceNegIndexUnaryNeg pins that the fold sees through the
+// unary-minus lowering of `-N`. The surface form `xs[-1]` parses as
+// unary `-` applied to literal `1`, which lowers to OpNegI64 of
+// OpConst(1), not directly to OpConst(-1). Without constI64's
+// negation-case the fold misses literal-negative indices entirely.
+// Dynamic-`i` negative indexing is a separate future phase and not
+// exercised here.
+func TestBuildSourceNegIndexUnaryNeg(t *testing.T) {
+	src := `let xs = [100, 200, 300]
+print(xs[-1])
+print(xs[-3])
+`
+	if got, want := runMochiBuild(t, src), "300\n100\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceV03MatchFixture pins the on-disk fixture verbatim
 // so a regression in either the example or the lowering surfaces
 // here. This is the user-facing motivation for Phase 4.2.11.

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -581,6 +581,28 @@ func (b *builder) lowerIndexedAssign(a *parser.AssignStmt) error {
 	if b.fn.Values[idxID].Type != ir.TypeI64 {
 		return fmt.Errorf("frontend: list index must be i64, got %s", b.fn.Values[idxID].Type)
 	}
+	// Phase 4.2.15: literal-negative index fold for indexed
+	// assignment, mirroring the read path. `xs[-1] = v` becomes
+	// `xs[len + -1] = v` so the C target's mochi_list_i64_set does
+	// not write past the start of the buffer. TypeMap excluded
+	// (keys, not offsets).
+	if listType == ir.TypeList || listType == ir.TypeF64Arr {
+		if cv, ok := b.constI64(idxID); ok && cv < 0 {
+			var lenOp ir.OpCode
+			if listType == ir.TypeList {
+				lenOp = ir.OpListLenI64
+			} else {
+				lenOp = ir.OpF64ArrayLenI64
+			}
+			lenID := b.addValue(ir.Value{Type: ir.TypeI64, Op: lenOp, Args: []uint32{listID}})
+			idxID = b.addValue(ir.Value{
+				Type:  ir.TypeI64,
+				Op:    ir.OpAddI64Imm,
+				Args:  []uint32{lenID},
+				Const: cv,
+			})
+		}
+	}
 	valID, err := b.lowerExpr(a.Value)
 	if err != nil {
 		return err
@@ -1402,6 +1424,25 @@ func exprAsCall(e *parser.Expr) *parser.CallExpr {
 
 // lowerExpr returns the SSA value ID for e. MVP handles BinaryExpr
 // with the i64-compatible operators and a handful of Primary forms.
+// constI64 returns the static integer carried by an SSA value if the
+// value is a constant or the unary negation of a constant (the surface
+// form `-1` lowers to `OpNegI64(OpConst(1))`, so the negation case is
+// needed for things like literal-negative list indexing).
+// Returns (value, true) on success.
+func (b *builder) constI64(id uint32) (int64, bool) {
+	v := &b.fn.Values[id]
+	if v.Op == ir.OpConst && v.Type == ir.TypeI64 {
+		return v.Const, true
+	}
+	if v.Op == ir.OpNegI64 && len(v.Args) == 1 {
+		inner := &b.fn.Values[v.Args[0]]
+		if inner.Op == ir.OpConst && inner.Type == ir.TypeI64 {
+			return -inner.Const, true
+		}
+	}
+	return 0, false
+}
+
 func (b *builder) lowerExpr(e *parser.Expr) (uint32, error) {
 	if e == nil || e.Binary == nil {
 		return 0, fmt.Errorf("frontend: empty expression")
@@ -1689,6 +1730,34 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 			}
 			if b.fn.Values[iID].Type != ir.TypeI64 {
 				return 0, fmt.Errorf("frontend: list index must be i64, got %s", b.fn.Values[iID].Type)
+			}
+			// Phase 4.2.15: literal-negative indices (`xs[-1]`,
+			// `xs[-2]`) fold at lower time to `xs[len + idx]`. Mochi's
+			// reference VM wraps negative indices against the list
+			// length; without this fold the C target reads
+			// `data[-1]` (undefined) and typically returns 0. Only
+			// constant-negative indices are folded; dynamic
+			// `xs[i]` for potentially-negative i is a separate
+			// future phase (needs a select/branch or a runtime
+			// helper). TypeMap is excluded because map indexing
+			// uses a key, not an offset, and negative keys are
+			// valid lookups.
+			if curType == ir.TypeList || curType == ir.TypeF64Arr {
+				if cv, ok := b.constI64(iID); ok && cv < 0 {
+					var lenOp ir.OpCode
+					if curType == ir.TypeList {
+						lenOp = ir.OpListLenI64
+					} else {
+						lenOp = ir.OpF64ArrayLenI64
+					}
+					lenID := b.addValue(ir.Value{Type: ir.TypeI64, Op: lenOp, Args: []uint32{cur}})
+					iID = b.addValue(ir.Value{
+						Type:  ir.TypeI64,
+						Op:    ir.OpAddI64Imm,
+						Args:  []uint32{lenID},
+						Const: cv,
+					})
+				}
 			}
 			switch curType {
 			case ir.TypeList:

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2162,6 +2162,32 @@ Phase 4.2.13 covered `list<int>`, which is enough for `examples/v0.2/list.mochi`
 - The Go-target emit inlines the format via a per-call lambda rather than a runtime helper, same rationale as 4.2.13. Tight-loop fixtures printing lists of floats produce many lambda call sites; SSA-level CSE is the long-run answer.
 - The C runtime's `mochi_f64_array_to_str` does not free the result. Same ownership convention as `mochi_list_i64_to_str` and `mochi_str_concat` (everything leaks, MVP doesn't run finalisers).
 
+## §10.42 Phase 4.2.15 closeout (LANDED 2026-05-22 10:30 GMT+7)
+
+Phase 4.2.15 makes literal-negative list indexing semantically correct on the C target. Mochi's reference VM wraps negative indices against the list length (`xs[-1]` returns the last element; `xs[-2]` the second-to-last); before this phase the C target lowered `xs[-1]` to `mochi_list_i64_get(l, -1)` which reads `l->data[-1]`, undefined behaviour that returned 0 on x86_64 with this allocator. The v0.2/list.mochi tutorial fixture's first conditional line (`print("last: ", values[-1])`) was a primary visible casualty.
+
+The fix is a small frontend fold rather than a runtime change. When the lowered index value is a constant (or the unary negation of a constant, which is how `-1` lowers; see `constI64` helper), and that constant is negative, the lowering replaces the bare get/set with `xs[len + idx]` via `OpListLenI64` + `OpAddI64Imm`. The path is symmetric for `list<int>` (TypeList -> OpListLenI64) and `list<float>` (TypeF64Arr -> OpF64ArrayLenI64). Dynamic-negative indexing (`xs[i]` where `i` is a runtime value that might be negative) is a separate future phase; that needs either a runtime helper with a branch or an SSA-level select op, both meaningfully more invasive.
+
+### Diff shape
+
+- `compiler3/frontend/lower.go`:
+  - New helper `constI64(id) (int64, bool)` that recognises both `OpConst(N)` and `OpNegI64(OpConst(N))` patterns. The latter case is necessary because the surface `-1` parses as unary `-` applied to literal `1`, not as a single negative literal.
+  - Fold site in `lowerPostfix`'s `op.Index != nil` branch: when `curType` is `TypeList` or `TypeF64Arr` and `constI64` returns a negative value, rewrite `xs[idx]` to `xs[len + idx]` before emitting the get op.
+  - Fold site in `lowerIndexedAssign`: same logic for the store side so `xs[-1] = v` lands in the right slot.
+- `compiler3/build/c/driver_test.go`: 4 new tests covering i64 read, f64 read, indexed assign, and the unary-minus parse shape (`-1` -> OpNegI64 of OpConst).
+
+### Why this closes a goal
+
+The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tutorial cluster. After Phase 4.2.14 the print(list<int>) and print(list<float>) lines compile, but the very next idiom in v0.2/list.mochi (`values[-1]`) was a silent miscompile rather than a hard error. Silent miscompiles are worse than rejections: a learner gets `last: 0` instead of `last: 5` and has no signal that the C target is the cause. This phase closes that footgun for the literal case, leaving dynamic-negative as a known-rejection (it still passes through and may UB, but the tutorial fixture doesn't exercise that path). Visible progress: `xs[-1]` on the C target byte-matches `mochi run`.
+
+### Limitations
+
+- Dynamic negative indices (`xs[i]` where `i` is a runtime value) still pass through unchanged. If `i` is negative at runtime the C target reads past the start of the buffer (undefined behaviour, typically 0). A future phase will either add a runtime wrap helper (one branch + add per get/set, paid on every index) or an SSA-level select op (no overhead on positive indices but a new op + emit case in two targets). The fixture corpus doesn't exercise dynamic negative today, so the decision is deferred.
+- Slicing (`xs[1:3]`) is still rejected by `lowerPostfix` (the `idx.Colon != nil` branch). That is a separate phase with its own runtime helper (`mochi_list_i64_slice`).
+- Negative *bound* in a slice (`xs[-2:]` or `xs[:-1]`) inherits the same dynamic-vs-literal split when slicing lands; the fold here is the shape that will extend.
+- TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
+- The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
+
 ## §11 Risks
 
 ### 11.1 Clang ABI drift breaks stencils


### PR DESCRIPTION
## Summary

- Frontend fold: literal-negative list indices (`xs[-1]`, `xs[-2]`) rewrite to `xs[len + idx]` at lower time so the C target's `mochi_list_i64_get` does not read past the start of the buffer.
- New `constI64` helper sees through `OpConst(N)` and `OpNegI64(OpConst(N))` (the surface `-1` parses as the latter).
- Symmetric fold for `list<float>` (TypeF64Arr) and for the indexed-assign path (`xs[-1] = v`).
- Dynamic-negative indices still pass through unchanged; deferred to a future phase.

Refs #22023.

## Test plan

- [x] `go test ./compiler3/build/c -run TestBuildSourceNegIndex -count=1` (4 tests pass)
- [x] `go test ./compiler3/... -count=1`
- [x] Hand probe: `xs[-1]`, `xs[-2]` on list<int> and list<float>, plus `xs[-1] = v`. Byte-matches `mochi run` on both `--target=c` and `--target=go`.

This builds on #22022 (Phase 4.2.14 print(list<float>)) and should be merged after it.