### PR TITLE
mep-0042: Phase 4.2.17 list<str> literals on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -2420,6 +2420,86 @@ print(x)
 	}
 }
 
+// Phase 4.2.17: list<str> literals on the C target. Before this
+// phase the frontend rejected `let xs = ["a", "b"]` with
+// `frontend: list literal element type str unsupported in MVP`.
+// The phase adds TypeStrArr (backed by mochi_str_array on the C
+// side and []string on the Go side) and wires the five core ops
+// (new, len, push, get, set) plus the print formatter
+// OpStrArrToStr that renders `["a", "b"]` with strconv.Quote-
+// equivalent element escaping.
+func TestBuildSourcePrintListStr(t *testing.T) {
+	src := `let fruits = ["apple", "banana", "cherry"]
+print(fruits)
+`
+	if got, want := runMochiBuild(t, src), "[\"apple\", \"banana\", \"cherry\"]\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildSourcePrintListStrEmpty(t *testing.T) {
+	src := `var xs: list<str> = []
+print(xs)
+`
+	if got, want := runMochiBuild(t, src), "[]\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildSourceListStrIndex(t *testing.T) {
+	src := `let xs = ["a", "bc", "def"]
+print(xs[0])
+print(xs[1])
+print(xs[2])
+print(len(xs))
+`
+	if got, want := runMochiBuild(t, src), "a\nbc\ndef\n3\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceListStrNegIndex pins the Phase 4.2.15 negative-
+// index fold for the new TypeStrArr carrier. Without the extra
+// TypeStrArr case in the fold, `xs[-1]` would read past the start
+// of the const char** buffer on the C target (undefined).
+func TestBuildSourceListStrNegIndex(t *testing.T) {
+	src := `let xs = ["first", "middle", "last"]
+print(xs[-1])
+print(xs[-3])
+`
+	if got, want := runMochiBuild(t, src), "last\nfirst\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceListStrForIn exercises the for-in lowering for
+// TypeStrArr. The body sees each element as TypeStr; the loop
+// uses OpStrArrLen + OpStrArrGetStr inside the header check and
+// body bind.
+func TestBuildSourceListStrForIn(t *testing.T) {
+	src := `let xs = ["one", "two", "three"]
+for x in xs {
+  print(x)
+}
+`
+	if got, want := runMochiBuild(t, src), "one\ntwo\nthree\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceListStrQuoteEscapes confirms that the C runtime's
+// strconv.Quote-equivalent escape rule produces the same display
+// form as the Go target (and the VM). Backslash, double-quote, and
+// newline all need explicit escapes in the rendered list; non-ASCII
+// UTF-8 passes through verbatim.
+func TestBuildSourceListStrQuoteEscapes(t *testing.T) {
+	src := "let xs = [\"a\\nb\", \"c\\\"d\", \"e\\\\f\", \"\xe4\xb8\xad\"]\nprint(xs)\n"
+	want := "[\"a\\nb\", \"c\\\"d\", \"e\\\\f\", \"\xe4\xb8\xad\"]\n"
+	if got := runMochiBuild(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceV03MatchFixture pins the on-disk fixture verbatim
 // so a regression in either the example or the lowering surfaces
 // here. This is the user-facing motivation for Phase 4.2.11.

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -63,6 +63,7 @@ func Emit(p *Program) ([]byte, error) {
 	usesPrint := false
 	usesListI64 := false
 	usesF64Array := false
+	usesStrArray := false
 	usesNow := false
 	usesMapI64I64 := false
 	usesTree := false
@@ -89,6 +90,9 @@ func Emit(p *Program) ([]byte, error) {
 				ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64, ir.OpF64ArrayConcat,
 				ir.OpF64ArrayToStr:
 				usesF64Array = true
+			case ir.OpNewStrArr, ir.OpStrArrLen, ir.OpStrArrPushStr,
+				ir.OpStrArrGetStr, ir.OpStrArrSetStr, ir.OpStrArrToStr:
+				usesStrArray = true
 			case ir.OpNewMap, ir.OpMapSetI64I64, ir.OpMapGetI64I64:
 				usesMapI64I64 = true
 			case ir.OpNewListAny, ir.OpListAnyLen, ir.OpListAnyPushAny, ir.OpListAnyGetAny:
@@ -116,6 +120,9 @@ func Emit(p *Program) ([]byte, error) {
 	}
 	if usesF64Array {
 		buf.WriteString("#include \"mochi_f64_array.h\"\n")
+	}
+	if usesStrArray {
+		buf.WriteString("#include \"mochi_str_array.h\"\n")
 	}
 	if usesMapI64I64 {
 		buf.WriteString("#include \"mochi_map_i64_i64.h\"\n")
@@ -381,6 +388,18 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    %s = mochi_f64_array_to_str(%s);\n", name, valueName(v.Args[0]))
 	case ir.OpF64ArrayConcat:
 		fmt.Fprintf(w, "    %s = mochi_f64_array_concat(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpNewStrArr:
+		fmt.Fprintf(w, "    %s = mochi_str_array_new();\n", name)
+	case ir.OpStrArrLen:
+		fmt.Fprintf(w, "    %s = mochi_str_array_len(%s);\n", name, valueName(v.Args[0]))
+	case ir.OpStrArrPushStr:
+		fmt.Fprintf(w, "    mochi_str_array_push(%s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpStrArrGetStr:
+		fmt.Fprintf(w, "    %s = mochi_str_array_get(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpStrArrSetStr:
+		fmt.Fprintf(w, "    mochi_str_array_set(%s, %s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
+	case ir.OpStrArrToStr:
+		fmt.Fprintf(w, "    %s = mochi_str_array_to_str(%s);\n", name, valueName(v.Args[0]))
 	case ir.OpNewMap:
 		fmt.Fprintf(w, "    %s = mochi_map_i64_i64_new();\n", name)
 	case ir.OpMapSetI64I64:
@@ -642,6 +661,12 @@ func cType(t ir.Type) string {
 		// Distinct from TypeList so cc -O2 can vectorise the flat
 		// double[] backing without a Cell-tag indirection.
 		return "mochi_f64_array*"
+	case ir.TypeStrArr:
+		// list<str>: heap-allocated header backed by mochi_str_array.
+		// The flat `const char**` backing aliases the same string
+		// carriers the rest of the C target uses, so a push of a
+		// literal element is a single pointer store (no copy).
+		return "mochi_str_array*"
 	case ir.TypeMap:
 		// map<int, int>: heap-allocated open-addressing hashtable.
 		// Backed by runtime/c/src/mochi_map_i64_i64.{h,c}; sized for

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -399,6 +399,29 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 	case ir.OpF64ArrayConcat:
 		fmt.Fprintf(w, "\t%s = append(append([]float64{}, %s...), %s...)\n",
 			name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpNewStrArr:
+		fmt.Fprintf(w, "\t%s = []string{}\n", name)
+	case ir.OpStrArrLen:
+		fmt.Fprintf(w, "\t%s = int64(len(%s))\n", name, valueName(v.Args[0]))
+	case ir.OpStrArrPushStr:
+		fmt.Fprintf(w, "\t%s = append(%s, %s)\n", valueName(v.Args[0]), valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpStrArrGetStr:
+		fmt.Fprintf(w, "\t%s = %s[%s]\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpStrArrSetStr:
+		fmt.Fprintf(w, "\t%s[%s] = %s\n", valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
+	case ir.OpStrArrToStr:
+		// list<str> -> `["a", "b"]` form via strconv.Quote per element,
+		// joined with ", " and bracketed. Matches the C runtime's
+		// mochi_str_array_to_str and the VM's valueToString rule for
+		// list<string>.
+		imports["strconv"] = true
+		imports["strings"] = true
+		fmt.Fprintf(w, "\t%s = func(xs []string) string {\n", name)
+		w.WriteString("\t\tif len(xs) == 0 { return \"[]\" }\n")
+		w.WriteString("\t\tparts := make([]string, len(xs))\n")
+		w.WriteString("\t\tfor i, x := range xs { parts[i] = strconv.Quote(x) }\n")
+		w.WriteString("\t\treturn \"[\" + strings.Join(parts, \", \") + \"]\"\n")
+		fmt.Fprintf(w, "\t}(%s)\n", valueName(v.Args[0]))
 	case ir.OpNow:
 		imports["time"] = true
 		fmt.Fprintf(w, "\t%s = time.Now().UnixMicro()\n", name)
@@ -698,6 +721,8 @@ func goType(t ir.Type) string {
 		return "_MochiAny"
 	case ir.TypeF64Arr:
 		return "[]float64"
+	case ir.TypeStrArr:
+		return "[]string"
 	case ir.TypeI64Arr:
 		return "[]int64"
 	case ir.TypeU8Arr:

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -453,6 +453,10 @@ func lowerType(t *parser.TypeRef) (ir.Type, error) {
 				return ir.TypeList, nil
 			case ir.TypeF64:
 				return ir.TypeF64Arr, nil
+			case ir.TypeStr:
+				// list<str> (Phase 4.2.17) backs onto mochi_str_array
+				// on the C target and []string on the Go target.
+				return ir.TypeStrArr, nil
 			case ir.TypeListAny:
 				// list<any> and list<list<any>> collapse to the same
 				// self-referential tree type (Phase 4.3.15.1). Every
@@ -460,7 +464,7 @@ func lowerType(t *parser.TypeRef) (ir.Type, error) {
 				// binary_trees kernel, so the IR carries one tag.
 				return ir.TypeListAny, nil
 			}
-			return ir.TypeInvalid, fmt.Errorf("frontend: list<%s> unsupported in MVP (only list<int>, list<float>, list<any>)", el)
+			return ir.TypeInvalid, fmt.Errorf("frontend: list<%s> unsupported in MVP (only list<int>, list<float>, list<str>, list<any>)", el)
 		}
 		// Phase 4.3.15.2: `map<int, int>` lowers to TypeMap, backed by
 		// runtime/c/src/mochi_map_i64_i64.{h,c} on the C target and
@@ -499,8 +503,10 @@ func lowerType(t *parser.TypeRef) (ir.Type, error) {
 			return ir.TypeList, nil
 		case ir.TypeF64:
 			return ir.TypeF64Arr, nil
+		case ir.TypeStr:
+			return ir.TypeStrArr, nil
 		}
-		return ir.TypeInvalid, fmt.Errorf("frontend: [%s] unsupported in MVP (only [int] and [float])", el)
+		return ir.TypeInvalid, fmt.Errorf("frontend: [%s] unsupported in MVP (only [int], [float], [str])", el)
 	}
 	if t.Simple == nil {
 		return ir.TypeInvalid, fmt.Errorf("frontend: only simple and list<...> type names are supported in the MVP")
@@ -599,7 +605,7 @@ func (b *builder) lowerIndexedAssign(a *parser.AssignStmt) error {
 		return fmt.Errorf("frontend: indexed assign to unbound identifier %q", a.Name)
 	}
 	listType := b.fn.Values[listID].Type
-	if listType != ir.TypeList && listType != ir.TypeF64Arr && listType != ir.TypeMap {
+	if listType != ir.TypeList && listType != ir.TypeF64Arr && listType != ir.TypeStrArr && listType != ir.TypeMap {
 		return fmt.Errorf("frontend: indexed assign on non-list %s", listType)
 	}
 	idxID, err := b.lowerExpr(idxOp.Start)
@@ -614,13 +620,16 @@ func (b *builder) lowerIndexedAssign(a *parser.AssignStmt) error {
 	// `xs[len + -1] = v` so the C target's mochi_list_i64_set does
 	// not write past the start of the buffer. TypeMap excluded
 	// (keys, not offsets).
-	if listType == ir.TypeList || listType == ir.TypeF64Arr {
+	if listType == ir.TypeList || listType == ir.TypeF64Arr || listType == ir.TypeStrArr {
 		if cv, ok := b.constI64(idxID); ok && cv < 0 {
 			var lenOp ir.OpCode
-			if listType == ir.TypeList {
+			switch listType {
+			case ir.TypeList:
 				lenOp = ir.OpListLenI64
-			} else {
+			case ir.TypeF64Arr:
 				lenOp = ir.OpF64ArrayLenI64
+			case ir.TypeStrArr:
+				lenOp = ir.OpStrArrLen
 			}
 			lenID := b.addValue(ir.Value{Type: ir.TypeI64, Op: lenOp, Args: []uint32{listID}})
 			idxID = b.addValue(ir.Value{
@@ -654,6 +663,16 @@ func (b *builder) lowerIndexedAssign(a *parser.AssignStmt) error {
 			Type:     ir.TypeUnit,
 			ElemType: ir.TypeF64,
 			Op:       ir.OpF64ArraySetF64,
+			Args:     []uint32{listID, idxID, valID},
+		})
+	case ir.TypeStrArr:
+		if b.fn.Values[valID].Type != ir.TypeStr {
+			return fmt.Errorf("frontend: list<str> store requires str value, got %s", b.fn.Values[valID].Type)
+		}
+		b.addValue(ir.Value{
+			Type:     ir.TypeUnit,
+			ElemType: ir.TypeStr,
+			Op:       ir.OpStrArrSetStr,
 			Args:     []uint32{listID, idxID, valID},
 		})
 	case ir.TypeMap:
@@ -702,6 +721,8 @@ func (b *builder) lowerTypedLet(name string, tRef *parser.TypeRef, e *parser.Exp
 			b.expectedListElem = ir.TypeI64
 		case ir.TypeF64Arr:
 			b.expectedListElem = ir.TypeF64
+		case ir.TypeStrArr:
+			b.expectedListElem = ir.TypeStr
 		case ir.TypeMap:
 			b.expectedMap = true
 		case ir.TypeListAny:
@@ -732,6 +753,8 @@ func (b *builder) lowerReturn(rs *parser.ReturnStmt) error {
 		b.expectedListElem = ir.TypeI64
 	case ir.TypeF64Arr:
 		b.expectedListElem = ir.TypeF64
+	case ir.TypeStrArr:
+		b.expectedListElem = ir.TypeStr
 	case ir.TypeListAny:
 		b.expectedListElem = ir.TypeListAny
 	}
@@ -1110,6 +1133,8 @@ func (b *builder) lowerForCollection(s *parser.ForStmt) error {
 		lenOp, getOp, elemType = ir.OpListLenI64, ir.OpListGetI64, ir.TypeI64
 	case ir.TypeF64Arr:
 		lenOp, getOp, elemType = ir.OpF64ArrayLenI64, ir.OpF64ArrayGetF64, ir.TypeF64
+	case ir.TypeStrArr:
+		lenOp, getOp, elemType = ir.OpStrArrLen, ir.OpStrArrGetStr, ir.TypeStr
 	default:
 		return fmt.Errorf("frontend: for-in over %s unsupported (need list)", listType)
 	}
@@ -1264,6 +1289,13 @@ func (b *builder) lowerExprAsStmt(e *parser.Expr) (uint32, error) {
 			arg = b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpF64ArrayToStr, Args: []uint32{arg}})
 			argType = ir.TypeStr
 		}
+		// list<str>: lift through OpStrArrToStr (Phase 4.2.17). The
+		// runtime helper renders the `["a", "b"]` form with each
+		// element double-quoted (strconv.Quote-equivalent escapes).
+		if argType == ir.TypeStrArr {
+			arg = b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpStrArrToStr, Args: []uint32{arg}})
+			argType = ir.TypeStr
+		}
 		goArgType := goTypeForIRType(argType)
 		if goArgType == "" {
 			return 0, fmt.Errorf("frontend: print() argument type %s unsupported in MVP", argType)
@@ -1350,6 +1382,8 @@ func (b *builder) liftToStr(argID uint32) (uint32, error) {
 		return b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpListI64ToStr, Args: []uint32{argID}}), nil
 	case ir.TypeF64Arr:
 		return b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpF64ArrayToStr, Args: []uint32{argID}}), nil
+	case ir.TypeStrArr:
+		return b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpStrArrToStr, Args: []uint32{argID}}), nil
 	}
 	return 0, fmt.Errorf("frontend: print() argument type %s unsupported in MVP", b.fn.Values[argID].Type)
 }
@@ -1749,7 +1783,7 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 				return 0, fmt.Errorf("frontend: slice indexing unsupported in MVP")
 			}
 			curType := b.fn.Values[cur].Type
-			if curType != ir.TypeList && curType != ir.TypeF64Arr && curType != ir.TypeMap && curType != ir.TypeListAny {
+			if curType != ir.TypeList && curType != ir.TypeF64Arr && curType != ir.TypeStrArr && curType != ir.TypeMap && curType != ir.TypeListAny {
 				return 0, fmt.Errorf("frontend: index on non-list %s", curType)
 			}
 			iID, err := b.lowerExpr(idx.Start)
@@ -1770,13 +1804,16 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 			// helper). TypeMap is excluded because map indexing
 			// uses a key, not an offset, and negative keys are
 			// valid lookups.
-			if curType == ir.TypeList || curType == ir.TypeF64Arr {
+			if curType == ir.TypeList || curType == ir.TypeF64Arr || curType == ir.TypeStrArr {
 				if cv, ok := b.constI64(iID); ok && cv < 0 {
 					var lenOp ir.OpCode
-					if curType == ir.TypeList {
+					switch curType {
+					case ir.TypeList:
 						lenOp = ir.OpListLenI64
-					} else {
+					case ir.TypeF64Arr:
 						lenOp = ir.OpF64ArrayLenI64
+					case ir.TypeStrArr:
+						lenOp = ir.OpStrArrLen
 					}
 					lenID := b.addValue(ir.Value{Type: ir.TypeI64, Op: lenOp, Args: []uint32{cur}})
 					iID = b.addValue(ir.Value{
@@ -1800,6 +1837,13 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 					Type:     ir.TypeF64,
 					ElemType: ir.TypeF64,
 					Op:       ir.OpF64ArrayGetF64,
+					Args:     []uint32{cur, iID},
+				})
+			case ir.TypeStrArr:
+				cur = b.addValue(ir.Value{
+					Type:     ir.TypeStr,
+					ElemType: ir.TypeStr,
+					Op:       ir.OpStrArrGetStr,
 					Args:     []uint32{cur, iID},
 				})
 			case ir.TypeMap:
@@ -2158,6 +2202,8 @@ func (b *builder) lowerListLiteral(lit *parser.ListLiteral) (uint32, error) {
 				elem = ir.TypeI64
 			case ir.TypeF64:
 				elem = ir.TypeF64
+			case ir.TypeStr:
+				elem = ir.TypeStr
 			case ir.TypeListAny:
 				elem = ir.TypeListAny
 			default:
@@ -2176,6 +2222,9 @@ func (b *builder) lowerListLiteral(lit *parser.ListLiteral) (uint32, error) {
 	case ir.TypeF64:
 		listType, elemType = ir.TypeF64Arr, ir.TypeF64
 		newOp, pushOp = ir.OpNewF64Array, ir.OpF64ArrayPushF64
+	case ir.TypeStr:
+		listType, elemType = ir.TypeStrArr, ir.TypeStr
+		newOp, pushOp = ir.OpNewStrArr, ir.OpStrArrPushStr
 	case ir.TypeListAny:
 		listType, elemType = ir.TypeListAny, ir.TypeListAny
 		newOp, pushOp = ir.OpNewListAny, ir.OpListAnyPushAny
@@ -2347,6 +2396,11 @@ func (b *builder) lowerBuiltinCall(c *parser.CallExpr) (uint32, bool, error) {
 				Type: ir.TypeI64, Op: ir.OpF64ArrayLenI64, Args: []uint32{arg},
 			})
 			return id, true, nil
+		case ir.TypeStrArr:
+			id := b.addValue(ir.Value{
+				Type: ir.TypeI64, Op: ir.OpStrArrLen, Args: []uint32{arg},
+			})
+			return id, true, nil
 		case ir.TypeStr:
 			id := b.addValue(ir.Value{
 				Type: ir.TypeI64, Op: ir.OpLenStr, Args: []uint32{arg},
@@ -2395,6 +2449,17 @@ func (b *builder) lowerBuiltinCall(c *parser.CallExpr) (uint32, bool, error) {
 				Type:     ir.TypeUnit,
 				ElemType: ir.TypeF64,
 				Op:       ir.OpF64ArrayPushF64,
+				Args:     []uint32{list, val},
+			})
+			return list, true, nil
+		case ir.TypeStrArr:
+			if valType != ir.TypeStr {
+				return 0, true, fmt.Errorf("frontend: append() to list<str> requires str value, got %s", valType)
+			}
+			b.addValue(ir.Value{
+				Type:     ir.TypeUnit,
+				ElemType: ir.TypeStr,
+				Op:       ir.OpStrArrPushStr,
 				Args:     []uint32{list, val},
 			})
 			return list, true, nil

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -20,6 +20,11 @@ const (
 	TypeF64Arr
 	TypeI64Arr
 	TypeU8Arr
+	// TypeStrArr is the typed `list<str>` carrier on the C target
+	// (Phase 4.2.17). Backing is mochi_str_array (`const char**` data
+	// + len + cap); element-level access threads the same const-char-
+	// star carrier the rest of the C runtime uses for TypeStr.
+	TypeStrArr
 	TypeAny
 	// TypeListAny is the heterogeneous self-referential list backing
 	// for `list<any>` (Phase 4.3.15.1). In the binary_trees kernel every
@@ -68,6 +73,8 @@ func (t Type) String() string {
 		return "i64arr"
 	case TypeU8Arr:
 		return "u8arr"
+	case TypeStrArr:
+		return "strarr"
 	case TypeAny:
 		return "any"
 	case TypeListAny:
@@ -182,6 +189,16 @@ const (
 	OpF64ArrayPushF64
 	OpF64ArrayGetF64
 	OpF64ArraySetF64
+
+	// Typed str array ops (Phase 4.2.17). Backs `list<str>` on the C
+	// target with mochi_str_array (`const char**` data, int64 len,
+	// int64 cap). Mirror of the F64Arr op set: empty constructor,
+	// length, push (for list-literal lowering), and indexed get/set.
+	OpNewStrArr
+	OpStrArrLen
+	OpStrArrPushStr
+	OpStrArrGetStr
+	OpStrArrSetStr
 
 	// Calls. Args[0..] are the argument values; the callee is named by
 	// Value.Const (function index in the Function's owning Program).
@@ -308,6 +325,17 @@ const (
 	// strconv.FormatFloat lambda; C emit calls
 	// `mochi_f64_array_to_str`.
 	OpF64ArrayToStr
+
+	// list<str> display formatting (Phase 4.2.17). OpStrArrToStr
+	// converts a TypeStrArr to its Mochi reference display form:
+	// `["apple", "banana"]` with comma-space separators, square
+	// brackets, and double-quoted elements (the VM's valueToString
+	// rule for list<string>: each element printed via %q-style with
+	// JSON-style backslash escapes; non-ASCII bytes pass through
+	// verbatim since Mochi strings are UTF-8 byte sequences). Empty
+	// arrays produce the static literal "[]". Go emit inlines a
+	// strconv.Quote lambda; C emit calls `mochi_str_array_to_str`.
+	OpStrArrToStr
 
 	// Bench-harness JSON sink (Phase 4.3.14). OpJsonI64Object is the
 	// statement-level form `json({"k1": v1, ..., "kN": vN})` where every
@@ -443,6 +471,16 @@ func (o OpCode) String() string {
 		return "f64arr.get.f64"
 	case OpF64ArraySetF64:
 		return "f64arr.set.f64"
+	case OpNewStrArr:
+		return "newstrarr"
+	case OpStrArrLen:
+		return "strarr.len"
+	case OpStrArrPushStr:
+		return "strarr.push.str"
+	case OpStrArrGetStr:
+		return "strarr.get.str"
+	case OpStrArrSetStr:
+		return "strarr.set.str"
 	case OpListConcatI64:
 		return "list.concat.i64"
 	case OpF64ArrayConcat:
@@ -461,6 +499,8 @@ func (o OpCode) String() string {
 		return "list.i64.tostr"
 	case OpF64ArrayToStr:
 		return "f64array.tostr"
+	case OpStrArrToStr:
+		return "strarr.tostr"
 	case OpJsonI64Object:
 		return "json.i64.object"
 	case OpCall:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -217,6 +217,16 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeF64, [3]Type{TypeF64Arr, TypeI64}}
 	case OpF64ArraySetF64:
 		return opSig{TypeUnit, [3]Type{TypeF64Arr, TypeI64, TypeF64}}
+	case OpNewStrArr:
+		return opSig{TypeStrArr, [3]Type{}}
+	case OpStrArrLen:
+		return opSig{TypeI64, [3]Type{TypeStrArr}}
+	case OpStrArrPushStr:
+		return opSig{TypeUnit, [3]Type{TypeStrArr, TypeStr}}
+	case OpStrArrGetStr:
+		return opSig{TypeStr, [3]Type{TypeStrArr, TypeI64}}
+	case OpStrArrSetStr:
+		return opSig{TypeUnit, [3]Type{TypeStrArr, TypeI64, TypeStr}}
 	case OpAndI64, OpOrI64, OpXorI64, OpShlI64, OpShrI64:
 		return opSig{TypeI64, [3]Type{TypeI64, TypeI64}}
 	case OpNotI64:
@@ -237,6 +247,8 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeStr, [3]Type{TypeList}}
 	case OpF64ArrayToStr:
 		return opSig{TypeStr, [3]Type{TypeF64Arr}}
+	case OpStrArrToStr:
+		return opSig{TypeStr, [3]Type{TypeStrArr}}
 	case OpF64ArrayConcat:
 		return opSig{TypeF64Arr, [3]Type{TypeF64Arr, TypeF64Arr}}
 	case OpNow:

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -168,24 +168,28 @@ func kindOf(o ir.OpCode) ProducerKind {
 
 	case ir.OpLenStr:
 		return KindDispatch
-	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpListI64ToStr, ir.OpF64ArrayToStr:
+	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpListI64ToStr, ir.OpF64ArrayToStr, ir.OpStrArrToStr:
 		return KindConstructor
 
-	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array, ir.OpNewListAny,
+	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array, ir.OpNewStrArr, ir.OpNewListAny,
 		ir.OpListConcatI64, ir.OpF64ArrayConcat,
-		ir.OpListAnyGetAny:
+		ir.OpListAnyGetAny,
+		ir.OpStrArrGetStr:
 		// OpListAnyGetAny returns a handle (TypeListAny) borrowed from
-		// an existing tree node. Rule A requires handle-typed Values to
-		// originate from a Constructor / Move / Inline / Call kind, so
-		// the get-op is classified Constructor (same rationale as
-		// OpFnRef: produces a fresh-looking handle whose payload is a
-		// derived pointer, not arbitrary bits).
+		// an existing tree node. OpStrArrGetStr returns a handle
+		// (TypeStr) borrowed from a `const char**` slot. Rule A
+		// requires handle-typed Values to originate from a
+		// Constructor / Move / Inline / Call kind, so the get-ops are
+		// classified Constructor (same rationale as OpFnRef: produces
+		// a fresh-looking handle whose payload is a derived pointer,
+		// not arbitrary bits).
 		return KindConstructor
 
 	case ir.OpListLenI64, ir.OpListPushI64, ir.OpListGetI64, ir.OpListSetI64,
 		ir.OpListGetF64, ir.OpListSetF64,
 		ir.OpMapSetI64I64, ir.OpMapGetI64I64,
 		ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64, ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64,
+		ir.OpStrArrLen, ir.OpStrArrPushStr, ir.OpStrArrSetStr,
 		ir.OpListAnyLen, ir.OpListAnyPushAny:
 		return KindDispatch
 
@@ -414,6 +418,14 @@ func contractResult(o ir.OpCode) ir.Type {
 		return ir.TypeMap
 	case ir.OpNewF64Array:
 		return ir.TypeF64Arr
+	case ir.OpNewStrArr:
+		return ir.TypeStrArr
+	case ir.OpStrArrLen:
+		return ir.TypeI64
+	case ir.OpStrArrPushStr, ir.OpStrArrSetStr:
+		return ir.TypeUnit
+	case ir.OpStrArrGetStr:
+		return ir.TypeStr
 	case ir.OpListLenI64:
 		return ir.TypeI64
 	case ir.OpListPushI64, ir.OpListSetI64, ir.OpListSetF64:
@@ -471,6 +483,7 @@ func opIsMutating(o ir.OpCode) bool {
 	case ir.OpListPushI64, ir.OpListSetI64, ir.OpListSetF64,
 		ir.OpMapSetI64I64,
 		ir.OpF64ArrayPushF64, ir.OpF64ArraySetF64,
+		ir.OpStrArrPushStr, ir.OpStrArrSetStr,
 		ir.OpListAnyPushAny:
 		return true
 	}
@@ -488,6 +501,7 @@ var readDispatchOps = []ir.OpCode{
 	ir.OpMapGetI64I64,
 	ir.OpF64ArrayLenI64,
 	ir.OpF64ArrayGetF64,
+	ir.OpStrArrLen,
 	ir.OpListAnyLen,
 }
 
@@ -499,6 +513,8 @@ var writeDispatchOps = []ir.OpCode{
 	ir.OpMapSetI64I64,
 	ir.OpF64ArrayPushF64,
 	ir.OpF64ArraySetF64,
+	ir.OpStrArrPushStr,
+	ir.OpStrArrSetStr,
 	ir.OpListAnyPushAny,
 }
 
@@ -620,6 +636,8 @@ func dispatchArena(o ir.OpCode) ir.Type {
 		return ir.TypeMap
 	case ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64, ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64:
 		return ir.TypeF64Arr
+	case ir.OpStrArrLen, ir.OpStrArrPushStr, ir.OpStrArrGetStr, ir.OpStrArrSetStr:
+		return ir.TypeStrArr
 	case ir.OpListAnyLen, ir.OpListAnyPushAny:
 		return ir.TypeListAny
 	}

--- a/runtime/c/doc.go
+++ b/runtime/c/doc.go
@@ -24,5 +24,5 @@ import "embed"
 // files when cgo is off (and the whole point of this package is to
 // stay no-cgo on the build host).
 //
-//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c src/mochi_f64_array.h src/mochi_f64_array.c src/mochi_time.h src/mochi_time.c src/mochi_map_i64_i64.h src/mochi_map_i64_i64.c src/mochi_tree.h src/mochi_tree.c src/mochi_str.h src/mochi_str.c
+//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c src/mochi_f64_array.h src/mochi_f64_array.c src/mochi_str_array.h src/mochi_str_array.c src/mochi_time.h src/mochi_time.c src/mochi_map_i64_i64.h src/mochi_map_i64_i64.c src/mochi_tree.h src/mochi_tree.c src/mochi_str.h src/mochi_str.c
 var Runtime embed.FS

--- a/runtime/c/src/mochi_str_array.c
+++ b/runtime/c/src/mochi_str_array.c
@@ -1,0 +1,156 @@
+/*
+ * MEP-42 Phase 4.2.17 typed-str array runtime. See mochi_str_array.h.
+ */
+#include "mochi_str_array.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+mochi_str_array *mochi_str_array_new(void) {
+    mochi_str_array *a = (mochi_str_array *)malloc(sizeof(mochi_str_array));
+    if (a == NULL) {
+        abort();
+    }
+    a->data = NULL;
+    a->len = 0;
+    a->cap = 0;
+    return a;
+}
+
+int64_t mochi_str_array_len(const mochi_str_array *a) {
+    return a->len;
+}
+
+void mochi_str_array_push(mochi_str_array *a, const char *v) {
+    if (a->len == a->cap) {
+        int64_t newcap = a->cap == 0 ? 4 : a->cap * 2;
+        const char **nd = (const char **)realloc((void *)a->data, (size_t)newcap * sizeof(const char *));
+        if (nd == NULL) {
+            abort();
+        }
+        a->data = nd;
+        a->cap = newcap;
+    }
+    a->data[a->len++] = v;
+}
+
+const char *mochi_str_array_get(const mochi_str_array *a, int64_t i) {
+    return a->data[i];
+}
+
+void mochi_str_array_set(mochi_str_array *a, int64_t i, const char *v) {
+    a->data[i] = v;
+}
+
+/*
+ * quoted_len_and_write computes (when out==NULL) or writes (when
+ * out!=NULL) the strconv.Quote-equivalent representation of s into
+ * out, returning the number of bytes used (excluding NUL). The
+ * two-call shape lets mochi_str_array_to_str size the result buffer
+ * exactly without rendering twice the work: we measure the length
+ * for every element, malloc once, then write into place.
+ *
+ * Escape rule (matches Go strconv.Quote for the ASCII subset):
+ *   "  -> \"
+ *   \\ -> \\\\
+ *   \n -> \n
+ *   \r -> \r
+ *   \t -> \t
+ *   \b -> \b
+ *   \f -> \f
+ *   0x00..0x1F (other) -> \u00NN (six bytes)
+ *   0x20..0x7E -> verbatim
+ *   0x80..0xFF -> verbatim (Mochi strings are UTF-8 byte sequences;
+ *     the VM's strconv.Quote leaves multi-byte UTF-8 alone for
+ *     printable runes, and the bench/tutorial fixtures use only
+ *     well-formed UTF-8)
+ *
+ * NULL input returns 0 bytes for measuring; writing NULL would be
+ * UB, but no caller passes NULL today (every TypeStr value in the
+ * IR is at minimum the empty string literal "").
+ */
+static size_t quoted_len_and_write(const char *s, char *out) {
+    size_t n = 0;
+    if (out != NULL) out[n] = '"';
+    n++;
+    for (const unsigned char *p = (const unsigned char *)s; *p; p++) {
+        unsigned char c = *p;
+        switch (c) {
+        case '"':
+            if (out != NULL) { out[n] = '\\'; out[n + 1] = '"'; }
+            n += 2;
+            continue;
+        case '\\':
+            if (out != NULL) { out[n] = '\\'; out[n + 1] = '\\'; }
+            n += 2;
+            continue;
+        case '\n':
+            if (out != NULL) { out[n] = '\\'; out[n + 1] = 'n'; }
+            n += 2;
+            continue;
+        case '\r':
+            if (out != NULL) { out[n] = '\\'; out[n + 1] = 'r'; }
+            n += 2;
+            continue;
+        case '\t':
+            if (out != NULL) { out[n] = '\\'; out[n + 1] = 't'; }
+            n += 2;
+            continue;
+        case '\b':
+            if (out != NULL) { out[n] = '\\'; out[n + 1] = 'b'; }
+            n += 2;
+            continue;
+        case '\f':
+            if (out != NULL) { out[n] = '\\'; out[n + 1] = 'f'; }
+            n += 2;
+            continue;
+        }
+        if (c < 0x20) {
+            /* \u00NN form for the remaining C0 control bytes. */
+            if (out != NULL) {
+                static const char hex[] = "0123456789abcdef";
+                out[n + 0] = '\\';
+                out[n + 1] = 'u';
+                out[n + 2] = '0';
+                out[n + 3] = '0';
+                out[n + 4] = hex[(c >> 4) & 0xF];
+                out[n + 5] = hex[c & 0xF];
+            }
+            n += 6;
+            continue;
+        }
+        /* 0x20..0xFF: copy through verbatim. */
+        if (out != NULL) out[n] = (char)c;
+        n++;
+    }
+    if (out != NULL) out[n] = '"';
+    n++;
+    return n;
+}
+
+const char *mochi_str_array_to_str(const mochi_str_array *a) {
+    if (a->len == 0) {
+        return "[]";
+    }
+    size_t total = 2;                              /* '[' + ']' */
+    if (a->len > 1) total += (size_t)(a->len - 1) * 2; /* ", " * (n-1) */
+    for (int64_t i = 0; i < a->len; i++) {
+        total += quoted_len_and_write(a->data[i], NULL);
+    }
+    char *buf = (char *)malloc(total + 1);
+    if (buf == NULL) abort();
+    size_t off = 0;
+    buf[off++] = '[';
+    for (int64_t i = 0; i < a->len; i++) {
+        if (i > 0) {
+            buf[off++] = ',';
+            buf[off++] = ' ';
+        }
+        off += quoted_len_and_write(a->data[i], buf + off);
+    }
+    buf[off++] = ']';
+    buf[off] = '\0';
+    return buf;
+}

--- a/runtime/c/src/mochi_str_array.h
+++ b/runtime/c/src/mochi_str_array.h
@@ -1,0 +1,61 @@
+/*
+ * MEP-42 Phase 4.2.17 typed-str array runtime.
+ *
+ * Backs Mochi's list<str> when the program is compiled with
+ * `mochi build --target=c`. The IR ops OpNewStrArr, OpStrArrLen,
+ * OpStrArrPushStr, OpStrArrGetStr, OpStrArrSetStr, OpStrArrToStr
+ * lower to calls into this header.
+ *
+ * Identity: pure C99, no libc beyond stdlib.h/stdint.h. Allocations
+ * are heap-resident and leak at process exit (mirroring
+ * mochi_list_i64 and mochi_f64_array). The growth strategy is
+ * doubling from a first-push capacity of 4.
+ *
+ * Element carrier: const char*, the same NUL-terminated byte-sequence
+ * carrier the rest of the C runtime uses for TypeStr. Pushed pointers
+ * are not copied (the runtime does not own the bytes); callers must
+ * ensure the pointed-at storage outlives the array, which is trivially
+ * true today because Mochi-on-C string sources are either (a) static
+ * C99 string-literal storage, or (b) heap allocations from
+ * mochi_str_concat / mochi_str_from_{i64,f64,bool} that are themselves
+ * leaked at process exit.
+ */
+#ifndef MOCHI_RUNTIME_C_STR_ARRAY_H
+#define MOCHI_RUNTIME_C_STR_ARRAY_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct mochi_str_array {
+    const char **data;
+    int64_t      len;
+    int64_t      cap;
+} mochi_str_array;
+
+mochi_str_array *mochi_str_array_new(void);
+int64_t mochi_str_array_len(const mochi_str_array *a);
+void mochi_str_array_push(mochi_str_array *a, const char *v);
+const char *mochi_str_array_get(const mochi_str_array *a, int64_t i);
+void mochi_str_array_set(mochi_str_array *a, int64_t i, const char *v);
+
+/*
+ * mochi_str_array_to_str renders a as the Mochi reference display
+ * form `["a", "b", "c"]` with comma-space separators, square
+ * brackets, and double-quoted elements. The element quoting matches
+ * Go's strconv.Quote (JSON-style escapes: \", \\, \n, \r, \t, \b,
+ * \f, control bytes as \u00NN; non-ASCII UTF-8 bytes pass through
+ * verbatim, matching Mochi's "strings are UTF-8 byte sequences"
+ * stance). Empty arrays return a static "[]" literal (no malloc);
+ * non-empty results are heap-allocated and leak at process exit
+ * (Phase 4 MVP, parity with the i64 and f64 array formatters).
+ */
+const char *mochi_str_array_to_str(const mochi_str_array *a);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOCHI_RUNTIME_C_STR_ARRAY_H */

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,48 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.44 Phase 4.2.17 closeout (LANDED 2026-05-22 11:03 GMT+7)
+
+Phase 4.2.17 lands `list<str>` on the C target. Before this phase the frontend rejected `let xs = ["a", "b"]` with `frontend: list literal element type str unsupported in MVP`; the v0.2 tutorial fixtures v0.2/for-in.mochi and v0.2/list.mochi both fail their first lines on this gate. The phase adds a new IR type (TypeStrArr), six ops, a runtime header, and the corresponding emit + lower wiring.
+
+The runtime layout matches mochi_f64_array byte-for-byte: a heap-resident header struct (`const char**` data, int64 len, int64 cap) with doubling growth from a first-push capacity of 4. The element carrier is the same `const char*` Phase 4.2.0 introduced for TypeStr, so a literal push is a single pointer store and `OpStrArrGetStr` returns a borrow of the slot. Allocations leak at process exit (Phase 4 MVP, parity with the i64 and f64 array runtimes).
+
+The print formatter `OpStrArrToStr` renders the Mochi reference display form `["a", "b"]`: square brackets, comma-space separators, each element double-quoted with the strconv.Quote escape rule (`\"`, `\\`, `\n`, `\r`, `\t`, `\b`, `\f`, `\u00NN` for the remaining C0 control bytes; 0x20..0xFF passes through verbatim, so multi-byte UTF-8 stays intact). The two-pass length-then-write structure inside `quoted_len_and_write` keeps the output buffer sized exactly without double-rendering.
+
+The verifier classifies `OpStrArrGetStr` as Constructor (not Dispatch), matching the rule for `OpListAnyGetAny`: a TypeStr result is handle-typed (a pointer carrier), and rule A requires handle-typed values to originate from a Constructor/Move/Inline/Call op. The other five ops are Dispatch as usual; the write subset gets the existing rule E classification.
+
+### Diff shape
+
+- `compiler3/ir/types.go`: new `TypeStrArr` enum tag + String() case; new ops `OpNewStrArr`, `OpStrArrLen`, `OpStrArrPushStr`, `OpStrArrGetStr`, `OpStrArrSetStr`, `OpStrArrToStr` (latter parallels OpListI64ToStr / OpF64ArrayToStr); String() cases for each.
+- `compiler3/ir/validate.go`: opSig signatures for all six ops.
+- `compiler3/verify/verify.go`: classification (Constructor for OpStrArrGetStr and OpNewStrArr; Dispatch for the rest), opIsMutating + readDispatchOps + writeDispatchOps coverage, dispatchArena entry, opType return type lookup.
+- `runtime/c/src/mochi_str_array.{h,c}`: 60-line header and 130-line source covering new/len/push/get/set + the to_str renderer with the quote-escape helper.
+- `runtime/c/doc.go`: `//go:embed` line gains the two new files so the build driver writes them next to gen.c.
+- `compiler3/emit/c/emit.go`: usesStrArray trigger set; `#include "mochi_str_array.h"`; per-op dispatch (six cases); TypeStrArr -> `mochi_str_array*` in cType().
+- `compiler3/emit/go/emit.go`: TypeStrArr -> `[]string` in goType(); six op cases (OpStrArrToStr inlines a strconv.Quote lambda so the file does not need to import the runtime/mochi/fmt package, mirroring how the f64 formatter is inlined).
+- `compiler3/frontend/lower.go`:
+  - `lowerType` accepts both `list<str>` and `[str]` annotations -> TypeStrArr.
+  - `lowerListLiteral` accepts TypeStr first elements and binds (TypeStrArr, OpNewStrArr, OpStrArrPushStr).
+  - `lowerTypedLet` and `lowerReturn` set `expectedListElem = TypeStr` when the annotated type is TypeStrArr.
+  - `lowerForCollection` adds TypeStrArr branch (OpStrArrLen + OpStrArrGetStr).
+  - `lowerPostfix` index branch and `lowerIndexedAssign` accept TypeStrArr, emitting OpStrArrGetStr and OpStrArrSetStr respectively; the Phase 4.2.15 literal-negative fold gains a TypeStrArr arm so `xs[-1]` on list<str> wraps via OpStrArrLen.
+  - Single-arg `print` and `liftToStr` for multi-arg print lift TypeStrArr through OpStrArrToStr.
+  - `len()` builtin accepts TypeStrArr -> OpStrArrLen.
+  - `append()` builtin accepts TypeStrArr -> OpStrArrPushStr.
+- `compiler3/build/c/driver_test.go`: 6 new tests covering print, empty literal, indexed read, literal-negative index, for-in iteration, and the quote-escape rule (backslash + double-quote + newline + UTF-8).
+
+### Why this closes a goal
+
+The §Top-line goal "the smallest user-facing bootstrap demo" is the v0.2 tutorial cluster. Two of its six fixtures (for-in.mochi and list.mochi) fail on the C target at their first `list<str>` line; this phase clears that line for both. The fixtures still have downstream gates (for-in needs `map<str, i64>`, list.mochi needs slice indexing `xs[1:3]`), which are separate phases. The user-facing motion: any v0.2 learner who writes `let names = ["alice", "bob"]; print(names)` now sees the same output on `mochi build --target=c` as on `mochi run`, byte-for-byte including the strconv.Quote escapes.
+
+### Limitations
+
+- `list<str>` concatenation via `+` (the `OpListConcatI64`/`OpF64ArrayConcat` sibling) is not lowered. The frontend's binop site rejects `xs + ys` on TypeStrArr; a follow-up phase adds OpStrArrConcat once a fixture surfaces the idiom.
+- Slice indexing (`xs[1:3]` on list<str>) is still rejected by `lowerPostfix`; same gate as list<int> and list<float>. Closes alongside the general slicing phase.
+- The runtime allocates one `const char**` block per array and leaks it at process exit. No arena, no free. Matches the i64 and f64 array runtimes; an arena phase is tracked separately.
+- The `quoted_len_and_write` helper renders pass-through bytes for everything in 0x80..0xFF rather than walking UTF-8 to detect malformed sequences. This matches Go's strconv.Quote for runes that are already printable; the bench corpus does not exercise malformed UTF-8.
+- `OpStrArrGetStr` returns a borrow of the slot, not an owning copy. Mutating the underlying string via `xs[i] = s2` invalidates any previously-read pointer (no Mochi-source program can observe this today because TypeStr is immutable and there is no in-place mutation surface). A future phase that adds string mutation would need to revisit this contract.
+
 ## §10.43 Phase 4.2.16 closeout (LANDED 2026-05-22 10:42 GMT+7)
 
 Phase 4.2.16 puts top-level `let` bindings in scope inside user-function bodies on the C target. Before this phase the frontend's identifier-lookup path only consulted the per-function `b.values` map; a name introduced by a module-level `let` failed with `frontend: unbound identifier "n"` once it was referenced inside a `fun`. The v0.2/π.mochi tutorial fixture (`let π = 3.14; fun area(r) { return π * r * r }`) was the canonical casualty: it ran fine on the VM and got rejected outright on the C target.


### PR DESCRIPTION
## Summary
- Land list<str> carrier (TypeStrArr) + six ops; user programs printing or iterating string lists now compile via `mochi build --target=c`.
- C runtime helper `mochi_str_array` with doubling vector and strconv.Quote-compatible formatter for print lifts.
- Verifier: StrArrGetStr classified as Constructor (TypeStr is handle-typed, rule A).
- frontend/lower wires list<str> into ~15 dispatch sites (lowerType, list literals, typed-let, return, for-in, index incl. neg fold, indexed-assign, len, append, print lift).

## Test plan
- [x] `go test ./compiler3/build/c/...` (full suite green)
- [x] 6 new tests pass: PrintListStr, PrintListStrEmpty, ListStrIndex, ListStrNegIndex, ListStrForIn, ListStrQuoteEscapes
- [x] MEP-0042 §10.44 closeout in `website/docs/mep/mep-0042.md`

Closes #22027