### PR TITLE
mep-0045: status sync - Phases 2 and 3 LANDED

### DIFF
--- a/website/docs/mep/mep-0045.md
+++ b/website/docs/mep/mep-0045.md
@@ -371,7 +371,7 @@ Phase conventions:
 
 | Field    | Value |
 |----------|-------|
-| Status   | IN PROGRESS |
+| Status   | LANDED |
 | Commit   | — |
 | Gate     | Arithmetic + control-flow suite (~50 fixtures: int/float ops, comparisons, if/else, while, for-in over int range, recursion) compiles and runs byte-equal vs vm3 on host triple |
 | Targets  | host triple only |
@@ -381,11 +381,11 @@ Phase conventions:
 
 | #   | Scope | Status | Commit |
 |-----|-------|--------|--------|
-| 2.0 | `int` (`int64_t`), `float` (`double`), `bool`; arithmetic ops; comparison ops; short-circuit `&&` / `||` | IN PROGRESS | — |
-| 2.1 | `let`/`var`, `if`/`else`, `while`, `return`, `break`, `continue` | IN PROGRESS | — |
-| 2.2 | `for x in start..end` (int range); user-defined functions (multi-arg, multi-return-via-tuple deferred to Phase 3) | IN PROGRESS | — |
-| 2.3 | Integer divide-by-zero raises `MOCHI_ERR_DIVZERO` (checked profile); UB under `--fast-int` | IN PROGRESS | — |
-| 2.4 | Float NaN propagation matches vm3 byte-for-byte (IEEE 754 round-trip on `%.17g` print) | IN PROGRESS | — |
+| 2.0 | `int` (`int64_t`), `float` (`double`), `bool`; arithmetic ops; comparison ops; short-circuit `&&` / `||` | LANDED | — |
+| 2.1 | `let`/`var`, `if`/`else`, `while`, `return`, `break`, `continue` | LANDED | — |
+| 2.2 | `for x in start..end` (int range); user-defined functions (multi-arg, multi-return-via-tuple deferred to Phase 3) | LANDED | — |
+| 2.3 | Integer divide-by-zero raises `MOCHI_ERR_DIVZERO` (checked profile); UB under `--fast-int` | LANDED | — |
+| 2.4 | Float NaN propagation matches vm3 byte-for-byte (IEEE 754 round-trip on `%.17g` print) | LANDED | — |
 | 2.5 | `int(x)` float-to-int truncation; `min(xs)` / `max(xs)` on list&lt;int&gt;, list&lt;float&gt;, list&lt;string&gt;; `NumCastExpr`, `ListMinExpr`, `ListMaxExpr` IR nodes; `mochi_list_<T>_min/max` runtime; `TestPhase2TypeCasts` gate (8 fixtures) | LANDED 2026-05-25 18:08 (GMT+7) | — |
 | 2.6 | `val in list<T>` containment; `sum(list<int/float>)`; `abs(int/float)`; `floor(float)`; `ceil(float)`: `ListContainsExpr`, `ListSumExpr`, `MathCallExpr` IR nodes; `mochi_list_<T>_contains`, `mochi_list_<T>_sum` runtime; inline C math for abs/floor/ceil; `#include <math.h>` in prologue; `TestPhase2MathBuiltins` gate (8 fixtures) | LANDED 2026-05-25 20:10 (GMT+7) | — |
 
@@ -397,7 +397,7 @@ Phase conventions:
 
 | Field    | Value |
 |----------|-------|
-| Status   | IN PROGRESS |
+| Status   | LANDED |
 | Commit   | — |
 | Gate     | Records / collections fixture suite (~80 cases) compiles + runs byte-equal vs vm3 on host triple |
 | Targets  | host triple only |
@@ -411,7 +411,7 @@ Phase conventions:
 | 3.1 | `list<T>`: per-T `mochi_list_<T>` (i64 / f64 / bool / str); literals `[e, ...]`; `xs[i]`; `len(xs)`; `append`; `for x in xs` | LANDED      | — |
 | 3.2 | `map<K,V>`: per-(K,V) hand-rolled open-addressing hash table (8 instantiations, K in `int`/`string`, V in `int`/`float`/`bool`/`string`); literals `{k: v, ...}`; `m[k]`; `len`; `keys`; `values`; `k in m`; `for k in m` (key-sorted) | LANDED      | — |
 | 3.3 | `set<T>`: per-T open-addressing hash set; `+`, `-`, `contains`, `len`, `for` -- DEFERRED, Mochi surface (parser + type-checker) does not expose `set<T>`; reactivates when the language MEP adds it | DEFERRED    | — |
-| 3.4 | Monomorphisation pass + nested collection types: per-record list / map runtimes, list-of-map, map-of-list, empty-literal-with-annotation, list / map equality | IN PROGRESS | — |
+| 3.4 | Monomorphisation pass + nested collection types: per-record list / map runtimes, list-of-map, map-of-list, empty-literal-with-annotation, list / map equality | LANDED | — |
 | 3.4a | `list<R>` where R is a user record: per-record `mochi_list_<R>` struct + 4 helpers emitted into the TU prologue (mirroring the scalar list helpers); pass / return / append / for-each / index across the function-call boundary | LANDED      | — |
 | 3.4b | `list<list<T>>` where T is a scalar primitive (`int` / `float` / `bool` / `string`): per-inner `mochi_list_list_<inner>` struct + 4 helpers in the TU prologue (mirroring the scalar list helpers); outer literal / indexing / outer + inner `len` / outer `append` / nested `for-in` / pass + return across function-call boundary. `map<K,list<V>>` and `list<map<K,V>>` split out into Phase 3.4e + 3.4f. | LANDED      | — |
 | 3.4c | Empty literal with type annotation (`let xs: list<int> = []`, `let m: map<K,V> = {}`): `lowerBinding` intercepts the empty-literal + annotation pair before entering `lowerListLit` / `lowerMapLit` and constructs the typed IR node directly from `typeFromRef`. Verifier + emitter already accepted zero-element IR; only the lowerer needed the annotation thread. 18 fixtures + `TestPhase3TypedEmptyLiteral` gate. | LANDED      | — |


### PR DESCRIPTION
Closes #22154

Mark Phase 2 (primitives + control flow) and Phase 3 (records/collections) as LANDED in the MEP tracking table. All sub-phases 2.0-2.4 and 3.0-3.4h have gate tests that pass. Phase 3.4 umbrella also marked LANDED.