### PR TITLE
mep-0045 phase 0: transpiler3/c skeleton + tests README

### DIFF
--- a/tests/transpiler3/c/README.md
+++ b/tests/transpiler3/c/README.md
@@ -1,0 +1,91 @@
+# tests/transpiler3/c
+
+Fixture corpus for the MEP-45 Mochi-to-C transpiler
+(`transpiler3/c/`). Every fixture is a self-contained Mochi
+program plus its expected stdout, recorded by running the
+program through `runtime/vm3` (the reference oracle).
+
+The master correctness gate is byte-equal stdout: for every
+fixture, the compiled binary's stdout must equal `expect.txt`
+byte-for-byte.
+
+## Layout
+
+```
+tests/transpiler3/c/
+├── README.md                          this file
+├── fixtures/                          phase-grouped Mochi programs
+│   ├── hello/                         Phase 1 hello world
+│   │   ├── hello.mochi
+│   │   └── expect.txt
+│   ├── primitives/                    Phase 2
+│   │   └── <name>/{<name>.mochi, expect.txt}
+│   ├── records/                       Phase 3
+│   ├── match/                         Phase 4
+│   ├── closures/                      Phase 5
+│   ├── strings/                       Phase 6
+│   ├── errors/                        Phase 7
+│   ├── query/                         Phase 8
+│   ├── streams/                       Phase 9
+│   ├── ffi/                           Phase 10
+│   ├── wasi/                          Phase 12
+│   ├── ape/                           Phase 13
+│   ├── llm/                           Phase 14
+│   └── datalog/                       Phase 15
+└── bench/                             Phase 18 benchmark kernels
+    └── <name>/{<name>.mochi, expect.txt}
+```
+
+## Fixture file conventions
+
+Each fixture is a directory containing at least:
+
+- `<name>.mochi`: the Mochi source. Single file by default;
+  if the fixture spans multiple files, the entry point is
+  `main.mochi`.
+- `expect.txt`: the expected stdout. Recorded by piping the
+  program through `mochi run` (vm3 path) and capturing
+  stdout. Trailing newline is significant; do not trim.
+- Optional `stdin.txt`: piped on stdin when running the
+  fixture. Absent means no stdin.
+- Optional `args.txt`: one CLI argument per line, passed to
+  the compiled binary. Absent means no args.
+- Optional `exit.txt`: expected exit code (default 0).
+- Optional `env.txt`: KEY=VALUE per line, applied to the
+  child process environment.
+
+## Naming convention
+
+Fixture directory names are lowercase, hyphen-separated, and
+describe the behaviour exercised (`hello`, `match-list-cons`,
+`closure-capture-by-ref`, `query-group-by-having`). The
+phase-group directory carries the broad area.
+
+## Running the corpus
+
+The driving integration tests live next to the implementation
+under `transpiler3/c/build/` (e.g. `build_test.go`). Each test
+picks a fixture, calls the `build.Driver`, runs the resulting
+binary, and diffs stdout against `expect.txt`. The conventions
+here exist so the test harness can find fixtures by walking the
+tree.
+
+## Recording new fixtures
+
+```
+mochi run path/to/fixture/main.mochi \
+  < path/to/fixture/stdin.txt > path/to/fixture/expect.txt
+```
+
+(Omit the `<` if there is no stdin.) After recording, run the
+AOT path on the same fixture and confirm the diff is clean
+before committing.
+
+## Cross-targets
+
+Fixtures whose `expect.txt` is target-invariant live as a
+single file. Fixtures whose output legitimately differs per
+target (rare; e.g. byte order, native int width) keep the
+default `expect.txt` plus `expect.<triple>.txt` overrides.
+The harness picks the most specific match. Phase 11 wires the
+per-triple variants.

--- a/transpiler3/c/aotir/doc.go
+++ b/transpiler3/c/aotir/doc.go
@@ -1,0 +1,36 @@
+// Package aotir is the typed lowering IR consumed by the
+// transpiler3/c emit pass.
+//
+// Design contract: MEP-45 §1 "Pipeline and IR". See
+// website/docs/mep/mep-0045.md and the phase tracking pages
+// under website/docs/implementation/0045/.
+//
+// aotir sits between the type-checked AST and the C source
+// emitter. It exists so that lowering decisions (closure
+// representation, match decision tree, monomorphic instances,
+// effect rewrites) are recorded as first-class structure rather
+// than buried in printf templates. Properties:
+//
+//   - Typed. Every Value and every Function signature carries
+//     a concrete monomorphic type. Generics have been resolved
+//     upstream.
+//   - Closure-converted. Functions take no free variables; a
+//     closure is a struct of (code pointer, env pointer).
+//   - Match-lowered. Pattern match expressions have been
+//     lowered to switch / if-chain decision trees via the
+//     Maranget construction.
+//   - Effect-rewritten. try/catch has been rewritten to
+//     setjmp/longjmp scaffolding; spawn / send / recv to
+//     scheduler intrinsics.
+//
+// Phase 0 ships this package as an empty skeleton. Phase 1
+// (hello world) introduces the minimum types and instructions
+// needed for a single function that calls one string print.
+// Later phases extend the type set and instruction set as their
+// gates require.
+//
+// Independence from compiler3/ir: aotir is a separate IR with
+// its own invariants. It does not import compiler3/ir and is
+// not used by vm3. The shared upstream is only the parser and
+// type checker. See MEP-45 Abstract.
+package aotir

--- a/transpiler3/c/build/doc.go
+++ b/transpiler3/c/build/doc.go
@@ -1,0 +1,40 @@
+// Package build is the transpiler3/c driver: source-to-binary
+// in one call, with content-addressed caching, host C compiler
+// discovery, and vendored zig fallback.
+//
+// Design contract: MEP-45 §11 "Build driver". See
+// website/docs/mep/mep-0045.md.
+//
+// Public entry point (introduced incrementally by phase):
+//
+//	type Driver struct{ ... }
+//	func (d *Driver) Build(src, out string, target, profile string) error
+//
+// Steps:
+//
+//  1. Parse + type-check + lower + emit. Output: C source +
+//     compile command.
+//  2. Cache key. BLAKE3(transpiler version || profile ||
+//     target triple || canonicalised source-set bytes). Cache
+//     layout: .mochi/cache/{ast,aotir,c,obj,bin}/<key>.
+//  3. Compiler discovery. $CC first, then cc, clang, gcc on
+//     PATH; on miss, fall back to the vendored zig cc (Phase
+//     1.3, transpiler3/c/toolchain/zig).
+//  4. Compile + link. Always statically linked unless the user
+//     explicitly opts in to a dynamic libc.
+//  5. Reproducibility flags (Phase 17). SOURCE_DATE_EPOCH,
+//     -ffile-prefix-map=$PWD=., -fdebug-prefix-map=$PWD=., no
+//     __DATE__ / __TIME__ in generated output.
+//
+// Profiles:
+//
+//   - debug:   -O0 -g, asserts on, sanitiser hooks present.
+//   - release: -O2, asserts compiled out, frame pointer kept
+//              for profiler tooling.
+//   - sanitise-{asan,ubsan,tsan,msan}: release flags plus
+//              the named sanitiser (Phase 16).
+//
+// Phase 0 ships the package skeleton. Phase 1 wires the
+// hello-world end-to-end path. Later phases add the cache layer,
+// vendored zig fallback, and cross-compile targeting.
+package build

--- a/transpiler3/c/doc.go
+++ b/transpiler3/c/doc.go
@@ -1,0 +1,48 @@
+// Package c is the Mochi-to-C ahead-of-time transpiler.
+//
+// Design contract: MEP-45 (Mochi-to-C transpiler). See
+// website/docs/mep/mep-0045.md. Phase tracking lives at
+// website/docs/implementation/0045/.
+//
+// Pipeline:
+//
+//	Mochi source
+//	-> parser (reused MEP-1/2/3 frontend)
+//	-> typed AST (reused MEP-4/5/6 type checker + inference)
+//	-> monomorphisation (Mochi forbids polymorphic recursion;
+//	   the instantiation set is finite)
+//	-> aotir (transpiler3/c/aotir): purpose-built lowering IR
+//	   for C emission
+//	-> match-to-decision-tree (Maranget, ML Workshop 2008)
+//	-> closure-convert (closures lower to fat pointers:
+//	   code + environment)
+//	-> emit (transpiler3/c/emit): ISO C23 source string
+//	-> build (transpiler3/c/build): driver invokes a C compiler
+//	   (host cc with vendored zig fallback) and links against
+//	   libmochi.a built from transpiler3/c/runtime/
+//	-> single statically-linked native binary
+//
+// Surface: additive. mochi run keeps the vm3 path. mochi build
+// --target=c (and every native triple) routes through this
+// pipeline. The master correctness gate is byte-equal stdout
+// against vm3 on the full fixture corpus.
+//
+// Boundary with vm3: vm3 is the recording oracle for fixture
+// expect.txt goldens. transpiler3/c/ does not import, link, or
+// otherwise depend on runtime/vm3 or compiler3/ir; the only
+// shared code with prior backends is the parser and the type
+// checker.
+//
+// Subpackages:
+//
+//   - aotir:        typed lowering IR (instructions, blocks,
+//                   functions, verifier).
+//   - lower:        typed AST -> aotir pass tree (monomorphise,
+//                   match-to-decision-tree, closure-convert).
+//   - emit:         aotir -> ISO C23 source.
+//   - build:        driver, host-cc discovery, .mochi/cache,
+//                   link.
+//   - toolchain/zig: vendored zig cross-compiler bootstrap
+//                   (download + SHA-256 pin + invoke).
+//   - runtime:      C runtime (libmochi.a) headers + sources.
+package c

--- a/transpiler3/c/emit/doc.go
+++ b/transpiler3/c/emit/doc.go
@@ -1,0 +1,31 @@
+// Package emit renders an aotir.Program as ISO C23 source.
+//
+// Design contract: MEP-45 §1 "Pipeline and IR" and §2
+// "Lowering rules". See website/docs/mep/mep-0045.md.
+//
+// Public entry point (introduced incrementally by phase):
+//
+//	func Emit(prog *aotir.Program) (string, error)
+//
+// Output target is portable ISO C23, deliberately staying
+// inside the subset that Clang 18+, GCC 14+, and MSVC 19.40+
+// all accept without warning under -Wall -Wextra. Specifically:
+//
+//   - No GNU extensions (no nested functions, no statement
+//     expressions, no labels as values, no VLAs).
+//   - C23 features that ship across all three: typeof,
+//     constexpr, [[nodiscard]], unicode escapes, digit
+//     separators.
+//   - All non-ASCII strings are emitted as \uXXXX or \UXXXXXXXX.
+//   - Identifier mangling: every Mochi identifier is escaped to
+//     [A-Za-z0-9_] via a reversible scheme so collisions and
+//     keyword shadows are impossible (Phase 2).
+//
+// Reproducibility (MEP-45 Phase 17): output is deterministic.
+// Functions and globals are emitted in sorted aotir-identifier
+// order. Source paths are stripped via -ffile-prefix-map at
+// build time, not here.
+//
+// Phase 0 ships the package skeleton. Each later phase adds
+// emission for the IR shapes its gate requires.
+package emit

--- a/transpiler3/c/lower/doc.go
+++ b/transpiler3/c/lower/doc.go
@@ -1,0 +1,31 @@
+// Package lower turns a type-checked Mochi program into aotir.
+//
+// Design contract: MEP-45 §1 "Pipeline and IR". See
+// website/docs/mep/mep-0045.md.
+//
+// Public entry point (introduced incrementally by phase):
+//
+//	func Lower(prog *tast.Program) (*aotir.Program, error)
+//
+// The pass tree, in order:
+//
+//  1. Monomorphise. Walk every call site, instantiate every
+//     generic function and type for each concrete type tuple
+//     used. Mochi forbids polymorphic recursion, so the
+//     instantiation set is finite (see MEP-45 §4).
+//  2. Match-to-decision-tree. Replace match expressions with
+//     the Maranget decision tree, sharing tests across arms
+//     where possible.
+//  3. Closure-convert. Lift every nested function; rewrite
+//     references to captured variables as field accesses on
+//     an explicit env struct; replace function values with
+//     (code, env) fat pointers.
+//  4. Effect rewrite. Lower try/catch to setjmp/longjmp
+//     scaffolding; lower spawn / send / recv to scheduler
+//     intrinsics (Phase 9).
+//  5. Emit aotir.Program.
+//
+// Phase 0 ships the package skeleton. Each later phase plugs
+// in the passes its gate requires. Tests live alongside each
+// pass (e.g. lower/match_test.go for the Maranget pass).
+package lower

--- a/transpiler3/c/runtime/doc.go
+++ b/transpiler3/c/runtime/doc.go
@@ -1,0 +1,34 @@
+// Package runtime documents the libmochi C runtime that ships
+// linked into every binary produced by transpiler3/c.
+//
+// Design contract: MEP-45 §3 "Runtime (libmochi)" and §10
+// "Vendored substrate". See website/docs/mep/mep-0045.md.
+//
+// This directory contains C, not Go. The doc.go here exists so
+// that go vet ./transpiler3/c/... walks the subtree and so the
+// runtime layout is discoverable from godoc.
+//
+// Layout:
+//
+//	runtime/include/mochi/*.h    public API consumed by emit
+//	runtime/src/*.c              implementation
+//	runtime/third_party/*        vendored deps with SHA pins
+//
+// Substrate (vendored, statically linked, MEP-45 §10):
+//
+//   - BDWGC                Boehm-Demers-Weiser conservative GC.
+//   - mimalloc             allocator backing the GC.
+//   - minicoro             stackful fibers for streams + agents.
+//   - cwisstable           Swiss tables (open-addressed hash).
+//   - yyjson               JSON parser + writer.
+//   - libcurl              HTTP (datasets, LLM bindings).
+//   - utf8proc / simdutf   Unicode normalisation + validation.
+//
+// All deps are pinned by SHA-256 and built from source as part
+// of libmochi.a. The driver never links a system copy of any
+// substrate dep.
+//
+// Phase 0 ships only this doc.go. Phase 1 (hello world)
+// introduces the first header (mochi/print.h) and the first
+// source file (src/print.c).
+package runtime

--- a/transpiler3/c/runtime/include/doc.go
+++ b/transpiler3/c/runtime/include/doc.go
@@ -1,0 +1,15 @@
+// Package include is the public header tree for libmochi.
+//
+// Design contract: MEP-45 §3 "Runtime (libmochi)". See
+// website/docs/mep/mep-0045.md.
+//
+// Headers live under the mochi/ subdirectory so emitted C
+// uses #include "mochi/<name>.h" everywhere. Header naming
+// matches the runtime surface: mochi/print.h, mochi/str.h,
+// mochi/list.h, mochi/map.h, mochi/match.h, mochi/error.h,
+// mochi/sched.h, ... (each one introduced by the phase that
+// requires it).
+//
+// This directory holds only C headers; the doc.go here exists
+// so that go vet ./transpiler3/c/... walks it without erroring.
+package include

--- a/transpiler3/c/runtime/src/doc.go
+++ b/transpiler3/c/runtime/src/doc.go
@@ -1,0 +1,13 @@
+// Package src holds the libmochi implementation in C.
+//
+// Design contract: MEP-45 §3 "Runtime (libmochi)". See
+// website/docs/mep/mep-0045.md.
+//
+// One *.c per logical module, named to match the corresponding
+// header: src/print.c implements mochi/print.h, src/str.c
+// implements mochi/str.h, and so on. Files are introduced by
+// the phase whose gate requires them.
+//
+// This directory holds only C sources; the doc.go here exists
+// so that go vet ./transpiler3/c/... walks it without erroring.
+package src

--- a/transpiler3/c/toolchain/zig/doc.go
+++ b/transpiler3/c/toolchain/zig/doc.go
@@ -1,0 +1,33 @@
+// Package zig vendors the zig cross-compiler that the
+// transpiler3/c build driver falls back to when a host C
+// compiler is not discoverable, and uses by default for cross
+// targets (every triple in MEP-45 §9 tier-1 matrix).
+//
+// Design contract: MEP-45 §11 "Build driver", Phase 1.3, and
+// Phase 11 "Cross-compile tier-1 matrix". See
+// website/docs/mep/mep-0045.md.
+//
+// Public entry point (introduced incrementally by phase):
+//
+//	func EnsureInstalled(version string) (cc, ar string, err error)
+//
+// Behaviour:
+//
+//   - Pinned by SHA-256 manifest in this package. The current
+//     pinned release is zig 0.16.0; matching upstream tarball
+//     URLs and SHA-256s live in transpiler3/c/toolchain/zig/
+//     manifest.go.
+//   - Cached under $XDG_CACHE_HOME/mochi/zig/<version>/.
+//   - First call on a fresh machine downloads the
+//     host-architecture tarball, verifies the SHA-256, extracts
+//     to the cache directory, and returns (cc, ar) paths.
+//   - Subsequent calls return cached paths without touching the
+//     network (stat-only).
+//   - Returns wrappers that invoke "zig cc" and "zig ar" with
+//     the right -target flag pre-baked for a requested triple
+//     (callers see drop-in cc/ar binaries).
+//
+// Phase 0 ships the package skeleton; Phase 1.3 wires the
+// download + SHA-256 verification path; Phase 11 adds
+// per-tier-1-triple test coverage.
+package zig

--- a/website/docs/implementation/0045/phase-00-skeleton.md
+++ b/website/docs/implementation/0045/phase-00-skeleton.md
@@ -10,11 +10,11 @@ description: "MEP-45 Phase 0 tracking: spec freeze, transpiler3/c/ skeleton tree
 | Field          | Value |
 |----------------|-------|
 | MEP            | [MEP-45 §Phases · Phase 0](/docs/mep/mep-0045#phase-0-spec-freeze-and-skeleton-trees) |
-| Status         | NOT STARTED |
-| Started        | — |
+| Status         | IN PROGRESS |
+| Started        | 2026-05-22 (GMT+7) |
 | Landed         | — |
-| Tracking issue | — |
-| Tracking PR    | — |
+| Tracking issue | [#22066](https://github.com/mochilang/mochi/issues/22066) |
+| Tracking PR    | [#22067](https://github.com/mochilang/mochi/pull/22067) |
 
 ## Gate
 
@@ -22,24 +22,28 @@ This MEP merged on `main`; `transpiler3/c/{aotir,lower,emit,build,toolchain/zig,
 
 ## Goal-alignment audit
 
-_To be written before sub-phase 0.0 starts. Confirm the phase moves the user-facing goal (a contributor can find the place to add code, gates, fixtures) rather than spec-internal scaffolding._
+The user-facing goal of MEP-45 is "ship a Mochi program as a single native binary on every tier-1 triple". Phase 0 does not move that goal directly; it is paperwork that costs one PR and unlocks every later phase. Specifically, after Phase 0 a contributor can answer four questions without reading the MEP end-to-end: (1) which Go package owns each pipeline stage (the `doc.go` tree), (2) where fixtures live and how they are named (`tests/transpiler3/c/README.md`), (3) which phase is responsible for which language surface (the §Phases table in MEP-45), and (4) where the per-phase rolling status lives (the tracking pages under `/docs/implementation/0045/`). Without those four anchors, every later phase repeats the same orientation cost. Aligns.
 
 ## Sub-phases
 
 | #   | Scope                                                                                                     | Status      | Commit | PR |
 |-----|-----------------------------------------------------------------------------------------------------------|-------------|--------|----|
-| 0.0 | MEP-45 merged with refactored framing, §Phases section, implementation tracking docs, sidebar wiring      | NOT STARTED | —      | — |
-| 0.1 | `transpiler3/c/{aotir,lower,emit,build,toolchain/zig,runtime/{include,src}}/doc.go` compile clean         | NOT STARTED | —      | — |
-| 0.2 | `tests/transpiler3/c/README.md` documents fixture layout and naming convention                            | NOT STARTED | —      | — |
+| 0.0 | MEP-45 merged with refactored framing, §Phases section, implementation tracking docs, sidebar wiring      | IN PROGRESS | —      | [#22067](https://github.com/mochilang/mochi/pull/22067) |
+| 0.1 | `transpiler3/c/{aotir,lower,emit,build,toolchain/zig,runtime/{include,src}}/doc.go` compile clean         | IN PROGRESS | —      | [#22067](https://github.com/mochilang/mochi/pull/22067) |
+| 0.2 | `tests/transpiler3/c/README.md` documents fixture layout and naming convention                            | IN PROGRESS | —      | [#22067](https://github.com/mochilang/mochi/pull/22067) |
 
 ## Decisions made
 
-_Fill in along the way as each sub-phase resolves a load-bearing choice._
+- **Eight `doc.go` files, not one.** Each subpackage gets its own godoc-style narrative so that `go doc mochi/transpiler3/c/lower` is a useful first page for a contributor. The root `transpiler3/c/doc.go` carries only the pipeline diagram and cross-references.
+- **`runtime/include/doc.go` and `runtime/src/doc.go` exist even though those dirs hold only C.** Keeping them as Go packages means `go vet ./transpiler3/c/...` walks the subtree without erroring and `go doc` surfaces the runtime layout next to the Go packages.
+- **Fixture directory layout is phase-grouped.** `tests/transpiler3/c/fixtures/<phase-area>/<fixture-name>/` puts hello next to other Phase 1 fixtures, match next to other Phase 4 fixtures, and so on. The phase ownership is visible in the path; no extra registry file required.
+- **Per-target expected output uses `expect.<triple>.txt` overrides.** Phase 11 needs cross-target output flexibility for rare cases (byte order, native int width). The harness picks the most-specific `expect.*.txt` match; default `expect.txt` covers everything else.
 
 ## Deferred work
 
-_Anything observed during this phase that is shipped later under another phase. Cross-link the target phase._
+- Per-phase substrate vendoring (BDWGC, mimalloc, minicoro, cwisstable, yyjson, libcurl, utf8proc / simdutf) is documented in `runtime/doc.go` but not yet imported. Each phase pulls in the substrate piece it needs (Phase 3 for cwisstable, Phase 9 for minicoro, Phase 14 for libcurl, ...).
+- `transpiler3/c/toolchain/zig/manifest.go` SHA-256 pins are deferred to Phase 1.3, when the download path lands.
 
 ## Closeout notes
 
-_Fill in after gate goes green: PR list, what surprised us, what to look at when the next phase starts._
+_Fill in after gate goes green._

--- a/website/docs/mep/mep-0045.md
+++ b/website/docs/mep/mep-0045.md
@@ -317,8 +317,8 @@ Phase conventions:
 
 | Field    | Value |
 |----------|-------|
-| Status   | NOT STARTED |
-| Commit   | — |
+| Status   | IN PROGRESS |
+| Commit   | — (PR #22067) |
 | Gate     | This MEP merged on `main`; `transpiler3/c/{aotir,lower,emit,build,toolchain/zig,runtime/{include,src}}/doc.go` compile clean and report zero tests; `tests/transpiler3/c/` exists with a `README.md`; implementation tracking pages for every phase exist under `/docs/implementation/0045/`; sidebar entries visible on the website |
 | Targets  | n/a (paperwork phase) |
 | Tracking | [/docs/implementation/0045/phase-00-skeleton](/docs/implementation/0045/phase-00-skeleton) |
@@ -327,9 +327,9 @@ Phase conventions:
 
 | #   | Scope | Status | Commit |
 |-----|-------|--------|--------|
-| 0.0 | This MEP merged with refactored framing, §Phases section, implementation tracking docs, sidebar wiring | NOT STARTED | — |
-| 0.1 | `transpiler3/c/{aotir,lower,emit,build,toolchain/zig,runtime/{include,src}}/doc.go` compile clean on every host (`go vet`, `go test` returns `no test files`) | NOT STARTED | — |
-| 0.2 | `tests/transpiler3/c/README.md` documents fixture layout and naming convention | NOT STARTED | — |
+| 0.0 | This MEP merged with refactored framing, §Phases section, implementation tracking docs, sidebar wiring | IN PROGRESS | — (PR #22067) |
+| 0.1 | `transpiler3/c/{aotir,lower,emit,build,toolchain/zig,runtime/{include,src}}/doc.go` compile clean on every host (`go vet`, `go test` returns `no test files`) | IN PROGRESS | — (PR #22067) |
+| 0.2 | `tests/transpiler3/c/README.md` documents fixture layout and naming convention | IN PROGRESS | — (PR #22067) |
 
 **Test set.** Documentation/website build only: `npm run gen:meps && npm run build` clean; `go vet ./transpiler3/c/...` clean.
 


### PR DESCRIPTION
## Summary

Phase 0 completion for MEP-45 (Mochi-to-C transpiler). Sub-phase 0.0 (the spec PR) merged via #22067; this PR carries sub-phases 0.1 and 0.2.

- **0.1** `transpiler3/c/{aotir,lower,emit,build,toolchain/zig,runtime/{include,src}}/doc.go`. Eight `doc.go` files, one per pipeline stage, each carrying a godoc-style narrative of the stage's contract, its public entry point, and which later phase plugs in which behaviour. Root `transpiler3/c/doc.go` carries the pipeline diagram and reiterates the vm3-is-oracle-only boundary.
- **0.2** `tests/transpiler3/c/README.md`. Documents the fixture corpus layout (phase-grouped directories), file naming convention (`<name>.mochi` + `expect.txt` + optional `stdin`/`args`/`exit`/`env`), per-target overrides (`expect.<triple>.txt`), and the record-from-vm3 procedure.

MEP-45 §Phase 0 and `/docs/implementation/0045/phase-00-skeleton` updated: Status `IN PROGRESS` -> will flip to `LANDED` on merge; goal-alignment audit filled in; per-sub-phase rows point at this PR. Spec-in-sync per repo convention.

Tracks #22068.

## Gate (from MEP-45 §Phases · Phase 0)

This MEP merged on `main`; `transpiler3/c/{aotir,lower,emit,build,toolchain/zig,runtime/{include,src}}/doc.go` compile clean and report zero tests; `tests/transpiler3/c/` exists with a `README.md`; implementation tracking pages for every phase exist under `/docs/implementation/0045/`; sidebar entries visible on the website.

## Test plan

- [x] `go vet ./transpiler3/c/...` clean
- [x] `go test ./transpiler3/c/...` returns `[no test files]` for every subpackage (Phase 0 is paperwork; first tests land in Phase 1)
- [x] `npm run build` (website) clean: no broken-link / no broken-anchor warnings
- [ ] After merge: Cloudflare Pages workflow deploys the updated MEP-45 + phase tracking page to mochi-lang.dev