### PR TITLE
mep-0042: phase 4.2.30 -- data-driven op registry (ir.OpInfo)

### DIFF
--- a/compiler3/ir/optable.go
+++ b/compiler3/ir/optable.go
@@ -1,0 +1,194 @@
+// MEP-42 Phase 4.2.30: data-driven op registry.
+//
+// Before this phase, adding a new IR op required hand-touching ~10
+// places across 5 files: the iota declaration and String() case in
+// ir/types.go, the opContract switch in ir/validate.go, the kindOf
+// and contractResult switches in verify/verify.go, the
+// readDispatchOps / writeDispatchOps slices in verify/verify.go (for
+// Dispatch ops), the emit case in emit/c/emit.go, the emit case in
+// emit/go/emit.go, plus the genuinely op-specific frontend lowering
+// hook. The same metadata (Result type, Arg types) appeared in two
+// independent switches (opContract and contractResult); drift was
+// silent.
+//
+// This file collapses everything except the op-specific emit logic
+// and the frontend lowering into a single declarative table:
+// `opTable` lists one OpInfo entry per registered op, and the
+// downstream consumers (OpCode.String, opContract, verify.kindOf,
+// verify.contractResult, verify.readDispatchOps,
+// verify.writeDispatchOps) read from it. Adding a new op now means
+// adding one OpInfo literal, plus the emit cases that are genuinely
+// op-specific. The init-time consistency check in this file rejects
+// double-registration; the analogous check in verify rejects ops
+// whose Kind contradicts their dispatch classification.
+//
+// Migration is incremental: ops registered here override the legacy
+// switches in validate.go and verify/verify.go; ops not yet
+// registered fall through to those switches unchanged. New ops
+// should always go through this file, even when an analogous old
+// op still lives in a switch.
+package ir
+
+// OpKind classifies how a Value comes into existence. Mirror of
+// verify.ProducerKind, lifted to ir so the optable can carry the
+// classification alongside the Result/Args contract. verify.kindOf
+// maps these onto its public ProducerKind constants.
+type OpKind uint8
+
+const (
+	// KindUnclassified is the zero value. Ops with this Kind are
+	// either unregistered (the downstream verifier reads them from
+	// its legacy switch) or registered with an unset Kind field
+	// (a registry mistake the init-time check catches).
+	KindUnclassified OpKind = iota
+
+	// KindMove copies an existing Value without touching the arena
+	// tag or generation. Phi joins and OpParam land here.
+	KindMove
+
+	// KindInline produces an inline-encoded payload (small int,
+	// float, bool, inline-short string). OpConst is the only member.
+	KindInline
+
+	// KindConstructor invokes an alloc constructor that returns a
+	// fresh handle. Rule A: handle-typed Values must come from
+	// Constructor, Move, Inline, or Call.
+	KindConstructor
+
+	// KindOperator produces a non-handle Value (arithmetic, compare,
+	// length). Result type is never a HandleType.
+	KindOperator
+
+	// KindDispatch reads (or mutates) a heap-allocated arena via an
+	// existing handle. The op's first argument carries the arena
+	// tag the dispatch jumps into.
+	KindDispatch
+
+	// KindCall invokes a function (Mochi-internal or Go FFI). The
+	// callee is verified separately.
+	KindCall
+
+	// KindReserved is for ops the verifier intentionally treats as
+	// a black box at this Phase.
+	KindReserved
+)
+
+// OpInfo declares everything the IR / validator / verifier need to
+// know about an op aside from its emit shape and frontend hook.
+// Name backs OpCode.String(). Result + Args + NumArgs back
+// opContract (and verify.contractResult). Kind drives verify.kindOf.
+// Mutates is consulted only when Kind == KindDispatch; it routes
+// the op into readDispatchOps (false) or writeDispatchOps (true).
+type OpInfo struct {
+	// Code is the OpCode this entry describes; required.
+	Code OpCode
+	// Name is the short debug name returned by OpCode.String().
+	Name string
+	// Result is the Type of the produced Value. Use TypeUnit for
+	// statement-shaped ops. TypeInvalid (the zero value) signals
+	// no constraint (use sparingly; the verifier won't check the
+	// result type).
+	Result Type
+	// Args lists the expected operand Types in source-position order.
+	// Positions past NumArgs must be TypeInvalid.
+	Args [3]Type
+	// NumArgs is the count of declared argument positions. Distinct
+	// from a Type filter because some ops accept variadic Args
+	// (NumArgs=0 with the operand list interpreted per-op).
+	NumArgs int
+	// Kind drives verify.kindOf. KindUnclassified is rejected at
+	// init.
+	Kind OpKind
+	// Mutates is consulted only when Kind == KindDispatch; true
+	// places the op in writeDispatchOps, false in readDispatchOps.
+	// Ignored for other Kinds.
+	Mutates bool
+}
+
+// opTable is the declarative registry. Entries here are the source
+// of truth; the legacy switches in validate.go and verify/verify.go
+// fall through to it. To add a new op:
+//
+//  1. Declare the OpCode constant in types.go.
+//  2. Append an OpInfo literal here.
+//  3. Add the genuinely op-specific emit case in emit/c and emit/go
+//     (and frontend/lower.go for source-language plumbing).
+//
+// Three steps, not ten.
+var opTable = []OpInfo{
+	// String surface (MEP-42 Phase 4.2.x). Migrated here as the
+	// proof of the registry mechanism in Phase 4.2.30.
+	{Code: OpLenStr, Name: "len.str", Result: TypeI64, Args: [3]Type{TypeStr}, NumArgs: 1, Kind: KindDispatch, Mutates: false},
+	{Code: OpConcatStr, Name: "concat.str", Result: TypeStr, Args: [3]Type{TypeStr, TypeStr}, NumArgs: 2, Kind: KindConstructor},
+	{Code: OpCmpEqStr, Name: "cmp.eq.str", Result: TypeBool, Args: [3]Type{TypeStr, TypeStr}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpCmpNeStr, Name: "cmp.ne.str", Result: TypeBool, Args: [3]Type{TypeStr, TypeStr}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpI64ToStr, Name: "i64.to.str", Result: TypeStr, Args: [3]Type{TypeI64}, NumArgs: 1, Kind: KindConstructor},
+	{Code: OpF64ToStr, Name: "f64.to.str", Result: TypeStr, Args: [3]Type{TypeF64}, NumArgs: 1, Kind: KindConstructor},
+	{Code: OpBoolToStr, Name: "bool.to.str", Result: TypeStr, Args: [3]Type{TypeBool}, NumArgs: 1, Kind: KindConstructor},
+	{Code: OpStrCharAt, Name: "str.charat", Result: TypeStr, Args: [3]Type{TypeStr, TypeI64}, NumArgs: 2, Kind: KindConstructor},
+	{Code: OpStrIn, Name: "str.in", Result: TypeBool, Args: [3]Type{TypeStr, TypeStr}, NumArgs: 2, Kind: KindDispatch, Mutates: false},
+	{Code: OpStrRuneLen, Name: "str.rune.len", Result: TypeI64, Args: [3]Type{TypeStr}, NumArgs: 1, Kind: KindDispatch, Mutates: false},
+}
+
+// opTableIndex maps OpCode to its index in opTable, or -1 if the op
+// is unregistered. Built once at init() from opTable.
+var opTableIndex [256]int
+
+func init() {
+	for i := range opTableIndex {
+		opTableIndex[i] = -1
+	}
+	for i, info := range opTable {
+		if info.Code == OpInvalid {
+			panic("ir: opTable entry has OpCode == OpInvalid")
+		}
+		if info.Kind == KindUnclassified {
+			panic("ir: opTable entry for " + info.Name + " has KindUnclassified; set Kind explicitly")
+		}
+		idx := int(info.Code)
+		if idx >= len(opTableIndex) {
+			panic("ir: OpCode value exceeds opTableIndex; bump the array size")
+		}
+		if opTableIndex[idx] != -1 {
+			panic("ir: opTable double registration for " + info.Name)
+		}
+		opTableIndex[idx] = i
+	}
+}
+
+// OpInfoOf returns the registry entry for o, or (zero, false) if o
+// is not registered. Downstream consumers (validate.opContract,
+// verify.kindOf, etc.) check ok first and fall back to their legacy
+// switches when the op is not yet migrated.
+func OpInfoOf(o OpCode) (OpInfo, bool) {
+	idx := opTableIndex[uint8(o)]
+	if idx < 0 {
+		return OpInfo{}, false
+	}
+	return opTable[idx], true
+}
+
+// ReadDispatchOps returns the OpCodes of every registered op whose
+// Kind == KindDispatch and Mutates == false. verify reads this to
+// build its rule E classification; non-registered Dispatch ops still
+// come from verify.readDispatchOps directly.
+func ReadDispatchOps() []OpCode {
+	var out []OpCode
+	for _, info := range opTable {
+		if info.Kind == KindDispatch && !info.Mutates {
+			out = append(out, info.Code)
+		}
+	}
+	return out
+}
+
+// WriteDispatchOps is the Mutates==true counterpart of ReadDispatchOps.
+func WriteDispatchOps() []OpCode {
+	var out []OpCode
+	for _, info := range opTable {
+		if info.Kind == KindDispatch && info.Mutates {
+			out = append(out, info.Code)
+		}
+	}
+	return out
+}

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -441,7 +441,12 @@ const (
 
 // String renders an OpCode's short name. Used by Validate and IR
 // dumps. Names match the Op* constants minus the OpCode prefix.
+// Phase 4.2.30: ops registered in opTable read their Name from the
+// registry; the switch below covers ops not yet migrated.
 func (o OpCode) String() string {
+	if info, ok := OpInfoOf(o); ok {
+		return info.Name
+	}
 	switch o {
 	case OpInvalid:
 		return "invalid"
@@ -507,26 +512,9 @@ func (o OpCode) String() string {
 		return "cmp.gt.i64.imm"
 	case OpCmpGeI64Imm:
 		return "cmp.ge.i64.imm"
-	case OpLenStr:
-		return "len.str"
-	case OpConcatStr:
-		return "concat.str"
-	case OpCmpEqStr:
-		return "cmp.eq.str"
-	case OpCmpNeStr:
-		return "cmp.ne.str"
-	case OpI64ToStr:
-		return "i64.to.str"
-	case OpF64ToStr:
-		return "f64.to.str"
-	case OpBoolToStr:
-		return "bool.to.str"
-	case OpStrCharAt:
-		return "str.charat"
-	case OpStrIn:
-		return "str.in"
-	case OpStrRuneLen:
-		return "str.rune.len"
+	// Phase 4.2.30: OpLenStr, OpConcatStr, OpCmpEqStr, OpCmpNeStr,
+	// OpI64ToStr, OpF64ToStr, OpBoolToStr, OpStrCharAt, OpStrIn,
+	// OpStrRuneLen migrated to opTable; OpInfoOf returns their Name.
 	case OpCmpEqBool:
 		return "cmp.eq.bool"
 	case OpCmpNeBool:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -156,6 +156,12 @@ type opSig struct {
 }
 
 func opContract(o OpCode) opSig {
+	// Phase 4.2.30: registered ops read their contract from opTable.
+	// Unregistered ops fall through to the legacy switch below; new
+	// ops should always be registered, never added to the switch.
+	if info, ok := OpInfoOf(o); ok {
+		return opSig{outType: info.Result, inTypes: info.Args}
+	}
 	switch o {
 	case OpAddI64, OpSubI64, OpMulI64, OpDivI64, OpModI64:
 		return opSig{TypeI64, [3]Type{TypeI64, TypeI64}}
@@ -171,24 +177,10 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeBool, [3]Type{TypeI64, TypeI64}}
 	case OpCmpEqI64Imm, OpCmpNeI64Imm, OpCmpLtI64Imm, OpCmpLeI64Imm, OpCmpGtI64Imm, OpCmpGeI64Imm:
 		return opSig{TypeBool, [3]Type{TypeI64}}
-	case OpLenStr:
-		return opSig{TypeI64, [3]Type{TypeStr}}
-	case OpConcatStr:
-		return opSig{TypeStr, [3]Type{TypeStr, TypeStr}}
-	case OpCmpEqStr, OpCmpNeStr:
-		return opSig{TypeBool, [3]Type{TypeStr, TypeStr}}
-	case OpI64ToStr:
-		return opSig{TypeStr, [3]Type{TypeI64}}
-	case OpF64ToStr:
-		return opSig{TypeStr, [3]Type{TypeF64}}
-	case OpBoolToStr:
-		return opSig{TypeStr, [3]Type{TypeBool}}
-	case OpStrCharAt:
-		return opSig{TypeStr, [3]Type{TypeStr, TypeI64}}
-	case OpStrIn:
-		return opSig{TypeBool, [3]Type{TypeStr, TypeStr}}
-	case OpStrRuneLen:
-		return opSig{TypeI64, [3]Type{TypeStr}}
+	// Phase 4.2.30: string ops (OpLenStr, OpConcatStr, OpCmpEqStr,
+	// OpCmpNeStr, OpI64ToStr, OpF64ToStr, OpBoolToStr, OpStrCharAt,
+	// OpStrIn, OpStrRuneLen) migrated to opTable; opContract reads
+	// them from the registry via OpInfoOf at the top of this function.
 	case OpCmpEqBool, OpCmpNeBool:
 		return opSig{TypeBool, [3]Type{TypeBool, TypeBool}}
 	case OpAndBool, OpOrBool:

--- a/compiler3/verify/rule_e_test.go
+++ b/compiler3/verify/rule_e_test.go
@@ -351,8 +351,14 @@ func TestMustClassifyAllDispatchCoversAllDispatchOps(t *testing.T) {
 	for _, o := range readDispatchOps {
 		read[o] = true
 	}
+	for _, o := range ir.ReadDispatchOps() {
+		read[o] = true
+	}
 	write := make(map[ir.OpCode]bool)
 	for _, o := range writeDispatchOps {
+		write[o] = true
+	}
+	for _, o := range ir.WriteDispatchOps() {
 		write[o] = true
 	}
 	const lastOpCode = ir.OpCallGo

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -109,6 +109,32 @@ const (
 	KindReserved
 )
 
+// producerKindFromIR projects an ir.OpKind (the in-registry
+// classification carried by ir.OpInfo) onto the verify-public
+// ProducerKind constants. The two enumerations are kept aligned by
+// the init-time coverage check (mustClassifyAll); a new ir.OpKind
+// value that lands without a corresponding ProducerKind here will
+// fall through to KindInvalid and trip the check.
+func producerKindFromIR(k ir.OpKind) ProducerKind {
+	switch k {
+	case ir.KindMove:
+		return KindMove
+	case ir.KindInline:
+		return KindInline
+	case ir.KindConstructor:
+		return KindConstructor
+	case ir.KindOperator:
+		return KindOperator
+	case ir.KindDispatch:
+		return KindDispatch
+	case ir.KindCall:
+		return KindCall
+	case ir.KindReserved:
+		return KindReserved
+	}
+	return KindInvalid
+}
+
 // String renders a ProducerKind for error messages.
 func (k ProducerKind) String() string {
 	switch k {
@@ -138,7 +164,14 @@ func (k ProducerKind) String() string {
 // from OpInvalid+1 through the last known op and asserts each gets a
 // non-Invalid classification. The kindOf result for OpInvalid itself
 // is intentionally KindInvalid; the coverage check excludes it.
+//
+// Phase 4.2.30: registered ops read their Kind from ir.OpInfoOf;
+// unregistered ops fall through to the legacy switch. New ops
+// should always be registered, never added to the switch.
 func kindOf(o ir.OpCode) ProducerKind {
+	if info, ok := ir.OpInfoOf(o); ok {
+		return producerKindFromIR(info.Kind)
+	}
 	switch o {
 	case ir.OpInvalid:
 		return KindInvalid
@@ -156,7 +189,6 @@ func kindOf(o ir.OpCode) ProducerKind {
 		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm,
 		ir.OpAndI64, ir.OpOrI64, ir.OpXorI64, ir.OpShlI64, ir.OpShrI64, ir.OpNotI64,
 		ir.OpCmpEqF64, ir.OpCmpNeF64, ir.OpCmpLtF64, ir.OpCmpLeF64, ir.OpCmpGtF64, ir.OpCmpGeF64,
-		ir.OpCmpEqStr, ir.OpCmpNeStr,
 		ir.OpCmpEqBool, ir.OpCmpNeBool,
 		ir.OpAndBool, ir.OpOrBool,
 		ir.OpNotBool,
@@ -166,9 +198,7 @@ func kindOf(o ir.OpCode) ProducerKind {
 		ir.OpJsonI64Object:
 		return KindOperator
 
-	case ir.OpLenStr, ir.OpStrIn, ir.OpStrRuneLen:
-		return KindDispatch
-	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpListI64ToStr, ir.OpF64ArrayToStr, ir.OpStrArrToStr, ir.OpStrCharAt:
+	case ir.OpListI64ToStr, ir.OpF64ArrayToStr, ir.OpStrArrToStr:
 		return KindConstructor
 
 	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array, ir.OpNewStrArr, ir.OpNewMapStrI64, ir.OpNewListAny,
@@ -400,10 +430,16 @@ func checkRuleD(fn *ir.Function) error {
 }
 
 // contractResult returns the OpCode's declared result Type, or
-// TypeInvalid if the op is not in the contract table. Mirrors the
-// table in ir/validate.go without taking a dependency on its private
-// opContract symbol.
+// TypeInvalid if the op is not in the contract table.
+//
+// Phase 4.2.30: registered ops read their Result from ir.OpInfoOf so
+// the registry is the single source of truth; unregistered ops fall
+// through to the legacy switch. The legacy switch will shrink to
+// zero as ops migrate into opTable.
 func contractResult(o ir.OpCode) ir.Type {
+	if info, ok := ir.OpInfoOf(o); ok {
+		return info.Result
+	}
 	switch o {
 	case ir.OpAddI64, ir.OpSubI64, ir.OpMulI64, ir.OpDivI64, ir.OpModI64, ir.OpNegI64,
 		ir.OpAddI64Imm, ir.OpSubI64Imm, ir.OpMulI64Imm, ir.OpDivI64Imm, ir.OpModI64Imm:
@@ -412,15 +448,9 @@ func contractResult(o ir.OpCode) ir.Type {
 		return ir.TypeF64
 	case ir.OpCmpEqI64, ir.OpCmpNeI64, ir.OpCmpLtI64, ir.OpCmpLeI64, ir.OpCmpGtI64, ir.OpCmpGeI64,
 		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm,
-		ir.OpCmpEqStr, ir.OpCmpNeStr,
 		ir.OpCmpEqBool, ir.OpCmpNeBool,
-		ir.OpAndBool, ir.OpOrBool,
-		ir.OpStrIn:
+		ir.OpAndBool, ir.OpOrBool:
 		return ir.TypeBool
-	case ir.OpLenStr, ir.OpStrRuneLen:
-		return ir.TypeI64
-	case ir.OpConcatStr, ir.OpI64ToStr, ir.OpF64ToStr, ir.OpBoolToStr, ir.OpStrCharAt:
-		return ir.TypeStr
 	case ir.OpNewList:
 		return ir.TypeList
 	case ir.OpNewMap:
@@ -521,13 +551,14 @@ func opIsMutating(o ir.OpCode) bool {
 	return false
 }
 
-// readDispatchOps lists every KindDispatch op that does not mutate its
-// arena. Kept as data (rather than a switch) so the coverage check can
-// enumerate both halves of the dispatch op set.
+// readDispatchOps lists every unregistered KindDispatch op that does
+// not mutate its arena. Kept as data (rather than a switch) so the
+// coverage check can enumerate both halves of the dispatch op set.
+//
+// Phase 4.2.30: ops migrated into ir.opTable carry their Mutates flag
+// in the registry; mustClassifyAllDispatch unions ir.ReadDispatchOps()
+// into the coverage set so a registered op need not be listed here.
 var readDispatchOps = []ir.OpCode{
-	ir.OpLenStr,
-	ir.OpStrIn,
-	ir.OpStrRuneLen,
 	ir.OpListLenI64,
 	ir.OpListGetI64,
 	ir.OpListGetF64,
@@ -647,6 +678,21 @@ func mustClassifyAllDispatch() {
 		}
 		if seen[o] {
 			panic(fmt.Sprintf("verify: %s listed in both readDispatchOps and writeDispatchOps", o))
+		}
+		seen[o] = true
+	}
+	// Phase 4.2.30: registered Dispatch ops carry their Mutates flag in
+	// ir.opTable; union those into the coverage set so a registered op
+	// need not be repeated in the verify-local slices.
+	for _, o := range ir.ReadDispatchOps() {
+		if seen[o] {
+			panic(fmt.Sprintf("verify: %s listed in ir.ReadDispatchOps and the verify-local slices", o))
+		}
+		seen[o] = true
+	}
+	for _, o := range ir.WriteDispatchOps() {
+		if seen[o] {
+			panic(fmt.Sprintf("verify: %s listed in ir.WriteDispatchOps and the verify-local slices", o))
 		}
 		seen[o] = true
 	}

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,51 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.57 Phase 4.2.30 closeout (LANDED 2026-05-22 15:46 GMT+7)
+
+Phase 4.2.30 collapses the per-op file-edit tax: a registered op now carries its name, result type, operand types, and verifier kind in a single declarative entry. The String surface (10 ops) is the migration proof; downstream phases add new ops by appending one OpInfo literal plus the op-specific emit cases, not by touching ten files.
+
+### The audit that motivated this
+
+The string surface phases (4.2.27 through 4.2.29) repeated the same pattern: declare an OpCode, write a String() case, write an opContract case in ir/validate.go, write a kindOf case in verify/verify.go, write a contractResult case in verify/verify.go, (for Dispatch ops) add an entry to readDispatchOps in verify/verify.go, write the emit case in emit/c/emit.go, write the emit case in emit/go/emit.go, write the frontend lowering hook, write the runtime helper. Nine sites for one op.
+
+Worse, two of those sites (opContract and contractResult) carried the same Result/Args data in independent switches; the Phase 4.2.28 verify panic about OpStrIn (`Dispatch OpCode str.in (=40) is not classified for rule E`) was the symptom of an additional fourth slot (readDispatchOps) drifting from the kindOf classification. The data was redundant; the drift was silent until the verifier ran.
+
+### The mechanism
+
+A new file, `compiler3/ir/optable.go`, declares an `OpInfo` struct and an `opTable` slice. Each entry names the op, its result Type, its operand Types, its `OpKind` classification (Move / Inline / Constructor / Operator / Dispatch / Call / Reserved), and a `Mutates` flag (consulted only for Dispatch). The registry is built once at init() into a `[256]int` index for O(1) lookup; double registration and `KindUnclassified` entries panic at import time.
+
+The four downstream consumers now read the registry first:
+
+- `OpCode.String()` consults `OpInfoOf` for the name.
+- `ir.opContract()` consults `OpInfoOf` for the operand contract.
+- `verify.kindOf()` consults `OpInfoOf` and projects `ir.OpKind` onto the verify-public `ProducerKind` via `producerKindFromIR`.
+- `verify.contractResult()` consults `OpInfoOf` for the result Type.
+- `verify.mustClassifyAllDispatch()` unions `ir.ReadDispatchOps()` and `ir.WriteDispatchOps()` (both derived from the registry's `Mutates` flag) into its rule-E coverage set.
+
+Unregistered ops fall through to the legacy switches unchanged. The migration is incremental: ops can move into the registry one at a time without touching the consumers' fall-through arms.
+
+### Diff shape
+
+- `compiler3/ir/optable.go`: new file. Declares `OpKind` and `OpInfo`, defines `opTable` with 10 entries (the string surface), builds `opTableIndex` at init, validates no `OpInvalid` or `KindUnclassified` entries, rejects double registration. Exposes `OpInfoOf`, `ReadDispatchOps`, `WriteDispatchOps`.
+- `compiler3/ir/types.go`: `OpCode.String()` consults `OpInfoOf` at the top; removed 10 migrated cases from the switch.
+- `compiler3/ir/validate.go`: `opContract` consults `OpInfoOf` at the top; removed 10 migrated cases from the switch.
+- `compiler3/verify/verify.go`: added `producerKindFromIR`; `kindOf` consults `OpInfoOf` at the top; removed 10 migrated cases (`OpCmpEqStr`, `OpCmpNeStr` from the Operator clause; `OpLenStr`, `OpStrIn`, `OpStrRuneLen` from the Dispatch clause; `OpConcatStr`, `OpI64ToStr`, `OpF64ToStr`, `OpBoolToStr`, `OpStrCharAt` from the Constructor clause, leaving `OpListI64ToStr`, `OpF64ArrayToStr`, `OpStrArrToStr` until their phases migrate). `contractResult` consults `OpInfoOf` at the top; removed the same 10 migrated cases. `readDispatchOps` drops `OpLenStr`, `OpStrIn`, `OpStrRuneLen` (registry-derived now). `mustClassifyAllDispatch` unions `ir.ReadDispatchOps()` and `ir.WriteDispatchOps()` into its coverage set with a same-op double-list panic.
+- `compiler3/verify/rule_e_test.go`: `TestMustClassifyAllDispatchCoversAllDispatchOps` also unions the registry-derived slices so the test mirrors the init-time check.
+
+### Why this closes a goal
+
+Adding a new IR op was the friction point that slowed every preceding phase. With the registry, the steps shrink to three: declare the OpCode in `ir/types.go`, append an `OpInfo` literal to `opTable`, write the genuinely op-specific emit cases in emit/c and emit/go (plus any frontend lowering hook). The validator, the verifier, and the rule-E classification are all derived from the same single entry; drift between independent switches is no longer possible.
+
+Concretely: the Phase 4.2.28 panic about `OpStrIn` not being classified for rule E was caused by a copy-paste omission in `readDispatchOps`. Under the registry, `OpStrIn`'s `Mutates: false` flag is the source of truth and `verify.mustClassifyAllDispatch` reads it directly. The same class of bug can't recur without explicitly contradicting the registry, which the init-time check rejects.
+
+### Limitations
+
+- Only the 10 string-surface ops are migrated in this phase. The remaining 70-ish ops still live in the legacy switches. Migration is mechanical (move the data, delete the case); follow-up phases will sweep the list / map / f64arr / strarr / listany / listlist families.
+- `OpInfo.NumArgs` is declared but not yet consulted; it is reserved for a future phase that will check args-count uniformly. Today validate.go's switch handles variadic ops (`OpJsonI64Object`) ad hoc.
+- The `OpKind` and `verify.ProducerKind` enumerations are kept aligned by `producerKindFromIR`; a future phase could collapse them, but the current split keeps `verify` independent of `ir` for new kinds that don't need IR-level structural meaning.
+- The legacy switch fall-through in each consumer is a deliberate compatibility shim; once every op is registered, the switches and their associated fall-through arms can be deleted. That cleanup is gated on completing the migration, not on a phase milestone.
+
 ## §10.56 Phase 4.2.29 closeout (LANDED 2026-05-22 15:30 GMT+7)
 
 Phase 4.2.29 closes the v0.5 string surface on the C target. `for ch in s` now iterates UTF-8 runes (matching the VM's `for _, ch := range []rune(s)` lowering), the v0.5/string.mochi and v0.5/string-index-iterator.mochi fixtures pin end to end, and the lowering combines this phase's new OpStrRuneLen with Phase 4.2.27's OpStrCharAt and Phase 4.2.28's OpStrIn.


### PR DESCRIPTION
Tracks #22053.

Phase 4.2.30 collapses the per-op file-edit tax. A registered op now carries its name, result type, operand types, and verifier kind in one declarative entry; downstream consumers (`OpCode.String`, `ir.opContract`, `verify.kindOf`, `verify.contractResult`, `verify.mustClassifyAllDispatch`) read from it.

## Why

Adding a new IR op was the friction point that slowed every preceding phase in this stream (4.2.27, 4.2.28, 4.2.29). Each phase touched the same ~10 sites in 5 files, and the Result/Args data lived in independent switches (`opContract` and `contractResult`). The 4.2.28 verify panic about `OpStrIn` (`Dispatch OpCode str.in (=40) is not classified for rule E`) was a symptom of exactly this drift between `kindOf` and `readDispatchOps`.

## Mechanism

New `compiler3/ir/optable.go`:

- `OpKind` (Move / Inline / Constructor / Operator / Dispatch / Call / Reserved)
- `OpInfo { Code, Name, Result, Args, NumArgs, Kind, Mutates }`
- `opTable` declarative slice; built into `opTableIndex [256]int` at init
- Init-time check rejects `OpInvalid`, `KindUnclassified`, and double registration
- `OpInfoOf(o)` returns registered info or (zero, false)
- `ReadDispatchOps()` / `WriteDispatchOps()` derived from Mutates flag

Consumers consult the registry first and fall through to legacy switches for unregistered ops:

- `ir.OpCode.String()` (name)
- `ir.opContract()` (operand contract)
- `verify.kindOf()` (via new `producerKindFromIR` projection)
- `verify.contractResult()` (result type)
- `verify.mustClassifyAllDispatch()` (union with `ir.ReadDispatchOps()` / `WriteDispatchOps()`)

## Migrated in this phase

10 String-surface ops as the proof point: OpLenStr, OpConcatStr, OpCmpEqStr, OpCmpNeStr, OpI64ToStr, OpF64ToStr, OpBoolToStr, OpStrCharAt, OpStrIn, OpStrRuneLen.

Adding a new IR op now shrinks from ~10 sites to 3: declare the OpCode constant, append an `OpInfo` literal, write the op-specific emit cases in C and Go. The same class of drift bug (4.2.28 panic) can't recur without explicitly contradicting the registry.

## Tests

- `go test ./compiler3/ir/...` green
- `go test ./compiler3/verify/...` green
- `go test ./compiler3/frontend/...` green
- `go test ./compiler3/emit/...` green
- `go test ./compiler3/build/c ./compiler3/build/go` green
- `TestMustClassifyAllDispatchCoversAllDispatchOps` updated to union the registry-derived slices

## Follow-up

The remaining ~70 ops still live in the legacy switches. Migration is mechanical (move the data, delete the case); follow-up phases will sweep the list / map / f64arr / strarr / listany / listlist families. Once every op is registered, the legacy switches and their fall-through arms can be deleted.

MEP §10.57 closeout documents the audit, mechanism, diff shape, and limitations.