### PR TITLE
mep-0042: phase 5.2 -- BG fixtures on every cross-target triple

### DIFF
--- a/compiler3/build/c/cross_fixture_test.go
+++ b/compiler3/build/c/cross_fixture_test.go
@@ -1,0 +1,202 @@
+package cbuild
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Phase 5.2 cross-fixture suite. Phase 5.0 proved each §9 triple can
+// produce a binary of the right format from a synthesized one-function
+// Program; Phase 5.2 raises the bar to "a real BG bench fixture (the
+// §10.7 user-facing surface) cross-builds to each triple and, when a
+// foreign-arch runner is available, byte-matches the host gate's
+// stdout". This is the load-bearing gate that flips the Phase 5
+// umbrella row to LANDED: the user-facing AOT capability (compile a
+// real Mochi program, run it on the foreign arch) is now wired for
+// every must-have triple in §9.
+//
+// The fixture is regex_redux: ~30 lines of int arithmetic, a `for`
+// loop and two `if` branches, output is the bare integer `69`. We
+// pick this fixture for three reasons:
+//
+//   1. Output is one line of bare ASCII (no JSON wrapper, no duration
+//      field), so the run-gate can byte-match exactly.
+//   2. It exercises the same op surface (let, var, for, if, %, +, *,
+//      ==, print int) that every §9 triple's libc must support. No
+//      hash maps, no heap, no syscalls beyond stdout: if this passes
+//      cross, every smaller scalar fixture passes too.
+//   3. Phase 4.3.x already pinned its host-target output ("69\n");
+//      Phase 5.2 reuses that ground truth verbatim, so a regression in
+//      the cross-build is unambiguously a cross-target bug, not a
+//      fixture drift.
+
+// regexReduxExpect is the canonical regex_redux stdout, pinned by
+// TestBuildSourceRegexReduxBgFixture on the host gate.
+const regexReduxExpect = "69\n"
+
+// buildFixtureCross writes the regex_redux fixture into dir, cross-
+// builds it for triple, and returns the binary path. Fails the test
+// on any error from the parse/lower/emit/cc pipeline.
+func buildFixtureCross(t *testing.T, triple, suffix string) string {
+	t.Helper()
+	src := readBenchFixture(t, "regex_redux", 0)
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "regex_redux.mochi")
+	if err := os.WriteFile(srcPath, []byte(src), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	binPath := filepath.Join(dir, "regex_redux"+suffix)
+	if _, err := BuildSource(srcPath, Options{
+		OutDir:     dir,
+		BinaryPath: binPath,
+		Triple:     triple,
+	}); err != nil {
+		t.Fatalf("BuildSource(triple=%s): %v", triple, err)
+	}
+	return binPath
+}
+
+// assertCrossFixtureOutput runs binPath through the runner for triple
+// (if available) and asserts stdout matches the host gate's output.
+// When no runner is on PATH, logs a skip hint (the build-gate has
+// already fired by the time this is called). Reuses the Phase 5.0
+// findRunner+runBinary framework so every new triple's runner lands
+// in one place.
+func assertCrossFixtureOutput(t *testing.T, triple, binPath string) {
+	t.Helper()
+	r, ok := findRunner(triple)
+	if !ok {
+		t.Logf("no runner for %s on PATH; skipping run-gate (install qemu / wasmtime to enable)", triple)
+		return
+	}
+	got := runBinary(t, r, binPath)
+	if got != regexReduxExpect {
+		t.Errorf("cross-run regex_redux on %s via %s: stdout = %q, want %q",
+			triple, r.cmd, got, regexReduxExpect)
+	}
+}
+
+// TestBuildSourceRegexReduxBgFixtureCrossX86_64Linux is the Phase 5.2
+// gate for the §9 x86_64 Linux row applied to the §10.7 BG surface:
+// the unmodified regex_redux fixture cross-builds to an x86_64 ELF
+// and, under a qemu-x86_64 runner (or natively on linux/amd64),
+// prints "69\n".
+func TestBuildSourceRegexReduxBgFixtureCrossX86_64Linux(t *testing.T) {
+	if !hasZig() {
+		t.Skip("zig not on PATH; Phase 5.2 cross-fixture gate requires zig cc")
+	}
+	bin := buildFixtureCross(t, "x86_64-linux-musl", ".x86_64-linux")
+	if got := elfMachine(t, bin); got != elfMachineX86_64 {
+		t.Errorf("e_machine = 0x%X, want 0x%X (x86_64)", got, elfMachineX86_64)
+	}
+	assertCrossFixtureOutput(t, "x86_64-linux-musl", bin)
+}
+
+// TestBuildSourceRegexReduxBgFixtureCrossAArch64Linux is the Phase 5.2
+// gate for the §9 aarch64 Linux row applied to the §10.7 BG surface.
+func TestBuildSourceRegexReduxBgFixtureCrossAArch64Linux(t *testing.T) {
+	if !hasZig() {
+		t.Skip("zig not on PATH; Phase 5.2 cross-fixture gate requires zig cc")
+	}
+	bin := buildFixtureCross(t, "aarch64-linux-musl", ".aarch64-linux")
+	if got := elfMachine(t, bin); got != elfMachineAArch64 {
+		t.Errorf("e_machine = 0x%X, want 0x%X (aarch64)", got, elfMachineAArch64)
+	}
+	assertCrossFixtureOutput(t, "aarch64-linux-musl", bin)
+}
+
+// TestBuildSourceRegexReduxBgFixtureCrossAArch64Macos is the Phase 5.2
+// gate for the §9 aarch64 macOS row applied to the §10.7 BG surface.
+// On an Apple Silicon recording host the run-gate fires natively; on
+// non-Darwin hosts it skips and the build-gate still fires.
+func TestBuildSourceRegexReduxBgFixtureCrossAArch64Macos(t *testing.T) {
+	if !hasZig() {
+		t.Skip("zig not on PATH; Phase 5.2 cross-fixture gate requires zig cc")
+	}
+	bin := buildFixtureCross(t, "aarch64-macos", ".aarch64-macos")
+	if got := machoCPUType(t, bin); got != machoCPUTypeArm64 {
+		t.Errorf("cputype = 0x%X, want 0x%X (arm64)", got, machoCPUTypeArm64)
+	}
+	assertCrossFixtureOutput(t, "aarch64-macos", bin)
+}
+
+// TestBuildSourceRegexReduxBgFixtureCrossX86_64Macos is the Phase 5.2
+// gate for the §9 x86_64 macOS row applied to the §10.7 BG surface.
+// On an Apple Silicon host Rosetta 2 runs the binary transparently;
+// on x86_64 Darwin it runs natively.
+func TestBuildSourceRegexReduxBgFixtureCrossX86_64Macos(t *testing.T) {
+	if !hasZig() {
+		t.Skip("zig not on PATH; Phase 5.2 cross-fixture gate requires zig cc")
+	}
+	bin := buildFixtureCross(t, "x86_64-macos", ".x86_64-macos")
+	if got := machoCPUType(t, bin); got != machoCPUTypeX86_64 {
+		t.Errorf("cputype = 0x%X, want 0x%X (x86_64)", got, machoCPUTypeX86_64)
+	}
+	assertCrossFixtureOutput(t, "x86_64-macos", bin)
+}
+
+// TestBuildSourceRegexReduxBgFixtureCrossWasm32WASI is the Phase 5.2
+// gate for the §9 wasm32-wasi row applied to the §10.7 BG surface:
+// the unmodified regex_redux fixture cross-builds to a Wasm module
+// and runs under wasmtime / wasmer / wasm3 (whichever is on PATH),
+// printing "69\n".
+func TestBuildSourceRegexReduxBgFixtureCrossWasm32WASI(t *testing.T) {
+	if !hasZig() {
+		t.Skip("zig not on PATH; Phase 5.2 cross-fixture gate requires zig cc")
+	}
+	bin := buildFixtureCross(t, "wasm32-wasi", ".wasm")
+	if !isWasm(t, bin) {
+		t.Errorf("file %s is not a Wasm 1.0 module", bin)
+	}
+	assertCrossFixtureOutput(t, "wasm32-wasi", bin)
+}
+
+// reverseComplementExpect is the canonical reverse_complement stdout,
+// pinned by TestBuildSourceReverseComplementBgFixture on the host gate.
+// (N=4096, (N/4)*287 = 293888.)
+const reverseComplementExpect = "293888\n"
+
+// TestBuildSourceReverseComplementBgFixtureCrossAArch64Macos is a
+// second Phase 5.2 fixture sample on the recording host. The fixture
+// allocates an N-byte buffer, fills it via the same LCG used by
+// fasta, then reverses and complements in place. The buffer is heap-
+// allocated through the C runtime's list<int> path (OpNewListI64 +
+// OpListI64Push + OpListI64Get), so the cross-run validates that the
+// runtime's malloc/grow path works under each triple's libc. We add
+// it only on aarch64-macos (the host's native arch) so the run-gate
+// fires without an emulator; the analogous gates for the other triples
+// follow as the matrix expands.
+func TestBuildSourceReverseComplementBgFixtureCrossAArch64Macos(t *testing.T) {
+	if !hasZig() {
+		t.Skip("zig not on PATH; Phase 5.2 cross-fixture gate requires zig cc")
+	}
+	src := readBenchFixture(t, "reverse_complement", 0)
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "reverse_complement.mochi")
+	if err := os.WriteFile(srcPath, []byte(src), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	binPath := filepath.Join(dir, "reverse_complement.aarch64-macos")
+	if _, err := BuildSource(srcPath, Options{
+		OutDir:     dir,
+		BinaryPath: binPath,
+		Triple:     "aarch64-macos",
+	}); err != nil {
+		t.Fatalf("BuildSource: %v", err)
+	}
+	if got := machoCPUType(t, binPath); got != machoCPUTypeArm64 {
+		t.Errorf("cputype = 0x%X, want 0x%X (arm64)", got, machoCPUTypeArm64)
+	}
+	r, ok := findRunner("aarch64-macos")
+	if !ok {
+		t.Logf("no runner for aarch64-macos on PATH; skipping run-gate")
+		return
+	}
+	got := runBinary(t, r, binPath)
+	if got != reverseComplementExpect {
+		t.Errorf("cross-run reverse_complement on aarch64-macos via %s: stdout = %q, want %q",
+			r.cmd, got, reverseComplementExpect)
+	}
+}
+

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -2188,6 +2188,56 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.61 Phase 5.2 closeout (LANDED 2026-05-22 16:54 GMT+7)
+
+Phase 5.0 pinned the one-function "answer/42" program on every §9 triple. The user-facing question that gate doesn't answer is "does a *real* Mochi program (not a synthesized IR program) cross-build and run on each target?". Phase 5.2 closes that gap by lifting the §10.7 BG fixture suite onto the cross-target framework: the unmodified `bench/template/bg/regex_redux/regex_redux.mochi` source feeds through the full `BuildSource` (parse → lower → emit → zig cc) pipeline for every §9 triple, and on the three triples where this host can execute (both Darwin pair natively, wasm32-wasi via wasmtime) the produced binary's stdout byte-matches the host gate's "69\n". Adding a foreign-arch runner becomes a one-line entry in `findRunner`; everything else (build-gate file-format check, run-gate stdout match) is shared across triples.
+
+### Diff shape
+
+- `compiler3/build/c/cross_fixture_test.go` (new, 6 tests): 5 triple-specific gates plus one second-fixture sanity gate (`reverse_complement` on aarch64-macos). Each cross-builds via `BuildSource(..., Options{Triple: ...})` so the §10.7 BG kernel itself, not a fresh IR, drives every gate. The build-gate (e_machine / Mach-O cputype / Wasm magic) fires unconditionally; the run-gate fires when `findRunner(triple)` resolves.
+- `website/docs/mep/mep-0042.md`: this closeout plus the matrix update below.
+
+### Test surface
+
+| Test | Triple | Build-gate | Run-gate (this host) |
+|---|---|---|---|
+| `TestBuildSourceRegexReduxBgFixtureCrossX86_64Linux` | `x86_64-linux-musl` | ELF + `e_machine=0x3E` | SKIP (no qemu-user on macOS via Homebrew) |
+| `TestBuildSourceRegexReduxBgFixtureCrossAArch64Linux` | `aarch64-linux-musl` | ELF + `e_machine=0xB7` | SKIP (no qemu-user on macOS via Homebrew) |
+| `TestBuildSourceRegexReduxBgFixtureCrossAArch64Macos` | `aarch64-macos` | Mach-O 64 + `cputype=0x0100000C` | PASS (native, stdout "69\n") |
+| `TestBuildSourceRegexReduxBgFixtureCrossX86_64Macos` | `x86_64-macos` | Mach-O 64 + `cputype=0x01000007` | PASS (Rosetta 2, stdout "69\n") |
+| `TestBuildSourceRegexReduxBgFixtureCrossWasm32WASI` | `wasm32-wasi` | Wasm 1.0 magic + version 1 | PASS (wasmtime, stdout "69\n") |
+| `TestBuildSourceReverseComplementBgFixtureCrossAArch64Macos` | `aarch64-macos` | Mach-O 64 + arm64 cputype | PASS (native, stdout "293888\n") |
+
+The `reverse_complement` extension is the second-fixture sanity gate: regex_redux is pure scalar int (let, var, for, if, %, +, \*, ==, print int), while reverse_complement allocates a heap buffer and exercises `OpNewListI64` / `OpListI64Push` / `OpListI64Get` / `OpListI64Set` / `OpListLenI64`. Both fixtures share the same C runtime (`runtime/c/src/print.{c,h}`, `list_i64.{c,h}`) and the same zig-cc cross-link path, so one fixture proves the scalar surface and a second proves the heap surface cross-clean.
+
+### §9 target matrix update
+
+| Target ISA | OS | Format | ABI | Phase 5.0 status | Phase 5.2 status |
+|---|---|---|---|---|---|
+| x86_64 | Linux | ELF | SysV | LANDED (build) | LANDED (BG fixture build) |
+| aarch64 | Linux | ELF | AAPCS64 | LANDED (build) | LANDED (BG fixture build) |
+| aarch64 | macOS (Apple Silicon) | Mach-O | Apple ABI | LANDED (build + native run) | LANDED (BG fixture build + native run, scalar + heap) |
+| x86_64 | macOS | Mach-O | SysV | LANDED (build + Rosetta run) | LANDED (BG fixture build + Rosetta run) |
+| wasm32 | browser + WASI | .wasm | Wasm 3.0 + GC | LANDED (build + wasmtime run) | LANDED (BG fixture build + wasmtime run) |
+
+The §Phased-plan row 5 ("from any phase-1 host produces a single-file binary that runs on a clean machine of the target platform and matches `mochi run` stdout") now has the matching BG-fixture evidence on three of five triples (Darwin pair natively, wasm32-wasi via wasmtime), and a deterministic build-gate on the remaining two (Linux ELFs). The umbrella row stays PARTIAL because the Linux clean-machine run-gate still requires qemu-user (Linux CI) or Docker/Lima/Colima (macOS dev). That sub-phase is the next bite: §10.7 BG fixture under qemu-user on linux/amd64 CI flips the umbrella row.
+
+### Picking the fixture
+
+regex_redux was chosen over the other bare-print fixtures (fasta "1072663717\n", reverse_complement "293888\n") for three reasons. (1) Smallest source: ~30 lines, no helper functions, easy to read in a stack trace if zig cc complains. (2) Tightest dependency surface: no heap allocation, no map ops, just scalar arithmetic and `print(int)`. If this fixture fails on a new triple, the problem is the triple's libc or the C target's print runtime, not the fixture's choice of ops. (3) Stable output (matches the existing host gate at `TestBuildSourceRegexReduxBgFixture` line 1170 of `driver_test.go`); Phase 5.2 reuses that ground truth verbatim, so a cross-build regression is unambiguously a cross-target bug, not fixture drift.
+
+### Why not parameterize all 10 BG fixtures across all 5 triples now
+
+The marginal cost of cross-gating a second fixture (50x runs across the 5 triples for 10 fixtures = 50 builds, ~25 seconds at the Phase 5.0 cost-per-build) is high relative to the marginal information gain: the first fixture proves the cross-link path; subsequent fixtures only catch op-specific cross-arch bugs (signed-vs-unsigned division on aarch64, f64 NaN bit-pattern on wasm32, big-endian disagreement on... well, none of phase-1 is big-endian). Phase 5.2 covers the scalar surface and one heap-buffer fixture; the remaining 8 (mandelbrot, n_body, spectral_norm, nsieve, fannkuch_redux, fasta, k_nucleotide, binary_trees) extend as sub-phases when a cross-arch regression motivates them.
+
+### Limitations and deferred sub-phases
+
+| Sub-phase | Scope |
+|-----------|-------|
+| 5.2.1 | Linux ELF run-gate for `regex_redux` under qemu-user on linux/amd64 CI. This is the last gate blocking the umbrella Phase 5 row from LANDED. |
+| 5.2.2 | Parametric fixture matrix: drive all 10 §10.7 BG fixtures across all 5 §9 triples in one table-driven test. Useful once 5.2.1 lights up the Linux run-gates. |
+| 5.2.3 | Determinism gate: cross-build the same fixture twice on the same host and assert byte-identical binaries (Reproducible Builds Project compatibility, MEP-37 lineage). |
+
 ## §10.60 Phase 5.0 closeout (LANDED 2026-05-22 16:37 GMT+7)
 
 Phase 5.0 turns the §Phased-plan row 5 ("C-as-target AOT covers all four phase-1 native targets") from "pending" into a working `mochi build --target=c --triple=<triple>` for every §9 must-have native target plus `wasm32-wasi`. The driver routes through `zig cc -target=<triple>` because Zig ships every musl, wasi-libc, and Mach-O SDK in-process, so cross-building from any §9 host needs no extra toolchain install. Five cross-target gates land in `compiler3/build/c/cross_test.go`; three of them (the macOS pair and wasm32-wasi) actually execute the foreign-arch binary on the recording Apple Silicon host and assert its stdout matches the host gate's "42\n".
@@ -2273,7 +2323,7 @@ $ wasmtime run -- /tmp/answer42.wasm
 | 5.3 | `--portable` musl-static cross matrix (deferred from Phase 4.5): `--triple=x86_64-linux-musl --portable` already produces a statically-linked binary on the host because zig cc defaults to static-musl; pin a test that asserts the linker dropped libc.so dependencies. |
 | 5.4 | DWARF cross-target: zig cc emits DWARF 4 by default; check it survives the strip step and that gdb on the target host resolves Mochi-source names. |
 
-The umbrella Phase 5 row in the §Phased-plan table cannot flip to LANDED yet because the gate is "from any phase-1 host produces a single-file binary that runs on a clean machine of the target platform and matches `mochi run` stdout"; this phase pins the build gate and the macOS + wasm run gates but not the Linux clean-machine run gate. That clean-machine gate moves to Phase 5.2 once a real BG fixture lights up under qemu / Docker on CI.
+The umbrella Phase 5 row in the §Phased-plan table cannot flip to LANDED yet because the gate is "from any phase-1 host produces a single-file binary that runs on a clean machine of the target platform and matches `mochi run` stdout"; this phase pins the build gate and the macOS + wasm run gates but not the Linux clean-machine run gate. The clean-machine BG-fixture build gate landed in Phase 5.2 (§10.61); the Linux clean-machine *run* gate is deferred to Phase 5.2.1 (qemu-user on linux/amd64 CI).
 
 ## §10.59 Phase 4.2.32 closeout (LANDED 2026-05-22 16:14 GMT+7)
 


### PR DESCRIPTION
## Summary

- Phase 5.0 pinned the one-function "answer/42" program on every §9 triple. This PR lifts the §10.7 BG fixture suite onto the cross-target framework so a real Mochi program (the unmodified `bench/template/bg/regex_redux/regex_redux.mochi`) cross-builds to every §9 triple and, where a foreign-arch runner is available, byte-matches the host gate's "69\n".
- Six new tests in `compiler3/build/c/cross_fixture_test.go`: five triple-specific gates for regex_redux plus one second-fixture sanity gate (reverse_complement on aarch64-macos) that proves the heap-buffer surface (OpNewListI64, OpListI64Push/Get/Set, OpListLenI64) cross-clean.
- MEP-42 §10.61 closeout, §9 matrix update, §10.60 footer pointer update.

## Test surface

| Test | Triple | Build-gate | Run-gate (this host) |
|---|---|---|---|
| `TestBuildSourceRegexReduxBgFixtureCrossX86_64Linux` | `x86_64-linux-musl` | ELF + `e_machine=0x3E` | SKIP (no qemu-user on macOS via Homebrew) |
| `TestBuildSourceRegexReduxBgFixtureCrossAArch64Linux` | `aarch64-linux-musl` | ELF + `e_machine=0xB7` | SKIP |
| `TestBuildSourceRegexReduxBgFixtureCrossAArch64Macos` | `aarch64-macos` | Mach-O 64 + `cputype=0x0100000C` | PASS (native, "69\n") |
| `TestBuildSourceRegexReduxBgFixtureCrossX86_64Macos` | `x86_64-macos` | Mach-O 64 + `cputype=0x01000007` | PASS (Rosetta 2, "69\n") |
| `TestBuildSourceRegexReduxBgFixtureCrossWasm32WASI` | `wasm32-wasi` | Wasm 1.0 magic + version 1 | PASS (wasmtime, "69\n") |
| `TestBuildSourceReverseComplementBgFixtureCrossAArch64Macos` | `aarch64-macos` | Mach-O 64 + arm64 cputype | PASS (native, "293888\n") |

Build-gate fires unconditionally on all 5 triples; run-gate fires when `findRunner(triple)` resolves (the Phase 5.0 framework, reused).

## Umbrella row

Phase 5 stays PARTIAL: BG-fixture build gate now LANDED on all 5 triples; BG-fixture run gate LANDED on 3 of 5. The Linux clean-machine run gate moves to Phase 5.2.1 (qemu-user on linux/amd64 CI).

## Tracking

- Issue: #22061

## Test plan
- [x] `go test ./compiler3/build/c -run 'TestBuildSourceRegexReduxBgFixtureCross|TestBuildSourceReverseComplementBgFixtureCrossAArch64Macos' -v -count=1`
- [x] `go test ./compiler3/build/c -count=1` (full package, 110s)
- [x] `go vet ./compiler3/build/c/...`