### PR TITLE
mep-0042: Phase 4.2.21 list<list<i64>> on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -2650,6 +2650,87 @@ func TestBuildSourceV02ListFixture(t *testing.T) {
 	}
 }
 
+// TestBuildSourceListListBasic exercises the Phase 4.2.21 nested
+// integer list shape: an untyped `[[1,2,3], [4,5,6]]` literal binds
+// to TypeListList, print(matrix) emits the nested `[[...], [...]]`
+// display form, and chained indexing `matrix[i][j]` returns int64.
+func TestBuildSourceListListBasic(t *testing.T) {
+	src := `let matrix = [
+  [1, 2, 3],
+  [4, 5, 6],
+]
+print(matrix)
+print(matrix[0])
+print(matrix[1][2])
+`
+	want := "[[1, 2, 3], [4, 5, 6]]\n" +
+		"[1, 2, 3]\n" +
+		"6\n"
+	if got := runMochiBuild(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceListListNegIndex pins the negative-index fold for
+// TypeListList. `matrix[-1]` lowers to `matrix[len + -1]` at lower
+// time, matching the Mochi VM's wrap rule and the existing fold for
+// TypeList/TypeF64Arr/TypeStrArr.
+func TestBuildSourceListListNegIndex(t *testing.T) {
+	src := `let matrix = [
+  [1, 2, 3],
+  [4, 5, 6],
+  [7, 8, 9],
+]
+print(matrix[-1])
+print(matrix[-1][0])
+`
+	want := "[7, 8, 9]\n7\n"
+	if got := runMochiBuild(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceListListLen exercises len() on a list<list<i64>>
+// outer and on a row that was bound through OpListListGet. Both
+// dispatch sites need to recognise the new TypeListList carrier.
+func TestBuildSourceListListLen(t *testing.T) {
+	src := `let matrix = [
+  [1, 2, 3],
+  [4, 5, 6],
+]
+print(len(matrix))
+let row = matrix[0]
+print(len(row))
+`
+	want := "2\n3\n"
+	if got := runMochiBuild(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceV02MatrixFixture pins the on-disk v0.2/matrix.mochi
+// fixture end-to-end. Phase 4.2.21 closed the list<list<i64>> gate;
+// combined with Phase 4.2.19's test-block skip, the fixture now
+// compiles top to bottom on the C target. With shadow, π, map,
+// list, and matrix all green, the v0.2 user-facing matrix stands at
+// 5 of 6 (for-in.mochi is the remaining gate).
+func TestBuildSourceV02MatrixFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.2/matrix.mochi")
+	if err != nil {
+		t.Fatalf("read v0.2/matrix.mochi fixture: %v", err)
+	}
+	want := "matrix:  [[1, 2, 3], [4, 5, 6], [7, 8, 9]]\n" +
+		"first row:  [1, 2, 3]\n" +
+		"last row:  [7, 8, 9]\n" +
+		"top-left:  1\n" +
+		"center:  5\n" +
+		"bottom-right:  9\n" +
+		"row 1 length:  3\n"
+	if got := runMochiBuild(t, string(srcBytes)); got != want {
+		t.Errorf("v0.2/matrix stdout = %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceV03MatchFixture pins the on-disk fixture verbatim
 // so a regression in either the example or the lowering surfaces
 // here. This is the user-facing motivation for Phase 4.2.11.

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -67,6 +67,7 @@ func Emit(p *Program) ([]byte, error) {
 	usesNow := false
 	usesMapI64I64 := false
 	usesMapStrI64 := false
+	usesListList := false
 	usesTree := false
 	usesStrH := false
 	usesStrRuntime := false
@@ -99,6 +100,10 @@ func Emit(p *Program) ([]byte, error) {
 				usesMapI64I64 = true
 			case ir.OpNewMapStrI64, ir.OpMapSetStrI64, ir.OpMapGetStrI64, ir.OpMapLenStrI64:
 				usesMapStrI64 = true
+			case ir.OpNewListList, ir.OpListListPush, ir.OpListListGet,
+				ir.OpListListLen, ir.OpListListToStr:
+				usesListList = true
+				usesListI64 = true
 			case ir.OpNewListAny, ir.OpListAnyLen, ir.OpListAnyPushAny, ir.OpListAnyGetAny:
 				usesTree = true
 			case ir.OpLenStr, ir.OpCmpEqStr, ir.OpCmpNeStr:
@@ -133,6 +138,9 @@ func Emit(p *Program) ([]byte, error) {
 	}
 	if usesMapStrI64 {
 		buf.WriteString("#include \"mochi_map_str_i64.h\"\n")
+	}
+	if usesListList {
+		buf.WriteString("#include \"mochi_list_list.h\"\n")
 	}
 	if usesTree {
 		buf.WriteString("#include \"mochi_tree.h\"\n")
@@ -423,6 +431,16 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    %s = mochi_map_str_i64_get(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpMapLenStrI64:
 		fmt.Fprintf(w, "    %s = mochi_map_str_i64_len(%s);\n", name, valueName(v.Args[0]))
+	case ir.OpNewListList:
+		fmt.Fprintf(w, "    %s = mochi_list_list_new();\n", name)
+	case ir.OpListListPush:
+		fmt.Fprintf(w, "    mochi_list_list_push(%s, %s);\n", valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpListListGet:
+		fmt.Fprintf(w, "    %s = mochi_list_list_get(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpListListLen:
+		fmt.Fprintf(w, "    %s = mochi_list_list_len(%s);\n", name, valueName(v.Args[0]))
+	case ir.OpListListToStr:
+		fmt.Fprintf(w, "    %s = mochi_list_list_to_str(%s);\n", name, valueName(v.Args[0]))
 	case ir.OpNewListAny:
 		fmt.Fprintf(w, "    %s = mochi_tree_new();\n", name)
 	case ir.OpListAnyLen:
@@ -701,6 +719,12 @@ func cType(t ir.Type) string {
 		// `mochi_tree*`, matching binary_trees-style kernels where
 		// every payload is recursively the same shape.
 		return "mochi_tree*"
+	case ir.TypeListList:
+		// list<list<int>>: heap-allocated outer array of mochi_list_i64
+		// pointers. Backed by runtime/c/src/mochi_list_list.{h,c}.
+		// Distinct from TypeListAny so the get-op can return a typed
+		// mochi_list_i64* directly without a tag check.
+		return "mochi_list_list*"
 	case ir.TypeUnit, ir.TypeInvalid:
 		return "void"
 	}

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -433,6 +433,31 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 	case ir.OpStrArrSlice:
 		fmt.Fprintf(w, "\t%s = append([]string{}, %s[%s:%s]...)\n",
 			name, valueName(v.Args[0]), valueName(v.Args[1]), valueName(v.Args[2]))
+	case ir.OpNewListList:
+		fmt.Fprintf(w, "\t%s = [][]int64{}\n", name)
+	case ir.OpListListPush:
+		fmt.Fprintf(w, "\t%s = append(%s, %s)\n", valueName(v.Args[0]), valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpListListGet:
+		fmt.Fprintf(w, "\t%s = %s[%s]\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpListListLen:
+		fmt.Fprintf(w, "\t%s = int64(len(%s))\n", name, valueName(v.Args[0]))
+	case ir.OpListListToStr:
+		// list<list<int>> -> `[[1, 2, 3], [4, 5, 6]]` form. Each row
+		// uses the same int-join shape as the OpListI64ToStr emit
+		// site, joined with ", " under outer brackets.
+		imports["strconv"] = true
+		imports["strings"] = true
+		fmt.Fprintf(w, "\t%s = func(xs [][]int64) string {\n", name)
+		w.WriteString("\t\tif len(xs) == 0 { return \"[]\" }\n")
+		w.WriteString("\t\trows := make([]string, len(xs))\n")
+		w.WriteString("\t\tfor i, row := range xs {\n")
+		w.WriteString("\t\t\tif len(row) == 0 { rows[i] = \"[]\"; continue }\n")
+		w.WriteString("\t\t\tparts := make([]string, len(row))\n")
+		w.WriteString("\t\t\tfor j, x := range row { parts[j] = strconv.FormatInt(x, 10) }\n")
+		w.WriteString("\t\t\trows[i] = \"[\" + strings.Join(parts, \", \") + \"]\"\n")
+		w.WriteString("\t\t}\n")
+		w.WriteString("\t\treturn \"[\" + strings.Join(rows, \", \") + \"]\"\n")
+		fmt.Fprintf(w, "\t}(%s)\n", valueName(v.Args[0]))
 	case ir.OpNow:
 		imports["time"] = true
 		fmt.Fprintf(w, "\t%s = time.Now().UnixMicro()\n", name)
@@ -736,6 +761,8 @@ func goType(t ir.Type) string {
 		return "[]float64"
 	case ir.TypeStrArr:
 		return "[]string"
+	case ir.TypeListList:
+		return "[][]int64"
 	case ir.TypeI64Arr:
 		return "[]int64"
 	case ir.TypeU8Arr:

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -469,8 +469,15 @@ func lowerType(t *parser.TypeRef) (ir.Type, error) {
 				// element of a list<any> is itself a list<any> in the
 				// binary_trees kernel, so the IR carries one tag.
 				return ir.TypeListAny, nil
+			case ir.TypeList:
+				// Phase 4.2.21: list<list<int>> backs onto mochi_list_list
+				// on the C target and [][]int64 on the Go target. The
+				// inner element type is locked to TypeI64 in the MVP
+				// (matching the v0.2/matrix.mochi shape); a list<list<float>>
+				// or list<list<str>> would need its own carrier.
+				return ir.TypeListList, nil
 			}
-			return ir.TypeInvalid, fmt.Errorf("frontend: list<%s> unsupported in MVP (only list<int>, list<float>, list<str>, list<any>)", el)
+			return ir.TypeInvalid, fmt.Errorf("frontend: list<%s> unsupported in MVP (only list<int>, list<float>, list<str>, list<any>, list<list<int>>)", el)
 		}
 		// Phase 4.3.15.2: `map<int, int>` lowers to TypeMap, backed by
 		// runtime/c/src/mochi_map_i64_i64.{h,c} on the C target and
@@ -1323,6 +1330,14 @@ func (b *builder) lowerExprAsStmt(e *parser.Expr) (uint32, error) {
 			arg = b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpStrArrToStr, Args: []uint32{arg}})
 			argType = ir.TypeStr
 		}
+		// list<list<int>>: lift through OpListListToStr (Phase 4.2.21).
+		// Renders the nested `[[1, 2], [3, 4]]` form via per-row
+		// mochi_list_i64_to_str on the C target and the equivalent
+		// strings.Join helper on the Go target.
+		if argType == ir.TypeListList {
+			arg = b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpListListToStr, Args: []uint32{arg}})
+			argType = ir.TypeStr
+		}
 		goArgType := goTypeForIRType(argType)
 		if goArgType == "" {
 			return 0, fmt.Errorf("frontend: print() argument type %s unsupported in MVP", argType)
@@ -1411,6 +1426,8 @@ func (b *builder) liftToStr(argID uint32) (uint32, error) {
 		return b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpF64ArrayToStr, Args: []uint32{argID}}), nil
 	case ir.TypeStrArr:
 		return b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpStrArrToStr, Args: []uint32{argID}}), nil
+	case ir.TypeListList:
+		return b.addValue(ir.Value{Type: ir.TypeStr, Op: ir.OpListListToStr, Args: []uint32{argID}}), nil
 	}
 	return 0, fmt.Errorf("frontend: print() argument type %s unsupported in MVP", b.fn.Values[argID].Type)
 }
@@ -1845,7 +1862,7 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 				return 0, fmt.Errorf("frontend: slice indexing unsupported in MVP")
 			}
 			curType := b.fn.Values[cur].Type
-			if curType != ir.TypeList && curType != ir.TypeF64Arr && curType != ir.TypeStrArr && curType != ir.TypeMap && curType != ir.TypeMapStrI64 && curType != ir.TypeListAny {
+			if curType != ir.TypeList && curType != ir.TypeF64Arr && curType != ir.TypeStrArr && curType != ir.TypeMap && curType != ir.TypeMapStrI64 && curType != ir.TypeListAny && curType != ir.TypeListList {
 				return 0, fmt.Errorf("frontend: index on non-list %s", curType)
 			}
 			iID, err := b.lowerExpr(idx.Start)
@@ -1870,7 +1887,7 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 			// helper). TypeMap is excluded because map indexing
 			// uses a key, not an offset, and negative keys are
 			// valid lookups.
-			if curType == ir.TypeList || curType == ir.TypeF64Arr || curType == ir.TypeStrArr {
+			if curType == ir.TypeList || curType == ir.TypeF64Arr || curType == ir.TypeStrArr || curType == ir.TypeListList {
 				if cv, ok := b.constI64(iID); ok && cv < 0 {
 					var lenOp ir.OpCode
 					switch curType {
@@ -1880,6 +1897,8 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 						lenOp = ir.OpF64ArrayLenI64
 					case ir.TypeStrArr:
 						lenOp = ir.OpStrArrLen
+					case ir.TypeListList:
+						lenOp = ir.OpListListLen
 					}
 					lenID := b.addValue(ir.Value{Type: ir.TypeI64, Op: lenOp, Args: []uint32{cur}})
 					iID = b.addValue(ir.Value{
@@ -1929,6 +1948,13 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 					Type: ir.TypeListAny,
 					Op:   ir.OpListAnyGetAny,
 					Args: []uint32{cur, iID},
+				})
+			case ir.TypeListList:
+				cur = b.addValue(ir.Value{
+					Type:     ir.TypeList,
+					ElemType: ir.TypeI64,
+					Op:       ir.OpListListGet,
+					Args:     []uint32{cur, iID},
 				})
 			}
 		case op.Cast != nil:
@@ -2309,6 +2335,12 @@ func (b *builder) lowerListLiteral(lit *parser.ListLiteral) (uint32, error) {
 				elem = ir.TypeStr
 			case ir.TypeListAny:
 				elem = ir.TypeListAny
+			case ir.TypeList:
+				// Phase 4.2.21: an untyped outer literal whose first
+				// element lowers to a TypeList (list<int>) infers
+				// list<list<int>>. The v0.2/matrix.mochi `let matrix =
+				// [[1,2,3], [4,5,6], ...]` is the gating fixture.
+				elem = ir.TypeList
 			default:
 				return 0, fmt.Errorf("frontend: list literal element type %s unsupported in MVP", b.fn.Values[id].Type)
 			}
@@ -2331,6 +2363,10 @@ func (b *builder) lowerListLiteral(lit *parser.ListLiteral) (uint32, error) {
 	case ir.TypeListAny:
 		listType, elemType = ir.TypeListAny, ir.TypeListAny
 		newOp, pushOp = ir.OpNewListAny, ir.OpListAnyPushAny
+	case ir.TypeList:
+		// Phase 4.2.21: list<list<int>>.
+		listType, elemType = ir.TypeListList, ir.TypeList
+		newOp, pushOp = ir.OpNewListList, ir.OpListListPush
 	default:
 		return 0, fmt.Errorf("frontend: list literal with element type %s unsupported", elem)
 	}
@@ -2517,6 +2553,11 @@ func (b *builder) lowerBuiltinCall(c *parser.CallExpr) (uint32, bool, error) {
 		case ir.TypeMapStrI64:
 			id := b.addValue(ir.Value{
 				Type: ir.TypeI64, Op: ir.OpMapLenStrI64, Args: []uint32{arg},
+			})
+			return id, true, nil
+		case ir.TypeListList:
+			id := b.addValue(ir.Value{
+				Type: ir.TypeI64, Op: ir.OpListListLen, Args: []uint32{arg},
 			})
 			return id, true, nil
 		default:

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -32,6 +32,15 @@ const (
 	// pick the right runtime struct and the verifier can route the
 	// right Set/Get ops.
 	TypeMapStrI64
+	// TypeListList is the typed `list<list<i64>>` carrier on the C
+	// target (Phase 4.2.21). Backing is mochi_list_list, a small
+	// struct holding a mochi_list_i64** data array + len + cap. The
+	// nested elements remain TypeList (not TypeListAny), so chained
+	// indexing `m[i][j]` stays in the typed-i64 path. Distinct from
+	// TypeListAny so emit/lower can pick the right runtime struct
+	// and produce typed-i64 element access without a runtime type
+	// tag check.
+	TypeListList
 	TypeAny
 	// TypeListAny is the heterogeneous self-referential list backing
 	// for `list<any>` (Phase 4.3.15.1). In the binary_trees kernel every
@@ -84,6 +93,8 @@ func (t Type) String() string {
 		return "strarr"
 	case TypeMapStrI64:
 		return "mapstri64"
+	case TypeListList:
+		return "listlist"
 	case TypeAny:
 		return "any"
 	case TypeListAny:
@@ -228,6 +239,20 @@ const (
 	OpMapSetStrI64
 	OpMapGetStrI64
 	OpMapLenStrI64
+
+	// Typed list<list<i64>> ops (Phase 4.2.21). Backs nested integer
+	// matrices like `[[1,2,3],[4,5,6]]` on the C target with
+	// mochi_list_list (a mochi_list_i64** data array + len + cap).
+	// OpListListGet returns TypeList (a borrowed handle into the
+	// outer array; element pointer carriers are not duplicated).
+	// OpListListToStr renders the nested list in Mochi reference
+	// display form: `[[1, 2, 3], [4, 5, 6]]` (no outer trailing
+	// comma; element separator is `, ` matching mochi_list_i64_to_str).
+	OpNewListList
+	OpListListPush
+	OpListListGet
+	OpListListLen
+	OpListListToStr
 
 	// Calls. Args[0..] are the argument values; the callee is named by
 	// Value.Const (function index in the Function's owning Program).
@@ -520,6 +545,16 @@ func (o OpCode) String() string {
 		return "map.get.str.i64"
 	case OpMapLenStrI64:
 		return "map.len.str.i64"
+	case OpNewListList:
+		return "newlistlist"
+	case OpListListPush:
+		return "listlist.push"
+	case OpListListGet:
+		return "listlist.get"
+	case OpListListLen:
+		return "listlist.len"
+	case OpListListToStr:
+		return "listlist.tostr"
 	case OpListConcatI64:
 		return "list.concat.i64"
 	case OpF64ArrayConcat:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -237,6 +237,16 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeI64, [3]Type{TypeMapStrI64, TypeStr}}
 	case OpMapLenStrI64:
 		return opSig{TypeI64, [3]Type{TypeMapStrI64}}
+	case OpNewListList:
+		return opSig{TypeListList, [3]Type{}}
+	case OpListListPush:
+		return opSig{TypeUnit, [3]Type{TypeListList, TypeList}}
+	case OpListListGet:
+		return opSig{TypeList, [3]Type{TypeListList, TypeI64}}
+	case OpListListLen:
+		return opSig{TypeI64, [3]Type{TypeListList}}
+	case OpListListToStr:
+		return opSig{TypeStr, [3]Type{TypeListList}}
 	case OpAndI64, OpOrI64, OpXorI64, OpShlI64, OpShrI64:
 		return opSig{TypeI64, [3]Type{TypeI64, TypeI64}}
 	case OpNotI64:

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -172,10 +172,13 @@ func kindOf(o ir.OpCode) ProducerKind {
 		return KindConstructor
 
 	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array, ir.OpNewStrArr, ir.OpNewMapStrI64, ir.OpNewListAny,
+		ir.OpNewListList,
 		ir.OpListConcatI64, ir.OpF64ArrayConcat,
 		ir.OpListAnyGetAny,
 		ir.OpStrArrGetStr,
-		ir.OpStrArrSlice:
+		ir.OpStrArrSlice,
+		ir.OpListListGet,
+		ir.OpListListToStr:
 		// OpListAnyGetAny returns a handle (TypeListAny) borrowed from
 		// an existing tree node. OpStrArrGetStr returns a handle
 		// (TypeStr) borrowed from a `const char**` slot. Rule A
@@ -192,7 +195,8 @@ func kindOf(o ir.OpCode) ProducerKind {
 		ir.OpMapSetStrI64, ir.OpMapGetStrI64, ir.OpMapLenStrI64,
 		ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64, ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64,
 		ir.OpStrArrLen, ir.OpStrArrPushStr, ir.OpStrArrSetStr,
-		ir.OpListAnyLen, ir.OpListAnyPushAny:
+		ir.OpListAnyLen, ir.OpListAnyPushAny,
+		ir.OpListListPush, ir.OpListListLen:
 		return KindDispatch
 
 	case ir.OpCall, ir.OpTailCall, ir.OpCallGo:
@@ -251,7 +255,7 @@ func HandleType(t ir.Type) bool {
 	case ir.TypeStr, ir.TypeList, ir.TypeMap, ir.TypeSet, ir.TypeStruct,
 		ir.TypeClosure, ir.TypeBignum, ir.TypeBytes, ir.TypePair,
 		ir.TypeF64Arr, ir.TypeI64Arr, ir.TypeU8Arr, ir.TypeListAny,
-		ir.TypeMapStrI64:
+		ir.TypeMapStrI64, ir.TypeListList:
 		return true
 	}
 	return false
@@ -469,6 +473,16 @@ func contractResult(o ir.OpCode) ir.Type {
 		return ir.TypeUnit
 	case ir.OpListAnyGetAny:
 		return ir.TypeListAny
+	case ir.OpNewListList:
+		return ir.TypeListList
+	case ir.OpListListPush:
+		return ir.TypeUnit
+	case ir.OpListListGet:
+		return ir.TypeList
+	case ir.OpListListLen:
+		return ir.TypeI64
+	case ir.OpListListToStr:
+		return ir.TypeStr
 	case ir.OpJsonI64Object:
 		return ir.TypeUnit
 	}
@@ -496,7 +510,8 @@ func opIsMutating(o ir.OpCode) bool {
 		ir.OpMapSetStrI64,
 		ir.OpF64ArrayPushF64, ir.OpF64ArraySetF64,
 		ir.OpStrArrPushStr, ir.OpStrArrSetStr,
-		ir.OpListAnyPushAny:
+		ir.OpListAnyPushAny,
+		ir.OpListListPush:
 		return true
 	}
 	return false
@@ -517,6 +532,7 @@ var readDispatchOps = []ir.OpCode{
 	ir.OpF64ArrayGetF64,
 	ir.OpStrArrLen,
 	ir.OpListAnyLen,
+	ir.OpListListLen,
 }
 
 // writeDispatchOps lists every KindDispatch op that mutates its arena.
@@ -531,6 +547,7 @@ var writeDispatchOps = []ir.OpCode{
 	ir.OpStrArrPushStr,
 	ir.OpStrArrSetStr,
 	ir.OpListAnyPushAny,
+	ir.OpListListPush,
 }
 
 // checkRuleE verifies the §6.9 reference-mode obligations. Default-mode
@@ -657,6 +674,8 @@ func dispatchArena(o ir.OpCode) ir.Type {
 		return ir.TypeStrArr
 	case ir.OpListAnyLen, ir.OpListAnyPushAny:
 		return ir.TypeListAny
+	case ir.OpListListPush, ir.OpListListLen:
+		return ir.TypeListList
 	}
 	return ir.TypeInvalid
 }

--- a/runtime/c/doc.go
+++ b/runtime/c/doc.go
@@ -24,5 +24,5 @@ import "embed"
 // files when cgo is off (and the whole point of this package is to
 // stay no-cgo on the build host).
 //
-//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c src/mochi_f64_array.h src/mochi_f64_array.c src/mochi_str_array.h src/mochi_str_array.c src/mochi_time.h src/mochi_time.c src/mochi_map_i64_i64.h src/mochi_map_i64_i64.c src/mochi_map_str_i64.h src/mochi_map_str_i64.c src/mochi_tree.h src/mochi_tree.c src/mochi_str.h src/mochi_str.c
+//go:embed src/print.h src/print.c src/mochi_list_i64.h src/mochi_list_i64.c src/mochi_f64_array.h src/mochi_f64_array.c src/mochi_str_array.h src/mochi_str_array.c src/mochi_time.h src/mochi_time.c src/mochi_map_i64_i64.h src/mochi_map_i64_i64.c src/mochi_map_str_i64.h src/mochi_map_str_i64.c src/mochi_tree.h src/mochi_tree.c src/mochi_str.h src/mochi_str.c src/mochi_list_list.h src/mochi_list_list.c
 var Runtime embed.FS

--- a/runtime/c/src/mochi_list_list.c
+++ b/runtime/c/src/mochi_list_list.c
@@ -1,0 +1,72 @@
+/*
+ * MEP-42 Phase 4.2.21 nested integer list runtime. See
+ * mochi_list_list.h.
+ */
+#include "mochi_list_list.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+mochi_list_list *mochi_list_list_new(void) {
+    mochi_list_list *m = (mochi_list_list *)malloc(sizeof(mochi_list_list));
+    if (m == NULL) abort();
+    m->data = NULL;
+    m->len = 0;
+    m->cap = 0;
+    return m;
+}
+
+int64_t mochi_list_list_len(const mochi_list_list *m) {
+    return m->len;
+}
+
+void mochi_list_list_push(mochi_list_list *m, mochi_list_i64 *row) {
+    if (m->len == m->cap) {
+        int64_t newcap = m->cap == 0 ? 4 : m->cap * 2;
+        mochi_list_i64 **nd = (mochi_list_i64 **)realloc(
+            (void *)m->data, (size_t)newcap * sizeof(mochi_list_i64 *));
+        if (nd == NULL) abort();
+        m->data = nd;
+        m->cap = newcap;
+    }
+    m->data[m->len++] = row;
+}
+
+mochi_list_i64 *mochi_list_list_get(const mochi_list_list *m, int64_t i) {
+    return m->data[i];
+}
+
+const char *mochi_list_list_to_str(const mochi_list_list *m) {
+    if (m->len == 0) return "[]";
+    /* Render each row, measure widths, then assemble. The rows are
+     * cached so each mochi_list_i64_to_str pays at most once per row.
+     * Memory for the per-row strings is owned by mochi_list_i64_to_str
+     * (heap, leaked at process exit), so we only store the pointers
+     * here. */
+    const char **rows = (const char **)malloc((size_t)m->len * sizeof(const char *));
+    if (rows == NULL) abort();
+    size_t total = 2; /* '[' + ']' */
+    if (m->len > 1) total += (size_t)(m->len - 1) * 2; /* ", " * (n-1) */
+    for (int64_t i = 0; i < m->len; i++) {
+        rows[i] = mochi_list_i64_to_str(m->data[i]);
+        total += strlen(rows[i]);
+    }
+    char *buf = (char *)malloc(total + 1);
+    if (buf == NULL) abort();
+    size_t off = 0;
+    buf[off++] = '[';
+    for (int64_t i = 0; i < m->len; i++) {
+        if (i > 0) {
+            buf[off++] = ',';
+            buf[off++] = ' ';
+        }
+        size_t n = strlen(rows[i]);
+        memcpy(buf + off, rows[i], n);
+        off += n;
+    }
+    buf[off++] = ']';
+    buf[off] = '\0';
+    free((void *)rows);
+    return buf;
+}

--- a/runtime/c/src/mochi_list_list.h
+++ b/runtime/c/src/mochi_list_list.h
@@ -1,0 +1,51 @@
+/*
+ * MEP-42 Phase 4.2.21 nested integer list runtime.
+ *
+ * Backs Mochi's list<list<int>> when the program is compiled with
+ * `mochi build --target=c`. The IR ops OpNewListList, OpListListLen,
+ * OpListListPush, OpListListGet, and OpListListToStr lower to calls
+ * into this header.
+ *
+ * Identity: pure C99, no libc beyond stdlib.h/string.h/stdint.h.
+ * The outer carrier owns a growable mochi_list_i64** array; the
+ * inner lists are not copied on push (the outer struct borrows the
+ * caller's mochi_list_i64 pointer). Allocations leak at process exit
+ * like the rest of the Phase 4 C runtime.
+ */
+#ifndef MOCHI_RUNTIME_C_LIST_LIST_H
+#define MOCHI_RUNTIME_C_LIST_LIST_H
+
+#include <stdint.h>
+
+#include "mochi_list_i64.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct mochi_list_list {
+    mochi_list_i64 **data;
+    int64_t          len;
+    int64_t          cap;
+} mochi_list_list;
+
+mochi_list_list *mochi_list_list_new(void);
+int64_t mochi_list_list_len(const mochi_list_list *m);
+void mochi_list_list_push(mochi_list_list *m, mochi_list_i64 *row);
+mochi_list_i64 *mochi_list_list_get(const mochi_list_list *m, int64_t i);
+
+/*
+ * mochi_list_list_to_str renders m in the Mochi reference display
+ * form `[[1, 2, 3], [4, 5, 6]]`: outer brackets, comma-space row
+ * separators, each row rendered via mochi_list_i64_to_str. Empty
+ * outer list returns a static "[]" literal (no malloc); non-empty
+ * results are heap-allocated and leak at process exit (Phase 4 MVP,
+ * parity with the i64 and f64 array formatters).
+ */
+const char *mochi_list_list_to_str(const mochi_list_list *m);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOCHI_RUNTIME_C_LIST_LIST_H */

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,50 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.48 Phase 4.2.21 closeout (LANDED 2026-05-22 13:12 GMT+7)
+
+Phase 4.2.21 lands the nested `list<list<int>>` carrier on the C target. Before this phase the v0.2/matrix.mochi binding `let matrix = [[1,2,3],[4,5,6],[7,8,9]]` failed at `lowerListLiteral` with `frontend: list literal element type list unsupported in MVP`, since the outer literal's first element resolved to `TypeList` and no carrier accepted it. The phase adds a typed nested-list family of ops + runtime, closing matrix.mochi end to end and moving the v0.2 user-facing matrix to 5 of 6 green.
+
+The carrier choice is deliberate. The IR could have routed the outer literal through `TypeListAny` (the existing self-referential any-list backed by mochi_tree), but the any-tree pays a tag-dispatch cost on every read and can't return a typed `int64_t` from a chained index without a runtime cast. Adding `TypeListList` as a typed nested-list keeps `matrix[i][j]` in the typed-i64 path: the outer get returns `mochi_list_i64*`, the inner get returns `int64_t`. The cost is one new runtime header and one new carrier; the win is zero tag overhead on the matrix-style fixtures the v0.2 corpus advertises as "this is what Mochi does well."
+
+The runtime layout mirrors mochi_list_i64: a heap struct with a `mochi_list_i64**` data array plus `len` / `cap`, doubling-growth from a first-push capacity of 4, no per-row copy on push (the outer struct borrows the caller's row pointer). The display formatter walks the outer array once, calls `mochi_list_i64_to_str` for each row (caching the per-row pointer), measures the joined width, then assembles the final `[[1, 2, 3], ...]` form in one malloc. Per-row strings remain owned by the inner formatter (heap, leaked at process exit), so the outer formatter only holds pointer carriers and the temporary scratch array is freed before return.
+
+Verifier classification follows the established handle-typed dispatch pattern. `OpNewListList` is Constructor (alloc). `OpListListGet` is Constructor too (its result is `TypeList`, a HandleType, so rule A requires Constructor origin; the rationale matches OpStrArrGetStr and OpListAnyGetAny: the get-op produces a fresh-looking handle whose payload is a derived pointer into the outer array, not arbitrary bits). `OpListListPush` is a write Dispatch (rule E mutating). `OpListListLen` is a read Dispatch returning `TypeI64` (value-shaped, no rule A obligation). `OpListListToStr` is Constructor (result is `TypeStr`, a HandleType). `TypeListList` joins HandleType so a future fun parameter of nested-list shape will permit OpParam origin (KindMove).
+
+### Diff shape
+
+- `compiler3/ir/types.go`: added `TypeListList` and ops `OpNewListList`, `OpListListPush`, `OpListListGet`, `OpListListLen`, `OpListListToStr`; String() cases for both.
+- `compiler3/ir/validate.go`: opContract entries (`TypeListList` / `TypeUnit` / `TypeList` / `TypeI64` / `TypeStr` results; arg type triples).
+- `compiler3/verify/verify.go`: `TypeListList` joins HandleType; ops join their respective kindOf / contractResult / opIsMutating / readDispatchOps / writeDispatchOps / dispatchArena tables.
+- `runtime/c/src/mochi_list_list.{h,c}`: new files. Outer struct + new / len / push / get / to_str. The header includes mochi_list_i64.h so callers see the full row type.
+- `runtime/c/doc.go`: added the two new files to the embed list.
+- `compiler3/emit/c/emit.go`: `usesListList` trigger (which also forces `usesListI64` so mochi_list_i64 is available for inner rows); `#include "mochi_list_list.h"`; emit cases for all five ops; cType case to `mochi_list_list*`.
+- `compiler3/emit/go/emit.go`: goType case to `[][]int64`; emit cases (native Go append/index/len for the structural ops; an inline two-level Join for OpListListToStr that matches the C runtime byte for byte).
+- `compiler3/frontend/lower.go`: `lowerType` accepts `list<list<int>>`; `lowerListLiteral` infers `TypeListList` when the first element resolves to `TypeList` and handles its allocate/push lowering; `lowerPostfix` accepts indexing on `TypeListList`, extends the constant-negative-index fold, and emits `OpListListGet`; `len()` builtin recognises `TypeListList`; both the single-arg `print()` path and `liftToStr` lift TypeListList through `OpListListToStr`.
+- `compiler3/build/c/driver_test.go`: 4 new tests. TestBuildSourceListListBasic pins the canonical literal + index + nested index shapes. TestBuildSourceListListNegIndex pins the negative-index fold for the outer carrier. TestBuildSourceListListLen pins `len(matrix)` and `len(row)` after extraction. TestBuildSourceV02MatrixFixture pins the on-disk v0.2/matrix.mochi fixture.
+
+### Why this closes a goal
+
+The v0.2 user-facing matrix moves from 4 of 6 green to 5 of 6 green:
+
+| Fixture | C target status |
+|---------|-----------------|
+| shadow.mochi | green (always was) |
+| π.mochi | green (Phase 4.2.19) |
+| map.mochi | green (Phase 4.2.18 + 4.2.19) |
+| list.mochi | green (Phase 4.2.20) |
+| matrix.mochi | green (Phase 4.2.21) |
+| for-in.mochi | still fails (untyped `let scores = {...}` map literal needs key-type inference + map iteration + range iteration) |
+
+Five of six v0.2 user-facing fixtures green on the C target. for-in.mochi is the last v0.2 gate, and it has three intertwined sub-gates (untyped map inference, `for k in map`, `for i in a..b`), so a future phase will likely split it into three sub-phases.
+
+### Limitations
+
+- The MVP locks the inner element type to `int64`. `list<list<float>>`, `list<list<str>>`, `list<list<list<int>>>` (three-deep) all fall back to the existing `frontend: list<...> unsupported` rejection. Each one needs its own typed carrier (matrix.mochi only exercises i64).
+- The Go emitter wraps the inner Push with `append(m, row)` which mutates the slice header in place; this is consistent with the existing TypeList Push behaviour but means an SSA value that aliases the outer slice header will see the post-push state. The Phase 4 MVP does not produce aliased outer handles today, so the difference is invisible from the source-program side.
+- `print(matrix)` lifts through `OpListListToStr` to get the display form, which means a future `print(matrix, sep)` shape (if Mochi ever exposes one) would need separate plumbing. The current `print` path is space-joined; the single-arg fast path uses one fmt.Println call.
+- Outer-list `concat` is not yet implemented. `[m1, m2]` works (it lowers as TypeListList), but `m1 + m2` (if Mochi ever surfaces it for list<list<i64>>) would need OpListListConcat. No v0.2 fixture exercises it.
+
 ## §10.47 Phase 4.2.20 closeout (LANDED 2026-05-22 12:54 GMT+7)
 
 Phase 4.2.20 lands the bound `xs[a:b]` slice form on TypeStrArr. Before this phase the v0.2/list.mochi binding `let some = fruits[1:3]` failed at the frontend `lowerPostfix` slice branch with `frontend: slice indexing unsupported in MVP`, blocking the v0.2 list fixture even though all surrounding statements already compiled. The phase adds OpStrArrSlice, a tiny runtime helper, and a one-arm lowering branch that closes list.mochi's last gate.


### PR DESCRIPTION
Closes #22035.

## Summary

- Adds IR carrier `TypeListList` + ops `OpNewListList`, `OpListListPush`, `OpListListGet`, `OpListListLen`, `OpListListToStr` so `[[1,2,3], [4,5,6]]` literals compile end to end on the C target.
- Tiny runtime helper `mochi_list_list.{h,c}` with doubling growth + a join helper that caches per-row pointers and sizes the buffer in one pass.
- C and Go emitters: C emits a `mochi_list_list*` carrier (forces `usesListI64` for the inner row type); Go emits native `[][]int64` with an inline two-level Join that byte-matches the C runtime.
- Frontend: `lowerType` accepts `list<list<int>>`; `lowerListLiteral` infers `TypeListList` when the first element is `TypeList`; `lowerPostfix` accepts indexing + negative-index fold; `len()` and both print paths recognise the new carrier.
- MEP-42 §10.48 closeout with carrier rationale (typed over `TypeListAny` to avoid tag dispatch on every read), verifier classification (rule A via `HandleType`), diff shape, the v0.2 matrix (5/6 green), and limitations.

## v0.2 matrix after this phase

| Fixture | Status |
|---|---|
| shadow.mochi | green |
| π.mochi | green |
| map.mochi | green |
| list.mochi | green |
| matrix.mochi | green (this phase) |
| for-in.mochi | still fails |

## Test plan

- [x] `go test ./compiler3/build/c/... -run TestBuildSourceListList` (4 new tests green)
- [x] `go test ./compiler3/build/c/...` (full driver regression green)
- [x] `go test ./compiler3/...` (compiler3 regression green)
- [x] v0.2/matrix.mochi byte-matches VM output on both C and Go targets