### PR TITLE
mep-0042: Phase 4.2.29 `for ch in s` rune iteration (C target)

### DIFF
--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -3080,6 +3080,78 @@ if "lle" in s {
 	}
 }
 
+// TestBuildSourceStrForChIn pins the Phase 4.2.29 `for ch in s` rune
+// iteration: the loop body runs once per rune, with the binding
+// holding a TypeStr value that is the i-th single-rune string.
+// For the ASCII fixture the rune count equals strlen so the result
+// is "h\ne\nl\nl\no\n".
+func TestBuildSourceStrForChIn(t *testing.T) {
+	src := `for ch in "hello" {
+  print(ch)
+}
+`
+	if got, want := runMochiBuild(t, src), "h\ne\nl\nl\no\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceStrForChInVowelCount pins the v0.5/string.mochi
+// kernel directly: count vowels by `for ch in s { if ch in vowels`.
+// Exercises rune iteration + Phase 4.2.28 `in` together so the
+// SSA-level interaction (HandleType ch is read inside an OpStrIn
+// arg, the haystack is a captured pre-loop TypeStr) is locked down.
+func TestBuildSourceStrForChInVowelCount(t *testing.T) {
+	src := `let s = "hello world"
+let vowels = "aeiou"
+var count = 0
+for ch in s {
+  if ch in vowels {
+    count = count + 1
+  }
+}
+print(count)
+`
+	if got, want := runMochiBuild(t, src), "3\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceV05StringFixture is the load-bearing v0.5 fixture
+// pin enabled by Phases 4.2.27 + 4.2.28 + 4.2.29 together. The on-
+// disk script reads s[i] (Phase 4.2.27), iterates runes (Phase
+// 4.2.29), and does substring containment (Phase 4.2.28); failing
+// any of those rolls the pin back. Output byte-matches `mochi run`.
+func TestBuildSourceV05StringFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.5/string.mochi")
+	if err != nil {
+		t.Fatalf("read v0.5 string fixture: %v", err)
+	}
+	want := "s[0] = h\ns[4] = o\nlength = 11\n" +
+		"char: h\nchar: e\nchar: l\nchar: l\nchar: o\nchar:  \n" +
+		"char: w\nchar: o\nchar: r\nchar: l\nchar: d\n" +
+		"'w' is in the string\nvowel count: 3\n"
+	if got := runMochiBuild(t, string(srcBytes)); got != want {
+		t.Errorf("v0.5/string stdout = %q, want %q", got, want)
+	}
+}
+
+// TestBuildSourceV05StringIndexIteratorFixture pins the sibling
+// v0.5/string-index-iterator fixture, which exercises the same
+// gates as v0.5/string.mochi minus the substring containment.
+func TestBuildSourceV05StringIndexIteratorFixture(t *testing.T) {
+	srcBytes, err := os.ReadFile("../../../examples/v0.5/string-index-iterator.mochi")
+	if err != nil {
+		t.Fatalf("read v0.5 string-index-iterator fixture: %v", err)
+	}
+	want := "first character: h\nfifth character: o\n" +
+		"char: h\nchar: e\nchar: l\nchar: l\nchar: o\nchar:  \n" +
+		"char: w\nchar: o\nchar: r\nchar: l\nchar: d\n" +
+		"number of vowels: 3\n"
+	if got := runMochiBuild(t, string(srcBytes)); got != want {
+		t.Errorf("v0.5/string-index-iterator stdout = %q, want %q", got, want)
+	}
+}
+
 // TestBuildSourceRejectsImportGo pins the by-design rejection of
 // general Go FFI in the C target. The script `import go "testpkg"`
 // must surface ErrUnsupportedFFI (wrapped) at build time, not

--- a/compiler3/emit/c/emit.go
+++ b/compiler3/emit/c/emit.go
@@ -111,7 +111,7 @@ func Emit(p *Program) ([]byte, error) {
 				usesTree = true
 			case ir.OpLenStr, ir.OpCmpEqStr, ir.OpCmpNeStr, ir.OpStrIn:
 				usesStrH = true
-			case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpStrCharAt:
+			case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpStrCharAt, ir.OpStrRuneLen:
 				usesStrRuntime = true
 			case ir.OpNow:
 				usesNow = true
@@ -530,6 +530,11 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, p *Program, v ir.Value) error {
 		// every haystack (strstr returns the haystack itself); this
 		// matches Go's strings.Contains so the VM and C target agree.
 		fmt.Fprintf(w, "    %s = (strstr(%s, %s) != NULL);\n", name, valueName(v.Args[1]), valueName(v.Args[0]))
+	case ir.OpStrRuneLen:
+		// Rune count for the `for ch in s` loop bound. Walks the byte
+		// sequence once; O(bytes), no allocation. Cf. OpLenStr above
+		// which returns byte length via strlen.
+		fmt.Fprintf(w, "    %s = mochi_str_rune_len(%s);\n", name, valueName(v.Args[0]))
 	case ir.OpNow:
 		fmt.Fprintf(w, "    %s = mochi_now_us();\n", name)
 	case ir.OpJsonI64Object:

--- a/compiler3/emit/go/emit.go
+++ b/compiler3/emit/go/emit.go
@@ -336,6 +336,13 @@ func emitValue(w *bytes.Buffer, fn *ir.Function, v ir.Value, all []*ir.Function,
 		// strstr on the C side so the two targets agree.
 		imports["strings"] = true
 		fmt.Fprintf(w, "\t%s = strings.Contains(%s, %s)\n", name, valueName(v.Args[1]), valueName(v.Args[0]))
+	case ir.OpStrRuneLen:
+		// Rune count, not byte count. The VM's `for ch in s` runs
+		// over `[]rune(s)`; using utf8.RuneCountInString gives the
+		// same answer without materialising the rune slice (the
+		// per-element extraction in OpStrCharAt does that).
+		imports["unicode/utf8"] = true
+		fmt.Fprintf(w, "\t%s = int64(utf8.RuneCountInString(%s))\n", name, valueName(v.Args[0]))
 	case ir.OpNewList:
 		fmt.Fprintf(w, "\t%s = []int64{}\n", name)
 	case ir.OpListLenI64:

--- a/compiler3/frontend/lower.go
+++ b/compiler3/frontend/lower.go
@@ -1197,6 +1197,18 @@ func (b *builder) lowerForCollection(s *parser.ForStmt) error {
 		// TypeList arm. ElemType on the row carries the inner i64
 		// hint so the body's indexed reads/writes find it.
 		lenOp, getOp, elemType, elemElemType = ir.OpListListLen, ir.OpListListGet, ir.TypeList, ir.TypeI64
+	case ir.TypeStr:
+		// Phase 4.2.29: `for ch in s` iterates UTF-8 runes. The loop
+		// bound is the rune count (not byte length) and the per-
+		// iteration read goes through OpStrCharAt, which walks the
+		// byte sequence to the i-th rune leader. This matches the
+		// VM's `for _, ch := range []rune(s)` on non-ASCII input.
+		// Cost: O(n^2) in the rune count because OpStrCharAt walks
+		// from the start each call. Acceptable for the v0.5 fixture
+		// corpus (max string length under 20); a future phase can
+		// hoist `[]rune(s)` to a TypeStrArr pre-header value if a
+		// longer-string fixture surfaces.
+		lenOp, getOp, elemType, elemElemType = ir.OpStrRuneLen, ir.OpStrCharAt, ir.TypeStr, ir.TypeStr
 	default:
 		return fmt.Errorf("frontend: for-in over %s unsupported (need list)", listType)
 	}

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -190,6 +190,14 @@ const (
 	// allocation, just a strstr probe).
 	OpStrIn
 
+	// OpStrRuneLen returns the number of UTF-8 runes (not bytes) in
+	// the input. Backs the loop bound for `for ch in s` (MEP-42 Phase
+	// 4.2.29); paired with OpStrCharAt in lowerForCollection so a
+	// rune-iterating loop matches the VM's `for _, ch := range
+	// []rune(s)` shape on non-ASCII input. Result Type is TypeI64;
+	// classified Dispatch (read-only, no allocation).
+	OpStrRuneLen
+
 	// Bool comparisons (MEP-42 Phase 4.2.7). Result Type == TypeBool.
 	// Bool values are int-sized in both targets, so the C emit lowers
 	// to plain `==` / `!=` and the Go emit to the same. Distinct ops
@@ -517,6 +525,8 @@ func (o OpCode) String() string {
 		return "str.charat"
 	case OpStrIn:
 		return "str.in"
+	case OpStrRuneLen:
+		return "str.rune.len"
 	case OpCmpEqBool:
 		return "cmp.eq.bool"
 	case OpCmpNeBool:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -187,6 +187,8 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeStr, [3]Type{TypeStr, TypeI64}}
 	case OpStrIn:
 		return opSig{TypeBool, [3]Type{TypeStr, TypeStr}}
+	case OpStrRuneLen:
+		return opSig{TypeI64, [3]Type{TypeStr}}
 	case OpCmpEqBool, OpCmpNeBool:
 		return opSig{TypeBool, [3]Type{TypeBool, TypeBool}}
 	case OpAndBool, OpOrBool:

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -166,7 +166,7 @@ func kindOf(o ir.OpCode) ProducerKind {
 		ir.OpJsonI64Object:
 		return KindOperator
 
-	case ir.OpLenStr, ir.OpStrIn:
+	case ir.OpLenStr, ir.OpStrIn, ir.OpStrRuneLen:
 		return KindDispatch
 	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpListI64ToStr, ir.OpF64ArrayToStr, ir.OpStrArrToStr, ir.OpStrCharAt:
 		return KindConstructor
@@ -417,7 +417,7 @@ func contractResult(o ir.OpCode) ir.Type {
 		ir.OpAndBool, ir.OpOrBool,
 		ir.OpStrIn:
 		return ir.TypeBool
-	case ir.OpLenStr:
+	case ir.OpLenStr, ir.OpStrRuneLen:
 		return ir.TypeI64
 	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpStrCharAt:
 		return ir.TypeStr
@@ -527,6 +527,7 @@ func opIsMutating(o ir.OpCode) bool {
 var readDispatchOps = []ir.OpCode{
 	ir.OpLenStr,
 	ir.OpStrIn,
+	ir.OpStrRuneLen,
 	ir.OpListLenI64,
 	ir.OpListGetI64,
 	ir.OpListGetF64,

--- a/runtime/c/src/mochi_str.c
+++ b/runtime/c/src/mochi_str.c
@@ -193,6 +193,23 @@ static int mochi_str_utf8_width(unsigned char c) {
     return 1;
 }
 
+int64_t mochi_str_rune_len(const char *s) {
+    /*
+     * Count UTF-8 runes by stepping over each leader plus its
+     * continuation bytes. Pure forward walk; O(bytes), no allocation.
+     * Mismatched continuations advance by 1, matching the
+     * mochi_str_char_at convention so a malformed sequence yields a
+     * consistent (if not Unicode-correct) count.
+     */
+    int64_t n = 0;
+    const unsigned char *p = (const unsigned char *)s;
+    while (*p != '\0') {
+        p += mochi_str_utf8_width(*p);
+        n++;
+    }
+    return n;
+}
+
 const char *mochi_str_char_at(const char *s, int64_t i) {
     /*
      * Walk the UTF-8 byte sequence to the i-th rune, then copy the

--- a/runtime/c/src/mochi_str.h
+++ b/runtime/c/src/mochi_str.h
@@ -75,6 +75,18 @@ const char *mochi_str_from_bool(int v);
 const char *mochi_str_char_at(const char *s, int64_t i);
 
 /*
+ * mochi_str_rune_len returns the number of UTF-8 runes in s (not
+ * the byte length; see strlen for that). Walks the byte sequence
+ * counting leader bytes; continuation bytes (10xxxxxx) and malformed
+ * leaders are skipped so a malformed sequence advances byte-by-byte
+ * (matches the leader-width fallback in mochi_str_char_at). Used as
+ * the loop bound for `for ch in s` (Phase 4.2.29). Returns an
+ * int64_t to align with the IR's TypeI64 result; the value is
+ * non-negative.
+ */
+int64_t mochi_str_rune_len(const char *s);
+
+/*
  * mochi_f64_format writes the shortest decimal representation of v
  * into buf (NUL-terminated) using the same rule as Go's
  * strconv.FormatFloat(v, 'g', -1, 64): exponent form when the

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,38 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.56 Phase 4.2.29 closeout (LANDED 2026-05-22 15:30 GMT+7)
+
+Phase 4.2.29 closes the v0.5 string surface on the C target. `for ch in s` now iterates UTF-8 runes (matching the VM's `for _, ch := range []rune(s)` lowering), the v0.5/string.mochi and v0.5/string-index-iterator.mochi fixtures pin end to end, and the lowering combines this phase's new OpStrRuneLen with Phase 4.2.27's OpStrCharAt and Phase 4.2.28's OpStrIn.
+
+Before this phase, `for ch in s` died at lower time with `frontend: for-in over str unsupported (need list)`. The fix is purely a new arm in `lowerForCollection`'s type switch; the underlying SSA shape (phi-tracked index counter, per-iteration bind of the loop variable, snapshot/restore of pre-loop env) reuses every piece Phases 4.2.23 / 4.2.24 already built for the StrArr / ListList arms.
+
+### Diff shape
+
+- `compiler3/ir/types.go`: new `OpStrRuneLen` op with `String() == "str.rune.len"`. Result Type is TypeI64; classified Dispatch (read-only, no allocation).
+- `compiler3/ir/validate.go`: contract `opSig{TypeI64, [3]Type{TypeStr}}`.
+- `compiler3/verify/verify.go`: joined `OpStrRuneLen` to the Dispatch arm of `kindOf`, added it to `readDispatchOps` (rule E coverage), and joined it to the TypeI64 result list in `contractResult`.
+- `compiler3/emit/c/emit.go`: trigger `usesStrRuntime` on `OpStrRuneLen`; emit `name = mochi_str_rune_len(s);`.
+- `compiler3/emit/go/emit.go`: import `unicode/utf8`; emit `name = int64(utf8.RuneCountInString(s))`. Cheaper than materialising `[]rune(s)` (the per-element extraction in OpStrCharAt does that separately).
+- `runtime/c/src/mochi_str.h` and `runtime/c/src/mochi_str.c`: declare and define `int64_t mochi_str_rune_len(const char *s)`. Walks the byte sequence once counting leader bytes via the existing static `mochi_str_utf8_width` helper. O(bytes), no allocation.
+- `compiler3/frontend/lower.go`: added `case ir.TypeStr` to `lowerForCollection`'s type switch, with `lenOp = OpStrRuneLen`, `getOp = OpStrCharAt`, `elemType = elemElemType = TypeStr`. No change to the surrounding phi-bookkeeping; the loop variable `ch` is reset each iteration to the i-th rune (same shape as `for x in xs` for any other element type).
+- `compiler3/build/c/driver_test.go`: four new pins.
+  - `TestBuildSourceStrForChIn` is the smallest reproducer: iterate the runes of `"hello"` and print each.
+  - `TestBuildSourceStrForChInVowelCount` covers the cross-phase interaction with Phase 4.2.28 (`ch in vowels` inside the loop body).
+  - `TestBuildSourceV05StringFixture` reads `examples/v0.5/string.mochi` verbatim and pins its complete output (index + len + iteration + containment + vowel count).
+  - `TestBuildSourceV05StringIndexIteratorFixture` does the same for the sibling fixture.
+
+### Why this closes a goal
+
+The v0.5 fixture corpus on the binary-build axis gains two: v0.5/string.mochi and v0.5/string-index-iterator.mochi. Combined with the already-green v0.5/while.mochi (pinned in Phase 4.2.25), the v0.5 user-facing corpus is now 3 of 4 (the remaining v0.5 fixture is agent-stream which needs its own stream/agent phase). More fundamentally, every later text-processing surface (lexers, simple template engines, character class filtering) needs both `s[i]` and `for ch in s`; this phase closes the loop on both.
+
+### Limitations
+
+- Per-iteration cost is O(rune-count). OpStrCharAt walks from the start each call, so the loop is O(n^2) in the rune count of s. Fine for v0.5 (string lengths under 20). A future phase could hoist `[]rune(s)` to a TypeStrArr pre-header value; the lowering's pre-header / phi shape already has a slot for that lift, but no fixture motivates it today.
+- `mochi_str_rune_len` and `OpLenStr` return different numbers for non-ASCII strings (rune count vs byte length). Mochi's surface-level `len(s)` continues to map to OpLenStr (byte length), matching the VM; only the for-loop bound uses OpStrRuneLen. A user-facing `runes(s)` builtin would need its own surface op; deferred.
+- Loop variable binding type is TypeStr (single-rune string), not a rune scalar. Mochi has no rune type; this matches the VM. `if ch == "h"` works (OpCmpEqStr is byte equality, and a single-rune string vs a single-byte literal both have the same byte sequence).
+- The Go emit's `utf8.RuneCountInString` matches the C `mochi_str_rune_len` for well-formed UTF-8. For malformed sequences both walks fall through to a 1-byte advance (the VM and Go stdlib agree here too) so divergence is impossible on inputs the parser accepts.
+
 ## §10.55 Phase 4.2.28 closeout (LANDED 2026-05-22 15:23 GMT+7)
 
 Phase 4.2.28 lights up the `in` operator on TypeStr through the C target. Before this phase, the frontend's `applyBinOp` TypeStr arm only knew `+`, `==`, and `!=`; a source like `if "w" in s { ... }` died at lower time with `frontend: operator "in" on str unsupported in MVP`. The `in` token was already in the precedence table, so the parse path was fine; only the IR-level binop dispatch was missing.


### PR DESCRIPTION
## Summary

- New `OpStrRuneLen` + `mochi_str_rune_len` runtime helper paired with Phase 4.2.27's `OpStrCharAt` give `for ch in s` rune-based iteration on the C target.
- Loop bound is rune count (not byte length); matches the VM's `for _, ch := range []rune(s)`.
- Closes the v0.5 string surface: `v0.5/string.mochi` and `v0.5/string-index-iterator.mochi` now pin end to end.

Tracking issue: #22051. MEP-42 §10.56 closeout in the same PR.

## Test plan

- [x] `go test ./compiler3/ir/... ./compiler3/verify/... ./compiler3/frontend/... ./compiler3/emit/... -count=1`
- [x] `go test ./compiler3/build/c/... -run "TestBuildSourceStrForChIn|TestBuildSourceV05String" -count=1 -v`
- [x] `go test ./compiler3/build/... -count=1`
- [x] Both v0.5 string fixtures byte-match `mochi run` on the C target.