### PR TITLE
mep-0042: Phase 4.2.18 map<str, i64> on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -2500,6 +2500,53 @@ func TestBuildSourceListStrQuoteEscapes(t *testing.T) {
 	}
 }
 
+// TestBuildSourceMapStrI64Literal pins the v0.2 map.mochi shape: a
+// `map<string, int>` literal with several entries, an indexed read,
+// and `len(m)`. Before Phase 4.2.18 the binding hit "map<str, i64>
+// unsupported in MVP"; the phase adds TypeMapStrI64 + new/get/set/len
+// ops backed by runtime/c/src/mochi_map_str_i64.{h,c} on the C
+// target and map[string]int64 on the Go target.
+func TestBuildSourceMapStrI64Literal(t *testing.T) {
+	src := `let scores: map<string, int> = {
+  "Alice": 10,
+  "Bob": 15
+}
+let aliceScore = scores["Alice"]
+print("Alice's score:", aliceScore)
+print("Total players:", len(scores))
+`
+	if got, want := runMochiBuild(t, src), "Alice's score: 10\nTotal players: 2\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceMapStrI64Default pins the Go-shaped zero-default:
+// `m[k]` on an absent key returns 0. Mochi sources rely on this for
+// counter-style accumulation; the C runtime probe returns 0 from
+// the unoccupied bucket the same way Go's map[string]int64 does.
+func TestBuildSourceMapStrI64Default(t *testing.T) {
+	src := `let scores: map<string, int> = {"Alice": 10}
+print(scores["Alice"])
+print(scores["Unknown"])
+`
+	if got, want := runMochiBuild(t, src), "10\n0\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceMapStrI64Empty exercises the empty-literal form
+// (which already worked for map<int, int>) under the new carrier.
+// `len(m) == 0` confirms the new len op routes through
+// mochi_map_str_i64_len rather than a stale TypeMap dispatch.
+func TestBuildSourceMapStrI64Empty(t *testing.T) {
+	src := `let m: map<string, int> = {}
+print(len(m))
+`
+	if got, want := runMochiBuild(t, src), "0\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceV03MatchFixture pins the on-disk fixture verbatim
 // so a regression in either the example or the lowering surfaces
 // here. This is the user-facing motivation for Phase 4.2.11.

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -66,6 +66,7 @@ func Emit(p *Program) ([]byte, error) {
 	usesStrArray := false
 	usesNow := false
 	usesMapI64I64 := false
+	usesMapStrI64 := false
 	usesTree := false
 	usesStrH := false
 	usesStrRuntime := false
@@ -95,6 +96,8 @@ func Emit(p *Program) ([]byte, error) {
 				usesStrArray = true
 			case ir.OpNewMap, ir.OpMapSetI64I64, ir.OpMapGetI64I64:
 				usesMapI64I64 = true
+			case ir.OpNewMapStrI64, ir.OpMapSetStrI64, ir.OpMapGetStrI64, ir.OpMapLenStrI64:
+				usesMapStrI64 = true
 			case ir.OpNewListAny, ir.OpListAnyLen, ir.OpListAnyPushAny, ir.OpListAnyGetAny:
 				usesTree = true
 			case ir.OpLenStr, ir.OpCmpEqStr, ir.OpCmpNeStr:
@@ -126,6 +129,9 @@ func Emit(p *Program) ([]byte, error) {
 	}
 	if usesMapI64I64 {
 		buf.WriteString("#include \"mochi_map_i64_i64.h\"\n")
+	}
+	if usesMapStrI64 {
+		buf.WriteString("#include \"mochi_map_str_i64.h\"\n")
 	}
 	if usesTree {
 		buf.WriteString("#include \"mochi_tree.h\"\n")
@@ -406,6 +412,14 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    mochi_map_i64_i64_set(%s, %s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
 	case ir.OpMapGetI64I64:
 		fmt.Fprintf(w, "    %s = mochi_map_i64_i64_get(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpNewMapStrI64:
+		fmt.Fprintf(w, "    %s = mochi_map_str_i64_new();\n", name)
+	case ir.OpMapSetStrI64:
+		fmt.Fprintf(w, "    mochi_map_str_i64_set(%s, %s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
+	case ir.OpMapGetStrI64:
+		fmt.Fprintf(w, "    %s = mochi_map_str_i64_get(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpMapLenStrI64:
+		fmt.Fprintf(w, "    %s = mochi_map_str_i64_len(%s);\n", name, valueName(v.Args[0]))
 	case ir.OpNewListAny:
 		fmt.Fprintf(w, "    %s = mochi_tree_new();\n", name)
 	case ir.OpListAnyLen:
@@ -672,6 +686,12 @@ func cType(t ir.Type) string {
 		// Backed by runtime/c/src/mochi_map_i64_i64.{h,c}; sized for
 		// k_nucleotide's 20-key worst case but grows on demand.
 		return "mochi_map_i64_i64*"
+	case ir.TypeMapStrI64:
+		// map<str, i64>: heap-allocated open-addressing hashtable
+		// keyed by `const char*`. Backed by
+		// runtime/c/src/mochi_map_str_i64.{h,c}. Get on an absent key
+		// returns 0 (Go's `map[string]int64{}` zero-default).
+		return "mochi_map_str_i64*"
 	case ir.TypeListAny:
 		// list<any>: heap-allocated recursive tree node. Backed by
 		// runtime/c/src/mochi_tree.{h,c}; every child is itself a

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -342,6 +342,14 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 		fmt.Fprintf(w, "\t%s[%s] = %s\n", valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
 	case ir.OpMapGetI64I64:
 		fmt.Fprintf(w, "\t%s = %s[%s]\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpNewMapStrI64:
+		fmt.Fprintf(w, "\t%s = map[string]int64{}\n", name)
+	case ir.OpMapSetStrI64:
+		fmt.Fprintf(w, "\t%s[%s] = %s\n", valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
+	case ir.OpMapGetStrI64:
+		fmt.Fprintf(w, "\t%s = %s[%s]\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpMapLenStrI64:
+		fmt.Fprintf(w, "\t%s = int64(len(%s))\n", name, valueName(v.Args[0]))
 	case ir.OpNewListAny:
 		fmt.Fprintf(w, "\t%s = _MochiAny{}\n", name)
 	case ir.OpListAnyLen:
@@ -717,6 +725,8 @@ func goType(t ir.Type) string {
 		return "[]int64"
 	case ir.TypeMap:
 		return "map[int64]int64"
+	case ir.TypeMapStrI64:
+		return "map[string]int64"
 	case ir.TypeListAny:
 		return "_MochiAny"
 	case ir.TypeF64Arr:

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -218,6 +218,12 @@ type builder struct {
 	// non-empty literals are out of scope until a sub-phase widens the
 	// IR's map family.
 	expectedMap bool
+	// expectedMapStrI64 is set by `let/var m: map<str, i64> = ...` just
+	// before lowerExpr and cleared after. lowerMapLiteralAsExpr
+	// consults it so a `{...}` literal with string keys and int values
+	// lowers to OpNewMapStrI64 + a chain of OpMapSetStrI64 (Phase
+	// 4.2.18).
+	expectedMapStrI64 bool
 	// loops is the lexical stack of enclosing loops, deepest last. Each
 	// entry knows where `break` and `continue` should jump to and which
 	// SSA bindings are phi-tracked at the header so an exit edge can
@@ -485,7 +491,13 @@ func lowerType(t *parser.TypeRef) (ir.Type, error) {
 			if k == ir.TypeI64 && v == ir.TypeI64 {
 				return ir.TypeMap, nil
 			}
-			return ir.TypeInvalid, fmt.Errorf("frontend: map<%s, %s> unsupported in MVP (only map<int, int>)", k, v)
+			// Phase 4.2.18: map<str, i64> for v0.2 user-facing fixtures
+			// (examples/v0.2/map.mochi). Backed by mochi_map_str_i64 on
+			// the C target and map[string]int64 on the Go target.
+			if k == ir.TypeStr && v == ir.TypeI64 {
+				return ir.TypeMapStrI64, nil
+			}
+			return ir.TypeInvalid, fmt.Errorf("frontend: map<%s, %s> unsupported in MVP (only map<int, int>, map<str, i64>)", k, v)
 		}
 		return ir.TypeInvalid, fmt.Errorf("frontend: generic %s<...> unsupported in MVP", t.Generic.Name)
 	}
@@ -725,6 +737,8 @@ func (b *builder) lowerTypedLet(name string, tRef *parser.TypeRef, e *parser.Exp
 			b.expectedListElem = ir.TypeStr
 		case ir.TypeMap:
 			b.expectedMap = true
+		case ir.TypeMapStrI64:
+			b.expectedMapStrI64 = true
 		case ir.TypeListAny:
 			b.expectedListElem = ir.TypeListAny
 		}
@@ -732,6 +746,7 @@ func (b *builder) lowerTypedLet(name string, tRef *parser.TypeRef, e *parser.Exp
 	vid, err := b.lowerExpr(e)
 	b.expectedListElem = ir.TypeInvalid
 	b.expectedMap = false
+	b.expectedMapStrI64 = false
 	if err != nil {
 		return err
 	}
@@ -1783,14 +1798,18 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 				return 0, fmt.Errorf("frontend: slice indexing unsupported in MVP")
 			}
 			curType := b.fn.Values[cur].Type
-			if curType != ir.TypeList && curType != ir.TypeF64Arr && curType != ir.TypeStrArr && curType != ir.TypeMap && curType != ir.TypeListAny {
+			if curType != ir.TypeList && curType != ir.TypeF64Arr && curType != ir.TypeStrArr && curType != ir.TypeMap && curType != ir.TypeMapStrI64 && curType != ir.TypeListAny {
 				return 0, fmt.Errorf("frontend: index on non-list %s", curType)
 			}
 			iID, err := b.lowerExpr(idx.Start)
 			if err != nil {
 				return 0, err
 			}
-			if b.fn.Values[iID].Type != ir.TypeI64 {
+			if curType == ir.TypeMapStrI64 {
+				if b.fn.Values[iID].Type != ir.TypeStr {
+					return 0, fmt.Errorf("frontend: map<str, i64> key must be str, got %s", b.fn.Values[iID].Type)
+				}
+			} else if b.fn.Values[iID].Type != ir.TypeI64 {
 				return 0, fmt.Errorf("frontend: list index must be i64, got %s", b.fn.Values[iID].Type)
 			}
 			// Phase 4.2.15: literal-negative indices (`xs[-1]`,
@@ -1850,6 +1869,12 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 				cur = b.addValue(ir.Value{
 					Type: ir.TypeI64,
 					Op:   ir.OpMapGetI64I64,
+					Args: []uint32{cur, iID},
+				})
+			case ir.TypeMapStrI64:
+				cur = b.addValue(ir.Value{
+					Type: ir.TypeI64,
+					Op:   ir.OpMapGetStrI64,
 					Args: []uint32{cur, iID},
 				})
 			case ir.TypeListAny:
@@ -2161,19 +2186,50 @@ func (b *builder) lowerIfExpr(e *parser.IfExpr) (uint32, error) {
 }
 
 // lowerMapLiteralAsExpr lowers a bare `{...}` map literal used as an
-// expression (not the statement-level json({...}) hook). Phase
-// 4.3.15.2 supports only empty literals under a `var m: map<int, int>
-// = {}` declaration; the empty case lowers to OpNewMap producing a
-// fresh empty heap-allocated table. Non-empty literals would need
-// every key+value to be a constant-folded int and the IR would need
-// either a chain of OpMapSetI64I64 ops or a new OpMapLit op; both
-// stay out of MVP scope until a fixture needs them.
+// expression (not the statement-level json({...}) hook). Two flavors
+// are supported today:
+//   - map<int, int> (Phase 4.3.15.2): only empty literals lower to
+//     OpNewMap; non-empty stays unsupported until a sub-phase widens
+//     the IR's i64->i64 map family.
+//   - map<str, i64> (Phase 4.2.18): empty and non-empty literals
+//     lower to OpNewMapStrI64 followed by a chain of OpMapSetStrI64,
+//     one per declared key/value pair. Keys must lower to TypeStr,
+//     values to TypeI64.
 func (b *builder) lowerMapLiteralAsExpr(m *parser.MapLiteral) (uint32, error) {
+	if b.expectedMapStrI64 {
+		// Reset the expectation while lowering element exprs so a
+		// nested map literal does not inherit it.
+		b.expectedMapStrI64 = false
+		defer func() { b.expectedMapStrI64 = true }()
+		mapID := b.addValue(ir.Value{Type: ir.TypeMapStrI64, Op: ir.OpNewMapStrI64})
+		for i, item := range m.Items {
+			kid, err := b.lowerExpr(item.Key)
+			if err != nil {
+				return 0, fmt.Errorf("frontend: map<str, i64> entry %d key: %w", i, err)
+			}
+			if b.fn.Values[kid].Type != ir.TypeStr {
+				return 0, fmt.Errorf("frontend: map<str, i64> entry %d key must be str, got %s", i, b.fn.Values[kid].Type)
+			}
+			vid, err := b.lowerExpr(item.Value)
+			if err != nil {
+				return 0, fmt.Errorf("frontend: map<str, i64> entry %d value: %w", i, err)
+			}
+			if b.fn.Values[vid].Type != ir.TypeI64 {
+				return 0, fmt.Errorf("frontend: map<str, i64> entry %d value must be i64, got %s", i, b.fn.Values[vid].Type)
+			}
+			b.addValue(ir.Value{
+				Type: ir.TypeUnit,
+				Op:   ir.OpMapSetStrI64,
+				Args: []uint32{mapID, kid, vid},
+			})
+		}
+		return mapID, nil
+	}
 	if !b.expectedMap {
-		return 0, fmt.Errorf("frontend: map literal requires `map<int, int>` type annotation on the binding")
+		return 0, fmt.Errorf("frontend: map literal requires `map<int, int>` or `map<str, i64>` type annotation on the binding")
 	}
 	if len(m.Items) != 0 {
-		return 0, fmt.Errorf("frontend: non-empty map literal unsupported in MVP (only `{}` initializer)")
+		return 0, fmt.Errorf("frontend: non-empty map<int, int> literal unsupported in MVP (only `{}` initializer)")
 	}
 	return b.addValue(ir.Value{Type: ir.TypeMap, Op: ir.OpNewMap}), nil
 }
@@ -2409,6 +2465,11 @@ func (b *builder) lowerBuiltinCall(c *parser.CallExpr) (uint32, bool, error) {
 		case ir.TypeListAny:
 			id := b.addValue(ir.Value{
 				Type: ir.TypeI64, Op: ir.OpListAnyLen, Args: []uint32{arg},
+			})
+			return id, true, nil
+		case ir.TypeMapStrI64:
+			id := b.addValue(ir.Value{
+				Type: ir.TypeI64, Op: ir.OpMapLenStrI64, Args: []uint32{arg},
 			})
 			return id, true, nil
 		default:

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -25,6 +25,13 @@ const (
 	// + len + cap); element-level access threads the same const-char-
 	// star carrier the rest of the C runtime uses for TypeStr.
 	TypeStrArr
+	// TypeMapStrI64 is the typed `map<str, i64>` carrier on the C
+	// target (Phase 4.2.18). Backing is mochi_map_str_i64, an open-
+	// addressing hashtable keyed by `const char*` with `int64_t`
+	// values. Distinct from TypeMap (which is i64->i64) so emit can
+	// pick the right runtime struct and the verifier can route the
+	// right Set/Get ops.
+	TypeMapStrI64
 	TypeAny
 	// TypeListAny is the heterogeneous self-referential list backing
 	// for `list<any>` (Phase 4.3.15.1). In the binary_trees kernel every
@@ -75,6 +82,8 @@ func (t Type) String() string {
 		return "u8arr"
 	case TypeStrArr:
 		return "strarr"
+	case TypeMapStrI64:
+		return "mapstri64"
 	case TypeAny:
 		return "any"
 	case TypeListAny:
@@ -199,6 +208,18 @@ const (
 	OpStrArrPushStr
 	OpStrArrGetStr
 	OpStrArrSetStr
+
+	// Typed map<str, i64> ops (Phase 4.2.18). Backs `map<string, int>`
+	// on the C target with mochi_map_str_i64 (open-addressing hash
+	// keyed by `const char*`, int64 values). Get on an absent key
+	// returns 0 (matches Go's zero-default for the int64 value type).
+	// Map literals (non-empty) lower to OpNewMapStrI64 followed by a
+	// chain of OpMapSetStrI64 ops, one per key/value pair. OpMapLenStrI64
+	// backs the `len(m)` builtin on this carrier.
+	OpNewMapStrI64
+	OpMapSetStrI64
+	OpMapGetStrI64
+	OpMapLenStrI64
 
 	// Calls. Args[0..] are the argument values; the callee is named by
 	// Value.Const (function index in the Function's owning Program).
@@ -481,6 +502,14 @@ func (o OpCode) String() string {
 		return "strarr.get.str"
 	case OpStrArrSetStr:
 		return "strarr.set.str"
+	case OpNewMapStrI64:
+		return "newmapstri64"
+	case OpMapSetStrI64:
+		return "map.set.str.i64"
+	case OpMapGetStrI64:
+		return "map.get.str.i64"
+	case OpMapLenStrI64:
+		return "map.len.str.i64"
 	case OpListConcatI64:
 		return "list.concat.i64"
 	case OpF64ArrayConcat:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -227,6 +227,14 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeStr, [3]Type{TypeStrArr, TypeI64}}
 	case OpStrArrSetStr:
 		return opSig{TypeUnit, [3]Type{TypeStrArr, TypeI64, TypeStr}}
+	case OpNewMapStrI64:
+		return opSig{TypeMapStrI64, [3]Type{}}
+	case OpMapSetStrI64:
+		return opSig{TypeUnit, [3]Type{TypeMapStrI64, TypeStr, TypeI64}}
+	case OpMapGetStrI64:
+		return opSig{TypeI64, [3]Type{TypeMapStrI64, TypeStr}}
+	case OpMapLenStrI64:
+		return opSig{TypeI64, [3]Type{TypeMapStrI64}}
 	case OpAndI64, OpOrI64, OpXorI64, OpShlI64, OpShrI64:
 		return opSig{TypeI64, [3]Type{TypeI64, TypeI64}}
 	case OpNotI64:

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -171,7 +171,7 @@ func kindOf(o ir.OpCode) ProducerKind {
 	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpListI64ToStr, ir.OpF64ArrayToStr, ir.OpStrArrToStr:
 		return KindConstructor
 
-	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array, ir.OpNewStrArr, ir.OpNewListAny,
+	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array, ir.OpNewStrArr, ir.OpNewMapStrI64, ir.OpNewListAny,
 		ir.OpListConcatI64, ir.OpF64ArrayConcat,
 		ir.OpListAnyGetAny,
 		ir.OpStrArrGetStr:
@@ -188,6 +188,7 @@ func kindOf(o ir.OpCode) ProducerKind {
 	case ir.OpListLenI64, ir.OpListPushI64, ir.OpListGetI64, ir.OpListSetI64,
 		ir.OpListGetF64, ir.OpListSetF64,
 		ir.OpMapSetI64I64, ir.OpMapGetI64I64,
+		ir.OpMapSetStrI64, ir.OpMapGetStrI64, ir.OpMapLenStrI64,
 		ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64, ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64,
 		ir.OpStrArrLen, ir.OpStrArrPushStr, ir.OpStrArrSetStr,
 		ir.OpListAnyLen, ir.OpListAnyPushAny:
@@ -248,7 +249,8 @@ func HandleType(t ir.Type) bool {
 	switch t {
 	case ir.TypeStr, ir.TypeList, ir.TypeMap, ir.TypeSet, ir.TypeStruct,
 		ir.TypeClosure, ir.TypeBignum, ir.TypeBytes, ir.TypePair,
-		ir.TypeF64Arr, ir.TypeI64Arr, ir.TypeU8Arr, ir.TypeListAny:
+		ir.TypeF64Arr, ir.TypeI64Arr, ir.TypeU8Arr, ir.TypeListAny,
+		ir.TypeMapStrI64:
 		return true
 	}
 	return false
@@ -438,6 +440,12 @@ func contractResult(o ir.OpCode) ir.Type {
 		return ir.TypeUnit
 	case ir.OpMapGetI64I64:
 		return ir.TypeI64
+	case ir.OpNewMapStrI64:
+		return ir.TypeMapStrI64
+	case ir.OpMapSetStrI64:
+		return ir.TypeUnit
+	case ir.OpMapGetStrI64, ir.OpMapLenStrI64:
+		return ir.TypeI64
 	case ir.OpF64ArrayLenI64:
 		return ir.TypeI64
 	case ir.OpF64ArrayPushF64, ir.OpF64ArraySetF64:
@@ -482,6 +490,7 @@ func opIsMutating(o ir.OpCode) bool {
 	switch o {
 	case ir.OpListPushI64, ir.OpListSetI64, ir.OpListSetF64,
 		ir.OpMapSetI64I64,
+		ir.OpMapSetStrI64,
 		ir.OpF64ArrayPushF64, ir.OpF64ArraySetF64,
 		ir.OpStrArrPushStr, ir.OpStrArrSetStr,
 		ir.OpListAnyPushAny:
@@ -499,6 +508,8 @@ var readDispatchOps = []ir.OpCode{
 	ir.OpListGetI64,
 	ir.OpListGetF64,
 	ir.OpMapGetI64I64,
+	ir.OpMapGetStrI64,
+	ir.OpMapLenStrI64,
 	ir.OpF64ArrayLenI64,
 	ir.OpF64ArrayGetF64,
 	ir.OpStrArrLen,
@@ -511,6 +522,7 @@ var writeDispatchOps = []ir.OpCode{
 	ir.OpListSetI64,
 	ir.OpListSetF64,
 	ir.OpMapSetI64I64,
+	ir.OpMapSetStrI64,
 	ir.OpF64ArrayPushF64,
 	ir.OpF64ArraySetF64,
 	ir.OpStrArrPushStr,
@@ -634,6 +646,8 @@ func dispatchArena(o ir.OpCode) ir.Type {
 		return ir.TypeList
 	case ir.OpMapSetI64I64, ir.OpMapGetI64I64:
 		return ir.TypeMap
+	case ir.OpMapSetStrI64, ir.OpMapGetStrI64, ir.OpMapLenStrI64:
+		return ir.TypeMapStrI64
 	case ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64, ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64:
 		return ir.TypeF64Arr
 	case ir.OpStrArrLen, ir.OpStrArrPushStr, ir.OpStrArrGetStr, ir.OpStrArrSetStr:

--- a/runtime/c/doc.go
+++ b/runtime/c/doc.go
@@ -24,5 +24,5 @@ import "embed"
 // files when cgo is off (and the whole point of this package is to
 // stay no-cgo on the build host).
 //
-//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c src/mochi_f64_array.h src/mochi_f64_array.c src/mochi_str_array.h src/mochi_str_array.c src/mochi_time.h src/mochi_time.c src/mochi_map_i64_i64.h src/mochi_map_i64_i64.c src/mochi_tree.h src/mochi_tree.c src/mochi_str.h src/mochi_str.c
+//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c src/mochi_f64_array.h src/mochi_f64_array.c src/mochi_str_array.h src/mochi_str_array.c src/mochi_time.h src/mochi_time.c src/mochi_map_i64_i64.h src/mochi_map_i64_i64.c src/mochi_map_str_i64.h src/mochi_map_str_i64.c src/mochi_tree.h src/mochi_tree.c src/mochi_str.h src/mochi_str.c
 var Runtime embed.FS

--- a/runtime/c/src/mochi_map_str_i64.c
+++ b/runtime/c/src/mochi_map_str_i64.c
@@ -1,0 +1,112 @@
+/*
+ * MEP-42 Phase 4.2.18 typed-str->i64 map runtime. See
+ * mochi_map_str_i64.h.
+ */
+#include "mochi_map_str_i64.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+static uint64_t mochi_map_str_hash(const char *k) {
+    /* FNV-1a 64-bit. Fast for short keys and gives a decent
+     * distribution after the cap-1 mask; matches the hash family used
+     * elsewhere in compiler3's str interning so the runtime is
+     * consistent under cc -O2 inlining. */
+    uint64_t h = 0xCBF29CE484222325ULL;
+    for (const unsigned char *p = (const unsigned char *)k; *p != 0; p++) {
+        h ^= (uint64_t)*p;
+        h *= 0x100000001B3ULL;
+    }
+    return h;
+}
+
+mochi_map_str_i64 *mochi_map_str_i64_new(void) {
+    mochi_map_str_i64 *m = (mochi_map_str_i64 *)malloc(sizeof(mochi_map_str_i64));
+    if (m == NULL) {
+        abort();
+    }
+    m->keys = NULL;
+    m->vals = NULL;
+    m->occ = NULL;
+    m->cap = 0;
+    m->len = 0;
+    return m;
+}
+
+int64_t mochi_map_str_i64_len(const mochi_map_str_i64 *m) {
+    return m->len;
+}
+
+static int64_t mochi_map_str_probe(const mochi_map_str_i64 *m, const char *k) {
+    /* Returns the bucket index where k lives (if occupied) or the
+     * first empty bucket on the probe path (if absent). Caller
+     * inspects occ[idx] to disambiguate. Cap must be > 0. */
+    uint64_t mask = (uint64_t)m->cap - 1;
+    uint64_t i = mochi_map_str_hash(k) & mask;
+    while (m->occ[i] != 0 && strcmp(m->keys[i], k) != 0) {
+        i = (i + 1) & mask;
+    }
+    return (int64_t)i;
+}
+
+static void mochi_map_str_grow(mochi_map_str_i64 *m) {
+    int64_t newcap = m->cap == 0 ? 8 : m->cap * 2;
+    const char **nkeys = (const char **)calloc((size_t)newcap, sizeof(const char *));
+    int64_t *nvals = (int64_t *)calloc((size_t)newcap, sizeof(int64_t));
+    uint8_t *nocc = (uint8_t *)calloc((size_t)newcap, sizeof(uint8_t));
+    if (nkeys == NULL || nvals == NULL || nocc == NULL) {
+        abort();
+    }
+    int64_t oldcap = m->cap;
+    const char **okeys = m->keys;
+    int64_t *ovals = m->vals;
+    uint8_t *oocc = m->occ;
+    m->keys = nkeys;
+    m->vals = nvals;
+    m->occ = nocc;
+    m->cap = newcap;
+    m->len = 0;
+    uint64_t mask = (uint64_t)newcap - 1;
+    for (int64_t b = 0; b < oldcap; b++) {
+        if (oocc[b] == 0) {
+            continue;
+        }
+        const char *k = okeys[b];
+        uint64_t i = mochi_map_str_hash(k) & mask;
+        while (m->occ[i] != 0) {
+            i = (i + 1) & mask;
+        }
+        m->keys[i] = k;
+        m->vals[i] = ovals[b];
+        m->occ[i] = 1;
+        m->len++;
+    }
+    free(okeys);
+    free(ovals);
+    free(oocc);
+}
+
+int64_t mochi_map_str_i64_get(const mochi_map_str_i64 *m, const char *k) {
+    if (m->cap == 0) {
+        return 0;
+    }
+    int64_t i = mochi_map_str_probe(m, k);
+    if (m->occ[i] == 0) {
+        return 0;
+    }
+    return m->vals[i];
+}
+
+void mochi_map_str_i64_set(mochi_map_str_i64 *m, const char *k, int64_t v) {
+    if (m->cap == 0 || (m->len + 1) * 4 > m->cap * 3) {
+        mochi_map_str_grow(m);
+    }
+    int64_t i = mochi_map_str_probe(m, k);
+    if (m->occ[i] == 0) {
+        m->occ[i] = 1;
+        m->keys[i] = k;
+        m->len++;
+    }
+    m->vals[i] = v;
+}

--- a/runtime/c/src/mochi_map_str_i64.h
+++ b/runtime/c/src/mochi_map_str_i64.h
@@ -1,0 +1,76 @@
+/*
+ * MEP-42 Phase 4.2.18 typed-str->i64 map runtime.
+ *
+ * Backs Mochi's `map<string, int>` when the program is compiled with
+ * `mochi build --target=c`. The IR ops OpNewMapStrI64, OpMapSetStrI64,
+ * OpMapGetStrI64, and OpMapLenStrI64 lower to calls into this header.
+ *
+ * Semantics mirror Go's `map[string]int64{}`: a get on an absent key
+ * returns 0 (matches Go's zero-value default for the int64 value
+ * type). Set overwrites any prior value for the same key. The
+ * iteration order is not defined.
+ *
+ * Keys are compared by byte-wise equality (strcmp). The map borrows
+ * the caller's key pointer on first insert; callers must ensure key
+ * lifetimes outlive the map (string literals from the program text
+ * and intern-allocated keys both satisfy this).
+ *
+ * Identity: pure C99, no libc beyond stdlib.h/string.h/stdint.h.
+ * Growth strategy doubles the bucket array when load factor exceeds
+ * 0.75, matching the shape of mochi_map_i64_i64.
+ */
+#ifndef MOCHI_RUNTIME_C_MAP_STR_I64_H
+#define MOCHI_RUNTIME_C_MAP_STR_I64_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * mochi_map_str_i64 is an open-addressing linear-probing hashtable.
+ * `keys` and `vals` are parallel arrays of size `cap`; `occ` marks
+ * each bucket as occupied (1) or empty (0). `len` is the number of
+ * occupied buckets. cap is always a power of two when nonzero so the
+ * probe step can use `(h + i) & (cap - 1)` instead of a modulo.
+ */
+typedef struct mochi_map_str_i64 {
+    const char **keys;
+    int64_t     *vals;
+    uint8_t     *occ;
+    int64_t      cap;
+    int64_t      len;
+} mochi_map_str_i64;
+
+/* mochi_map_str_i64_new returns a fresh empty map (cap=0, len=0). */
+mochi_map_str_i64 *mochi_map_str_i64_new(void);
+
+/*
+ * mochi_map_str_i64_len returns the number of occupied buckets.
+ * Backs the `len(m)` builtin for this carrier (Phase 4.2.18).
+ */
+int64_t mochi_map_str_i64_len(const mochi_map_str_i64 *m);
+
+/*
+ * mochi_map_str_i64_get returns m[k], or 0 if k is not present.
+ * Matches Go's `m[k]` zero-default semantics for the int64 value
+ * type, which is what compiler3 emits when lowering a TypeMapStrI64
+ * read.
+ */
+int64_t mochi_map_str_i64_get(const mochi_map_str_i64 *m, const char *k);
+
+/*
+ * mochi_map_str_i64_set writes v to m[k]. If k already maps to a
+ * value, that value is overwritten. If the table is more than 75%
+ * full after the insert, the backing arrays double and every key is
+ * re-probed. The map borrows the caller's key pointer; ownership
+ * stays with the caller.
+ */
+void mochi_map_str_i64_set(mochi_map_str_i64 *m, const char *k, int64_t v);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOCHI_RUNTIME_C_MAP_STR_I64_H */

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,43 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.45 Phase 4.2.18 closeout (LANDED 2026-05-22 12:33 GMT+7)
+
+Phase 4.2.18 lands `map<str, i64>` on the C target. Before this phase the binding `let scores: map<string, int> = {"Alice": 10, "Bob": 15}` from examples/v0.2/map.mochi failed at `lowerType` with `map<str, i64> unsupported in MVP (only map<int, int>)`, and for-in.mochi failed its very first map literal with the same message. The phase adds the TypeMapStrI64 carrier, four ops, a C runtime, and the lowering wiring needed to close map.mochi's main body (everything but its `test` block) and the map literal at the head of for-in.mochi's map section.
+
+The runtime layout mirrors mochi_map_i64_i64: an open-addressing linear-probing hashtable with a power-of-two cap, doubling growth at the 75 percent load threshold, parallel `keys`/`vals`/`occ` arrays, FNV-1a 64-bit hash over the key bytes, byte-equal comparison via strcmp, and Go's `map[string]int64{}` zero-default for absent reads. The map borrows the caller's key pointer on first insert; the C target already keeps every string literal alive for the duration of the process (Phase 4.2.0 backed TypeStr with `const char*` carriers that point at the program text or interned slot), so the borrow contract is satisfied without an extra copy.
+
+The verifier classification reuses the existing handle-typed pattern. OpNewMapStrI64 is Constructor (the alloc); OpMapSetStrI64 is a write Dispatch (rule E mutating); OpMapGetStrI64 is a read Dispatch returning TypeI64 (no rule A obligation because the result is value-shaped, not handle-shaped); OpMapLenStrI64 is a read Dispatch returning TypeI64. TypeMapStrI64 itself is added to HandleType so a future fun parameter taking `map<str, i64>` will be permitted to originate via OpParam (KindMove).
+
+### Diff shape
+
+- `compiler3/ir/types.go`: new `TypeMapStrI64` enum tag + String() case; new ops `OpNewMapStrI64`, `OpMapSetStrI64`, `OpMapGetStrI64`, `OpMapLenStrI64`; String() cases for each.
+- `compiler3/ir/validate.go`: opSig signatures for the four new ops.
+- `compiler3/verify/verify.go`: classification (Constructor for OpNewMapStrI64; Dispatch for the rest), HandleType gains TypeMapStrI64, opIsMutating + readDispatchOps + writeDispatchOps coverage, dispatchArena entry, contractResult lookups.
+- `runtime/c/src/mochi_map_str_i64.{h,c}`: ~75-line header and ~120-line source covering new/get/set/len with the FNV-1a hash, open-addressing probe, and doubling-growth rehash.
+- `runtime/c/doc.go`: `//go:embed` line gains the two new files so the build driver writes them next to gen.c.
+- `compiler3/emit/c/emit.go`: usesMapStrI64 trigger set; `#include "mochi_map_str_i64.h"`; per-op dispatch (four cases); TypeMapStrI64 -> `mochi_map_str_i64*` in cType().
+- `compiler3/emit/go/emit.go`: TypeMapStrI64 -> `map[string]int64` in goType(); four op cases mapping to native Go map syntax.
+- `compiler3/frontend/lower.go`:
+  - `lowerType` accepts `map<str, i64>` (and the surface aliases `map<string, int>`) -> TypeMapStrI64.
+  - A new `expectedMapStrI64` builder flag is set by `lowerTypedLet` when the annotated type is TypeMapStrI64; cleared after the RHS lowers.
+  - `lowerMapLiteralAsExpr` gains a TypeMapStrI64 branch that emits OpNewMapStrI64 followed by one OpMapSetStrI64 per declared entry, validating that each key lowers to TypeStr and each value to TypeI64.
+  - `lowerPostfix` index branch accepts TypeMapStrI64; the index check is widened to require TypeStr for map<str, i64> keys (and stays TypeI64 for list-shaped carriers and map<int, int>); the post-resolve switch emits OpMapGetStrI64.
+  - `len()` builtin accepts TypeMapStrI64 -> OpMapLenStrI64.
+- `compiler3/build/c/driver_test.go`: 3 new tests pinning the literal-plus-get-plus-len shape from v0.2/map.mochi, the Go-shaped zero-default on absent keys, and the empty literal under the new carrier.
+
+### Why this closes a goal
+
+The §Top-line goal is "every v0.2 fixture compiles via `mochi build --target=c`". Two of the six fixtures (map.mochi and for-in.mochi) failed on the very first map line of their main body; this phase clears that line. map.mochi now compiles its full main body (the only remaining gate is the trailing `test "map basic operations" {...}` block, which is the v0.2 test-block phase). for-in.mochi still has downstream gates (map iteration `for name in scores` and nested for-in over a 2D list), but the literal-plus-get-plus-len shape that drives the map section is unblocked. A v0.2 learner who writes `let s: map<string, int> = {"a": 1, "b": 2}; print(s["a"])` now sees `1` on the C target, matching `mochi run` byte for byte.
+
+### Limitations
+
+- The carrier is fixed to `map<str, i64>`. Other key/value combinations (`map<str, str>`, `map<i64, str>`, etc.) still hit the same "unsupported in MVP" message. Each requires its own carrier and runtime; templating the IR across key/value types is a separate refactor.
+- Map iteration (`for k in m`) is not implemented. The runtime has no public iterator helper and the frontend's `lowerForCollection` only knows the list-shaped carriers. for-in.mochi's map section still fails on this gate.
+- `len()` is the only read aggregate. There is no `contains(m, k)` builtin (the v0.2 fixtures don't use it; Mochi spells the membership check with `m[k] or default` today, which is a separate gate).
+- Deletion (`del m[k]`) is rejected by the parser surface and unimplemented in the runtime; matches map<int, int>.
+- The runtime allocates the bucket arrays from malloc and leaks them at process exit. Matches every other Phase 4 C runtime helper; an arena phase is tracked separately.
+
 ## §10.44 Phase 4.2.17 closeout (LANDED 2026-05-22 11:03 GMT+7)
 
 Phase 4.2.17 lands `list<str>` on the C target. Before this phase the frontend rejected `let xs = ["a", "b"]` with `frontend: list literal element type str unsupported in MVP`; the v0.2 tutorial fixtures v0.2/for-in.mochi and v0.2/list.mochi both fail their first lines on this gate. The phase adds a new IR type (TypeStrArr), six ops, a runtime header, and the corresponding emit + lower wiring.


### PR DESCRIPTION
## Summary
- Land TypeMapStrI64 carrier + four ops; user programs declaring `map<string, int>` now compile via `mochi build --target=c`.
- C runtime `mochi_map_str_i64` with FNV-1a + open-addressing + doubling growth at 0.75 load. Go-shaped zero-default on absent keys.
- Verifier: NewMapStrI64 Constructor; Set mutating Dispatch; Get/Len read Dispatch. HandleType gains TypeMapStrI64.
- frontend/lower: map type, expectedMapStrI64 flag, non-empty literal lower (entry-wise TypeStr/TypeI64 validation), postfix index (TypeStr key + OpMapGetStrI64), len() builtin.

## Test plan
- [x] `go test ./compiler3/...` (full suite green incl. existing 6 list<str> tests from 4.2.17)
- [x] 3 new tests pass: MapStrI64Literal, MapStrI64Default, MapStrI64Empty
- [x] examples/v0.2/map.mochi minus the test block compiles and runs (`Alice's score: 10` / `Total players: 2`)
- [x] MEP-0042 §10.45 closeout in `website/docs/mep/mep-0042.md`

Closes #22029