### PR TITLE
mep-0042: Phase 4.2.27 string indexing s[i] on C target

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -2992,6 +2992,55 @@ func TestBuildSourceSpectralNormBgFixture(t *testing.T) {
 	}
 }
 
+// TestBuildSourceStrCharAtBasic pins the Phase 4.2.27 string-index
+// surface on the C target: `s[i]` on TypeStr lowers to the
+// OpStrCharAt op which delegates to mochi_str_char_at; for ASCII
+// input the i-th byte and i-th rune coincide so `"hello"[0]` is "h"
+// and `"hello"[4]` is "o", byte-matching `mochi run` on the same
+// source.
+func TestBuildSourceStrCharAtBasic(t *testing.T) {
+	src := `let s = "hello"
+print(s[0])
+print(s[4])
+`
+	if got, want := runMochiBuild(t, src), "h\no\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStrCharAtConcat pins the interaction between
+// indexing and concat: the i-th rune is a TypeStr value that can be
+// the operand of `+` (which routes through mochi_str_concat). This
+// also exercises HandleType liveness: the OpStrCharAt allocation
+// must outlive the surrounding OpConcatStr that reads it.
+func TestBuildSourceStrCharAtConcat(t *testing.T) {
+	src := `let s = "abc"
+print(s[0] + s[2])
+`
+	if got, want := runMochiBuild(t, src), "ac\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStrCharAtLoopIndex pins indexing inside a while
+// loop. The induction variable is an i64 and the printed value is
+// the corresponding single-rune string; this verifies the V's
+// OpStrCharAt argument typing through the lowering's TypeStr arm
+// guard. Walks the full "hello" string one rune per iteration so
+// the runtime helper's UTF-8 walk loop is exercised five times.
+func TestBuildSourceStrCharAtLoopIndex(t *testing.T) {
+	src := `let s = "hello"
+var i = 0
+while i < len(s) {
+  print(s[i])
+  i = i + 1
+}
+`
+	if got, want := runMochiBuild(t, src), "h\ne\nl\nl\no\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceRejectsImportGo pins the by-design rejection of
 // general Go FFI in the C target. The script `import go "testpkg"`
 // must surface ErrUnsupportedFFI (wrapped) at build time, not

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -111,7 +111,7 @@ func Emit(p *Program) ([]byte, error) {
 				usesTree = true
 			case ir.OpLenStr, ir.OpCmpEqStr, ir.OpCmpNeStr:
 				usesStrH = true
-			case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr:
+			case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpStrCharAt:
 				usesStrRuntime = true
 			case ir.OpNow:
 				usesNow = true
@@ -517,6 +517,12 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		// allocation. The literal type matches every other Phase 4.2.x
 		// string carrier so downstream concat/print/len/strcmp work.
 		fmt.Fprintf(w, "    %s = mochi_str_from_bool(%s);\n", name, valueName(v.Args[0]))
+	case ir.OpStrCharAt:
+		// `s[i]` on TypeStr. The runtime helper walks the UTF-8 byte
+		// sequence to the i-th rune and returns a freshly-allocated
+		// NUL-terminated single-rune string. Matches the VM's
+		// `string([]rune(s)[i])` semantics on the v0.5 fixture corpus.
+		fmt.Fprintf(w, "    %s = mochi_str_char_at(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpNow:
 		fmt.Fprintf(w, "    %s = mochi_now_us();\n", name)
 	case ir.OpJsonI64Object:

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -321,6 +321,14 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 	case ir.OpBoolToStr:
 		imports["strconv"] = true
 		fmt.Fprintf(w, "\t%s = strconv.FormatBool(%s)\n", name, valueName(v.Args[0]))
+	case ir.OpStrCharAt:
+		// `s[i]` returns the i-th rune as a single-rune string, matching
+		// the VM's `string([]rune(s)[i])` lowering. Plain byte-indexing
+		// `string(s[i])` would diverge from the VM on non-ASCII input
+		// (it produces a single byte, not a rune). The runes slice is
+		// computed per call; the IR pre-evaluates the index so no extra
+		// SSA shape is needed.
+		fmt.Fprintf(w, "\t%s = string([]rune(%s)[%s])\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
 	case ir.OpNewList:
 		fmt.Fprintf(w, "\t%s = []int64{}\n", name)
 	case ir.OpListLenI64:

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1890,7 +1890,7 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 				return 0, fmt.Errorf("frontend: slice indexing unsupported in MVP")
 			}
 			curType := b.fn.Values[cur].Type
-			if curType != ir.TypeList && curType != ir.TypeF64Arr && curType != ir.TypeStrArr && curType != ir.TypeMap && curType != ir.TypeMapStrI64 && curType != ir.TypeListAny && curType != ir.TypeListList {
+			if curType != ir.TypeList && curType != ir.TypeF64Arr && curType != ir.TypeStrArr && curType != ir.TypeMap && curType != ir.TypeMapStrI64 && curType != ir.TypeListAny && curType != ir.TypeListList && curType != ir.TypeStr {
 				return 0, fmt.Errorf("frontend: index on non-list %s", curType)
 			}
 			iID, err := b.lowerExpr(idx.Start)
@@ -1900,6 +1900,10 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 			if curType == ir.TypeMapStrI64 {
 				if b.fn.Values[iID].Type != ir.TypeStr {
 					return 0, fmt.Errorf("frontend: map<str, i64> key must be str, got %s", b.fn.Values[iID].Type)
+				}
+			} else if curType == ir.TypeStr {
+				if b.fn.Values[iID].Type != ir.TypeI64 {
+					return 0, fmt.Errorf("frontend: string index must be i64, got %s", b.fn.Values[iID].Type)
 				}
 			} else if b.fn.Values[iID].Type != ir.TypeI64 {
 				return 0, fmt.Errorf("frontend: list index must be i64, got %s", b.fn.Values[iID].Type)
@@ -1983,6 +1987,18 @@ func (b *builder) lowerPostfix(pe *parser.PostfixExpr) (uint32, error) {
 					ElemType: ir.TypeI64,
 					Op:       ir.OpListListGet,
 					Args:     []uint32{cur, iID},
+				})
+			case ir.TypeStr:
+				// Phase 4.2.27: `s[i]` on TypeStr returns a single-rune
+				// string. Result Type is TypeStr (HandleType,
+				// Constructor under rule A; the runtime helper
+				// mochi_str_char_at allocates a fresh NUL-terminated
+				// buffer). Mochi has no char type; `s[i]` and
+				// `for ch in s` both produce TypeStr scalars.
+				cur = b.addValue(ir.Value{
+					Type: ir.TypeStr,
+					Op:   ir.OpStrCharAt,
+					Args: []uint32{cur, iID},
 				})
 			}
 		case op.Cast != nil:

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -170,6 +170,16 @@ const (
 	OpF64ToStr
 	OpBoolToStr
 
+	// OpStrCharAt returns a freshly-allocated single-rune string from
+	// the i-th rune of a UTF-8 source. Backs `s[i]` on TypeStr (MEP-42
+	// Phase 4.2.27). Result Type is TypeStr; classified Constructor
+	// under rule A because TypeStr is HandleType and the returned
+	// pointer is a fresh allocation owned by the runtime (currently
+	// leaked). Index is rune-based, matching the Mochi VM's
+	// `[]rune(s)[i]` lowering. OOB is unchecked, matching the
+	// existing C-target list-get pattern.
+	OpStrCharAt
+
 	// Bool comparisons (MEP-42 Phase 4.2.7). Result Type == TypeBool.
 	// Bool values are int-sized in both targets, so the C emit lowers
 	// to plain `==` / `!=` and the Go emit to the same. Distinct ops
@@ -493,6 +503,8 @@ func (o OpCode) String() string {
 		return "f64.to.str"
 	case OpBoolToStr:
 		return "bool.to.str"
+	case OpStrCharAt:
+		return "str.charat"
 	case OpCmpEqBool:
 		return "cmp.eq.bool"
 	case OpCmpNeBool:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -183,6 +183,8 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeStr, [3]Type{TypeF64}}
 	case OpBoolToStr:
 		return opSig{TypeStr, [3]Type{TypeBool}}
+	case OpStrCharAt:
+		return opSig{TypeStr, [3]Type{TypeStr, TypeI64}}
 	case OpCmpEqBool, OpCmpNeBool:
 		return opSig{TypeBool, [3]Type{TypeBool, TypeBool}}
 	case OpAndBool, OpOrBool:

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -168,7 +168,7 @@ func kindOf(o ir.OpCode) ProducerKind {
 
 	case ir.OpLenStr:
 		return KindDispatch
-	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpListI64ToStr, ir.OpF64ArrayToStr, ir.OpStrArrToStr:
+	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpListI64ToStr, ir.OpF64ArrayToStr, ir.OpStrArrToStr, ir.OpStrCharAt:
 		return KindConstructor
 
 	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array, ir.OpNewStrArr, ir.OpNewMapStrI64, ir.OpNewListAny,
@@ -418,7 +418,7 @@ func contractResult(o ir.OpCode) ir.Type {
 		return ir.TypeBool
 	case ir.OpLenStr:
 		return ir.TypeI64
-	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr:
+	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpStrCharAt:
 		return ir.TypeStr
 	case ir.OpNewList:
 		return ir.TypeList

--- a/runtime/c/src/mochi_str.c
+++ b/runtime/c/src/mochi_str.c
@@ -177,3 +177,45 @@ const char *mochi_str_from_bool(int v) {
      */
     return v ? "true" : "false";
 }
+
+static int mochi_str_utf8_width(unsigned char c) {
+    /*
+     * UTF-8 leading-byte rules. Continuation bytes (10xxxxxx) and
+     * malformed leaders fall through to width 1 so a malformed
+     * sequence does not loop forever; it advances byte-by-byte
+     * instead. The v0.5 fixture corpus is ASCII so this branch
+     * runs the 1-byte arm exclusively in practice.
+     */
+    if ((c & 0x80) == 0x00) return 1;
+    if ((c & 0xE0) == 0xC0) return 2;
+    if ((c & 0xF0) == 0xE0) return 3;
+    if ((c & 0xF8) == 0xF0) return 4;
+    return 1;
+}
+
+const char *mochi_str_char_at(const char *s, int64_t i) {
+    /*
+     * Walk the UTF-8 byte sequence to the i-th rune, then copy the
+     * leader plus its continuation bytes into a freshly allocated
+     * NUL-terminated buffer. Matches the VM's `string([]rune(s)[i])`.
+     * Bounds are not checked (matches the C-target list-get
+     * convention); past-end indices land on the NUL terminator and
+     * return an allocation holding "".
+     */
+    const char *p = s;
+    int64_t cur = 0;
+    while (*p != '\0' && cur < i) {
+        p += mochi_str_utf8_width((unsigned char)*p);
+        cur++;
+    }
+    int n = (*p == '\0') ? 0 : mochi_str_utf8_width((unsigned char)*p);
+    char *out = (char *)malloc((size_t)n + 1);
+    if (out == NULL) {
+        abort();
+    }
+    if (n > 0) {
+        memcpy(out, p, (size_t)n);
+    }
+    out[n] = '\0';
+    return out;
+}

--- a/runtime/c/src/mochi_str.h
+++ b/runtime/c/src/mochi_str.h
@@ -23,6 +23,8 @@
 #ifndef MOCHI_RUNTIME_C_STR_H
 #define MOCHI_RUNTIME_C_STR_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -52,6 +54,25 @@ const char *mochi_str_concat(const char *a, const char *b);
 const char *mochi_str_from_i64(long long v);
 const char *mochi_str_from_f64(double v);
 const char *mochi_str_from_bool(int v);
+
+/*
+ * mochi_str_char_at returns a freshly allocated NUL-terminated
+ * single-rune string holding the i-th rune of s. UTF-8 decoded: a
+ * byte 0xxxxxxx is 1 byte, 110xxxxx + 1 continuation is 2 bytes,
+ * 1110xxxx + 2 continuations is 3 bytes, 11110xxx + 3 continuations
+ * is 4 bytes. This matches the Mochi VM's `string([]rune(s)[i])`
+ * lowering so the C target byte-matches `mochi run` for non-ASCII
+ * inputs too.
+ *
+ * Bounds are not checked: `i` past the end of the string walks to
+ * the NUL terminator and returns a copy of the empty string. The
+ * caller is responsible for staying in range (matches the existing
+ * mochi_list_i64_get convention on the C target).
+ *
+ * The returned buffer is owned by the runtime (leaked at process
+ * exit; see the ownership note above).
+ */
+const char *mochi_str_char_at(const char *s, int64_t i);
 
 /*
  * mochi_f64_format writes the shortest decimal representation of v

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,37 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.54 Phase 4.2.27 closeout (LANDED 2026-05-22 15:14 GMT+7)
+
+Phase 4.2.27 lights up `s[i]` on TypeStr through the C target. Before this phase, the frontend's `lowerPostfix` index branch rejected anything that wasn't TypeList, TypeF64Arr, TypeStrArr, TypeMap, TypeMapStrI64, TypeListAny, or TypeListList; a Mochi source like `print("hello"[0])` died at lower time with "index on non-list str". The VM lowering for the same expression is `string([]rune(s)[i])` (rune-based, not byte-based), so the C target's runtime helper walks the UTF-8 byte sequence to the i-th rune leader and copies its leader + continuation bytes into a freshly allocated NUL-terminated buffer. ASCII input (the entire v0.5 fixture corpus) collapses to the 1-byte arm.
+
+### Diff shape
+
+- `compiler3/ir/types.go`: new `OpStrCharAt` op with `String() == "str.charat"`. Result Type is TypeStr; classified Constructor under verifier rule A because TypeStr is HandleType and the helper returns a fresh allocation.
+- `compiler3/ir/validate.go`: contract `opSig{TypeStr, [3]Type{TypeStr, TypeI64}}` so `Validate` enforces argument shape.
+- `compiler3/verify/verify.go`: joined `OpStrCharAt` to the Constructor list (`kindOf`) and the contract-result table (`contractResult`).
+- `compiler3/emit/c/emit.go`: trigger `usesStrRuntime` on OpStrCharAt (so `mochi_str.h` gets included) and emit `name = mochi_str_char_at(s, i);`.
+- `compiler3/emit/go/emit.go`: emit `name = string([]rune(s)[i])` so the Go target byte-matches the VM and the C target.
+- `runtime/c/src/mochi_str.h`: add `#include <stdint.h>`; declare `const char *mochi_str_char_at(const char *s, int64_t i);`.
+- `runtime/c/src/mochi_str.c`: add static `mochi_str_utf8_width(unsigned char)` helper (UTF-8 leading-byte width: 1/2/3/4 by prefix, falling through to 1 for continuation bytes or malformed leaders) and `mochi_str_char_at` that walks the byte sequence to the i-th rune leader and allocates a fresh single-rune string.
+- `compiler3/frontend/lower.go`: relax the index rejection check to admit TypeStr; require the index to be i64 (parallel to the list arm); add a `case ir.TypeStr` to the get-op switch that emits OpStrCharAt.
+- `compiler3/build/c/driver_test.go`: three new pins.
+  - `TestBuildSourceStrCharAtBasic` covers literal indexing twice, `s[0]` and `s[4]` on `"hello"`.
+  - `TestBuildSourceStrCharAtConcat` covers HandleType liveness: the result of `s[0]` is fed straight into `+` (OpConcatStr).
+  - `TestBuildSourceStrCharAtLoopIndex` covers indexing under a dynamic i64 induction variable (while-loop walking the full string one rune per iteration).
+
+### Why this closes a goal
+
+The v0.5/string.mochi fixture's first three lines (`let s = "hello world"`, `print("s[0] =", s[0])`, `print("s[4] =", s[4])`) now build on the C target. The remainder of v0.5/string.mochi (`for ch in s` and `"x" in s`) still needs separate phases (rune iteration and substring containment); Phase 4.2.28 / 4.2.29 will tackle those in turn. The v0.5/string-index-iterator.mochi fixture has the same shape and is unblocked at the same point. More broadly, string indexing is the load-bearing primitive that every later string-handling fixture (text search, parser-style loops, ASCII transforms) needs, so this phase unlocks the runway for the rest of the string surface even before the iteration / containment ops land.
+
+### Limitations
+
+- OOB is unchecked. Past-end indices walk to the NUL terminator and return an allocation holding `""`. This matches the existing C-target list-get convention; a future hardening phase can add a runtime wrap helper if a fixture motivates it.
+- Negative indices on strings are not supported. The Phase 4.2.24 constant-fold for negative list indices is the same trick that would apply here, but no v0.5/v0.6 fixture exercises a negative string index today.
+- Slicing (`s[1:3]`) remains rejected by the same `idx.Colon != nil` branch that gates list slicing. Strings would route through a separate `mochi_str_slice` helper; deferred until a fixture surfaces.
+- The Go emit currently rebuilds `[]rune(s)` on every index. That's quadratic on a tight loop. The VM does the same so this matches `mochi run` byte for byte; a per-loop hoist would be an optimiser pass, not a Phase 4.2.x correctness gate.
+- The runtime helper allocates per call and never frees. Identical to the existing concat / i64-to-str / f64-to-str carriers; the process-exit leak is documented in `mochi_str.h`.
+
 ## §10.53 Phase 4.2.26 closeout (LANDED 2026-05-22 15:02 GMT+7)
 
 Phase 4.2.26 fixes a long-standing link-time failure on declaration-only and commented-out Mochi sources. Before this phase, `mochi build --target=c examples/v0.1/stream.mochi` (entirely block-commented) and `examples/v0.6/extern.mochi` (only `extern` declarations) failed at `cc` with `Undefined symbols: _main`. The frontend lowered the empty program to a Program with zero Funcs, the emitter then skipped `int main(void)` because `p.Main == ""`, and the resulting object had no entry point.


### PR DESCRIPTION
## Summary

- New `OpStrCharAt` op + `mochi_str_char_at` runtime helper light up `s[i]` on TypeStr through the C target.
- UTF-8 rune-based (walks leader + continuations); matches the VM's `string([]rune(s)[i])` lowering so the C target byte-matches `mochi run` on non-ASCII input.
- Go emit mirrors the same rune-based form; three new fixture pins (literal index, index + concat, while-loop indexing).

Tracking issue: #22047. MEP-42 §10.54 closeout in the same PR.

## Test plan

- [x] `go test ./compiler3/ir/... ./compiler3/verify/... ./compiler3/frontend/... -count=1`
- [x] `go test ./compiler3/emit/... -count=1`
- [x] `go test ./compiler3/build/c/... -run TestBuildSourceStrCharAt -count=1 -v`
- [x] `go test ./compiler3/build/... -count=1`
- [x] All three new fixture tests pass on a host with cc available.