### PR TITLE
mep-0045 docs: mark Phase 0 and Phase 1 LANDED

### DIFF
--- a/website/docs/implementation/0045/phase-00-skeleton.md
+++ b/website/docs/implementation/0045/phase-00-skeleton.md
@@ -10,9 +10,9 @@ description: "MEP-45 Phase 0 tracking: spec freeze, transpiler3/c/ skeleton tree
 | Field          | Value |
 |----------------|-------|
 | MEP            | [MEP-45 §Phases · Phase 0](/docs/mep/mep-0045#phase-0-spec-freeze-and-skeleton-trees) |
-| Status         | IN PROGRESS |
+| Status         | LANDED |
 | Started        | 2026-05-22 (GMT+7) |
-| Landed         | — |
+| Landed         | 2026-05-22 19:01 (GMT+7) |
 | Tracking issue | [#22066](https://github.com/mochilang/mochi/issues/22066) |
 | Tracking PR    | [#22067](https://github.com/mochilang/mochi/pull/22067) |
 
@@ -28,9 +28,9 @@ The user-facing goal of MEP-45 is "ship a Mochi program as a single native binar
 
 | #   | Scope                                                                                                     | Status      | Commit | PR |
 |-----|-----------------------------------------------------------------------------------------------------------|-------------|--------|----|
-| 0.0 | MEP-45 merged with refactored framing, §Phases section, implementation tracking docs, sidebar wiring      | IN PROGRESS | —      | [#22067](https://github.com/mochilang/mochi/pull/22067) |
-| 0.1 | `transpiler3/c/{aotir,lower,emit,build,toolchain/zig,runtime/{include,src}}/doc.go` compile clean         | IN PROGRESS | —      | [#22067](https://github.com/mochilang/mochi/pull/22067) |
-| 0.2 | `tests/transpiler3/c/README.md` documents fixture layout and naming convention                            | IN PROGRESS | —      | [#22067](https://github.com/mochilang/mochi/pull/22067) |
+| 0.0 | MEP-45 merged with refactored framing, §Phases section, implementation tracking docs, sidebar wiring      | LANDED 2026-05-22 17:42 (GMT+7) | —      | [#22067](https://github.com/mochilang/mochi/pull/22067) |
+| 0.1 | `transpiler3/c/{aotir,lower,emit,build,toolchain/zig,runtime/{include,src}}/doc.go` compile clean         | LANDED 2026-05-22 19:01 (GMT+7) | —      | [#22069](https://github.com/mochilang/mochi/pull/22069) |
+| 0.2 | `tests/transpiler3/c/README.md` documents fixture layout and naming convention                            | LANDED 2026-05-22 19:01 (GMT+7) | —      | [#22069](https://github.com/mochilang/mochi/pull/22069) |
 
 ## Decisions made
 
@@ -46,4 +46,4 @@ The user-facing goal of MEP-45 is "ship a Mochi program as a single native binar
 
 ## Closeout notes
 
-_Fill in after gate goes green._
+All 3 sub-phases landed. Phase 0 gate is green. PR #22069 delivered the complete skeleton; PR #22067 delivered the MEP framing.

--- a/website/docs/implementation/0045/phase-01-hello-world.md
+++ b/website/docs/implementation/0045/phase-01-hello-world.md
@@ -10,9 +10,9 @@ description: "MEP-45 Phase 1 tracking: source-to-binary minimum viable pipeline 
 | Field          | Value |
 |----------------|-------|
 | MEP            | [MEP-45 §Phases · Phase 1](/docs/mep/mep-0045#phase-1-hello-world) |
-| Status         | IN PROGRESS |
+| Status         | LANDED |
 | Started        | 2026-05-22 19:26 (GMT+7) |
-| Landed         | — |
+| Landed         | 2026-05-22 19:50 (GMT+7) |
 | Tracking issue | [#22072](https://github.com/mochilang/mochi/issues/22072) |
 | Tracking PR    | — |
 
@@ -28,10 +28,10 @@ The user-facing goal of MEP-45 is "ship a Mochi program as a single native binar
 
 | #   | Scope                                                                                                                                     | Status      | Commit | PR |
 |-----|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|--------|----|
-| 1.0 | Source-to-binary minimum: parser reused; lower; emit; build via host `cc` discovery; single integration test passes                       | IN PROGRESS | —      | — |
-| 1.1 | `--target=c-aot`, `--out PATH`, `--emit=c\|executable` CLI flags wired through `cmd/mochi/main.go`                                        | IN PROGRESS | —      | — |
-| 1.2 | `.mochi/cache/` BLAKE3 content-addressed cache; rebuild on unchanged source is copyFile no-op; `--emit=c` bypasses cache                  | IN PROGRESS | —      | — |
-| 1.3 | Vendored `zig cc` fallback under `transpiler3/c/toolchain/zig/install.go`; pinned zig 0.16.0 SHA-256 manifest; six tier-1 hosts            | IN PROGRESS | —      | — |
+| 1.0 | Source-to-binary minimum: parser reused; lower; emit; build via host `cc` discovery; single integration test passes                       | LANDED 2026-05-22 19:50 (GMT+7) | —      | [#22073](https://github.com/mochilang/mochi/pull/22073) |
+| 1.1 | `--target=c-aot`, `--out PATH`, `--emit=c\|executable` CLI flags wired through `cmd/mochi/main.go`                                        | LANDED 2026-05-22 19:50 (GMT+7) | —      | [#22073](https://github.com/mochilang/mochi/pull/22073) |
+| 1.2 | `.mochi/cache/` BLAKE3 content-addressed cache; rebuild on unchanged source is copyFile no-op; `--emit=c` bypasses cache                  | LANDED 2026-05-22 19:50 (GMT+7) | —      | [#22073](https://github.com/mochilang/mochi/pull/22073) |
+| 1.3 | Vendored `zig cc` fallback under `transpiler3/c/toolchain/zig/install.go`; pinned zig 0.16.0 SHA-256 manifest; six tier-1 hosts            | LANDED 2026-05-22 19:50 (GMT+7) | —      | [#22073](https://github.com/mochilang/mochi/pull/22073) |
 
 ## Decisions made
 
@@ -67,4 +67,4 @@ _Cross matrix is Phase 11. Reproducibility of the hello binary across hosts is P
 
 ## Closeout notes
 
-_Fill in after gate green._
+All 4 sub-phases landed in a single PR (#22073). Phase 1 gate is green: `mochi build --target=c-aot --out=/tmp/hello tests/transpiler3/c/fixtures/hello/hello.mochi && /tmp/hello | diff - tests/transpiler3/c/fixtures/hello/expect.txt` exits 0 on host triple. The full CLI, cache, and zig-fallback story is complete.

--- a/website/docs/mep/mep-0045.md
+++ b/website/docs/mep/mep-0045.md
@@ -317,8 +317,8 @@ Phase conventions:
 
 | Field    | Value |
 |----------|-------|
-| Status   | IN PROGRESS |
-| Commit   | — (PR #22067) |
+| Status   | LANDED 2026-05-22 19:01 (GMT+7) |
+| Commit   | — (PR #22069) |
 | Gate     | This MEP merged on `main`; `transpiler3/c/{aotir,lower,emit,build,toolchain/zig,runtime/{include,src}}/doc.go` compile clean and report zero tests; `tests/transpiler3/c/` exists with a `README.md`; implementation tracking pages for every phase exist under `/docs/implementation/0045/`; sidebar entries visible on the website |
 | Targets  | n/a (paperwork phase) |
 | Tracking | [/docs/implementation/0045/phase-00-skeleton](/docs/implementation/0045/phase-00-skeleton) |
@@ -327,9 +327,9 @@ Phase conventions:
 
 | #   | Scope | Status | Commit |
 |-----|-------|--------|--------|
-| 0.0 | This MEP merged with refactored framing, §Phases section, implementation tracking docs, sidebar wiring | IN PROGRESS | — (PR #22067) |
-| 0.1 | `transpiler3/c/{aotir,lower,emit,build,toolchain/zig,runtime/{include,src}}/doc.go` compile clean on every host (`go vet`, `go test` returns `no test files`) | IN PROGRESS | — (PR #22067) |
-| 0.2 | `tests/transpiler3/c/README.md` documents fixture layout and naming convention | IN PROGRESS | — (PR #22067) |
+| 0.0 | This MEP merged with refactored framing, §Phases section, implementation tracking docs, sidebar wiring | LANDED 2026-05-22 17:42 (GMT+7) | — (PR #22067) |
+| 0.1 | `transpiler3/c/{aotir,lower,emit,build,toolchain/zig,runtime/{include,src}}/doc.go` compile clean on every host (`go vet`, `go test` returns `no test files`) | LANDED 2026-05-22 19:01 (GMT+7) | — (PR #22069) |
+| 0.2 | `tests/transpiler3/c/README.md` documents fixture layout and naming convention | LANDED 2026-05-22 19:01 (GMT+7) | — (PR #22069) |
 
 **Test set.** Documentation/website build only: `npm run gen:meps && npm run build` clean; `go vet ./transpiler3/c/...` clean.
 
@@ -339,8 +339,8 @@ Phase conventions:
 
 | Field    | Value |
 |----------|-------|
-| Status   | NOT STARTED |
-| Commit   | — |
+| Status   | LANDED 2026-05-22 19:50 (GMT+7) |
+| Commit   | — (PR #22073) |
 | Gate     | `mochi build --target=c-aot --out=/tmp/hello tests/transpiler3/c/fixtures/hello/hello.mochi && /tmp/hello \| diff - tests/transpiler3/c/fixtures/hello/expect.txt` exits 0 on host triple (Phase 1.1 onward; Phase 1.0 ships the in-process `Driver.Build` only). `--target=c-aot` is the staging target value used until MEP-42's `--target=c` is retired; the eventual one-flag shape is `mochi build --target=c <file> --out=<path>` |
 | Targets  | host triple only |
 | Tracking | [/docs/implementation/0045/phase-01-hello-world](/docs/implementation/0045/phase-01-hello-world) |
@@ -349,10 +349,10 @@ Phase conventions:
 
 | #   | Scope | Status | Commit |
 |-----|-------|--------|--------|
-| 1.0 | Source-to-binary minimum: parser reused; lower (one fn returning unit, one `print(string)` call); emit; build via host `cc` discovery (`$CC`, then `cc`, then `clang`, then `gcc`); single integration test passes | NOT STARTED | — |
-| 1.1 | `--target=c-aot`, `--out PATH`, `--emit=c\|executable` CLI flags wired through `cmd/mochi/main.go`; `--emit=c` dumps the generated C as `<out>.c` next to the binary for review | IN PROGRESS | — (this PR) |
-| 1.2 | `.mochi/cache/` BLAKE3 content-addressed cache layer (default root: `$HOME/.mochi/cache`, override via `MOCHI_CACHE_DIR`); rebuild on unchanged source is a copyFile no-op; cache key is BLAKE3 over `(transpiler-version, profile, target-triple, runtime-fingerprint, source-path, source-bytes)`; `--emit=c` builds bypass the cache | IN PROGRESS | — (this PR) |
-| 1.3 | Fallback to vendored `zig cc` when host `cc` discovery fails; `transpiler3/c/toolchain/zig/install.go` downloads zig 0.16.0 on first use and pins via SHA-256 manifest covering the six tier-1 hosts (x86_64-linux, aarch64-linux, x86_64-macos, aarch64-macos, x86_64-windows, aarch64-windows); opt-out via `Driver.NoZigFallback` | IN PROGRESS | — (this PR) |
+| 1.0 | Source-to-binary minimum: parser reused; lower (one fn returning unit, one `print(string)` call); emit; build via host `cc` discovery (`$CC`, then `cc`, then `clang`, then `gcc`); single integration test passes | LANDED 2026-05-22 19:50 (GMT+7) | — (PR #22073) |
+| 1.1 | `--target=c-aot`, `--out PATH`, `--emit=c\|executable` CLI flags wired through `cmd/mochi/main.go`; `--emit=c` dumps the generated C as `<out>.c` next to the binary for review | LANDED 2026-05-22 19:50 (GMT+7) | — (PR #22073) |
+| 1.2 | `.mochi/cache/` BLAKE3 content-addressed cache layer (default root: `$HOME/.mochi/cache`, override via `MOCHI_CACHE_DIR`); rebuild on unchanged source is a copyFile no-op; cache key is BLAKE3 over `(transpiler-version, profile, target-triple, runtime-fingerprint, source-path, source-bytes)`; `--emit=c` builds bypass the cache | LANDED 2026-05-22 19:50 (GMT+7) | — (PR #22073) |
+| 1.3 | Fallback to vendored `zig cc` when host `cc` discovery fails; `transpiler3/c/toolchain/zig/install.go` downloads zig 0.16.0 on first use and pins via SHA-256 manifest covering the six tier-1 hosts (x86_64-linux, aarch64-linux, x86_64-macos, aarch64-macos, x86_64-windows, aarch64-windows); opt-out via `Driver.NoZigFallback` | LANDED 2026-05-22 19:50 (GMT+7) | — (PR #22073) |
 
 **Deliverables.**
 


### PR DESCRIPTION
Closes #22172

## Summary

- Phase 0 sub-phases (0.0, 0.1, 0.2) marked LANDED with correct timestamps and PR references (#22067, #22069)
- Phase 1 sub-phases (1.0, 1.1, 1.2, 1.3) marked LANDED with timestamps and PR reference (#22073)
- Closeout notes added to both impl tracking pages
- mep-0045.md Phase 0 and Phase 1 tables updated to match

## Test plan

- [ ] Docs build clean (no broken links to non-existent PRs or issues)
- [ ] Status values are LANDED with correct timestamps for all 7 sub-phases (0.0-0.2, 1.0-1.3)