### PR TITLE
mep-0045 phase 16.2: TSan clean on streams/agents corpus

### DIFF
--- a/transpiler3/c/build/phase16_2_test.go
+++ b/transpiler3/c/build/phase16_2_test.go
@@ -1,0 +1,127 @@
+package build
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestPhase16TSan is the MEP-45 Phase 16.2 gate. It compiles the streams
+// and agents fixture corpus with -fsanitize=thread (TSan) and asserts
+// byte-equal stdout against expect.txt.
+//
+// All Phase 9 concurrency primitives (scheduler fibers, chan<T>, stream<T>,
+// agents, method shims) run on a single OS thread via cooperative ucontext
+// scheduling, so no actual data races exist. TSan clean on this corpus
+// confirms that the runtime's stack-switching and ring-buffer operations do
+// not trigger false positives under thread sanitisation.
+//
+// Platform notes:
+//   - macOS (Apple clang): -fsanitize=thread is supported.
+//   - Linux (clang/gcc): -fsanitize=thread is supported.
+//   - Windows: skipped (TSan not available in the Phase 16 toolchain).
+func TestPhase16TSan(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TSan gate skipped on Windows")
+	}
+	if !tsanAvailable(t) {
+		t.Skip("TSan not available on this host (no -fsanitize=thread support)")
+	}
+
+	suites := []string{
+		"agent",
+		"chan",
+		"method_shim",
+		"scheduler",
+		"stream",
+	}
+
+	tsanFlags := []string{"-fsanitize=thread"}
+	tsanEnv := "TSAN_OPTIONS=halt_on_error=1"
+
+	for _, suite := range suites {
+		suite := suite
+		t.Run(suite, func(t *testing.T) {
+			runFixtureSuiteTSan(t, suite, tsanFlags, tsanEnv)
+		})
+	}
+}
+
+// tsanAvailable probes whether the host cc understands -fsanitize=thread.
+func tsanAvailable(t *testing.T) bool {
+	t.Helper()
+	src := filepath.Join(t.TempDir(), "probe.c")
+	if err := writeProbeC(src); err != nil {
+		t.Logf("tsanAvailable: write probe: %v", err)
+		return false
+	}
+	out := filepath.Join(t.TempDir(), "probe")
+	cmd := exec.Command("cc", "-fsanitize=thread", src, "-o", out)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Logf("tsanAvailable: cc probe failed: %v\n%s", err, output)
+		return false
+	}
+	return true
+}
+
+// runFixtureSuiteTSan is like runFixtureSuiteASan but for TSan.
+func runFixtureSuiteTSan(t *testing.T, dir string, extraFlags []string, tsanEnv string) {
+	t.Helper()
+	root := repoRoot(t)
+	base := filepath.Join(root, "tests", "transpiler3", "c", "fixtures", dir)
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		t.Fatalf("read fixtures dir %s: %v", base, err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		t.Fatalf("no fixtures under %s", base)
+	}
+
+	for _, name := range names {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			fixture := filepath.Join(base, name)
+			src := filepath.Join(fixture, name+".mochi")
+			expect, err := os.ReadFile(filepath.Join(fixture, "expect.txt"))
+			if err != nil {
+				t.Fatalf("read expect.txt: %v", err)
+			}
+
+			outBin := filepath.Join(t.TempDir(), name)
+			d := &Driver{
+				CacheDir:   t.TempDir(),
+				NoCache:    true,
+				ExtraFlags: extraFlags,
+			}
+			if err := d.Build(src, outBin, "", ""); err != nil {
+				t.Fatalf("Driver.Build %s: %v", src, err)
+			}
+
+			cmd := exec.Command(outBin)
+			cmd.Env = append(os.Environ(), strings.Split(tsanEnv, " ")...)
+			var stdout bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("run %s (TSan): %v\nstdout so far: %q", name, err, stdout.String())
+			}
+			if got := stdout.String(); got != string(expect) {
+				t.Fatalf("stdout mismatch for %s:\n--- want ---\n%q\n--- got ---\n%q",
+					name, string(expect), got)
+			}
+		})
+	}
+}

--- a/website/docs/implementation/0045/phase-16-sanitisers.md
+++ b/website/docs/implementation/0045/phase-16-sanitisers.md
@@ -30,7 +30,7 @@ Sanitiser clean is the strongest internal correctness signal short of formal ver
 |------|--------------------------------------------------------------------------------------------------------------------|-------------|--------|----|
 | 16.0 | ASan clean on full corpus (aarch64-darwin). `-fsanitize=address`, `detect_leaks=0` (GC-less runtime intentionally does not free at exit). `TestPhase16ASan` gate (33 suites). | LANDED 2026-05-25 21:46 (GMT+7) | — | — |
 | 16.1 | UBSan clean on full corpus. `-fsanitize=undefined -fno-sanitize-recover=all`. `TestPhase16UBSan` gate (33 suites). | LANDED 2026-05-25 21:46 (GMT+7) | — | — |
-| 16.2 | TSan clean on streams/agents corpus                                                                                | NOT STARTED | —      | — |
+| 16.2 | TSan clean on streams/agents corpus: `TestPhase16TSan` gate runs agent/chan/method_shim/scheduler/stream suites (28 fixtures) under `-fsanitize=thread`; all clean (cooperative single-OS-thread scheduling, no actual data races) | LANDED 2026-05-26 05:05 (GMT+7) | (this PR) | — |
 | 16.3 | MSan clean on Linux (Apple-silicon MSan unsupported upstream)                                                      | LANDED 2026-05-26 00:07 (GMT+7) | — | — |
 | 16.4 | Build profile `--debug` wires sanitisers; CI nightly job runs the matrix                                           | LANDED 2026-05-25 22:46 (GMT+7) | — | — |
 
@@ -78,10 +78,20 @@ Sanitiser clean is the strongest internal correctness signal short of formal ver
 ## Deferred work
 
 - Full LeakSan clean: requires explicit free() at every exit path or a global arena. Tracked as sub-phase 16.0.1.
-- TSan clean (16.2): blocked on Phase 9 (streams/agents) landing.
+- TSan clean (16.2): LANDED. 28 fixtures across agent/chan/method_shim/scheduler/stream all clean.
 - `file_io` + `csv_adapters` MSan: deferred; clang intercepts fopen/fgets but edge-cases need verification on CI.
 - FFI MSan: requires compiling the neighbour `.c` with MSan flags too; deferred to Phase 10.1 scope.
 
+## Phase 16.2 decisions
+
+**Single OS thread, no races.** All Phase 9 concurrency primitives (fibers via `ucontext`, `chan<T>` ring buffer, `stream<T>` MPMC ring, agents, method shims) run on a single OS thread using cooperative scheduling. There are no actual data races: only one fiber executes at a time, and `mochi_fiber_yield()` provides the voluntary yield point. TSan instruments the binary correctly and reports zero races.
+
+**`tsanAvailable` probe.** Mirrors `asanAvailable` from Phase 16.0: compiles a trivial C file with `-fsanitize=thread`. Returns false (and calls `t.Skip`) on hosts where TSan is not available, rather than failing the gate.
+
+**`TSAN_OPTIONS=halt_on_error=1`.** Makes the first race report abort the binary (non-zero exit), which the runner catches as a test failure.
+
+**`runFixtureSuiteTSan` helper.** Structurally identical to `runFixtureSuiteASan` with `tsanEnv` instead of `asanEnv`. Kept as a separate helper (not parameterised further) to keep the test code readable.
+
 ## Closeout notes
 
-Sub-phases 16.0, 16.1, 16.3, and 16.4 are LANDED. Sub-phase 16.2 (TSan) is deferred, pending Phase 9 (streams/agents).
+Sub-phases 16.0, 16.1, 16.2, 16.3, and 16.4 are LANDED.

--- a/website/docs/mep/mep-0045.md
+++ b/website/docs/mep/mep-0045.md
@@ -711,7 +711,7 @@ Phase conventions:
 |------|-------|--------|--------|
 | 16.0 | ASan clean on full corpus (aarch64-darwin). `Driver.ExtraFlags` wires sanitiser flags; `ASAN_OPTIONS=detect_leaks=0` suppresses expected GC-less leaks; `TestPhase16ASan` gate (33 suites). | LANDED 2026-05-25 21:46 (GMT+7) | — |
 | 16.1 | UBSan clean on full corpus. `-fsanitize=undefined -fno-sanitize-recover=all`; `TestPhase16UBSan` gate (33 suites). | LANDED 2026-05-25 21:46 (GMT+7) | — |
-| 16.2 | TSan clean on streams/agents corpus | NOT STARTED | — |
+| 16.2 | TSan clean on streams/agents corpus: `TestPhase16TSan` gate runs agent/chan/method_shim/scheduler/stream suites (28 fixtures) under `-fsanitize=thread`; all clean (single OS thread, cooperative scheduling, no actual data races) | LANDED 2026-05-26 05:05 (GMT+7) | (this PR) |
 | 16.3 | MSan clean on host that supports it (Linux only; Apple-silicon MSan still unsupported per upstream) | LANDED 2026-05-26 00:07 (GMT+7) | — |
 | 16.4 | Build profile `--debug` wires sanitisers; CI nightly job runs the matrix | LANDED 2026-05-25 22:46 (GMT+7) | — |
 


### PR DESCRIPTION
## Summary

- `TestPhase16TSan` gate: compiles and runs 28 fixtures across agent/chan/method_shim/scheduler/stream under `-fsanitize=thread`.
- All clean: Phase 9 uses cooperative ucontext fiber scheduling on a single OS thread, so no actual data races exist.
- `tsanAvailable` probe skips on hosts without TSan support.
- `runFixtureSuiteTSan` helper mirrors `runFixtureSuiteASan` from Phase 16.0.

Closes #22208

## Test plan

- [x] `TestPhase16TSan` (28 fixtures, 5 suites) all green.
- [x] `TestPhase5MethodShim`, `TestPhase9Agent`, `TestPhase9Chan`, `TestPhase9Stream` still green (no regressions).