### PR TITLE
mep-0042: Phase 4.2.26 empty-main link path

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -2904,6 +2904,66 @@ func TestBuildSourceV07EmptyListFixture(t *testing.T) {
 	}
 }
 
+// TestBuildSourceV01StreamFixture pins examples/v0.1/stream.mochi
+// (entirely block-commented out) on the C target. Before Phase 4.2.26
+// the build failed at link time with `Undefined symbols: _main`
+// because the frontend lowered the empty program to a Program with
+// no main function and the emitter then skipped main entirely. The
+// fix emits a no-op `int main(void) { return 0; }` whenever
+// p.Main == "", so a declaration-only or commented-out source builds
+// to a binary that runs and exits 0 with empty stdout.
+func TestBuildSourceV01StreamFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.1/stream.mochi")
+	if err != nil {
+		t.Fatalf("read v0.1 stream fixture: %v", err)
+	}
+	if got := runMochiBuild(t, string(srcBytes)); got != "" {
+		t.Errorf("v0.1/stream stdout = %q, want empty", got)
+	}
+}
+
+// TestBuildSourceV01AgentFixture pins examples/v0.1/agent.mochi (same
+// commented-out shape as v0.1/stream.mochi). Both v0.1 sources serve
+// as syntax-only references in the tutorial; the build target should
+// still produce a runnable binary with empty stdout instead of
+// failing at link time.
+func TestBuildSourceV01AgentFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.1/agent.mochi")
+	if err != nil {
+		t.Fatalf("read v0.1 agent fixture: %v", err)
+	}
+	if got := runMochiBuild(t, string(srcBytes)); got != "" {
+		t.Errorf("v0.1/agent stdout = %q, want empty", got)
+	}
+}
+
+// TestBuildSourceV06ExternFixture pins examples/v0.6/extern.mochi, a
+// declaration-only script: `extern type ...`, `extern var ...`,
+// `extern fun ...`, `extern object ...`. None of those have call
+// sites in the body (the only call sites are inside a block
+// comment). Lower produces an empty Program; Phase 4.2.26's no-op
+// main keeps the cc link step from failing.
+func TestBuildSourceV06ExternFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.6/extern.mochi")
+	if err != nil {
+		t.Fatalf("read v0.6 extern fixture: %v", err)
+	}
+	if got := runMochiBuild(t, string(srcBytes)); got != "" {
+		t.Errorf("v0.6/extern stdout = %q, want empty", got)
+	}
+}
+
+// TestBuildSourceEmptyScriptLinks covers the empty-statement edge
+// case directly: a script with literally no statements (after parsing
+// strips comments) must link and run. Without Phase 4.2.26 the cc
+// step would fail with `Undefined symbols: _main`.
+func TestBuildSourceEmptyScriptLinks(t *testing.T) {
+	src := "// just a comment, no statements\n"
+	if got := runMochiBuild(t, src); got != "" {
+		t.Errorf("empty-script stdout = %q, want empty", got)
+	}
+}
+
 // TestBuildSourceV03MatchFixture pins the on-disk fixture verbatim
 // so a regression in either the example or the lowering surfaces
 // here. This is the user-facing motivation for Phase 4.2.11.

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -174,6 +174,15 @@ func Emit(p *Program) ([]byte, error) {
 		if err := emitMain(&buf, p); err != nil {
 			return nil, err
 		}
+	} else {
+		// Phase 4.2.26: a Mochi source with no executable top-level
+		// statements (commented-out scripts, declaration-only files
+		// like v0.6/extern.mochi) lowers to a Program with no main
+		// function. Without a `_main` symbol the cc link step fails.
+		// Emit a no-op `int main(void) { return 0; }` so the binary
+		// links and runs with empty stdout, matching `mochi run` on
+		// the same source.
+		buf.WriteString("int main(void) { return 0; }\n")
 	}
 	return buf.Bytes(), nil
 }

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,33 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.53 Phase 4.2.26 closeout (LANDED 2026-05-22 15:02 GMT+7)
+
+Phase 4.2.26 fixes a long-standing link-time failure on declaration-only and commented-out Mochi sources. Before this phase, `mochi build --target=c examples/v0.1/stream.mochi` (entirely block-commented) and `examples/v0.6/extern.mochi` (only `extern` declarations) failed at `cc` with `Undefined symbols: _main`. The frontend lowered the empty program to a Program with zero Funcs, the emitter then skipped `int main(void)` because `p.Main == ""`, and the resulting object had no entry point.
+
+The fix is a one-line emit-time fallback: when `p.Main == ""`, emit `int main(void) { return 0; }` instead of nothing. This changes the contract of "empty Main" from "no main, library-style object" to "no-op main, runs and exits 0". The previously-referenced "future `--emit=c-library` mode" is not wired up today, and when it lands it will need a distinct `Options.Library` flag (or a sentinel `Options.Main` value) to gate this branch off explicitly.
+
+The semantics match `mochi run` on the same sources: a program with no executable top-level statements does nothing and exits 0. Three v0.1/v0.6 fixtures now build to runnable binaries that print empty stdout (verified end to end with `runMochiBuild`).
+
+### Diff shape
+
+- `compiler3/emit/c/emit.go`: the `if p.Main != ""` block in `Emit` gets an `else` arm that writes `int main(void) { return 0; }`.
+- `compiler3/build/c/driver_test.go`: four new pins.
+  - `TestBuildSourceV01StreamFixture` reads `examples/v0.1/stream.mochi` (entirely block-commented), expects empty stdout.
+  - `TestBuildSourceV01AgentFixture` reads `examples/v0.1/agent.mochi` (same shape), expects empty stdout.
+  - `TestBuildSourceV06ExternFixture` reads `examples/v0.6/extern.mochi` (declaration-only), expects empty stdout.
+  - `TestBuildSourceEmptyScriptLinks` covers the comment-only edge case directly with an inline `// just a comment` source.
+
+### Why this closes a goal
+
+The v0.1 user-facing corpus on the binary-build axis goes from 7 of 17 to 9 of 17 green (stream + agent newly link). The v0.6 corpus is unblocked at the extern-declarations gate, raising it from 0 of 18 to 1 of 18; the remaining v0.6 fixtures all require dataset/query operations that stay a separate gate. The bigger win is that `mochi build` no longer requires every script to have at least one executable statement, which removes a footgun for users following the v0.1 tutorials that introduce syntax via commented-out examples.
+
+### Limitations
+
+- Does not address v0.4/stream.mochi (a fully-uncommented stream/agent program) or v0.5/agent*.mochi: those still hit `frontend: statement kind unsupported in MVP` at lower time, well before reaching cc. Stream/agent semantics need their own phase.
+- The emit-time fallback is unconditional. A future library-mode build (`--emit=c-library`) will need an explicit opt-out so it doesn't get a spurious `main` symbol; this is fine since the library mode is not yet implemented.
+- The Go target was not audited in this phase. If a parallel link failure exists there, it would be a separate Go-emit fix.
+
 ## §10.52 Phase 4.2.25 closeout (LANDED 2026-05-22 14:55 GMT+7)
 
 Phase 4.2.25 is a defensive-pin phase. After Phase 4.2.24 closed the v0.2 user-facing corpus, auditing the next user-facing version corpora (v0.5, v0.7) surfaced three fixtures that already build and run correctly on the C target without any code change: `examples/v0.5/while.mochi`, `examples/v0.7/if_expr.mochi`, and `examples/v0.7/empty_list.mochi`. None had a fixture-level regression test pinning the exact on-disk bytes against the C-target stdout, so a future regression in either the example or the lowering would have gone silent on these programs. This phase pins all three.


### PR DESCRIPTION
Closes #22045.

Fix `cc: Undefined symbols: _main` on Mochi sources with no executable top-level statements. Three v0.1/v0.6 fixtures hit this: `v0.1/stream.mochi` and `v0.1/agent.mochi` are entirely block-commented; `v0.6/extern.mochi` is only `extern` declarations. All three parse-and-lower successfully but produced an unlinkable object because the emitter skipped `int main(void)` whenever `p.Main == ""`.

## Fix

One-line emit-time fallback in `compiler3/emit/c/emit.go`: when `p.Main == ""`, emit `int main(void) { return 0; }` instead of nothing. Matches `mochi run` on the same sources (does nothing, exits 0).

## Coverage

Four new fixture pins in `compiler3/build/c/driver_test.go`:

- `TestBuildSourceV01StreamFixture` (`examples/v0.1/stream.mochi`)
- `TestBuildSourceV01AgentFixture` (`examples/v0.1/agent.mochi`)
- `TestBuildSourceV06ExternFixture` (`examples/v0.6/extern.mochi`)
- `TestBuildSourceEmptyScriptLinks` (inline comment-only source)

## Goal alignment

v0.1 binary-build matrix: 7/17 -> 9/17 green. v0.6 binary-build matrix: 0/18 -> 1/18 green. Removes a footgun where the v0.1 tutorial's syntax-only examples didn't `mochi build`.

## Non-goals

- v0.4/stream.mochi (uncommented stream/agent) still hits `frontend: statement kind unsupported in MVP`.
- Future `--emit=c-library` mode will need an explicit opt-out for this fallback. Not wired up today.

## Spec

MEP-42 §10.53.

## Test plan

- [x] `go test ./compiler3/build/c/... -run "TestBuildSourceV01StreamFixture|TestBuildSourceV01AgentFixture|TestBuildSourceV06ExternFixture|TestBuildSourceEmptyScriptLinks" -count=1 -v`
- [x] `go test ./compiler3/emit/c/...` and `go test ./compiler3/build/c/...` full suites