### PR TITLE
mep-0045: phase 3.3 + 3.5 -- DEFERRED, Mochi surface missing set / omap

### DIFF
--- a/website/docs/implementation/0045/phase-03-records-collections.md
+++ b/website/docs/implementation/0045/phase-03-records-collections.md
@@ -30,10 +30,10 @@ _To be written before sub-phase 3.0 starts. Records + collections unlock realist
 |-----|--------------------------------------------------------------------------------------------------------------------------------|-------------|--------|----|
 | 3.0 | Record types: `struct mochi_R` in source field order; field access; record literals; equality                                  | LANDED      | —      | — |
 | 3.1 | `list<T>`: per-T `mochi_list_<T>` (i64 / f64 / bool / str); literals `[e, ...]`; `xs[i]`; `len(xs)`; `append`; `for x in xs`   | LANDED      | —      | — |
-| 3.2 | `map<K,V>`: per-(K,V) open-addressing hash table; literals `{k: v, ...}`; `m[k]`; `len`; `keys`; `values`; `k in m`; `for k in m` | IN PROGRESS | —      | — |
-| 3.3 | `set<T>`: Swiss table with elided value slot; `+`, `-`, `contains`, `len`                                                      | NOT STARTED | —      | — |
+| 3.2 | `map<K,V>`: per-(K,V) open-addressing hash table; literals `{k: v, ...}`; `m[k]`; `len`; `keys`; `values`; `k in m`; `for k in m` | LANDED      | —      | — |
+| 3.3 | `set<T>`: per-T open-addressing hash set; `+`, `-`, `contains`, `len`, `for`                                                   | DEFERRED    | —      | — |
 | 3.4 | Monomorphisation pass: `transpiler3/c/lower/mono.go` lowers each concrete instantiation once, deterministic ordering           | NOT STARTED | —      | — |
-| 3.5 | `omap<K,V>` (insertion-order map): Swiss table + parallel insertion-order list (needed by Phase 8)                             | NOT STARTED | —      | — |
+| 3.5 | `omap<K,V>` (insertion-order map): hash table + parallel insertion-order list (needed by Phase 8)                              | DEFERRED    | —      | — |
 
 ## Decisions made
 
@@ -81,6 +81,20 @@ _To be written before sub-phase 3.0 starts. Records + collections unlock realist
 - **`for k in m` is sugar for `for k in keys(m)`.** The lowerer synthesises a `MapKeysExpr` inline and re-uses the existing `ForEachStmt`. No new IR node, no new emit-time path; the emitter doesn't even know the loop's source was a map. This keeps the for-each shape stable across collection types.
 - **Empty map literal `{}` is rejected (mirrors list rule).** A bare `{}` has no `(K, V)` for the lowerer to pick an instantiation, and the surface has no annotated-empty form yet. A future typed-empty path lands with Phase 3.4 once the lowerer threads annotated-binding types into literal-time resolution. Rejection message: `"empty map literal: Phase 3.2 requires at least one entry so the key and value types can be inferred"`.
 - **Lifetime: leak on program exit, same as 3.1.** No `free()` for table buffers or the per-call snapshot allocations under `keys()` / `values()`. Phase 7 (panic unwinding) adds a real reclamation path. The per-call snapshot allocations are a known leak proportional to call count, accepted for fixture-scale programs.
+
+### Phase 3.3 (sets): DEFERRED
+
+- **Audit date:** 2026-05-22 23:55 (GMT+7)
+- **Goal-alignment audit verdict: DEFERRED.** Mochi has no `set<T>` surface syntax. `parser/ast.go` has no `SetLit` or `SetType` node; `types/kinds.go` has no `SetType` (only `ListType`, `MapType`, `GroupType`); the type-checker recognises a `distinct(list)` builtin that dedupes a list into another list, not a set value. Implementing `set<T>` in transpiler3 alone would produce a runtime + IR + emit chain that no Mochi program can reach: the parser would reject `let s: set<int> = {1, 2}` before the lowerer ever ran. The user-facing goal moves by zero, every Phase 3.3 LOC would be unreachable scaffolding. Per the goal-alignment-audit rule we defer.
+- **Unblock condition.** Adding `set<T>` to MEP-45's user-facing surface requires Mochi parser + type-checker work that belongs in a different MEP (likely the Mochi language MEP track, not the AOT-backend MEP-45). Once Mochi gains `set<T>` parsing + a `SetType` kind, Phase 3.3 reactivates: per-T open-addressing hash set (4 instantiations: i64 / f64 / bool / str), `+` (union), `-` (difference), `contains(s, e)`, `len(s)`, `for e in s` key-sorted iteration. The runtime drops into `transpiler3/c/runtime/{include/mochi/set.h, src/set.c}` as a value-slot-elided cousin of `mochi_map_<K>_<V>_*`; the IR + lower + emit chain mirrors Phase 3.2 exactly, swapping the (K,V) pair for a single (T) element.
+- **No fixture corpus today.** Without a parsable Mochi surface there is nothing to fixture against the vm3 oracle. `TestPhase3Sets` is not authored; the gate row in the table reads DEFERRED and will not block downstream phases.
+
+### Phase 3.5 (omap): DEFERRED
+
+- **Audit date:** 2026-05-22 23:55 (GMT+7)
+- **Goal-alignment audit verdict: DEFERRED.** Same blocker as 3.3: Mochi has no `omap<K, V>` surface. There is no `OmapLit`, no `OmapType`, no insertion-order-map literal syntax that distinguishes from the existing `map<K, V>` (which is key-sorted in the vm3 oracle). Implementing `omap<K, V>` in transpiler3 alone would be unreachable scaffolding for the same reason.
+- **Unblock condition.** When Mochi gains `omap<K, V>` parsing + an `OMapType` kind (likely driven by Phase 8 query DSL's group-by row shape), Phase 3.5 reactivates: open-addressing hash table for O(1) lookup + a parallel insertion-order list for iteration (the only difference vs Phase 3.2's `map<K, V>`). Eight (K,V) instantiations matching Phase 3.2.
+- **Phase 8 ripple effect.** If the Phase 8 query DSL's group-by row needs insertion-order iteration, Phase 3.5 must reactivate before Phase 8 ships. The Phase 8 spec doc should call this out when it begins. Until then 3.5 stays DEFERRED with no fixture corpus.
 
 ## Deferred work
 

--- a/website/docs/mep/mep-0045.md
+++ b/website/docs/mep/mep-0045.md
@@ -407,14 +407,14 @@ Phase conventions:
 |-----|-------|--------|--------|
 | 3.0 | Record types: `struct mochi_R` in source field order; field access; record literals; equality | LANDED      | — |
 | 3.1 | `list<T>`: per-T `mochi_list_<T>` (i64 / f64 / bool / str); literals `[e, ...]`; `xs[i]`; `len(xs)`; `append`; `for x in xs` | LANDED      | — |
-| 3.2 | `map<K,V>`: per-(K,V) hand-rolled open-addressing hash table (8 instantiations, K in `int`/`string`, V in `int`/`float`/`bool`/`string`); literals `{k: v, ...}`; `m[k]`; `len`; `keys`; `values`; `k in m`; `for k in m` (key-sorted) | IN PROGRESS | — |
-| 3.3 | `set<T>`: Swiss table with elided value slot; `+`, `-`, `contains`, `len` | NOT STARTED | — |
+| 3.2 | `map<K,V>`: per-(K,V) hand-rolled open-addressing hash table (8 instantiations, K in `int`/`string`, V in `int`/`float`/`bool`/`string`); literals `{k: v, ...}`; `m[k]`; `len`; `keys`; `values`; `k in m`; `for k in m` (key-sorted) | LANDED      | — |
+| 3.3 | `set<T>`: per-T open-addressing hash set; `+`, `-`, `contains`, `len`, `for` -- DEFERRED, Mochi surface (parser + type-checker) does not expose `set<T>`; reactivates when the language MEP adds it | DEFERRED    | — |
 | 3.4 | Monomorphisation pass: a `MType.Instances` walk that lowers each concrete `(K,V)` once and shares the C type across call sites; deterministic ordering | NOT STARTED | — |
-| 3.5 | `omap<K,V>` (insertion-order map): Swiss table + parallel insertion-order list; needed by query DSL but ships here so Phase 8 has it ready | NOT STARTED | — |
+| 3.5 | `omap<K,V>` (insertion-order map): hash table + parallel insertion-order list -- DEFERRED, same Mochi-surface blocker as 3.3; reactivates if Phase 8 query DSL needs insertion-order group-by rows | DEFERRED    | — |
 
-**Deliverables.** New runtime modules per `(K,V)` instantiation under `transpiler3/c/runtime/src/{list,map,set,omap}/` (generated, gitignored beneath `runtime/src/gen/`); monomorphisation pass under `transpiler3/c/lower/mono.go`.
+**Deliverables.** New runtime modules per `(K,V)` instantiation under `transpiler3/c/runtime/src/{list,map}/`; monomorphisation pass under `transpiler3/c/lower/mono.go`. (`set/` + `omap/` reactivate when Phase 3.3 + 3.5 unblock.)
 
-**Test set.** `tests/transpiler3/c/fixtures/{records,lists,maps,sets}/*.mochi` (80 cases total).
+**Test set.** `tests/transpiler3/c/fixtures/{records,lists,maps}/*.mochi` (3.0 + 3.1 + 3.2 land 68 cases; the original "~80" target was set against 4 sub-phases including `sets`).
 
 **Risks.** Determinism of monomorphisation pass output order (3.4 sorts by canonical type printing, so two builds of the same program produce identical generated runtime files). Phase 3.2 originally named cwisstable as the map's underlying table; it shipped as a hand-rolled open-addressing + linear-probe + load-factor-0.5 implementation (~120 LOC under `MOCHI_MAP_DEFINE`). The macro-expanded helpers compile into per-(K,V) externally-visible symbols, so a future cwisstable swap is a symbol-set substitution behind the same `mochi_map_<K>_<V>_*` ABI; the perf delta doesn't matter until Phase 18.
 


### PR DESCRIPTION
Closes #22090.

Documents the Phase 3.3 (`set<T>`) + Phase 3.5 (`omap<K, V>`) deferrals per the goal-alignment-audit rule.

## Summary

Both sub-phases require Mochi parser + type-checker surface that doesn't exist today (`parser/ast.go` has no `SetLit` / `OmapLit`, `types/kinds.go` has no `SetType` / `OMapType`). Implementing them in transpiler3 alone would produce unreachable scaffolding because the parser rejects `let s: set<int> = {1, 2}` before the lowerer ever runs.

- `phase-03-records-collections.md`: marks 3.3 + 3.5 DEFERRED in the sub-phases table; adds `### Phase 3.3 (sets): DEFERRED` and `### Phase 3.5 (omap): DEFERRED` sections with audit verdict + unblock conditions + handoff implementation plan
- `mep-0045.md`: 3.3 + 3.5 rows updated to DEFERRED with one-line rationale; deliverables paragraph drops the `set/` + `omap/` runtime dirs; test-set count adjusted (3.0 + 3.1 + 3.2 land 68 cases; the original 80-case target was set against 4 sub-phases including sets)

Also marks 3.2 LANDED so the Phase 3 row reflects the actual ship state after #22089 merges.

## Test plan

- [x] No transpiler3 code touched; CI just re-runs the existing suite to confirm no regression
- [x] `go test ./transpiler3/... -count=1` green (`TestPhase3Maps` + all prior gates)

## Unblock recipes (recorded in the implementation doc for future handoff)

- 3.3: per-T open-addressing hash set under `mochi_set_<T>_*` (4 instantiations: i64 / f64 / bool / str), `+` / `-` / `contains` / `len` / `for e in s`. Value-slot-elided cousin of Phase 3.2's `mochi_map_<K>_<V>_*`; IR + lower + emit chain mirrors Phase 3.2 with (K,V) -> (T).
- 3.5: hash table + parallel insertion-order list, eight (K,V) instantiations matching Phase 3.2.