### PR TITLE
mep-0042: phase 5.0 -- cross-target C AOT via zig cc

### DIFF
--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -83,6 +83,7 @@ type BuildCmd struct {
 	CC             string `arg:"--cc" help:"C compiler to invoke (default: $MOCHI_CC or 'cc'); --target=c only"`
 	BinaryPath     string `arg:"--binary" help:"Output binary path; --target=c only"`
 	Static         bool   `arg:"--portable" help:"Statically link the binary (musl/glibc-static); --target=c only"`
+	Triple         string `arg:"--triple" help:"Target triple (e.g. x86_64-linux-musl, aarch64-macos, wasm32-wasi); --target=c only. When set, the driver defaults to 'zig cc' and passes -target=<triple>"`
 }
 
 type RunCmd struct {
@@ -268,6 +269,7 @@ func runBuildC(cmd *BuildCmd) error {
 		KeepEmit:   cmd.KeepEmit,
 		CC:         cmd.CC,
 		Static:     cmd.Static,
+		Triple:     cmd.Triple,
 	}
 	r, err := cbuild.BuildSource(cmd.File, opts)
 	if err != nil {
@@ -782,6 +784,7 @@ func newBuildCmd() *cobra.Command {
 	c.Flags().StringVar(&bc.CC, "cc", "", "C compiler to invoke (default: $MOCHI_CC or 'cc'); --target=c only")
 	c.Flags().StringVar(&bc.BinaryPath, "binary", "", "Output binary path; --target=c only")
 	c.Flags().BoolVar(&bc.Static, "portable", false, "Statically link the binary (musl/glibc-static); --target=c only")
+	c.Flags().StringVar(&bc.Triple, "triple", "", "Target triple (e.g. x86_64-linux-musl, aarch64-macos, wasm32-wasi); --target=c only. When set, the driver defaults to 'zig cc' and passes -target=<triple>")
 	return c
 }
 

--- a/compiler3/build/c/cross_test.go
+++ b/compiler3/build/c/cross_test.go
@@ -1,0 +1,329 @@
+package cbuild
+
+import (
+	"encoding/binary"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	cgen "mochi/compiler3/emit/c"
+	"mochi/compiler3/ir"
+)
+
+// Phase 5.0 cross-target test suite. The §9 phase-1 matrix lists five
+// must-have targets; Phase 4.0 covers the host (x86_64 Linux). Phase
+// 5.0 unlocks the other four by routing through `zig cc -target=<triple>`.
+// We do not (and cannot) execute the produced binaries on this host,
+// so the gate is "the binary is the expected file format for the
+// requested triple". Format is verified by reading the magic bytes
+// (ELF e_machine for Linux triples, Wasm 1.0 magic for wasm32-wasi).
+//
+// Skip the whole suite when `zig` is not on PATH. The host-target tests
+// in driver_test.go remain the load-bearing gate when zig is absent.
+
+// hasZig reports whether `zig` is on PATH. Used to skip cross-target
+// tests on machines that ship only `cc`; the host gate is unaffected.
+func hasZig() bool {
+	_, err := exec.LookPath("zig")
+	return err == nil
+}
+
+// elfMachine reads the e_machine field of an ELF file (offset 0x12,
+// 2 bytes, little-endian). Returns 0 if the file is not an ELF.
+const (
+	elfMachineX86_64  = 0x3E
+	elfMachineAArch64 = 0xB7
+)
+
+func elfMachine(t *testing.T, path string) uint16 {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if len(data) < 0x14 {
+		t.Fatalf("file %s too short to be ELF (%d bytes)", path, len(data))
+	}
+	if string(data[:4]) != "\x7fELF" {
+		t.Fatalf("file %s is not ELF (magic=%q)", path, data[:4])
+	}
+	return binary.LittleEndian.Uint16(data[0x12:0x14])
+}
+
+// machoCPUType reads the cputype field of a Mach-O file (offset 4,
+// 4 bytes, little-endian). Returns 0 if the file is not Mach-O 64.
+// Magic 0xFEEDFACF is Mach-O 64-bit; cputype 0x01000007 is x86_64
+// and 0x0100000C is arm64.
+const (
+	machoMagic64       = 0xFEEDFACF
+	machoCPUTypeX86_64 = 0x01000007
+	machoCPUTypeArm64  = 0x0100000C
+)
+
+func machoCPUType(t *testing.T, path string) uint32 {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if len(data) < 8 {
+		t.Fatalf("file %s too short to be Mach-O (%d bytes)", path, len(data))
+	}
+	if magic := binary.LittleEndian.Uint32(data[0:4]); magic != machoMagic64 {
+		t.Fatalf("file %s is not Mach-O 64 (magic=0x%X)", path, magic)
+	}
+	return binary.LittleEndian.Uint32(data[4:8])
+}
+
+// isWasm reports whether the file at path starts with the Wasm 1.0
+// magic (`\0asm` followed by version 1).
+func isWasm(t *testing.T, path string) bool {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if len(data) < 8 {
+		return false
+	}
+	return string(data[:4]) == "\x00asm" &&
+		binary.LittleEndian.Uint32(data[4:8]) == 1
+}
+
+// crossProgram builds a one-function Program that returns 42. The
+// emitter wraps it in `int main(void)` via Program.Main so the
+// produced object links as a standalone executable. This is the same
+// shape TestBuildHelloEndToEnd uses on the host; Phase 5.0 reuses it
+// across triples to keep the cross-target gate aligned with the
+// host gate (identical input, identical expected return).
+func crossProgram() *cgen.Program {
+	fn := &ir.Function{Name: "answer", Result: ir.TypeI64}
+	bid := fn.AddBlock()
+	c := fn.AddValue(ir.Value{Type: ir.TypeI64, Op: ir.OpConst, Const: 42})
+	blk := fn.Block(bid)
+	blk.Values = []uint32{c}
+	blk.Term = ir.Terminator{Kind: ir.TermReturn, Value: c}
+	return &cgen.Program{Funcs: []*ir.Function{fn}, Main: "answer"}
+}
+
+// runner names a foreign-arch executor: the command + flag prefix
+// that runs a binary built for some target on this host. When PATH
+// has no runner for a triple, the test skips the run-gate (the
+// build-gate still fires).
+//
+// Linux ELFs run under qemu-user (qemu-x86_64 / qemu-aarch64). Wasm
+// modules run under wasmtime (`wasmtime run --`). The framework is
+// extensible: every new triple lands its runner here, in one place.
+type runner struct {
+	cmd  string
+	args []string
+}
+
+func findRunner(triple string) (runner, bool) {
+	switch triple {
+	case "x86_64-linux-musl", "x86_64-linux-gnu":
+		// Linux x86_64 ELF runs natively on a linux/amd64 host, or
+		// under qemu-user on any host with the binary on PATH.
+		if runtime.GOOS == "linux" && runtime.GOARCH == "amd64" {
+			return runner{}, true
+		}
+		if p, err := exec.LookPath("qemu-x86_64"); err == nil {
+			return runner{cmd: p}, true
+		}
+		if p, err := exec.LookPath("qemu-x86_64-static"); err == nil {
+			return runner{cmd: p}, true
+		}
+	case "aarch64-linux-musl", "aarch64-linux-gnu":
+		if runtime.GOOS == "linux" && runtime.GOARCH == "arm64" {
+			return runner{}, true
+		}
+		if p, err := exec.LookPath("qemu-aarch64"); err == nil {
+			return runner{cmd: p}, true
+		}
+		if p, err := exec.LookPath("qemu-aarch64-static"); err == nil {
+			return runner{cmd: p}, true
+		}
+	case "aarch64-macos":
+		// Native execution on arm64 Darwin. On x86_64 Darwin this
+		// would require Rosetta-reverse (does not exist); skip there.
+		if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+			return runner{}, true
+		}
+	case "x86_64-macos":
+		// Native on x86_64 Darwin, or under Rosetta 2 on arm64 Darwin
+		// (which the OS handles transparently, no runner prefix
+		// needed). On non-Darwin hosts there is no way to run a
+		// Mach-O binary, so we skip.
+		if runtime.GOOS == "darwin" {
+			return runner{}, true
+		}
+	case "wasm32-wasi":
+		if p, err := exec.LookPath("wasmtime"); err == nil {
+			return runner{cmd: p, args: []string{"run", "--"}}, true
+		}
+		if p, err := exec.LookPath("wasmer"); err == nil {
+			return runner{cmd: p, args: []string{"run"}}, true
+		}
+		if p, err := exec.LookPath("wasm3"); err == nil {
+			return runner{cmd: p}, true
+		}
+	}
+	return runner{}, false
+}
+
+// runBinary executes binPath through r and returns its stdout. Fails
+// the test on non-zero exit. The trailing newline is preserved so
+// callers can match the emitter's "%lld\n" output byte-for-byte.
+// When r.cmd is empty, the binary is executed directly (native host
+// matches target ABI; no emulator prefix needed).
+func runBinary(t *testing.T, r runner, binPath string) string {
+	t.Helper()
+	var cmd *exec.Cmd
+	if r.cmd == "" {
+		cmd = exec.Command(binPath)
+	} else {
+		argv := append(append([]string{}, r.args...), binPath)
+		cmd = exec.Command(r.cmd, argv...)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run %s: %v\n%s", strings.Join(cmd.Args, " "), err, out)
+	}
+	return string(out)
+}
+
+// assertCrossOutput is the Phase 5.0 run-gate: when a runner is
+// available, execute the foreign-arch binary and assert stdout
+// matches the host gate's output ("42\n"). When no runner is on
+// PATH, skip the run-gate (the build-gate's file-format check has
+// already fired) and log a hint pointing at the install command.
+func assertCrossOutput(t *testing.T, triple, binPath string) {
+	t.Helper()
+	r, ok := findRunner(triple)
+	if !ok {
+		t.Logf("no runner for %s on PATH; skipping run-gate (install qemu / wasmtime to enable)", triple)
+		return
+	}
+	got := runBinary(t, r, binPath)
+	const want = "42\n"
+	if got != want {
+		t.Errorf("cross-run %s via %s: stdout = %q, want %q", triple, r.cmd, got, want)
+	}
+}
+
+// TestBuildCrossX86_64Linux is the Phase 5.0 gate for the §9
+// x86_64 Linux row: `mochi build --target=c --triple=x86_64-linux-musl`
+// produces an ELF that names x86_64 in its e_machine.
+func TestBuildCrossX86_64Linux(t *testing.T) {
+	if !hasZig() {
+		t.Skip("zig not on PATH; Phase 5.0 cross-target gate requires zig cc")
+	}
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "answer.x86_64-linux")
+	_, err := Build(crossProgram(), Options{
+		OutDir:     dir,
+		BinaryPath: binPath,
+		Triple:     "x86_64-linux-musl",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := elfMachine(t, binPath); got != elfMachineX86_64 {
+		t.Errorf("e_machine = 0x%X, want 0x%X (x86_64)", got, elfMachineX86_64)
+	}
+	assertCrossOutput(t, "x86_64-linux-musl", binPath)
+}
+
+// TestBuildCrossAArch64Linux is the Phase 5.0 gate for the §9
+// aarch64 Linux row.
+func TestBuildCrossAArch64Linux(t *testing.T) {
+	if !hasZig() {
+		t.Skip("zig not on PATH; Phase 5.0 cross-target gate requires zig cc")
+	}
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "answer.aarch64-linux")
+	_, err := Build(crossProgram(), Options{
+		OutDir:     dir,
+		BinaryPath: binPath,
+		Triple:     "aarch64-linux-musl",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := elfMachine(t, binPath); got != elfMachineAArch64 {
+		t.Errorf("e_machine = 0x%X, want 0x%X (aarch64)", got, elfMachineAArch64)
+	}
+	assertCrossOutput(t, "aarch64-linux-musl", binPath)
+}
+
+// TestBuildCrossAArch64Macos is the Phase 5.0 gate for the §9
+// aarch64 macOS row. On an Apple Silicon host the binary runs
+// natively; on other hosts the build-gate (Mach-O cputype check)
+// still fires and the run-gate skips.
+func TestBuildCrossAArch64Macos(t *testing.T) {
+	if !hasZig() {
+		t.Skip("zig not on PATH; Phase 5.0 cross-target gate requires zig cc")
+	}
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "answer.aarch64-macos")
+	_, err := Build(crossProgram(), Options{
+		OutDir:     dir,
+		BinaryPath: binPath,
+		Triple:     "aarch64-macos",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := machoCPUType(t, binPath); got != machoCPUTypeArm64 {
+		t.Errorf("cputype = 0x%X, want 0x%X (arm64)", got, machoCPUTypeArm64)
+	}
+	assertCrossOutput(t, "aarch64-macos", binPath)
+}
+
+// TestBuildCrossX86_64Macos is the Phase 5.0 gate for the §9
+// x86_64 macOS row. On an Apple Silicon host Rosetta 2 runs the
+// binary transparently; on an x86_64 Darwin host it runs natively.
+func TestBuildCrossX86_64Macos(t *testing.T) {
+	if !hasZig() {
+		t.Skip("zig not on PATH; Phase 5.0 cross-target gate requires zig cc")
+	}
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "answer.x86_64-macos")
+	_, err := Build(crossProgram(), Options{
+		OutDir:     dir,
+		BinaryPath: binPath,
+		Triple:     "x86_64-macos",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := machoCPUType(t, binPath); got != machoCPUTypeX86_64 {
+		t.Errorf("cputype = 0x%X, want 0x%X (x86_64)", got, machoCPUTypeX86_64)
+	}
+	assertCrossOutput(t, "x86_64-macos", binPath)
+}
+
+// TestBuildCrossWasm32WASI is the Phase 5.0 gate for the §9
+// wasm32 row: the produced file starts with the Wasm 1.0 magic.
+func TestBuildCrossWasm32WASI(t *testing.T) {
+	if !hasZig() {
+		t.Skip("zig not on PATH; Phase 5.0 cross-target gate requires zig cc")
+	}
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "answer.wasm")
+	_, err := Build(crossProgram(), Options{
+		OutDir:     dir,
+		BinaryPath: binPath,
+		Triple:     "wasm32-wasi",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !isWasm(t, binPath) {
+		t.Errorf("file %s is not a Wasm 1.0 module", binPath)
+	}
+	assertCrossOutput(t, "wasm32-wasi", binPath)
+}

--- a/compiler3/build/c/driver.go
+++ b/compiler3/build/c/driver.go
@@ -44,6 +44,15 @@ type Options struct {
 	// main and the produced object cannot link as a standalone
 	// executable (suitable for the future --emit=c-library mode).
 	Main string
+	// Triple, when non-empty, requests a cross-compile to the given
+	// target triple (e.g. "x86_64-linux-musl", "aarch64-linux-musl",
+	// "wasm32-wasi"). The driver passes `-target=<triple>` to cc and,
+	// when CC and $MOCHI_CC are both empty, prefers `zig cc` as the
+	// default cross-compiler because Zig ships every musl + wasi-libc
+	// sysroot in-process, satisfying the §Top-line objective (single
+	// foreign-arch binary from any §9 host with no extra toolchain
+	// install). MEP-42 Phase 5.0.
+	Triple string
 }
 
 // Result is what the driver returns on success.
@@ -97,8 +106,12 @@ func Build(p *cgen.Program, opts Options) (Result, error) {
 		binPath = filepath.Join(opts.OutDir, "a.out")
 	}
 
-	cc := resolveCC(opts.CC)
-	args := []string{"-std=c99", "-O2", "-I", opts.OutDir}
+	ccExe, ccPrefix := resolveCC(opts.CC, opts.Triple)
+	args := append([]string{}, ccPrefix...)
+	args = append(args, "-std=c99", "-O2", "-I", opts.OutDir)
+	if opts.Triple != "" {
+		args = append(args, "-target", opts.Triple)
+	}
 	if opts.Static {
 		args = append(args, "-static")
 	}
@@ -109,14 +122,16 @@ func Build(p *cgen.Program, opts Options) (Result, error) {
 	// includes <math.h>, and Phase 4.3.5 onward emits real math
 	// builtins (sqrt and friends). On glibc/musl Linux libm is a
 	// separate archive; on macOS / *BSD the symbols live in libSystem
-	// so -lm is a no-op there. Either way it is harmless.
+	// so -lm is a no-op there. Either way it is harmless. On wasm32-wasi
+	// the wasi-libc archive already carries the math symbols, so -lm
+	// resolves to a vacuous archive and is still safe.
 	args = append(args, "-lm")
 
-	cmd := exec.Command(cc, args...)
+	cmd := exec.Command(ccExe, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return Result{SourcePath: srcPath}, fmt.Errorf("cbuild.Build: %s %s: %w\n%s",
-			cc, strings.Join(args, " "), err, out)
+			ccExe, strings.Join(args, " "), err, out)
 	}
 
 	if !opts.KeepEmit {
@@ -218,14 +233,43 @@ func BuildSource(srcPath string, opts Options) (Result, error) {
 	return Build(cp, opts)
 }
 
-// resolveCC returns the C compiler to invoke. Priority: explicit
-// Options.CC, then $MOCHI_CC, then "cc".
-func resolveCC(explicit string) string {
+// resolveCC returns the C compiler executable plus any leading
+// argument prefix the caller needs to splice in before the compiler's
+// own flags. Priority: explicit Options.CC, then $MOCHI_CC, then a
+// triple-aware default. When triple is non-empty and no explicit CC
+// is configured, the driver prefers `zig cc` (Zig ships every musl
+// and wasi-libc sysroot in-process, so cross-compiling needs no extra
+// install). When triple is empty the driver falls back to the host
+// `cc`. The argument prefix is the second return value: callers that
+// invoke `zig cc` need "cc" as the first argv element after the zig
+// binary path; host `cc` needs no prefix.
+func resolveCC(explicit, triple string) (string, []string) {
 	if explicit != "" {
-		return explicit
+		exe, prefix := splitCC(explicit)
+		return exe, prefix
 	}
 	if env := os.Getenv("MOCHI_CC"); env != "" {
-		return env
+		exe, prefix := splitCC(env)
+		return exe, prefix
 	}
-	return "cc"
+	if triple != "" {
+		return "zig", []string{"cc"}
+	}
+	return "cc", nil
+}
+
+// splitCC accepts either a bare executable ("cc", "/usr/bin/clang") or
+// a wrapper-form string with whitespace ("zig cc", "ccache clang") and
+// returns the executable plus any leading argv tokens. This lets users
+// pass `--cc="zig cc"` or `MOCHI_CC="ccache cc"` without the driver
+// having to special-case wrapper compilers.
+func splitCC(s string) (string, []string) {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return "cc", nil
+	}
+	if len(fields) == 1 {
+		return fields[0], nil
+	}
+	return fields[0], fields[1:]
 }

--- a/compiler3/build/c/driver_test.go
+++ b/compiler3/build/c/driver_test.go
@@ -33,7 +33,7 @@ func helloProgram() *cgen.Program {
 // assert its stdout matches the expected single line. This is the
 // load-bearing gate of MEP-42 §Phased-plan row 4.
 func TestBuildHelloEndToEnd(t *testing.T) {
-	cc := resolveCC("")
+	cc, _ := resolveCC("", "")
 	if _, err := exec.LookPath(cc); err != nil {
 		t.Skipf("cc %q not available: %v", cc, err)
 	}
@@ -68,7 +68,8 @@ func TestBuildHelloEndToEnd(t *testing.T) {
 // TestBuildCleanupEmit covers the KeepEmit=false default: the .c
 // file is removed on successful build, leaving only the binary.
 func TestBuildCleanupEmit(t *testing.T) {
-	if _, err := exec.LookPath(resolveCC("")); err != nil {
+	cc, _ := resolveCC("", "")
+	if _, err := exec.LookPath(cc); err != nil {
 		t.Skipf("cc not available")
 	}
 	dir := t.TempDir()
@@ -105,19 +106,27 @@ func TestBuildMissingOutDir(t *testing.T) {
 	}
 }
 
-// TestResolveCC covers the env/explicit/default precedence.
+// TestResolveCC covers the env/explicit/default precedence and the
+// Phase 5.0 triple-aware default (zig cc when a target triple is set
+// and no explicit compiler is configured).
 func TestResolveCC(t *testing.T) {
 	t.Setenv("MOCHI_CC", "")
-	if got := resolveCC("explicit"); got != "explicit" {
-		t.Errorf("explicit precedence: got %q", got)
+	if got, prefix := resolveCC("explicit", ""); got != "explicit" || len(prefix) != 0 {
+		t.Errorf("explicit precedence: got (%q, %v)", got, prefix)
 	}
 	t.Setenv("MOCHI_CC", "from-env")
-	if got := resolveCC(""); got != "from-env" {
-		t.Errorf("env fallback: got %q", got)
+	if got, prefix := resolveCC("", ""); got != "from-env" || len(prefix) != 0 {
+		t.Errorf("env fallback: got (%q, %v)", got, prefix)
 	}
 	t.Setenv("MOCHI_CC", "")
-	if got := resolveCC(""); got != "cc" {
-		t.Errorf("default cc: got %q", got)
+	if got, prefix := resolveCC("", ""); got != "cc" || len(prefix) != 0 {
+		t.Errorf("default cc: got (%q, %v)", got, prefix)
+	}
+	if got, prefix := resolveCC("", "wasm32-wasi"); got != "zig" || len(prefix) != 1 || prefix[0] != "cc" {
+		t.Errorf("triple-aware default: got (%q, %v), want (\"zig\", [\"cc\"])", got, prefix)
+	}
+	if got, prefix := resolveCC("zig cc", "x86_64-linux-musl"); got != "zig" || len(prefix) != 1 || prefix[0] != "cc" {
+		t.Errorf("wrapper-form explicit: got (%q, %v), want (\"zig\", [\"cc\"])", got, prefix)
 	}
 }
 
@@ -128,7 +137,7 @@ func TestResolveCC(t *testing.T) {
 // same source. Skip when cc is unavailable.
 func runMochiBuild(t *testing.T, src string) string {
 	t.Helper()
-	cc := resolveCC("")
+	cc, _ := resolveCC("", "")
 	if _, err := exec.LookPath(cc); err != nil {
 		t.Skipf("cc %q not available: %v", cc, err)
 	}
@@ -3160,7 +3169,7 @@ func TestBuildSourceRejectsImportGo(t *testing.T) {
 	src := `import go "mochi/runtime/ffi/go/testpkg" as testpkg auto
 print(testpkg.Add(2, 3))
 `
-	cc := resolveCC("")
+	cc, _ := resolveCC("", "")
 	if _, err := exec.LookPath(cc); err != nil {
 		t.Skipf("cc %q not available: %v", cc, err)
 	}
@@ -3186,7 +3195,8 @@ print(testpkg.Add(2, 3))
 // libc cannot satisfy `-static` so this case doesn't block the gate
 // on non-musl Linux developer machines.
 func TestBuildStaticFlag(t *testing.T) {
-	if _, err := exec.LookPath(resolveCC("")); err != nil {
+	cc, _ := resolveCC("", "")
+	if _, err := exec.LookPath(cc); err != nil {
 		t.Skipf("cc not available")
 	}
 	dir := t.TempDir()

--- a/runtime/c/src/mochi_time.c
+++ b/runtime/c/src/mochi_time.c
@@ -3,6 +3,7 @@
  */
 #include "mochi_time.h"
 
+#include <stddef.h>
 #include <stdint.h>
 #include <sys/time.h>
 

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,93 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.60 Phase 5.0 closeout (LANDED 2026-05-22 16:37 GMT+7)
+
+Phase 5.0 turns the §Phased-plan row 5 ("C-as-target AOT covers all four phase-1 native targets") from "pending" into a working `mochi build --target=c --triple=<triple>` for every §9 must-have native target plus `wasm32-wasi`. The driver routes through `zig cc -target=<triple>` because Zig ships every musl, wasi-libc, and Mach-O SDK in-process, so cross-building from any §9 host needs no extra toolchain install. Five cross-target gates land in `compiler3/build/c/cross_test.go`; three of them (the macOS pair and wasm32-wasi) actually execute the foreign-arch binary on the recording Apple Silicon host and assert its stdout matches the host gate's "42\n".
+
+### Why now (goal-alignment audit)
+
+Phases 4.2.30 → 4.2.32 closed out the data-driven op registry, which covers ~94 of ~100 IR ops. The remaining 6 ops are call-site-typed or variadic and would each require extending `OpInfo`'s schema, a higher-ceremony refactor for diminishing returns. At the same boundary, §10.7 reports "all 10 in-scope BG fixtures landed. Zero remaining gaps for the user-facing goal" on x86_64 Linux. The user-facing surface that was actually unaddressed sat at Phase 5 (single binary on the other four §9 targets). Per the goal-alignment audit memo, the next sub-phase had to pivot off the registry stream onto Phase 5.
+
+### `compiler3/build/c/driver.go` changes
+
+| Area | Change |
+|------|--------|
+| `Options.Triple` | New string field. When non-empty, the driver passes `-target=<triple>` to cc. When CC and `$MOCHI_CC` are both empty, the default cc switches from `cc` to `zig cc`. |
+| `resolveCC(explicit, triple)` | Returns `(executable, argv-prefix)` instead of a single string. The argv-prefix is the leading tokens that have to precede the compiler's own flags (e.g. `["cc"]` for `zig cc`). The triple parameter selects `zig` as the default when no explicit cc is configured. |
+| `splitCC(s)` | New helper. Accepts either a bare executable (`"cc"`, `"/usr/bin/clang"`) or a wrapper-form string (`"zig cc"`, `"ccache clang"`) and splits on whitespace, so users can pass `--cc="zig cc"` or `MOCHI_CC="ccache cc"` without driver-side special casing. |
+| `Build(p, opts)` | Splices the argv-prefix in front of `-std=c99 -O2 -I <outdir>`; appends `-target <triple>` after the std flags when `opts.Triple != ""`. The `-lm` tail stays unconditional (vacuous on wasm32-wasi where wasi-libc carries the math symbols; harmless on the Darwin Mach-O cases where libSystem already does). |
+
+### `runtime/c/src/mochi_time.c` portability fix
+
+`gettimeofday(&tv, NULL)` referenced `NULL` without including a header that defines it. Apple's vendored `cc` indirectly pulled it in via `<sys/time.h>`, which masked the issue on the Phase 4.0 host gate. Zig cc's musl + wasi-libc sysroots are strict (no transitive `NULL` from `<sys/time.h>`), so the cross-build surfaced the missing `#include <stddef.h>`. Added the include; the host gate is unaffected.
+
+### `cmd/mochi/main.go` CLI change
+
+| Flag | Purpose |
+|------|---------|
+| `--triple <triple>` | Target triple (e.g. `x86_64-linux-musl`, `aarch64-linux-musl`, `aarch64-macos`, `x86_64-macos`, `wasm32-wasi`). `--target=c` only. When set, the driver defaults to `zig cc` and passes `-target=<triple>`. |
+
+The flag is wired through both the `arg`-parser and the cobra command (the file dual-registers for the two CLI shells).
+
+### `compiler3/build/c/cross_test.go` gate
+
+Five tests, one per §9 row:
+
+| Test | Triple | Build-gate | Run-gate |
+|------|--------|------------|----------|
+| `TestBuildCrossX86_64Linux` | `x86_64-linux-musl` | ELF e_machine == 0x3E (x86_64) | qemu-x86_64 when on PATH; skip with hint on macOS |
+| `TestBuildCrossAArch64Linux` | `aarch64-linux-musl` | ELF e_machine == 0xB7 (aarch64) | qemu-aarch64 when on PATH; skip with hint on macOS |
+| `TestBuildCrossAArch64Macos` | `aarch64-macos` | Mach-O cputype == 0x0100000C (arm64) | native execution on arm64 Darwin |
+| `TestBuildCrossX86_64Macos` | `x86_64-macos` | Mach-O cputype == 0x01000007 (x86_64) | native on x86_64 Darwin; Rosetta 2 on arm64 Darwin |
+| `TestBuildCrossWasm32WASI` | `wasm32-wasi` | Wasm 1.0 magic + version 1 | wasmtime / wasmer / wasm3 when on PATH |
+
+The run-gate is the load-bearing piece of "the target binary actually runs and prints 42". On the Apple Silicon recording host, three of the five gates execute (both Darwin triples natively, wasm32-wasi via wasmtime) and assert stdout matches "42\n". The two Linux ELF gates skip the run-step (Homebrew on macOS does not ship qemu-user; only qemu-system) but the build-gate (e_machine field) still fires. On a linux/amd64 CI runner with `apt install qemu-user-static`, all five run-gates fire.
+
+The runner detection lives in one helper (`findRunner(triple)`) so adding a new target is a single switch arm. Native execution is encoded as `runner{cmd:""}` (`runBinary` invokes the binary directly with no emulator prefix) which lets the macOS native pair share the same runner-dispatch shape as the qemu / wasmtime cases.
+
+### §9 target matrix update
+
+| Target ISA | OS | Format | ABI | Phase 5.0 status |
+|---|---|---|---|---|
+| x86_64 | Linux | ELF | SysV | LANDED (build) |
+| aarch64 | Linux | ELF | AAPCS64 | LANDED (build) |
+| aarch64 | macOS (Apple Silicon) | Mach-O | Apple ABI | LANDED (build + native run) |
+| x86_64 | macOS | Mach-O | SysV | LANDED (build + Rosetta run) |
+| wasm32 | browser + WASI | .wasm | Wasm 3.0 + GC | LANDED (build + wasmtime run) |
+
+The `--target=c --triple=<each>` invocation from this aarch64-darwin host produces the correctly-tagged foreign-arch binary in every row; the macOS pair and wasm32-wasi rows also exercise the binary end-to-end.
+
+### Smoke test (CLI, recorded on the Phase 5.0 host)
+
+```
+$ echo 'print(42)' > /tmp/answer42.mochi
+$ mochi build --target=c --triple=aarch64-macos --binary=/tmp/answer42.arm64 /tmp/answer42.mochi
+binary /tmp/answer42.arm64
+$ /tmp/answer42.arm64
+42
+$ mochi build --target=c --triple=x86_64-macos --binary=/tmp/answer42.x64 /tmp/answer42.mochi
+binary /tmp/answer42.x64
+$ /tmp/answer42.x64
+42
+$ mochi build --target=c --triple=wasm32-wasi --binary=/tmp/answer42.wasm /tmp/answer42.mochi
+binary /tmp/answer42.wasm
+$ wasmtime run -- /tmp/answer42.wasm
+42
+```
+
+### Limitations and deferred sub-phases
+
+| Sub-phase | Scope |
+|-----------|-------|
+| 5.0.1 | Linux ELF run-gate via Docker / Lima / Colima fallback on macOS hosts (qemu-user is Linux-only via Homebrew). Currently the macOS dev-loop skips that run-step; CI fires it. |
+| 5.1 | Auto-detect the host triple and use the system cc directly when `--triple` matches the host (skip the zig-cc default to avoid the extra `zig` dependency on hosts that already have a native toolchain). |
+| 5.2 | Larger-program cross-builds: the §10.7 BG fixture suite under every §9 triple, not just the one-function answer/42 gate. This is the next user-facing slice; gating one BG fixture per triple lights up the "real Mochi programs build everywhere" promise. |
+| 5.3 | `--portable` musl-static cross matrix (deferred from Phase 4.5): `--triple=x86_64-linux-musl --portable` already produces a statically-linked binary on the host because zig cc defaults to static-musl; pin a test that asserts the linker dropped libc.so dependencies. |
+| 5.4 | DWARF cross-target: zig cc emits DWARF 4 by default; check it survives the strip step and that gdb on the target host resolves Mochi-source names. |
+
+The umbrella Phase 5 row in the §Phased-plan table cannot flip to LANDED yet because the gate is "from any phase-1 host produces a single-file binary that runs on a clean machine of the target platform and matches `mochi run` stdout"; this phase pins the build gate and the macOS + wasm run gates but not the Linux clean-machine run gate. That clean-machine gate moves to Phase 5.2 once a real BG fixture lights up under qemu / Docker on CI.
+
 ## §10.59 Phase 4.2.32 closeout (LANDED 2026-05-22 16:14 GMT+7)
 
 Phase 4.2.32 migrates the heap-allocating op families (list, map, f64arr, strarr, mapstri64, listlist, listany, plus the `*.tostr` constructors) to the registry. Combined with Phases 4.2.30 (string surface) and 4.2.31 (scalar surface), the registry now covers every IR op except the handful whose contracts depend on call-site data or variadic argument shapes.


### PR DESCRIPTION
Tracks #22059.

Phase 5.0 of the MEP-42 AOT track. The C build driver gains an Options.Triple field; when set, the driver defaults to \`zig cc\` and passes \`-target=<triple>\`. Zig ships every musl, wasi-libc, and Mach-O SDK in-process, so cross-building from any §9 host needs no extra toolchain install. Five cross-target gates land in \`compiler3/build/c/cross_test.go\`, one per §9 row.

## Goal-alignment audit

After 4.2.30-32, §10.7 reports all 10 in-scope BG fixtures green on x86_64 Linux. The next user-facing gap sits at Phase 5 (single binary on the other four §9 targets). Per the goal-alignment audit memo, the next sub-phase had to pivot off the registry stream onto Phase 5.

## Run-gate behavior

| Triple | Build-gate | Run-gate (this aarch64-darwin host) |
|---|---|---|
| x86_64-linux-musl | ELF e_machine 0x3E | skip (macOS has no qemu-user; fires on Linux CI) |
| aarch64-linux-musl | ELF e_machine 0xB7 | skip (same) |
| aarch64-macos | Mach-O cputype 0x0100000C | native run, stdout == "42\n" |
| x86_64-macos | Mach-O cputype 0x01000007 | Rosetta 2 run, stdout == "42\n" |
| wasm32-wasi | Wasm 1.0 magic + version 1 | wasmtime run, stdout == "42\n" |

The runner detection lives in one helper (\`findRunner(triple)\`) so adding a new target is a single switch arm.

## Also fixes

\`runtime/c/src/mochi_time.c\` missing \`#include <stddef.h>\` for NULL: Apple's vendored cc pulled it in transitively via \`<sys/time.h>\`; zig cc's strict musl/wasi-libc sysroots do not. Surfaced by the cross-build; host gate is unaffected.

## Test plan
- [x] \`go test ./compiler3/build/c/... ./compiler3/ir/... ./compiler3/verify/... ./compiler3/emit/c/...\`
- [x] \`mochi build --target=c --triple=aarch64-macos /tmp/answer42.mochi\` and run the produced binary natively → prints 42
- [x] \`mochi build --target=c --triple=x86_64-macos /tmp/answer42.mochi\` and run via Rosetta → prints 42
- [x] \`mochi build --target=c --triple=wasm32-wasi /tmp/answer42.mochi\` and run via wasmtime → prints 42