### PR TITLE
mep-0042: Phase 4.2.24 for-in over list<list<i64>> (closes v0.2 corpus)

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -2814,6 +2814,46 @@ print("after")
 	}
 }
 
+// TestBuildSourceForInListList pins Phase 4.2.24: `for row in
+// matrix` over a list<list<i64>> binds row to the inner TypeList,
+// and a nested `for col in row` then dispatches through the
+// TypeList arm. The output mirrors block 4 of v0.2/for-in.mochi.
+func TestBuildSourceForInListList(t *testing.T) {
+	src := `let matrix = [
+  [1, 2],
+  [3, 4],
+]
+for row in matrix {
+  for col in row {
+    print("cell: ", col)
+  }
+}
+`
+	want := "cell:  1\ncell:  2\ncell:  3\ncell:  4\n"
+	if got := runMochiBuild(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceV02ForInFixture closes the v0.2 user-facing corpus
+// gate. All four blocks (list<str> iteration, map iteration with
+// sorted keys, range iteration, nested list<list<i64>> iteration)
+// compile and print the same bytes as `mochi run`. With this phase
+// the v0.2 binary-build matrix is 6 of 6 green.
+func TestBuildSourceV02ForInFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.2/for-in.mochi")
+	if err != nil {
+		t.Fatalf("read v0.2/for-in.mochi fixture: %v", err)
+	}
+	want := "fruit:  apple\nfruit:  banana\nfruit:  cherry\n" +
+		"Alice  scored  90\nBob  scored  82\nCharlie  scored  88\n" +
+		"number:  1\nnumber:  2\nnumber:  3\nnumber:  4\n" +
+		"cell:  1\ncell:  2\ncell:  3\ncell:  4\n"
+	if got := runMochiBuild(t, string(srcBytes)); got != want {
+		t.Errorf("v0.2/for-in stdout = %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceV03MatchFixture pins the on-disk fixture verbatim
 // so a regression in either the example or the lowering surfaces
 // here. This is the user-facing motivation for Phase 4.2.11.

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1177,13 +1177,26 @@ func (b *builder) lowerForCollection(s *parser.ForStmt) error {
 	var lenOp ir.OpCode
 	var getOp ir.OpCode
 	var elemType ir.Type
+	// elemElemType is the ElemType field set on the loop-body bind.
+	// For scalar element types (i64, f64, str) it is the same as
+	// elemType; for nested-list element types it names the inner
+	// row's element type so a follow-on for-in or indexed read sees
+	// the right ElemType hint.
+	var elemElemType ir.Type
 	switch listType {
 	case ir.TypeList:
-		lenOp, getOp, elemType = ir.OpListLenI64, ir.OpListGetI64, ir.TypeI64
+		lenOp, getOp, elemType, elemElemType = ir.OpListLenI64, ir.OpListGetI64, ir.TypeI64, ir.TypeI64
 	case ir.TypeF64Arr:
-		lenOp, getOp, elemType = ir.OpF64ArrayLenI64, ir.OpF64ArrayGetF64, ir.TypeF64
+		lenOp, getOp, elemType, elemElemType = ir.OpF64ArrayLenI64, ir.OpF64ArrayGetF64, ir.TypeF64, ir.TypeF64
 	case ir.TypeStrArr:
-		lenOp, getOp, elemType = ir.OpStrArrLen, ir.OpStrArrGetStr, ir.TypeStr
+		lenOp, getOp, elemType, elemElemType = ir.OpStrArrLen, ir.OpStrArrGetStr, ir.TypeStr, ir.TypeStr
+	case ir.TypeListList:
+		// Phase 4.2.24: `for row in matrix` over list<list<i64>>.
+		// The loop variable binds to TypeList (the inner row); a
+		// nested `for col in row` then dispatches through the
+		// TypeList arm. ElemType on the row carries the inner i64
+		// hint so the body's indexed reads/writes find it.
+		lenOp, getOp, elemType, elemElemType = ir.OpListListLen, ir.OpListListGet, ir.TypeList, ir.TypeI64
 	default:
 		return fmt.Errorf("frontend: for-in over %s unsupported (need list)", listType)
 	}
@@ -1265,7 +1278,7 @@ func (b *builder) lowerForCollection(s *parser.ForStmt) error {
 	// Bind the loop variable to xs[idx] for the duration of the body.
 	elemID := b.addValue(ir.Value{
 		Type:     elemType,
-		ElemType: elemType,
+		ElemType: elemElemType,
 		Op:       getOp,
 		Args:     []uint32{xs, idxPhi},
 	})

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,40 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.51 Phase 4.2.24 closeout (LANDED 2026-05-22 14:42 GMT+7)
+
+Phase 4.2.24 is the third and last sub-phase of the v0.2/for-in.mochi gate. After Phases 4.2.22 (map literal inference) and 4.2.23 (map iteration), the fixture failed at block 4's `for row in matrix; for col in row` with `frontend: for-in over listlist unsupported (need list)`. This phase adds TypeListList to `lowerForCollection` and closes the whole v0.2 user-facing corpus on the C target.
+
+The implementation is a one-arm extension of the existing for-collection lowerer. TypeListList already has `OpListListLen` (read Dispatch) and `OpListListGet` (Constructor: returns the inner TypeList row as a borrowed handle into the outer array, classified Constructor under rule A because TypeList is HandleType). The loop variable binds to the inner TypeList, and a nested `for col in row` then dispatches through the existing TypeList arm. No new IR ops, no runtime change.
+
+One subtle correctness fix lives in this phase: the elemID bind in `lowerForCollection` was setting `ElemType = elemType`, which is fine for scalar element types (TypeI64, TypeF64, TypeStr ignore the field on a scalar value) but wrong for the new TypeList element case where ElemType should be the row's element type (TypeI64), matching the convention `lowerPostfix` uses when emitting `OpListListGet` directly. The fix introduces `elemElemType` as the ElemType hint per case; existing arms set it to the same value as elemType for byte-identical behaviour, and the new arm sets it to TypeI64.
+
+### Diff shape
+
+- `compiler3/frontend/lower.go`: `lowerForCollection` adds a TypeListList arm (OpListListLen + OpListListGet + elemType TypeList + elemElemType TypeI64). The elemID `addValue` now uses `elemElemType` instead of `elemType` for the ElemType field.
+- `compiler3/build/c/driver_test.go`: TestBuildSourceForInListList pins the canonical nested-list iteration shape from block 4. TestBuildSourceV02ForInFixture pins the on-disk v0.2/for-in.mochi fixture verbatim against `mochi run`'s output.
+
+### Why this closes a goal
+
+The v0.2/for-in.mochi fixture compiles end to end on the C target. With for-in.mochi green the v0.2 user-facing matrix on the binary-build axis goes from 5 of 6 to **6 of 6 green**:
+
+| Fixture | C target status |
+|---------|-----------------|
+| shadow.mochi | green |
+| π.mochi | green (Phase 4.2.19) |
+| map.mochi | green (Phases 4.2.18 + 4.2.19) |
+| list.mochi | green (Phase 4.2.20) |
+| matrix.mochi | green (Phase 4.2.21) |
+| for-in.mochi | green (Phases 4.2.22 + 4.2.23 + 4.2.24, this phase) |
+
+The MEP-42 Phase 4 umbrella's user-facing goal ("Mochi v0.2 programs compile via `mochi build --target=c` and produce byte-identical output to `mochi run`") is now satisfied for the entire v0.2 user-facing corpus. The umbrella phase still has its broader fixture-corpus targets in §10's matrix; this phase closes the v0.2/* sub-target.
+
+### Limitations
+
+- Mochi's `for k, v in m` (key-value destructuring) is still not handled; the fixture only exercises `for k in m`, so this stays a future widening.
+- Nested-list iteration is locked to int64 element rows (TypeListList only carries `list<list<int>>`). `list<list<float>>` and `list<list<str>>` iteration would each need its own carrier first.
+- The ElemType fix shifts a subtle field for the existing TypeList/TypeF64Arr/TypeStrArr arms (all from `elemType` to `elemElemType`, which is bound to the same value as elemType for those arms). This is bit-identical with the previous behaviour for scalar element types but means a future "iterate over a nested list whose inner list also has a nontrivial elem hint" would need to re-examine the field plumbing.
+
 ## §10.50 Phase 4.2.23 closeout (LANDED 2026-05-22 14:37 GMT+7)
 
 Phase 4.2.23 is the second of the three sub-phases for v0.2/for-in.mochi. After Phase 4.2.22 cleared the untyped map binding, the fixture next failed at `for name in scores` with `frontend: for-in over mapstri64 unsupported (need list)`. This phase adds map iteration on the C target by lowering `for k in m` (where m is TypeMapStrI64) to iteration over a sorted-keys list, matching the Mochi reference VM which `sort.Strings` the keys before iterating.


### PR DESCRIPTION
Closes #22041.

## Summary

- Adds a TypeListList arm to `lowerForCollection`: `for row in matrix` binds row to TypeList via `OpListListGet`, and a nested `for col in row` then dispatches through the existing TypeList arm. No new IR ops, no runtime change.
- Fixes elemID bind to thread the inner element type through ElemType (was reusing elemType, which is fine for scalar element types but wrong for the new nested-list case). Bit-identical for the existing scalar arms.
- MEP-42 §10.51 closeout with the diff shape and the 6/6 v0.2 corpus snapshot.

## v0.2 fixture progress

This closes v0.2/for-in.mochi. The v0.2 user-facing corpus on the binary-build axis is now **6 of 6 green** (shadow, π, map, list, matrix, for-in). The MEP-42 Phase 4 umbrella's user-facing goal "Mochi v0.2 programs compile via `mochi build --target=c` and produce byte-identical output to `mochi run`" is satisfied for the entire v0.2/* sub-target.

## Test plan

- [x] `go test ./compiler3/build/c/... -run TestBuildSourceForInListList` (canonical nested iteration green)
- [x] `go test ./compiler3/build/c/... -run TestBuildSourceV02ForInFixture` (on-disk fixture byte-matches `mochi run`)
- [x] `go test ./compiler3/...` (full compiler3 regression green)
- [x] `mochi build --target=c examples/v0.2/for-in.mochi && ./bin` byte-matches `mochi run examples/v0.2/for-in.mochi`