### PR TITLE
mep-0045 phase 16.4: --profile=debug wires ASan+UBSan + nightly CI

### DIFF
--- a/.github/workflows/transpiler3-c-sanitise-nightly.yml
+++ b/.github/workflows/transpiler3-c-sanitise-nightly.yml
@@ -1,0 +1,53 @@
+name: Transpiler3-C Sanitiser Matrix (nightly)
+
+# MEP-45 Phase 16.4: nightly CI job that runs the full ASan and UBSan
+# fixture suites. Runs on a schedule so sanitiser regressions surface
+# quickly without blocking every PR with the ~60-second suite overhead.
+# Also fires on workflow_dispatch for on-demand runs.
+
+on:
+  schedule:
+    # 02:00 UTC daily (09:00 GMT+7)
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  sanitise:
+    name: Sanitiser matrix (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '^1.26'
+          cache-dependency-path: go.sum
+
+      - name: Install clang (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends clang
+          clang --version | head -1
+
+      - name: Run ASan gate (Phase 16.0)
+        run: |
+          go test -vet=off -v -count=1 -timeout=300s \
+            ./transpiler3/c/build/ -run TestPhase16ASan
+
+      - name: Run UBSan gate (Phase 16.1)
+        run: |
+          go test -vet=off -v -count=1 -timeout=300s \
+            ./transpiler3/c/build/ -run TestPhase16UBSan
+
+      - name: Run debug-profile gate (Phase 16.4)
+        run: |
+          go test -vet=off -v -count=1 -timeout=60s \
+            ./transpiler3/c/build/ -run TestPhase16DebugProfile

--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -85,6 +85,7 @@ type BuildCmd struct {
 	BinaryPath     string `arg:"--binary" help:"Output binary path; --target=c only"`
 	Static         bool   `arg:"--portable" help:"Statically link the binary (musl/glibc-static); --target=c only"`
 	Triple         string `arg:"--triple" help:"Target triple (e.g. x86_64-linux-musl, aarch64-macos, wasm32-wasi); --target=c only. When set, the driver defaults to 'zig cc' and passes -target=<triple>"`
+	Profile        string `arg:"--profile" default:"release" help:"Build profile for --target=c-aot: 'release' (default) or 'debug' (adds -fsanitize=address,undefined)"`
 }
 
 type RunCmd struct {
@@ -280,7 +281,7 @@ func runBuildCAOT(cmd *BuildCmd) error {
 		CC:       cmd.CC,
 		KeepEmit: keepEmit,
 	}
-	if err := d.Build(cmd.File, cmd.Out, cmd.Triple, ""); err != nil {
+	if err := d.Build(cmd.File, cmd.Out, cmd.Triple, cmd.Profile); err != nil {
 		return err
 	}
 	if d.CacheHit {

--- a/transpiler3/c/build/driver.go
+++ b/transpiler3/c/build/driver.go
@@ -195,6 +195,16 @@ func (d *Driver) Build(src, out, target, profile string) error {
 	if gort.GOOS == "darwin" {
 		ccArgs = append(ccArgs, "-Wl,-no_uuid")
 	}
+	// Phase 16.4: debug profile adds ASan+UBSan so `mochi build --profile=debug`
+	// produces a sanitiser-instrumented binary without requiring the caller to
+	// know the flags. ExtraFlags is applied after so tests can still override.
+	if profile == "debug" {
+		ccArgs = append(ccArgs,
+			"-g",
+			"-fsanitize=address,undefined",
+			"-fno-sanitize-recover=all",
+		)
+	}
 	ccArgs = append(ccArgs, d.ExtraFlags...)
 	args := ccArgs
 	cmd := exec.Command(cc, args...)

--- a/transpiler3/c/build/phase16_4_test.go
+++ b/transpiler3/c/build/phase16_4_test.go
@@ -1,0 +1,60 @@
+package build
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestPhase16DebugProfile is the MEP-45 Phase 16.4 gate. It verifies that
+// passing profile="debug" to Driver.Build adds -fsanitize=address,undefined
+// to the compiler invocation without the caller having to set ExtraFlags
+// manually.
+//
+// The test builds the primitives/add_ints fixture with profile="debug" and
+// asserts that the resulting binary produces the correct output, proving the
+// sanitiser-instrumented build is both compilable and correct.
+//
+// Skipped on Windows (no ASan runtime in Phase 16 toolchain) and on hosts
+// where the cc does not support -fsanitize=address.
+func TestPhase16DebugProfile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("debug-profile sanitiser gate skipped on Windows")
+	}
+	if !asanAvailable(t) {
+		t.Skip("ASan not available on this host")
+	}
+
+	root := repoRoot(t)
+	fixture := filepath.Join(root, "tests", "transpiler3", "c", "fixtures", "primitives", "add_ints")
+	src := filepath.Join(fixture, "add_ints.mochi")
+	if _, err := os.Stat(src); err != nil {
+		t.Skipf("fixture not found: %v", err)
+	}
+	want, err := os.ReadFile(filepath.Join(fixture, "expect.txt"))
+	if err != nil {
+		t.Fatalf("read expect.txt: %v", err)
+	}
+
+	outBin := filepath.Join(t.TempDir(), "add_ints_debug")
+	d := &Driver{NoCache: true}
+	if err := d.Build(src, outBin, "", "debug"); err != nil {
+		t.Fatalf("Driver.Build(profile=debug): %v", err)
+	}
+
+	cmd := exec.Command(outBin)
+	cmd.Env = append(os.Environ(), strings.Split("ASAN_OPTIONS=detect_leaks=0:halt_on_error=1", " ")...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run debug binary: %v", err)
+	}
+	if got := stdout.String(); got != string(want) {
+		t.Fatalf("output mismatch:\nwant %q\n got %q", want, got)
+	}
+}

--- a/website/docs/implementation/0045/phase-16-sanitisers.md
+++ b/website/docs/implementation/0045/phase-16-sanitisers.md
@@ -32,7 +32,7 @@ Sanitiser clean is the strongest internal correctness signal short of formal ver
 | 16.1 | UBSan clean on full corpus. `-fsanitize=undefined -fno-sanitize-recover=all`. `TestPhase16UBSan` gate (33 suites). | LANDED 2026-05-25 21:46 (GMT+7) | — | — |
 | 16.2 | TSan clean on streams/agents corpus                                                                                | NOT STARTED | —      | — |
 | 16.3 | MSan clean on Linux (Apple-silicon MSan unsupported upstream)                                                      | NOT STARTED | —      | — |
-| 16.4 | Build profile `--debug` wires sanitisers; CI nightly job runs the matrix                                           | NOT STARTED | —      | — |
+| 16.4 | Build profile `--debug` wires sanitisers; CI nightly job runs the matrix                                           | LANDED 2026-05-25 22:46 (GMT+7) | — | — |
 
 ## Decisions made
 
@@ -51,13 +51,22 @@ Sanitiser clean is the strongest internal correctness signal short of formal ver
 
 **runFixtureSuiteASan helper.** A new function in `phase16_0_test.go` wraps the standard fixture runner pattern. It accepts `extraFlags []string` (added to `Driver.ExtraFlags`) and `asanEnv string` (appended to the subprocess environment). Reused by both Phase 16.0 (ASan) and Phase 16.1 (UBSan) tests.
 
+## Phase 16.4 decisions
+
+**`--profile=debug` in CLI.** A new `Profile string` field (with `--profile` arg tag, default `"release"`) was added to `BuildCmd`. `runBuildCAOT` passes `cmd.Profile` as the `profile` parameter to `Driver.Build`. This gives users `mochi build --target=c-aot --profile=debug --out=<bin> <src>` to get a sanitiser-instrumented binary without knowing the flags.
+
+**Profile handling in Driver.Build.** When `profile == "debug"`, the driver appends `-g -fsanitize=address,undefined -fno-sanitize-recover=all` to `ccArgs` before `ExtraFlags`. This ensures tests that set `ExtraFlags` can still override or append, while the CLI path is zero-config. The production `""` and `"release"` profiles are unchanged.
+
+**Nightly CI workflow.** `.github/workflows/transpiler3-c-sanitise-nightly.yml` runs `TestPhase16ASan`, `TestPhase16UBSan`, and `TestPhase16DebugProfile` on `ubuntu-latest` and `macos-latest` at 02:00 UTC daily. Runs on `workflow_dispatch` for on-demand use. Ubuntu step installs `clang` so ASan is available even on minimal images.
+
+**Gate.** `TestPhase16DebugProfile` builds `primitives/add_ints` with `profile="debug"` and asserts the binary produces correct output under `ASAN_OPTIONS=detect_leaks=0:halt_on_error=1`. Skips on Windows and on hosts where `asanAvailable` returns false.
+
 ## Deferred work
 
 - Full LeakSan clean: requires explicit free() at every exit path or a global arena. Tracked as sub-phase 16.0.1.
 - TSan clean: blocked on Phase 9 (streams/agents) landing.
 - MSan clean: Linux-only; current CI is aarch64-darwin only.
-- Build profile `--debug` wires sanitisers: Phase 16.4.
 
 ## Closeout notes
 
-_Fill in after all 5 sub-phases green._
+Sub-phases 16.0, 16.1, and 16.4 are LANDED. Sub-phases 16.2 (TSan) and 16.3 (MSan) are blocked on Phase 9 (streams/agents) and Linux CI respectively.

--- a/website/docs/mep/mep-0045.md
+++ b/website/docs/mep/mep-0045.md
@@ -713,7 +713,7 @@ Phase conventions:
 | 16.1 | UBSan clean on full corpus. `-fsanitize=undefined -fno-sanitize-recover=all`; `TestPhase16UBSan` gate (33 suites). | LANDED 2026-05-25 21:46 (GMT+7) | — |
 | 16.2 | TSan clean on streams/agents corpus | NOT STARTED | — |
 | 16.3 | MSan clean on host that supports it (Linux only; Apple-silicon MSan still unsupported per upstream) | NOT STARTED | — |
-| 16.4 | Build profile `--debug` wires sanitisers; CI nightly job runs the matrix | NOT STARTED | — |
+| 16.4 | Build profile `--debug` wires sanitisers; CI nightly job runs the matrix | LANDED 2026-05-25 22:46 (GMT+7) | — |
 
 **Risks.** BDWGC false-positive races under TSan (upstream documents the workaround: `GC_no_dls = 1` + race-suppression file).
 


### PR DESCRIPTION
Closes #22162

## Summary

- `Driver.Build`: `profile=="debug"` appends `-g -fsanitize=address,undefined -fno-sanitize-recover=all` before `ExtraFlags`; release/empty profiles unchanged
- `cmd/mochi/main.go`: `--profile=release|debug` flag added to `BuildCmd`; `runBuildCAOT` passes `cmd.Profile` to `d.Build` (was hardcoded `""`)
- `TestPhase16DebugProfile` gate: builds `primitives/add_ints` with `profile="debug"`, runs under `ASAN_OPTIONS=detect_leaks=0:halt_on_error=1`, asserts correct output
- `.github/workflows/transpiler3-c-sanitise-nightly.yml`: daily 02:00 UTC job runs ASan + UBSan + debug-profile gates on ubuntu and macos; `workflow_dispatch` for on-demand
- Impl doc and MEP spec updated: Phase 16.4 LANDED

## Test plan

- [ ] `go test ./transpiler3/c/build/ -run TestPhase16DebugProfile` passes
- [ ] `mochi build --target=c-aot --profile=debug --out=/tmp/test tests/transpiler3/c/fixtures/hello/hello.mochi` compiles and runs