### PR TITLE
fix: min/max/int builtins yield to user-defined functions of same name

### DIFF
--- a/transpiler3/c/lower/lower.go
+++ b/transpiler3/c/lower/lower.go
@@ -2746,13 +2746,19 @@ func (l *lowerer) lowerUserCallExpr(call *parser.CallExpr) (aotir.Expr, error) {
 		return l.lowerStrConvertCall(call)
 	}
 	if call.Func == "int" {
-		return l.lowerIntCastCall(call)
+		if _, isUserDef := l.funcs[call.Func]; !isUserDef {
+			return l.lowerIntCastCall(call)
+		}
 	}
 	if call.Func == "min" {
-		return l.lowerListMinCall(call)
+		if _, isUserDef := l.funcs[call.Func]; !isUserDef {
+			return l.lowerListMinCall(call)
+		}
 	}
 	if call.Func == "max" {
-		return l.lowerListMaxCall(call)
+		if _, isUserDef := l.funcs[call.Func]; !isUserDef {
+			return l.lowerListMaxCall(call)
+		}
 	}
 	// Phase 5.0: check if this is a call to a fun-typed variable in scope.
 	if b, ok := l.scope.lookup(call.Func); ok && b.t == aotir.TypeFun {


### PR DESCRIPTION
Closes #22130

## Summary

Phase 2.5 introduced // builtins in , but they fired before checking user-defined functions, so  would break with 'max() takes exactly one argument, got 2'.

Fixed by checking  first; only routes to builtin when no user-defined function exists with that name.

## Test plan

- [x] TestPhase2Functions/fun_max_two -- green
- [x] TestPhase2TypeCasts -- still green (builtins still fire for list args)
