### PR TITLE
mep-0042: Phase 4.2.25 pin v0.5/v0.7 already-green fixtures

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -2854,6 +2854,56 @@ func TestBuildSourceV02ForInFixture(t *testing.T) {
 	}
 }
 
+// TestBuildSourceV05WhileFixture pins examples/v0.5/while.mochi
+// verbatim on the C target. This program (var + while + print + i++)
+// has been green since the early while/var phases. Phase 4.2.25 just
+// pins the existing win so a regression on var-mutation-in-while
+// surfaces here instead of going silent.
+func TestBuildSourceV05WhileFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.5/while.mochi")
+	if err != nil {
+		t.Fatalf("read v0.5 while fixture: %v", err)
+	}
+	want := "0\n1\n2\n"
+	if got := runMochiBuild(t, string(srcBytes)); got != want {
+		t.Errorf("v0.5/while stdout = %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceV07IfExprFixture pins examples/v0.7/if_expr.mochi
+// verbatim on the C target. The fixture uses the block-form
+// if-as-value (`let s = if cond { "a" } else { "b" }`) which is
+// distinct from the v0.10 `if then else` expression form already
+// pinned by TestBuildSourceV010IfThenElseFixture. Both forms now have
+// fixture-level regression coverage.
+func TestBuildSourceV07IfExprFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.7/if_expr.mochi")
+	if err != nil {
+		t.Fatalf("read v0.7 if_expr fixture: %v", err)
+	}
+	want := "Status: adult\n"
+	if got := runMochiBuild(t, string(srcBytes)); got != want {
+		t.Errorf("v0.7/if_expr stdout = %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceV07EmptyListFixture pins examples/v0.7/empty_list.mochi
+// verbatim on the C target. The fixture exercises both shapes of an
+// empty list<int>: a type-annotated binding (`let xs: list<int> = []`)
+// and an `as`-cast expression (`let xs = [] as list<int>`). Both lower
+// to TypeList carriers that print as `[]` via mochi_list_i64_to_str's
+// static empty-string fast path.
+func TestBuildSourceV07EmptyListFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.7/empty_list.mochi")
+	if err != nil {
+		t.Fatalf("read v0.7 empty_list fixture: %v", err)
+	}
+	want := "[]\n[]\n"
+	if got := runMochiBuild(t, string(srcBytes)); got != want {
+		t.Errorf("v0.7/empty_list stdout = %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceV03MatchFixture pins the on-disk fixture verbatim
 // so a regression in either the example or the lowering surfaces
 // here. This is the user-facing motivation for Phase 4.2.11.

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,36 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.52 Phase 4.2.25 closeout (LANDED 2026-05-22 14:55 GMT+7)
+
+Phase 4.2.25 is a defensive-pin phase. After Phase 4.2.24 closed the v0.2 user-facing corpus, auditing the next user-facing version corpora (v0.5, v0.7) surfaced three fixtures that already build and run correctly on the C target without any code change: `examples/v0.5/while.mochi`, `examples/v0.7/if_expr.mochi`, and `examples/v0.7/empty_list.mochi`. None had a fixture-level regression test pinning the exact on-disk bytes against the C-target stdout, so a future regression in either the example or the lowering would have gone silent on these programs. This phase pins all three.
+
+No frontend, IR, emit, or runtime change. The features each fixture exercises (while + var mutation; block-form `if` as a value; explicit `list<int>` empty binding plus the `as`-cast empty form) were each landed in earlier phases for unrelated reasons; this phase just extends the corpus-level safety net to cover them.
+
+### Diff shape
+
+- `compiler3/build/c/driver_test.go`: three new fixture pins.
+  - `TestBuildSourceV05WhileFixture` reads `examples/v0.5/while.mochi`, expects `0\n1\n2\n`.
+  - `TestBuildSourceV07IfExprFixture` reads `examples/v0.7/if_expr.mochi`, expects `Status: adult\n`.
+  - `TestBuildSourceV07EmptyListFixture` reads `examples/v0.7/empty_list.mochi`, expects `[]\n[]\n`.
+
+### Why this closes a goal
+
+The MEP-42 Phase 4 umbrella's user-facing goal extends beyond v0.2. v0.5 and v0.7 are tutorial corpora that today have a mixed pass/fail profile on the C target (audit notes below). Pinning the already-green fixtures locks in the wins so the visible user-facing coverage stays at least at today's level. The next code-change sub-phase (Phase 4.2.26 onward) is then free to attack a real feature gap without risking silent regression on these programs.
+
+Audit snapshot at the time of this phase (binary-build axis only):
+
+| Corpus | Green / Total | Already-pinned | Newly pinned this phase | Notes |
+|--------|---------------|----------------|-------------------------|-------|
+| v0.5   | 1 / 5         | 0              | while.mochi             | string, string-index-iterator need string indexing; agent, agent-stream need stream/agent statements |
+| v0.7   | 2 / 8         | 0              | if_expr.mochi, empty_list.mochi | eval, input need builtins; main, docs need package/import; tree needs ADT union types; strings_trim needs go FFI for strings.Split |
+
+### Limitations
+
+- This phase does not move the user-facing v0.5 or v0.7 *corpus* gates (1/5 and 2/8 stay at 1/5 and 2/8 respectively). Closing those corpora needs separate phases for string indexing, eval/input builtins, package/import, ADT/union types, and stream/agent statements.
+- The fixture pins are read-only on the examples. If a fixture's expected stdout ever drifts intentionally (a tutorial rewrite) the test would catch it as a regression. That is the desired shape: the test is the gate, the fixture is the source of truth.
+- No regression-test for v0.6 / v0.8 / v0.9 / v0.11 was added in this phase; v0.6 is entirely dataset/query operations (separate gate), v0.8 / v0.9 / v0.11 have no examples directory today, and v0.10 already has `TestBuildSourceV010IfThenElseFixture` pinned.
+
 ## §10.51 Phase 4.2.24 closeout (LANDED 2026-05-22 14:42 GMT+7)
 
 Phase 4.2.24 is the third and last sub-phase of the v0.2/for-in.mochi gate. After Phases 4.2.22 (map literal inference) and 4.2.23 (map iteration), the fixture failed at block 4's `for row in matrix; for col in row` with `frontend: for-in over listlist unsupported (need list)`. This phase adds TypeListList to `lowerForCollection` and closes the whole v0.2 user-facing corpus on the C target.


### PR DESCRIPTION
Closes #22043.

After Phase 4.2.24 closed the v0.2 user-facing corpus, audit of v0.5 and v0.7 surfaced three fixtures that already build and run correctly on the C target without code change. None had fixture-level regression coverage. This phase pins all three.

## What's pinned

- `TestBuildSourceV05WhileFixture` — `examples/v0.5/while.mochi`, expects `0\n1\n2\n`.
- `TestBuildSourceV07IfExprFixture` — `examples/v0.7/if_expr.mochi`, expects `Status: adult\n` (block-form if-as-value, distinct from the `if then else` form pinned by `TestBuildSourceV010IfThenElseFixture`).
- `TestBuildSourceV07EmptyListFixture` — `examples/v0.7/empty_list.mochi`, expects `[]\n[]\n` (covers both `let xs: list<int> = []` and `[] as list<int>`).

## What's NOT changed

No frontend, IR, emit, or runtime change. The features each fixture exercises landed in earlier phases for unrelated reasons; this phase only extends the corpus-level safety net.

## Why this matters

Without these pins, a regression in while+var, block-form if-as-value, or empty-list binding lowering would have gone silent on these tutorial programs. With them, user-facing v0.5/v0.7 coverage is at least visible at today's level (1/5 and 2/8 respectively).

## Remaining v0.5 / v0.7 gaps (deferred to later sub-phases)

- v0.5: string indexing, stream/agent statements.
- v0.7: `eval()` / `input()` builtins, package/import, ADT/union types, Go FFI for `strings.Split`.

## Spec

MEP-42 §10.52 documents the closeout, the audit snapshot, and the remaining gaps.

## Test plan

- [x] `go test ./compiler3/build/c/... -run "TestBuildSourceV05WhileFixture|TestBuildSourceV07IfExprFixture|TestBuildSourceV07EmptyListFixture" -count=1 -v`
- [x] `go test ./compiler3/build/c/... -count=1` full driver suite (96s)