### PR TITLE
mep-0045 phase 14.3: Google live provider via libcurl

### DIFF
--- a/transpiler3/c/build/phase14_3_test.go
+++ b/transpiler3/c/build/phase14_3_test.go
@@ -1,0 +1,90 @@
+package build
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestPhase14Google is the MEP-45 Phase 14.3 gate. It verifies that:
+//  1. A program using generate google { ... } compiles correctly when built
+//     with -DMOCHI_LLM_HAVE_CURL -lcurl (enabling the live HTTP provider).
+//  2. In cassette mode (MOCHI_LLM_CASSETTE_DIR set), the curl-enabled binary
+//     still returns the pre-recorded cassette response (cassette takes priority).
+//  3. In no-cassette mode without GOOGLE_API_KEY, the binary exits cleanly with
+//     an empty result (the live provider prints a diagnostic but does not crash).
+//
+// The gate does NOT make live HTTP calls to generativelanguage.googleapis.com
+// (no API key required). Live mode is validated by the absence of a crash.
+//
+// Skip conditions:
+//   - Windows: no C toolchain in CI
+//   - libcurl not linkable via cc -lcurl
+func TestPhase14Google(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("C toolchain not available in Windows CI")
+	}
+
+	if !probeLibcurl(t) {
+		t.Skip("libcurl not available on this host; skipping Phase 14.3 curl gate")
+	}
+
+	root := repoRoot(t)
+	fixture := filepath.Join(root, "tests", "transpiler3", "c", "fixtures", "llm", "generate_google")
+	src := filepath.Join(fixture, "generate_google.mochi")
+	cassetteDir := filepath.Join(fixture, "cassette")
+	expect, err := os.ReadFile(filepath.Join(fixture, "expect.txt"))
+	if err != nil {
+		t.Fatalf("read expect.txt: %v", err)
+	}
+
+	// Build with -DMOCHI_LLM_HAVE_CURL -lcurl.
+	outBin := filepath.Join(t.TempDir(), "generate_google_curl")
+	d := &Driver{
+		CacheDir:   t.TempDir(),
+		NoCache:    true,
+		ExtraFlags: []string{"-DMOCHI_LLM_HAVE_CURL", "-lcurl"},
+	}
+	if err := d.Build(src, outBin, "", ""); err != nil {
+		t.Fatalf("Driver.Build with curl flags: %v", err)
+	}
+
+	// Sub-test 1: cassette mode still works with curl-enabled binary.
+	t.Run("cassette_mode", func(t *testing.T) {
+		cmd := exec.Command(outBin)
+		cmd.Env = append(os.Environ(), "MOCHI_LLM_CASSETTE_DIR="+cassetteDir)
+		var stdout bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("run with cassette: %v\nstdout: %q", err, stdout.String())
+		}
+		if got := stdout.String(); got != string(expect) {
+			t.Fatalf("stdout mismatch:\n--- want ---\n%q\n--- got ---\n%q", string(expect), got)
+		}
+	})
+
+	// Sub-test 2: live mode without API key returns empty string (no crash).
+	t.Run("live_no_api_key", func(t *testing.T) {
+		env := filterEnv(os.Environ(), "MOCHI_LLM_CASSETTE_DIR", "GOOGLE_API_KEY")
+		cmd := exec.Command(outBin)
+		cmd.Env = env
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		_ = cmd.Run()
+		// The binary must not produce the cassette response (cassette dir is unset).
+		got := stdout.String()
+		if got == string(expect) {
+			t.Fatalf("live mode without API key produced cassette output unexpectedly")
+		}
+		// stderr should mention GOOGLE_API_KEY or live mode.
+		errOut := stderr.String()
+		if errOut == "" {
+			t.Logf("warning: no stderr output from live mode (expected diagnostic)")
+		}
+	})
+}

--- a/transpiler3/c/runtime/src/llm.c
+++ b/transpiler3/c/runtime/src/llm.c
@@ -332,6 +332,100 @@ static const char *llm_anthropic_live(const char *model, const char *prompt,
     }
     return text;
 }
+
+/* ---- Google live provider (Phase 14.3) ---- */
+
+/* Build the Google Generative Language API JSON body. */
+static char *llm_google_build_body(const char *prompt) {
+    size_t prompt_len = strlen(prompt);
+    char *escaped = (char *)malloc(prompt_len * 6 + 1);
+    if (!escaped) return NULL;
+    size_t j = 0;
+    for (size_t i = 0; i < prompt_len; i++) {
+        unsigned char c = (unsigned char)prompt[i];
+        if (c == '"')       { escaped[j++] = '\\'; escaped[j++] = '"'; }
+        else if (c == '\\') { escaped[j++] = '\\'; escaped[j++] = '\\'; }
+        else if (c == '\n') { escaped[j++] = '\\'; escaped[j++] = 'n'; }
+        else if (c == '\r') { escaped[j++] = '\\'; escaped[j++] = 'r'; }
+        else if (c == '\t') { escaped[j++] = '\\'; escaped[j++] = 't'; }
+        else { escaped[j++] = (char)c; }
+    }
+    escaped[j] = '\0';
+
+    size_t body_cap = j + 128;
+    char *body = (char *)malloc(body_cap);
+    if (!body) { free(escaped); return NULL; }
+    snprintf(body, body_cap,
+             "{\"contents\":[{\"parts\":[{\"text\":\"%s\"}]}]}",
+             escaped);
+    free(escaped);
+    return body;
+}
+
+/* Call Google Generative Language API and return the generated text.
+ * API key goes in the URL query parameter (not a header). */
+static const char *llm_google_live(const char *model, const char *prompt,
+                                    const char *api_key) {
+    CURL *curl = curl_easy_init();
+    if (!curl) {
+        fprintf(stderr, "mochi_llm_generate: curl_easy_init failed\n");
+        return "";
+    }
+
+    const char *m = (model && *model) ? model : "gemini-1.5-flash";
+    char *body = llm_google_build_body(prompt);
+    if (!body) {
+        curl_easy_cleanup(curl);
+        return "";
+    }
+
+    /* URL: https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key} */
+    char url[2048];
+    snprintf(url, sizeof(url),
+             "https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent?key=%s",
+             m, api_key);
+
+    struct curl_slist *headers = NULL;
+    headers = curl_slist_append(headers, "Content-Type: application/json");
+
+    llm_buf_t resp = {NULL, 0, 0};
+
+    curl_easy_setopt(curl, CURLOPT_URL, url);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, llm_curl_write);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &resp);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
+
+    CURLcode rc = curl_easy_perform(curl);
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+    free(body);
+
+    if (rc != CURLE_OK) {
+        fprintf(stderr, "mochi_llm_generate: curl error: %s\n", curl_easy_strerror(rc));
+        if (resp.data) free(resp.data);
+        return "";
+    }
+
+    if (!resp.data) return "";
+
+    /* Extract candidates[0].content.parts[0].text from Google response JSON.
+     * Strategy: find "candidates" then "text" within it. */
+    const char *cand_pos = strstr(resp.data, "\"candidates\"");
+    if (!cand_pos) {
+        fprintf(stderr, "mochi_llm_generate: no 'candidates' key in Google response: %.200s\n", resp.data);
+        free(resp.data);
+        return "";
+    }
+    char *text = llm_json_str(cand_pos, "text");
+    free(resp.data);
+    if (!text) {
+        fprintf(stderr, "mochi_llm_generate: failed to extract text from Google response\n");
+        return "";
+    }
+    return text;
+}
 #endif /* MOCHI_LLM_HAVE_CURL */
 
 /* ---- provider dispatch ---- */
@@ -358,13 +452,23 @@ static const char *llm_live_dispatch(const char *provider, const char *model, co
         }
         return llm_anthropic_live(model, prompt, api_key);
     }
+    if (strcmp(provider, "google") == 0) {
+        const char *api_key = getenv("GOOGLE_API_KEY");
+        if (!api_key || !*api_key) {
+            fprintf(stderr,
+                    "mochi_llm_generate: GOOGLE_API_KEY not set "
+                    "(provider=google, live mode requires an API key)\n");
+            return "";
+        }
+        return llm_google_live(model, prompt, api_key);
+    }
 #endif /* MOCHI_LLM_HAVE_CURL */
 
     (void)provider; (void)model; (void)prompt;
     fprintf(stderr,
             "mochi_llm_generate: live mode for provider=%s not implemented; "
             "set MOCHI_LLM_CASSETTE_DIR for cassette replay, or compile with "
-            "-DMOCHI_LLM_HAVE_CURL -lcurl and set ANTHROPIC_API_KEY / OPENAI_API_KEY\n",
+            "-DMOCHI_LLM_HAVE_CURL -lcurl and set GOOGLE_API_KEY / ANTHROPIC_API_KEY / OPENAI_API_KEY\n",
             provider);
     return "";
 }

--- a/website/docs/implementation/0045/phase-14-llm.md
+++ b/website/docs/implementation/0045/phase-14-llm.md
@@ -31,11 +31,15 @@ LLM generation is the user-facing AI-augmented workflow that Mochi positions its
 | 14.0 | `mochi/llm.h` + `llm.c` cassette runtime; `LLMGenerateExpr` IR; lower + emit for `generate <provider> { prompt, model }`; type-checker recognises openai/anthropic/google/llama providers; 10 fixtures; `TestPhase14LLM` gate | LANDED 2026-05-26 07:14 (GMT+7) | — | — |
 | 14.1 | OpenAI live provider via libcurl (`-DMOCHI_LLM_HAVE_CURL -lcurl`); simple JSON extraction for `choices[0].message.content`; `TestPhase14OpenAI` gate (cassette + live-no-api-key sub-tests; no real API call) | LANDED 2026-05-26 07:24 (GMT+7) | — | — |
 | 14.2 | Anthropic live provider via libcurl (`ANTHROPIC_API_KEY`); `llm_anthropic_live()` with `x-api-key` + `anthropic-version` headers; extracts `content[0].text` via strstr; `TestPhase14Anthropic` gate (cassette + live-no-api-key sub-tests) | LANDED 2026-05-26 07:30 (GMT+7) | — | — |
-| 14.3 | Google provider                                                                                                    | NOT STARTED | —      | — |
+| 14.3 | Google live provider (`GOOGLE_API_KEY`; API key in URL query param; `gemini-1.5-flash` default; extracts `candidates[0].content.parts[0].text` via strstr); `TestPhase14Google` gate | LANDED 2026-05-26 07:32 (GMT+7) | — | — |
 | 14.4 | llama.cpp local provider (linked only with `--with-llama`)                                                         | NOT STARTED | —      | — |
 | 14.5 | Live HTTP providers via libcurl + yyjson; cassette recording mode                                                  | NOT STARTED | —      | — |
 
 ## Decisions made
+
+**Phase 14.3: Google API key in URL.** The Google Generative Language API authenticates via a `?key=<GOOGLE_API_KEY>` query parameter appended to the URL (`https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}`), not a header. The URL is built with `snprintf` in `llm_google_live()`. Default model is `gemini-1.5-flash`.
+
+**Phase 14.3: candidates[0].text extraction.** The Google response nests the output under `candidates[0].content.parts[0].text`. The existing `llm_json_str` helper is reused: find `"candidates"` in the response, then find `"text"` from that position. This is sufficient for single-candidate responses (the common case).
 
 **Phase 14.2: Anthropic request format.** The Anthropic messages API uses `POST https://api.anthropic.com/v1/messages` with headers `x-api-key: <key>` and `anthropic-version: 2023-06-01`. The request body includes `"max_tokens": 1024` (required by Anthropic). Default model is `claude-3-haiku-20240307` when none is specified.
 
@@ -67,4 +71,4 @@ _Provider-specific tool-use / function-calling integration tests: a follow-up ph
 
 ## Closeout notes
 
-Sub-phases 14.0, 14.1, and 14.2 are LANDED. The `generate <provider> { ... }` expression compiles and runs in cassette replay mode with 10 fixtures; OpenAI and Anthropic live providers are available when compiled with `-DMOCHI_LLM_HAVE_CURL -lcurl`. Providers 14.3-14.4 (Google, llama.cpp) and cassette recording (14.5) remain NOT STARTED.
+Sub-phases 14.0 through 14.3 are LANDED. The `generate <provider> { ... }` expression compiles and runs in cassette replay mode with 10 fixtures; OpenAI, Anthropic, and Google live providers are available when compiled with `-DMOCHI_LLM_HAVE_CURL -lcurl`. Provider 14.4 (llama.cpp) and cassette recording (14.5) remain NOT STARTED.

--- a/website/docs/mep/mep-0045.md
+++ b/website/docs/mep/mep-0045.md
@@ -669,7 +669,7 @@ Phase conventions:
 | 14.0 | `mochi/llm.h` + `llm.c` cassette runtime (DJB2-keyed files, `MOCHI_LLM_CASSETTE_DIR`); `LLMGenerateExpr` IR; lower + emit for `generate <provider> { prompt, model }`; type-checker provider whitelist; 10 fixtures; `TestPhase14LLM` gate | LANDED 2026-05-26 07:14 (GMT+7) | — |
 | 14.1 | OpenAI live provider via libcurl (opt-in `-DMOCHI_LLM_HAVE_CURL -lcurl`); simple JSON extractor for `choices[0].message.content`; `TestPhase14OpenAI` gate (cassette + live-no-api-key) | LANDED 2026-05-26 07:24 (GMT+7) | — |
 | 14.2 | Anthropic live provider (`ANTHROPIC_API_KEY`; `anthropic-version: 2023-06-01`; `content[0].text` extraction) | LANDED 2026-05-26 07:30 (GMT+7) | — |
-| 14.3 | Google provider | NOT STARTED | — |
+| 14.3 | Google live provider (`GOOGLE_API_KEY`; key in URL query param; `gemini-1.5-flash` default; `candidates[0].content.parts[0].text` extraction) | LANDED 2026-05-26 07:32 (GMT+7) | — |
 | 14.4 | llama.cpp local provider (linked in only when `--with-llama` is set; otherwise stub) | NOT STARTED | — |
 | 14.5 | Live HTTP providers; cassette recording mode | NOT STARTED | — |
 


### PR DESCRIPTION
## Summary

- Adds `llm_google_live()` in `llm.c` behind `#if MOCHI_LLM_HAVE_CURL`, reusing existing `llm_buf_t` / `llm_curl_write` / `llm_json_str` helpers
- Google API: `POST https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={GOOGLE_API_KEY}`; body `{contents:[{parts:[{text:"..."}]}]}`; extracts `candidates[0].content.parts[0].text` by finding `"candidates"` then `"text"` via `llm_json_str`; default model `gemini-1.5-flash`
- Wired in `llm_live_dispatch()` for `provider == "google"`, using `GOOGLE_API_KEY` env var
- Gate: `TestPhase14Google` (cassette_mode + live_no_api_key; no real HTTP calls)
- Spec: `phase-14-llm.md` and `mep-0045.md` updated to LANDED

Closes #22226