### PR TITLE
hotfix: cross-aot workflow Zig URL + bump to 0.16.0

### DIFF
--- a/.github/workflows/cross-aot.yml
+++ b/.github/workflows/cross-aot.yml
@@ -42,8 +42,10 @@ jobs:
       - name: Install Zig (cross-cc for every §9 triple)
         run: |
           set -euo pipefail
-          ZIG_VERSION=0.15.1
-          curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" -o /tmp/zig.tar.xz
+          ZIG_VERSION=0.16.0
+          # Filename layout is `zig-<arch>-<os>-<version>.tar.xz` as of
+          # Zig 0.14+ (older releases used `zig-<os>-<arch>-<version>`).
+          curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" -o /tmp/zig.tar.xz
           mkdir -p "$HOME/.local/zig"
           tar -xJf /tmp/zig.tar.xz -C "$HOME/.local/zig" --strip-components=1
           echo "$HOME/.local/zig" >> "$GITHUB_PATH"


### PR DESCRIPTION
## Summary

PR #22064 (Phase 5.2.1) merged with a broken Zig install step: the URL template `zig-linux-x86_64-VERSION.tar.xz` 404s on ziglang.org (Zig 0.14+ switched the filename layout to `zig-x86_64-linux-VERSION.tar.xz`). This hotfix corrects the URL and bumps to Zig 0.16.0 (current stable per `ziglang.org/download/index.json` on 2026-05-22).

Without this fix the Cross AOT job aborts in the Install Zig step on every run, so the Linux ELF + wasm run-gates that the MEP-42 §10.62 closeout claims are firing on linux/amd64 actually skip. This re-greens the load-bearing claim of the Phase 5 umbrella row.

## Test plan
- [ ] Validated on this PR's Cross AOT run (workflow should reach the "Run cross-fixture gates (Phase 5.2)" step and assert "69\n" for x86_64-linux-musl, aarch64-linux-musl, and wasm32-wasi)