### PR TITLE
mep-0042: Phase 4.2.20 list<str> slicing on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -2598,6 +2598,58 @@ func TestBuildSourceV02MapFixture(t *testing.T) {
 	}
 }
 
+// TestBuildSourceListStrSlice pins the Phase 4.2.20 list<str>
+// slice lowering. `xs[1:3]` on a 4-element TypeStrArr lowers to
+// OpStrArrSlice, which the C target backs with
+// mochi_str_array_slice and the Go target with `append([]string{},
+// xs[a:b]...)`. The display form matches the VM's list<string>
+// rendering used by TestBuildSourceListStrQuoteEscapes.
+func TestBuildSourceListStrSlice(t *testing.T) {
+	src := `let fruits = ["a", "b", "c", "d"]
+let some = fruits[1:3]
+print(some)
+`
+	if got, want := runMochiBuild(t, src), "[\"b\", \"c\"]\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceListStrSliceClamp checks the runtime's clamp
+// rule: an end past the source length returns up to the source
+// length; start past end returns an empty array. This mirrors the
+// half-open semantics documented in mochi_str_array_slice.
+func TestBuildSourceListStrSliceClamp(t *testing.T) {
+	src := `let fruits = ["a", "b", "c"]
+print(fruits[1:10])
+print(fruits[2:2])
+`
+	if got, want := runMochiBuild(t, src), "[\"b\", \"c\"]\n[]\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceV02ListFixture pins the on-disk v0.2/list.mochi
+// fixture end-to-end. Phase 4.2.20 closed the list<str> slice
+// gate; combined with Phase 4.2.19's test-block skip, the fixture
+// now compiles top to bottom on the C target.
+func TestBuildSourceV02ListFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.2/list.mochi")
+	if err != nil {
+		t.Fatalf("read v0.2/list.mochi fixture: %v", err)
+	}
+	want := "[1, 2, 3, 4, 5]\n" +
+		"first:  1\n" +
+		"last:  5\n" +
+		"second to last:  4\n" +
+		"len:  5\n" +
+		"fruits:  [\"🍎\", \"🍌\", \"🍇\", \"🍓\"]\n" +
+		"favorite:  🍇\n" +
+		"some fruits:  [\"🍌\", \"🍇\"]\n"
+	if got := runMochiBuild(t, string(srcBytes)); got != want {
+		t.Errorf("v0.2/list stdout = %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceV03MatchFixture pins the on-disk fixture verbatim
 // so a regression in either the example or the lowering surfaces
 // here. This is the user-facing motivation for Phase 4.2.11.

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -92,7 +92,8 @@ func Emit(p *Program) ([]byte, error) {
 				ir.OpF64ArrayToStr:
 				usesF64Array = true
 			case ir.OpNewStrArr, ir.OpStrArrLen, ir.OpStrArrPushStr,
-				ir.OpStrArrGetStr, ir.OpStrArrSetStr, ir.OpStrArrToStr:
+				ir.OpStrArrGetStr, ir.OpStrArrSetStr, ir.OpStrArrToStr,
+				ir.OpStrArrSlice:
 				usesStrArray = true
 			case ir.OpNewMap, ir.OpMapSetI64I64, ir.OpMapGetI64I64:
 				usesMapI64I64 = true
@@ -406,6 +407,8 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    mochi_str_array_set(%s, %s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
 	case ir.OpStrArrToStr:
 		fmt.Fprintf(w, "    %s = mochi_str_array_to_str(%s);\n", name, valueName(v.Args[0]))
+	case ir.OpStrArrSlice:
+		fmt.Fprintf(w, "    %s = mochi_str_array_slice(%s, %s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
 	case ir.OpNewMap:
 		fmt.Fprintf(w, "    %s = mochi_map_i64_i64_new();\n", name)
 	case ir.OpMapSetI64I64:

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -430,6 +430,9 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 		w.WriteString("\t\tfor i, x := range xs { parts[i] = strconv.Quote(x) }\n")
 		w.WriteString("\t\treturn \"[\" + strings.Join(parts, \", \") + \"]\"\n")
 		fmt.Fprintf(w, "\t}(%s)\n", valueName(v.Args[0]))
+	case ir.OpStrArrSlice:
+		fmt.Fprintf(w, "\t%s = append([]string{}, %s[%s:%s]...)\n",
+			name, valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
 	case ir.OpNow:
 		imports["time"] = true
 		fmt.Fprintf(w, "\t%s = time.Now().UnixMicro()\n", name)

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1806,6 +1806,41 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 		switch {
 		case op.Index != nil:
 			idx := op.Index
+			// Phase 4.2.20: `xs[a:b]` on TypeStrArr lowers to
+			// OpStrArrSlice. Mochi requires both bounds (the surface
+			// allows `xs[:b]` and `xs[a:]` too, but the v0.2 fixture
+			// corpus only exercises the bound case, so a half-open
+			// shorthand stays out of the MVP). Colon2 (`[a:b:c]`) and
+			// Step remain rejected. Other element types still fall
+			// through to the MVP rejection until their slice runtime
+			// helper is in place.
+			if idx.Colon != nil && idx.Colon2 == nil && idx.Step == nil && idx.Start != nil && idx.End != nil {
+				curType := b.fn.Values[cur].Type
+				if curType != ir.TypeStrArr {
+					return 0, fmt.Errorf("frontend: slice unsupported on %s", curType)
+				}
+				startID, err := b.lowerExpr(idx.Start)
+				if err != nil {
+					return 0, err
+				}
+				if b.fn.Values[startID].Type != ir.TypeI64 {
+					return 0, fmt.Errorf("frontend: slice start must be i64, got %s", b.fn.Values[startID].Type)
+				}
+				endID, err := b.lowerExpr(idx.End)
+				if err != nil {
+					return 0, err
+				}
+				if b.fn.Values[endID].Type != ir.TypeI64 {
+					return 0, fmt.Errorf("frontend: slice end must be i64, got %s", b.fn.Values[endID].Type)
+				}
+				cur = b.addValue(ir.Value{
+					Type:     ir.TypeStrArr,
+					ElemType: ir.TypeStr,
+					Op:       ir.OpStrArrSlice,
+					Args:     []uint32{cur, startID, endID},
+				})
+				continue
+			}
 			if idx.Colon != nil || idx.Colon2 != nil || idx.End != nil || idx.Step != nil || idx.Start == nil {
 				return 0, fmt.Errorf("frontend: slice indexing unsupported in MVP")
 			}

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -209,6 +209,14 @@ const (
 	OpStrArrGetStr
 	OpStrArrSetStr
 
+	// list<str> slicing (Phase 4.2.20). OpStrArrSlice produces a new
+	// TypeStrArr containing the elements in the half-open interval
+	// [start, end) of the source array. Backs the Mochi surface
+	// `xs[a:b]` on TypeStrArr. The runtime copies the element
+	// pointer carriers, not the underlying string bytes; element
+	// lifetimes are unchanged.
+	OpStrArrSlice
+
 	// Typed map<str, i64> ops (Phase 4.2.18). Backs `map<string, int>`
 	// on the C target with mochi_map_str_i64 (open-addressing hash
 	// keyed by `const char*`, int64 values). Get on an absent key
@@ -502,6 +510,8 @@ func (o OpCode) String() string {
 		return "strarr.get.str"
 	case OpStrArrSetStr:
 		return "strarr.set.str"
+	case OpStrArrSlice:
+		return "strarr.slice"
 	case OpNewMapStrI64:
 		return "newmapstri64"
 	case OpMapSetStrI64:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -227,6 +227,8 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeStr, [3]Type{TypeStrArr, TypeI64}}
 	case OpStrArrSetStr:
 		return opSig{TypeUnit, [3]Type{TypeStrArr, TypeI64, TypeStr}}
+	case OpStrArrSlice:
+		return opSig{TypeStrArr, [3]Type{TypeStrArr, TypeI64, TypeI64}}
 	case OpNewMapStrI64:
 		return opSig{TypeMapStrI64, [3]Type{}}
 	case OpMapSetStrI64:

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -174,7 +174,8 @@ func kindOf(o ir.OpCode) ProducerKind {
 	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array, ir.OpNewStrArr, ir.OpNewMapStrI64, ir.OpNewListAny,
 		ir.OpListConcatI64, ir.OpF64ArrayConcat,
 		ir.OpListAnyGetAny,
-		ir.OpStrArrGetStr:
+		ir.OpStrArrGetStr,
+		ir.OpStrArrSlice:
 		// OpListAnyGetAny returns a handle (TypeListAny) borrowed from
 		// an existing tree node. OpStrArrGetStr returns a handle
 		// (TypeStr) borrowed from a `const char**` slot. Rule A
@@ -428,6 +429,8 @@ func contractResult(o ir.OpCode) ir.Type {
 		return ir.TypeUnit
 	case ir.OpStrArrGetStr:
 		return ir.TypeStr
+	case ir.OpStrArrSlice:
+		return ir.TypeStrArr
 	case ir.OpListLenI64:
 		return ir.TypeI64
 	case ir.OpListPushI64, ir.OpListSetI64, ir.OpListSetF64:

--- a/runtime/c/src/mochi_str_array.c
+++ b/runtime/c/src/mochi_str_array.c
@@ -154,3 +154,23 @@ const char *mochi_str_array_to_str(const mochi_str_array *a) {
     buf[off] = '\0';
     return buf;
 }
+
+mochi_str_array *mochi_str_array_slice(const mochi_str_array *src, int64_t start, int64_t end) {
+    int64_t srclen = src->len;
+    if (start < 0) start = 0;
+    if (end > srclen) end = srclen;
+    if (end < start) end = start;
+    int64_t n = end - start;
+    mochi_str_array *out = (mochi_str_array *)malloc(sizeof(mochi_str_array));
+    if (out == NULL) abort();
+    out->len = n;
+    out->cap = n;
+    if (n == 0) {
+        out->data = NULL;
+        return out;
+    }
+    out->data = (const char **)malloc((size_t)n * sizeof(const char *));
+    if (out->data == NULL) abort();
+    memcpy((void *)out->data, (const void *)(src->data + start), (size_t)n * sizeof(const char *));
+    return out;
+}

--- a/runtime/c/src/mochi_str_array.h
+++ b/runtime/c/src/mochi_str_array.h
@@ -54,6 +54,18 @@ void mochi_str_array_set(mochi_str_array *a, int64_t i, const char *v);
  */
 const char *mochi_str_array_to_str(const mochi_str_array *a);
 
+/*
+ * mochi_str_array_slice returns a freshly-allocated mochi_str_array
+ * containing the elements of src in the half-open interval
+ * [start, end). Element pointer carriers are copied verbatim; the
+ * underlying string bytes are not duplicated, so the returned array
+ * borrows the same C-string pointers (whose storage already outlives
+ * the array per the carrier contract above). Behaviour mirrors Go's
+ * xs[start:end] for the bound subset; start and end are clamped to
+ * [0, src->len] and end < start yields an empty array. Phase 4.2.20.
+ */
+mochi_str_array *mochi_str_array_slice(const mochi_str_array *src, int64_t start, int64_t end);
+
 #ifdef __cplusplus
 }
 #endif

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,47 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.47 Phase 4.2.20 closeout (LANDED 2026-05-22 12:54 GMT+7)
+
+Phase 4.2.20 lands the bound `xs[a:b]` slice form on TypeStrArr. Before this phase the v0.2/list.mochi binding `let some = fruits[1:3]` failed at the frontend `lowerPostfix` slice branch with `frontend: slice indexing unsupported in MVP`, blocking the v0.2 list fixture even though all surrounding statements already compiled. The phase adds OpStrArrSlice, a tiny runtime helper, and a one-arm lowering branch that closes list.mochi's last gate.
+
+The runtime helper `mochi_str_array_slice` does a single-pass copy of the element pointer carriers; the underlying string bytes are not duplicated, mirroring Go's slice-shares-backing-array semantics for the read path. Bounds are clamped to `[0, src->len]` and `end < start` returns the empty array, matching Go's behaviour for the equivalent inputs (the C target deliberately does not panic on out-of-range bounds in this MVP; panicking would require a stack-unwind path, which Phase 4 does not yet have). The Go emitter uses native `xs[a:b]` syntax wrapped in `append([]string{}, ...)` to break the backing-array share so the source array's later mutations do not corrupt the slice.
+
+The verifier classification reuses the existing handle-typed dispatch pattern. OpStrArrSlice is Constructor: it produces a fresh TypeStrArr, so rule A is satisfied by origin (the alloc itself is the constructor, not a move from an existing carrier). The element pointers stored inside the returned struct are not separate IR values, so rule A does not propagate to them; lifetime of the pointed-at bytes is the carrier contract of TypeStr documented in mochi_str_array.h.
+
+### Diff shape
+
+- `compiler3/ir/types.go`: added `OpStrArrSlice` op + `strarr.slice` String case.
+- `compiler3/ir/validate.go`: opContract entry returning `(TypeStrArr, [TypeStrArr, TypeI64, TypeI64])`.
+- `compiler3/verify/verify.go`: OpStrArrSlice joins Constructor list and contractResult.
+- `runtime/c/src/mochi_str_array.{h,c}`: added `mochi_str_array_slice` declaration plus implementation. Clamp + memcpy of element pointer carriers.
+- `compiler3/emit/c/emit.go`: trigger usesStrArray on OpStrArrSlice; emit one-line call to `mochi_str_array_slice`.
+- `compiler3/emit/go/emit.go`: emit `append([]string{}, xs[a:b]...)` so the returned slice does not share the source's backing array.
+- `compiler3/frontend/lower.go`: new branch in `lowerPostfix`'s index op handler that catches `idx.Colon != nil && idx.Start != nil && idx.End != nil` (no Colon2, no Step), validates the element type is TypeStrArr and both bounds are TypeI64, then emits OpStrArrSlice. The pre-existing MVP rejection still fires for unsupported slice shapes (half-open, full-copy, step) and for slicing other element types.
+- `compiler3/build/c/driver_test.go`: 3 new tests. TestBuildSourceListStrSlice covers the canonical `xs[1:3]` case; TestBuildSourceListStrSliceClamp covers the runtime's end-past-len clamp and the empty-result rule; TestBuildSourceV02ListFixture pins the v0.2/list.mochi fixture end to end.
+
+### Why this closes a goal
+
+The v0.2 user-facing matrix moves from 3 of 6 green to 4 of 6 green:
+
+| Fixture | C target status |
+|---------|-----------------|
+| shadow.mochi | green (always was) |
+| π.mochi | green (Phase 4.2.19) |
+| map.mochi | green (Phase 4.2.18 + 4.2.19) |
+| list.mochi | green (Phase 4.2.20) |
+| for-in.mochi | still fails (untyped `let scores = {...}` map literal needs key-type inference; also map iteration `for k in m`) |
+| matrix.mochi | still fails on nested `list<list<i64>>` |
+
+Four of six fixtures green. The remaining two each map cleanly onto a future phase.
+
+### Limitations
+
+- Half-open slice shorthand (`xs[:b]`, `xs[a:]`, `xs[:]`) is still rejected by the MVP gate. The v0.2 fixture corpus only exercises the bound form; the comment in list.mochi explicitly notes the open-end forms are not supported. Adding them is a frontend-only change (default bounds to 0 and OpStrArrLen respectively) and stays out of scope until a fixture surfaces it.
+- Slicing other element types (TypeList for i64, TypeF64Arr, TypeMap, TypeMapStrI64, TypeListAny) is still rejected by the MVP gate. Each needs its own runtime helper; adding them is mechanical but adds runtime surface area.
+- Negative bounds are NOT folded yet. `xs[-2:]` would lower to a literal-negative `OpConst` for the start, which the slice helper would then clamp to 0 (so `xs[-2:]` returns the whole list, not the last two). The constant-negative fold that 4.2.15 added for `OpListGetI64` could be ported here, but the v0.2 fixture corpus does not exercise it.
+- Three-index slicing (`xs[a:b:c]`, governed by the parser's `Colon2` field) remains rejected. Mochi does not have a documented semantics for the capacity bound, so the gate stays in place.
+
 ## §10.46 Phase 4.2.19 closeout (LANDED 2026-05-22 12:41 GMT+7)
 
 Phase 4.2.19 makes `test "name" { ... }` blocks a no-op at the frontend lower pass. Before this phase the v0.2/π.mochi and v0.2/map.mochi fixtures both ended with a test block and hit `frontend: statement kind unsupported in MVP` on the very last statement, even though every line of executable code in them already compiled. The phase adds one `case st.Test != nil: return nil` arm to `lowerStmt` and pins the rule with three driver tests.


### PR DESCRIPTION
Closes #22033.

## Summary

- Adds `OpStrArrSlice` so `xs[a:b]` on a TypeStrArr lowers to a single-pass copy of element pointer carriers.
- Runtime: `mochi_str_array_slice` in mochi_str_array.{h,c}. Clamp `start`/`end` to `[0, src->len]`, memcpy pointer carriers, no byte duplication.
- Closes the v0.2/list.mochi gate (`let some = fruits[1:3]`). The v0.2 fixture matrix now stands at 4 of 6 green on the C target.

## v0.2 matrix after this phase

| Fixture | Status |
|---------|--------|
| shadow.mochi | green |
| π.mochi | green |
| map.mochi | green |
| list.mochi | green (this phase) |
| for-in.mochi | still fails |
| matrix.mochi | still fails |

## Diff shape

- `compiler3/ir/types.go`, `compiler3/ir/validate.go`, `compiler3/verify/verify.go`: OpStrArrSlice (Constructor; result TypeStrArr).
- `runtime/c/src/mochi_str_array.{h,c}`: `mochi_str_array_slice` declaration + implementation.
- `compiler3/emit/c/emit.go`: trigger `usesStrArray`; emit `mochi_str_array_slice(src, start, end)`.
- `compiler3/emit/go/emit.go`: emit `append([]string{}, xs[a:b]...)` so the slice does not share the source's backing array.
- `compiler3/frontend/lower.go`: one-arm branch in `lowerPostfix` catching `Colon != nil && Start != nil && End != nil`.
- `compiler3/build/c/driver_test.go`: 3 new tests (canonical slice, clamp + empty, v0.2/list.mochi fixture).
- `website/docs/mep/mep-0042.md`: §10.47 closeout with rationale, diff shape, fixture matrix, limitations.

## Test plan

- [x] `go build ./compiler3/...` clean.
- [x] `go test ./compiler3/...` green (no regressions).
- [x] New tests pass: TestBuildSourceListStrSlice, TestBuildSourceListStrSliceClamp, TestBuildSourceV02ListFixture.

## Limitations (carried in §10.47)

- Half-open `xs[:b]`, `xs[a:]`, `xs[:]` still rejected; v0.2 fixture corpus does not exercise them.
- Slicing on TypeList (i64), TypeF64Arr, TypeMap, TypeMapStrI64, TypeListAny still rejected; each needs its own runtime helper.
- Negative bounds not folded; the 4.2.15 literal-negative fold could be ported but no fixture exercises it.