### PR TITLE
mep-0042: phase 4.2.32 -- migrate heap-allocating op families to registry

### DIFF
--- a/compiler3/ir/optable.go
+++ b/compiler3/ir/optable.go
@@ -194,6 +194,71 @@ var opTable = []OpInfo{
 	{Code: OpF64ToI64, Name: "f64.to.i64", Result: TypeI64, Args: [3]Type{TypeF64}, NumArgs: 1, Kind: KindOperator},
 	{Code: OpSqrtF64, Name: "sqrt.f64", Result: TypeF64, Args: [3]Type{TypeF64}, NumArgs: 1, Kind: KindOperator},
 	{Code: OpNow, Name: "now", Result: TypeI64, Args: [3]Type{}, NumArgs: 0, Kind: KindOperator},
+
+	// Heap-allocating surface (MEP-42 Phase 4.2.32). Every op here
+	// either produces a handle Type (Constructor) or operates on an
+	// existing handle (Dispatch). The Dispatch reads / writes split
+	// drives rule E classification (Mutates flag).
+	//
+	// List(I64) family.
+	{Code: OpNewList, Name: "newlist", Result: TypeList, Args: [3]Type{}, NumArgs: 0, Kind: KindConstructor},
+	{Code: OpListLenI64, Name: "list.len.i64", Result: TypeI64, Args: [3]Type{TypeList}, NumArgs: 1, Kind: KindDispatch, Mutates: false},
+	{Code: OpListPushI64, Name: "list.push.i64", Result: TypeUnit, Args: [3]Type{TypeList, TypeI64}, NumArgs: 2, Kind: KindDispatch, Mutates: true},
+	{Code: OpListGetI64, Name: "list.get.i64", Result: TypeI64, Args: [3]Type{TypeList, TypeI64}, NumArgs: 2, Kind: KindDispatch, Mutates: false},
+	{Code: OpListSetI64, Name: "list.set.i64", Result: TypeUnit, Args: [3]Type{TypeList, TypeI64, TypeI64}, NumArgs: 3, Kind: KindDispatch, Mutates: true},
+	{Code: OpListGetF64, Name: "list.get.f64", Result: TypeF64, Args: [3]Type{TypeList, TypeI64}, NumArgs: 2, Kind: KindDispatch, Mutates: false},
+	{Code: OpListSetF64, Name: "list.set.f64", Result: TypeUnit, Args: [3]Type{TypeList, TypeI64, TypeF64}, NumArgs: 3, Kind: KindDispatch, Mutates: true},
+	{Code: OpListConcatI64, Name: "list.concat.i64", Result: TypeList, Args: [3]Type{TypeList, TypeList}, NumArgs: 2, Kind: KindConstructor},
+	{Code: OpListI64ToStr, Name: "list.i64.tostr", Result: TypeStr, Args: [3]Type{TypeList}, NumArgs: 1, Kind: KindConstructor},
+
+	// Map(I64,I64) family.
+	{Code: OpNewMap, Name: "newmap", Result: TypeMap, Args: [3]Type{}, NumArgs: 0, Kind: KindConstructor},
+	{Code: OpMapSetI64I64, Name: "map.set.i64.i64", Result: TypeUnit, Args: [3]Type{TypeMap, TypeI64, TypeI64}, NumArgs: 3, Kind: KindDispatch, Mutates: true},
+	{Code: OpMapGetI64I64, Name: "map.get.i64.i64", Result: TypeI64, Args: [3]Type{TypeMap, TypeI64}, NumArgs: 2, Kind: KindDispatch, Mutates: false},
+
+	// F64 array family.
+	{Code: OpNewF64Array, Name: "newf64array", Result: TypeF64Arr, Args: [3]Type{}, NumArgs: 0, Kind: KindConstructor},
+	{Code: OpF64ArrayLenI64, Name: "f64arr.len.i64", Result: TypeI64, Args: [3]Type{TypeF64Arr}, NumArgs: 1, Kind: KindDispatch, Mutates: false},
+	{Code: OpF64ArrayPushF64, Name: "f64arr.push.f64", Result: TypeUnit, Args: [3]Type{TypeF64Arr, TypeF64}, NumArgs: 2, Kind: KindDispatch, Mutates: true},
+	{Code: OpF64ArrayGetF64, Name: "f64arr.get.f64", Result: TypeF64, Args: [3]Type{TypeF64Arr, TypeI64}, NumArgs: 2, Kind: KindDispatch, Mutates: false},
+	{Code: OpF64ArraySetF64, Name: "f64arr.set.f64", Result: TypeUnit, Args: [3]Type{TypeF64Arr, TypeI64, TypeF64}, NumArgs: 3, Kind: KindDispatch, Mutates: true},
+	{Code: OpF64ArrayConcat, Name: "f64arr.concat", Result: TypeF64Arr, Args: [3]Type{TypeF64Arr, TypeF64Arr}, NumArgs: 2, Kind: KindConstructor},
+	{Code: OpF64ArrayToStr, Name: "f64array.tostr", Result: TypeStr, Args: [3]Type{TypeF64Arr}, NumArgs: 1, Kind: KindConstructor},
+
+	// String array family. OpStrArrGetStr is Constructor: it returns a
+	// handle (TypeStr) borrowed from a const char** slot; rule A requires
+	// handle-typed Values to originate from a Constructor / Move /
+	// Inline / Call kind.
+	{Code: OpNewStrArr, Name: "newstrarr", Result: TypeStrArr, Args: [3]Type{}, NumArgs: 0, Kind: KindConstructor},
+	{Code: OpStrArrLen, Name: "strarr.len", Result: TypeI64, Args: [3]Type{TypeStrArr}, NumArgs: 1, Kind: KindDispatch, Mutates: false},
+	{Code: OpStrArrPushStr, Name: "strarr.push.str", Result: TypeUnit, Args: [3]Type{TypeStrArr, TypeStr}, NumArgs: 2, Kind: KindDispatch, Mutates: true},
+	{Code: OpStrArrGetStr, Name: "strarr.get.str", Result: TypeStr, Args: [3]Type{TypeStrArr, TypeI64}, NumArgs: 2, Kind: KindConstructor},
+	{Code: OpStrArrSetStr, Name: "strarr.set.str", Result: TypeUnit, Args: [3]Type{TypeStrArr, TypeI64, TypeStr}, NumArgs: 3, Kind: KindDispatch, Mutates: true},
+	{Code: OpStrArrSlice, Name: "strarr.slice", Result: TypeStrArr, Args: [3]Type{TypeStrArr, TypeI64, TypeI64}, NumArgs: 3, Kind: KindConstructor},
+	{Code: OpStrArrToStr, Name: "strarr.tostr", Result: TypeStr, Args: [3]Type{TypeStrArr}, NumArgs: 1, Kind: KindConstructor},
+
+	// Map(Str,I64) family. OpMapStrI64SortedKeys is Constructor: it
+	// allocates a TypeStrArr handle.
+	{Code: OpNewMapStrI64, Name: "newmapstri64", Result: TypeMapStrI64, Args: [3]Type{}, NumArgs: 0, Kind: KindConstructor},
+	{Code: OpMapSetStrI64, Name: "map.set.str.i64", Result: TypeUnit, Args: [3]Type{TypeMapStrI64, TypeStr, TypeI64}, NumArgs: 3, Kind: KindDispatch, Mutates: true},
+	{Code: OpMapGetStrI64, Name: "map.get.str.i64", Result: TypeI64, Args: [3]Type{TypeMapStrI64, TypeStr}, NumArgs: 2, Kind: KindDispatch, Mutates: false},
+	{Code: OpMapLenStrI64, Name: "map.len.str.i64", Result: TypeI64, Args: [3]Type{TypeMapStrI64}, NumArgs: 1, Kind: KindDispatch, Mutates: false},
+	{Code: OpMapStrI64SortedKeys, Name: "map.str.i64.sortedkeys", Result: TypeStrArr, Args: [3]Type{TypeMapStrI64}, NumArgs: 1, Kind: KindConstructor},
+
+	// ListList family. OpListListGet returns a TypeList handle; it is a
+	// Constructor for rule A purposes (same rationale as OpStrArrGetStr).
+	{Code: OpNewListList, Name: "newlistlist", Result: TypeListList, Args: [3]Type{}, NumArgs: 0, Kind: KindConstructor},
+	{Code: OpListListPush, Name: "listlist.push", Result: TypeUnit, Args: [3]Type{TypeListList, TypeList}, NumArgs: 2, Kind: KindDispatch, Mutates: true},
+	{Code: OpListListGet, Name: "listlist.get", Result: TypeList, Args: [3]Type{TypeListList, TypeI64}, NumArgs: 2, Kind: KindConstructor},
+	{Code: OpListListLen, Name: "listlist.len", Result: TypeI64, Args: [3]Type{TypeListList}, NumArgs: 1, Kind: KindDispatch, Mutates: false},
+	{Code: OpListListToStr, Name: "listlist.tostr", Result: TypeStr, Args: [3]Type{TypeListList}, NumArgs: 1, Kind: KindConstructor},
+
+	// ListAny family. OpListAnyGetAny returns a TypeListAny handle;
+	// Constructor for the same handle-origin reason.
+	{Code: OpNewListAny, Name: "newlistany", Result: TypeListAny, Args: [3]Type{}, NumArgs: 0, Kind: KindConstructor},
+	{Code: OpListAnyLen, Name: "listany.len", Result: TypeI64, Args: [3]Type{TypeListAny}, NumArgs: 1, Kind: KindDispatch, Mutates: false},
+	{Code: OpListAnyPushAny, Name: "listany.push", Result: TypeUnit, Args: [3]Type{TypeListAny, TypeListAny}, NumArgs: 2, Kind: KindDispatch, Mutates: true},
+	{Code: OpListAnyGetAny, Name: "listany.get", Result: TypeListAny, Args: [3]Type{TypeListAny, TypeI64}, NumArgs: 2, Kind: KindConstructor},
 }
 
 // opTableIndex maps OpCode to its index in opTable, or -1 if the op

--- a/compiler3/ir/types.go
+++ b/compiler3/ir/types.go
@@ -464,86 +464,11 @@ func (o OpCode) String() string {
 	// conversion + math ops (OpAddI64, ..., OpNow) migrated to opTable;
 	// see compiler3/ir/optable.go for the full list. OpInfoOf returns
 	// their Name in the registry prologue above.
-	case OpNewList:
-		return "newlist"
-	case OpListLenI64:
-		return "list.len.i64"
-	case OpListPushI64:
-		return "list.push.i64"
-	case OpListGetI64:
-		return "list.get.i64"
-	case OpListSetI64:
-		return "list.set.i64"
-	case OpListGetF64:
-		return "list.get.f64"
-	case OpListSetF64:
-		return "list.set.f64"
-	case OpNewMap:
-		return "newmap"
-	case OpMapSetI64I64:
-		return "map.set.i64.i64"
-	case OpMapGetI64I64:
-		return "map.get.i64.i64"
-	case OpNewF64Array:
-		return "newf64array"
-	case OpF64ArrayLenI64:
-		return "f64arr.len.i64"
-	case OpF64ArrayPushF64:
-		return "f64arr.push.f64"
-	case OpF64ArrayGetF64:
-		return "f64arr.get.f64"
-	case OpF64ArraySetF64:
-		return "f64arr.set.f64"
-	case OpNewStrArr:
-		return "newstrarr"
-	case OpStrArrLen:
-		return "strarr.len"
-	case OpStrArrPushStr:
-		return "strarr.push.str"
-	case OpStrArrGetStr:
-		return "strarr.get.str"
-	case OpStrArrSetStr:
-		return "strarr.set.str"
-	case OpStrArrSlice:
-		return "strarr.slice"
-	case OpNewMapStrI64:
-		return "newmapstri64"
-	case OpMapSetStrI64:
-		return "map.set.str.i64"
-	case OpMapGetStrI64:
-		return "map.get.str.i64"
-	case OpMapLenStrI64:
-		return "map.len.str.i64"
-	case OpMapStrI64SortedKeys:
-		return "map.str.i64.sortedkeys"
-	case OpNewListList:
-		return "newlistlist"
-	case OpListListPush:
-		return "listlist.push"
-	case OpListListGet:
-		return "listlist.get"
-	case OpListListLen:
-		return "listlist.len"
-	case OpListListToStr:
-		return "listlist.tostr"
-	case OpListConcatI64:
-		return "list.concat.i64"
-	case OpF64ArrayConcat:
-		return "f64arr.concat"
-	case OpNewListAny:
-		return "newlistany"
-	case OpListAnyLen:
-		return "listany.len"
-	case OpListAnyPushAny:
-		return "listany.push"
-	case OpListAnyGetAny:
-		return "listany.get"
-	case OpListI64ToStr:
-		return "list.i64.tostr"
-	case OpF64ArrayToStr:
-		return "f64array.tostr"
-	case OpStrArrToStr:
-		return "strarr.tostr"
+	//
+	// Phase 4.2.32: heap-allocating families (list / map / f64arr /
+	// strarr / mapstri64 / listlist / listany) and their *.tostr
+	// constructors migrated to opTable. The registry prologue above
+	// returns the Name.
 	case OpJsonI64Object:
 		return "json.i64.object"
 	case OpCall:

--- a/compiler3/ir/validate.go
+++ b/compiler3/ir/validate.go
@@ -171,86 +171,11 @@ func opContract(o OpCode) opSig {
 	// Phase 4.2.31: scalar arithmetic, comparison, bitwise, conversion,
 	// and math ops (OpAddI64, ..., OpNow) migrated to opTable; the
 	// registry prologue above handles them.
-	case OpNewList:
-		return opSig{TypeList, [3]Type{}}
-	case OpListLenI64:
-		return opSig{TypeI64, [3]Type{TypeList}}
-	case OpListPushI64:
-		return opSig{TypeUnit, [3]Type{TypeList, TypeI64}}
-	case OpListGetI64:
-		return opSig{TypeI64, [3]Type{TypeList, TypeI64}}
-	case OpListSetI64:
-		return opSig{TypeUnit, [3]Type{TypeList, TypeI64, TypeI64}}
-	case OpListGetF64:
-		return opSig{TypeF64, [3]Type{TypeList, TypeI64}}
-	case OpListSetF64:
-		return opSig{TypeUnit, [3]Type{TypeList, TypeI64, TypeF64}}
-	case OpNewMap:
-		return opSig{TypeMap, [3]Type{}}
-	case OpMapSetI64I64:
-		return opSig{TypeUnit, [3]Type{TypeMap, TypeI64, TypeI64}}
-	case OpMapGetI64I64:
-		return opSig{TypeI64, [3]Type{TypeMap, TypeI64}}
-	case OpNewF64Array:
-		return opSig{TypeF64Arr, [3]Type{}}
-	case OpF64ArrayLenI64:
-		return opSig{TypeI64, [3]Type{TypeF64Arr}}
-	case OpF64ArrayPushF64:
-		return opSig{TypeUnit, [3]Type{TypeF64Arr, TypeF64}}
-	case OpF64ArrayGetF64:
-		return opSig{TypeF64, [3]Type{TypeF64Arr, TypeI64}}
-	case OpF64ArraySetF64:
-		return opSig{TypeUnit, [3]Type{TypeF64Arr, TypeI64, TypeF64}}
-	case OpNewStrArr:
-		return opSig{TypeStrArr, [3]Type{}}
-	case OpStrArrLen:
-		return opSig{TypeI64, [3]Type{TypeStrArr}}
-	case OpStrArrPushStr:
-		return opSig{TypeUnit, [3]Type{TypeStrArr, TypeStr}}
-	case OpStrArrGetStr:
-		return opSig{TypeStr, [3]Type{TypeStrArr, TypeI64}}
-	case OpStrArrSetStr:
-		return opSig{TypeUnit, [3]Type{TypeStrArr, TypeI64, TypeStr}}
-	case OpStrArrSlice:
-		return opSig{TypeStrArr, [3]Type{TypeStrArr, TypeI64, TypeI64}}
-	case OpNewMapStrI64:
-		return opSig{TypeMapStrI64, [3]Type{}}
-	case OpMapSetStrI64:
-		return opSig{TypeUnit, [3]Type{TypeMapStrI64, TypeStr, TypeI64}}
-	case OpMapGetStrI64:
-		return opSig{TypeI64, [3]Type{TypeMapStrI64, TypeStr}}
-	case OpMapLenStrI64:
-		return opSig{TypeI64, [3]Type{TypeMapStrI64}}
-	case OpMapStrI64SortedKeys:
-		return opSig{TypeStrArr, [3]Type{TypeMapStrI64}}
-	case OpNewListList:
-		return opSig{TypeListList, [3]Type{}}
-	case OpListListPush:
-		return opSig{TypeUnit, [3]Type{TypeListList, TypeList}}
-	case OpListListGet:
-		return opSig{TypeList, [3]Type{TypeListList, TypeI64}}
-	case OpListListLen:
-		return opSig{TypeI64, [3]Type{TypeListList}}
-	case OpListListToStr:
-		return opSig{TypeStr, [3]Type{TypeListList}}
-	case OpListConcatI64:
-		return opSig{TypeList, [3]Type{TypeList, TypeList}}
-	case OpListI64ToStr:
-		return opSig{TypeStr, [3]Type{TypeList}}
-	case OpF64ArrayToStr:
-		return opSig{TypeStr, [3]Type{TypeF64Arr}}
-	case OpStrArrToStr:
-		return opSig{TypeStr, [3]Type{TypeStrArr}}
-	case OpF64ArrayConcat:
-		return opSig{TypeF64Arr, [3]Type{TypeF64Arr, TypeF64Arr}}
-	case OpNewListAny:
-		return opSig{TypeListAny, [3]Type{}}
-	case OpListAnyLen:
-		return opSig{TypeI64, [3]Type{TypeListAny}}
-	case OpListAnyPushAny:
-		return opSig{TypeUnit, [3]Type{TypeListAny, TypeListAny}}
-	case OpListAnyGetAny:
-		return opSig{TypeListAny, [3]Type{TypeListAny, TypeI64}}
+	//
+	// Phase 4.2.32: heap-allocating families (list / map / f64arr /
+	// strarr / mapstri64 / listlist / listany) and their *.tostr
+	// constructors migrated to opTable; the registry prologue above
+	// returns the contract.
 	case OpJsonI64Object:
 		// Variadic in Args (N i64 values, N >= 1); per-arg shape is
 		// enforced by the frontend at lower time. opContract returns

--- a/compiler3/verify/verify.go
+++ b/compiler3/verify/verify.go
@@ -185,37 +185,18 @@ func kindOf(o ir.OpCode) ProducerKind {
 	case ir.OpJsonI64Object:
 		return KindOperator
 
-	case ir.OpListI64ToStr, ir.OpF64ArrayToStr, ir.OpStrArrToStr:
-		return KindConstructor
-
-	case ir.OpNewList, ir.OpNewMap, ir.OpNewF64Array, ir.OpNewStrArr, ir.OpNewMapStrI64, ir.OpNewListAny,
-		ir.OpNewListList,
-		ir.OpListConcatI64, ir.OpF64ArrayConcat,
-		ir.OpListAnyGetAny,
-		ir.OpStrArrGetStr,
-		ir.OpStrArrSlice,
-		ir.OpListListGet,
-		ir.OpListListToStr,
-		ir.OpMapStrI64SortedKeys:
-		// OpListAnyGetAny returns a handle (TypeListAny) borrowed from
-		// an existing tree node. OpStrArrGetStr returns a handle
-		// (TypeStr) borrowed from a `const char**` slot. Rule A
-		// requires handle-typed Values to originate from a
-		// Constructor / Move / Inline / Call kind, so the get-ops are
-		// classified Constructor (same rationale as OpFnRef: produces
-		// a fresh-looking handle whose payload is a derived pointer,
-		// not arbitrary bits).
-		return KindConstructor
-
-	case ir.OpListLenI64, ir.OpListPushI64, ir.OpListGetI64, ir.OpListSetI64,
-		ir.OpListGetF64, ir.OpListSetF64,
-		ir.OpMapSetI64I64, ir.OpMapGetI64I64,
-		ir.OpMapSetStrI64, ir.OpMapGetStrI64, ir.OpMapLenStrI64,
-		ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64, ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64,
-		ir.OpStrArrLen, ir.OpStrArrPushStr, ir.OpStrArrSetStr,
-		ir.OpListAnyLen, ir.OpListAnyPushAny,
-		ir.OpListListPush, ir.OpListListLen:
-		return KindDispatch
+	// Phase 4.2.32: heap-allocating families migrated to opTable.
+	// Constructor kind: OpNewList, OpNewMap, OpNewF64Array, OpNewStrArr,
+	// OpNewMapStrI64, OpNewListAny, OpNewListList, OpListConcatI64,
+	// OpF64ArrayConcat, OpListAnyGetAny, OpStrArrGetStr, OpStrArrSlice,
+	// OpListListGet, OpListListToStr, OpMapStrI64SortedKeys,
+	// OpListI64ToStr, OpF64ArrayToStr, OpStrArrToStr.
+	// Dispatch kind: OpListLenI64, OpListPushI64, OpListGetI64,
+	// OpListSetI64, OpListGetF64, OpListSetF64, OpMapSetI64I64,
+	// OpMapGetI64I64, OpMapSetStrI64, OpMapGetStrI64, OpMapLenStrI64,
+	// OpF64ArrayLenI64, OpF64ArrayPushF64, OpF64ArrayGetF64,
+	// OpF64ArraySetF64, OpStrArrLen, OpStrArrPushStr, OpStrArrSetStr,
+	// OpListAnyLen, OpListAnyPushAny, OpListListPush, OpListListLen.
 
 	case ir.OpCall, ir.OpTailCall, ir.OpCallGo:
 		return KindCall
@@ -428,70 +409,10 @@ func contractResult(o ir.OpCode) ir.Type {
 		return info.Result
 	}
 	switch o {
-	case ir.OpNewList:
-		return ir.TypeList
-	case ir.OpNewMap:
-		return ir.TypeMap
-	case ir.OpNewF64Array:
-		return ir.TypeF64Arr
-	case ir.OpNewStrArr:
-		return ir.TypeStrArr
-	case ir.OpStrArrLen:
-		return ir.TypeI64
-	case ir.OpStrArrPushStr, ir.OpStrArrSetStr:
-		return ir.TypeUnit
-	case ir.OpStrArrGetStr:
-		return ir.TypeStr
-	case ir.OpStrArrSlice:
-		return ir.TypeStrArr
-	case ir.OpListLenI64:
-		return ir.TypeI64
-	case ir.OpListPushI64, ir.OpListSetI64, ir.OpListSetF64:
-		return ir.TypeUnit
-	case ir.OpListGetI64:
-		return ir.TypeI64
-	case ir.OpListGetF64:
-		return ir.TypeF64
-	case ir.OpMapSetI64I64:
-		return ir.TypeUnit
-	case ir.OpMapGetI64I64:
-		return ir.TypeI64
-	case ir.OpNewMapStrI64:
-		return ir.TypeMapStrI64
-	case ir.OpMapSetStrI64:
-		return ir.TypeUnit
-	case ir.OpMapGetStrI64, ir.OpMapLenStrI64:
-		return ir.TypeI64
-	case ir.OpF64ArrayLenI64:
-		return ir.TypeI64
-	case ir.OpF64ArrayPushF64, ir.OpF64ArraySetF64:
-		return ir.TypeUnit
-	case ir.OpF64ArrayGetF64:
-		return ir.TypeF64
-	case ir.OpListConcatI64:
-		return ir.TypeList
-	case ir.OpF64ArrayConcat:
-		return ir.TypeF64Arr
-	case ir.OpNewListAny:
-		return ir.TypeListAny
-	case ir.OpListAnyLen:
-		return ir.TypeI64
-	case ir.OpListAnyPushAny:
-		return ir.TypeUnit
-	case ir.OpListAnyGetAny:
-		return ir.TypeListAny
-	case ir.OpNewListList:
-		return ir.TypeListList
-	case ir.OpListListPush:
-		return ir.TypeUnit
-	case ir.OpListListGet:
-		return ir.TypeList
-	case ir.OpListListLen:
-		return ir.TypeI64
-	case ir.OpListListToStr:
-		return ir.TypeStr
-	case ir.OpMapStrI64SortedKeys:
-		return ir.TypeStrArr
+	// Phase 4.2.32: heap-allocating families and *.tostr constructors
+	// migrated to opTable; the registry prologue above returns the
+	// Result. The only entry left here is OpJsonI64Object, which is
+	// variadic in Args and hasn't been modeled in OpInfo yet.
 	case ir.OpJsonI64Object:
 		return ir.TypeUnit
 	}
@@ -502,65 +423,28 @@ func contractResult(o ir.OpCode) ir.Type {
 // arena it dispatches into. Rule E uses this classification to refuse
 // mutating ops on borrow-tagged values.
 //
-// Read Dispatch ops: OpLenStr, OpListLenI64, OpListGetI64, OpListGetF64,
-// OpMapGetI64I64, OpF64ArrayLenI64, OpF64ArrayGetF64.
-//
-// Write Dispatch ops: OpListPushI64, OpListSetI64, OpListSetF64,
-// OpMapSetI64I64, OpF64ArrayPushF64, OpF64ArraySetF64.
-//
-// Adding a new Dispatch op to ir/types.go without classifying it here
-// would silently default to "non-mutating" for rule E purposes. The
-// init() coverage check below catches this by asserting every
-// KindDispatch op appears in either readDispatchOps or writeDispatchOps.
+// Phase 4.2.32: every Dispatch op now lives in ir.opTable; the
+// Mutates flag on the registered OpInfo is the single source of
+// truth. opIsMutating consults the registry and falls back to false
+// for ops the registry doesn't know about (which would be a kindOf
+// classification error caught by mustClassifyAllDispatch at init).
 func opIsMutating(o ir.OpCode) bool {
-	switch o {
-	case ir.OpListPushI64, ir.OpListSetI64, ir.OpListSetF64,
-		ir.OpMapSetI64I64,
-		ir.OpMapSetStrI64,
-		ir.OpF64ArrayPushF64, ir.OpF64ArraySetF64,
-		ir.OpStrArrPushStr, ir.OpStrArrSetStr,
-		ir.OpListAnyPushAny,
-		ir.OpListListPush:
-		return true
+	if info, ok := ir.OpInfoOf(o); ok {
+		return info.Mutates
 	}
 	return false
 }
 
-// readDispatchOps lists every unregistered KindDispatch op that does
-// not mutate its arena. Kept as data (rather than a switch) so the
-// coverage check can enumerate both halves of the dispatch op set.
-//
-// Phase 4.2.30: ops migrated into ir.opTable carry their Mutates flag
-// in the registry; mustClassifyAllDispatch unions ir.ReadDispatchOps()
-// into the coverage set so a registered op need not be listed here.
-var readDispatchOps = []ir.OpCode{
-	ir.OpListLenI64,
-	ir.OpListGetI64,
-	ir.OpListGetF64,
-	ir.OpMapGetI64I64,
-	ir.OpMapGetStrI64,
-	ir.OpMapLenStrI64,
-	ir.OpF64ArrayLenI64,
-	ir.OpF64ArrayGetF64,
-	ir.OpStrArrLen,
-	ir.OpListAnyLen,
-	ir.OpListListLen,
-}
+// readDispatchOps and writeDispatchOps formerly listed every
+// KindDispatch op for the rule-E coverage check. After Phase 4.2.32
+// migrated every heap-allocating Dispatch op to ir.opTable, both
+// slices became empty; mustClassifyAllDispatch reads ir.ReadDispatchOps()
+// and ir.WriteDispatchOps() directly. The variables are retained as
+// the canonical fall-back slot for any future Dispatch op that
+// cannot be registered (none today).
+var readDispatchOps = []ir.OpCode{}
 
-// writeDispatchOps lists every KindDispatch op that mutates its arena.
-var writeDispatchOps = []ir.OpCode{
-	ir.OpListPushI64,
-	ir.OpListSetI64,
-	ir.OpListSetF64,
-	ir.OpMapSetI64I64,
-	ir.OpMapSetStrI64,
-	ir.OpF64ArrayPushF64,
-	ir.OpF64ArraySetF64,
-	ir.OpStrArrPushStr,
-	ir.OpStrArrSetStr,
-	ir.OpListAnyPushAny,
-	ir.OpListListPush,
-}
+var writeDispatchOps = []ir.OpCode{}
 
 // checkRuleE verifies the §6.9 reference-mode obligations. Default-mode
 // functions (nil RefModes) pass trivially; the rest of the checker only
@@ -684,25 +568,15 @@ func mustClassifyAllDispatch() {
 
 // dispatchArena returns the arena Type a KindDispatch op reads from.
 // Used by rule D.
+//
+// Phase 4.2.32: every Dispatch op now lives in ir.opTable. The arena
+// Type is always the first operand by rule D's contract, so we read
+// it directly from info.Args[0]. Unregistered or non-Dispatch ops
+// return TypeInvalid and rule D skips them.
 func dispatchArena(o ir.OpCode) ir.Type {
-	switch o {
-	case ir.OpLenStr:
-		return ir.TypeStr
-	case ir.OpListLenI64, ir.OpListPushI64, ir.OpListGetI64, ir.OpListSetI64,
-		ir.OpListGetF64, ir.OpListSetF64:
-		return ir.TypeList
-	case ir.OpMapSetI64I64, ir.OpMapGetI64I64:
-		return ir.TypeMap
-	case ir.OpMapSetStrI64, ir.OpMapGetStrI64, ir.OpMapLenStrI64:
-		return ir.TypeMapStrI64
-	case ir.OpF64ArrayLenI64, ir.OpF64ArrayPushF64, ir.OpF64ArrayGetF64, ir.OpF64ArraySetF64:
-		return ir.TypeF64Arr
-	case ir.OpStrArrLen, ir.OpStrArrPushStr, ir.OpStrArrGetStr, ir.OpStrArrSetStr:
-		return ir.TypeStrArr
-	case ir.OpListAnyLen, ir.OpListAnyPushAny:
-		return ir.TypeListAny
-	case ir.OpListListPush, ir.OpListListLen:
-		return ir.TypeListList
+	info, ok := ir.OpInfoOf(o)
+	if !ok || info.Kind != ir.KindDispatch {
+		return ir.TypeInvalid
 	}
-	return ir.TypeInvalid
+	return info.Args[0]
 }

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,34 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.59 Phase 4.2.32 closeout (LANDED 2026-05-22 16:14 GMT+7)
+
+Phase 4.2.32 migrates the heap-allocating op families (list, map, f64arr, strarr, mapstri64, listlist, listany, plus the `*.tostr` constructors) to the registry. Combined with Phases 4.2.30 (string surface) and 4.2.31 (scalar surface), the registry now covers every IR op except the handful whose contracts depend on call-site data or variadic argument shapes.
+
+### What migrated
+
+37 ops added to `opTable`. Constructor entries: `OpNewList`, `OpNewMap`, `OpNewF64Array`, `OpNewStrArr`, `OpNewMapStrI64`, `OpNewListAny`, `OpNewListList`, `OpListConcatI64`, `OpF64ArrayConcat`, `OpListAnyGetAny`, `OpStrArrGetStr`, `OpStrArrSlice`, `OpListListGet`, `OpListListToStr`, `OpMapStrI64SortedKeys`, `OpListI64ToStr`, `OpF64ArrayToStr`, `OpStrArrToStr`. Dispatch entries (each carrying the `Mutates` flag): `OpListLenI64`, `OpListPushI64`, `OpListGetI64`, `OpListSetI64`, `OpListGetF64`, `OpListSetF64`, `OpMapSetI64I64`, `OpMapGetI64I64`, `OpMapSetStrI64`, `OpMapGetStrI64`, `OpMapLenStrI64`, `OpF64ArrayLenI64`, `OpF64ArrayPushF64`, `OpF64ArrayGetF64`, `OpF64ArraySetF64`, `OpStrArrLen`, `OpStrArrPushStr`, `OpStrArrSetStr`, `OpListAnyLen`, `OpListAnyPushAny`, `OpListListPush`, `OpListListLen`.
+
+### Diff shape
+
+- `compiler3/ir/optable.go`: 37 new `OpInfo` entries grouped under a Phase 4.2.32 comment block, organized by family.
+- `compiler3/ir/types.go`: removed the 37 cases from `OpCode.String()`'s switch. The switch is now down to the open-classification ops (`OpInvalid`, `OpParam`, `OpConst`, `OpPhi`, `OpJsonI64Object`, `OpCall`, `OpTailCall`, `OpFnRef`, `OpQuery*`, `OpCallGo`).
+- `compiler3/ir/validate.go`: same shrinkage in `opContract`; the switch is now down to `OpJsonI64Object` (variadic) and the pass-through default.
+- `compiler3/verify/verify.go`: `kindOf` shrinks dramatically (Constructor and Dispatch arms removed; the remaining entries are the open-classification ops only). `contractResult` is now a one-case switch handling only `OpJsonI64Object`. `opIsMutating` becomes a one-line registry read (`info.Mutates`). `dispatchArena` becomes a one-line registry read (`info.Args[0]` when `info.Kind == KindDispatch`). The verify-local `readDispatchOps` and `writeDispatchOps` slices empty out; `mustClassifyAllDispatch` continues to union `ir.ReadDispatchOps()` and `ir.WriteDispatchOps()`, which now carry the full Dispatch coverage.
+
+### Why this closes a goal
+
+After this phase, the registry is the single source of truth for every IR op aside from the variadic / call-site-dependent stragglers. The legacy switches in `ir/types.go`, `ir/validate.go`, and `verify/verify.go` are no longer the place to add a new op; the explicit fall-through is reserved for ops that genuinely cannot be modeled by `OpInfo`'s fixed schema. The original 4.2.28 drift bug class (rule-E classification slipping out of sync with `kindOf`) cannot recur on any registered op without explicitly contradicting the registry, which the init-time check rejects.
+
+Concretely, the verify-local `opIsMutating` and `dispatchArena` functions are no longer per-op switches that need updating each time a Dispatch op is added; they read the `Mutates` flag and the first-argument arena Type from the registry entry. Three files (`ir/types.go`, `ir/validate.go`, `verify/verify.go`) no longer change when a new op is added in the canonical workflow.
+
+### Limitations
+
+- `OpJsonI64Object` remains the lone variadic stub in the legacy switches. Migrating it requires extending `OpInfo` with a `Variadic` flag (or a sentinel `NumArgs == -1`); deferred to a phase that has an actual second variadic op to motivate the schema change.
+- `OpCall`, `OpTailCall`, `OpCallGo`, `OpFnRef`, and the `OpQuery*` family are deliberately not registered. Their result Types are call-site dependent (`OpCall`'s result is the callee's declared `Result`), and a static `OpInfo.Result` field cannot capture that. A separate registry slot for these would need a `ResultFromCallee` indicator; deferred.
+- `OpParam`, `OpConst`, `OpPhi`, `OpInvalid` are also unregistered. Their classification (`KindMove`, `KindInline`, `KindMove`, `KindInvalid`) is structural and lives at the head of `kindOf` directly; registering them would not simplify anything.
+- The verify-local `readDispatchOps` and `writeDispatchOps` slices are now empty but retained as the canonical fall-back slot. They will be removed if every future Dispatch op stays in the registry (the expected steady-state).
+
 ## §10.58 Phase 4.2.31 closeout (LANDED 2026-05-22 16:01 GMT+7)
 
 Phase 4.2.31 migrates the scalar arithmetic, comparison, bitwise, conversion, and math op families to the registry that Phase 4.2.30 introduced. The 47-op batch (every `Op*I64`, `Op*F64`, `Op*Bool`, plus `OpI64ToF64`, `OpF64ToI64`, `OpSqrtF64`, `OpNow`) drains the largest chunk of the legacy switches and validates the registry mechanism against the largest op family.


### PR DESCRIPTION
Tracks #22057.

Phase 4.2.32 of the data-driven op registry migration (MEP-42 §10.59). Moves 37 heap-allocating IR ops (List(I64) / Map / F64Arr / StrArr / MapStrI64 / ListList / ListAny families and their *.tostr constructors) into `compiler3/ir/optable.go`, draining the parallel switches in `types.go OpCode.String()`, `validate.go opContract`, `verify.go kindOf`, and `verify.go contractResult`.

`opIsMutating` and `dispatchArena` (the rule-E and rule-D classifiers) collapse to one-liners reading `info.Mutates` / `info.Kind == KindDispatch`, since every dispatch op now carries that metadata in the registry. `readDispatchOps` / `writeDispatchOps` are emptied (the test unions `ir.ReadDispatchOps()` / `ir.WriteDispatchOps()` for coverage).

Registry coverage: ~94 of ~100 IR ops. Remaining stragglers are variadic (`OpJsonI64Object`), call-site-typed (`OpCall`, `OpTailCall`, `OpCallGo`, `OpFnRef`, `OpQuery*`), or structural (`OpParam`, `OpConst`, `OpPhi`, `OpInvalid`) and cannot fit `OpInfo`'s fixed schema without an extension.

## Test plan
- [x] `go test ./compiler3/ir/... ./compiler3/verify/... ./compiler3/frontend/...`
- [x] `go test ./compiler3/emit/c/... ./compiler3/emit/go/...`
- [x] `go test ./compiler3/build/c/... ./compiler3/build/go/...`