### PR TITLE
mep-0042: Phase 4.2.22 untyped map<str,i64> literal inference

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -2731,6 +2731,49 @@ func TestBuildSourceV02MatrixFixture(t *testing.T) {
 	}
 }
 
+// TestBuildSourceMapStrI64Inferred exercises the Phase 4.2.22
+// untyped-map-literal inference. The binding has no type annotation,
+// so the literal infers map<str, i64> from its first key (a str
+// literal). The probe-on-an-absent-key 0 default still applies and
+// `len(m)` still routes through OpMapLenStrI64.
+func TestBuildSourceMapStrI64Inferred(t *testing.T) {
+	src := `let scores = {
+  "Alice": 10,
+  "Bob": 15,
+}
+print(scores["Alice"])
+print(scores["Bob"])
+print(scores["Missing"])
+print(len(scores))
+`
+	if got, want := runMochiBuild(t, src), "10\n15\n0\n2\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceMapStrI64InferredNonStrKey pins the rejection
+// path: an untyped map literal whose first key is an int falls
+// outside the only map carrier the inference path accepts. The
+// error mentions the offending shape so the user can either
+// annotate the binding or fix the key.
+func TestBuildSourceMapStrI64InferredNonStrKey(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "test.mochi")
+	src := `let m = {1: 2}
+print(len(m))
+`
+	if err := os.WriteFile(srcPath, []byte(src), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	_, err := BuildSource(srcPath, Options{OutDir: dir, BinaryPath: filepath.Join(dir, "bin")})
+	if err == nil {
+		t.Fatalf("expected lower error for non-str inferred map key")
+	}
+	if got, want := err.Error(), "first key must be str"; !strings.Contains(got, want) {
+		t.Errorf("error %q does not mention %q", got, want)
+	}
+}
+
 // TestBuildSourceV03MatchFixture pins the on-disk fixture verbatim
 // so a regression in either the example or the lowering surfaces
 // here. This is the user-facing motivation for Phase 4.2.11.

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -2268,43 +2268,75 @@ func (b *builder) lowerIfExpr(e *parser.IfExpr) (uint32, error) {
 //     lower to OpNewMapStrI64 followed by a chain of OpMapSetStrI64,
 //     one per declared key/value pair. Keys must lower to TypeStr,
 //     values to TypeI64.
+//
+// Phase 4.2.22: when neither expectation is set (untyped `let m =
+// {...}` binding), the literal infers map<str, i64> by lowering the
+// first key and checking it is TypeStr. This unblocks the
+// v0.2/for-in.mochi `let scores = {"Alice": 90, ...}` binding.
+// Inference into map<int, int> stays unsupported because the IR
+// backing only handles empty initializers there, and an empty literal
+// without a hint can't disambiguate the two map families anyway.
 func (b *builder) lowerMapLiteralAsExpr(m *parser.MapLiteral) (uint32, error) {
 	if b.expectedMapStrI64 {
 		// Reset the expectation while lowering element exprs so a
 		// nested map literal does not inherit it.
 		b.expectedMapStrI64 = false
 		defer func() { b.expectedMapStrI64 = true }()
-		mapID := b.addValue(ir.Value{Type: ir.TypeMapStrI64, Op: ir.OpNewMapStrI64})
-		for i, item := range m.Items {
-			kid, err := b.lowerExpr(item.Key)
-			if err != nil {
-				return 0, fmt.Errorf("frontend: map<str, i64> entry %d key: %w", i, err)
-			}
-			if b.fn.Values[kid].Type != ir.TypeStr {
-				return 0, fmt.Errorf("frontend: map<str, i64> entry %d key must be str, got %s", i, b.fn.Values[kid].Type)
-			}
-			vid, err := b.lowerExpr(item.Value)
-			if err != nil {
-				return 0, fmt.Errorf("frontend: map<str, i64> entry %d value: %w", i, err)
-			}
-			if b.fn.Values[vid].Type != ir.TypeI64 {
-				return 0, fmt.Errorf("frontend: map<str, i64> entry %d value must be i64, got %s", i, b.fn.Values[vid].Type)
-			}
-			b.addValue(ir.Value{
-				Type: ir.TypeUnit,
-				Op:   ir.OpMapSetStrI64,
-				Args: []uint32{mapID, kid, vid},
-			})
-		}
-		return mapID, nil
+		return b.lowerMapStrI64Body(m, 0, false)
 	}
 	if !b.expectedMap {
-		return 0, fmt.Errorf("frontend: map literal requires `map<int, int>` or `map<str, i64>` type annotation on the binding")
+		if len(m.Items) == 0 {
+			return 0, fmt.Errorf("frontend: map literal requires `map<int, int>` or `map<str, i64>` type annotation on the binding")
+		}
+		firstKey, err := b.lowerExpr(m.Items[0].Key)
+		if err != nil {
+			return 0, fmt.Errorf("frontend: map literal entry 0 key: %w", err)
+		}
+		if b.fn.Values[firstKey].Type != ir.TypeStr {
+			return 0, fmt.Errorf("frontend: untyped map literal first key must be str (inferred map<str, i64>), got %s", b.fn.Values[firstKey].Type)
+		}
+		return b.lowerMapStrI64Body(m, firstKey, true)
 	}
 	if len(m.Items) != 0 {
 		return 0, fmt.Errorf("frontend: non-empty map<int, int> literal unsupported in MVP (only `{}` initializer)")
 	}
 	return b.addValue(ir.Value{Type: ir.TypeMap, Op: ir.OpNewMap}), nil
+}
+
+// lowerMapStrI64Body emits OpNewMapStrI64 plus the OpMapSetStrI64
+// chain for a map<str, i64> literal. When firstKeyLowered is true,
+// firstKeyID is reused as the entry-0 key so an inference caller does
+// not re-lower a possibly side-effecting key expression.
+func (b *builder) lowerMapStrI64Body(m *parser.MapLiteral, firstKeyID uint32, firstKeyLowered bool) (uint32, error) {
+	mapID := b.addValue(ir.Value{Type: ir.TypeMapStrI64, Op: ir.OpNewMapStrI64})
+	for i, item := range m.Items {
+		var kid uint32
+		if i == 0 && firstKeyLowered {
+			kid = firstKeyID
+		} else {
+			id, err := b.lowerExpr(item.Key)
+			if err != nil {
+				return 0, fmt.Errorf("frontend: map<str, i64> entry %d key: %w", i, err)
+			}
+			kid = id
+		}
+		if b.fn.Values[kid].Type != ir.TypeStr {
+			return 0, fmt.Errorf("frontend: map<str, i64> entry %d key must be str, got %s", i, b.fn.Values[kid].Type)
+		}
+		vid, err := b.lowerExpr(item.Value)
+		if err != nil {
+			return 0, fmt.Errorf("frontend: map<str, i64> entry %d value: %w", i, err)
+		}
+		if b.fn.Values[vid].Type != ir.TypeI64 {
+			return 0, fmt.Errorf("frontend: map<str, i64> entry %d value must be i64, got %s", i, b.fn.Values[vid].Type)
+		}
+		b.addValue(ir.Value{
+			Type: ir.TypeUnit,
+			Op:   ir.OpMapSetStrI64,
+			Args: []uint32{mapID, kid, vid},
+		})
+	}
+	return mapID, nil
 }
 
 // lowerListLiteral lowers `[e1, e2, ...]` to an empty-list constructor

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,29 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.49 Phase 4.2.22 closeout (LANDED 2026-05-22 13:40 GMT+7)
+
+Phase 4.2.22 is the first of three sub-phases targeting the v0.2/for-in.mochi fixture, the only remaining v0.2 user-facing gate. The fixture has four blocks; the first one to fail is block 2's untyped binding `let scores = {"Alice": 90, ...}`, which previously hit `frontend: map literal requires map<int, int> or map<str, i64> type annotation on the binding`. This phase teaches `lowerMapLiteralAsExpr` to infer the carrier from the first key when no annotation is set.
+
+The inference rule is intentionally narrow. With two map families on the C target today (`TypeMap` for the `map<int, int>` empty-only carrier and `TypeMapStrI64` for the full str-keyed family), the only inference path that can produce a working non-empty literal is map<str, i64>; the int-keyed family stays empty-only and would reject the next push anyway. Choosing that target means the inference contract is: an untyped non-empty `{...}` literal whose first key is a str literal infers `map<str, i64>`; everything else still reports the annotation error so the user can clarify. Empty `{}` literals without a hint still report the annotation error (no first key to peek at, and choosing one carrier silently would be confusing).
+
+The implementation extracts the entry-0 key-lowering into the inference probe and feeds the resulting SSA value into a shared `lowerMapStrI64Body` helper that both the annotated and inferred paths now call. Reusing the lowered key id avoids re-evaluating a side-effecting key expression a second time. The rejection path reports `untyped map literal first key must be str (inferred map<str, i64>), got <T>` so the user sees both the inferred carrier and the offending key type.
+
+### Diff shape
+
+- `compiler3/frontend/lower.go`: `lowerMapLiteralAsExpr` now has three arms (annotated map<str, i64>, untyped non-empty inference, annotated map<int, int>); the str-i64 body is factored into `lowerMapStrI64Body` and called from both the annotated and inferred arms. No new IR ops, no runtime change.
+- `compiler3/build/c/driver_test.go`: TestBuildSourceMapStrI64Inferred pins the canonical untyped `let scores = {"Alice": 10, "Bob": 15}` shape, including the implicit zero-default on an absent key and `len(scores)`. TestBuildSourceMapStrI64InferredNonStrKey pins the rejection error for `let m = {1: 2}` so a future widening of the int-keyed family doesn't silently let it through.
+
+### Why this closes a goal
+
+The for-in.mochi fixture had three intertwined sub-gates blocking it (untyped map literal, map iteration, range iteration). With this phase, the first block-2 line `let scores = {"Alice": 90, ...}` now lowers; the next failure on the fixture moves from the literal binding to `frontend: for-in over mapstri64 unsupported (need list)`. The user-facing matrix is unchanged on the binary-build axis (still 5 of 6 green), but the path to closing for-in.mochi is now narrower: the next sub-phase is for-in over map<str, i64>, then for-in over list<list<i64>> for block 4. Range iteration (block 3) and list<str> iteration (block 1) already work, so once map iteration and nested-list iteration land the fixture closes.
+
+### Limitations
+
+- Untyped empty `{}` still reports the annotation error. An empty literal could in principle infer to either map family, but the int-keyed carrier can't accept a later non-empty assignment to the same binding (it's empty-only), so silently picking one carrier would surprise the user when a later push fails. The annotation-required error is the safer default until the int-keyed carrier widens.
+- Inference targets only map<str, i64>. A binding like `let m = {1: 2}` rejects because the int-keyed carrier still only supports empty literals; widening it is its own carrier-family change, not an inference change.
+- The inference probe lowers the first key in the outer scope (no nested map-literal context applies). A key expression that itself contains a nested untyped map literal would inherit no inference context for the nested literal; the nested literal would have to be annotated. No v0.2 fixture exercises that.
+
 ## §10.48 Phase 4.2.21 closeout (LANDED 2026-05-22 13:12 GMT+7)
 
 Phase 4.2.21 lands the nested `list<list<int>>` carrier on the C target. Before this phase the v0.2/matrix.mochi binding `let matrix = [[1,2,3],[4,5,6],[7,8,9]]` failed at `lowerListLiteral` with `frontend: list literal element type list unsupported in MVP`, since the outer literal's first element resolved to `TypeList` and no carrier accepted it. The phase adds a typed nested-list family of ops + runtime, closing matrix.mochi end to end and moving the v0.2 user-facing matrix to 5 of 6 green.


### PR DESCRIPTION
Closes #22037.

## Summary

- `lowerMapLiteralAsExpr` infers `map<str, i64>` from `let m = {"k": v, ...}` when no annotation is set, by lowering the first key and checking it is `TypeStr`. Empty `{}` still requires the annotation (carrier ambiguity).
- Factored the OpNewMapStrI64 + OpMapSetStrI64 chain into `lowerMapStrI64Body` so both the annotated and inferred arms call the same emitter; the inferred arm reuses the lowered first-key id so a side-effecting key expression is not re-evaluated.
- MEP-42 §10.49 closeout with carrier-choice rationale, diff shape, error-message text, and limitations.

## v0.2 fixture progress

This unblocks the v0.2/for-in.mochi block-2 binding. The fixture now fails at `for name in scores` instead of at the literal binding. The binary-build matrix is unchanged on its own axis (still 5/6 green), but the path to closing for-in.mochi is now narrower (map iteration is next).

## Test plan

- [x] `go test ./compiler3/build/c/... -run TestBuildSourceMapStrI64Inferred` (both new tests green)
- [x] `go test ./compiler3/...` (full compiler3 regression green)
- [x] `mochi build --target=c examples/v0.2/for-in.mochi` now fails at `for-in over mapstri64 unsupported` instead of the literal binding (confirms the gate moved)