### PR TITLE
mep-0042: Phase 4.2.19 skip test blocks at lower time

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -2547,6 +2547,57 @@ print(len(m))
 	}
 }
 
+// TestBuildSourceTestBlockSkipped pins the Phase 4.2.19 rule: a
+// `test "name" { ... }` block in source is a no-op at lower time
+// (mirrors `mochi run`, which does not execute test bodies). The
+// rest of the program lowers and runs normally. The body of the
+// test block here uses a comparison that would type-error if it
+// were lowered (Mochi's reference VM rejects it during type-check),
+// confirming the body is not visited.
+func TestBuildSourceTestBlockSkipped(t *testing.T) {
+	src := `let x = 7
+print(x)
+test "skipped" {
+  expect undefined_name_that_would_break == 42
+}
+print(x + 1)
+`
+	if got, want := runMochiBuild(t, src), "7\n8\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceV02PiFixture pins the on-disk v0.2/π.mochi fixture
+// end-to-end. With Phase 4.2.19 dropping the trailing `test "π"`
+// block, the C target now produces the same two-line stdout as
+// `mochi run` on the fixture. UTF-8 identifiers (π, 🍡) and the
+// UTF-8 string literal pass through the C string carrier verbatim.
+func TestBuildSourceV02PiFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.2/π.mochi")
+	if err != nil {
+		t.Fatalf("read v0.2/π.mochi fixture: %v", err)
+	}
+	want := "314\n🍡૮₍ ˃ ⤙ ˂ ₎ა\n"
+	if got := runMochiBuild(t, string(srcBytes)); got != want {
+		t.Errorf("v0.2/π stdout = %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceV02MapFixture pins the on-disk v0.2/map.mochi
+// fixture end-to-end. Phase 4.2.18 closed the map<str, i64>
+// literal+get+len gate; Phase 4.2.19 drops the trailing test block
+// so the fixture compiles top to bottom on the C target.
+func TestBuildSourceV02MapFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.2/map.mochi")
+	if err != nil {
+		t.Fatalf("read v0.2/map.mochi fixture: %v", err)
+	}
+	want := "Alice's score: 10\nTotal players: 2\n"
+	if got := runMochiBuild(t, string(srcBytes)); got != want {
+		t.Errorf("v0.2/map stdout = %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceV03MatchFixture pins the on-disk fixture verbatim
 // so a regression in either the example or the lowering surfaces
 // here. This is the user-facing motivation for Phase 4.2.11.

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -597,6 +597,18 @@ func (b *builder) lowerStmt(st *parser.Statement) error {
 	case st.Expr != nil:
 		_, err := b.lowerExprAsStmt(st.Expr.Expr)
 		return err
+	case st.Test != nil:
+		// Phase 4.2.19: skip `test "..." { ... }` blocks at lower
+		// time. `mochi build` produces an executable, not a test
+		// runner; the VM equivalent of `mochi run` likewise does not
+		// execute test bodies (those run via `mochi test`). The
+		// frontend silently drops the block so the surrounding
+		// fixture compiles. The block's body is not lowered, so any
+		// type errors inside it (e.g., the Option<int> map indexing
+		// shape used in v0.2/map.mochi's `expect`) do not surface
+		// here; matching VM behaviour, those errors would only fire
+		// under `mochi test`.
+		return nil
 	}
 	return fmt.Errorf("frontend: statement kind unsupported in MVP")
 }

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,38 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.46 Phase 4.2.19 closeout (LANDED 2026-05-22 12:41 GMT+7)
+
+Phase 4.2.19 makes `test "name" { ... }` blocks a no-op at the frontend lower pass. Before this phase the v0.2/π.mochi and v0.2/map.mochi fixtures both ended with a test block and hit `frontend: statement kind unsupported in MVP` on the very last statement, even though every line of executable code in them already compiled. The phase adds one `case st.Test != nil: return nil` arm to `lowerStmt` and pins the rule with three driver tests.
+
+The decision is parity with `mochi run`: the reference VM's `run` mode does not execute test bodies (those run under `mochi test`). A `mochi build --target=c` user is asking for an executable, not a test runner; dropping the block at lower time makes the C-target binary's stdout match `mochi run`'s stdout byte for byte. The body of the test block is not walked at all, so any expressions inside it (including expressions that would not type-check, such as the `Option<int>` map indexing shape in v0.2/map.mochi's `expect scores["Alice"] == 10`) do not surface as errors at build time. This matches the VM contract: under `mochi run` those type errors are also suppressed; they only fire under `mochi test`.
+
+### Diff shape
+
+- `compiler3/frontend/lower.go`: one new `case st.Test != nil` arm in `lowerStmt`, returning nil. Accompanying comment cites the `mochi run` parity rationale.
+- `compiler3/build/c/driver_test.go`: 3 new tests. TestBuildSourceTestBlockSkipped uses an `expect` body that would type-error if visited, confirming the body is never lowered. TestBuildSourceV02PiFixture and TestBuildSourceV02MapFixture pin the on-disk v0.2/π.mochi and v0.2/map.mochi fixtures end to end.
+
+### Why this closes a goal
+
+Two of the six v0.2 tutorial fixtures (π.mochi and map.mochi) now compile and run to completion on the C target. Combined with Phase 4.2.18 (which closed map.mochi's main-body map<str, i64> gate) and Phase 4.2.17 (list<str>), the v0.2 user-facing matrix is now:
+
+| Fixture | C target status |
+|---------|-----------------|
+| shadow.mochi | green (always was) |
+| π.mochi | green (Phase 4.2.19) |
+| map.mochi | green (Phase 4.2.18 + 4.2.19) |
+| for-in.mochi | still fails (untyped `let scores = {...}` map literal needs key-type inference; also map iteration `for k in m`) |
+| list.mochi | still fails on `fruits[1:3]` (slice indexing) |
+| matrix.mochi | still fails on nested `list<list<i64>>` |
+
+Three of six fixtures green. The remaining three each have a distinct gate that maps cleanly onto a future phase.
+
+### Limitations
+
+- `bench "name" { ... }` blocks are NOT skipped; they still trip the unsupported-statement gate. The v0.2 fixtures don't use `bench`, so this stays out of scope until a fixture surfaces it.
+- Function definitions inside a test block (a `fun` declared between `{` and `}`) are silently dropped along with the rest of the body. If a future fixture relies on `test`-block-scoped helpers leaking into the surrounding namespace, this skip would need to revisit.
+- The test block is not parsed for unused-import or unused-variable diagnostics. Since the C target has no such diagnostics today (Phase 4 MVP), this is not a regression.
+
 ## §10.45 Phase 4.2.18 closeout (LANDED 2026-05-22 12:33 GMT+7)
 
 Phase 4.2.18 lands `map<str, i64>` on the C target. Before this phase the binding `let scores: map<string, int> = {"Alice": 10, "Bob": 15}` from examples/v0.2/map.mochi failed at `lowerType` with `map<str, i64> unsupported in MVP (only map<int, int>)`, and for-in.mochi failed its very first map literal with the same message. The phase adds the TypeMapStrI64 carrier, four ops, a C runtime, and the lowering wiring needed to close map.mochi's main body (everything but its `test` block) and the map literal at the head of for-in.mochi's map section.


### PR DESCRIPTION
## Summary
- One-arm change to lowerStmt: `case st.Test != nil: return nil`. Test blocks lower to a no-op.
- Parity with `mochi run` — the VM's run mode does not execute test bodies (those run under `mochi test`); the C target now matches.
- Body is never walked, so type-incompatible expressions inside `expect` (e.g., Option-shaped map indexing in v0.2/map.mochi) do not surface as build errors.

## Test plan
- [x] `go test ./compiler3/...` (full suite green)
- [x] TestBuildSourceTestBlockSkipped — body contains an undefined name, confirms it is never visited
- [x] TestBuildSourceV02PiFixture — full on-disk v0.2/π.mochi fixture
- [x] TestBuildSourceV02MapFixture — full on-disk v0.2/map.mochi fixture
- [x] v0.2 fixture matrix: 3 of 6 green (shadow, π, map)
- [x] MEP-0042 §10.46 closeout

Closes #22031