### PR TITLE
mep-0045 phase 18.0: benchmark harness with 5 BG kernels

### DIFF
--- a/tests/transpiler3/c/bench/fib_iter.mochi
+++ b/tests/transpiler3/c/bench/fib_iter.mochi
@@ -1,0 +1,13 @@
+fun fib(n: int): int {
+  var a = 0
+  var b = 1
+  var i = 0
+  while i < n {
+    let c = a + b
+    a = b
+    b = c
+    i = i + 1
+  }
+  return a
+}
+print(fib(50))

--- a/tests/transpiler3/c/bench/fib_rec.mochi
+++ b/tests/transpiler3/c/bench/fib_rec.mochi
@@ -1,0 +1,7 @@
+fun fib(n: int): int {
+  if n <= 1 {
+    return n
+  }
+  return fib(n - 1) + fib(n - 2)
+}
+print(fib(35))

--- a/tests/transpiler3/c/bench/hello_world.mochi
+++ b/tests/transpiler3/c/bench/hello_world.mochi
@@ -1,0 +1,1 @@
+print("Hello, World!")

--- a/tests/transpiler3/c/bench/list_sum.mochi
+++ b/tests/transpiler3/c/bench/list_sum.mochi
@@ -1,0 +1,12 @@
+let n = 10000
+var xs: list<int> = []
+var i = 0
+while i < n {
+  xs = append(xs, i)
+  i = i + 1
+}
+var sum = 0
+for x in xs {
+  sum = sum + x
+}
+print(sum)

--- a/tests/transpiler3/c/bench/sum_loop.mochi
+++ b/tests/transpiler3/c/bench/sum_loop.mochi
@@ -1,0 +1,7 @@
+var sum = 0
+var i = 0
+while i <= 1000000 {
+  sum = sum + i
+  i = i + 1
+}
+print(sum)

--- a/transpiler3/c/build/phase18_0_test.go
+++ b/transpiler3/c/build/phase18_0_test.go
@@ -1,0 +1,113 @@
+package build
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"testing"
+	"time"
+)
+
+// TestPhase18BenchHarness is the MEP-45 Phase 18.0 gate. It builds
+// each kernel under tests/transpiler3/c/bench/ via the AOT transpiler,
+// runs it 5 times, and records wall-clock time (median) and binary size.
+// The test does NOT enforce the 2x gate vs vm3 yet (Phase 18.1+);
+// it asserts only that:
+//   - each kernel compiles and runs successfully,
+//   - the output matches the vm3 oracle, and
+//   - the binary size and median wall-clock are logged for human review.
+//
+// BG kernel corpus:
+//   - hello_world  baseline binary size + startup overhead
+//   - sum_loop     tight integer arithmetic loop (sum 1..1_000_000)
+//   - fib_iter     iterative Fibonacci(50)
+//   - fib_rec      recursive Fibonacci(35)  - function-call overhead
+//   - list_sum     list append + for-in iteration (10 000 elements)
+func TestPhase18BenchHarness(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Phase 18 bench harness skipped on Windows; Phase 11 wires Windows CI")
+	}
+
+	root := repoRoot(t)
+	benchDir := filepath.Join(root, "tests", "transpiler3", "c", "bench")
+
+	// kernel → expected stdout (obtained from vm3)
+	kernels := []struct {
+		name   string
+		expect string
+	}{
+		{"hello_world", "Hello, World!\n"},
+		{"sum_loop", "500000500000\n"},
+		{"fib_iter", "12586269025\n"},
+		{"fib_rec", "9227465\n"},
+		{"list_sum", "49995000\n"},
+	}
+
+	const runs = 5
+	t.Logf("%-16s  %8s  %10s  %10s  %10s", "kernel", "binsize", "min_ms", "med_ms", "max_ms")
+	t.Logf("%-16s  %8s  %10s  %10s  %10s", "------", "-------", "------", "------", "------")
+
+	for _, k := range kernels {
+		t.Run(k.name, func(t *testing.T) {
+			src := filepath.Join(benchDir, k.name+".mochi")
+			outBin := filepath.Join(t.TempDir(), k.name)
+
+			d := &Driver{CacheDir: t.TempDir(), NoCache: true}
+			if err := d.Build(src, outBin, "", ""); err != nil {
+				t.Fatalf("build: %v", err)
+			}
+
+			fi, err := os.Stat(outBin)
+			if err != nil {
+				t.Fatalf("stat: %v", err)
+			}
+			binSize := fi.Size()
+
+			var durations []time.Duration
+			for range runs {
+				cmd := exec.Command(outBin)
+				var stdout bytes.Buffer
+				cmd.Stdout = &stdout
+				cmd.Stderr = os.Stderr
+				start := time.Now()
+				if err := cmd.Run(); err != nil {
+					t.Fatalf("run: %v", err)
+				}
+				dur := time.Since(start)
+				durations = append(durations, dur)
+
+				if got := stdout.String(); got != k.expect {
+					t.Fatalf("stdout mismatch:\n--- want ---\n%q\n--- got ---\n%q", k.expect, got)
+				}
+			}
+
+			slices.Sort(durations)
+			minMs := float64(durations[0]) / float64(time.Millisecond)
+			medMs := float64(durations[runs/2]) / float64(time.Millisecond)
+			maxMs := float64(durations[runs-1]) / float64(time.Millisecond)
+
+			t.Logf("%-16s  %8s  %10s  %10s  %10s",
+				k.name,
+				fmtBytes(binSize),
+				fmt.Sprintf("%.2fms", minMs),
+				fmt.Sprintf("%.2fms", medMs),
+				fmt.Sprintf("%.2fms", maxMs),
+			)
+		})
+	}
+}
+
+func fmtBytes(n int64) string {
+	switch {
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1fMiB", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.1fKiB", float64(n)/(1<<10))
+	default:
+		return fmt.Sprintf("%dB", n)
+	}
+}

--- a/website/docs/implementation/0045/phase-18-perf.md
+++ b/website/docs/implementation/0045/phase-18-perf.md
@@ -10,8 +10,8 @@ description: "MEP-45 Phase 18 tracking: median fixture wall-clock within 2x of G
 | Field          | Value |
 |----------------|-------|
 | MEP            | [MEP-45 §Phases · Phase 18](/docs/mep/mep-0045#phase-18-performance-gate) |
-| Status         | NOT STARTED |
-| Started        | — |
+| Status         | IN PROGRESS |
+| Started        | 2026-05-25 22:01 (GMT+7) |
 | Landed         | — |
 | Tracking issue | — |
 | Tracking PR    | — |
@@ -22,25 +22,53 @@ Median fixture wall-clock time on the BG corpus is within 2x of the equivalent G
 
 ## Goal-alignment audit
 
-_To be written before sub-phase 18.0 starts. Performance gate exists so a regression cannot ship silently; the user-facing payoff is "your native build is at least as fast as the Go-embedded one". Aligns._
+Performance gate exists so a regression cannot ship silently. The user-facing payoff is "your native AOT build is at least as fast as the Go-embedded VM build." Without a gate, a slow code-generation path could ship undetected and erode the core AOT value proposition. Aligns directly with user-facing goal.
 
 ## Sub-phases
 
 | #    | Scope                                                                                                              | Status      | Commit | PR |
 |------|--------------------------------------------------------------------------------------------------------------------|-------------|--------|----|
-| 18.0 | Benchmark harness: `tests/transpiler3/c/bench/` with BG kernels (sum_loop, fib_iter, hello_world, ...)             | NOT STARTED | —      | — |
+| 18.0 | Benchmark harness: `tests/transpiler3/c/bench/` with 5 BG kernels; `TestPhase18BenchHarness` builds + runs each 5x, logs median wall-clock and binary size; asserts output correctness vs vm3-derived expected values. | LANDED 2026-05-25 22:01 (GMT+7) | — | — |
 | 18.1 | Wall-clock, peak RSS, binary size (release/strip), compile time recorded per fixture                               | NOT STARTED | —      | — |
 | 18.2 | Per-release report published to a static page                                                                      | NOT STARTED | —      | — |
 | 18.3 | Regression alert: > 10% wall-clock regression vs previous main posts a comment on the PR                           | NOT STARTED | —      | — |
 
 ## Decisions made
 
-_Fill in along the way._
+**Phase 18.0: kernel corpus.** Five kernels representative of different workload shapes:
+- `hello_world`: baseline startup + print overhead (binary size reference)
+- `sum_loop`: tight integer arithmetic loop (sum 1..1_000_000, no allocation)
+- `fib_iter`: iterative Fibonacci(50) (function call + simple loop)
+- `fib_rec`: recursive Fibonacci(35) (deep function-call overhead; tests stack frame efficiency)
+- `list_sum`: list append × 10_000 + for-in iteration (allocation-heavy path)
+
+All five use only features present in the current AOT transpiler (integer arithmetic, while loops, `fun` declarations, `list<int>`, `append`, `for x in xs`).
+
+**Phase 18.0: expected outputs from vm3 oracle.** Each kernel's expected stdout was produced by running `mochi run <kernel>.mochi` and hardcoded in the test. The test asserts byte-exact match so any regression in correctness also shows up in the bench gate.
+
+**Phase 18.0: harness runs each kernel 5 times.** Five runs reduces jitter from OS scheduling while keeping the total gate time under 10 s. Median (index 2 of sorted 5) is the reported figure. Min and max are also logged for variance analysis.
+
+**Phase 18.0: 2x gate deferred to Phase 18.1.** Phase 18.0 only asserts correctness + records timing; no vm3 comparison is performed. The 2x comparison requires running `mochi run` for each kernel and timing it, plus deciding how to handle JIT warm-up effects. That is Phase 18.1 scope.
+
+**Phase 18.0 measured results (aarch64-darwin, Apple clang 17, 2026-05-25):**
+
+| kernel      | binsize | min_ms | med_ms | max_ms |
+|-------------|---------|--------|--------|--------|
+| hello_world | 73.9KiB |   4.97 |  11.50 | 289.79 |
+| sum_loop    | 73.9KiB |   4.19 |  11.70 | 311.95 |
+| fib_iter    | 73.9KiB |   3.82 |   4.16 | 369.75 |
+| fib_rec     | 73.9KiB |  86.09 |  97.83 | 342.03 |
+| list_sum    | 73.9KiB |  65.87 |  77.71 | 318.81 |
+
+The first-run latency (max_ms) is dominated by macOS dyld startup. The min_ms values (cold-start excluded from sorted tail) show the actual execution time: fib_rec(35) takes ~86 ms (expected for O(2^35) recursive calls) and list_sum takes ~66 ms.
 
 ## Deferred work
 
-_Tighter (1.5x) gate: revisit after Phase 19 with measured data._
+- Phase 18.1: Add vm3 baseline timing and enforce the 2x gate.
+- Phase 18.2: CI-published static HTML report.
+- Phase 18.3: PR regression alert (>10% wall-clock regression vs main).
+- Tighter (1.5x) gate: revisit after Phase 19 with measured data.
 
 ## Closeout notes
 
-_Fill in after gate green._
+_Fill in after all 4 sub-phases green._

--- a/website/docs/mep/mep-0045.md
+++ b/website/docs/mep/mep-0045.md
@@ -744,7 +744,7 @@ Phase conventions:
 
 | Field    | Value |
 |----------|-------|
-| Status   | NOT STARTED |
+| Status   | IN PROGRESS |
 | Commit   | — |
 | Gate     | Median fixture wall-clock time on the BG corpus is within 2× of the equivalent Go-backend build, on x86_64-linux-gnu and aarch64-darwin |
 | Targets  | x86_64-linux-gnu, aarch64-darwin |
@@ -754,8 +754,8 @@ Phase conventions:
 
 | #    | Scope | Status | Commit |
 |------|-------|--------|--------|
-| 18.0 | Benchmark harness: `tests/transpiler3/c/bench/` with the BG kernels (sum_loop, fib_iter, hello_world, etc.) | NOT STARTED | — |
-| 18.1 | Wall-clock, peak RSS, binary size (release/strip), and compile time recorded per fixture | NOT STARTED | — |
+| 18.0 | Benchmark harness: `tests/transpiler3/c/bench/` with 5 BG kernels (hello_world, sum_loop, fib_iter, fib_rec, list_sum); `TestPhase18BenchHarness` builds + runs each 5x, asserts correct output, logs median wall-clock + binary size. | LANDED 2026-05-25 22:01 (GMT+7) | — |
+| 18.1 | Wall-clock, peak RSS, binary size (release/strip), and compile time recorded per fixture; 2x vm3 gate enforced | NOT STARTED | — |
 | 18.2 | Per-release report published to a static page | NOT STARTED | — |
 | 18.3 | Regression alert: > 10% wall-clock regression vs previous main posts a comment on the PR | NOT STARTED | — |
 


### PR DESCRIPTION
Closes #22152

## Summary

- `tests/transpiler3/c/bench/`: 5 BG kernel programs (hello_world, sum_loop, fib_iter, fib_rec, list_sum)
- `TestPhase18BenchHarness`: builds each kernel via AOT transpiler, runs 5x, asserts correct stdout, logs timing
- Results: all kernels pass; fib_rec(35) ~98ms median, list_sum ~78ms, arithmetic ~4-12ms

## Test plan

- `go test ./transpiler3/c/build/ -run TestPhase18BenchHarness -v` passes in ~6s
- All 5 kernels produce correct output matching vm3 oracle