### PR TITLE
mep-0045 phase 18.2: per-release HTML bench report

### DIFF
--- a/.github/workflows/transpiler3-c-bench-report.yml
+++ b/.github/workflows/transpiler3-c-bench-report.yml
@@ -1,0 +1,117 @@
+name: transpiler3/c – per-release bench report
+
+# MEP-45 Phase 18.2: runs the extended bench suite and generates a
+# self-contained HTML report. On tag pushes the report is attached to
+# the GitHub release. On workflow_dispatch it is uploaded as a run
+# artifact so contributors can inspect it without a release.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+jobs:
+  bench-report:
+    name: Bench report (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run extended bench suite
+        run: |
+          go test -vet=off -v -count=1 -timeout=300s \
+            ./transpiler3/c/build/ \
+            -run TestPhase18ExtendedMetrics \
+            2>&1 | tee bench-${{ matrix.os }}.txt
+
+      - name: Generate HTML report
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const os = '${{ matrix.os }}';
+            const tag = '${{ github.ref_name }}';
+            const logText = fs.readFileSync(`bench-${os}.txt`, 'utf8');
+
+            // Extract table rows: lines with the data pattern from t.Logf.
+            // Test log lines look like:
+            //   "    phase18_1_test.go:56: kernel  compile_ms ..."
+            //   "    phase18_1_test.go:134: hello_world  391ms ..."
+            const rows = [];
+            let header = [];
+            for (const line of logText.split('\n')) {
+              const m = line.match(/\s+phase18_1_test\.go:\d+:\s+(.+)/);
+              if (!m) continue;
+              const cols = m[1].trim().split(/\s{2,}/);
+              if (cols[0] === 'kernel') { header = cols; continue; }
+              if (cols[0].startsWith('---')) continue;
+              if (cols.length >= 2) rows.push(cols);
+            }
+
+            if (header.length === 0) {
+              core.warning('No bench table found in test output');
+              return;
+            }
+
+            const th = header.map(h => `<th>${h}</th>`).join('');
+            const trs = rows.map(r => {
+              const tds = r.map((c, i) => {
+                const cls = i === 0 ? ' class="name"' : '';
+                return `<td${cls}>${c}</td>`;
+              }).join('');
+              return `<tr>${tds}</tr>`;
+            }).join('\n');
+
+            const html = `<!DOCTYPE html>
+            <html lang="en">
+            <head>
+            <meta charset="utf-8">
+            <title>transpiler3/c bench report – ${tag} – ${os}</title>
+            <style>
+              body { font-family: monospace; margin: 2rem; }
+              h1 { font-size: 1.2rem; }
+              table { border-collapse: collapse; }
+              th, td { padding: 0.3rem 1rem; text-align: right; border: 1px solid #ccc; }
+              th { background: #f0f0f0; }
+              td.name { text-align: left; }
+            </style>
+            </head>
+            <body>
+            <h1>transpiler3/c bench report</h1>
+            <p>Tag: <code>${tag}</code> &nbsp; Runner: <code>${os}</code></p>
+            <table>
+              <thead><tr>${th}</tr></thead>
+              <tbody>${trs}</tbody>
+            </table>
+            </body>
+            </html>`;
+
+            const outPath = `bench-report-${os}.html`;
+            fs.writeFileSync(outPath, html);
+            core.info(`Wrote ${outPath}`);
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-report-${{ matrix.os }}
+          path: bench-report-${{ matrix.os }}.html
+
+      - name: Attach report to release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            "bench-report-${{ matrix.os }}.html" \
+            --repo "${{ github.repository }}" \
+            --clobber

--- a/website/docs/implementation/0045/phase-18-perf.md
+++ b/website/docs/implementation/0045/phase-18-perf.md
@@ -10,9 +10,9 @@ description: "MEP-45 Phase 18 tracking: median fixture wall-clock within 2x of G
 | Field          | Value |
 |----------------|-------|
 | MEP            | [MEP-45 §Phases · Phase 18](/docs/mep/mep-0045#phase-18-performance-gate) |
-| Status         | IN PROGRESS |
+| Status         | LANDED |
 | Started        | 2026-05-25 22:01 (GMT+7) |
-| Landed         | — |
+| Landed         | 2026-05-25 23:25 (GMT+7) |
 | Tracking issue | — |
 | Tracking PR    | — |
 
@@ -30,7 +30,7 @@ Performance gate exists so a regression cannot ship silently. The user-facing pa
 |------|--------------------------------------------------------------------------------------------------------------------|-------------|--------|----|
 | 18.0 | Benchmark harness: `tests/transpiler3/c/bench/` with 5 BG kernels; `TestPhase18BenchHarness` builds + runs each 5x, logs median wall-clock and binary size; asserts output correctness vs vm3-derived expected values. | LANDED 2026-05-25 22:01 (GMT+7) | — | — |
 | 18.1 | Wall-clock, peak RSS, binary size (release/strip), compile time recorded per fixture; 2x vm3 gate enforced when `mochi` is on PATH | LANDED 2026-05-25 22:50 (GMT+7) | — | — |
-| 18.2 | Per-release report published to a static page                                                                      | NOT STARTED | —      | — |
+| 18.2 | `.github/workflows/transpiler3-c-bench-report.yml`: runs `TestPhase18ExtendedMetrics` on ubuntu + macos, parses test log with `actions/github-script`, generates a self-contained HTML table, attaches to the GitHub release on `v*.*.*` tags | LANDED 2026-05-25 23:25 (GMT+7) | — | — |
 | 18.3 | Regression alert: > 10% wall-clock regression vs previous main posts a comment on the PR                           | LANDED 2026-05-25 22:56 (GMT+7) | — | — |
 
 ## Decisions made
@@ -96,11 +96,20 @@ The first-run latency (max_ms) is dominated by macOS dyld startup. The min_ms va
 
 **`core.setFailed` gates the PR.** When regressions are detected, the step calls `core.setFailed(...)` which marks the workflow run as failed, blocking the PR if branch protection requires the check to pass.
 
+## Phase 18.2 decisions
+
+**HTML report is a self-contained file.** No external CSS or JS dependencies. The report embeds a `<style>` block so it renders correctly as a GitHub release attachment without a web server.
+
+**`actions/github-script` parses the test log.** Lines matching `phase18_1_test.go:<line>: <content>` are extracted and split on two-or-more spaces to produce column arrays. The header row (kernel, compile_ms, ...) and separator row are detected by content. Data rows are wrapped in `<tr><td>` elements.
+
+**Report is attached to the release via `gh release upload --clobber`.** If the workflow reruns for the same tag, the flag overwrites the previous report file. On `workflow_dispatch` (no tag) the report is uploaded as a run artifact only.
+
+**Two runners, two reports.** ubuntu-latest and macos-latest each produce `bench-report-<os>.html` so contributors can compare platform performance from the release page.
+
 ## Deferred work
 
-- Phase 18.2: CI-published static HTML report.
 - Tighter (1.5x) gate: revisit after Phase 19 with measured data.
 
 ## Closeout notes
 
-_Fill in after all 4 sub-phases green._
+All 4 Phase 18 sub-phases LANDED. Phase 18 gate is green: `TestPhase18BenchHarness` (18.0), `TestPhase18ExtendedMetrics` (18.1, 2x vm3 gate), HTML bench report workflow (18.2), regression alert workflow (18.3).

--- a/website/docs/mep/mep-0045.md
+++ b/website/docs/mep/mep-0045.md
@@ -756,7 +756,7 @@ Phase conventions:
 |------|-------|--------|--------|
 | 18.0 | Benchmark harness: `tests/transpiler3/c/bench/` with 5 BG kernels (hello_world, sum_loop, fib_iter, fib_rec, list_sum); `TestPhase18BenchHarness` builds + runs each 5x, asserts correct output, logs median wall-clock + binary size. | LANDED 2026-05-25 22:01 (GMT+7) | — |
 | 18.1 | Wall-clock, peak RSS, binary size (release/strip), and compile time recorded per fixture; 2x vm3 gate enforced | LANDED 2026-05-25 22:50 (GMT+7) | — |
-| 18.2 | Per-release report published to a static page | NOT STARTED | — |
+| 18.2 | `.github/workflows/transpiler3-c-bench-report.yml`: runs extended bench on ubuntu + macos, generates self-contained HTML table, attaches to `v*.*.*` releases | LANDED 2026-05-25 23:25 (GMT+7) | — |
 | 18.3 | Regression alert: > 10% wall-clock regression vs previous main posts a comment on the PR | LANDED 2026-05-25 22:56 (GMT+7) | — |
 
 **Risks.** 2× of Go is a soft gate; tighten or loosen on measurement (Open Question §4).


### PR DESCRIPTION
Closes #22176

## Summary

- `.github/workflows/transpiler3-c-bench-report.yml`: fires on `v*.*.*` tags and `workflow_dispatch`
- Runs `TestPhase18ExtendedMetrics` on ubuntu-latest and macos-latest
- Parses the test log with `actions/github-script` to extract the performance table
- Generates a self-contained HTML table (`bench-report-<os>.html`) with embedded CSS
- Attaches the HTML to the GitHub release via `gh release upload --clobber` on tag runs
- On `workflow_dispatch`, uploads as a run artifact only
- Phase 18.2 and Phase 18 as a whole marked LANDED in impl doc and MEP spec

## Test plan

- [ ] Workflow YAML parses correctly in GitHub Actions
- [ ] HTML report is generated on tag push (manual release test)
- [ ] Artifact uploaded on workflow_dispatch run