### PR TITLE
[codex] flatten changelog release sidebar

### DIFF
--- a/website/scripts/gen-releases.js
+++ b/website/scripts/gen-releases.js
@@ -6,7 +6,7 @@
 //
 //   website/docs/releases/vX.Y.Z.md       - one doc page per release
 //   website/src/data/releases.json        - release metadata for changelog.mdx
-//   website/src/data/release-sidebar.json - release page refs for sidebars.js
+//   website/src/data/release-sidebar.json - flat release page refs for sidebars.js
 
 const fs = require('fs');
 const path = require('path');
@@ -111,18 +111,11 @@ fs.writeFileSync(
   ) + '\n',
 );
 
-const groups = [];
-for (const release of releases) {
-  const label = `v${release.major}.${release.minor}`;
-  let group = groups.find(g => g.label === label);
-  if (!group) {
-    group = { label, items: [] };
-    groups.push(group);
-  }
-  group.items.push(release.docId);
-}
-fs.writeFileSync(sidebarOut, JSON.stringify(groups, null, 2) + '\n');
+fs.writeFileSync(
+  sidebarOut,
+  JSON.stringify(releases.map(release => release.docId), null, 2) + '\n',
+);
 
 console.log(`wrote ${releases.length} release docs to ${path.relative(root, docsOutDir)}`);
 console.log(`wrote release metadata to ${path.relative(root, dataOut)}`);
-console.log(`wrote ${groups.length} release sidebar group(s) to ${path.relative(root, sidebarOut)}`);
+console.log(`wrote ${releases.length} release sidebar entries to ${path.relative(root, sidebarOut)}`);

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -7,7 +7,7 @@ const mepGroups = require('./src/data/mep-sidebar.json');
 // from website/docs/research/NNNN/*.md. Dropping a new file or
 // directory makes it appear in the nav on the next build.
 const researchGroups = require('./src/data/research-sidebar.json');
-const releaseGroups = require('./src/data/release-sidebar.json');
+const releaseItems = require('./src/data/release-sidebar.json');
 
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 const sidebars = {
@@ -93,13 +93,7 @@ const sidebars = {
 
   changelogSidebar: [
     'changelog',
-    ...releaseGroups.map(g => ({
-      label: g.label,
-      type: 'category',
-      className: 'sidebar-heading',
-      collapsed: g.label !== releaseGroups[0]?.label,
-      items: g.items,
-    })),
+    ...releaseItems,
   ],
 
   implementationSidebar: [


### PR DESCRIPTION
## Summary

Flattens the website changelog sidebar so release pages appear as direct links instead of nested version-train categories.

- `gen-releases.js` now writes `release-sidebar.json` as a flat list of release doc IDs
- `sidebars.js` spreads those doc IDs directly into `changelogSidebar`

## Validation

- `npm ci && npm run build`
- `postbuild` sitemap audit reported: `sitemap covers 358 generated route(s)`
- verified generated sidebar has `0` category rows and `118` direct release links