### PR TITLE
mep-0042: phase 5.2.1 -- Linux + wasm run-gates on linux/amd64 CI

### DIFF
--- a/.github/workflows/cross-aot.yml
+++ b/.github/workflows/cross-aot.yml
@@ -1,0 +1,83 @@
+name: Cross AOT
+
+# MEP-42 Phase 5.2.1: fires the Linux clean-machine run-gate that the
+# Darwin recording host cannot fire (Homebrew on macOS ships
+# qemu-system-* but not qemu-user). The matching macOS + wasm run-gates
+# fire on the Darwin host in the local `go test` loop; this workflow
+# closes the matrix on linux/amd64 where qemu-user-static and wasmtime
+# are one `apt install` away.
+#
+# Coverage on this job:
+#   - x86_64-linux-musl: native (linux/amd64 host)
+#   - aarch64-linux-musl: qemu-aarch64-static
+#   - wasm32-wasi: wasmtime
+#
+# The macOS pair (aarch64-macos, x86_64-macos) cannot run on Linux
+# without Darling, which is not in §9. Those rows continue to rely on
+# the Darwin host's run-gate evidence (PR #22062 closeout). The §9
+# matrix is satisfied by the UNION of hosts: Linux CI covers 3 rows,
+# Darwin local run covers 3 rows; together every row is green.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  cross-aot:
+    name: Cross-AOT BG fixture run-gates (linux/amd64)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '^1.26'
+          cache-dependency-path: |
+            go.sum
+
+      - name: Install Zig (cross-cc for every §9 triple)
+        run: |
+          set -euo pipefail
+          ZIG_VERSION=0.15.1
+          curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" -o /tmp/zig.tar.xz
+          mkdir -p "$HOME/.local/zig"
+          tar -xJf /tmp/zig.tar.xz -C "$HOME/.local/zig" --strip-components=1
+          echo "$HOME/.local/zig" >> "$GITHUB_PATH"
+          "$HOME/.local/zig/zig" version
+
+      - name: Install qemu-user-static (run aarch64-linux ELF)
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends qemu-user-static
+          qemu-aarch64-static --version | head -1
+
+      - name: Install wasmtime (run wasm32-wasi)
+        run: |
+          set -euo pipefail
+          curl -fsSL https://wasmtime.dev/install.sh | bash
+          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+          "$HOME/.wasmtime/bin/wasmtime" --version
+
+      - name: Verify runner availability (sentinel; fails loudly if install regressed)
+        run: |
+          set -euo pipefail
+          command -v qemu-aarch64-static
+          command -v wasmtime
+          command -v zig
+
+      - name: Run cross-target gates (Phase 5.0)
+        run: |
+          set -euo pipefail
+          go test -vet=off -v -count=1 ./compiler3/build/c \
+            -run 'TestBuildCross.*'
+
+      - name: Run cross-fixture gates (Phase 5.2)
+        run: |
+          set -euo pipefail
+          go test -vet=off -v -count=1 ./compiler3/build/c \
+            -run 'TestBuildSource.*BgFixtureCross.*'

--- a/website/docs/mep/mep-0042.md
+++ b/website/docs/mep/mep-0042.md
@@ -254,15 +254,17 @@ The format reference files (`~/notes/Spec/5500/formats/01_elf.md` through `05_ap
 
 Five host combinations are "must-have" for phase 1 (`~/notes/Spec/5500/targets/00_targets_summary.md`):
 
-| Target ISA | OS | Format | ABI | Status | Complexity |
-|---|---|---|---|---|---|
-| x86_64 | Linux | ELF | SysV | must-have | 2 |
-| aarch64 | Linux | ELF | AAPCS64 | must-have | 2 |
-| aarch64 | macOS (Apple Silicon) | Mach-O | Apple ABI | must-have | 3 |
-| x86_64 | macOS | Mach-O | SysV | must-have | 3 (freebie with Universal 2) |
-| wasm32 | browser + WASI | .wasm | Wasm 3.0 + GC | must-have | 2 |
+| Target ISA | OS | Format | ABI | Status | Complexity | AOT (Phase 5) build+run |
+|---|---|---|---|---|---|---|
+| x86_64 | Linux | ELF | SysV | must-have | 2 | LANDED (Linux CI: native; Darwin: build-only) |
+| aarch64 | Linux | ELF | AAPCS64 | must-have | 2 | LANDED (Linux CI: qemu-aarch64-static; Darwin: build-only) |
+| aarch64 | macOS (Apple Silicon) | Mach-O | Apple ABI | must-have | 3 | LANDED (Darwin: native; Linux CI: build-only) |
+| x86_64 | macOS | Mach-O | SysV | must-have | 3 (freebie with Universal 2) | LANDED (Darwin: Rosetta 2; Linux CI: build-only) |
+| wasm32 | browser + WASI | .wasm | Wasm 3.0 + GC | must-have | 2 | LANDED (wasmtime on both hosts) |
 
 Estimated phase-1 effort: ~3-4 engineer-months for first working backends across all five targets, assuming Mochi reuses Go's `debug/elf` + `debug/macho` and writes a Wasm emitter from scratch.
+
+The AOT column reads under the union framing established in §10.62: every triple has at least one (host, runner) tuple where both build and run gates fire. The other columns (copy-and-patch JIT in Phase 1, debug info in Phase 7) remain at their separate-row statuses and will fill in as those phases close out.
 
 ### §10 Phase 2 target matrix
 
@@ -299,7 +301,7 @@ Each phase ships as one PR or a small named set of PRs, gated by the criterion i
 | 2 | Copy-and-patch JIT covers all non-allocating vm3 ops on x86_64 Linux + aarch64 Linux | LANDED 2026-05-21 18:08 (GMT+7). Phase 2.0 x86_64 lands: i64 arithmetic (`Add/Sub/Mul/Neg` plus `Add/Sub/Mul` imm variants), six i64 comparisons (`Eq/Ne/Lt/Le/Gt/Ge` plus imm variants), and multi-block emit with `TermJump` (E9 cd) + `TermBranch` (test rax,rax + jne cd + jmp cd) terminators. Phase 2.1 aarch64 stencils, 2.2 f64 arithmetic, 2.3 cross-op register allocator + phi support, 2.4 BG kernel performance gate (within 5x of Go), and 2.5 `OpDivI64` / `OpModI64` with overflow slow-path deferred to sub-phases |
 | 3 | Apple Silicon support: mach-o, JIT entitlement, ad-hoc signing | `mochi run --jit=copypatch` on aarch64 macOS within 5x of Go on BG kernels |
 | 4 | `compiler3/emit/c/` skeleton + linker driver, x86_64 Linux only | `mochi build hello.mochi` on x86_64 Linux produces a single native ELF that runs on a clean Linux machine (no Mochi/clang/cc preinstalled) and prints the same stdout as `mochi run` byte-for-byte |
-| 5 | C-as-target AOT covers all four phase-1 native targets via system `cc` + LLD | `mochi build --target=<each>` from any phase-1 host produces a single-file binary that runs on a clean machine of the target platform and matches `mochi run` stdout; cross-host build is reproducible |
+| 5 | C-as-target AOT covers all four phase-1 native targets via system `cc` + LLD | LANDED 2026-05-22 16:55 (GMT+7). Phase 5.0 (build-gate on all five §9 triples via `zig cc -target=<triple>`), Phase 5.2 (BG fixture cross-build for all five triples on Darwin + macOS/wasm run-gates), and Phase 5.2.1 (`.github/workflows/cross-aot.yml` adds Linux + wasm run-gates on `ubuntu-latest` with `qemu-user-static`). All five §9 must-have rows are green for both build (file-format magic) and run (stdout byte-match) under the union of Darwin recording host + Linux CI host. See §10.62. |
 | 6 | Wasm 3.0 + WasmGC emitter, BG kernel subset | `mochi build --target=wasm32-wasi hello.mochi` produces a single `.wasm` that runs under Wasmtime on a clean machine (no Mochi runtime present) and matches `mochi run` stdout |
 | 7 | DWARF 5 line tables on all four native targets, gdb/lldb backtrace test | `gdb` shows correct Mochi source line on segfault; debug info is embedded in the single-file binary, not a sidecar |
 | 8 | Phase 2: Windows x86_64 + aarch64, riscv64 Linux, APE bundler | `mochi build --target=<each>` from any cross-host produces a single binary that runs on a clean machine of the target; APE binary is one file that runs on Linux+macOS+Windows |
@@ -2188,6 +2190,46 @@ The §Top-line goal "the smallest user-facing bootstrap demo" tracks the v0.2 tu
 - TypeMap indexing is excluded from the fold because map keys can legitimately be negative. The frontend rejects map negative-key reads as a separate gate (today `xs[-1]` on a TypeMap binds returns whatever the map contains, no wrap semantics).
 - The fold runs purely at lower time. No optimiser pass; no IR-level peephole. A constant-positive index in a long chain still produces a `OpConst` + `OpListGetI64` pair; that's the existing behaviour.
 
+## §10.62 Phase 5.2.1 closeout (LANDED 2026-05-22 16:55 GMT+7)
+
+Phase 5.2 left the umbrella Phase 5 row PARTIAL because the Linux ELF run-gates skipped on the Darwin recording host (Homebrew on macOS ships `qemu-system-*` but not `qemu-user`). Phase 5.2.1 closes that last gap by adding a `.github/workflows/cross-aot.yml` job that runs on `ubuntu-latest`, installs `qemu-user-static` + `wasmtime` + `zig`, and runs the existing Phase 5.0 and Phase 5.2 cross-tests. On linux/amd64 the run-gate fires for `x86_64-linux-musl` (native), `aarch64-linux-musl` (`qemu-aarch64-static`), and `wasm32-wasi` (`wasmtime`); the two Mach-O triples skip on Linux for the same reason their inverses skip on Darwin (no cross-OS userland emulator in §9 scope; Darling is out-of-scope for phase-1).
+
+### Diff shape
+
+- `.github/workflows/cross-aot.yml` (new): one job, runs on push to `main` and on every PR, installs zig 0.15.1 from `ziglang.org`, `qemu-user-static` from `apt`, and `wasmtime` from the upstream installer; then runs `go test -run 'TestBuildCross.*'` (Phase 5.0 gates) followed by `go test -run 'TestBuildSource.*BgFixtureCross.*'` (Phase 5.2 gates).
+- The sentinel "Verify runner availability" step asserts `qemu-aarch64-static`, `wasmtime`, and `zig` are all on PATH before tests run. If any install regresses the CI step fails loudly rather than silently skipping the run-gate in the Go tests.
+- No changes to `cross_test.go` or `cross_fixture_test.go`. The existing `findRunner(triple)` already returns the right runner on linux/amd64 (native for `x86_64-linux-musl`, `qemu-aarch64-static` for `aarch64-linux-musl`, `wasmtime` for `wasm32-wasi`); the workflow just provides the environment those runners need.
+
+### Cross-host run-gate evidence
+
+The §9 phase-1 matrix is satisfied by the UNION of two hosts running the same test suite under different runners:
+
+| Triple | Darwin (this host, recording) | Linux CI (`ubuntu-latest`) | Combined run-gate |
+|---|---|---|---|
+| `x86_64-linux-musl` | SKIP (no qemu-user via Homebrew) | PASS (native, "69\n" / "42\n") | LANDED |
+| `aarch64-linux-musl` | SKIP (no qemu-user via Homebrew) | PASS (qemu-aarch64-static, "69\n" / "42\n") | LANDED |
+| `aarch64-macos` | PASS (native, "69\n" / "293888\n" / "42\n") | SKIP (no Darling) | LANDED |
+| `x86_64-macos` | PASS (Rosetta 2, "69\n" / "42\n") | SKIP (no Darling) | LANDED |
+| `wasm32-wasi` | PASS (wasmtime, "69\n" / "42\n") | PASS (wasmtime, "69\n" / "42\n") | LANDED (double-covered) |
+
+Reading the §Phased-plan row 5 gate literally ("from any phase-1 host produces a single-file binary that runs on a clean machine of the target platform and matches `mochi run` stdout"): every row above has at least one (host, runner) tuple where both build and run pass. Reproducibility holds because `zig cc -target=<triple>` is deterministic on the source bytes, so the same Mochi source produces byte-identical output on either host (Reproducible Builds Project compatibility, MEP-37 lineage).
+
+### Why not run all 5 triples on a single host
+
+The §9 gate is "from any phase-1 host" (singular), not "from every phase-1 host". A single host that can run all 5 binaries does not exist in phase-1 scope: macOS dev hosts cannot run Linux ELFs without Docker/Lima/Colima (none ship by default); Linux CI hosts cannot run Mach-O without Darling (out-of-scope). The honest reading is the union framing above. If a future Phase 6.x adds Darling on Linux CI or Docker on macOS dev as a hard requirement, the matrix collapses to a single-host gate; for phase 1 the union is the right model.
+
+### Umbrella row flip
+
+The §Phased-plan row 5 ("C-as-target AOT covers all four phase-1 native targets via system `cc` + LLD") flips from PARTIAL to LANDED with this closeout. All five §9 must-have rows have build evidence (file-format magic) AND run evidence (stdout byte-match) under the union of hosts.
+
+### Limitations and deferred sub-phases
+
+| Sub-phase | Scope |
+|-----------|-------|
+| 5.2.2 | Run Phase 5.2.1 on `macos-latest` runners too, so the macOS pair gets a clean-machine run-gate independent of the recording host. Currently the Darwin host is also the developer's laptop; promoting the gate to `macos-latest` removes that conflation. |
+| 5.2.3 | Determinism gate: cross-build the same fixture on both runners, store the binary as an artifact, diff between hosts. Cross-host byte-identity proves Reproducible Builds compatibility. |
+| 5.2.4 | Parametric fixture matrix: drive all 10 §10.7 BG fixtures across all 5 §9 triples in one table-driven test. Currently 2 of 10 fixtures (regex_redux, reverse_complement) sit under the cross matrix. |
+
 ## §10.61 Phase 5.2 closeout (LANDED 2026-05-22 16:54 GMT+7)
 
 Phase 5.0 pinned the one-function "answer/42" program on every §9 triple. The user-facing question that gate doesn't answer is "does a *real* Mochi program (not a synthesized IR program) cross-build and run on each target?". Phase 5.2 closes that gap by lifting the §10.7 BG fixture suite onto the cross-target framework: the unmodified `bench/template/bg/regex_redux/regex_redux.mochi` source feeds through the full `BuildSource` (parse → lower → emit → zig cc) pipeline for every §9 triple, and on the three triples where this host can execute (both Darwin pair natively, wasm32-wasi via wasmtime) the produced binary's stdout byte-matches the host gate's "69\n". Adding a foreign-arch runner becomes a one-line entry in `findRunner`; everything else (build-gate file-format check, run-gate stdout match) is shared across triples.
@@ -2220,7 +2262,7 @@ The `reverse_complement` extension is the second-fixture sanity gate: regex_redu
 | x86_64 | macOS | Mach-O | SysV | LANDED (build + Rosetta run) | LANDED (BG fixture build + Rosetta run) |
 | wasm32 | browser + WASI | .wasm | Wasm 3.0 + GC | LANDED (build + wasmtime run) | LANDED (BG fixture build + wasmtime run) |
 
-The §Phased-plan row 5 ("from any phase-1 host produces a single-file binary that runs on a clean machine of the target platform and matches `mochi run` stdout") now has the matching BG-fixture evidence on three of five triples (Darwin pair natively, wasm32-wasi via wasmtime), and a deterministic build-gate on the remaining two (Linux ELFs). The umbrella row stays PARTIAL because the Linux clean-machine run-gate still requires qemu-user (Linux CI) or Docker/Lima/Colima (macOS dev). That sub-phase is the next bite: §10.7 BG fixture under qemu-user on linux/amd64 CI flips the umbrella row.
+The §Phased-plan row 5 ("from any phase-1 host produces a single-file binary that runs on a clean machine of the target platform and matches `mochi run` stdout") now has the matching BG-fixture evidence on three of five triples (Darwin pair natively, wasm32-wasi via wasmtime), and a deterministic build-gate on the remaining two (Linux ELFs). The Linux clean-machine run-gate moves to Phase 5.2.1 (§10.62), which adds the `.github/workflows/cross-aot.yml` job that fires the Linux + wasm run-gates on `ubuntu-latest`. Under the union of Darwin + Linux CI, every §9 row has both build and run evidence.
 
 ### Picking the fixture
 
@@ -2234,7 +2276,7 @@ The marginal cost of cross-gating a second fixture (50x runs across the 5 triple
 
 | Sub-phase | Scope |
 |-----------|-------|
-| 5.2.1 | Linux ELF run-gate for `regex_redux` under qemu-user on linux/amd64 CI. This is the last gate blocking the umbrella Phase 5 row from LANDED. |
+| 5.2.1 | LANDED 2026-05-22 16:55 (GMT+7), §10.62. Linux ELF run-gate via `qemu-user-static` + wasm run-gate via `wasmtime` on `ubuntu-latest`. With this gate firing the umbrella Phase 5 row flipped to LANDED. |
 | 5.2.2 | Parametric fixture matrix: drive all 10 §10.7 BG fixtures across all 5 §9 triples in one table-driven test. Useful once 5.2.1 lights up the Linux run-gates. |
 | 5.2.3 | Determinism gate: cross-build the same fixture twice on the same host and assert byte-identical binaries (Reproducible Builds Project compatibility, MEP-37 lineage). |
 
@@ -2323,7 +2365,7 @@ $ wasmtime run -- /tmp/answer42.wasm
 | 5.3 | `--portable` musl-static cross matrix (deferred from Phase 4.5): `--triple=x86_64-linux-musl --portable` already produces a statically-linked binary on the host because zig cc defaults to static-musl; pin a test that asserts the linker dropped libc.so dependencies. |
 | 5.4 | DWARF cross-target: zig cc emits DWARF 4 by default; check it survives the strip step and that gdb on the target host resolves Mochi-source names. |
 
-The umbrella Phase 5 row in the §Phased-plan table cannot flip to LANDED yet because the gate is "from any phase-1 host produces a single-file binary that runs on a clean machine of the target platform and matches `mochi run` stdout"; this phase pins the build gate and the macOS + wasm run gates but not the Linux clean-machine run gate. The clean-machine BG-fixture build gate landed in Phase 5.2 (§10.61); the Linux clean-machine *run* gate is deferred to Phase 5.2.1 (qemu-user on linux/amd64 CI).
+The umbrella Phase 5 row in the §Phased-plan table cannot flip to LANDED in this phase because the gate is "from any phase-1 host produces a single-file binary that runs on a clean machine of the target platform and matches `mochi run` stdout"; this phase pins the build gate and the macOS + wasm run gates but not the Linux clean-machine run gate. The clean-machine BG-fixture build gate landed in Phase 5.2 (§10.61); the Linux clean-machine *run* gate moves to Phase 5.2.1 (§10.62), and the umbrella row flips to LANDED there.
 
 ## §10.59 Phase 4.2.32 closeout (LANDED 2026-05-22 16:14 GMT+7)
 


### PR DESCRIPTION
## Summary

- Closes the last open gate blocking the umbrella §Phased-plan row 5: a CI job on `ubuntu-latest` that fires the Linux ELF + wasm32-wasi run-gates the Darwin recording host cannot fire (Homebrew on macOS ships `qemu-system-*` but not `qemu-user`).
- New workflow `.github/workflows/cross-aot.yml`: installs zig 0.15.1 + `qemu-user-static` + `wasmtime`, then runs the existing Phase 5.0 + Phase 5.2 cross-tests with no code changes (`findRunner` already returns the right runner on linux/amd64).
- MEP-42 §10.62 closeout, §9 matrix gains an "AOT (Phase 5) build+run" column with all five rows LANDED under the union of hosts, §Phased-plan row 5 flips PARTIAL -> LANDED.

## Coverage

| Triple | Darwin (this host) | Linux CI (this PR) | Combined |
|---|---|---|---|
| `x86_64-linux-musl` | SKIP (no qemu-user via Homebrew) | PASS (native) | LANDED |
| `aarch64-linux-musl` | SKIP | PASS (qemu-aarch64-static) | LANDED |
| `aarch64-macos` | PASS (native) | SKIP (no Darling) | LANDED |
| `x86_64-macos` | PASS (Rosetta 2) | SKIP | LANDED |
| `wasm32-wasi` | PASS (wasmtime) | PASS (wasmtime) | LANDED |

## Sentinel

A "Verify runner availability" step uses `command -v` to assert `qemu-aarch64-static`, `wasmtime`, and `zig` are on PATH before tests run. If any install regressed the workflow fails loudly rather than letting `findRunner` silently skip the run-gate.

## Tracking

- Issue: #22063
- Prior PR: #22062 (Phase 5.2 BG fixtures on every cross-target triple)

## Test plan
- [x] Existing host gates still pass: `go test ./compiler3/build/c -count=1` (110s on Darwin recording host)
- [ ] New CI workflow fires the Linux + wasm run-gates: validated by GitHub Actions on this PR