### PR TITLE
mep-0042: Phase 4.2.23 for-in over map<str,i64> on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -2774,6 +2774,46 @@ print(len(m))
 	}
 }
 
+// TestBuildSourceForInMapStrI64 pins the Phase 4.2.23 iteration:
+// `for k in m` over a map<str, i64> walks the keys in strcmp
+// ascending order, matching the Mochi reference VM which sorts map
+// keys before iterating. The keys "Charlie" / "Alice" / "Bob" are
+// deliberately inserted out of order to make the sort observable;
+// the output must come back Alice / Bob / Charlie.
+func TestBuildSourceForInMapStrI64(t *testing.T) {
+	src := `let scores = {
+  "Charlie": 88,
+  "Alice": 90,
+  "Bob": 82,
+}
+for name in scores {
+  let score = scores[name]
+  print(name, " scored ", score)
+}
+`
+	want := "Alice  scored  90\nBob  scored  82\nCharlie  scored  88\n"
+	if got := runMochiBuild(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceForInMapStrI64Empty exercises the empty-map iteration
+// path: zero passes through the loop, prefix and suffix prints still
+// fire. Pins that the sorted-keys runtime helper returns a usable
+// empty mochi_str_array (cap=0, len=0) rather than crashing.
+func TestBuildSourceForInMapStrI64Empty(t *testing.T) {
+	src := `let m: map<string, int> = {}
+print("before")
+for k in m {
+  print("never:", k)
+}
+print("after")
+`
+	if got, want := runMochiBuild(t, src), "before\nafter\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceV03MatchFixture pins the on-disk fixture verbatim
 // so a regression in either the example or the lowering surfaces
 // here. This is the user-facing motivation for Phase 4.2.11.

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -100,6 +100,9 @@ func Emit(p *Program) ([]byte, error) {
 				usesMapI64I64 = true
 			case ir.OpNewMapStrI64, ir.OpMapSetStrI64, ir.OpMapGetStrI64, ir.OpMapLenStrI64:
 				usesMapStrI64 = true
+			case ir.OpMapStrI64SortedKeys:
+				usesMapStrI64 = true
+				usesStrArray = true
 			case ir.OpNewListList, ir.OpListListPush, ir.OpListListGet,
 				ir.OpListListLen, ir.OpListListToStr:
 				usesListList = true
@@ -431,6 +434,8 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		fmt.Fprintf(w, "    %s = mochi_map_str_i64_get(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpMapLenStrI64:
 		fmt.Fprintf(w, "    %s = mochi_map_str_i64_len(%s);\n", name, valueName(v.Args[0]))
+	case ir.OpMapStrI64SortedKeys:
+		fmt.Fprintf(w, "    %s = mochi_map_str_i64_sorted_keys(%s);\n", name, valueName(v.Args[0]))
 	case ir.OpNewListList:
 		fmt.Fprintf(w, "    %s = mochi_list_list_new();\n", name)
 	case ir.OpListListPush:

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -350,6 +350,18 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 		fmt.Fprintf(w, "\t%s = %s[%s]\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpMapLenStrI64:
 		fmt.Fprintf(w, "\t%s = int64(len(%s))\n", name, valueName(v.Args[0]))
+	case ir.OpMapStrI64SortedKeys:
+		// Mochi VM iterates maps in sorted-key order; the C runtime
+		// (mochi_map_str_i64_sorted_keys) does the same with strcmp.
+		// Mirror it here so `for k in m` on the Go target produces
+		// byte-identical output to the C target and to `mochi run`.
+		imports["sort"] = true
+		fmt.Fprintf(w, "\t%s = func(m map[string]int64) []string {\n", name)
+		w.WriteString("\t\tks := make([]string, 0, len(m))\n")
+		w.WriteString("\t\tfor k := range m { ks = append(ks, k) }\n")
+		w.WriteString("\t\tsort.Strings(ks)\n")
+		w.WriteString("\t\treturn ks\n")
+		fmt.Fprintf(w, "\t}(%s)\n", valueName(v.Args[0]))
 	case ir.OpNewListAny:
 		fmt.Fprintf(w, "\t%s = _MochiAny{}\n", name)
 	case ir.OpListAnyLen:

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1159,6 +1159,21 @@ func (b *builder) lowerForCollection(s *parser.ForStmt) error {
 		return err
 	}
 	listType := b.fn.Values[xs].Type
+	// Phase 4.2.23: `for k in m` on map<str, i64> desugars to iteration
+	// over the sorted-keys list. The Mochi reference VM sorts map keys
+	// before iterating; mochi_map_str_i64_sorted_keys mirrors that on
+	// the C target so the produced output matches `mochi run` byte for
+	// byte. After this rewrite the loop continues through the existing
+	// TypeStrArr arm.
+	if listType == ir.TypeMapStrI64 {
+		xs = b.addValue(ir.Value{
+			Type:     ir.TypeStrArr,
+			ElemType: ir.TypeStr,
+			Op:       ir.OpMapStrI64SortedKeys,
+			Args:     []uint32{xs},
+		})
+		listType = ir.TypeStrArr
+	}
 	var lenOp ir.OpCode
 	var getOp ir.OpCode
 	var elemType ir.Type

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -239,6 +239,12 @@ const (
 	OpMapSetStrI64
 	OpMapGetStrI64
 	OpMapLenStrI64
+	// OpMapStrI64SortedKeys returns the map's keys as a TypeStrArr
+	// sorted ascending by strcmp. Backs `for k in m` on the C target
+	// (Phase 4.2.23) by lowering map iteration to iteration over the
+	// sorted-keys carrier. Sorted order is required to match the
+	// Mochi reference VM which sorts keys before iterating maps.
+	OpMapStrI64SortedKeys
 
 	// Typed list<list<i64>> ops (Phase 4.2.21). Backs nested integer
 	// matrices like `[[1,2,3],[4,5,6]]` on the C target with
@@ -545,6 +551,8 @@ func (o OpCode) String() string {
 		return "map.get.str.i64"
 	case OpMapLenStrI64:
 		return "map.len.str.i64"
+	case OpMapStrI64SortedKeys:
+		return "map.str.i64.sortedkeys"
 	case OpNewListList:
 		return "newlistlist"
 	case OpListListPush:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -237,6 +237,8 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeI64, [3]Type{TypeMapStrI64, TypeStr}}
 	case OpMapLenStrI64:
 		return opSig{TypeI64, [3]Type{TypeMapStrI64}}
+	case OpMapStrI64SortedKeys:
+		return opSig{TypeStrArr, [3]Type{TypeMapStrI64}}
 	case OpNewListList:
 		return opSig{TypeListList, [3]Type{}}
 	case OpListListPush:

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -178,7 +178,8 @@ func kindOf(o ir.OpCode) ProducerKind {
 		ir.OpStrArrGetStr,
 		ir.OpStrArrSlice,
 		ir.OpListListGet,
-		ir.OpListListToStr:
+		ir.OpListListToStr,
+		ir.OpMapStrI64SortedKeys:
 		// OpListAnyGetAny returns a handle (TypeListAny) borrowed from
 		// an existing tree node. OpStrArrGetStr returns a handle
 		// (TypeStr) borrowed from a `const char**` slot. Rule A
@@ -483,6 +484,8 @@ func contractResult(o ir.OpCode) ir.Type {
 		return ir.TypeI64
 	case ir.OpListListToStr:
 		return ir.TypeStr
+	case ir.OpMapStrI64SortedKeys:
+		return ir.TypeStrArr
 	case ir.OpJsonI64Object:
 		return ir.TypeUnit
 	}

--- a/runtime/c/src/mochi_map_str_i64.c
+++ b/runtime/c/src/mochi_map_str_i64.c
@@ -110,3 +110,38 @@ void mochi_map_str_i64_set(mochi_map_str_i64 *m, const char *k, int64_t v) {
     }
     m->vals[i] = v;
 }
+
+static int mochi_map_str_keycmp(const void *a, const void *b) {
+    const char *const *pa = (const char *const *)a;
+    const char *const *pb = (const char *const *)b;
+    return strcmp(*pa, *pb);
+}
+
+mochi_str_array *mochi_map_str_i64_sorted_keys(const mochi_map_str_i64 *m) {
+    mochi_str_array *out = mochi_str_array_new();
+    if (m->len == 0) {
+        return out;
+    }
+    /* Collect every occupied key into a fresh contiguous buffer, qsort
+     * it by strcmp, then push each key into the returned array. The
+     * push path doubles cap from 4 on first push and again as needed,
+     * which is fine: m->len is the upper bound on capacity here. The
+     * intermediate buffer is freed before return; the array's own
+     * data backing is owned by the returned mochi_str_array. */
+    const char **keys = (const char **)malloc((size_t)m->len * sizeof(const char *));
+    if (keys == NULL) {
+        abort();
+    }
+    int64_t n = 0;
+    for (int64_t b = 0; b < m->cap; b++) {
+        if (m->occ[b] != 0) {
+            keys[n++] = m->keys[b];
+        }
+    }
+    qsort(keys, (size_t)n, sizeof(const char *), mochi_map_str_keycmp);
+    for (int64_t i = 0; i < n; i++) {
+        mochi_str_array_push(out, keys[i]);
+    }
+    free(keys);
+    return out;
+}

--- a/runtime/c/src/mochi_map_str_i64.h
+++ b/runtime/c/src/mochi_map_str_i64.h
@@ -24,6 +24,8 @@
 
 #include <stdint.h>
 
+#include "mochi_str_array.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -68,6 +70,17 @@ int64_t mochi_map_str_i64_get(const mochi_map_str_i64 *m, const char *k);
  * stays with the caller.
  */
 void mochi_map_str_i64_set(mochi_map_str_i64 *m, const char *k, int64_t v);
+
+/*
+ * mochi_map_str_i64_sorted_keys returns a freshly-allocated
+ * mochi_str_array whose entries are m's keys in strcmp ascending
+ * order. Backs `for k in m` on the C target (Phase 4.2.23) by
+ * lowering map iteration to iteration over the sorted-keys carrier,
+ * matching the Mochi reference VM which sort.Strings the keys before
+ * iterating. Key pointers are borrowed from the map; the returned
+ * array shares the same `const char *` storage as the map.
+ */
+mochi_str_array *mochi_map_str_i64_sorted_keys(const mochi_map_str_i64 *m);
 
 #ifdef __cplusplus
 }

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,36 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.50 Phase 4.2.23 closeout (LANDED 2026-05-22 14:37 GMT+7)
+
+Phase 4.2.23 is the second of the three sub-phases for v0.2/for-in.mochi. After Phase 4.2.22 cleared the untyped map binding, the fixture next failed at `for name in scores` with `frontend: for-in over mapstri64 unsupported (need list)`. This phase adds map iteration on the C target by lowering `for k in m` (where m is TypeMapStrI64) to iteration over a sorted-keys list, matching the Mochi reference VM which `sort.Strings` the keys before iterating.
+
+The carrier choice is "convert, don't iterate." The IR could grow a dedicated map-iterator op family (next, valid, key), but that would duplicate the cursor machinery the existing for-collection arm already provides for TypeStrArr. Adding a single `OpMapStrI64SortedKeys` op that returns a fresh TypeStrArr means map iteration desugars to `let keys = sortedkeys(m); for k in keys { body }`, which goes through the existing TypeStrArr arm unchanged. The cost is one map walk + qsort per loop entry; the win is zero new iteration ops and a one-line frontend rewrite. The sorted-order requirement comes from the VM (it does `sort.Strings` before iterating in vm_eval.go:1364), so reuse-of-sorted-keys would not have been right either: each loop entry deserves its own walk in case the map mutated between iterations.
+
+The runtime helper `mochi_map_str_i64_sorted_keys` collects every occupied bucket into a temporary `const char **` buffer, runs `qsort` with a `strcmp`-based comparator, then pushes each key into a freshly-allocated mochi_str_array via the existing `mochi_str_array_push` (which itself doubles from cap=4 on first push). The intermediate buffer is freed before return. Keys are borrowed (the array shares the same `const char *` storage as the map), so a key whose pointer outlives the map outlives the array too. The Go emitter mirrors the same shape with an inline IIFE that does `make + range + append + sort.Strings`.
+
+### Diff shape
+
+- `compiler3/ir/types.go`: new op `OpMapStrI64SortedKeys`; String() case `"map.str.i64.sortedkeys"`.
+- `compiler3/ir/validate.go`: opContract entry `TypeStrArr -> TypeMapStrI64`.
+- `compiler3/verify/verify.go`: op joins the Constructor list (rule A: TypeStrArr is HandleType, so the get-op must originate from Constructor/Move/Inline/Call); contractResult returns TypeStrArr. Not a Dispatch, so no dispatchArena entry.
+- `compiler3/emit/c/emit.go`: trigger sets both `usesMapStrI64` and `usesStrArray` so the str-array header lands too; emit case `mochi_map_str_i64_sorted_keys(m)`.
+- `compiler3/emit/go/emit.go`: emit case for the IIFE shape (registers the `"sort"` import on the spot).
+- `runtime/c/src/mochi_map_str_i64.{h,c}`: header now `#include "mochi_str_array.h"`; new `mochi_map_str_i64_sorted_keys` function + a static `mochi_map_str_keycmp` comparator.
+- `compiler3/frontend/lower.go`: `lowerForCollection` recognises TypeMapStrI64, emits `OpMapStrI64SortedKeys`, and rewrites the loop subject to the produced TypeStrArr. Everything else (header phis, body, cont) goes through the existing TypeStrArr arm.
+- `compiler3/build/c/driver_test.go`: TestBuildSourceForInMapStrI64 pins the canonical block-2 shape with deliberately-out-of-order inserts (Charlie, Alice, Bob) so the sort is observable. TestBuildSourceForInMapStrI64Empty pins the empty-map path: zero passes through the loop, prefix and suffix prints still fire.
+
+### Why this closes a goal
+
+The v0.2/for-in.mochi fixture's block 2 now compiles. The next failure on the fixture moves from `for-in over mapstri64 unsupported` to `for-in over listlist unsupported`, which is block 4's `for row in matrix`. The binary-build matrix is still 5 of 6 green on its own axis, but the for-in.mochi gate is one sub-phase from closing (Phase 4.2.24 for nested-list iteration). Block 1 (list<str>) and block 3 (range) were already supported, so once nested-list iteration lands the whole fixture compiles end to end.
+
+### Limitations
+
+- Sorted-order iteration is part of the contract on both targets. A future "iterate in insertion order" mode (if Mochi ever surfaces one) would need its own op family because the map carrier does not track insertion order today.
+- The conversion walk is O(n) on every loop entry. A map that grows mid-loop will not surface its new entries because the keys snapshot was taken before the loop began. This matches `mochi run` behaviour (the VM also snapshots the sorted key list at OpIter time).
+- The helper only covers map<str, i64>. A future map<i64, i64> iteration phase would need its own SortedKeys op (or a generic one) and another runtime helper.
+- Keys are borrowed; freeing the map invalidates the returned mochi_str_array. The Phase 4 MVP leaks both at process exit, so this is invisible from the source-program side.
+
 ## §10.49 Phase 4.2.22 closeout (LANDED 2026-05-22 13:40 GMT+7)
 
 Phase 4.2.22 is the first of three sub-phases targeting the v0.2/for-in.mochi fixture, the only remaining v0.2 user-facing gate. The fixture has four blocks; the first one to fail is block 2's untyped binding `let scores = {"Alice": 90, ...}`, which previously hit `frontend: map literal requires map<int, int> or map<str, i64> type annotation on the binding`. This phase teaches `lowerMapLiteralAsExpr` to infer the carrier from the first key when no annotation is set.


### PR DESCRIPTION
Closes #22039.

## Summary

- New IR op `OpMapStrI64SortedKeys` (Constructor, `TypeMapStrI64 -> TypeStrArr`) + runtime helper `mochi_map_str_i64_sorted_keys` that `qsort`s an occupied-key snapshot and pushes into a fresh mochi_str_array.
- C and Go emitters: C calls the runtime helper; Go emits an inline IIFE `make + range + append + sort.Strings`.
- Frontend: `lowerForCollection` rewrites `for k in m` (where m is TypeMapStrI64) into iteration over the sorted-keys carrier, dispatching through the existing TypeStrArr loop arm. No new iteration cursor ops.
- Sorted-key contract matches the Mochi reference VM, which `sort.Strings` the keys before iterating maps (vm_eval.go:1364).
- MEP-42 §10.50 closeout with carrier-choice rationale, diff shape, the v0.2 matrix, and limitations.

## v0.2 fixture progress

This unblocks v0.2/for-in.mochi block 2. The fixture now fails at block 4 (`for row in matrix`) instead of at the map loop. for-in.mochi is one sub-phase from closing (nested-list iteration is Phase 4.2.24).

## Test plan

- [x] `go test ./compiler3/build/c/... -run TestBuildSourceForInMapStrI64` (2 new tests green)
- [x] `go test ./compiler3/...` (full compiler3 regression green)
- [x] `mochi build --target=c examples/v0.2/for-in.mochi` now fails at `for-in over listlist unsupported` instead of `for-in over mapstri64 unsupported` (confirms the gate moved)