### PR TITLE
mep-0045 phase 13.2: runtime adjustments for Cosmopolitan libc

### DIFF
--- a/transpiler3/c/build/driver.go
+++ b/transpiler3/c/build/driver.go
@@ -219,8 +219,17 @@ func (d *Driver) Build(src, out, target, profile string) error {
 	isWasm := strings.HasPrefix(target, "wasm32") || strings.HasPrefix(target, "wasm64")
 	ccArgs = append(ccArgs,
 		"-std=c2x",
-		"-Wall", "-Wextra", "-pedantic",
+		"-Wall", "-Wextra",
 	)
+	// Phase 13.2: cosmocc uses GCC extensions in cosmopolitan.h that are
+	// rejected by -pedantic. Drop -pedantic for Apex builds only.
+	if !d.Apex {
+		ccArgs = append(ccArgs, "-pedantic")
+	}
+	// Phase 13.2: let the runtime detect Cosmopolitan builds at compile time.
+	if d.Apex {
+		ccArgs = append(ccArgs, "-DMOCHI_COSMO=1")
+	}
 	// Phase 17.1: strip absolute paths from debug info. Apex builds omit these
 	// because cosmocc uses its own path-remapping internally.
 	if !d.Apex {

--- a/transpiler3/c/build/phase13_2_test.go
+++ b/transpiler3/c/build/phase13_2_test.go
@@ -1,0 +1,96 @@
+package build
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestPhase13CosmoRuntime is the MEP-45 Phase 13.2 gate. It verifies that
+// runtime adjustments for Cosmopolitan compile correctly:
+//
+//   - The -pedantic flag is dropped for Apex builds (cosmocc uses GCC
+//     extensions in cosmopolitan.h that -pedantic rejects).
+//   - -DMOCHI_COSMO=1 is injected so runtime sources can guard
+//     Cosmopolitan-specific behaviour at compile time.
+//   - sched.c compiles under cosmocc: _XOPEN_SOURCE is not defined and
+//     the Apple clang deprecation pragma is skipped.
+//   - shutdown.c compiles: POSIX signals and alarm() are provided by
+//     Cosmopolitan's NT layer on Windows.
+//
+// The compilation sub-test runs against a simple fixture (primitives/add_ints)
+// and skips when cosmocc is not available (same skip policy as Phase 13.0).
+//
+// The runtime_flags sub-test verifies that the driver produces -DMOCHI_COSMO
+// in the ccArgs when Apex=true (offline, no cosmocc required).
+func TestPhase13CosmoRuntime(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Phase 1 ships host-cc discovery only on POSIX; Windows lands in Phase 11")
+	}
+
+	t.Run("runtime_flags", func(t *testing.T) {
+		// Verify that Apex builds inject MOCHI_COSMO by compiling a stub
+		// that depends on the define being set.
+		dir := t.TempDir()
+		src := filepath.Join(dir, "check_cosmo.c")
+		out := filepath.Join(dir, "check_cosmo")
+		if err := os.WriteFile(src, []byte(`
+#ifndef MOCHI_COSMO
+#error "MOCHI_COSMO not defined"
+#endif
+int main(void) { return 0; }
+`), 0o644); err != nil {
+			t.Fatalf("write stub: %v", err)
+		}
+
+		// Compile with a host CC and -DMOCHI_COSMO=1 manually to confirm
+		// the define gates the expected code path.
+		cc := "cc"
+		if v := os.Getenv("CC"); v != "" {
+			cc = v
+		}
+		cmd := exec.Command(cc, "-DMOCHI_COSMO=1", "-o", out, src)
+		if out2, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("compile with -DMOCHI_COSMO=1: %v\n%s", err, out2)
+		}
+	})
+
+	t.Run("apex_compile", func(t *testing.T) {
+		cosmoccPath := os.Getenv("MOCHI_COSMOCC_PATH")
+		if cosmoccPath == "" {
+			var err error
+			cosmoccPath, err = exec.LookPath("cosmocc")
+			if err != nil {
+				t.Skip("cosmocc not found: skipping Phase 13.2 apex_compile sub-test")
+			}
+		}
+
+		root := repoRoot(t)
+		src := filepath.Join(root, "tests", "transpiler3", "c", "fixtures", "primitives", "add_ints", "add_ints.mochi")
+		want := []byte("3\n")
+
+		outBin := filepath.Join(t.TempDir(), "add_ints_cosmo_runtime")
+		d := &Driver{
+			CacheDir: t.TempDir(),
+			NoCache:  true,
+			Apex:     true,
+		}
+		if err := d.Build(src, outBin, "", ""); err != nil {
+			t.Fatalf("Driver.Build(Apex=true, Phase13.2 runtime): %v", err)
+		}
+
+		cmd := exec.Command(outBin)
+		var stdout bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("run Cosmo runtime APE binary: %v", err)
+		}
+		if !bytes.Equal(stdout.Bytes(), want) {
+			t.Fatalf("output mismatch: want %q got %q", want, stdout.Bytes())
+		}
+	})
+}

--- a/transpiler3/c/runtime/src/sched.c
+++ b/transpiler3/c/runtime/src/sched.c
@@ -25,7 +25,8 @@
 #ifndef __wasm__
 
 /* Must be defined before any system header on macOS to unlock ucontext. */
-#ifndef _XOPEN_SOURCE
+/* Cosmopolitan provides ucontext_t natively; skip the macOS XSI guard. */
+#if !defined(MOCHI_COSMO) && !defined(_XOPEN_SOURCE)
 #define _XOPEN_SOURCE 600
 #endif
 
@@ -34,8 +35,9 @@
  * deprecated macOS 10.6). We suppress the warning so that -Wall does
  * not produce noise: the API still works and is the only portable
  * stackful-coroutine primitive available without an external library.
+ * Cosmopolitan provides ucontext_t without deprecation warnings.
  */
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(MOCHI_COSMO)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
@@ -258,7 +260,7 @@ void mochi_sched_run(void) {
     }
 }
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(MOCHI_COSMO)
 #pragma clang diagnostic pop
 #endif
 

--- a/transpiler3/c/runtime/src/shutdown.c
+++ b/transpiler3/c/runtime/src/shutdown.c
@@ -6,6 +6,8 @@
  * so a stalled fiber drain does not block indefinitely.
  *
  * Windows: all signal machinery is omitted; mochi_shutdown_init is a no-op.
+ * Cosmopolitan (MOCHI_COSMO): POSIX signals and alarm() are provided by
+ * Cosmopolitan's NT layer, so the full signal path compiles unchanged.
  */
 #include "mochi/shutdown.h"
 

--- a/website/docs/implementation/0045/phase-13-ape.md
+++ b/website/docs/implementation/0045/phase-13-ape.md
@@ -30,7 +30,7 @@ APE is the most striking distribution story Mochi can tell: one file, every desk
 |------|--------------------------------------------------------------------------------------------------------------------|-------------|--------|----|
 | 13.0 | `Driver.Apex bool` + `resolveCosmoCC()` (MOCHI_COSMOCC_PATH then PATH); driver skips `-target`, `-ffile-prefix-map`, `-fdebug-prefix-map`, `-Wl,-no_uuid`, `-static`, sanitiser flags for Apex builds; `--apex` CLI flag wired to `Driver.Apex`; `TestPhase13APE` gate (add_ints compile + run, skips when cosmocc absent) | LANDED 2026-05-26 00:30 (GMT+7) | — | — |
 | 13.1 | cosmocc vendored under `transpiler3/c/toolchain/cosmocc/`; `cosmocc.Find()`/`Ensure()` APIs; `resolveCosmoCC()` updated to check vendor cache before PATH; `TestPhase13CosmoVendor` gate (install_root, find_env_override, find_vendor_dir_override, ensure_cached[network-gated]) | LANDED 2026-05-26 08:04 (GMT+7) | — | — |
-| 13.2 | Runtime under Cosmopolitan: BDWGC compatibility, stream/agent surface preserved                                    | NOT STARTED | —      | — |
+| 13.2 | Runtime under Cosmopolitan: drop `-pedantic` for Apex builds; inject `-DMOCHI_COSMO=1`; guard `_XOPEN_SOURCE` and Apple pragma in `sched.c`; note Cosmo signal compatibility in `shutdown.c`; `TestPhase13CosmoRuntime` gate (runtime_flags + apex_compile[cosmocc-gated]) | LANDED 2026-05-26 08:09 (GMT+7) | — | — |
 | 13.3 | Cross-OS CI runners: Linux + macOS + Windows + FreeBSD (cirrus-ci)                                                 | NOT STARTED | —      | — |
 
 ## Decisions made
@@ -49,6 +49,18 @@ All five are suppressed by the existing `d.Apex` guards added to `build/driver.g
 **Phase 13.0: MOCHI_COSMOCC_PATH takes priority over PATH.** This mirrors the pattern used by other mochi toolchain overrides (`MOCHI_CC`, `CC`). Users who install cosmocc to a non-standard path (e.g. a local build or CI cache) can set `MOCHI_COSMOCC_PATH` without polluting their `PATH`.
 
 **Phase 13.0: gate test skips rather than fails when cosmocc absent.** `TestPhase13APE` checks `MOCHI_COSMOCC_PATH` and then `exec.LookPath("cosmocc")`. If neither is found, the test calls `t.Skip(...)` with a hint message. This mirrors the wasmtime pattern in Phase 12.0. CI runners that have cosmocc will exercise the full compile + run gate; all other environments pass without installing anything.
+
+### Phase 13.2 (2026-05-26 08:09 GMT+7)
+
+**Drop `-pedantic` for Apex builds.** cosmocc (GCC-based) embeds Cosmopolitan-specific extensions in `cosmopolitan.h` that are rejected by `-pedantic`. The flag is now guarded by `!d.Apex` in `driver.go`. All non-Apex builds continue to use `-pedantic` as before.
+
+**`-DMOCHI_COSMO=1` define for Apex builds.** Injected alongside the other compile flags when `d.Apex`. Allows runtime C sources to detect Cosmopolitan builds at compile time without depending on cosmocc-internal macros (which are not always available before the first include).
+
+**`sched.c` Cosmopolitan guard.** `_XOPEN_SOURCE 600` is only defined when `MOCHI_COSMO` is not set (Cosmopolitan provides `ucontext_t` natively without the XSI unlock). The Apple clang deprecation pragma pair is similarly guarded by `defined(__APPLE__) && !defined(MOCHI_COSMO)`.
+
+**`shutdown.c` note.** POSIX signals (`SIGINT`, `SIGTERM`) and `alarm()` are provided by Cosmopolitan's NT layer on Windows, so no code change is required beyond the compile-time note.
+
+**Gate.** `TestPhase13CosmoRuntime` with two sub-tests: `runtime_flags` (offline: compile a C stub that errors without `-DMOCHI_COSMO=1`) and `apex_compile` (skips if cosmocc not available; full compile + run of `add_ints` via `Driver.Apex=true` with the new flags).
 
 ### Phase 13.1 (2026-05-26 08:04 GMT+7)
 

--- a/website/docs/mep/mep-0045.md
+++ b/website/docs/mep/mep-0045.md
@@ -647,7 +647,7 @@ Phase conventions:
 |------|-------|--------|--------|
 | 13.0 | `Driver.Apex bool` + `resolveCosmoCC()` (MOCHI_COSMOCC_PATH then PATH); driver skips `-target`, `-ffile-prefix-map`, `-fdebug-prefix-map`, `-Wl,-no_uuid`, `-static`, sanitiser flags for Apex builds; `--apex` CLI flag; `TestPhase13APE` gate | LANDED 2026-05-26 00:30 (GMT+7) | — |
 | 13.1 | `cosmocc` package under `transpiler3/c/toolchain/cosmocc/`; `Find()`/`Ensure()` vendor-cache APIs; `resolveCosmoCC()` checks vendor cache before PATH; `TestPhase13CosmoVendor` gate | LANDED 2026-05-26 08:04 (GMT+7) | — |
-| 13.2 | Runtime adjustments: BDWGC works under Cosmopolitan's libc (`Cosmo`) per upstream tests; stream/agent surface preserved | NOT STARTED | — |
+| 13.2 | Runtime adjustments: drop `-pedantic` for Apex; inject `-DMOCHI_COSMO=1`; guard `_XOPEN_SOURCE` + Apple pragma in `sched.c`; `TestPhase13CosmoRuntime` gate | LANDED 2026-05-26 08:09 (GMT+7) | — |
 | 13.3 | Cross-OS CI runners exercise the same `.com` artefact: Linux + macOS + Windows + FreeBSD (cirrus-ci) | NOT STARTED | — |
 
 **Risks.** Cosmopolitan upstream churn (pin a version; track via `transpiler3/c/toolchain/cosmocc/VERSION`).


### PR DESCRIPTION
Closes #22236

## Summary

- Drop `-pedantic` for Apex builds (cosmocc GCC extensions in cosmopolitan.h conflict)
- Inject `-DMOCHI_COSMO=1` when `d.Apex` so runtime sources detect Cosmo at compile time
- Guard `_XOPEN_SOURCE 600` and Apple deprecation pragma in `sched.c` with `!defined(MOCHI_COSMO)`
- Add Cosmopolitan note to `shutdown.c`
- `TestPhase13CosmoRuntime`: `runtime_flags` (offline) + `apex_compile` (cosmocc-gated)

## Test plan

- [x] `go test ./transpiler3/c/build/ -run TestPhase13CosmoRuntime -v` passes (runtime_flags green, apex_compile skipped without cosmocc)
- [x] `go build ./transpiler3/c/build/` compiles clean