### PR TITLE
mep-0045 phase 16.3: MSan gate on Linux

### DIFF
--- a/.github/workflows/transpiler3-c-sanitise-nightly.yml
+++ b/.github/workflows/transpiler3-c-sanitise-nightly.yml
@@ -1,9 +1,10 @@
 name: Transpiler3-C Sanitiser Matrix (nightly)
 
-# MEP-45 Phase 16.4: nightly CI job that runs the full ASan and UBSan
-# fixture suites. Runs on a schedule so sanitiser regressions surface
+# MEP-45 Phase 16.4: nightly CI job that runs the full ASan, UBSan, and
+# MSan fixture suites. Runs on a schedule so sanitiser regressions surface
 # quickly without blocking every PR with the ~60-second suite overhead.
 # Also fires on workflow_dispatch for on-demand runs.
+# Phase 16.3: MSan runs on ubuntu-latest only (Linux clang requirement).
 
 on:
   schedule:
@@ -51,3 +52,9 @@ jobs:
         run: |
           go test -vet=off -v -count=1 -timeout=60s \
             ./transpiler3/c/build/ -run TestPhase16DebugProfile
+
+      - name: Run MSan gate (Phase 16.3, Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          go test -vet=off -v -count=1 -timeout=300s \
+            ./transpiler3/c/build/ -run TestPhase16MSan

--- a/transpiler3/c/build/phase16_3_test.go
+++ b/transpiler3/c/build/phase16_3_test.go
@@ -1,0 +1,167 @@
+package build
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestPhase16MSan is the MEP-45 Phase 16.3 gate. It compiles the full
+// current fixture corpus with clang's -fsanitize=memory and runs each
+// binary, asserting byte-equal stdout against expect.txt. Any read from
+// uninitialized memory causes the binary to abort, which the test runner
+// catches as a non-zero exit.
+//
+// MSan requirements:
+//   - Linux only: Apple-silicon MSan is unsupported upstream.
+//   - clang only: gcc does not implement MemorySanitizer.
+//   - All code must be compiled with MSan instrumentation; the mochi
+//     runtime is compiled from source in each Driver.Build call, so the
+//     instrumentation is complete. System libc functions are intercepted
+//     by clang's MSan runtime automatically.
+//
+// Suites excluded from this gate (same rationale as Phase 16.0 ASan):
+//   - divzero-trip: intentionally exits non-zero.
+//   - hello: flat fixture (no subdirectory per fixture).
+//   - file_io: deferred; fopen/fread MSan interception edge-cases are
+//     tracked as a follow-on.
+//   - csv_adapters: uses fopen/fgets; deferred alongside file_io.
+//   - ffi: requires a neighbour .c file compiled without MSan flags;
+//     the cross-TU boundary makes instrumentation incomplete.
+func TestPhase16MSan(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Phase 16.3 MSan gate runs on Linux only (Apple-silicon MSan unsupported upstream)")
+	}
+
+	clangPath, clangErr := exec.LookPath("clang")
+	if clangErr != nil {
+		t.Skip("Phase 16.3 MSan gate requires clang (not found on PATH)")
+	}
+	if !msanAvailable(t, clangPath) {
+		t.Skip("Phase 16.3 MSan not available with this clang build (no -fsanitize=memory support)")
+	}
+
+	suites := []string{
+		"arena_query",
+		"capturing_closures",
+		"closures",
+		"collection_equality",
+		"control-flow",
+		"divzero",
+		"for-range",
+		"free_function_shim",
+		"functions",
+		"index_assign",
+		"list_of_list",
+		"list_of_map",
+		"list_of_record",
+		"list_slice",
+		"lists",
+		"map_of_list",
+		"maps",
+		"math_builtins",
+		"nan-inf",
+		"primitives",
+		"query",
+		"query_join",
+		"records",
+		"str_convert",
+		"string_extra",
+		"string_methods",
+		"string_ops",
+		"strings",
+		"sum_types",
+		"type_cast",
+		"typed_empty_literal",
+	}
+
+	msanFlags := []string{"-fsanitize=memory", "-fno-omit-frame-pointer"}
+	// halt_on_error=1: abort on first MSan error (non-zero exit).
+	// poison_in_dtor=0: suppress synthetic destructor poisoning noise.
+	msanEnv := "MSAN_OPTIONS=halt_on_error=1:poison_in_dtor=0"
+
+	for _, suite := range suites {
+		t.Run(suite, func(t *testing.T) {
+			runFixtureSuiteMSan(t, suite, clangPath, msanFlags, msanEnv)
+		})
+	}
+}
+
+// msanAvailable probes whether clang supports -fsanitize=memory by compiling
+// a trivial C file. Returns false (and logs) on failure so the caller can skip.
+func msanAvailable(t *testing.T, clangPath string) bool {
+	t.Helper()
+	src := filepath.Join(t.TempDir(), "msan_probe.c")
+	if err := os.WriteFile(src, []byte("int main(void){return 0;}\n"), 0o644); err != nil {
+		t.Logf("msanAvailable: write probe: %v", err)
+		return false
+	}
+	out := filepath.Join(t.TempDir(), "msan_probe")
+	cmd := exec.Command(clangPath, "-fsanitize=memory", src, "-o", out)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Logf("msanAvailable: clang probe failed: %v\n%s", err, output)
+		return false
+	}
+	return true
+}
+
+// runFixtureSuiteMSan is like runFixtureSuiteASan but forces clang as the
+// compiler (MSan is clang-only) via Driver.CC.
+func runFixtureSuiteMSan(t *testing.T, dir, clangPath string, extraFlags []string, msanEnv string) {
+	t.Helper()
+	root := repoRoot(t)
+	base := filepath.Join(root, "tests", "transpiler3", "c", "fixtures", dir)
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		t.Fatalf("read fixtures dir %s: %v", base, err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	if len(names) == 0 {
+		t.Fatalf("no fixtures under %s", base)
+	}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			fixture := filepath.Join(base, name)
+			src := filepath.Join(fixture, name+".mochi")
+			expect, err := os.ReadFile(filepath.Join(fixture, "expect.txt"))
+			if err != nil {
+				t.Fatalf("read expect.txt: %v", err)
+			}
+
+			outBin := filepath.Join(t.TempDir(), name)
+			d := &Driver{
+				CC:         clangPath,
+				CacheDir:   t.TempDir(),
+				NoCache:    true,
+				ExtraFlags: extraFlags,
+			}
+			if err := d.Build(src, outBin, "", ""); err != nil {
+				t.Fatalf("Driver.Build %s: %v", src, err)
+			}
+
+			cmd := exec.Command(outBin)
+			cmd.Env = append(os.Environ(), msanEnv)
+			var stdout, stderr strings.Builder
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("run %s (MSan): %v\nstdout: %q\nstderr: %q",
+					name, err, stdout.String(), stderr.String())
+			}
+			if got := stdout.String(); got != string(expect) {
+				t.Fatalf("stdout mismatch for %s:\n--- want ---\n%q\n--- got ---\n%q",
+					name, string(expect), got)
+			}
+		})
+	}
+}

--- a/website/docs/implementation/0045/phase-16-sanitisers.md
+++ b/website/docs/implementation/0045/phase-16-sanitisers.md
@@ -31,7 +31,7 @@ Sanitiser clean is the strongest internal correctness signal short of formal ver
 | 16.0 | ASan clean on full corpus (aarch64-darwin). `-fsanitize=address`, `detect_leaks=0` (GC-less runtime intentionally does not free at exit). `TestPhase16ASan` gate (33 suites). | LANDED 2026-05-25 21:46 (GMT+7) | — | — |
 | 16.1 | UBSan clean on full corpus. `-fsanitize=undefined -fno-sanitize-recover=all`. `TestPhase16UBSan` gate (33 suites). | LANDED 2026-05-25 21:46 (GMT+7) | — | — |
 | 16.2 | TSan clean on streams/agents corpus                                                                                | NOT STARTED | —      | — |
-| 16.3 | MSan clean on Linux (Apple-silicon MSan unsupported upstream)                                                      | NOT STARTED | —      | — |
+| 16.3 | MSan clean on Linux (Apple-silicon MSan unsupported upstream)                                                      | LANDED 2026-05-26 00:07 (GMT+7) | — | — |
 | 16.4 | Build profile `--debug` wires sanitisers; CI nightly job runs the matrix                                           | LANDED 2026-05-25 22:46 (GMT+7) | — | — |
 
 ## Decisions made
@@ -61,12 +61,27 @@ Sanitiser clean is the strongest internal correctness signal short of formal ver
 
 **Gate.** `TestPhase16DebugProfile` builds `primitives/add_ints` with `profile="debug"` and asserts the binary produces correct output under `ASAN_OPTIONS=detect_leaks=0:halt_on_error=1`. Skips on Windows and on hosts where `asanAvailable` returns false.
 
+## Phase 16.3 decisions
+
+**clang required for MSan.** `gcc` does not implement MemorySanitizer; the test uses `exec.LookPath("clang")` and sets `Driver.CC = clangPath`. The nightly CI workflow already installs `clang` on `ubuntu-latest` for the ASan step.
+
+**`runFixtureSuiteMSan` variant.** A new helper in `phase16_3_test.go` differs from `runFixtureSuiteASan` only in the CC override. This avoids touching the existing helpers and keeps the MSan CC selection explicit.
+
+**Suite exclusions for MSan.** In addition to the ASan exclusions (`divzero-trip`, `hello`, `file_io`), the MSan gate also excludes:
+- `csv_adapters`: uses `fopen`/`fgets`; deferred alongside `file_io`.
+- `ffi`: the neighbour `.c` file is compiled without MSan flags, creating an incompletely instrumented binary. Deferred.
+
+**`MSAN_OPTIONS=halt_on_error=1:poison_in_dtor=0`.** `halt_on_error=1` makes the first MSan error abort the binary (non-zero exit, caught by the runner). `poison_in_dtor=0` suppresses synthetic destructor poisoning which can fire on some libc++ builds and is irrelevant for the Mochi C runtime.
+
+**Nightly CI step.** The `transpiler3-c-sanitise-nightly.yml` workflow adds a `Phase 16.3 MSan` step gated on `runner.os == 'Linux'`. macOS runners skip it (Apple-silicon MSan unsupported upstream).
+
 ## Deferred work
 
 - Full LeakSan clean: requires explicit free() at every exit path or a global arena. Tracked as sub-phase 16.0.1.
-- TSan clean: blocked on Phase 9 (streams/agents) landing.
-- MSan clean: Linux-only; current CI is aarch64-darwin only.
+- TSan clean (16.2): blocked on Phase 9 (streams/agents) landing.
+- `file_io` + `csv_adapters` MSan: deferred; clang intercepts fopen/fgets but edge-cases need verification on CI.
+- FFI MSan: requires compiling the neighbour `.c` with MSan flags too; deferred to Phase 10.1 scope.
 
 ## Closeout notes
 
-Sub-phases 16.0, 16.1, and 16.4 are LANDED. Sub-phases 16.2 (TSan) and 16.3 (MSan) are blocked on Phase 9 (streams/agents) and Linux CI respectively.
+Sub-phases 16.0, 16.1, 16.3, and 16.4 are LANDED. Sub-phase 16.2 (TSan) is deferred, pending Phase 9 (streams/agents).

--- a/website/docs/mep/mep-0045.md
+++ b/website/docs/mep/mep-0045.md
@@ -712,7 +712,7 @@ Phase conventions:
 | 16.0 | ASan clean on full corpus (aarch64-darwin). `Driver.ExtraFlags` wires sanitiser flags; `ASAN_OPTIONS=detect_leaks=0` suppresses expected GC-less leaks; `TestPhase16ASan` gate (33 suites). | LANDED 2026-05-25 21:46 (GMT+7) | — |
 | 16.1 | UBSan clean on full corpus. `-fsanitize=undefined -fno-sanitize-recover=all`; `TestPhase16UBSan` gate (33 suites). | LANDED 2026-05-25 21:46 (GMT+7) | — |
 | 16.2 | TSan clean on streams/agents corpus | NOT STARTED | — |
-| 16.3 | MSan clean on host that supports it (Linux only; Apple-silicon MSan still unsupported per upstream) | NOT STARTED | — |
+| 16.3 | MSan clean on host that supports it (Linux only; Apple-silicon MSan still unsupported per upstream) | LANDED 2026-05-26 00:07 (GMT+7) | — |
 | 16.4 | Build profile `--debug` wires sanitisers; CI nightly job runs the matrix | LANDED 2026-05-25 22:46 (GMT+7) | — |
 
 **Risks.** BDWGC false-positive races under TSan (upstream documents the workaround: `GC_no_dls = 1` + race-suppression file).


### PR DESCRIPTION
Closes #22182

## Summary

- `TestPhase16MSan`: Linux-only, requires clang, compiles 31 suites with `-fsanitize=memory`
- Probes clang availability via `exec.LookPath("clang")` + `msanAvailable` probe
- `Driver.CC = clangPath` forces clang (gcc has no MSan support)
- CI nightly workflow extended with MSan step (Linux-only via `if: runner.os == 'Linux'`)

## Test plan

- [ ] `go build ./...` clean
- [ ] `go test ./transpiler3/c/build/ -run TestPhase16MSan` on Linux with clang installed
- [ ] macOS/Windows: test skips gracefully