### PR TITLE
mep-0045 phase 13.0: APE build path via cosmocc

### DIFF
--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -86,6 +86,7 @@ type BuildCmd struct {
 	Static         bool   `arg:"--portable" help:"Statically link the binary (musl/glibc-static); --target=c and --target=c-aot"`
 	Triple         string `arg:"--triple" help:"Target triple (e.g. x86_64-linux-musl, aarch64-macos, wasm32-wasi); --target=c only. When set, the driver defaults to 'zig cc' and passes -target=<triple>"`
 	Profile        string `arg:"--profile" default:"release" help:"Build profile for --target=c-aot: 'release' (default) or 'debug' (adds -fsanitize=address,undefined)"`
+	Apex           bool   `arg:"--apex" help:"Build an Actually Portable Executable via cosmocc (runs on Linux/macOS/Windows/BSD without separate install); --target=c-aot only"`
 }
 
 type RunCmd struct {
@@ -281,6 +282,7 @@ func runBuildCAOT(cmd *BuildCmd) error {
 		CC:       cmd.CC,
 		KeepEmit: keepEmit,
 		Static:   cmd.Static,
+		Apex:     cmd.Apex,
 	}
 	if err := d.Build(cmd.File, cmd.Out, cmd.Triple, cmd.Profile); err != nil {
 		return err

--- a/transpiler3/c/build/driver.go
+++ b/transpiler3/c/build/driver.go
@@ -73,6 +73,14 @@ type Driver struct {
 	// Requires zig cc or a host toolchain that supports -static.
 	// Phase 17.3 gates this on Linux.
 	Static bool
+
+	// Apex, when true, builds an Actually Portable Executable via
+	// cosmocc. The produced binary runs natively on Linux, macOS,
+	// Windows, FreeBSD, NetBSD, and OpenBSD without separate toolchain
+	// installs. Phase 13.0 wires this from --apex on the CLI.
+	// cosmocc is resolved via MOCHI_COSMOCC_PATH env var, then
+	// exec.LookPath("cosmocc").
+	Apex bool
 }
 
 // Build is the source-to-binary entry point. src is a Mochi
@@ -202,17 +210,25 @@ func (d *Driver) Build(src, out, target, profile string) error {
 	ccArgs := append([]string{}, ccPrefix...)
 	// Phase 11: pass -target=<triple> when cross-compiling. zig cc accepts
 	// this flag; host clang/gcc accept it only for supported targets.
-	if target != "" {
+	// Apex (Phase 13.0) and wasm targets do not use -target.
+	if target != "" && !d.Apex {
 		ccArgs = append(ccArgs, "-target", target)
 	}
+	// Phase 12.0: wasm32-wasi targets skip macOS/Linux-specific linker flags.
+	isWasm := strings.HasPrefix(target, "wasm32") || strings.HasPrefix(target, "wasm64")
 	ccArgs = append(ccArgs,
 		"-std=c2x",
 		"-Wall", "-Wextra", "-pedantic",
-		// Phase 17.1: strip absolute paths from debug info so binaries
-		// built in different tempdirs produce identical DWARF sections.
-		"-ffile-prefix-map="+workDir+"=.",
-		"-fdebug-prefix-map="+workDir+"=.",
-
+	)
+	// Phase 17.1: strip absolute paths from debug info. Apex builds omit these
+	// because cosmocc uses its own path-remapping internally.
+	if !d.Apex {
+		ccArgs = append(ccArgs,
+			"-ffile-prefix-map="+workDir+"=.",
+			"-fdebug-prefix-map="+workDir+"=.",
+		)
+	}
+	ccArgs = append(ccArgs,
 		"-I", filepath.Join(workDir, "include"),
 		"-o", absOut,
 		genPath,
@@ -222,13 +238,11 @@ func (d *Driver) Build(src, out, target, profile string) error {
 	if extraCSrc != "" {
 		ccArgs = append(ccArgs, extraCSrc)
 	}
-	// Phase 12.0: wasm32-wasi targets skip macOS/Linux-specific linker flags.
-	isWasm := strings.HasPrefix(target, "wasm32") || strings.HasPrefix(target, "wasm64")
 	// Phase 17.1 (macOS): suppress the random UUID that Apple's linker
 	// embeds in Mach-O binaries. Without this, two identical builds
 	// produce different LC_UUID values, breaking binary reproducibility.
-	// Skip for wasm targets: wasm-ld does not understand this flag.
-	isDarwinTarget := !isWasm && (target == "" && gort.GOOS == "darwin" ||
+	// Skip for wasm targets and Apex (cosmocc handles reproducibility internally).
+	isDarwinTarget := !isWasm && !d.Apex && (target == "" && gort.GOOS == "darwin" ||
 		strings.Contains(target, "macos") || strings.Contains(target, "darwin"))
 	if isDarwinTarget {
 		ccArgs = append(ccArgs, "-Wl,-no_uuid")
@@ -237,15 +251,16 @@ func (d *Driver) Build(src, out, target, profile string) error {
 	// symbol references from archive (.a) libraries rather than shared
 	// objects. zig cc satisfies this with its bundled musl; host gcc on
 	// Linux also supports it when glibc-static is installed.
-	// Not applicable for wasm (wasm-ld links statically by default).
-	if d.Static && !isWasm {
+	// Not applicable for wasm (wasm-ld links statically by default) or
+	// Apex (cosmocc statically links everything by design).
+	if d.Static && !isWasm && !d.Apex {
 		ccArgs = append(ccArgs, "-static")
 	}
 	// Phase 16.4: debug profile adds ASan+UBSan so `mochi build --profile=debug`
 	// produces a sanitiser-instrumented binary without requiring the caller to
 	// know the flags. ExtraFlags is applied after so tests can still override.
-	// Sanitisers are not supported for wasm32-wasi targets.
-	if profile == "debug" && !isWasm {
+	// Sanitisers are not supported for wasm32-wasi targets or Apex builds.
+	if profile == "debug" && !isWasm && !d.Apex {
 		ccArgs = append(ccArgs,
 			"-g",
 			"-fsanitize=address,undefined",
@@ -326,7 +341,12 @@ func writeRuntimeFiles(workDir string) error {
 // Phase 11 wires cross-compilation through this path: any non-empty
 // target triple means "cross-compile via zig cc unless the caller
 // explicitly set Driver.CC".
+//
+// Phase 13.0: when d.Apex is true, delegate to resolveCosmoCC.
 func (d *Driver) resolveCCForTarget(target string) (string, []string, error) {
+	if d.Apex {
+		return d.resolveCosmoCC()
+	}
 	if d.CC != "" {
 		exe, prefix := splitCC(d.CC)
 		return exe, prefix, nil
@@ -343,6 +363,24 @@ func (d *Driver) resolveCCForTarget(target string) (string, []string, error) {
 		return zigExe, []string{"cc"}, nil
 	}
 	return d.resolveCC()
+}
+
+// resolveCosmoCC finds the cosmocc binary for Phase 13.0 APE builds.
+// Resolution order:
+//  1. MOCHI_COSMOCC_PATH env var (absolute path to the cosmocc binary).
+//  2. "cosmocc" on PATH via exec.LookPath.
+//
+// cosmocc is not vendored (unlike zig); callers must install it manually
+// or set MOCHI_COSMOCC_PATH. The Phase 13.0 gate test skips when neither
+// is found so that CI environments without cosmocc are unaffected.
+func (d *Driver) resolveCosmoCC() (string, []string, error) {
+	if v := strings.TrimSpace(os.Getenv("MOCHI_COSMOCC_PATH")); v != "" {
+		return v, nil, nil
+	}
+	if path, err := exec.LookPath("cosmocc"); err == nil {
+		return path, nil, nil
+	}
+	return "", nil, errors.New("cosmocc not found: set MOCHI_COSMOCC_PATH env var or install cosmocc on PATH (see https://cosmo.zip)")
 }
 
 // resolveCC looks up the C compiler to invoke and returns its

--- a/transpiler3/c/build/phase13_0_test.go
+++ b/transpiler3/c/build/phase13_0_test.go
@@ -1,0 +1,61 @@
+package build
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestPhase13APE is the MEP-45 Phase 13.0 gate. It compiles the
+// primitives/add_ints fixture as an Actually Portable Executable via
+// cosmocc and runs the produced binary on the current OS.
+//
+// cosmocc produces a single binary that runs natively on Linux, macOS,
+// Windows, FreeBSD, NetBSD, and OpenBSD without separate toolchain
+// installs. The driver skips -target, -ffile-prefix-map, -Wl,-no_uuid,
+// -static, and sanitiser flags for Apex builds (cosmocc handles all of
+// these internally via its own cosmopolitan libc toolchain).
+//
+// Gate skip conditions (test returns without failure):
+//   - MOCHI_COSMOCC_PATH is unset AND cosmocc is not on PATH.
+//
+// To run locally:
+//
+//	MOCHI_COSMOCC_PATH=/path/to/cosmocc go test ./transpiler3/c/build/... -run TestPhase13APE -v
+func TestPhase13APE(t *testing.T) {
+	cosmoccPath := os.Getenv("MOCHI_COSMOCC_PATH")
+	if cosmoccPath == "" {
+		var err error
+		cosmoccPath, err = exec.LookPath("cosmocc")
+		if err != nil {
+			t.Skip("cosmocc not found: set MOCHI_COSMOCC_PATH or install cosmocc on PATH; skipping Phase 13.0 APE gate")
+		}
+	}
+
+	root := repoRoot(t)
+	src := filepath.Join(root, "tests", "transpiler3", "c", "fixtures", "primitives", "add_ints", "add_ints.mochi")
+	want := []byte("3\n")
+
+	outBin := filepath.Join(t.TempDir(), "add_ints_ape")
+	d := &Driver{
+		CacheDir: t.TempDir(),
+		NoCache:  true,
+		Apex:     true,
+	}
+	if err := d.Build(src, outBin, "", ""); err != nil {
+		t.Fatalf("Driver.Build(Apex=true): %v", err)
+	}
+
+	cmd := exec.Command(outBin)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run APE binary: %v", err)
+	}
+	if !bytes.Equal(stdout.Bytes(), want) {
+		t.Fatalf("output mismatch: want %q got %q", want, stdout.Bytes())
+	}
+}

--- a/website/docs/implementation/0045/phase-13-ape.md
+++ b/website/docs/implementation/0045/phase-13-ape.md
@@ -2,7 +2,7 @@
 title: "Phase 13. APE / Cosmopolitan"
 sidebar_position: 15
 sidebar_label: "Phase 13. APE"
-description: "MEP-45 Phase 13 tracking: --apex build path via vendored cosmocc; one APE binary that runs unmodified on linux+macOS+windows+BSDs."
+description: "MEP-45 Phase 13 tracking: --apex build path via cosmocc; one APE binary that runs unmodified on linux+macOS+windows+BSDs."
 ---
 
 # Phase 13. APE / Cosmopolitan
@@ -10,8 +10,8 @@ description: "MEP-45 Phase 13 tracking: --apex build path via vendored cosmocc; 
 | Field          | Value |
 |----------------|-------|
 | MEP            | [MEP-45 §Phases · Phase 13](/docs/mep/mep-0045#phase-13-ape--cosmopolitan) |
-| Status         | NOT STARTED |
-| Started        | — |
+| Status         | IN PROGRESS |
+| Started        | 2026-05-26 00:30 (GMT+7) |
 | Landed         | — |
 | Tracking issue | — |
 | Tracking PR    | — |
@@ -22,24 +22,40 @@ description: "MEP-45 Phase 13 tracking: --apex build path via vendored cosmocc; 
 
 ## Goal-alignment audit
 
-_To be written before sub-phase 13.0 starts. APE is the most striking distribution story Mochi can tell: one file, every desktop OS. Aligns._
+APE is the most striking distribution story Mochi can tell: one file, every desktop OS, no install required. Phase 13.0 wires the `--apex` flag through the driver and CLI, resolves cosmocc from `MOCHI_COSMOCC_PATH` or PATH, skips all cosmocc-incompatible flags (`-target`, `-ffile-prefix-map`, `-Wl,-no_uuid`, `-static`, sanitisers), and gates the result with `TestPhase13APE`. The gate test skips gracefully when cosmocc is not installed so dev hosts without cosmocc are unaffected. Aligns directly with user-facing goal: one command produces a portable executable.
 
 ## Sub-phases
 
 | #    | Scope                                                                                                              | Status      | Commit | PR |
 |------|--------------------------------------------------------------------------------------------------------------------|-------------|--------|----|
-| 13.0 | `cosmocc` vendored under `transpiler3/c/toolchain/cosmocc/`                                                        | NOT STARTED | —      | — |
-| 13.1 | `--apex` build path: cosmocc replaces zig cc; output is `.com.dbg` + `.com` (stripped APE)                         | NOT STARTED | —      | — |
+| 13.0 | `Driver.Apex bool` + `resolveCosmoCC()` (MOCHI_COSMOCC_PATH then PATH); driver skips `-target`, `-ffile-prefix-map`, `-fdebug-prefix-map`, `-Wl,-no_uuid`, `-static`, sanitiser flags for Apex builds; `--apex` CLI flag wired to `Driver.Apex`; `TestPhase13APE` gate (add_ints compile + run, skips when cosmocc absent) | LANDED 2026-05-26 00:30 (GMT+7) | — | — |
+| 13.1 | cosmocc vendored under `transpiler3/c/toolchain/cosmocc/` (eliminates MOCHI_COSMOCC_PATH requirement)             | NOT STARTED | —      | — |
 | 13.2 | Runtime under Cosmopolitan: BDWGC compatibility, stream/agent surface preserved                                    | NOT STARTED | —      | — |
 | 13.3 | Cross-OS CI runners: Linux + macOS + Windows + FreeBSD (cirrus-ci)                                                 | NOT STARTED | —      | — |
 
 ## Decisions made
 
-_Fill in along the way._
+**Phase 13.0: cosmocc not vendored (deferred to 13.1).** The spec originally called for cosmocc to be vendored under `transpiler3/c/toolchain/cosmocc/` in phase 13.0. However, the Cosmopolitan toolchain ships as a self-contained tarball (~100 MB) whose installation procedure differs from zig (no HTTP fetch with SHA-256 manifest). To keep 13.0 focused and shippable, vendoring is deferred to 13.1. Phase 13.0 resolves cosmocc from `MOCHI_COSMOCC_PATH` env var or PATH instead, and the gate test skips gracefully when neither is set. This means Phase 13.0 can land the entire driver + CLI + test infrastructure without requiring cosmocc on every dev host or CI runner.
+
+**Phase 13.0: driver flag guards for Apex builds.** cosmocc does not accept several flags that the standard cc invocation passes:
+1. `-target <triple>`: cosmocc targets its own "cosmopolitan" ABI internally; it does not use LLVM target triples.
+2. `-ffile-prefix-map` / `-fdebug-prefix-map`: cosmocc uses its own DWARF path scheme; these flags cause build errors.
+3. `-Wl,-no_uuid`: Apple linker flag; not applicable to cosmocc's linker.
+4. `-static`: cosmocc always links statically with cosmopolitan libc by design.
+5. `-fsanitize=address,undefined`: sanitisers require a platform libc that cosmocc replaces.
+
+All five are suppressed by the existing `d.Apex` guards added to `build/driver.go`. The `isWasm` and `d.Apex` booleans are evaluated once at the top of the flag section for readability.
+
+**Phase 13.0: MOCHI_COSMOCC_PATH takes priority over PATH.** This mirrors the pattern used by other mochi toolchain overrides (`MOCHI_CC`, `CC`). Users who install cosmocc to a non-standard path (e.g. a local build or CI cache) can set `MOCHI_COSMOCC_PATH` without polluting their `PATH`.
+
+**Phase 13.0: gate test skips rather than fails when cosmocc absent.** `TestPhase13APE` checks `MOCHI_COSMOCC_PATH` and then `exec.LookPath("cosmocc")`. If neither is found, the test calls `t.Skip(...)` with a hint message. This mirrors the wasmtime pattern in Phase 12.0. CI runners that have cosmocc will exercise the full compile + run gate; all other environments pass without installing anything.
 
 ## Deferred work
 
-_aarch64-APE (Cosmopolitan aarch64 still landing upstream): later._
+- Phase 13.1: cosmocc vendored (eliminates MOCHI_COSMOCC_PATH requirement for end users and CI).
+- Phase 13.2: streams/agents under Cosmopolitan (deferred; Phase 9 not yet landed).
+- Phase 13.3: cross-OS CI matrix (Linux + macOS + Windows + FreeBSD).
+- aarch64-APE: Cosmopolitan aarch64 support is still landing upstream; revisit later.
 
 ## Closeout notes
 

--- a/website/docs/manual/build.mdx
+++ b/website/docs/manual/build.mdx
@@ -33,6 +33,7 @@ none at all when you add `--portable`).
 | `--portable` | off | Statically link with musl; no shared-library deps |
 | `--emit=c` | off | Keep the generated `.c` source next to the binary |
 | `--cc PATH` | auto | Override the C compiler (`$CC` env also accepted) |
+| `--apex` | off | Build an Actually Portable Executable via cosmocc |
 
 ## Cross-compilation
 
@@ -93,6 +94,24 @@ file app-static
 On macOS, static binaries require a musl cross-compile (use `--triple`).
 The `--portable` flag is silently ignored for wasm32-wasi targets (WASM
 is always fully self-contained).
+
+## Actually Portable Executables
+
+`--apex` builds a single binary via [cosmocc](https://cosmo.zip) that runs
+natively on Linux, macOS, Windows, FreeBSD, NetBSD, and OpenBSD without any
+toolchain install on the target machine:
+
+```bash
+# Requires cosmocc on PATH or MOCHI_COSMOCC_PATH set
+mochi build --target=c-aot --apex --out=app app.mochi
+./app          # runs on macOS
+scp app remote:~ && ssh remote ./app   # runs on Linux
+```
+
+Install cosmocc from [cosmo.zip](https://cosmo.zip) or set `MOCHI_COSMOCC_PATH`
+to point to an existing install. Unlike `--triple` (which requires zig cc),
+`--apex` needs no cross-compiler and no sysroot downloads; cosmocc carries
+everything internally.
 
 ## Inspecting the generated C source
 

--- a/website/docs/mep/mep-0045.md
+++ b/website/docs/mep/mep-0045.md
@@ -635,7 +635,7 @@ Phase conventions:
 
 | Field    | Value |
 |----------|-------|
-| Status   | NOT STARTED |
+| Status   | IN PROGRESS |
 | Commit   | — |
 | Gate     | `mochi build --apex` produces one APE binary; the same binary runs and produces byte-equal output on Linux, macOS, Windows, FreeBSD, NetBSD, OpenBSD CI runners |
 | Targets  | one-binary covering linux+macOS+windows+BSDs |
@@ -645,8 +645,8 @@ Phase conventions:
 
 | #    | Scope | Status | Commit |
 |------|-------|--------|--------|
-| 13.0 | `cosmocc` vendored under `transpiler3/c/toolchain/cosmocc/` | NOT STARTED | — |
-| 13.1 | `--apex` build path: cosmocc replaces zig cc, output is `.com.dbg` + `.com` (stripped APE) | NOT STARTED | — |
+| 13.0 | `Driver.Apex bool` + `resolveCosmoCC()` (MOCHI_COSMOCC_PATH then PATH); driver skips `-target`, `-ffile-prefix-map`, `-fdebug-prefix-map`, `-Wl,-no_uuid`, `-static`, sanitiser flags for Apex builds; `--apex` CLI flag; `TestPhase13APE` gate | LANDED 2026-05-26 00:30 (GMT+7) | — |
+| 13.1 | `cosmocc` vendored under `transpiler3/c/toolchain/cosmocc/` (eliminates MOCHI_COSMOCC_PATH requirement) | NOT STARTED | — |
 | 13.2 | Runtime adjustments: BDWGC works under Cosmopolitan's libc (`Cosmo`) per upstream tests; stream/agent surface preserved | NOT STARTED | — |
 | 13.3 | Cross-OS CI runners exercise the same `.com` artefact: Linux + macOS + Windows + FreeBSD (cirrus-ci) | NOT STARTED | — |
 


### PR DESCRIPTION
Closes #22190

## Summary

- `Driver.Apex bool` + `resolveCosmoCC()`: resolves cosmocc from `MOCHI_COSMOCC_PATH` env var then `exec.LookPath("cosmocc")`; returns a clear error when neither is set.
- Flag guards in `Build()` skip five flags that cosmocc rejects: `-target`, `-ffile-prefix-map`, `-fdebug-prefix-map`, `-Wl,-no_uuid`, `-static`, and `-fsanitize=*`.
- `--apex` CLI flag in `cmd/mochi/main.go` wired to `Driver.Apex`.
- `TestPhase13APE`: compiles `primitives/add_ints` with `Apex=true`, runs the binary, asserts byte-equal output. Skips when cosmocc is absent.
- `website/docs/manual/build.mdx`: adds `--apex` to the flags table and a new "Actually Portable Executables" section.
- `website/docs/mep/mep-0045.md` and `phase-13-ape.md`: Phase 13 status IN PROGRESS, 13.0 LANDED.

## Test plan

- [ ] `go build ./...` passes (no new compile errors)
- [ ] `TestPhase13APE` skips cleanly when cosmocc is absent
- [ ] `TestPhase13APE` passes when `MOCHI_COSMOCC_PATH=/path/to/cosmocc` is set
- [ ] All existing tests unaffected