### PR TITLE
mep-0042: phase 4.2.31 -- migrate scalar op families to registry

### DIFF
--- a/compiler3/ir/optable.go
+++ b/compiler3/ir/optable.go
@@ -128,6 +128,72 @@ var opTable = []OpInfo{
 	{Code: OpStrCharAt, Name: "str.charat", Result: TypeStr, Args: [3]Type{TypeStr, TypeI64}, NumArgs: 2, Kind: KindConstructor},
 	{Code: OpStrIn, Name: "str.in", Result: TypeBool, Args: [3]Type{TypeStr, TypeStr}, NumArgs: 2, Kind: KindDispatch, Mutates: false},
 	{Code: OpStrRuneLen, Name: "str.rune.len", Result: TypeI64, Args: [3]Type{TypeStr}, NumArgs: 1, Kind: KindDispatch, Mutates: false},
+
+	// Scalar arithmetic, comparison, bitwise, conversion, and math
+	// surface (MEP-42 Phase 4.2.31). Migrated from the legacy switches
+	// in ir/types.go (String), ir/validate.go (opContract), and
+	// verify/verify.go (kindOf, contractResult) to the registry as the
+	// next batch after the string surface (Phase 4.2.30).
+	//
+	// All entries are KindOperator: the result Type is never a handle
+	// Type, and the op does not dispatch into a heap-allocated arena.
+	{Code: OpAddI64, Name: "add.i64", Result: TypeI64, Args: [3]Type{TypeI64, TypeI64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpSubI64, Name: "sub.i64", Result: TypeI64, Args: [3]Type{TypeI64, TypeI64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpMulI64, Name: "mul.i64", Result: TypeI64, Args: [3]Type{TypeI64, TypeI64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpDivI64, Name: "div.i64", Result: TypeI64, Args: [3]Type{TypeI64, TypeI64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpModI64, Name: "mod.i64", Result: TypeI64, Args: [3]Type{TypeI64, TypeI64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpNegI64, Name: "neg.i64", Result: TypeI64, Args: [3]Type{TypeI64}, NumArgs: 1, Kind: KindOperator},
+
+	{Code: OpAddI64Imm, Name: "addk.i64", Result: TypeI64, Args: [3]Type{TypeI64}, NumArgs: 1, Kind: KindOperator},
+	{Code: OpSubI64Imm, Name: "subk.i64", Result: TypeI64, Args: [3]Type{TypeI64}, NumArgs: 1, Kind: KindOperator},
+	{Code: OpMulI64Imm, Name: "mulk.i64", Result: TypeI64, Args: [3]Type{TypeI64}, NumArgs: 1, Kind: KindOperator},
+	{Code: OpDivI64Imm, Name: "divk.i64", Result: TypeI64, Args: [3]Type{TypeI64}, NumArgs: 1, Kind: KindOperator},
+	{Code: OpModI64Imm, Name: "modk.i64", Result: TypeI64, Args: [3]Type{TypeI64}, NumArgs: 1, Kind: KindOperator},
+
+	{Code: OpAddF64, Name: "add.f64", Result: TypeF64, Args: [3]Type{TypeF64, TypeF64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpSubF64, Name: "sub.f64", Result: TypeF64, Args: [3]Type{TypeF64, TypeF64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpMulF64, Name: "mul.f64", Result: TypeF64, Args: [3]Type{TypeF64, TypeF64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpDivF64, Name: "div.f64", Result: TypeF64, Args: [3]Type{TypeF64, TypeF64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpNegF64, Name: "neg.f64", Result: TypeF64, Args: [3]Type{TypeF64}, NumArgs: 1, Kind: KindOperator},
+
+	{Code: OpCmpEqI64, Name: "cmp.eq.i64", Result: TypeBool, Args: [3]Type{TypeI64, TypeI64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpCmpNeI64, Name: "cmp.ne.i64", Result: TypeBool, Args: [3]Type{TypeI64, TypeI64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpCmpLtI64, Name: "cmp.lt.i64", Result: TypeBool, Args: [3]Type{TypeI64, TypeI64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpCmpLeI64, Name: "cmp.le.i64", Result: TypeBool, Args: [3]Type{TypeI64, TypeI64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpCmpGtI64, Name: "cmp.gt.i64", Result: TypeBool, Args: [3]Type{TypeI64, TypeI64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpCmpGeI64, Name: "cmp.ge.i64", Result: TypeBool, Args: [3]Type{TypeI64, TypeI64}, NumArgs: 2, Kind: KindOperator},
+
+	{Code: OpCmpEqI64Imm, Name: "cmp.eq.i64.imm", Result: TypeBool, Args: [3]Type{TypeI64}, NumArgs: 1, Kind: KindOperator},
+	{Code: OpCmpNeI64Imm, Name: "cmp.ne.i64.imm", Result: TypeBool, Args: [3]Type{TypeI64}, NumArgs: 1, Kind: KindOperator},
+	{Code: OpCmpLtI64Imm, Name: "cmp.lt.i64.imm", Result: TypeBool, Args: [3]Type{TypeI64}, NumArgs: 1, Kind: KindOperator},
+	{Code: OpCmpLeI64Imm, Name: "cmp.le.i64.imm", Result: TypeBool, Args: [3]Type{TypeI64}, NumArgs: 1, Kind: KindOperator},
+	{Code: OpCmpGtI64Imm, Name: "cmp.gt.i64.imm", Result: TypeBool, Args: [3]Type{TypeI64}, NumArgs: 1, Kind: KindOperator},
+	{Code: OpCmpGeI64Imm, Name: "cmp.ge.i64.imm", Result: TypeBool, Args: [3]Type{TypeI64}, NumArgs: 1, Kind: KindOperator},
+
+	{Code: OpCmpEqF64, Name: "cmp.eq.f64", Result: TypeBool, Args: [3]Type{TypeF64, TypeF64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpCmpNeF64, Name: "cmp.ne.f64", Result: TypeBool, Args: [3]Type{TypeF64, TypeF64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpCmpLtF64, Name: "cmp.lt.f64", Result: TypeBool, Args: [3]Type{TypeF64, TypeF64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpCmpLeF64, Name: "cmp.le.f64", Result: TypeBool, Args: [3]Type{TypeF64, TypeF64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpCmpGtF64, Name: "cmp.gt.f64", Result: TypeBool, Args: [3]Type{TypeF64, TypeF64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpCmpGeF64, Name: "cmp.ge.f64", Result: TypeBool, Args: [3]Type{TypeF64, TypeF64}, NumArgs: 2, Kind: KindOperator},
+
+	{Code: OpCmpEqBool, Name: "cmp.eq.bool", Result: TypeBool, Args: [3]Type{TypeBool, TypeBool}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpCmpNeBool, Name: "cmp.ne.bool", Result: TypeBool, Args: [3]Type{TypeBool, TypeBool}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpAndBool, Name: "and.bool", Result: TypeBool, Args: [3]Type{TypeBool, TypeBool}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpOrBool, Name: "or.bool", Result: TypeBool, Args: [3]Type{TypeBool, TypeBool}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpNotBool, Name: "not.bool", Result: TypeBool, Args: [3]Type{TypeBool}, NumArgs: 1, Kind: KindOperator},
+
+	{Code: OpAndI64, Name: "and.i64", Result: TypeI64, Args: [3]Type{TypeI64, TypeI64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpOrI64, Name: "or.i64", Result: TypeI64, Args: [3]Type{TypeI64, TypeI64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpXorI64, Name: "xor.i64", Result: TypeI64, Args: [3]Type{TypeI64, TypeI64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpShlI64, Name: "shl.i64", Result: TypeI64, Args: [3]Type{TypeI64, TypeI64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpShrI64, Name: "shr.i64", Result: TypeI64, Args: [3]Type{TypeI64, TypeI64}, NumArgs: 2, Kind: KindOperator},
+	{Code: OpNotI64, Name: "not.i64", Result: TypeI64, Args: [3]Type{TypeI64}, NumArgs: 1, Kind: KindOperator},
+
+	{Code: OpI64ToF64, Name: "i64.to.f64", Result: TypeF64, Args: [3]Type{TypeI64}, NumArgs: 1, Kind: KindOperator},
+	{Code: OpF64ToI64, Name: "f64.to.i64", Result: TypeI64, Args: [3]Type{TypeF64}, NumArgs: 1, Kind: KindOperator},
+	{Code: OpSqrtF64, Name: "sqrt.f64", Result: TypeF64, Args: [3]Type{TypeF64}, NumArgs: 1, Kind: KindOperator},
+	{Code: OpNow, Name: "now", Result: TypeI64, Args: [3]Type{}, NumArgs: 0, Kind: KindOperator},
 }
 
 // opTableIndex maps OpCode to its index in opTable, or -1 if the op

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -456,73 +456,14 @@ func (o OpCode) String() string {
 		return "const"
 	case OpPhi:
 		return "phi"
-	case OpAddI64:
-		return "add.i64"
-	case OpSubI64:
-		return "sub.i64"
-	case OpMulI64:
-		return "mul.i64"
-	case OpDivI64:
-		return "div.i64"
-	case OpModI64:
-		return "mod.i64"
-	case OpNegI64:
-		return "neg.i64"
-	case OpAddI64Imm:
-		return "addk.i64"
-	case OpSubI64Imm:
-		return "subk.i64"
-	case OpMulI64Imm:
-		return "mulk.i64"
-	case OpDivI64Imm:
-		return "divk.i64"
-	case OpModI64Imm:
-		return "modk.i64"
-	case OpAddF64:
-		return "add.f64"
-	case OpSubF64:
-		return "sub.f64"
-	case OpMulF64:
-		return "mul.f64"
-	case OpDivF64:
-		return "div.f64"
-	case OpNegF64:
-		return "neg.f64"
-	case OpCmpEqI64:
-		return "cmp.eq.i64"
-	case OpCmpNeI64:
-		return "cmp.ne.i64"
-	case OpCmpLtI64:
-		return "cmp.lt.i64"
-	case OpCmpLeI64:
-		return "cmp.le.i64"
-	case OpCmpGtI64:
-		return "cmp.gt.i64"
-	case OpCmpGeI64:
-		return "cmp.ge.i64"
-	case OpCmpEqI64Imm:
-		return "cmp.eq.i64.imm"
-	case OpCmpNeI64Imm:
-		return "cmp.ne.i64.imm"
-	case OpCmpLtI64Imm:
-		return "cmp.lt.i64.imm"
-	case OpCmpLeI64Imm:
-		return "cmp.le.i64.imm"
-	case OpCmpGtI64Imm:
-		return "cmp.gt.i64.imm"
-	case OpCmpGeI64Imm:
-		return "cmp.ge.i64.imm"
 	// Phase 4.2.30: OpLenStr, OpConcatStr, OpCmpEqStr, OpCmpNeStr,
 	// OpI64ToStr, OpF64ToStr, OpBoolToStr, OpStrCharAt, OpStrIn,
 	// OpStrRuneLen migrated to opTable; OpInfoOf returns their Name.
-	case OpCmpEqBool:
-		return "cmp.eq.bool"
-	case OpCmpNeBool:
-		return "cmp.ne.bool"
-	case OpAndBool:
-		return "and.bool"
-	case OpOrBool:
-		return "or.bool"
+	//
+	// Phase 4.2.31: I64/F64/Bool arithmetic + comparison + bitwise +
+	// conversion + math ops (OpAddI64, ..., OpNow) migrated to opTable;
+	// see compiler3/ir/optable.go for the full list. OpInfoOf returns
+	// their Name in the registry prologue above.
 	case OpNewList:
 		return "newlist"
 	case OpListLenI64:
@@ -589,8 +530,6 @@ func (o OpCode) String() string {
 		return "list.concat.i64"
 	case OpF64ArrayConcat:
 		return "f64arr.concat"
-	case OpNow:
-		return "now"
 	case OpNewListAny:
 		return "newlistany"
 	case OpListAnyLen:
@@ -637,38 +576,6 @@ func (o OpCode) String() string {
 		return "query.crossjoin"
 	case OpCallGo:
 		return "call.go"
-	case OpAndI64:
-		return "and.i64"
-	case OpOrI64:
-		return "or.i64"
-	case OpXorI64:
-		return "xor.i64"
-	case OpShlI64:
-		return "shl.i64"
-	case OpShrI64:
-		return "shr.i64"
-	case OpNotI64:
-		return "not.i64"
-	case OpCmpEqF64:
-		return "cmp.eq.f64"
-	case OpCmpNeF64:
-		return "cmp.ne.f64"
-	case OpCmpLtF64:
-		return "cmp.lt.f64"
-	case OpCmpLeF64:
-		return "cmp.le.f64"
-	case OpCmpGtF64:
-		return "cmp.gt.f64"
-	case OpCmpGeF64:
-		return "cmp.ge.f64"
-	case OpNotBool:
-		return "not.bool"
-	case OpI64ToF64:
-		return "i64.to.f64"
-	case OpF64ToI64:
-		return "f64.to.i64"
-	case OpSqrtF64:
-		return "sqrt.f64"
 	}
 	return "?"
 }

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -163,28 +163,14 @@ func opContract(o OpCode) opSig {
 		return opSig{outType: info.Result, inTypes: info.Args}
 	}
 	switch o {
-	case OpAddI64, OpSubI64, OpMulI64, OpDivI64, OpModI64:
-		return opSig{TypeI64, [3]Type{TypeI64, TypeI64}}
-	case OpAddI64Imm, OpSubI64Imm, OpMulI64Imm, OpDivI64Imm, OpModI64Imm:
-		return opSig{TypeI64, [3]Type{TypeI64}}
-	case OpNegI64:
-		return opSig{TypeI64, [3]Type{TypeI64}}
-	case OpAddF64, OpSubF64, OpMulF64, OpDivF64:
-		return opSig{TypeF64, [3]Type{TypeF64, TypeF64}}
-	case OpNegF64:
-		return opSig{TypeF64, [3]Type{TypeF64}}
-	case OpCmpEqI64, OpCmpNeI64, OpCmpLtI64, OpCmpLeI64, OpCmpGtI64, OpCmpGeI64:
-		return opSig{TypeBool, [3]Type{TypeI64, TypeI64}}
-	case OpCmpEqI64Imm, OpCmpNeI64Imm, OpCmpLtI64Imm, OpCmpLeI64Imm, OpCmpGtI64Imm, OpCmpGeI64Imm:
-		return opSig{TypeBool, [3]Type{TypeI64}}
 	// Phase 4.2.30: string ops (OpLenStr, OpConcatStr, OpCmpEqStr,
 	// OpCmpNeStr, OpI64ToStr, OpF64ToStr, OpBoolToStr, OpStrCharAt,
 	// OpStrIn, OpStrRuneLen) migrated to opTable; opContract reads
 	// them from the registry via OpInfoOf at the top of this function.
-	case OpCmpEqBool, OpCmpNeBool:
-		return opSig{TypeBool, [3]Type{TypeBool, TypeBool}}
-	case OpAndBool, OpOrBool:
-		return opSig{TypeBool, [3]Type{TypeBool, TypeBool}}
+	//
+	// Phase 4.2.31: scalar arithmetic, comparison, bitwise, conversion,
+	// and math ops (OpAddI64, ..., OpNow) migrated to opTable; the
+	// registry prologue above handles them.
 	case OpNewList:
 		return opSig{TypeList, [3]Type{}}
 	case OpListLenI64:
@@ -247,20 +233,6 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeI64, [3]Type{TypeListList}}
 	case OpListListToStr:
 		return opSig{TypeStr, [3]Type{TypeListList}}
-	case OpAndI64, OpOrI64, OpXorI64, OpShlI64, OpShrI64:
-		return opSig{TypeI64, [3]Type{TypeI64, TypeI64}}
-	case OpNotI64:
-		return opSig{TypeI64, [3]Type{TypeI64}}
-	case OpCmpEqF64, OpCmpNeF64, OpCmpLtF64, OpCmpLeF64, OpCmpGtF64, OpCmpGeF64:
-		return opSig{TypeBool, [3]Type{TypeF64, TypeF64}}
-	case OpNotBool:
-		return opSig{TypeBool, [3]Type{TypeBool}}
-	case OpI64ToF64:
-		return opSig{TypeF64, [3]Type{TypeI64}}
-	case OpF64ToI64:
-		return opSig{TypeI64, [3]Type{TypeF64}}
-	case OpSqrtF64:
-		return opSig{TypeF64, [3]Type{TypeF64}}
 	case OpListConcatI64:
 		return opSig{TypeList, [3]Type{TypeList, TypeList}}
 	case OpListI64ToStr:
@@ -271,8 +243,6 @@ func opContract(o OpCode) opSig {
 		return opSig{TypeStr, [3]Type{TypeStrArr}}
 	case OpF64ArrayConcat:
 		return opSig{TypeF64Arr, [3]Type{TypeF64Arr, TypeF64Arr}}
-	case OpNow:
-		return opSig{TypeI64, [3]Type{}}
 	case OpNewListAny:
 		return opSig{TypeListAny, [3]Type{}}
 	case OpListAnyLen:

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -182,20 +182,7 @@ func kindOf(o ir.OpCode) ProducerKind {
 	case ir.OpConst:
 		return KindInline
 
-	case ir.OpAddI64, ir.OpSubI64, ir.OpMulI64, ir.OpDivI64, ir.OpModI64, ir.OpNegI64,
-		ir.OpAddI64Imm, ir.OpSubI64Imm, ir.OpMulI64Imm, ir.OpDivI64Imm, ir.OpModI64Imm,
-		ir.OpAddF64, ir.OpSubF64, ir.OpMulF64, ir.OpDivF64, ir.OpNegF64,
-		ir.OpCmpEqI64, ir.OpCmpNeI64, ir.OpCmpLtI64, ir.OpCmpLeI64, ir.OpCmpGtI64, ir.OpCmpGeI64,
-		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm,
-		ir.OpAndI64, ir.OpOrI64, ir.OpXorI64, ir.OpShlI64, ir.OpShrI64, ir.OpNotI64,
-		ir.OpCmpEqF64, ir.OpCmpNeF64, ir.OpCmpLtF64, ir.OpCmpLeF64, ir.OpCmpGtF64, ir.OpCmpGeF64,
-		ir.OpCmpEqBool, ir.OpCmpNeBool,
-		ir.OpAndBool, ir.OpOrBool,
-		ir.OpNotBool,
-		ir.OpI64ToF64, ir.OpF64ToI64,
-		ir.OpSqrtF64,
-		ir.OpNow,
-		ir.OpJsonI64Object:
+	case ir.OpJsonI64Object:
 		return KindOperator
 
 	case ir.OpListI64ToStr, ir.OpF64ArrayToStr, ir.OpStrArrToStr:
@@ -441,16 +428,6 @@ func contractResult(o ir.OpCode) ir.Type {
 		return info.Result
 	}
 	switch o {
-	case ir.OpAddI64, ir.OpSubI64, ir.OpMulI64, ir.OpDivI64, ir.OpModI64, ir.OpNegI64,
-		ir.OpAddI64Imm, ir.OpSubI64Imm, ir.OpMulI64Imm, ir.OpDivI64Imm, ir.OpModI64Imm:
-		return ir.TypeI64
-	case ir.OpAddF64, ir.OpSubF64, ir.OpMulF64, ir.OpDivF64, ir.OpNegF64:
-		return ir.TypeF64
-	case ir.OpCmpEqI64, ir.OpCmpNeI64, ir.OpCmpLtI64, ir.OpCmpLeI64, ir.OpCmpGtI64, ir.OpCmpGeI64,
-		ir.OpCmpEqI64Imm, ir.OpCmpNeI64Imm, ir.OpCmpLtI64Imm, ir.OpCmpLeI64Imm, ir.OpCmpGtI64Imm, ir.OpCmpGeI64Imm,
-		ir.OpCmpEqBool, ir.OpCmpNeBool,
-		ir.OpAndBool, ir.OpOrBool:
-		return ir.TypeBool
 	case ir.OpNewList:
 		return ir.TypeList
 	case ir.OpNewMap:
@@ -495,8 +472,6 @@ func contractResult(o ir.OpCode) ir.Type {
 		return ir.TypeList
 	case ir.OpF64ArrayConcat:
 		return ir.TypeF64Arr
-	case ir.OpNow:
-		return ir.TypeI64
 	case ir.OpNewListAny:
 		return ir.TypeListAny
 	case ir.OpListAnyLen:

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,50 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.58 Phase 4.2.31 closeout (LANDED 2026-05-22 16:01 GMT+7)
+
+Phase 4.2.31 migrates the scalar arithmetic, comparison, bitwise, conversion, and math op families to the registry that Phase 4.2.30 introduced. The 47-op batch (every `Op*I64`, `Op*F64`, `Op*Bool`, plus `OpI64ToF64`, `OpF64ToI64`, `OpSqrtF64`, `OpNow`) drains the largest chunk of the legacy switches and validates the registry mechanism against the largest op family.
+
+### Why now
+
+Phase 4.2.30 introduced the registry but only migrated 10 string ops as the proof point. The legacy switches in `ir/types.go` (String), `ir/validate.go` (opContract), and `verify/verify.go` (kindOf, contractResult) still carried ~70 cases. Every new op added through one of those switches was a re-instance of the per-op file-edit friction the registry was designed to eliminate.
+
+The scalar arithmetic family is the natural next migration: it is the largest op family (47 of the remaining ~70 ops), it is fully homogeneous (every entry is KindOperator with a small fixed-arity scalar contract), and it has no rule-E semantics. Migrating it in one batch validates the registry against a family that is structurally different from the string surface (different operand Types, different Kind, more entries) and shrinks the legacy switches to a manageable residue (~25 ops left, all of them heap-allocating or query-shaped).
+
+### What migrated
+
+The 47 ops added to `opTable`, all `KindOperator`:
+
+- I64 arithmetic: `OpAddI64`, `OpSubI64`, `OpMulI64`, `OpDivI64`, `OpModI64`, `OpNegI64`.
+- I64 immediate arithmetic: `OpAddI64Imm`, `OpSubI64Imm`, `OpMulI64Imm`, `OpDivI64Imm`, `OpModI64Imm`. One I64 arg (the immediate is encoded in `Value.Const`, not an operand).
+- F64 arithmetic: `OpAddF64`, `OpSubF64`, `OpMulF64`, `OpDivF64`, `OpNegF64`.
+- I64 comparisons: `OpCmpEqI64`, `OpCmpNeI64`, `OpCmpLtI64`, `OpCmpLeI64`, `OpCmpGtI64`, `OpCmpGeI64`.
+- I64 immediate comparisons: `OpCmpEqI64Imm`, `OpCmpNeI64Imm`, `OpCmpLtI64Imm`, `OpCmpLeI64Imm`, `OpCmpGtI64Imm`, `OpCmpGeI64Imm`.
+- F64 comparisons: `OpCmpEqF64`, `OpCmpNeF64`, `OpCmpLtF64`, `OpCmpLeF64`, `OpCmpGtF64`, `OpCmpGeF64`.
+- Bool comparisons and logic: `OpCmpEqBool`, `OpCmpNeBool`, `OpAndBool`, `OpOrBool`, `OpNotBool`.
+- I64 bitwise: `OpAndI64`, `OpOrI64`, `OpXorI64`, `OpShlI64`, `OpShrI64`, `OpNotI64`.
+- Conversions: `OpI64ToF64`, `OpF64ToI64`.
+- Math + time: `OpSqrtF64`, `OpNow` (zero-args).
+
+### Diff shape
+
+- `compiler3/ir/optable.go`: 47 new `OpInfo` entries appended to `opTable` under a `// Phase 4.2.31` comment.
+- `compiler3/ir/types.go`: removed 47 cases from `OpCode.String()`'s switch. Three head-of-switch comment blocks point to opTable for the migrated names.
+- `compiler3/ir/validate.go`: removed the corresponding 47 cases from `opContract`'s switch (the I64 arith group, I64 imm group, F64 arith group, all comparison groups, bitwise group, conversion group, math group, `OpNow`). The registry prologue at the top of the function handles them.
+- `compiler3/verify/verify.go`: removed 47 cases from `kindOf` (the giant `KindOperator` arm shrinks to `case ir.OpJsonI64Object:`) and 47 cases from `contractResult` (the I64/F64/Bool result arms collapse; `OpNow` removed from its standalone case).
+
+### Why this closes a goal
+
+After this phase, the registry covers 57 of the ~80 IR ops. The remaining legacy switch entries are heap-allocating ops (list / map / f64arr / strarr / listany / listlist families) and query/call/control-flow ops (`OpFnRef`, `OpCall`, `OpTailCall`, `OpCallGo`, `OpQuery*`, `OpPhi`, `OpParam`, `OpConst`, `OpInvalid`). The next-phase batch (heap-allocating families) is mechanical; the call/control-flow ops need their own classification pass because their contracts depend on call-site data the registry doesn't yet model.
+
+Adding a new scalar op now requires three edits: declare the OpCode, append the `OpInfo` literal, write the emit case. The string family in Phase 4.2.30 demonstrated this on KindConstructor / KindDispatch; this phase confirms it on KindOperator, the largest classification.
+
+### Limitations
+
+- `OpJsonI64Object` is still classified ad-hoc in `kindOf` because its variadic argument shape doesn't match the fixed `[3]Type` slot. A future phase will extend `OpInfo` (or add a `Variadic` flag) so it can join the registry.
+- The legacy switches in `ir/types.go`, `ir/validate.go`, and `verify/verify.go` still exist as fall-throughs. They will shrink to zero as remaining ops migrate; the final cleanup deletes the switches once `opTable` is the only source of truth.
+- The `Args` slot is a `[3]Type` fixed array; ops with more than three operands (none today, but query joins lean close) would need a wider slot. Deferred to the heap-family migration where the question naturally arises.
+
 ## §10.57 Phase 4.2.30 closeout (LANDED 2026-05-22 15:46 GMT+7)
 
 Phase 4.2.30 collapses the per-op file-edit tax: a registered op now carries its name, result type, operand types, and verifier kind in a single declarative entry. The String surface (10 ops) is the migration proof; downstream phases add new ops by appending one OpInfo literal plus the op-specific emit cases, not by touching ten files.


### PR DESCRIPTION
Tracks #22055.

Migrates the 47-op scalar surface (I64/F64/Bool arithmetic, comparison, bitwise, conversion, math, OpNow) to the data-driven op registry introduced in Phase 4.2.30. The legacy switches shrink by ~150 lines total.

## What migrates

All `KindOperator`, all with fixed scalar contracts:

- I64 arithmetic: `OpAddI64`, `OpSubI64`, `OpMulI64`, `OpDivI64`, `OpModI64`, `OpNegI64` + 5 immediate variants
- F64 arithmetic: `OpAddF64`, `OpSubF64`, `OpMulF64`, `OpDivF64`, `OpNegF64`
- I64 comparisons: `OpCmpEqI64` ... `OpCmpGeI64` + 6 immediate variants
- F64 comparisons: `OpCmpEqF64` ... `OpCmpGeF64`
- Bool: `OpCmpEqBool`, `OpCmpNeBool`, `OpAndBool`, `OpOrBool`, `OpNotBool`
- I64 bitwise: `OpAndI64`, `OpOrI64`, `OpXorI64`, `OpShlI64`, `OpShrI64`, `OpNotI64`
- Conversions + math + time: `OpI64ToF64`, `OpF64ToI64`, `OpSqrtF64`, `OpNow`

## Why this batch

- Largest homogeneous family in the IR (4.7x the size of the Phase 4.2.30 string surface).
- Structurally different: validates the registry on `KindOperator` at scale, with different operand Types and zero rule-E semantics.
- Mechanical: every op shares the same shape, so the migration is one batch instead of a multi-phase drip.

## Coverage after this phase

The registry now covers 57 of ~80 IR ops. Remaining legacy entries are heap-allocating families (list / map / f64arr / strarr / listany / listlist) and call / control-flow / query ops whose contracts depend on call-site data the registry does not yet model. Those follow in later phases.

## Diff shape

- `compiler3/ir/optable.go`: 47 new `OpInfo` entries under a Phase 4.2.31 comment.
- `compiler3/ir/types.go`: removed 47 cases from `OpCode.String()`.
- `compiler3/ir/validate.go`: removed 47 cases from `opContract` (registry prologue handles them).
- `compiler3/verify/verify.go`: removed 47 cases each from `kindOf` and `contractResult`.

## Tests

- `go test ./compiler3/ir/...` green
- `go test ./compiler3/verify/...` green
- `go test ./compiler3/frontend/...` green (40s)
- `go test ./compiler3/emit/c ./compiler3/emit/go` green
- `go test ./compiler3/build/c` green (135s)
- `go test ./compiler3/build/go` green

MEP §10.58 closeout documents the migration, diff shape, and remaining families.