### PR TITLE
mep-0042: Phase 4.2.16 top-level let visible from user fns on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -2330,6 +2330,96 @@ print(xs[-3])
 	}
 }
 
+// Phase 4.2.16: top-level `let` is in scope inside user functions.
+// Before this phase, a fun body that referenced a module-level let
+// failed with `frontend: unbound identifier`. The frontend now
+// pre-scans top-level lets and inlines the RHS at each use site
+// inside fun bodies, caching the lowered value per builder so the
+// constant is materialised once per function body.
+func TestBuildSourceGlobalLetIntFromFn(t *testing.T) {
+	src := `let n = 21
+
+fun twice(): int {
+  return n * 2
+}
+
+print(twice())
+`
+	if got, want := runMochiBuild(t, src), "42\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildSourceGlobalLetFloatFromFn(t *testing.T) {
+	src := `let pi = 3.14
+
+fun area(r: float): float {
+  return pi * r * r
+}
+
+print(area(10.0))
+`
+	if got, want := runMochiBuild(t, src), "314\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceGlobalLetMultipleRefs pins the per-builder cache:
+// referencing the same global twice in one fun body must lower the
+// RHS once (re-using the same SSA value), not twice. Result-wise
+// either still prints "44", so this test is a behavioural smoke
+// check; cache correctness is observed via the test suite staying
+// fast and the emitted code having a single OpConst for the global.
+func TestBuildSourceGlobalLetMultipleRefs(t *testing.T) {
+	src := `let n = 22
+
+fun add(): int {
+  return n + n
+}
+
+print(add())
+`
+	if got, want := runMochiBuild(t, src), "44\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildSourceGlobalLetMixedScopes(t *testing.T) {
+	src := `let a = 10
+let b = 5
+
+fun diff(): int {
+  return a - b
+}
+
+print(a)
+print(b)
+print(diff())
+`
+	if got, want := runMochiBuild(t, src), "10\n5\n5\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceGlobalLetShadowedByParam confirms that a function
+// parameter still shadows a same-named module global. The fallback
+// only fires when the name is not in b.values, so the param binding
+// (which writes b.values) wins.
+func TestBuildSourceGlobalLetShadowedByParam(t *testing.T) {
+	src := `let x = 100
+
+fun id(x: int): int {
+  return x
+}
+
+print(id(7))
+print(x)
+`
+	if got, want := runMochiBuild(t, src), "7\n100\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceV03MatchFixture pins the on-disk fixture verbatim
 // so a regression in either the example or the lowering surfaces
 // here. This is the user-facing motivation for Phase 4.2.11.

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -91,10 +91,27 @@ func Lower(prog *parser.Program) (*gogen.Program, error) {
 		}
 	}
 
+	// Collect top-level (module-scope) `let NAME = EXPR` bindings.
+	// User functions can read these as if they were lexically in
+	// scope, mirroring the reference VM. Phase 4.2.16 inlines the
+	// RHS expression at each use site in a user function; the cache
+	// in builder.globalCache ensures each function materialises one
+	// SSA value per global it reads. `var` is excluded because
+	// mutable globals would need a shared storage cell; only `let`
+	// bindings (immutable) are advertised. The map is built before
+	// user funs are lowered so any forward reference (a function
+	// defined before the global it uses) resolves correctly.
+	globals := map[string]*parser.Expr{}
+	for _, st := range prog.Statements {
+		if st.Let != nil && st.Let.Value != nil {
+			globals[st.Let.Name] = st.Let.Value
+		}
+	}
+
 	// Lower each user fun. Each lowering must finish before the next
 	// because they share the program-level function table.
 	for name, e := range userFns {
-		if err := lowerFun(p, e.index, e.stmt, userFns, goImports); err != nil {
+		if err := lowerFun(p, e.index, e.stmt, userFns, goImports, globals); err != nil {
 			return nil, fmt.Errorf("lower fun %s: %w", name, err)
 		}
 	}
@@ -116,7 +133,7 @@ func Lower(prog *parser.Program) (*gogen.Program, error) {
 	if len(topLevel) > 0 {
 		mainFn := &ir.Function{Name: "main", Result: ir.TypeUnit}
 		p.Funcs = append(p.Funcs, mainFn)
-		b := newBuilder(mainFn, userFns, p, goImports)
+		b := newBuilder(mainFn, userFns, p, goImports, globals)
 		entry := b.fn.AddBlock()
 		b.curBlock = entry
 		for _, st := range topLevel {
@@ -175,6 +192,15 @@ type builder struct {
 	// query/loop work needed for full phi insertion is part of the
 	// post-MVP widening.
 	values map[string]uint32
+	// globals is the module-scope `let NAME = EXPR` table (Phase
+	// 4.2.16). When identifier lookup misses `values`, the builder
+	// inlines the global's RHS expression at the use site so a user
+	// function can read top-level constants. The map is shared across
+	// every builder in the program; the per-function `globalCache`
+	// below memoises so each function materialises one SSA value per
+	// global it actually reads.
+	globals     map[string]*parser.Expr
+	globalCache map[string]uint32
 	// expectedListElem optionally hints the element type of an
 	// upcoming list literal lowering, set by `let/var x: list<T> = ...`
 	// just before lowerExpr and cleared after. Only lowerListLiteral
@@ -350,22 +376,24 @@ func (b *builder) finishCont(loop loopCtx, headID, contID uint32) map[string]uin
 	return env
 }
 
-func newBuilder(fn *ir.Function, userFns map[string]funEntry, prog *gogen.Program, goImports map[string]*goImport) *builder {
+func newBuilder(fn *ir.Function, userFns map[string]funEntry, prog *gogen.Program, goImports map[string]*goImport, globals map[string]*parser.Expr) *builder {
 	return &builder{
-		fn:        fn,
-		prog:      prog,
-		userFns:   userFns,
-		goImports: goImports,
-		values:    map[string]uint32{},
+		fn:          fn,
+		prog:        prog,
+		userFns:     userFns,
+		goImports:   goImports,
+		values:      map[string]uint32{},
+		globals:     globals,
+		globalCache: map[string]uint32{},
 	}
 }
 
-func lowerFun(p *gogen.Program, idx uint32, fs *parser.FunStmt, userFns map[string]funEntry, goImports map[string]*goImport) error {
+func lowerFun(p *gogen.Program, idx uint32, fs *parser.FunStmt, userFns map[string]funEntry, goImports map[string]*goImport, globals map[string]*parser.Expr) error {
 	fn := p.Funcs[idx]
 	// fn.Result is pre-populated by Lower's first pass so cross-fun
 	// calls can resolve their value type regardless of map iteration
 	// order. lowerFun only fills in Params and Blocks.
-	b := newBuilder(fn, userFns, p, goImports)
+	b := newBuilder(fn, userFns, p, goImports, globals)
 	// Params: every param is an OpParam value of the declared type.
 	for _, param := range fs.Params {
 		pt := ir.TypeI64
@@ -1832,6 +1860,22 @@ func (b *builder) lowerPrimary(p *parser.Primary) (uint32, error) {
 		}
 		id, ok := b.values[p.Selector.Root]
 		if !ok {
+			// Phase 4.2.16: module-scope `let NAME = EXPR` falls
+			// through to the program-level globals table. The first
+			// use materialises a fresh SSA value by lowering the RHS
+			// expression in the current builder; subsequent uses
+			// return the cached id so each function has one copy.
+			if cached, ok := b.globalCache[p.Selector.Root]; ok {
+				return cached, nil
+			}
+			if gexpr, ok := b.globals[p.Selector.Root]; ok {
+				gid, err := b.lowerExpr(gexpr)
+				if err != nil {
+					return 0, fmt.Errorf("frontend: lower global %q: %w", p.Selector.Root, err)
+				}
+				b.globalCache[p.Selector.Root] = gid
+				return gid, nil
+			}
 			return 0, fmt.Errorf("frontend: unbound identifier %q", p.Selector.Root)
 		}
 		return id, nil

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,33 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.43 Phase 4.2.16 closeout (LANDED 2026-05-22 10:42 GMT+7)
+
+Phase 4.2.16 puts top-level `let` bindings in scope inside user-function bodies on the C target. Before this phase the frontend's identifier-lookup path only consulted the per-function `b.values` map; a name introduced by a module-level `let` failed with `frontend: unbound identifier "n"` once it was referenced inside a `fun`. The v0.2/π.mochi tutorial fixture (`let π = 3.14; fun area(r) { return π * r * r }`) was the canonical casualty: it ran fine on the VM and got rejected outright on the C target.
+
+The chosen approach is to pre-scan top-level lets into a `map[string]*parser.Expr` once at the entry of `Lower()`, then thread that map through `lowerFun -> newBuilder` so each function builder gets a fallback in its identifier-lookup path. When a name is not in `b.values`, the builder checks a per-builder cache (`globalCache map[string]uint32`) and lowers the global's RHS expression once, materialising it as SSA inside the current function and recording the resulting value id. Subsequent references to the same global within the same function body re-use the cached id (no duplicate `OpConst` for `pi` if `pi` appears three times in `area`).
+
+### Diff shape
+
+- `compiler3/frontend/lower.go`:
+  - `Lower()` pre-scans `prog.Statements` for top-level `Let` nodes with non-nil `Value` into `globals map[string]*parser.Expr` before any user-function lowering.
+  - `lowerFun` signature gains a `globals` parameter; both existing call sites pass the pre-scanned map.
+  - `builder` struct gains `globals map[string]*parser.Expr` and `globalCache map[string]uint32` fields; `newBuilder` initialises the cache empty per function.
+  - Identifier-lookup fallback (`p.Selector.Root` path): cache hit returns the cached SSA id; cache miss lowers `globals[name]` via `b.lowerExpr` and stores the result in the cache. A name still missing from both maps falls through to the existing `unbound identifier` error.
+- `compiler3/build/c/driver_test.go`: 5 new tests covering int global from fn, float global from fn, multiple references to one global (cache observability), mixed scope (main and fn both read it), and parameter-shadows-global.
+
+### Why this closes a goal
+
+The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tutorial cluster, and v0.2/π.mochi is one of three fixtures in that cluster (`area`, `circ`, `vol`-style geometry primitives). The previous hard-error on the C target meant any v0.2 learner who reads `area`'s body and runs `mochi build --target=c` gets a `frontend: unbound identifier "π"` rejection that does not surface on `mochi run`. After this phase, `mochi build --target=c π.mochi` succeeds for the geometry portion of the fixture (the `test "π" { ... }` block remains rejected as `statement kind unsupported in MVP`, scope of a separate phase). Visible progress: every user function in user-written code can now reference module constants, which is the Mochi convention for naming literals.
+
+### Limitations
+
+- The `test` block in v0.2/π.mochi is still rejected (`statement kind unsupported in MVP`). That is a separate frontend feature, scoped to its own phase. The geometry portion of the fixture compiles and runs.
+- A top-level let with a side-effecting RHS is materialised at *each function's first use*, not once at module init. For pure constant initialisers (the only shape the parser permits as a top-level let RHS in practice) this is observationally equivalent. If the language ever allows side-effecting top-level lets, the model has to change.
+- The fallback only fires for the simple selector case (`p.Selector.Root` with no tail). Field/index access on a global (`config.timeout`, `xs[0]` when `xs` is global) is not covered by this phase; the v0.2 tutorial fixtures don't use that shape.
+- Mutual recursion through globals is not exercised. A let whose RHS calls a function that references another let could trigger order-of-lowering issues; the bench corpus and v0.2 fixtures don't hit that pattern, so it is deferred to a follow-up if it surfaces.
+- No emit-side change. The cache lives inside the frontend builder; from the IR consumer's perspective each function still receives a self-contained `Function` with all the constants it needs.
+
 ## §11 Risks
 
 ### 11.1 Clang ABI drift breaks stencils


### PR DESCRIPTION
## Summary

- Top-level `let` bindings are now reachable from inside user `fun` bodies on the C target (`mochi build --target=c`). Before this phase the same code raised `frontend: unbound identifier` even though `mochi run` handled it; v0.2/π.mochi (geometry primitives) was the canonical casualty.
- `Lower()` pre-scans top-level lets into `map[string]*parser.Expr` and threads it through `lowerFun -> newBuilder`. Each function builder gains a per-builder `globalCache`; the identifier-lookup fallback materialises the global's RHS as SSA once per function and re-uses it for subsequent references.
- 5 new driver tests cover int global, float global, multiple references (cache observability), mixed scope (main and fn read same global), and param-shadows-global. Full compiler3 suite stays green.
- Closeout: §10.43 of website/docs/mep/mep-0042.md (LANDED 2026-05-22 10:42 GMT+7).

Refs: #22025

## Test plan

- [x] `go build ./compiler3/...` clean
- [x] `go run ./cmd/mochi build --target=c --binary=/tmp/global /tmp/global.mochi` byte-matches `mochi run` (`314`)
- [x] `go test ./compiler3/build/c/ -run TestBuildSourceGlobalLet -count=1` (5/5 green)
- [x] `go test ./compiler3/... -count=1` (no regressions)