### PR TITLE
mep-0042: Phase 4.2.28 `in` operator on TypeStr (C target)

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -3041,6 +3041,45 @@ while i < len(s) {
 	}
 }
 
+// TestBuildSourceStrInBasic pins the Phase 4.2.28 `in` operator on
+// TypeStr: `needle in haystack` lowers to OpStrIn which the C target
+// emits as strstr(haystack, needle) != NULL. The fixture covers both
+// arms: "w" is in "hello world", "z" is not.
+func TestBuildSourceStrInBasic(t *testing.T) {
+	src := `let s = "hello world"
+if "w" in s {
+  print("yes")
+}
+if "z" in s {
+  print("nope")
+} else {
+  print("no")
+}
+`
+	if got, want := runMochiBuild(t, src), "yes\nno\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStrInSubstring pins multi-byte needle matches. The
+// strstr probe must match an arbitrary contiguous substring, not
+// just single characters; "ell" appears at offset 1 of "hello".
+func TestBuildSourceStrInSubstring(t *testing.T) {
+	src := `let s = "hello"
+if "ell" in s {
+  print("ok")
+}
+if "lle" in s {
+  print("ordered")
+} else {
+  print("unordered match would be wrong")
+}
+`
+	if got, want := runMochiBuild(t, src), "ok\nunordered match would be wrong\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceRejectsImportGo pins the by-design rejection of
 // general Go FFI in the C target. The script `import go "testpkg"`
 // must surface ErrUnsupportedFFI (wrapped) at build time, not

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -109,7 +109,7 @@ func Emit(p *Program) ([]byte, error) {
 				usesListI64 = true
 			case ir.OpNewListAny, ir.OpListAnyLen, ir.OpListAnyPushAny, ir.OpListAnyGetAny:
 				usesTree = true
-			case ir.OpLenStr, ir.OpCmpEqStr, ir.OpCmpNeStr:
+			case ir.OpLenStr, ir.OpCmpEqStr, ir.OpCmpNeStr, ir.OpStrIn:
 				usesStrH = true
 			case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpStrCharAt:
 				usesStrRuntime = true
@@ -523,6 +523,13 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		// NUL-terminated single-rune string. Matches the VM's
 		// `string([]rune(s)[i])` semantics on the v0.5 fixture corpus.
 		fmt.Fprintf(w, "    %s = mochi_str_char_at(%s, %s);\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpStrIn:
+		// `needle in haystack`. strstr returns the first occurrence of
+		// the needle's byte sequence inside the haystack, or NULL when
+		// the needle is absent. The empty needle is a substring of
+		// every haystack (strstr returns the haystack itself); this
+		// matches Go's strings.Contains so the VM and C target agree.
+		fmt.Fprintf(w, "    %s = (strstr(%s, %s) != NULL);\n", name, valueName(v.Args[1]), valueName(v.Args[0]))
 	case ir.OpNow:
 		fmt.Fprintf(w, "    %s = mochi_now_us();\n", name)
 	case ir.OpJsonI64Object:

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -329,6 +329,13 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 		// computed per call; the IR pre-evaluates the index so no extra
 		// SSA shape is needed.
 		fmt.Fprintf(w, "\t%s = string([]rune(%s)[%s])\n", name, valueName(v.Args[0]), valueName(v.Args[1]))
+	case ir.OpStrIn:
+		// `needle in haystack`. Args[0] is the needle, Args[1] the
+		// haystack (surface order). strings.Contains is byte-wise
+		// (substring search on the underlying byte slice), matching
+		// strstr on the C side so the two targets agree.
+		imports["strings"] = true
+		fmt.Fprintf(w, "\t%s = strings.Contains(%s, %s)\n", name, valueName(v.Args[1]), valueName(v.Args[0]))
 	case ir.OpNewList:
 		fmt.Fprintf(w, "\t%s = []int64{}\n", name)
 	case ir.OpListLenI64:

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1743,6 +1743,12 @@ func (b *builder) applyBinOp(op string, l, r uint32) (uint32, error) {
 		case "!=":
 			code = ir.OpCmpNeStr
 			resType = ir.TypeBool
+		case "in":
+			// Phase 4.2.28: `needle in haystack` substring search. l is
+			// the needle, r the haystack (Args[0]=l, Args[1]=r is the
+			// shape applyBinOp passes to addValue below).
+			code = ir.OpStrIn
+			resType = ir.TypeBool
 		default:
 			return 0, fmt.Errorf("frontend: operator %q on str unsupported in MVP", op)
 		}

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -180,6 +180,16 @@ const (
 	// existing C-target list-get pattern.
 	OpStrCharAt
 
+	// OpStrIn backs `needle in haystack` on TypeStr (MEP-42 Phase
+	// 4.2.28): true when the needle's byte sequence appears as a
+	// contiguous substring of the haystack. Args[0] is the needle,
+	// Args[1] the haystack -- the surface-order convention from
+	// `lower.go applyBinOp(op, l, r)`, where l is the LHS of `in`
+	// (the needle) and r is the RHS (the haystack). Result Type is
+	// TypeBool; classified Dispatch under the verifier (no
+	// allocation, just a strstr probe).
+	OpStrIn
+
 	// Bool comparisons (MEP-42 Phase 4.2.7). Result Type == TypeBool.
 	// Bool values are int-sized in both targets, so the C emit lowers
 	// to plain `==` / `!=` and the Go emit to the same. Distinct ops
@@ -505,6 +515,8 @@ func (o OpCode) String() string {
 		return "bool.to.str"
 	case OpStrCharAt:
 		return "str.charat"
+	case OpStrIn:
+		return "str.in"
 	case OpCmpEqBool:
 		return "cmp.eq.bool"
 	case OpCmpNeBool:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -185,6 +185,8 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeStr, [3]Type{TypeBool}}
 	case OpStrCharAt:
 		return opSig{TypeStr, [3]Type{TypeStr, TypeI64}}
+	case OpStrIn:
+		return opSig{TypeBool, [3]Type{TypeStr, TypeStr}}
 	case OpCmpEqBool, OpCmpNeBool:
 		return opSig{TypeBool, [3]Type{TypeBool, TypeBool}}
 	case OpAndBool, OpOrBool:

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -166,7 +166,7 @@ func kindOf(o ir.OpCode) ProducerKind {
 		ir.OpJsonI64Object:
 		return KindOperator
 
-	case ir.OpLenStr:
+	case ir.OpLenStr, ir.OpStrIn:
 		return KindDispatch
 	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpListI64ToStr, ir.OpF64ArrayToStr, ir.OpStrArrToStr, ir.OpStrCharAt:
 		return KindConstructor
@@ -414,7 +414,8 @@ func contractResult(o ir.OpCode) ir.Type {
 		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm,
 		ir.OpCmpEqStr, ir.OpCmpNeStr,
 		ir.OpCmpEqBool, ir.OpCmpNeBool,
-		ir.OpAndBool, ir.OpOrBool:
+		ir.OpAndBool, ir.OpOrBool,
+		ir.OpStrIn:
 		return ir.TypeBool
 	case ir.OpLenStr:
 		return ir.TypeI64
@@ -525,6 +526,7 @@ func opIsMutating(o ir.OpCode) bool {
 // enumerate both halves of the dispatch op set.
 var readDispatchOps = []ir.OpCode{
 	ir.OpLenStr,
+	ir.OpStrIn,
 	ir.OpListLenI64,
 	ir.OpListGetI64,
 	ir.OpListGetF64,

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,35 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.55 Phase 4.2.28 closeout (LANDED 2026-05-22 15:23 GMT+7)
+
+Phase 4.2.28 lights up the `in` operator on TypeStr through the C target. Before this phase, the frontend's `applyBinOp` TypeStr arm only knew `+`, `==`, and `!=`; a source like `if "w" in s { ... }` died at lower time with `frontend: operator "in" on str unsupported in MVP`. The `in` token was already in the precedence table, so the parse path was fine; only the IR-level binop dispatch was missing.
+
+The new op `OpStrIn` takes (needle, haystack) and returns TypeBool. C target emits `(strstr(haystack, needle) != NULL)` (strstr is in `<string.h>`, already wired through `usesStrH`). Go target emits `strings.Contains(haystack, needle)`. Both probes are byte-wise so the two targets agree byte for byte with the VM.
+
+### Diff shape
+
+- `compiler3/ir/types.go`: new `OpStrIn` op with `String() == "str.in"`. Result Type is TypeBool; classified Dispatch (read-only, no allocation).
+- `compiler3/ir/validate.go`: contract `opSig{TypeBool, [3]Type{TypeStr, TypeStr}}`.
+- `compiler3/verify/verify.go`: joined `OpStrIn` to the Dispatch arm of `kindOf`, added it to `readDispatchOps` (rule E coverage), and joined it to the TypeBool result list in `contractResult`.
+- `compiler3/emit/c/emit.go`: trigger `usesStrH` on `OpStrIn` and emit `name = (strstr(haystack, needle) != NULL);`.
+- `compiler3/emit/go/emit.go`: import `strings` and emit `name = strings.Contains(haystack, needle)`.
+- `compiler3/frontend/lower.go`: added `case "in"` to the TypeStr arm of `applyBinOp`, setting `code = OpStrIn` and `resType = TypeBool`. The l/r argument order from `applyBinOp(op, l, r)` lines up with the op contract directly (Args[0]=needle=l, Args[1]=haystack=r).
+- `compiler3/build/c/driver_test.go`: two new pins.
+  - `TestBuildSourceStrInBasic` covers both arms: a positive `if "w" in s` and a negative `if "z" in s` (else branch).
+  - `TestBuildSourceStrInSubstring` covers multi-byte needles. "ell" appears at offset 1 of "hello"; the reversed "lle" does not. This catches a buggy implementation that only checks for single-character containment.
+
+### Why this closes a goal
+
+The v0.5/string.mochi fixture has two `in` lines (`if "w" in s` and `if "z" in s`) that previously rejected at lower time; both now build on the C target. The same gate also unblocks the inner `if ch in vowels` line of the rune-iteration loop, so once Phase 4.2.29 lands the rune iterator, the full fixture pins end to end. More broadly, substring containment is the load-bearing primitive for every later text-processing fixture (lexers, simple template engines, log filtering).
+
+### Limitations
+
+- TypeMapStrI64 still rejects `k in m` at the same `applyBinOp` site. Maps are a separate phase: the runtime probe is `mochi_map_str_i64_has(m, k)` rather than `strstr`, and the op classification is the same (Dispatch, read-only) but the contract is `[3]Type{TypeStr, TypeMapStrI64}`. Deferred until a fixture motivates it.
+- TypeList / TypeF64Arr / TypeStrArr `x in xs` containment is also unsupported (linear scan over the array). No v0.5 fixture exercises this today.
+- The empty-needle case (`"" in haystack`) returns true on both targets (strstr returns the haystack pointer; strings.Contains returns true). This matches the VM and is by design but is worth flagging in case a future fixture relies on `""` being absent (it never will be).
+- Substring search is byte-wise. For multi-byte UTF-8 needles that share a leading byte with a non-needle multi-byte rune, the strstr probe still produces the right answer because UTF-8 is self-synchronising (any byte that could start a continuation cannot be a leading byte of a different rune). No special handling needed.
+
 ## §10.54 Phase 4.2.27 closeout (LANDED 2026-05-22 15:14 GMT+7)
 
 Phase 4.2.27 lights up `s[i]` on TypeStr through the C target. Before this phase, the frontend's `lowerPostfix` index branch rejected anything that wasn't TypeList, TypeF64Arr, TypeStrArr, TypeMap, TypeMapStrI64, TypeListAny, or TypeListList; a Mochi source like `print("hello"[0])` died at lower time with "index on non-list str". The VM lowering for the same expression is `string([]rune(s)[i])` (rune-based, not byte-based), so the C target's runtime helper walks the UTF-8 byte sequence to the i-th rune leader and copies its leader + continuation bytes into a freshly allocated NUL-terminated buffer. ASCII input (the entire v0.5 fixture corpus) collapses to the 1-byte arm.


### PR DESCRIPTION
## Summary

- New `OpStrIn` op (Dispatch, read-only) lights up `needle in haystack` substring containment on TypeStr through the C target.
- C emits `(strstr(haystack, needle) != NULL)`; Go emits `strings.Contains(haystack, needle)`. Both probes are byte-wise so the two targets agree with the VM.
- Two new fixture pins (positive + negative arm, multi-byte substring).

Tracking issue: #22049. MEP-42 §10.55 closeout in the same PR.

## Test plan

- [x] `go test ./compiler3/ir/... ./compiler3/verify/... ./compiler3/frontend/... ./compiler3/emit/... -count=1`
- [x] `go test ./compiler3/build/c/... -run TestBuildSourceStrIn -count=1 -v`
- [x] `go test ./compiler3/build/... -count=1`
- [x] Smoke test on /tmp fixtures: positive match, negative match, multi-byte needle, all byte-match VM output.