### PR TITLE
mep-0045 phase 9.0: M:N scheduler foundation (sched.h + ucontext backend)

### DIFF
--- a/tests/transpiler3/c/fixtures/scheduler/sched_basic/expect.txt
+++ b/tests/transpiler3/c/fixtures/scheduler/sched_basic/expect.txt
@@ -1,0 +1,4 @@
+fiber_a start
+fiber_b start
+fiber_a end
+fiber_b end

--- a/tests/transpiler3/c/fixtures/scheduler/sched_basic/sched_basic.c
+++ b/tests/transpiler3/c/fixtures/scheduler/sched_basic/sched_basic.c
@@ -1,0 +1,40 @@
+/*
+ * sched_basic: two fibers ping-pong via yield.
+ *
+ * Expected output (in order):
+ *   fiber_a start
+ *   fiber_b start
+ *   fiber_a end
+ *   fiber_b end
+ *
+ * Execution trace:
+ *   main spawns A then B onto the scheduler.
+ *   A runs: prints "fiber_a start", yields.
+ *   B runs: prints "fiber_b start", yields.
+ *   A resumes: prints "fiber_a end", returns.
+ *   B resumes: prints "fiber_b end", returns.
+ *   Scheduler queue empty; run_scheduler returns.
+ */
+
+#include "mochi/sched.h"
+#include <stdio.h>
+
+static void fiber_a(void *unused) {
+    (void)unused;
+    printf("fiber_a start\n");
+    mochi_fiber_yield();
+    printf("fiber_a end\n");
+}
+
+static void fiber_b(void *unused) {
+    (void)unused;
+    printf("fiber_b start\n");
+    mochi_fiber_yield();
+    printf("fiber_b end\n");
+}
+
+void run_scheduler(void) {
+    mochi_sched_spawn(fiber_a, NULL);
+    mochi_sched_spawn(fiber_b, NULL);
+    mochi_sched_run();
+}

--- a/tests/transpiler3/c/fixtures/scheduler/sched_basic/sched_basic.mochi
+++ b/tests/transpiler3/c/fixtures/scheduler/sched_basic/sched_basic.mochi
@@ -1,0 +1,2 @@
+extern fun run_scheduler(): unit
+run_scheduler()

--- a/tests/transpiler3/c/fixtures/scheduler/sched_nested/expect.txt
+++ b/tests/transpiler3/c/fixtures/scheduler/sched_nested/expect.txt
@@ -1,0 +1,6 @@
+producer: send
+consumer: recv
+observer: watch
+producer: done
+consumer: done
+observer: done

--- a/tests/transpiler3/c/fixtures/scheduler/sched_nested/sched_nested.c
+++ b/tests/transpiler3/c/fixtures/scheduler/sched_nested/sched_nested.c
@@ -1,0 +1,45 @@
+/*
+ * sched_nested: three fibers (producer, consumer, observer) interleave
+ * cooperatively. Each fiber yields once between its two print statements,
+ * so the round-robin scheduler interleaves them.
+ *
+ * Spawn order: producer, consumer, observer.
+ * Expected output (round-robin over three fibers, each yielding once):
+ *   producer: send
+ *   consumer: recv
+ *   observer: watch
+ *   producer: done
+ *   consumer: done
+ *   observer: done
+ */
+
+#include "mochi/sched.h"
+#include <stdio.h>
+
+static void producer(void *unused) {
+    (void)unused;
+    printf("producer: send\n");
+    mochi_fiber_yield();
+    printf("producer: done\n");
+}
+
+static void consumer(void *unused) {
+    (void)unused;
+    printf("consumer: recv\n");
+    mochi_fiber_yield();
+    printf("consumer: done\n");
+}
+
+static void observer(void *unused) {
+    (void)unused;
+    printf("observer: watch\n");
+    mochi_fiber_yield();
+    printf("observer: done\n");
+}
+
+void run_scheduler(void) {
+    mochi_sched_spawn(producer, NULL);
+    mochi_sched_spawn(consumer, NULL);
+    mochi_sched_spawn(observer, NULL);
+    mochi_sched_run();
+}

--- a/tests/transpiler3/c/fixtures/scheduler/sched_nested/sched_nested.mochi
+++ b/tests/transpiler3/c/fixtures/scheduler/sched_nested/sched_nested.mochi
@@ -1,0 +1,2 @@
+extern fun run_scheduler(): unit
+run_scheduler()

--- a/tests/transpiler3/c/fixtures/scheduler/sched_yield/expect.txt
+++ b/tests/transpiler3/c/fixtures/scheduler/sched_yield/expect.txt
@@ -1,0 +1,4 @@
+step 1
+step 2
+step 3
+done

--- a/tests/transpiler3/c/fixtures/scheduler/sched_yield/sched_yield.c
+++ b/tests/transpiler3/c/fixtures/scheduler/sched_yield/sched_yield.c
@@ -1,0 +1,29 @@
+/*
+ * sched_yield: a single fiber yields three times, printing its step
+ * number before each yield and after the final resume.
+ *
+ * Expected output:
+ *   step 1
+ *   step 2
+ *   step 3
+ *   done
+ */
+
+#include "mochi/sched.h"
+#include <stdio.h>
+
+static void counting_fiber(void *unused) {
+    (void)unused;
+    printf("step 1\n");
+    mochi_fiber_yield();
+    printf("step 2\n");
+    mochi_fiber_yield();
+    printf("step 3\n");
+    mochi_fiber_yield();
+    printf("done\n");
+}
+
+void run_scheduler(void) {
+    mochi_sched_spawn(counting_fiber, NULL);
+    mochi_sched_run();
+}

--- a/tests/transpiler3/c/fixtures/scheduler/sched_yield/sched_yield.mochi
+++ b/tests/transpiler3/c/fixtures/scheduler/sched_yield/sched_yield.mochi
@@ -1,0 +1,2 @@
+extern fun run_scheduler(): unit
+run_scheduler()

--- a/transpiler3/c/build/phase09_0_test.go
+++ b/transpiler3/c/build/phase09_0_test.go
@@ -1,0 +1,32 @@
+package build
+
+import (
+	"runtime"
+	"testing"
+)
+
+// TestPhase9Scheduler is the MEP-45 Phase 9.0 gate for the cooperative
+// fiber scheduler foundation. It walks every fixture under
+// tests/transpiler3/c/fixtures/scheduler and runs the same end-to-end
+// pipeline as all other phase gates.
+//
+// Phase 9.0 adds:
+//   - transpiler3/c/runtime/include/mochi/sched.h: public scheduler API
+//     (mochi_fiber_create/destroy/resume/yield/current, mochi_sched_spawn/run).
+//   - transpiler3/c/runtime/src/sched.c: ucontext_t implementation of the
+//     above, providing minicoro-compatible cooperative fiber scheduling.
+//
+// The fixtures use `extern fun` FFI to call a C harness that exercises the
+// scheduler API directly; no language-level stream/agent syntax is required
+// at this phase.
+//
+// Phase 9.0 fixtures:
+//   - sched_basic: two fibers ping-pong via yield; verifies interleaving order.
+//   - sched_yield: single fiber yields multiple times; verifies resume count.
+//   - sched_nested: three fibers interleaved round-robin; verifies FIFO queue.
+func TestPhase9Scheduler(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Phase 9 scheduler gate skipped on Windows; ucontext ships POSIX only")
+	}
+	runFixtureSuite(t, "scheduler")
+}

--- a/transpiler3/c/lower/lower.go
+++ b/transpiler3/c/lower/lower.go
@@ -1959,6 +1959,8 @@ func typeFromRef(records map[string]*aotir.RecordDecl, unions map[string]*aotir.
 		return typeResolution{t: aotir.TypeBool}, nil
 	case "string":
 		return typeResolution{t: aotir.TypeString}, nil
+	case "unit":
+		return typeResolution{t: aotir.TypeUnit}, nil
 	}
 	if _, ok := records[*ref.Simple]; ok {
 		return typeResolution{t: aotir.TypeRecord, rec: *ref.Simple}, nil

--- a/transpiler3/c/runtime/embed.go
+++ b/transpiler3/c/runtime/embed.go
@@ -11,5 +11,5 @@ import "embed"
 // phase that lands a new runtime module appends its files to
 // the directive list below.
 //
-//go:embed include/mochi/print.h include/mochi/errors.h include/mochi/except.h include/mochi/arena.h include/mochi/list.h include/mochi/map.h include/mochi/strings.h include/mochi/fileio.h include/mochi/csv.h src/print.c src/errors.c src/except.c src/arena.c src/list.c src/map.c src/strings.c src/fileio.c src/csv.c
+//go:embed include/mochi/print.h include/mochi/errors.h include/mochi/except.h include/mochi/arena.h include/mochi/list.h include/mochi/map.h include/mochi/strings.h include/mochi/fileio.h include/mochi/csv.h include/mochi/sched.h src/print.c src/errors.c src/except.c src/arena.c src/list.c src/map.c src/strings.c src/fileio.c src/csv.c src/sched.c
 var Files embed.FS

--- a/transpiler3/c/runtime/include/mochi/sched.h
+++ b/transpiler3/c/runtime/include/mochi/sched.h
@@ -1,0 +1,109 @@
+/*
+ * libmochi: cooperative fiber scheduler (Phase 9.0).
+ *
+ * MEP-45 Phase 9.0 — M:N scheduler foundation using minicoro-compatible
+ * stackful fibers. This header exposes the public API consumed by
+ * Phase 9.1+ language-level streams and agents.
+ *
+ * Implementation: transpiler3/c/runtime/src/sched.c (ucontext_t backend).
+ *
+ * ABI stability: every symbol here is part of libmochi's versioned
+ * surface. Existing prototypes never change shape.
+ */
+#ifndef MOCHI_SCHED_H
+#define MOCHI_SCHED_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Opaque fiber handle. */
+typedef struct mochi_fiber_s mochi_fiber_t;
+
+/* Function signature for fiber entry points. */
+typedef void (*mochi_fiber_fn)(void *userdata);
+
+/*
+ * mochi_fiber_create -- allocate and initialise a new fiber.
+ *
+ * fn        : entry point called when the fiber is first resumed.
+ * userdata  : arbitrary pointer forwarded to fn; the scheduler does
+ *             not inspect it.
+ * stack_size: requested stack in bytes; 0 uses MOCHI_DEFAULT_STACK_SIZE
+ *             (128 KiB).
+ *
+ * Returns a pointer to the new fiber. The fiber starts in FIBER_READY
+ * state and will not execute until the first mochi_fiber_resume() call.
+ * The caller owns the fiber until it reaches FIBER_DEAD state, at
+ * which point mochi_fiber_destroy() may be called.
+ *
+ * Panics (abort) on allocation failure.
+ */
+mochi_fiber_t *mochi_fiber_create(mochi_fiber_fn fn, void *userdata,
+                                  size_t stack_size);
+
+/*
+ * mochi_fiber_destroy -- release all resources owned by a dead fiber.
+ *
+ * The fiber MUST be in FIBER_DEAD state. Destroying a live fiber is
+ * undefined behaviour.
+ */
+void mochi_fiber_destroy(mochi_fiber_t *f);
+
+/*
+ * mochi_fiber_resume -- transfer control into a fiber.
+ *
+ * The caller suspends until the fiber yields (mochi_fiber_yield) or
+ * returns from its entry function. On return, the fiber is either in
+ * FIBER_SUSPENDED or FIBER_DEAD state.
+ *
+ * Calling resume on a FIBER_RUNNING or FIBER_DEAD fiber is undefined
+ * behaviour.
+ */
+void mochi_fiber_resume(mochi_fiber_t *f);
+
+/*
+ * mochi_fiber_yield -- suspend the currently running fiber.
+ *
+ * Control returns to the code that called mochi_fiber_resume(). Must
+ * only be called from inside a fiber; calling from the main stack is
+ * undefined behaviour.
+ */
+void mochi_fiber_yield(void);
+
+/*
+ * mochi_fiber_current -- return the currently executing fiber.
+ *
+ * Returns NULL when called from the main (non-fiber) stack.
+ */
+mochi_fiber_t *mochi_fiber_current(void);
+
+/*
+ * mochi_sched_spawn -- enqueue a new fiber onto the global scheduler.
+ *
+ * The fiber is created with the given fn/userdata/stack_size and added
+ * to the run queue. mochi_sched_run() drives it to completion.
+ * stack_size=0 uses the default.
+ */
+void mochi_sched_spawn(mochi_fiber_fn fn, void *userdata);
+
+/*
+ * mochi_sched_run -- drive the global scheduler until all spawned
+ * fibers have completed.
+ *
+ * Fibers are executed cooperatively in FIFO order. A fiber that yields
+ * is placed back at the tail of the queue; a fiber that returns is
+ * destroyed and removed from the queue.
+ *
+ * Returns only when the queue is empty (all fibers dead).
+ */
+void mochi_sched_run(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOCHI_SCHED_H */

--- a/transpiler3/c/runtime/src/sched.c
+++ b/transpiler3/c/runtime/src/sched.c
@@ -1,0 +1,253 @@
+/*
+ * libmochi: cooperative fiber scheduler — Phase 9.0.
+ *
+ * MEP-45 Phase 9.0: lightweight M:N cooperative scheduler built on
+ * POSIX ucontext_t. Provides the same external API surface as the
+ * planned minicoro substrate (MEP-45 §10), so Phase 9.1+ can swap in
+ * the real minicoro header without touching call sites.
+ *
+ * Platform notes:
+ *   - ucontext_t is POSIX.1-2001 and ships on Linux and macOS.
+ *   - macOS's ucontext.h guards itself with "#error ... requires
+ *     _XOPEN_SOURCE to be defined".  We define _XOPEN_SOURCE 600
+ *     (SUSv3/POSIX.1-2001) before any system header so the guard
+ *     passes.  The definition must precede all #includes.
+ *   - _XOPEN_SOURCE additionally silences the Clang deprecation
+ *     warnings on Apple platforms, so no extra pragma is needed.
+ *   - The two-uint32 argument trick used in fiber_entry is the
+ *     canonical portable way to pass a 64-bit pointer through the
+ *     int-sized makecontext variadic arguments on both ILP32 and LP64
+ *     ABIs (POSIX explicitly endorses this pattern).
+ */
+
+/* Must be defined before any system header on macOS to unlock ucontext. */
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 600
+#endif
+
+/*
+ * On Apple platforms the ucontext API is tagged deprecated (first
+ * deprecated macOS 10.6). We suppress the warning so that -Wall does
+ * not produce noise: the API still works and is the only portable
+ * stackful-coroutine primitive available without an external library.
+ */
+#ifdef __APPLE__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+#include "mochi/sched.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ucontext.h>
+
+/* --------------------------------------------------------------------- */
+/* Internal constants                                                      */
+/* --------------------------------------------------------------------- */
+
+#define MOCHI_DEFAULT_STACK_SIZE (128u * 1024u)
+
+/*
+ * Maximum number of fibers the global scheduler queue can hold at once.
+ * The queue is a fixed-size circular buffer; spawning more than this
+ * many concurrently-live fibers is a programming error. Phase 9.3 will
+ * replace this with a growable deque.
+ */
+#define MOCHI_SCHED_MAX_FIBERS 256
+
+/* --------------------------------------------------------------------- */
+/* Fiber state machine                                                     */
+/* --------------------------------------------------------------------- */
+
+typedef enum {
+    FIBER_READY,      /* created, not yet started */
+    FIBER_RUNNING,    /* currently executing on the CPU */
+    FIBER_SUSPENDED,  /* yielded; waiting to be resumed */
+    FIBER_DEAD        /* entry function has returned */
+} fiber_state;
+
+/* --------------------------------------------------------------------- */
+/* Fiber struct                                                            */
+/* --------------------------------------------------------------------- */
+
+struct mochi_fiber_s {
+    ucontext_t ctx;         /* fiber execution context */
+    ucontext_t caller_ctx;  /* saved caller context (resume site) */
+    char      *stack;       /* heap-allocated stack buffer */
+    size_t     stack_size;  /* size of stack buffer in bytes */
+    mochi_fiber_fn fn;      /* user entry point */
+    void      *userdata;    /* forwarded to fn */
+    fiber_state state;
+};
+
+/* --------------------------------------------------------------------- */
+/* Thread-local current fiber                                              */
+/* --------------------------------------------------------------------- */
+
+/*
+ * Points to the fiber currently executing on this thread, or NULL when
+ * running on the main (non-fiber) stack. Phase 9.3 will move this to a
+ * true thread-local once multi-threaded OS threads are introduced.
+ */
+static mochi_fiber_t *__mochi_current_fiber = NULL;
+
+/* --------------------------------------------------------------------- */
+/* Global scheduler queue (simple circular buffer, FIFO)                  */
+/* --------------------------------------------------------------------- */
+
+static mochi_fiber_t *__sched_queue[MOCHI_SCHED_MAX_FIBERS];
+static int __sched_head = 0; /* index of next item to dequeue */
+static int __sched_tail = 0; /* index where next item will be enqueued */
+
+static int sched_queue_size(void) {
+    return (__sched_tail - __sched_head + MOCHI_SCHED_MAX_FIBERS)
+           % MOCHI_SCHED_MAX_FIBERS;
+}
+
+static void sched_enqueue(mochi_fiber_t *f) {
+    __sched_queue[__sched_tail] = f;
+    __sched_tail = (__sched_tail + 1) % MOCHI_SCHED_MAX_FIBERS;
+}
+
+static mochi_fiber_t *sched_dequeue(void) {
+    mochi_fiber_t *f = __sched_queue[__sched_head];
+    __sched_head = (__sched_head + 1) % MOCHI_SCHED_MAX_FIBERS;
+    return f;
+}
+
+/* --------------------------------------------------------------------- */
+/* Fiber entry trampoline                                                  */
+/* --------------------------------------------------------------------- */
+
+/*
+ * fiber_entry is the function passed to makecontext(). POSIX requires
+ * that makecontext arguments be int-sized, so a 64-bit pointer is split
+ * into two uint32_t halves and reassembled here.
+ */
+static void fiber_entry(uint32_t hi, uint32_t lo) {
+    mochi_fiber_t *f =
+        (mochi_fiber_t *)(((uintptr_t)hi << 32) | (uintptr_t)lo);
+
+    f->fn(f->userdata);
+
+    /* Mark the fiber dead and return control to the resume caller. */
+    f->state = FIBER_DEAD;
+    swapcontext(&f->ctx, &f->caller_ctx);
+
+    /* Unreachable: swapcontext does not return here. */
+    abort();
+}
+
+/* --------------------------------------------------------------------- */
+/* Public API: fiber lifecycle                                             */
+/* --------------------------------------------------------------------- */
+
+mochi_fiber_t *mochi_fiber_create(mochi_fiber_fn fn, void *userdata,
+                                  size_t stack_size) {
+    if (stack_size == 0) {
+        stack_size = MOCHI_DEFAULT_STACK_SIZE;
+    }
+
+    mochi_fiber_t *f = (mochi_fiber_t *)malloc(sizeof(mochi_fiber_t));
+    if (!f) abort();
+    memset(f, 0, sizeof(*f));
+
+    f->stack = (char *)malloc(stack_size);
+    if (!f->stack) abort();
+
+    f->stack_size = stack_size;
+    f->fn         = fn;
+    f->userdata   = userdata;
+    f->state      = FIBER_READY;
+
+    /* Initialise the ucontext for the fiber. */
+    if (getcontext(&f->ctx) != 0) abort();
+    f->ctx.uc_stack.ss_sp   = f->stack;
+    f->ctx.uc_stack.ss_size = stack_size;
+    f->ctx.uc_link          = NULL; /* we manage the link via swapcontext */
+
+    /*
+     * Split the pointer into two 32-bit halves for makecontext.
+     * This pattern is sanctioned by POSIX (see Austin Group Defect 63).
+     */
+    uintptr_t ptr = (uintptr_t)f;
+    uint32_t  hi  = (uint32_t)(ptr >> 32);
+    uint32_t  lo  = (uint32_t)(ptr & 0xFFFFFFFFu);
+    makecontext(&f->ctx, (void (*)(void))fiber_entry, 2, hi, lo);
+
+    return f;
+}
+
+void mochi_fiber_destroy(mochi_fiber_t *f) {
+    if (!f) return;
+    free(f->stack);
+    free(f);
+}
+
+/* --------------------------------------------------------------------- */
+/* Public API: execution                                                   */
+/* --------------------------------------------------------------------- */
+
+void mochi_fiber_resume(mochi_fiber_t *f) {
+    mochi_fiber_t *prev    = __mochi_current_fiber;
+    __mochi_current_fiber  = f;
+    f->state               = FIBER_RUNNING;
+
+    /*
+     * swapcontext saves the current register state into f->caller_ctx
+     * and restores f->ctx, transferring control to the fiber.
+     * When the fiber yields or returns, swapcontext in fiber_entry or
+     * mochi_fiber_yield restores caller_ctx here.
+     */
+    swapcontext(&f->caller_ctx, &f->ctx);
+
+    __mochi_current_fiber = prev;
+}
+
+void mochi_fiber_yield(void) {
+    mochi_fiber_t *f = __mochi_current_fiber;
+    f->state = FIBER_SUSPENDED;
+    swapcontext(&f->ctx, &f->caller_ctx);
+    /* Execution resumes here after the next mochi_fiber_resume(). */
+    f->state = FIBER_RUNNING;
+}
+
+mochi_fiber_t *mochi_fiber_current(void) {
+    return __mochi_current_fiber;
+}
+
+/* --------------------------------------------------------------------- */
+/* Public API: global scheduler                                            */
+/* --------------------------------------------------------------------- */
+
+void mochi_sched_spawn(mochi_fiber_fn fn, void *userdata) {
+    mochi_fiber_t *f = mochi_fiber_create(fn, userdata, 0);
+    sched_enqueue(f);
+}
+
+void mochi_sched_run(void) {
+    while (sched_queue_size() > 0) {
+        mochi_fiber_t *f = sched_dequeue();
+
+        /* Skip any fibers that somehow ended up dead in the queue. */
+        if (f->state == FIBER_DEAD) {
+            mochi_fiber_destroy(f);
+            continue;
+        }
+
+        mochi_fiber_resume(f);
+
+        if (f->state == FIBER_DEAD) {
+            mochi_fiber_destroy(f);
+        } else {
+            /* Fiber yielded; put it back at the tail of the queue. */
+            sched_enqueue(f);
+        }
+    }
+}
+
+#ifdef __APPLE__
+#pragma clang diagnostic pop
+#endif


### PR DESCRIPTION
Closes #22198.

## Summary

- Adds `mochi/sched.h` + `src/sched.c` to libmochi: a cooperative fiber scheduler built on POSIX `ucontext_t`, providing the same external API surface as the planned minicoro substrate (MEP-45 §10).
- Fixes `typeFromRef` in the lowerer to accept `unit` as a valid return type for `extern fun` declarations.
- Adds 3 gate fixtures and `TestPhase9Scheduler`.

## Key decisions

- `_XOPEN_SOURCE 600` defined at the top of `sched.c` (before any system header) to satisfy macOS's `ucontext.h` guard; a `#pragma clang diagnostic push/pop` suppresses the deprecation warnings on Apple platforms.
- The two-uint32 pointer split in `fiber_entry` is the POSIX-sanctioned pattern for passing 64-bit pointers through `makecontext`'s int-sized variadic args.
- The scheduler queue is a fixed-size circular buffer (256 slots) with FIFO discipline; yielded fibers rejoin the tail.

## Test plan

- `go test ./transpiler3/c/build/... -run TestPhase9Scheduler -v` — all 3 sub-tests pass (sched_basic, sched_yield, sched_nested).
- `go build ./...` — no compilation errors.