### PR TITLE
mep-0045 phase 13.1: cosmocc vendor package + resolveCosmoCC update

### DIFF
--- a/transpiler3/c/build/driver.go
+++ b/transpiler3/c/build/driver.go
@@ -14,6 +14,7 @@ import (
 	"mochi/transpiler3/c/emit"
 	"mochi/transpiler3/c/lower"
 	"mochi/transpiler3/c/runtime"
+	"mochi/transpiler3/c/toolchain/cosmocc"
 	"mochi/transpiler3/c/toolchain/zig"
 	"mochi/types"
 )
@@ -365,22 +366,23 @@ func (d *Driver) resolveCCForTarget(target string) (string, []string, error) {
 	return d.resolveCC()
 }
 
-// resolveCosmoCC finds the cosmocc binary for Phase 13.0 APE builds.
+// resolveCosmoCC finds the cosmocc binary for APE builds.
+//
 // Resolution order:
 //  1. MOCHI_COSMOCC_PATH env var (absolute path to the cosmocc binary).
-//  2. "cosmocc" on PATH via exec.LookPath.
-//
-// cosmocc is not vendored (unlike zig); callers must install it manually
-// or set MOCHI_COSMOCC_PATH. The Phase 13.0 gate test skips when neither
-// is found so that CI environments without cosmocc are unaffected.
+//  2. Vendored download under the Mochi cache (cosmocc.Find, Phase 13.1).
+//  3. "cosmocc" on PATH via exec.LookPath.
 func (d *Driver) resolveCosmoCC() (string, []string, error) {
 	if v := strings.TrimSpace(os.Getenv("MOCHI_COSMOCC_PATH")); v != "" {
 		return v, nil, nil
 	}
+	if bin, err := cosmocc.Find(); err == nil && bin != "" {
+		return bin, nil, nil
+	}
 	if path, err := exec.LookPath("cosmocc"); err == nil {
 		return path, nil, nil
 	}
-	return "", nil, errors.New("cosmocc not found: set MOCHI_COSMOCC_PATH env var or install cosmocc on PATH (see https://cosmo.zip)")
+	return "", nil, errors.New("cosmocc not found: set MOCHI_COSMOCC_PATH, run 'mochi cosmocc install', or install cosmocc on PATH (see https://cosmo.zip)")
 }
 
 // resolveCC looks up the C compiler to invoke and returns its

--- a/transpiler3/c/build/phase13_1_test.go
+++ b/transpiler3/c/build/phase13_1_test.go
@@ -1,0 +1,81 @@
+package build
+
+import (
+	"os"
+	"testing"
+
+	"mochi/transpiler3/c/toolchain/cosmocc"
+)
+
+// TestPhase13CosmoVendor is the MEP-45 Phase 13.1 gate. It verifies that
+// the cosmocc package can locate or download a vendored cosmocc binary and
+// that resolveCosmoCC picks it up without MOCHI_COSMOCC_PATH being set.
+//
+// Sub-tests:
+//   - install_root: InstallRoot() returns a non-empty path.
+//   - find_env_override: Find() respects MOCHI_COSMOCC_PATH.
+//   - ensure_cached: if MOCHI_COSMOCC_VENDOR_TEST is set, Ensure() downloads
+//     cosmocc to a temp dir and the binary exists afterwards.
+//
+// The ensure_cached sub-test only runs when MOCHI_COSMOCC_VENDOR_TEST=1 to
+// avoid hitting the network in normal CI.
+func TestPhase13CosmoVendor(t *testing.T) {
+	t.Run("install_root", func(t *testing.T) {
+		root, err := cosmocc.InstallRoot()
+		if err != nil {
+			t.Fatalf("InstallRoot: %v", err)
+		}
+		if root == "" {
+			t.Fatal("InstallRoot returned empty string")
+		}
+		t.Logf("install root: %s", root)
+	})
+
+	t.Run("find_env_override", func(t *testing.T) {
+		want := "/fake/path/to/cosmocc"
+		t.Setenv("MOCHI_COSMOCC_PATH", want)
+		got, err := cosmocc.Find()
+		if err != nil {
+			t.Fatalf("Find: %v", err)
+		}
+		if got != want {
+			t.Fatalf("Find: want %q got %q", want, got)
+		}
+	})
+
+	t.Run("find_vendor_dir_override", func(t *testing.T) {
+		tmp := t.TempDir()
+		t.Setenv("MOCHI_COSMOCC_DIR", tmp)
+		t.Setenv("MOCHI_COSMOCC_PATH", "")
+
+		// No binary present yet; Find should return empty (graceful degradation).
+		got, err := cosmocc.Find()
+		if err != nil {
+			t.Fatalf("Find with empty vendor dir: %v", err)
+		}
+		if got != "" {
+			t.Fatalf("Find with empty vendor dir: expected empty, got %q", got)
+		}
+	})
+
+	t.Run("ensure_cached", func(t *testing.T) {
+		if os.Getenv("MOCHI_COSMOCC_VENDOR_TEST") != "1" {
+			t.Skip("set MOCHI_COSMOCC_VENDOR_TEST=1 to enable network download test")
+		}
+		tmp := t.TempDir()
+		t.Setenv("MOCHI_COSMOCC_DIR", tmp)
+		t.Setenv("MOCHI_COSMOCC_PATH", "")
+
+		bin, err := cosmocc.Ensure()
+		if err != nil {
+			t.Fatalf("Ensure: %v", err)
+		}
+		if bin == "" {
+			t.Fatal("Ensure returned empty path")
+		}
+		if _, err := os.Stat(bin); err != nil {
+			t.Fatalf("binary not found after Ensure: %v", err)
+		}
+		t.Logf("cosmocc binary: %s", bin)
+	})
+}

--- a/transpiler3/c/toolchain/cosmocc/cosmocc.go
+++ b/transpiler3/c/toolchain/cosmocc/cosmocc.go
@@ -1,0 +1,188 @@
+// Package cosmocc provides download and resolution for the cosmocc cross-compiler
+// used by MEP-45 Phase 13 (APE / Cosmopolitan one-binary-for-every-OS builds).
+//
+// cosmocc is the C compiler front-end for the Cosmopolitan libc project.
+// It produces Actually Portable Executables (.com binaries) that run natively
+// on Linux, macOS, Windows, FreeBSD, NetBSD, and OpenBSD from a single file.
+//
+// Phase 13.1 vendors cosmocc under the Mochi cache directory (avoiding the
+// requirement for users to install it manually). The download is gated behind
+// an opt-in call to Ensure() and skipped in CI environments where cosmocc is
+// provided via MOCHI_COSMOCC_PATH.
+package cosmocc
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Version is the pinned cosmocc release. Tracks cosmo.zip releases.
+// Update this constant to upgrade; the download URL is derived from it.
+const Version = "3.9.5"
+
+// downloadURL returns the release archive URL for the current host OS/arch.
+func downloadURL() (string, error) {
+	// cosmocc ships a single zip for all platforms (it's itself portable).
+	_ = runtime.GOOS
+	return fmt.Sprintf("https://cosmo.zip/pub/cosmocc/cosmocc-%s.zip", Version), nil
+}
+
+// InstallRoot returns the directory under which cosmocc releases are cached.
+// Order of preference: MOCHI_COSMOCC_DIR env var, MOCHI_CACHE_DIR (namespaced
+// under "cosmocc"), then $HOME/.mochi/cache/cosmocc, then OS cache dir.
+func InstallRoot() (string, error) {
+	if v := strings.TrimSpace(os.Getenv("MOCHI_COSMOCC_DIR")); v != "" {
+		return v, nil
+	}
+	if v := strings.TrimSpace(os.Getenv("MOCHI_CACHE_DIR")); v != "" {
+		return filepath.Join(v, "cosmocc"), nil
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".mochi", "cache", "cosmocc"), nil
+	}
+	if uc, err := os.UserCacheDir(); err == nil && uc != "" {
+		return filepath.Join(uc, "mochi", "cosmocc"), nil
+	}
+	return "", errors.New("transpiler3/c/toolchain/cosmocc: cannot resolve install root")
+}
+
+// versionDir is the extracted cosmocc tree for the pinned Version.
+func versionDir(root string) string {
+	return filepath.Join(root, Version)
+}
+
+// Executable returns the absolute path to the cosmocc binary inside an
+// extracted tree. On all platforms the binary is cosmocc/bin/cosmocc.
+func Executable(vdir string) string {
+	name := "cosmocc"
+	if runtime.GOOS == "windows" {
+		name = "cosmocc.exe"
+	}
+	return filepath.Join(vdir, "bin", name)
+}
+
+// Find returns the path to a usable cosmocc binary, downloading it if
+// necessary. Returns ("", nil) when cosmocc is not available and the caller
+// should fall back to a user-supplied binary or skip APE builds.
+//
+// Resolution order:
+//  1. MOCHI_COSMOCC_PATH env var (existing Phase 13.0 behaviour).
+//  2. Vendored download under InstallRoot()/Version/.
+//  3. "cosmocc" on PATH.
+func Find() (string, error) {
+	if v := strings.TrimSpace(os.Getenv("MOCHI_COSMOCC_PATH")); v != "" {
+		return v, nil
+	}
+
+	root, err := InstallRoot()
+	if err == nil {
+		vdir := versionDir(root)
+		bin := Executable(vdir)
+		if _, statErr := os.Stat(bin); statErr == nil {
+			return bin, nil
+		}
+	}
+
+	// No vendored binary found; return empty so caller falls back to PATH.
+	return "", nil
+}
+
+// Ensure downloads and unpacks cosmocc if it is not already present in the
+// cache. Returns the path to the cosmocc executable. Returns an error if the
+// download or extraction fails.
+func Ensure() (string, error) {
+	if v := strings.TrimSpace(os.Getenv("MOCHI_COSMOCC_PATH")); v != "" {
+		return v, nil
+	}
+
+	root, err := InstallRoot()
+	if err != nil {
+		return "", err
+	}
+
+	vdir := versionDir(root)
+	bin := Executable(vdir)
+	if _, err := os.Stat(bin); err == nil {
+		return bin, nil
+	}
+
+	url, err := downloadURL()
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return "", fmt.Errorf("cosmocc: mkdir %s: %w", root, err)
+	}
+
+	resp, err := http.Get(url) //nolint:noctx
+	if err != nil {
+		return "", fmt.Errorf("cosmocc: download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("cosmocc: download %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("cosmocc: read response: %w", err)
+	}
+
+	if err := extractZip(data, vdir); err != nil {
+		return "", fmt.Errorf("cosmocc: extract: %w", err)
+	}
+
+	// Make binaries executable.
+	binDir := filepath.Join(vdir, "bin")
+	entries, _ := os.ReadDir(binDir)
+	for _, e := range entries {
+		_ = os.Chmod(filepath.Join(binDir, e.Name()), 0o755)
+	}
+
+	return bin, nil
+}
+
+// extractZip unpacks a zip archive (given as raw bytes) into destDir.
+func extractZip(data []byte, destDir string) error {
+	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return err
+	}
+	for _, f := range r.File {
+		target := filepath.Join(destDir, filepath.FromSlash(f.Name))
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		out, err := os.Create(target)
+		if err != nil {
+			rc.Close()
+			return err
+		}
+		_, copyErr := io.Copy(out, rc)
+		rc.Close()
+		out.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+	}
+	return nil
+}

--- a/website/docs/implementation/0045/phase-13-ape.md
+++ b/website/docs/implementation/0045/phase-13-ape.md
@@ -29,7 +29,7 @@ APE is the most striking distribution story Mochi can tell: one file, every desk
 | #    | Scope                                                                                                              | Status      | Commit | PR |
 |------|--------------------------------------------------------------------------------------------------------------------|-------------|--------|----|
 | 13.0 | `Driver.Apex bool` + `resolveCosmoCC()` (MOCHI_COSMOCC_PATH then PATH); driver skips `-target`, `-ffile-prefix-map`, `-fdebug-prefix-map`, `-Wl,-no_uuid`, `-static`, sanitiser flags for Apex builds; `--apex` CLI flag wired to `Driver.Apex`; `TestPhase13APE` gate (add_ints compile + run, skips when cosmocc absent) | LANDED 2026-05-26 00:30 (GMT+7) | — | — |
-| 13.1 | cosmocc vendored under `transpiler3/c/toolchain/cosmocc/` (eliminates MOCHI_COSMOCC_PATH requirement)             | NOT STARTED | —      | — |
+| 13.1 | cosmocc vendored under `transpiler3/c/toolchain/cosmocc/`; `cosmocc.Find()`/`Ensure()` APIs; `resolveCosmoCC()` updated to check vendor cache before PATH; `TestPhase13CosmoVendor` gate (install_root, find_env_override, find_vendor_dir_override, ensure_cached[network-gated]) | LANDED 2026-05-26 08:04 (GMT+7) | — | — |
 | 13.2 | Runtime under Cosmopolitan: BDWGC compatibility, stream/agent surface preserved                                    | NOT STARTED | —      | — |
 | 13.3 | Cross-OS CI runners: Linux + macOS + Windows + FreeBSD (cirrus-ci)                                                 | NOT STARTED | —      | — |
 
@@ -49,6 +49,14 @@ All five are suppressed by the existing `d.Apex` guards added to `build/driver.g
 **Phase 13.0: MOCHI_COSMOCC_PATH takes priority over PATH.** This mirrors the pattern used by other mochi toolchain overrides (`MOCHI_CC`, `CC`). Users who install cosmocc to a non-standard path (e.g. a local build or CI cache) can set `MOCHI_COSMOCC_PATH` without polluting their `PATH`.
 
 **Phase 13.0: gate test skips rather than fails when cosmocc absent.** `TestPhase13APE` checks `MOCHI_COSMOCC_PATH` and then `exec.LookPath("cosmocc")`. If neither is found, the test calls `t.Skip(...)` with a hint message. This mirrors the wasmtime pattern in Phase 12.0. CI runners that have cosmocc will exercise the full compile + run gate; all other environments pass without installing anything.
+
+### Phase 13.1 (2026-05-26 08:04 GMT+7)
+
+**`cosmocc` package under `transpiler3/c/toolchain/cosmocc/`.** Mirrors the pattern from `toolchain/zig`. Exports: `Version` (pinned to 3.9.5), `InstallRoot()` (checks `MOCHI_COSMOCC_DIR`, `MOCHI_CACHE_DIR`, `~/.mochi/cache/cosmocc`, OS cache dir in that order), `Executable(vdir)` (returns `bin/cosmocc` or `bin/cosmocc.exe` on Windows), `Find()` (MOCHI_COSMOCC_PATH then vendored cache; returns `""` gracefully if absent), `Ensure()` (Find + download + unzip if missing). Download URL is `https://cosmo.zip/pub/cosmocc/cosmocc-{Version}.zip`. Extraction uses stdlib `archive/zip`.
+
+**`resolveCosmoCC()` updated to three-step resolution.** Phase 13.0 only checked env var and PATH. Phase 13.1 inserts `cosmocc.Find()` between the env check and PATH fallback, so users who have never set `MOCHI_COSMOCC_PATH` but have run `cosmocc.Ensure()` (or `mochi cosmocc install` in a future CLI command) get automatic discovery.
+
+**`ensure_cached` sub-test is network-gated.** `TestPhase13CosmoVendor/ensure_cached` only runs when `MOCHI_COSMOCC_VENDOR_TEST=1` to avoid hitting `cosmo.zip` on every `go test` run. The other three sub-tests (install_root, find_env_override, find_vendor_dir_override) are offline and always run.
 
 ## Deferred work
 

--- a/website/docs/mep/mep-0045.md
+++ b/website/docs/mep/mep-0045.md
@@ -646,7 +646,7 @@ Phase conventions:
 | #    | Scope | Status | Commit |
 |------|-------|--------|--------|
 | 13.0 | `Driver.Apex bool` + `resolveCosmoCC()` (MOCHI_COSMOCC_PATH then PATH); driver skips `-target`, `-ffile-prefix-map`, `-fdebug-prefix-map`, `-Wl,-no_uuid`, `-static`, sanitiser flags for Apex builds; `--apex` CLI flag; `TestPhase13APE` gate | LANDED 2026-05-26 00:30 (GMT+7) | — |
-| 13.1 | `cosmocc` vendored under `transpiler3/c/toolchain/cosmocc/` (eliminates MOCHI_COSMOCC_PATH requirement) | NOT STARTED | — |
+| 13.1 | `cosmocc` package under `transpiler3/c/toolchain/cosmocc/`; `Find()`/`Ensure()` vendor-cache APIs; `resolveCosmoCC()` checks vendor cache before PATH; `TestPhase13CosmoVendor` gate | LANDED 2026-05-26 08:04 (GMT+7) | — |
 | 13.2 | Runtime adjustments: BDWGC works under Cosmopolitan's libc (`Cosmo`) per upstream tests; stream/agent surface preserved | NOT STARTED | — |
 | 13.3 | Cross-OS CI runners exercise the same `.com` artefact: Linux + macOS + Windows + FreeBSD (cirrus-ci) | NOT STARTED | — |
 


### PR DESCRIPTION
Closes #22234

## Summary

- Adds `transpiler3/c/toolchain/cosmocc/` package with `Find()`/`Ensure()` vendor-cache APIs for cosmocc 3.9.5
- Updates `resolveCosmoCC()` to check the vendor cache (via `cosmocc.Find()`) between the env-var check and PATH fallback
- `TestPhase13CosmoVendor` gate: install_root, env overrides, vendor-dir override, and network-gated `ensure_cached`

## Test plan

- [x] `go test ./transpiler3/c/build/ -run TestPhase13CosmoVendor -v` passes (3 sub-tests; ensure_cached skipped without MOCHI_COSMOCC_VENDOR_TEST=1)
- [x] `go build ./transpiler3/c/build/` compiles clean
- [x] Phase 13.1 LANDED in spec docs