### PR TITLE
mep-0046: detailed implementation specs for all 20 phases (0-19)

### DIFF
--- a/website/docs/implementation/0046/phase-00-skeleton.md
+++ b/website/docs/implementation/0046/phase-00-skeleton.md
@@ -1,15 +1,15 @@
 ---
 title: "Phase 0. Spec freeze and skeleton trees"
 sidebar_position: 2
-sidebar_label: "Phase 0. Spec freeze and skeleton trees"
-description: "MEP-46 Phase 0. Spec freeze and skeleton trees tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+sidebar_label: "Phase 0. Skeleton"
+description: "MEP-46 Phase 0 tracking: spec freeze, transpiler3/beam/ skeleton trees, OTP app stub, implementation tracking pages, sidebar wiring."
 ---
 
 # Phase 0. Spec freeze and skeleton trees
 
 | Field          | Value |
 |----------------|-------|
-| MEP            | [MEP-46 §Phases · Phase 0. Spec freeze and skeleton trees](/docs/mep/mep-0046#phase-0-spec-freeze-and-skeleton-trees) |
+| MEP            | [MEP-46 §Phases · Phase 0](/docs/mep/mep-0046#phase-0-spec-freeze-and-skeleton-trees) |
 | Status         | NOT STARTED |
 | Started        | — |
 | Landed         | — |
@@ -18,23 +18,157 @@ description: "MEP-46 Phase 0. Spec freeze and skeleton trees tracking stub. Fill
 
 ## Gate
 
-See [MEP-46 §Phases · Phase 0. Spec freeze and skeleton trees](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+MEP-46 merged on `main`; `transpiler3/beam/{lower,emit,build}/doc.go` files exist and `go vet ./transpiler3/beam/...` is clean; `transpiler3/beam/runtime/src/{mochi_app,mochi_sup,mochi_atoms}.erl` stubs and `mochi.app.src` exist; `rebar3 compile` on the OTP app skeleton exits 0; `tests/transpiler3/beam/README.md` documents fixture layout; implementation tracking pages for every phase exist under `/docs/implementation/0046/`.
 
 ## Goal-alignment audit
 
-_Pending phase open._
+The user-facing goal of MEP-46 is "ship a Mochi program as an OTP application or standalone escript targeting the BEAM VM". Phase 0 does not move that goal directly. It plants the four structural anchors that make every later phase cheap to open: (1) the Go package tree tells a contributor which stage owns which concern without reading the MEP end-to-end, (2) the OTP app skeleton means every downstream phase can `rebar3 compile` its Erlang runtime pieces against a known module namespace, (3) the fixture README establishes the naming convention so fixture authors don't ask the same orientation questions twice, and (4) the per-phase tracking pages give a contributor a landing page with gate, decisions, and deferred work before the phase even opens. The cost is one PR; without it every later phase repeats this orientation cost inline.
 
 ## Sub-phases
 
-_Pending phase open._
+| #   | Scope | Status | Commit | PR |
+|-----|-------|--------|--------|----|
+| 0.0 | MEP-46 merged with §Phases section; implementation tracking pages created under `/docs/implementation/0046/`; Docusaurus sidebar wired | NOT STARTED | — | — |
+| 0.1 | `transpiler3/beam/{lower,emit,build}/doc.go` created; `go vet ./transpiler3/beam/...` clean | NOT STARTED | — | — |
+| 0.2 | `tests/transpiler3/beam/README.md` documents fixture layout and naming convention; `runVm3` test helper defined in `transpiler3/beam/build/build_test.go` | NOT STARTED | — | — |
+| 0.3 | OTP app skeleton: `mochi.app.src`, `mochi_app.erl`, `mochi_sup.erl`, `mochi_atoms.erl`; `rebar3 compile` exits 0 | NOT STARTED | — | — |
+
+## Sub-phase 0.0
+
+MEP-46 spec merged on `main`. The spec includes the §Phases section that lists every phase, its gate, and the fixture target counts. Implementation tracking pages (the files under `/docs/implementation/0046/`) are created as stubs; each stub links back to the MEP §Phases anchor so a contributor can navigate spec -> tracking page and back without ambiguity. The Docusaurus sidebar entry for MEP-46 is wired so the pages appear in the website's implementation section alongside MEP-45.
+
+The `website/docs/mep/mep-0046.md` file is the normative spec; the tracking pages under `/docs/implementation/0046/` are the mutable rolling status. These are two different documents with two different purposes.
+
+## Sub-phase 0.1
+
+Three Go packages are created under `transpiler3/beam/`:
+
+- `transpiler3/beam/lower/` -- owns the `Lower(prog *aotir.Program) (*cerl.Module, error)` entry point; converts the MEP-45 aotir IR to a tree of `cerl` records.
+- `transpiler3/beam/emit/` -- owns `Emit(mod *cerl.Module, workDir string) ([]BeamFile, error)`; serialises a `cerl.Module` to binary Erlang term format and drives `compile:forms/2` via an `erl -noshell` subprocess.
+- `transpiler3/beam/build/` -- owns `Driver.Build(src, out string, target Target)`; glues lower -> emit -> escript packaging.
+
+Each package gets a `doc.go` with a one-paragraph package doc that (a) states what the package owns, (b) names the entry-point function, and (c) cross-references the adjacent packages. A `transpiler3/beam/doc.go` at the root carries the pipeline diagram:
+
+```
+Mochi source
+  -> parser/typechecker (shared with MEP-45)
+  -> aotir.Program (MEP-45 IR, reused unchanged)
+  -> beam/lower: aotir -> cerl.Module
+  -> beam/emit: cerl.Module -> .beam bytes (via erl -noshell compile:forms/2)
+  -> beam/build: .beam bytes -> escript or OTP release
+```
+
+The `go vet ./transpiler3/beam/...` gate catches import cycles and missing doc comments before any real code lands in these packages.
+
+A `transpiler3/beam/cerl/` package is also created in 0.1. It defines the Go-side `cerl.Module`, `cerl.FunctionDef`, and the expression types that mirror the Core Erlang AST (`c_int`, `c_float`, `c_atom`, `c_var`, `c_let`, `c_case`, `c_call`, `c_cons`, `c_nil`, `c_tuple`, `c_map`, `c_try`, `c_catch`, `c_fun`, `c_values`). These are pure Go structs; no Erlang is invoked in this package. The package also defines `Module.MarshalBinary() ([]byte, error)` which serialises the module to an Erlang external term (ETF) binary that can be passed to `compile:forms/2` via stdin or a temp file.
+
+## Sub-phase 0.2
+
+`tests/transpiler3/beam/README.md` documents:
+
+- Fixture directory layout: `tests/transpiler3/beam/fixtures/phase{N}/{NNN}_{name}.mochi` and `{NNN}_{name}.out`. The three-digit prefix sorts fixtures visually and lets the gate test walker pick them up in a deterministic order without sorting by name.
+- How `.out` files are generated: run `vm3 run {NNN}_{name}.mochi > {NNN}_{name}.out`. The `.out` file is the ground truth; the BEAM-compiled binary's stdout must match it byte-for-byte.
+- The `runVm3(t *testing.T, src string) []byte` helper in `transpiler3/beam/build/build_test.go`: it finds the `vm3` binary on `PATH`, runs it on the given source file, and returns the captured stdout. Used only in the rare case where a `.out` file needs to be regenerated programmatically during fixture authoring; in CI the `.out` files are committed and `runVm3` is not called.
+- The `runBeamFixture(t *testing.T, mochiPath, outPath string)` helper: calls `Driver.Build` on `mochiPath`, runs the resulting escript, captures stdout, and diffs against `outPath`. Shared across all phase gate tests.
+- Naming conventions: `001_` through `099_` for Phase 1, `100_` through `199_` for Phase 2 (sub-phases 2.0-2.4 share the range), `200_` through `299_` for Phase 3, `300_` through `399_` for Phase 4.
+
+## Sub-phase 0.3
+
+The OTP app skeleton is the Erlang-side foundation that every later phase links against. It ships in Phase 0 because: (a) `mochi_str.erl` (Phase 1) must belong to a compiled OTP application to be loadable by an escript, (b) `rebar3` needs `mochi.app.src` to know how to build the project, and (c) establishing the module namespace (`mochi_*`) now prevents collisions later.
+
+`mochi.app.src` content:
+```erlang
+{application, mochi, [
+  {description, "Mochi runtime for BEAM"},
+  {vsn, "0.1.0"},
+  {modules, []},
+  {registered, []},
+  {applications, [kernel, stdlib, sasl]},
+  {mod, {mochi_app, []}}
+]}.
+```
+
+`mochi_app.erl` implements the `application` behaviour:
+```erlang
+-module(mochi_app).
+-behaviour(application).
+-export([start/2, stop/1]).
+
+start(_StartType, _StartArgs) ->
+    mochi_sup:start_link().
+
+stop(_State) ->
+    ok.
+```
+
+`mochi_sup.erl` implements a `one_for_one` supervisor with an empty child list. This is intentional: no long-lived processes are needed in Phase 0. Later phases (agents, streams) will add supervised children.
+
+```erlang
+-module(mochi_sup).
+-behaviour(supervisor).
+-export([start_link/0, init/1]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    SupFlags = #{strategy => one_for_one, intensity => 5, period => 10},
+    {ok, {SupFlags, []}}.
+```
+
+`mochi_atoms.erl` is a compile-time atom registry. It declares atoms that are referenced across modules so that beam's atom table is populated at load time:
+```erlang
+-module(mochi_atoms).
+-export([all/0]).
+
+all() ->
+    [mochi_record_tag, mochi_error, mochi_break, mochi_continue,
+     mochi_err_divzero, mochi_err_index, mochi_err_type].
+```
+
+The `rebar3 compile` gate runs on `transpiler3/beam/runtime/` using the project's `rebar.config`. OTP 27 is the minimum version.
 
 ## Decisions made
 
-_Pending phase open._
+- **OTP app skeleton ships in Phase 0, not Phase 1.** Every BEAM-compiled escript must load its runtime modules from somewhere. Without `mochi.app.src` and `mochi_app.erl`, `Phase 1`'s escript packaging step has nowhere to put `mochi_str.beam`. Moving the skeleton to Phase 1 would mean 1.0 conflates two concerns (pipeline wiring and OTP app setup) in one PR. Separating them keeps Phase 0 cheap and Phase 1 focused on the actual transpiler.
+- **`go vet` is the Go-side gate, not `go build`.** The packages in 0.1 have no real implementation yet, just `doc.go` stubs. `go build` would succeed vacuously. `go vet` is the minimal signal that imports, package names, and doc comment structure are correct.
+- **`rebar3 compile` is the Erlang-side gate.** It gives exactly the same signal for the OTP skeleton: no implementation, but the module names, behaviours, export lists, and `app.src` are syntactically valid and type-consistent with OTP 27.
+- **Three `doc.go` files, not one.** Same rationale as MEP-45 Phase 0: `go doc mochi/transpiler3/beam/lower` is the first page a contributor opens when debugging a lowering bug; it should tell them exactly what the package does and where the entry point is.
+- **`cerl/` package uses Go structs, not cgo.** The Core Erlang records are represented as Go structs that serialise to ETF via `encoding/binary`. This avoids a cgo dependency and keeps the Go build hermetic. The Erlang runtime is invoked only at `emit` time via `os/exec`.
+- **Module namespace is `mochi_*`.** All runtime modules use this prefix to avoid collisions with user code. The name-mangling spec (`mochi_{pkg}__{mod}__{name}`) applies to transpiled user code; runtime modules use the flat `mochi_*` prefix.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `website/docs/mep/mep-0046.md` | Normative spec (merged in 0.0) |
+| `website/docs/implementation/0046/index.md` | Phase index (created in 0.0) |
+| `website/docs/implementation/0046/phase-{00..19}.md` | Per-phase tracking stubs (created in 0.0) |
+| `transpiler3/beam/doc.go` | Pipeline diagram (created in 0.1) |
+| `transpiler3/beam/lower/doc.go` | Package doc for the lowerer (created in 0.1) |
+| `transpiler3/beam/emit/doc.go` | Package doc for the emitter (created in 0.1) |
+| `transpiler3/beam/build/doc.go` | Package doc for the build driver (created in 0.1) |
+| `transpiler3/beam/cerl/cerl.go` | Go-side Core Erlang AST types + ETF serialiser (created in 0.1) |
+| `tests/transpiler3/beam/README.md` | Fixture layout and naming convention (created in 0.2) |
+| `transpiler3/beam/build/build_test.go` | `runVm3` and `runBeamFixture` helpers (created in 0.2) |
+| `transpiler3/beam/runtime/src/mochi_app.erl` | OTP application callback (created in 0.3) |
+| `transpiler3/beam/runtime/src/mochi_sup.erl` | One-for-one supervisor skeleton (created in 0.3) |
+| `transpiler3/beam/runtime/src/mochi_atoms.erl` | Compile-time atom registry (created in 0.3) |
+| `transpiler3/beam/runtime/src/mochi.app.src` | OTP application resource file (created in 0.3) |
+| `transpiler3/beam/runtime/rebar.config` | rebar3 project config (created in 0.3) |
 
 ## Test set
 
-_Pending phase open._
+- `go vet ./transpiler3/beam/...` -- no test functions, but this is the 0.1 gate.
+- `rebar3 compile` in `transpiler3/beam/runtime/` -- no Erlang unit tests yet; this is the 0.3 gate.
+- `transpiler3/beam/cerl/cerl_test.go::TestCerlETFRoundTrip` -- 6 cases verifying that small `cerl.Module` trees serialise to valid ETF that `erl -noshell` can decode with `binary_to_term/1`.
+
+## Deferred work
+
+- The `cerl/` package's ETF serialiser handles only the Core Erlang subset needed through Phase 4. Tuples with arity > 8, bit strings, and compressed terms are not supported; they are added as needed in later phases.
+- `mochi_sup.erl`'s child list is empty through Phase 8. Supervised workers for streams and agents land in Phase 9.
+- `rebar3 dialyzer` is not part of the Phase 0 gate; it requires PLT construction which is slow and belongs in Phase 17 (Dialyzer clean pass).
+- OTP release packaging (`relx` config) is Phase 15; Phase 0 only ships the OTP app, not a packaged release.
 
 ## Closeout notes
 

--- a/website/docs/implementation/0046/phase-01-hello.md
+++ b/website/docs/implementation/0046/phase-01-hello.md
@@ -2,14 +2,14 @@
 title: "Phase 1. Hello world"
 sidebar_position: 3
 sidebar_label: "Phase 1. Hello world"
-description: "MEP-46 Phase 1. Hello world tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+description: "MEP-46 Phase 1 tracking: end-to-end pipeline from print(\"hello, mochi!\") to a runnable escript; CLI flags; BLAKE3 cache; mochi_str runtime."
 ---
 
 # Phase 1. Hello world
 
 | Field          | Value |
 |----------------|-------|
-| MEP            | [MEP-46 §Phases · Phase 1. Hello world](/docs/mep/mep-0046#phase-1-hello-world) |
+| MEP            | [MEP-46 §Phases · Phase 1](/docs/mep/mep-0046#phase-1-hello-world) |
 | Status         | NOT STARTED |
 | Started        | — |
 | Landed         | — |
@@ -18,23 +18,212 @@ description: "MEP-46 Phase 1. Hello world tracking stub. Filled in when the phas
 
 ## Gate
 
-See [MEP-46 §Phases · Phase 1. Hello world](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+`print("hello, mochi!")` compiles to a runnable escript via `mochi build --target=beam-escript`; the escript's stdout matches `vm3`'s stdout byte-for-byte; `TestPhase1Hello` in `transpiler3/beam/build/phase01_test.go` is green; `go vet ./transpiler3/beam/...` clean; `rebar3 compile` clean.
 
 ## Goal-alignment audit
 
-_Pending phase open._
+Phase 1 is the first point where the BEAM transpiler produces a *real* runnable artifact. Before Phase 1, the Go packages exist as stubs and the OTP app skeleton compiles but does nothing. After Phase 1, a user can run `mochi build --target=beam-escript hello.mochi` and get an escript that prints text and exits 0. This is the minimal proof that the pipeline -- parser -> typechecker -> aotir -> lower -> emit -> escript -- works end-to-end. Every later phase extends Phase 1's pipeline without replacing it. Aligns directly with the user-facing goal.
 
 ## Sub-phases
 
-_Pending phase open._
+| #   | Scope | Status | Commit | PR |
+|-----|-------|--------|--------|----|
+| 1.0 | End-to-end pipeline: `lower.go`, `emit.go`, `driver.go`, `mochi_str.erl` stub; `001_hello.mochi` fixture green | NOT STARTED | — | — |
+| 1.1 | CLI flags `--target=beam-escript`, `--out`, `--emit=core\|erl\|beam` wired in `cmd/mochi/main.go` | NOT STARTED | — | — |
+| 1.2 | `.mochi/cache/beam/` BLAKE3 cache; hit/miss paths | NOT STARTED | — | — |
+| 1.3 | `mochi_str.erl` fully implemented: binary, integer, float, bool, atom, list | NOT STARTED | — | — |
 
-## Decisions made
+## Sub-phase 1.0 -- End-to-end pipeline
 
-_Pending phase open._
+### Goal-alignment audit (1.0)
+
+The pipeline must produce a runnable artifact on the first sub-phase so that 1.1, 1.2, and 1.3 each have something real to extend. Starting with the CLI flags (1.1) or the cache (1.2) before the pipeline works would mean those sub-phases have nothing to test.
+
+### Decisions made (1.0)
+
+**`Lower(prog *aotir.Program) (*cerl.Module, error)`** in `transpiler3/beam/lower/lower.go` is the entry point. It walks the `aotir.Program`'s function list and dispatches each function to `lowerFunction`. The initial `lowerFunction` handles only `PrintStmt` and the `StringLit` expression. For `print("hello, mochi!")` the lowered body is:
+
+```
+c_call(
+  c_atom(mochi_str),
+  c_atom(print),
+  [c_binary([{bin_element, {string, "hello, mochi!"}, default, [utf8]}])]
+)
+```
+
+The `cerl.Module` produced by `Lower` carries: module name (from `aotir.Program.Name`, mangled as `mochi_{pkg}__{mod}`), export list (only `main/0` for a top-level program), and one function definition `main/0` whose body is the `c_call` above.
+
+**`Emit(mod *cerl.Module, workDir string) ([]BeamFile, error)`** in `transpiler3/beam/emit/emit.go` serialises the `cerl.Module` to ETF via `mod.MarshalBinary()`, writes it to `workDir/module.core.etf`, then invokes:
+
+```
+erl -noshell -eval '
+  {ok, Bin} = file:read_file("module.core.etf"),
+  Form = binary_to_term(Bin),
+  case compile:forms(Form, [from_core, debug_info, return_errors]) of
+    {ok, Mod, BeamBin, _Ws} ->
+      file:write_file("module.beam", BeamBin),
+      halt(0);
+    {error, Es, _Ws} ->
+      io:format(standard_error, "~p~n", [Es]),
+      halt(1)
+  end.' -s init stop
+```
+
+The subprocess is launched via `os/exec`. Stdout is discarded; stderr is captured for error reporting. The resulting `.beam` file is read back into `[]byte` and returned as `BeamFile{Name: ModName, Bytes: beamBytes}`.
+
+Why `erl -noshell` rather than embedding an Erlang runtime: OTP is not embeddable as a C library; the standard way to drive the Erlang compiler from an external process is via `os/exec`. The `erl -noshell` subprocess adds approximately 30ms of overhead per compilation unit. For a whole-program compilation of a Mochi source with N modules, the build driver batches all modules into a single `erl -noshell` session to amortise the startup cost.
+
+Why ETF (binary term encoding) rather than text `.core` files: The Core Erlang text format (`*.core`) has drifted across OTP versions (spacing, atom quoting, annotation syntax). Binary ETF encoding is stable across all OTP 24+ releases and does not require invoking the Core Erlang text parser.
+
+**`Driver.Build(src, out string, target Target)`** in `transpiler3/beam/build/driver.go`:
+1. Reads and parses the Mochi source file.
+2. Runs the type checker.
+3. Runs `aotir.Lower` (MEP-45 lowerer) to produce `*aotir.Program`.
+4. Calls `lower.Lower` to produce `*cerl.Module`.
+5. Calls `emit.Emit` to get `[]BeamFile`.
+6. For `TargetBeamEscript`: calls `packEscript(out, beamFiles, runtimeBeams)` which invokes a small Erlang helper to `escript:create/2`.
+
+The escript packaging helper is an embedded Erlang script (`transpiler3/beam/build/escript_pack.erl`) that is extracted to a temp file and run via `erl -noshell -s escript_pack main Args`. It calls:
+
+```erlang
+escript:create(OutFile, [
+  shebang,
+  {archive, [{Name, Bytes} || {Name, Bytes} <- AllBeams], []}
+]).
+```
+
+The shebang is `#!/usr/bin/env escript`. The archive contains the user module's `.beam` plus all runtime module `.beam` files from `mochi.app`. This makes the escript self-contained: no OTP code path configuration is needed at run time.
+
+**`mochi_str.erl` stub** implements one function:
+
+```erlang
+-module(mochi_str).
+-export([print/1]).
+
+print(Bin) when is_binary(Bin) ->
+    io:put_chars([Bin, $\n]).
+```
+
+The Phase 1.0 stub accepts only binaries. `lowerExpr` for a `StringLit` always produces a `c_binary` node with `utf8` encoding, so the binary clause is sufficient for Phase 1.
+
+**Fixture:** `tests/transpiler3/beam/fixtures/phase1/001_hello.mochi`:
+```
+print("hello, mochi!")
+```
+
+`tests/transpiler3/beam/fixtures/phase1/001_hello.out`:
+```
+hello, mochi!
+```
+
+**Gate test:** `transpiler3/beam/build/phase01_test.go::TestPhase1Hello` walks `tests/transpiler3/beam/fixtures/phase1/`, calls `runBeamFixture` on each pair, and diffs stdout against the `.out` file byte-for-byte.
+
+## Sub-phase 1.1 -- CLI integration
+
+### Decisions made (1.1)
+
+`cmd/mochi/main.go` gains a `runBuildBEAM` function dispatched from the existing `runBuild` when `--target=beam-escript` is detected:
+
+```
+mochi build --target=beam-escript [--out PATH] [--emit=core|beam] INPUT
+```
+
+- `--target=beam-escript` selects the BEAM pipeline. Future targets: `beam-release` (Phase 15).
+- `--out PATH` sets the output escript path. Default: `INPUT` with `.mochi` stripped, or `a.out` if no `.mochi` extension.
+- `--emit=core` stops after serialising the ETF core file and writes it to `--out`. Useful for debugging the lowerer.
+- `--emit=beam` stops after `compile:forms/2` and writes the `.beam` file to `--out`. Useful for debugging the emitter.
+- `--emit=escript` (default) runs the full pipeline.
+
+The `runBuildBEAM` function constructs a `build.Driver` with the flags and calls `Driver.Build`. Error messages from the OTP compiler subprocess are unwrapped from ETF and printed as human-readable diagnostics to stderr.
+
+The existing `runBuild` dispatch table gains:
+
+```go
+case "beam-escript":
+    return runBuildBEAM(ctx, flags)
+```
+
+## Sub-phase 1.2 -- BLAKE3 cache
+
+### Decisions made (1.2)
+
+Cache directory: `.mochi/cache/beam/` in the directory containing the source file (or the current working directory if the source has no parent). The cache is keyed by a BLAKE3 hash:
+
+```
+cacheKey = BLAKE3(
+  source_bytes ||
+  otp_version_string ||   // from `erl -eval 'erlang:system_info(otp_release)'`
+  transpiler_version ||   // from `build.Version` (Go build info)
+  runtime_fingerprint     // BLAKE3 of all runtime .erl source files concatenated in sorted order
+)
+```
+
+Cache entry: `{cacheKey}.escript`. Hit path: `os.Stat(cachedEscript)` succeeds -> `copyFile(cachedEscript, out)` -> return. Miss path: full lower -> emit -> pack -> `copyFile(packResult, cachedEscript)` -> `copyFile(cachedEscript, out)`.
+
+The `runtime_fingerprint` is computed once per `Driver` lifetime and memoised. This ensures that adding a new `mochi_str.erl` function (e.g., in Phase 1.3) invalidates all cached escripts without changing the transpiler version.
+
+Why BLAKE3: it is the hash algorithm used elsewhere in the Mochi codebase (MEP-45 Phase 1.2 uses it for the C-AOT cache). Consistency reduces the number of hash library dependencies.
+
+Cache entries are never evicted automatically in Phase 1. A `mochi cache clean --target=beam-escript` command is deferred to Phase 15.
+
+## Sub-phase 1.3 -- mochi_str fully implemented
+
+### Decisions made (1.3)
+
+`mochi_str:print/1` handles all Mochi value types that can be passed to `print`:
+
+```erlang
+print(Bin) when is_binary(Bin) ->
+    io:put_chars([Bin, $\n]);
+print(N) when is_integer(N) ->
+    io:put_chars([integer_to_binary(N), $\n]);
+print(F) when is_float(F) ->
+    io:put_chars([float_to_binary(F), $\n]);
+print(true) ->
+    io:put_chars(<<"true\n">>);
+print(false) ->
+    io:put_chars(<<"false\n">>);
+print(A) when is_atom(A) ->
+    io:put_chars([atom_to_binary(A, utf8), $\n]);
+print(L) when is_list(L) ->
+    %% String-as-list (legacy path; Mochi strings are binaries in Phase 1+)
+    io:put_chars([L, $\n]).
+```
+
+The `float_to_binary/1` helper is defined in `mochi_str` rather than calling `io_lib:format("~p", [F])` because OTP's `~p` format uses its own shortest-round-trip algorithm that may differ from vm3's Go `strconv.FormatFloat`. The canonical float-to-string spec for Mochi BEAM is: shortest decimal that round-trips via `binary_to_float/1`, falling back to `float_to_binary(F, [{scientific, 17}])` with trailing zeros stripped. This matches Phase 2.4's float-print requirement. The full `mochi_str:float_to_binary/1` implementation lands in Phase 2.4; the Phase 1.3 stub routes float through `io_lib:format("~.17g", [F])` as a placeholder that is correct for the Phase 1 fixture set (no floats in hello-world programs).
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/beam/lower/lower.go` | `Lower` entry point; `lowerFunction`, `lowerStmt`, `lowerExpr` for Phase 1 surface |
+| `transpiler3/beam/emit/emit.go` | `Emit` entry point; `erl -noshell` subprocess driver; ETF file I/O |
+| `transpiler3/beam/build/driver.go` | `Driver.Build`; pipeline glue; escript packaging |
+| `transpiler3/beam/build/escript_pack.erl` | Embedded Erlang helper for `escript:create/2` |
+| `transpiler3/beam/build/phase01_test.go` | `TestPhase1Hello` gate test |
+| `transpiler3/beam/build/build_test.go` | `runBeamFixture` helper (extended from Phase 0.2 stub) |
+| `transpiler3/beam/runtime/src/mochi_str.erl` | `print/1` runtime function |
+| `cmd/mochi/main.go` | `runBuildBEAM` dispatch; `--target`, `--out`, `--emit` flags |
+| `tests/transpiler3/beam/fixtures/phase1/001_hello.mochi` | Hello-world source fixture |
+| `tests/transpiler3/beam/fixtures/phase1/001_hello.out` | Expected output |
 
 ## Test set
 
-_Pending phase open._
+- `transpiler3/beam/build/phase01_test.go::TestPhase1Hello` -- end-to-end gate: compiles `001_hello.mochi`, runs the escript, diffs stdout against `001_hello.out`. Must be byte-exact.
+- `transpiler3/beam/lower/lower_test.go::TestLowerHello` -- unit test: `Lower` on a single-function `PrintStmt` program produces the expected `cerl.Module` shape (module name, export `main/0`, one function def with a `c_call` to `mochi_str:print`).
+- `transpiler3/beam/emit/emit_test.go::TestEmitRoundTrip` -- unit test: `Emit` on the `cerl.Module` from `TestLowerHello` produces a `.beam` file that `erl -noshell` can load and call `main/0` on, with stdout matching `"hello, mochi!\n"`.
+- `transpiler3/beam/cerl/cerl_test.go::TestCerlETFMarshal` -- 8 cases verifying ETF encoding of each `cerl` node type used in Phase 1 (`c_atom`, `c_binary`, `c_call`, `c_module`, `c_function`).
+- `transpiler3/beam/build/driver_cache_test.go::TestDriverBLAKE3CacheHit` -- verifies that building the same source twice with unchanged OTP version and runtime fingerprint hits the cache (second build skips `erl -noshell`).
+- `transpiler3/beam/build/driver_cache_test.go::TestDriverCacheInvalidatedOnRuntimeChange` -- verifies that modifying a runtime `.erl` file invalidates the cache.
+
+## Deferred work
+
+- `--target=beam-release` (OTP release packaging via `relx`) is Phase 15.
+- `mochi_str:print/1` for records and sum-type variants is Phase 4 and Phase 5 respectively.
+- Hot-code reloading and `sys:get_state` integration are not in scope for MEP-46 v1.
+- The `erl -noshell` subprocess timeout (currently unlimited) should have a configurable deadline; deferred to Phase 15.
+- Cache eviction (`mochi cache clean`) is Phase 15.
+- Windows support: `escript` shebangs are not meaningful on Windows; a `--target=beam-windows-bat` wrapper is Phase 15.
 
 ## Closeout notes
 

--- a/website/docs/implementation/0046/phase-02-primitives.md
+++ b/website/docs/implementation/0046/phase-02-primitives.md
@@ -1,15 +1,15 @@
 ---
 title: "Phase 2. Primitives and control flow"
 sidebar_position: 4
-sidebar_label: "Phase 2. Primitives and control flow"
-description: "MEP-46 Phase 2. Primitives and control flow tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+sidebar_label: "Phase 2. Primitives + control flow"
+description: "MEP-46 Phase 2 tracking: int/float/bool arithmetic, comparisons, short-circuit, if/while/for, user functions, divide-by-zero, float print parity."
 ---
 
 # Phase 2. Primitives and control flow
 
 | Field          | Value |
 |----------------|-------|
-| MEP            | [MEP-46 §Phases · Phase 2. Primitives and control flow](/docs/mep/mep-0046#phase-2-primitives-and-control-flow) |
+| MEP            | [MEP-46 §Phases · Phase 2](/docs/mep/mep-0046#phase-2-primitives-and-control-flow) |
 | Status         | NOT STARTED |
 | Started        | — |
 | Landed         | — |
@@ -18,23 +18,275 @@ description: "MEP-46 Phase 2. Primitives and control flow tracking stub. Filled 
 
 ## Gate
 
-See [MEP-46 §Phases · Phase 2. Primitives and control flow](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+Arithmetic + control-flow suite (~30 fixtures: int/float ops, comparisons, short-circuit, if/else, while, for-in over int range, user functions, recursion, divide-by-zero, float-print parity) compiles via `mochi build --target=beam-escript` and runs byte-equal vs vm3 on host; `TestPhase2Primitives` is green.
 
 ## Goal-alignment audit
 
-_Pending phase open._
+Primitives + control flow is the smallest language surface that lets a real (non-toy) Mochi program compile to BEAM. Without these sub-phases the only valid BEAM program is `print("string literal")`; with them the arithmetic-heavy benchmark loops (`fib_iter`, `sum_loop`, `factorial`) compile to escripts that match vm3 byte-for-byte. This is the phase where "one Mochi source, one BEAM escript" becomes true of non-trivial programs.
 
 ## Sub-phases
 
-_Pending phase open._
+| #   | Scope | Status | Commit | PR |
+|-----|-------|--------|--------|----|
+| 2.0 | `int`, `float`, `bool`; arithmetic; comparisons; short-circuit `&&`/`\|\|` | NOT STARTED | — | — |
+| 2.1 | `let`/`var`; `if`/`else`; `while`; `return`; `break`; `continue` | NOT STARTED | — | — |
+| 2.2 | `for x in start..end` (int range); user-defined multi-arg functions | NOT STARTED | — | — |
+| 2.3 | Integer divide-by-zero raises `mochi_err_divzero`; wrapped try in lowerer | NOT STARTED | — | — |
+| 2.4 | Float print parity with vm3: `mochi_str:float_to_binary/1` shortest-round-trip | NOT STARTED | — | — |
 
-## Decisions made
+## Sub-phase 2.0 -- int/float/bool primitives
 
-_Pending phase open._
+### Goal-alignment audit (2.0)
+
+The smallest extension of Phase 1 that lets the BEAM pipeline compile programs that compute anything. Without 2.0 the only legal program is `print("string literal")`; with 2.0 the entire arithmetic and boolean expression layer compiles. Strict slice: no statements other than `print(<expr>)`, no variables (2.1), no control flow (2.1).
+
+### Decisions made (2.0)
+
+**`int` -> BEAM integer (arbitrary precision).** `lowerExpr` for an `aotir.IntLit{V: N}` emits `c_int(N)`. BEAM integers are arbitrary precision by default; no overflow or wrapping. This diverges from vm3 (which uses Go `int64` and wraps on overflow) for programs that produce values outside `[-2^63, 2^63)`. MEP-46 §Compatibility notes this divergence; it is a feature, not a bug, for the BEAM target.
+
+**`float` -> BEAM boxed double.** `c_float(F)` for float literals. BEAM's float is an IEEE 754 double stored as a boxed heap object. Arithmetic uses the same `erlang:'+'` / `erlang:'-'` / `erlang:'*'` / `erlang:'/'` BIFs as integers; the BEAM dispatcher selects the float implementation by inspecting the tag bits at runtime.
+
+**`bool` -> atoms `true` / `false`.** `c_atom(true)` and `c_atom(false)`. BEAM has no native boolean type; `true` and `false` are atoms. This is the natural Erlang convention and means `if cond` in a `c_case` matches on the atom `true`, which is what the OTP standard library expects.
+
+**Arithmetic ops** `+`, `-`, `*`, `/` are lowered via:
+```
+c_call(c_atom(erlang), c_atom('+'), [lowerExpr(A), lowerExpr(B)])
+```
+The `erlang` module BIFs are inlined by the BEAM JIT on all OTP 27 targets, so there is no function-call overhead for these operations at runtime.
+
+**Comparisons** `==`, `!=`, `<`, `>`, `<=`, `>=` map to BEAM operators:
+- `==` -> `erlang:'=:='` (structural equality, type-exact)
+- `!=` -> `erlang:'=/='`
+- `<` -> `erlang:'<'`
+- `>` -> `erlang:'>'`
+- `<=` -> `erlang:'=<'` (note: BEAM spells it `=<`, not `<=`)
+- `>=` -> `erlang:'>='`
+
+All emit as `c_call(c_atom(erlang), c_atom('=:='), [A, B])` etc.
+
+**Short-circuit `&&` and `||`** require special treatment because Core Erlang has no short-circuit binary operators at the IR level. They are lowered to `c_case`:
+
+```erlang
+%% A && B
+c_case(lowerExpr(A), [
+  c_clause([c_atom(false)], c_atom(true), c_atom(false)),
+  c_clause([c_var('_')],   c_atom(true), lowerExpr(B))
+])
+
+%% A || B
+c_case(lowerExpr(A), [
+  c_clause([c_atom(true)],  c_atom(true), c_atom(true)),
+  c_clause([c_var('_')],    c_atom(true), lowerExpr(B))
+])
+```
+
+The guard `c_atom(true)` on each clause is the Core Erlang guard expression (it is the literal `true` atom, meaning "always match"). This ensures `B` is only evaluated when the `c_case` arm is selected, giving correct short-circuit semantics.
+
+## Sub-phase 2.1 -- let/var, if/else, while, return, break, continue
+
+### Decisions made (2.1)
+
+**`let x = E` / `var x = E`** -- Core Erlang is an expression language; there is no statement-level variable binding. Every `let` in the source becomes a `c_let` node wrapping the continuation:
+
+```erlang
+c_let([c_var('V_x')], lowerExpr(E), lowerBlock(rest_of_block))
+```
+
+The `rest_of_block` is the lowered continuation (all subsequent statements in the same block). This means `lowerBlock` is a right-recursive descent: it pops the head statement, lowers it with the tail as continuation. The variable name is prefixed with `V_` to avoid clashing with Core Erlang reserved names (which are lowercase atoms in Core Erlang's text format).
+
+**`if cond { body } else { alt }`** -- lowered to `c_case` on the boolean condition:
+
+```erlang
+c_case(lowerExpr(cond), [
+  c_clause([c_atom(true)],  c_atom(true), lowerBlock(body)),
+  c_clause([c_atom(false)], c_atom(true), lowerBlock(alt))
+])
+```
+
+If there is no `else` branch, the `false` arm returns `c_atom(ok)` (the unit value on BEAM).
+
+**`while cond { body }`** -- BEAM has no native loop construct. The lowerer emits a tail-recursive helper function at the module level:
+
+```erlang
+'__while_1'() ->
+  case cond_expr of
+    true  -> body_expr, '__while_1'();
+    false -> ok
+  end.
+```
+
+The while loop at the call site becomes `'__while_1'()`. The loop counter `1` (or `2`, `3`, ... for nested whiles) is assigned by a monotonic counter in the lowerer's state, so nested while loops get distinct helper names. The tail call `'__while_1'()` is a self-recursive call; BEAM's last-call optimisation (LCO) ensures it does not grow the stack.
+
+**`break`** -- throws `{mochi_break, N}` where N is the while loop's counter. The `'__while_N'` helper wraps its body in a `c_try`/`c_catch` that catches `{mochi_break, N}` and returns `ok`:
+
+```erlang
+'__while_1'() ->
+  case cond_expr of
+    true ->
+      c_try(
+        body_expr,
+        [{mochi_break, 1}],  %% catch pattern
+        ok                   %% handler: exit loop
+      ),
+      '__while_1'();
+    false -> ok
+  end.
+```
+
+**`continue`** -- throws `{mochi_continue, N}`. The handler for `mochi_continue` calls `'__while_N'()` again (re-entering the loop from the top) instead of returning `ok`.
+
+**`return`** in a user function -- Core Erlang functions return the value of their body expression. A `return` in the middle of a block is modelled as throwing a `{mochi_return, V}` exception caught at the function boundary. The lowerer wraps the entire function body in a `c_try`/`c_catch` on `mochi_return` when a non-tail `return` statement is detected in the body. Tail-position `return` does not need the wrapper.
+
+## Sub-phase 2.2 -- for-in over int range, user functions
+
+### Decisions made (2.2)
+
+**`for x in start..end { body }`** -- lowered to a tail-recursive helper:
+
+```erlang
+'__for_range_1'(V_x, V_end) ->
+  case V_x >= V_end of
+    true  -> ok;
+    false ->
+      body_expr,
+      '__for_range_1'(erlang:'+'(V_x, 1), V_end)
+  end.
+```
+
+The call site evaluates `start` and `end` once (hoisting prevents re-evaluation of side-effecting bounds), then calls `'__for_range_1'(start_val, end_val)`. The range is half-open `[start, end)`, matching vm3 semantics.
+
+**User functions** are two-pass. Pass 1 walks all top-level `fun` declarations and records their name, parameter types, and return type into a shared `funcSig` map. Pass 2 lowers each function body with parameters bound as immutable `V_` variables. Module-level exports: functions that are the entry point of a Mochi module are exported; all others are module-private (not exported) in the Core Erlang module definition.
+
+**Name mangling** for user functions in generated modules: `mochi_{pkg}__{mod}__{funcname}`. For a top-level single-module program this is `mochi_main__main__funcname`. The `main/0` entry is always exported.
+
+**Two-pass lowering is required** because Mochi allows a function to call another function declared later in the source. Core Erlang allows forward references within a module (unlike C), so the two passes on the Go side just need to collect signatures before lowering bodies; no forward-declaration emission is needed in the Core Erlang output.
+
+## Sub-phase 2.3 -- integer divide-by-zero
+
+### Decisions made (2.3)
+
+BEAM raises `{badarith, []}` (or `{badarith, {V1, V2}}` depending on OTP version) when integer division by zero occurs. The lowerer wraps every integer `div` and `rem` operation in a `c_try`/`c_catch` that converts this to the Mochi error convention:
+
+```erlang
+c_try(
+  c_call(c_atom(erlang), c_atom('div'), [A, B]),
+  [c_var('V___result')],
+  c_var('V___result'),
+  [c_var('V___class'), c_var('V___reason')],
+  c_case(c_var('V___reason'), [
+    c_clause(
+      [c_tuple([c_atom(badarith), c_var('_')])],
+      c_atom(true),
+      c_call(c_atom(mochi_core), c_atom(raise_err),
+             [c_atom(mochi_err_divzero),
+              c_binary([{bin_element, {string, "integer divide by zero"}, default, [utf8]}])])
+    ),
+    c_clause([c_var('_')], c_atom(true),
+      c_primop(c_atom(raise), [c_var('V___class'), c_var('V___reason'), c_nil()]))
+  ])
+)
+```
+
+`mochi_core:raise_err/2` is:
+```erlang
+raise_err(Code, Msg) ->
+    erlang:error({mochi_error, Code, Msg}).
+```
+
+The `mochi_error` tuple is the Mochi-wide error convention on BEAM; it carries a symbol code and a human-readable binary message. The escript's top-level runner catches `{mochi_error, Code, Msg}` and prints it to stderr, then exits with a non-zero code.
+
+**Only integer division is wrapped.** Float division by zero in BEAM produces `+infinity` or `-infinity` (IEEE 754), not an error. This matches vm3 semantics (Go's `float64` follows IEEE 754). No wrapping is needed for float division.
+
+**The wrapper adds one BEAM instruction on the hot path** (the `c_try` sets up an exception handler). On OTP 27's JIT this is approximately 3ns overhead. Given that the alternative is a SIGFPE-equivalent crash, this is acceptable.
+
+## Sub-phase 2.4 -- float print parity with vm3
+
+### Decisions made (2.4)
+
+vm3 uses Go's `fmt.Println(f)` which calls `strconv.FormatFloat(f, 'g', -1, 64)` -- the shortest decimal that round-trips. OTP's built-in float formatting (`io_lib:format("~p", [F])` and `float_to_list/1`) uses a different algorithm (Ryu as of OTP 26, but with different trailing-zero stripping rules) that produces different output for many values.
+
+`mochi_str:float_to_binary/1` implements the matching algorithm:
+
+1. Use `float_to_binary(F, [{scientific, 17}])` to get a 17-significant-digit scientific notation string.
+2. Parse it with the Erlang float parser.
+3. Find the shortest decimal prefix that round-trips (binary search on the significant digit count from 1 to 17).
+4. Format it using the same rules as Go: no trailing zeros, always include a decimal point, use `e+N` / `e-N` notation for very large/small values.
+
+Special cases:
+- `nan` -> `<<"NaN">>` (Go prints `NaN`, Erlang's `isnan` equivalent is `catch erlang:is_nan(F)` -- not a real BIF; use `F /= F` to detect NaN).
+- `+inf` -> `<<"+Inf">>`.
+- `-inf` -> `<<"-Inf">>`.
+
+NaN detection: `F /= F` is `true` iff F is NaN (IEEE 754 property). `F > 1.0e308 + 1.0e308` is `true` iff F is positive infinity; similarly for negative infinity.
+
+The `float_to_binary/1` function is called from `print/1`'s float clause. The Phase 1.3 placeholder (`io_lib:format("~.17g", [F])`) is replaced.
+
+**Fixtures** in `tests/transpiler3/beam/fixtures/phase2/` include `013_float_print.mochi` through `020_float_special.mochi` covering: basic float arithmetic, values like `0.1 + 0.2`, NaN production via `0.0/0.0`, `+Inf` via `1.0/0.0`, `-Inf` via `-1.0/0.0`, NaN propagation through `+`, `-`, `*`, `/`, and NaN comparison (`nan == nan` -> `false`).
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/beam/lower/lower.go` | Extended with `lowerBinOp`, `lowerUnaryOp`, `lowerIfStmt`, `lowerWhileStmt`, `lowerForRangeStmt`, `lowerLetStmt`, `lowerUserFunction`; while/for helper emitters |
+| `transpiler3/beam/lower/lower_state.go` | Lowerer state: loop counter, function-sig map, while/for nesting depth |
+| `transpiler3/beam/lower/lower_reject_test.go` | Negative tests: 2.0+ shapes rejected when lower surface is Phase 1 |
+| `transpiler3/beam/emit/emit.go` | No change in 2.0-2.4 (emit is driven by `cerl.Module`, which the lowerer builds) |
+| `transpiler3/beam/build/phase02_test.go` | `TestPhase2Primitives`, `TestPhase2ControlFlow`, `TestPhase2Functions`, `TestPhase2Divzero`, `TestPhase2FloatPrint` gate tests |
+| `transpiler3/beam/runtime/src/mochi_str.erl` | `float_to_binary/1` full implementation; NaN/Inf special cases |
+| `transpiler3/beam/runtime/src/mochi_core.erl` | `raise_err/2`; `mochi_error` tuple convention |
+| `tests/transpiler3/beam/fixtures/phase2/` | 30 fixture pairs (`.mochi` + `.out`) |
 
 ## Test set
 
-_Pending phase open._
+30 fixtures across sub-phases 2.0-2.4:
+
+| Fixture | Description |
+|---------|-------------|
+| `002_int_arith.mochi` | `+`, `-`, `*`, `/`, `%` on int literals |
+| `003_float_arith.mochi` | `+`, `-`, `*`, `/` on float literals |
+| `004_bool_ops.mochi` | `&&`, `\|\|`, `!`; short-circuit behaviour |
+| `005_comparison.mochi` | `==`, `!=`, `<`, `>`, `<=`, `>=` on int and float |
+| `006_short_circuit.mochi` | `&&` with side-effecting RHS (not evaluated when LHS is false) |
+| `007_if_else.mochi` | `if`/`else`; `if` without `else` |
+| `008_while_loop.mochi` | While loop with counter; while + break |
+| `009_while_continue.mochi` | While + continue; nested while with inner break |
+| `010_for_range.mochi` | `for x in 0..10`; empty range |
+| `011_let_var.mochi` | `let` (immutable); `var` (mutable); shadowing |
+| `012_user_function.mochi` | Single-arg function; multi-arg function; void function |
+| `013_recursion.mochi` | Factorial (recursive); fib (recursive) |
+| `014_mutual_recursion.mochi` | `is_even`/`is_odd` mutual recursion |
+| `015_divzero.mochi` | Safe int division (non-zero divisor) |
+| `016_divzero_trip.mochi` | `print(1 / 0)` -> mochi_error on stderr, exit non-zero |
+| `017_modulo.mochi` | `%` operator; `% 0` trip |
+| `018_float_basic.mochi` | Float literals; float arithmetic |
+| `019_float_print.mochi` | `0.1`, `0.1 + 0.2`, `1.0 / 3.0` |
+| `020_float_nan.mochi` | `0.0 / 0.0` -> `NaN`; NaN propagation |
+| `021_float_inf.mochi` | `1.0 / 0.0` -> `+Inf`; `-1.0 / 0.0` -> `-Inf` |
+| `022_nested_while.mochi` | Two nested while loops; inner break doesn't exit outer |
+| `023_for_range_func.mochi` | For loop inside a function |
+| `024_bool_return.mochi` | Function returning bool; if on returned bool |
+| `025_int_comparison_chain.mochi` | Chained comparisons in while condition |
+| `026_float_comparison.mochi` | Float `<`, `>`, NaN comparison (`nan == nan` -> false) |
+| `027_large_int.mochi` | Integers larger than int64 max (BEAM arbitrary precision) |
+| `028_negative_mod.mochi` | Negative modulo (`-7 % 3`) matching vm3 semantics |
+| `029_early_return.mochi` | Non-tail return in the middle of a function body |
+| `030_fib_iter.mochi` | Iterative fibonacci via while loop |
+| `031_sum_loop.mochi` | Sum of 1..100 via for loop |
+
+Gate tests:
+- `TestPhase2Primitives` -- runs 002-006, 015, 017-021, 025-028.
+- `TestPhase2ControlFlow` -- runs 007-011.
+- `TestPhase2Functions` -- runs 012-014, 023-024, 029.
+- `TestPhase2Divzero` -- positive fixtures (015, 017, 028); negative fixtures (016 exit code + stderr).
+- `TestPhase2FloatPrint` -- runs 018-021, 026.
+
+## Deferred work
+
+- `int` conversion (`int(f)` float-to-int truncation) is Phase 3 alongside the type-conversion surface.
+- `min(xs)`, `max(xs)`, `sum(xs)` builtins are Phase 3 alongside lists.
+- String concatenation and comparison are Phase 6 (strings and I/O).
+- Float NaN/Inf propagation through functions is tested in 2.4 but float formatting for very small/large non-special values (subnormals, exponent > 15) is a known gap; exact parity with vm3's `strconv.FormatFloat` for those edge cases is Phase 17 (reproducibility audit).
+- `int` overflow (wrapping vs panic) is not gated in Phase 2; BEAM integers are arbitrary precision and do not overflow, so this is a permanent divergence from vm3 for values outside `[-2^63, 2^63)`. Documented in MEP-46 §Compatibility.
 
 ## Closeout notes
 

--- a/website/docs/implementation/0046/phase-03-collections.md
+++ b/website/docs/implementation/0046/phase-03-collections.md
@@ -1,15 +1,15 @@
 ---
-title: "Phase 3. Collections (lists, maps, sets, omaps)"
+title: "Phase 3. Collections"
 sidebar_position: 5
-sidebar_label: "Phase 3. Collections (lists, maps, sets, omaps)"
-description: "MEP-46 Phase 3. Collections (lists, maps, sets, omaps) tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+sidebar_label: "Phase 3. Collections"
+description: "MEP-46 Phase 3 tracking: list<T>, map<K,V>, set<T>, omap<K,V>, list<record> on BEAM; BEAM cons cells, OTP maps module, sets module, insertion-order map."
 ---
 
-# Phase 3. Collections (lists, maps, sets, omaps)
+# Phase 3. Collections
 
 | Field          | Value |
 |----------------|-------|
-| MEP            | [MEP-46 §Phases · Phase 3. Collections (lists, maps, sets, omaps)](/docs/mep/mep-0046#phase-3-collections-lists-maps-sets-omaps) |
+| MEP            | [MEP-46 §Phases · Phase 3](/docs/mep/mep-0046#phase-3-collections) |
 | Status         | NOT STARTED |
 | Started        | — |
 | Landed         | — |
@@ -18,23 +18,320 @@ description: "MEP-46 Phase 3. Collections (lists, maps, sets, omaps) tracking st
 
 ## Gate
 
-See [MEP-46 §Phases · Phase 3. Collections (lists, maps, sets, omaps)](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+Collection suite (~90 fixtures: list literal/index/len/append/for-in/comprehension; map literal/index/len/keys/values/has/for; set literal/add/has/len/union/intersection/for; omap insert/get/for; list&lt;record&gt;) compiles via `mochi build --target=beam-escript` and runs byte-equal vs vm3; `TestPhase3Collections` is green.
 
 ## Goal-alignment audit
 
-_Pending phase open._
+Collections are the second-largest language surface after primitives/control-flow, and they appear in virtually every non-trivial Mochi program. A BEAM transpiler that cannot handle `list<int>` or `map<string, int>` cannot compile the query DSL (Phase 8) or the agent primitives (Phase 9). Phase 3 also establishes the BEAM representation conventions (cons cells, OTP maps, OTP sets) that Phase 4 (records) and Phase 5 (sum types) build on. Aligns directly.
 
 ## Sub-phases
 
-_Pending phase open._
+| #   | Scope | Status | Commit | PR |
+|-----|-------|--------|--------|----|
+| 3.1 | `list<T>`: literal, index, OOB, len, append, for-in, comprehension | NOT STARTED | — | — |
+| 3.2 | `map<K,V>`: literal, index, OOB, len, keys, values, has, for-in | NOT STARTED | — | — |
+| 3.3 | `set<T>`: literal, add, has, len, intersection, union, for-in | NOT STARTED | — | — |
+| 3.4 | `omap<K,V>`: insertion-order map; `mochi_omap.erl` | NOT STARTED | — | — |
+| 3.5 | `list<record>`: list whose element type is a record; no special representation needed | NOT STARTED | — | — |
 
-## Decisions made
+## Sub-phase 3.1 -- list&lt;T&gt;
 
-_Pending phase open._
+### Goal-alignment audit (3.1)
+
+Lists appear in more Mochi programs than any other collection type. The BEAM representation (cons cells) is native and performant; there is no impedance mismatch. Getting list right in Phase 3.1 unblocks list comprehensions (used heavily in the query DSL) and sets up the `for x in list` pattern used throughout Phase 8 fixtures.
+
+### Decisions made (3.1)
+
+**Representation: BEAM cons cells.** A Mochi `list<T>` maps to a standard Erlang proper list: a right-recursive chain of cons cells terminated by `[]` (nil). This is the native BEAM list representation; every OTP standard library function (`lists:*`) works on it directly. No boxing, no length prefix, no separate allocation.
+
+**Literal `[1, 2, 3]`** emits:
+```erlang
+c_cons(c_int(1), c_cons(c_int(2), c_cons(c_int(3), c_nil())))
+```
+An empty list `[]` emits `c_nil()`. The lowerer recurses right-to-left to build the cons chain.
+
+**Index `xs[i]`** -- Mochi lists are 0-indexed; BEAM `lists:nth/2` is 1-indexed. The lowerer adds 1 to the index and wraps with a bounds check:
+
+```erlang
+c_try(
+  c_call(c_atom(lists), c_atom(nth),
+         [c_call(c_atom(erlang), c_atom('+'), [V_i, c_int(1)]), V_xs]),
+  [c_var('V___val')],
+  c_var('V___val'),
+  [c_var('V___class'), c_var('V___reason')],
+  c_call(c_atom(mochi_core), c_atom(raise_err),
+         [c_atom(mochi_err_index),
+          c_binary([{bin_element, {string, "list index out of bounds"}, default, [utf8]}])])
+)
+```
+
+`lists:nth/2` raises `function_clause` when the index is out of range. The catch pattern matches any exception and converts it to `mochi_err_index`. This is coarser than ideal (it also catches errors inside `V_i` evaluation), but is correct for the Phase 3.1 fixture set where `V_i` is always a simple variable or integer literal.
+
+**`len(xs)`** -> `c_call(c_atom(erlang), c_atom(length), [V_xs])`. BEAM's `erlang:length/1` is O(n); it walks the full list. This matches vm3 semantics. A constant-time length would require a different representation (deferred).
+
+**`append(xs, v)`** -> `c_call(c_atom(mochi_list), c_atom(append), [V_xs, V_v])`.
+
+`mochi_list.erl`:
+```erlang
+append(L, E) -> L ++ [E].
+```
+
+`L ++ [E]` is `lists:append(L, [E])`, which is O(length(L)). This is the correct Mochi semantics (list is a value; append produces a new list). Mochi lists are immutable values, not mutable arrays.
+
+**`for x in xs`** -- uses `lists:foreach/2`:
+```erlang
+c_call(c_atom(lists), c_atom(foreach),
+  [c_fun([c_var('V_x')], lowerBlock(body)),
+   V_xs])
+```
+
+`lists:foreach/2` is a standard OTP HOF. The body closure is emitted as an anonymous `c_fun`. Loop variables (`break`, `continue`) inside a `for x in xs` loop use the same exception mechanism as `while` loops (throwing `{mochi_break, N}` / `{mochi_continue, N}`).
+
+**List comprehension `[E || x <- xs]`** -- Core Erlang has native list comprehensions (`c_comp`). The lowerer emits:
+
+```erlang
+c_comp(lowerExpr(E), [c_generate(c_var('V_x'), V_xs)])
+```
+
+For `[f(x) || x <- xs, cond(x)]` (with a filter), an additional `c_filter(lowerExpr(cond))` qualifier is appended.
+
+**`mochi_list.erl`** is a new runtime module added in 3.1. It exports `append/2` and, later in Phase 3.5, list-of-records helpers.
+
+### Test set (3.1)
+
+Fixtures `200_list_literal.mochi` through `220_list_comprehension.mochi` (21 fixtures). Key cases:
+- Empty list `[]` printed as `[]`.
+- Single-element list.
+- Index into list: 0-indexed boundary cases.
+- OOB index: exits with `mochi_err_index`.
+- `len` of empty and non-empty list.
+- `append` produces a new list (old list unmodified).
+- `for x in xs` with print inside body.
+- `for x in xs` with break and continue.
+- List comprehension with and without filter.
+- Nested `for` over two lists.
+
+## Sub-phase 3.2 -- map&lt;K,V&gt;
+
+### Decisions made (3.2)
+
+**Representation: BEAM maps.** Mochi `map<K,V>` maps to a BEAM map (`#{...}`). BEAM maps are hash-array mapped trie (HAMT) structures; they are immutable, persistent, and support O(log n) lookup and update. The `maps` module provides all required operations.
+
+**Literal `{"a": 1, "b": 2}`** emits:
+```erlang
+c_map([
+  c_map_pair(c_binary([{bin_element, {string, "a"}, default, [utf8]}]), c_int(1)),
+  c_map_pair(c_binary([{bin_element, {string, "b"}, default, [utf8]}]), c_int(2))
+])
+```
+
+String keys are UTF-8 binaries (consistent with Mochi's string representation). Integer keys use `c_int`.
+
+**Index `m[k]`** wraps `maps:get/2` in a try/catch for `{badkey, K}`:
+```erlang
+c_try(
+  c_call(c_atom(maps), c_atom(get), [lowerExpr(k), V_m]),
+  ...,
+  c_call(c_atom(mochi_core), c_atom(raise_err), [c_atom(mochi_err_index), ...])
+)
+```
+
+**`len(m)`** -> `c_call(c_atom(erlang), c_atom(map_size), [V_m])`. `map_size/1` is O(1) on BEAM (the size is stored in the map header).
+
+**`keys(m)`** -> `c_call(c_atom(maps), c_atom(keys), [V_m])`. Returns a list; ordering is not guaranteed (BEAM maps are unordered). Matches vm3 semantics (Go's `map` keys have no guaranteed order).
+
+**`values(m)`** -> `c_call(c_atom(maps), c_atom(values), [V_m])`.
+
+**`k in m`** -> `c_call(c_atom(maps), c_atom(is_key), [lowerExpr(k), V_m])`. Returns `true`/`false` atom.
+
+**`m[k] = v` (map update)** -- Mochi map update syntax produces a new map:
+```erlang
+c_map_update(V_m, [c_map_pair(lowerExpr(k), lowerExpr(v))])
+```
+
+`c_map_pair` corresponds to `=>` (create or update). For Mochi semantics (map update creates or overwrites), we use `c_map_pair` rather than `c_map_pair_exact` (which would error if the key is absent).
+
+**`for k in m`** -- iterates over `maps:keys(M)` (unordered, matching vm3):
+```erlang
+c_call(c_atom(lists), c_atom(foreach),
+  [c_fun([c_var('V_k')], lowerBlock(body)),
+   c_call(c_atom(maps), c_atom(keys), [V_m])])
+```
+
+**`for k, v in m`** (key-value iteration) -- iterates over `maps:to_list(M)`, destructuring each `{K, V}` tuple:
+```erlang
+lists:foreach(fun({V_k, V_v}) -> body end, maps:to_list(V_m))
+```
+
+### Test set (3.2)
+
+Fixtures `221_map_literal.mochi` through `240_map_iteration.mochi` (20 fixtures). Key cases: empty map; single-entry map; multi-entry map; string key; integer key; OOB key; `len`; `keys` (unordered, so test with sorted output); `values`; `k in m`; map update; `for k in m`; `for k, v in m`; nested map (`map<string, map<string, int>>`).
+
+## Sub-phase 3.3 -- set&lt;T&gt;
+
+### Decisions made (3.3)
+
+**Representation: OTP `sets` module (v2, default in OTP 27).** The `sets` module in OTP 27 uses a hash-based representation (version 2, introduced in OTP 24). It is the idiomatic OTP set type. `ordsets` is not used because it is O(n) for most operations; `gb_sets` is not used because it requires `Ord` keys.
+
+**Literal `set{1, 2, 3}`** emits:
+```erlang
+c_call(c_atom(sets), c_atom(from_list),
+  [c_cons(c_int(1), c_cons(c_int(2), c_cons(c_int(3), c_nil())))])
+```
+
+An empty set `set{}` emits `c_call(c_atom(sets), c_atom(new), [])`.
+
+**`add(s, v)`** -> `c_call(c_atom(sets), c_atom(add_element), [V_v, V_s])`. Returns a new set (immutable value semantics). Note the argument order: `sets:add_element(Elem, Set)` takes element first.
+
+**`has(s, v)`** -> `c_call(c_atom(sets), c_atom(is_element), [V_v, V_s])`.
+
+**`len(s)`** -> `c_call(c_atom(sets), c_atom(size), [V_s])`. `sets:size/1` is O(1) in sets v2.
+
+**Set intersection** -> `c_call(c_atom(sets), c_atom(intersection), [V_s1, V_s2])`.
+
+**Set union** -> `c_call(c_atom(sets), c_atom(union), [V_s1, V_s2])`.
+
+**Set difference** -> `c_call(c_atom(sets), c_atom(subtract), [V_s1, V_s2])`.
+
+**`delete(s, v)`** -> `c_call(c_atom(sets), c_atom(del_element), [V_v, V_s])`.
+
+**`for x in s`** -- sets have no ordering guarantee; iteration converts to list first:
+```erlang
+lists:foreach(fun(V_x) -> body end, sets:to_list(V_s))
+```
+
+The iteration order is not specified (matches vm3, which uses Go's `map[T]struct{}` with non-deterministic iteration). Phase 3.3 fixtures that print set contents sort the output before printing to ensure byte-equality.
+
+### Test set (3.3)
+
+Fixtures `241_set_literal.mochi` through `255_set_ops.mochi` (15 fixtures). Key cases: empty set; single-element; `add`; `has` (true/false); `len`; `delete`; union; intersection; difference; `for x in s` (with sorted print); set of strings; set of ints.
+
+## Sub-phase 3.4 -- omap&lt;K,V&gt;
+
+### Decisions made (3.4)
+
+**Why a separate type.** `map<K,V>` on BEAM (and vm3) has no guaranteed iteration order. `omap<K,V>` is Mochi's ordered map: iteration yields entries in insertion order. This matches Python's `dict` (Python 3.7+) semantics.
+
+**Representation: `{Keys :: [K], Map :: #{K => V}}` 2-tuple.** The first element is a list of keys in insertion order; the second is a BEAM map for O(log n) lookup. This representation is carried through the type system as an opaque tuple; the lowerer always accesses it via `mochi_omap:*` functions.
+
+`mochi_omap.erl`:
+```erlang
+-module(mochi_omap).
+-export([new/0, put/3, get/2, keys/1, values/1, to_list/1, size/1, is_key/2, delete/2]).
+
+new() -> {[], #{}}.
+
+put(K, V, {Keys, Map}) ->
+    NewKeys = case lists:member(K, Keys) of
+        true  -> Keys;
+        false -> Keys ++ [K]
+    end,
+    {NewKeys, Map#{K => V}}.
+
+get(K, {_Keys, Map}) ->
+    case maps:find(K, Map) of
+        {ok, V} -> V;
+        error   -> erlang:error({mochi_error, mochi_err_index,
+                                 <<"omap key not found">>})
+    end.
+
+keys({Keys, _Map}) -> Keys.
+
+values({Keys, Map}) -> [maps:get(K, Map) || K <- Keys].
+
+to_list({Keys, Map}) -> [{K, maps:get(K, Map)} || K <- Keys].
+
+size({Keys, _Map}) -> length(Keys).
+
+is_key(K, {_Keys, Map}) -> maps:is_key(K, Map).
+
+delete(K, {Keys, Map}) ->
+    {lists:delete(K, Keys), maps:remove(K, Map)}.
+```
+
+**`omap{}` literal** -- lowered as a sequence of `mochi_omap:put/3` calls starting from `mochi_omap:new()`:
+```erlang
+mochi_omap:put(K3, V3,
+  mochi_omap:put(K2, V2,
+    mochi_omap:put(K1, V1,
+      mochi_omap:new())))
+```
+Keys are inserted in source order. This is O(n^2) due to `lists:member` in `put/3`, but is correct and acceptable for Phase 3.4's fixture sizes (up to ~20 entries). A more efficient initialization path is Phase 3.X.
+
+**`for k in m`** (omap) -- iterates over `mochi_omap:keys(M)`, which returns keys in insertion order:
+```erlang
+lists:foreach(fun(V_k) -> body end, mochi_omap:keys(V_m))
+```
+
+**`for k, v in m`** (omap key-value) -- iterates over `mochi_omap:to_list(M)`.
+
+**Index `m[k]`** -> `c_call(c_atom(mochi_omap), c_atom(get), [lowerExpr(k), V_m])`. `mochi_omap:get/2` raises `mochi_err_index` for missing keys directly; no external try/catch wrapper is needed.
+
+### Test set (3.4)
+
+Fixtures `256_omap_basic.mochi` through `265_omap_order.mochi` (10 fixtures). Key cases: `omap{}` literal with 3 entries; insertion order preserved in `for k in m`; `get` existing key; `get` missing key; `put` new key (appended to order); `put` existing key (order preserved); `delete`; `keys` returns in insertion order; `values` returns in insertion order; nested omap.
+
+## Sub-phase 3.5 -- list&lt;record&gt;
+
+### Decisions made (3.5)
+
+**No special representation.** Mochi records are tagged BEAM maps (see Phase 4). A `list<Person>` is a standard BEAM cons-cell list whose elements are tagged maps. No additional lowering work is required; the existing `list<T>` lowering handles this correctly as long as the element type's `lowerExpr` returns the correct tagged-map shape.
+
+**What Phase 3.5 actually does:**
+1. Verifies that `aotir`'s type verifier accepts `list<RecordType>` as a valid list element type.
+2. Ensures `lowerExpr` for `RecordLit` (from Phase 4.0) is present in the lowerer's type switch.
+3. Adds fixtures that create a `list<Person>`, append to it, index into it, and iterate over it with `for p in people`.
+
+**Fixture pattern:**
+```mochi
+type Person { name: string, age: int }
+let people = [Person{name: "alice", age: 30}, Person{name: "bob", age: 25}]
+for p in people {
+    print(p.name)
+}
+```
+
+Expected output:
+```
+alice
+bob
+```
+
+Phase 3.5 depends on Phase 4.0 (record literal lowering) and may land in the same PR.
+
+### Test set (3.5)
+
+Fixtures `266_list_of_records.mochi` through `270_list_of_records_ops.mochi` (5 fixtures): basic list of records; append record to list; index into `list<record>`; for-in over `list<record>`; `list<record>` passed to function.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/beam/lower/lower.go` | `lowerListLit`, `lowerListIndex`, `lowerListLen`, `lowerListAppend`, `lowerForInList`, `lowerListComp`, `lowerMapLit`, `lowerMapIndex`, `lowerMapUpdate`, `lowerForInMap`, `lowerSetLit`, `lowerOmapLit`, `lowerOmapOps` |
+| `transpiler3/beam/runtime/src/mochi_list.erl` | `append/2`; Phase 3.5 helpers |
+| `transpiler3/beam/runtime/src/mochi_omap.erl` | Full omap implementation (new/0, put/3, get/2, keys/1, values/1, to_list/1, size/1, is_key/2, delete/2) |
+| `transpiler3/beam/build/phase03_test.go` | `TestPhase3List`, `TestPhase3Map`, `TestPhase3Set`, `TestPhase3Omap`, `TestPhase3ListOfRecords` |
+| `tests/transpiler3/beam/fixtures/phase3/` | ~90 fixture pairs covering all sub-phases |
 
 ## Test set
 
-_Pending phase open._
+~90 fixtures total:
+- Phase 3.1: 21 fixtures (`200_` through `220_`).
+- Phase 3.2: 20 fixtures (`221_` through `240_`).
+- Phase 3.3: 15 fixtures (`241_` through `255_`).
+- Phase 3.4: 10 fixtures (`256_` through `265_`).
+- Phase 3.5: 5 fixtures (`266_` through `270_`).
+
+All fixtures are byte-equal vs vm3. Fixtures that involve unordered iteration (set, map) sort their output before printing.
+
+## Deferred work
+
+- `list<list<T>>` (nested lists) -- Phase 3.X follow-up. The lowerer supports it generically (BEAM lists are untyped), but the aotir type verifier's nested-type support needs to be verified.
+- `map<string, list<T>>` and similar nested types -- same deferral.
+- Constant-time `len(list)` -- requires a different list representation. Deferred; O(n) `erlang:length/1` is correct and sufficient for Phase 3.
+- `omap` with O(n^2) initialization -- acceptable for small maps in Phase 3; a batch-build path using `lists:foldl` is Phase 3.X.
+- `set` ordering guarantees -- BEAM's `sets` v2 does not guarantee any iteration order. If a future MEP requires stable `for x in set` ordering, `ordsets` would be introduced as a separate type.
+- List mutation (e.g., `xs[i] = v`) is not in Mochi's current surface; all collections are immutable values.
 
 ## Closeout notes
 

--- a/website/docs/implementation/0046/phase-04-records.md
+++ b/website/docs/implementation/0046/phase-04-records.md
@@ -2,14 +2,14 @@
 title: "Phase 4. Records"
 sidebar_position: 6
 sidebar_label: "Phase 4. Records"
-description: "MEP-46 Phase 4. Records tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+description: "MEP-46 Phase 4 tracking: record literal, field access, field update, methods, equality on BEAM using tagged maps."
 ---
 
 # Phase 4. Records
 
 | Field          | Value |
 |----------------|-------|
-| MEP            | [MEP-46 §Phases · Phase 4. Records](/docs/mep/mep-0046#phase-4-records) |
+| MEP            | [MEP-46 §Phases · Phase 4](/docs/mep/mep-0046#phase-4-records) |
 | Status         | NOT STARTED |
 | Started        | — |
 | Landed         | — |
@@ -18,23 +18,244 @@ description: "MEP-46 Phase 4. Records tracking stub. Filled in when the phase op
 
 ## Gate
 
-See [MEP-46 §Phases · Phase 4. Records](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+Records suite (25 fixtures: literal construction, field access, field update, methods, equality, list&lt;record&gt; round-trip) compiles via `mochi build --target=beam-escript` and runs byte-equal vs vm3; `TestPhase4Records` is green.
 
 ## Goal-alignment audit
 
-_Pending phase open._
+Records are the primary user-defined data type in Mochi. Without records the BEAM target cannot compile any realistic Mochi program (the query DSL, agent state, and virtually all non-trivial Mochi libraries use records). Phase 4 is also the phase that validates the BEAM representation decision (tagged maps rather than Erlang records or tuples) under the full field-access, update, and pattern-matching surface. Aligns directly with the user-facing goal.
 
 ## Sub-phases
 
-_Pending phase open._
+| #   | Scope | Status | Commit | PR |
+|-----|-------|--------|--------|----|
+| 4.0 | Record literal construction: `Person{name: "alice", age: 30}` | NOT STARTED | — | — |
+| 4.1 | Field access `p.name`; field update `p with {age: 31}`; pattern matching on records | NOT STARTED | — | — |
+| 4.2 | Record methods: `fun (p: Person) greet() -> string` lowered to module-level functions | NOT STARTED | — | — |
+| 4.3 | Record equality: `p1 == p2` via BEAM structural equality `=:=` | NOT STARTED | — | — |
 
-## Decisions made
+## Sub-phase 4.0 -- Record literal construction
 
-_Pending phase open._
+### Goal-alignment audit (4.0)
+
+Record literals are the minimum foothold needed before any other Phase 4 sub-phase can be tested. Without `lowerRecordLit`, there are no record values to access fields on, update, or compare. All 25 Phase 4 fixtures depend on record construction. Phase 3.5 (list&lt;record&gt;) also depends on this sub-phase.
+
+### Decisions made (4.0)
+
+**Representation: tagged BEAM maps.** A Mochi record `Person{name: "alice", age: 30}` is represented as:
+```erlang
+#{mochi_record_tag => person, name => <<"alice"/utf8>>, age => 30}
+```
+
+The `mochi_record_tag` key carries a lowercase atom identifying the record type. This is a compile-time constant key used for variant discrimination in pattern matching (Phase 5) and for `is_record`-style guards.
+
+**Why tagged maps rather than Erlang records.** Erlang's `record` construct is a compile-time syntactic sugar over tuples (e.g., `#person{name=..., age=...}` compiles to `{person, ..., ...}`). They have fixed field order, no structural equality, and no dynamic field access. BEAM maps support all three. Using maps means the transpiler can implement field access as `maps:get(FieldName, Map)` rather than generating record header files. Maps also support the `with` update syntax natively via Core Erlang's `c_map_update`.
+
+**Why tagged maps rather than bare maps.** Without a tag, two records with the same field names and values would be indistinguishable. The `mochi_record_tag` key enables:
+1. Pattern matching in Phase 5 sum types (`match v { Point{x, y} => ... }`).
+2. Meaningful error messages when a wrong record type is passed to a function.
+3. Future Dialyzer specs (Phase 17) to narrow the map type per tag value.
+
+**Record type name is lowercased atom.** `Person` -> `person`, `HTTPRequest` -> `httprequest`. The lowercasing is applied at lower time (not parse time) so the aotir IR preserves the original casing for diagnostics. `lowerRecordLit` lowercases the record name when building the `c_atom`.
+
+**`lowerRecordLit(RecordLit) -> cerl.Expr`:**
+```
+c_map([
+  c_map_pair_exact(c_atom(mochi_record_tag), c_atom(person)),
+  c_map_pair_exact(c_atom(name), lowerExpr(NameExpr)),
+  c_map_pair_exact(c_atom(age),  lowerExpr(AgeExpr))
+])
+```
+
+`c_map_pair_exact` corresponds to Core Erlang's exact-match map constructor (`:=`), which is used for construction (not update). The pairs are emitted in the order the fields appear in the `type` declaration, not the order they appear in the literal. This ensures a deterministic map construction order independent of source order, which matters for Phase 17 (reproducibility) and for future Dialyzer map specs.
+
+**Field order in the type declaration is the canonical order.** The aotir type checker enforces that all record literals include every required field (no optional fields in Phase 4). The lowerer trusts the type checker and emits fields in declaration order.
+
+**String field values are UTF-8 binaries.** `"alice"` -> `c_binary([{bin_element, {string, "alice"}, default, [utf8]}])`. This is consistent with all other string lowering in the pipeline.
+
+### Test set (4.0)
+
+Fixtures `300_record_basic.mochi` through `304_record_nested.mochi` (5 fixtures):
+- `300_record_basic.mochi`: single record, print one field.
+- `301_record_two_fields.mochi`: print both fields.
+- `302_record_in_function.mochi`: record constructed inside a function, returned and printed.
+- `303_record_list.mochi`: `[Person{name: "alice", age: 30}]` -- cross with Phase 3.5.
+- `304_record_nested.mochi`: record containing another record as a field value.
+
+## Sub-phase 4.1 -- Field access, update, and pattern matching
+
+### Goal-alignment audit (4.1)
+
+Field access and update are the day-to-day operations on records. Without them a record is a write-once value with no way to read it back. Pattern matching on records (used pervasively in Phase 5 sum types and Phase 8 query DSL) requires the `c_map_pattern` lowering that this sub-phase establishes.
+
+### Decisions made (4.1)
+
+**Field access `p.name`** -> `c_call(c_atom(maps), c_atom(get), [c_atom(name), V_p])`.
+
+If the field is not present in the map, `maps:get/2` raises `{badkey, name}`. The lowerer wraps field access in a try/catch only when the type checker cannot prove the field exists at compile time (which for typed records it always can). In Phase 4.1, the type checker always knows the record type of `p`, so the field access is emitted without a try/catch wrapper. The type checker's field-existence guarantee is an invariant; the runtime try/catch is defence-in-depth and is deferred to Phase 17 (defensive hardening pass).
+
+**Why `maps:get/2` rather than pattern matching for field access.** Core Erlang supports map pattern matching (`c_map_pattern`), but using it for every field access would generate a `c_case` with one clause for each field accessed. `maps:get/2` is simpler, is a single BIF call, and is JIT-compiled in OTP 27 to an efficient hash lookup. Pattern matching is used only for `match` expressions (Phase 5).
+
+**Field update `p with {age: 31}`** (Mochi update syntax) -> Core Erlang map update:
+```erlang
+c_map_update(V_p, [c_map_pair(c_atom(age), c_int(31))])
+```
+
+`c_map_update` in Core Erlang corresponds to `Map#{Key := Value}` (exact-update semantics in Erlang). The `mochi_record_tag` field is carried over automatically (BEAM map update preserves all existing keys). The result is a new map; the original `p` is unmodified.
+
+Why `c_map_pair` (not `c_map_pair_exact`) for update: `c_map_pair` is `=>` semantics in Erlang (create or update), while `c_map_pair_exact` is `:=` (must exist). Since the Mochi type checker guarantees the field exists in the record, both are semantically correct; `c_map_pair` is used because it is slightly more forgiving and matches how `c_map_update` is typically used in generated Core Erlang.
+
+**Updating `mochi_record_tag` is not allowed.** The lowerer rejects an update literal that includes `mochi_record_tag` as a field name (this would be a name collision; the Mochi source can't spell it anyway since `mochi_record_tag` is not a valid Mochi identifier).
+
+**Pattern matching on records: `match p { Person{name: n} => ... }`** lowered to:
+
+```erlang
+c_case(V_p, [
+  c_clause(
+    [c_map_pattern([
+      c_map_pair_exact(c_atom(mochi_record_tag), c_atom(person)),
+      c_map_pair_exact(c_atom(name), c_var('V_n'))
+    ])],
+    c_atom(true),   %% guard: always true
+    lowerBlock(body)
+  )
+])
+```
+
+`c_map_pattern` in Core Erlang matches a map if it contains at least the listed key-value pairs. The `mochi_record_tag` pair ensures the match is type-specific: a `Circle{name: n}` would not match a `Person{name: n}` even though both have a `name` field. Additional fields in the record that are not bound in the pattern are ignored (BEAM map patterns are subset matches).
+
+**Partial patterns are OK.** `match p { Person{age: a} => ... }` matches any `Person` map and binds `age` to `V_a`; it does not need to bind `name`. The map pattern matches if the map contains `mochi_record_tag => person` and `age => <anything>`.
+
+### Test set (4.1)
+
+Fixtures `305_field_access.mochi` through `315_record_pattern.mochi` (11 fixtures):
+- `305_field_access.mochi`: `p.name`, `p.age` on a constructed record.
+- `306_field_access_nested.mochi`: `p.address.city` (nested record field access).
+- `307_field_update.mochi`: `p with {age: 31}`; verify original unchanged; verify updated value.
+- `308_field_update_multiple.mochi`: `p with {name: "bob", age: 25}` (multi-field update).
+- `309_record_in_if.mochi`: record field used as `if` condition (`p.active == true`).
+- `310_record_in_while.mochi`: record field used as while condition.
+- `311_record_passed_to_fn.mochi`: record passed as function argument; field read inside function.
+- `312_record_returned.mochi`: function returns a record; caller reads fields.
+- `313_record_pattern_basic.mochi`: `match p { Person{name: n} => print(n) }`.
+- `314_record_pattern_multi_field.mochi`: `match p { Person{name: n, age: a} => ... }`.
+- `315_record_pattern_in_for.mochi`: `for p in people { match p { Person{name: n} => print(n) } }`.
+
+## Sub-phase 4.2 -- Methods on records
+
+### Goal-alignment audit (4.2)
+
+Methods on records are used throughout the Mochi standard library and user programs to encapsulate record operations. Without methods the BEAM target cannot compile any Mochi code that calls `p.greet()` or `circle.area()`. This is a significant fraction of idiomatic Mochi code.
+
+### Decisions made (4.2)
+
+**Methods are module-level functions.** A Mochi method:
+```mochi
+fun (p: Person) greet() -> string = "hello, " ++ p.name
+```
+is lowered to a Core Erlang function:
+```erlang
+person__greet(V_p) ->
+    string:concat(<<"hello, ">>, maps:get(name, V_p)).
+```
+
+The mangled name is `RecordName_lowercase__methodName`. This is a module-level function, not a closure. There is no `self` or `this`; the receiver is the first parameter.
+
+**Method calls `p.greet()`** are lowered to `c_call(c_atom(module), c_atom(person__greet), [V_p])` where `module` is the current module name. If the method takes additional arguments `p.greet(x, y)`, they follow the receiver: `person__greet(V_p, V_x, V_y)`.
+
+**No `self` mutation.** Methods that appear to "mutate" the receiver actually return a new record. For example:
+```mochi
+fun (p: Person) with_age(a: int) -> Person = p with {age: a}
+```
+lowers to:
+```erlang
+person__with_age(V_p, V_a) ->
+    maps:update(age, V_a, V_p).  %% or: V_p#{age => V_a}
+```
+
+**Method resolution is static.** The lowerer knows the type of `p` (from the aotir type checker) and looks up the method in the type's method table at lower time. There is no runtime dispatch. This is correct because Mochi does not have interface polymorphism in Phase 4 (that is Phase 7, the error model / trait-like interfaces).
+
+**Exported methods vs private methods.** All methods are module-private by default (not in the Core Erlang export list). A `pub fun` declaration makes the method exported. For Phase 4 fixtures, all methods are private.
+
+**Method name collision with field names.** If a record has a field `greet` and a method `greet()`, this is a compile-time error in the Mochi type checker. The lowerer need not handle this case.
+
+### Test set (4.2)
+
+Fixtures `316_method_basic.mochi` through `322_method_chain.mochi` (7 fixtures):
+- `316_method_basic.mochi`: `fun (p: Person) greet() -> string = "hello, " ++ p.name`; call `p.greet()`.
+- `317_method_with_arg.mochi`: method with one extra argument.
+- `318_method_returns_record.mochi`: method that returns an updated record.
+- `319_method_calls_method.mochi`: method that calls another method on the same receiver.
+- `320_method_in_for.mochi`: call method inside `for p in people` loop.
+- `321_method_recursive.mochi`: recursive method (e.g., `fun (n: Node) depth() -> int`).
+- `322_method_chain.mochi`: `p.with_age(30).greet()` (chained method calls on updated records).
+
+## Sub-phase 4.3 -- Record equality
+
+### Goal-alignment audit (4.3)
+
+Record equality `p1 == p2` is used in assertions, deduplication, and query join conditions. Without it the BEAM target cannot compile programs that compare records. This sub-phase is cheap because BEAM's structural equality already does the right thing.
+
+### Decisions made (4.3)
+
+**`p1 == p2`** -> `c_call(c_atom(erlang), c_atom('=:='), [V_p1, V_p2])`.
+
+BEAM's `=:=` operator on maps is deep structural equality: it checks that both maps have exactly the same key-value pairs (including `mochi_record_tag`). This matches Mochi's value semantics: two records are equal iff all their fields are equal and they have the same type. No custom `equals` method is needed.
+
+**`mochi_record_tag` is part of equality.** Because `mochi_record_tag` is a key in the map, `=:=` naturally checks it. A `Person{name: "alice", age: 30}` is not `=:=` to a `Customer{name: "alice", age: 30}` even if both have the same non-tag fields, because their `mochi_record_tag` values differ.
+
+**`p1 != p2`** -> `c_call(c_atom(erlang), c_atom('=/='), [V_p1, V_p2])`.
+
+**Ordering (`<`, `>`) on records is not supported.** Mochi does not define a total order on records (there is no `Ord` trait in Phase 4). The type checker rejects `p1 < p2` with a type error. The lowerer does not handle this case.
+
+**Nested record equality is structural.** If `Address` is a nested record inside `Person`, then `p1 == p2` requires that `p1.address =:= p2.address`, which requires that all fields of the two `Address` values match. BEAM's `=:=` handles this recursively without any additional lowering.
+
+**Float equality in records.** If a record field is `float`, `=:=` on floats is exact bit-pattern equality (same as `==` on `float64` in Go). NaN `=:=` NaN is `false` in both BEAM and Go (IEEE 754 property). This is byte-equal to vm3.
+
+### Test set (4.3)
+
+Fixtures `323_record_eq_basic.mochi` through `325_record_eq_nested.mochi` (3 fixtures):
+- `323_record_eq_basic.mochi`: `p1 == p2` (same fields), `p1 == p3` (different fields).
+- `324_record_eq_type.mochi`: `person == customer` (same field values, different tags) -> `false`.
+- `325_record_eq_nested.mochi`: records with nested record fields; equality checks all levels.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/beam/lower/lower.go` | `lowerRecordLit`, `lowerFieldAccess`, `lowerFieldUpdate`, `lowerRecordPattern`, `lowerMethodCall`, `lowerMethod` (module-level function from method decl) |
+| `transpiler3/beam/lower/lower_state.go` | Method table per record type (populated in pass 1); lowercased type name helper |
+| `transpiler3/beam/build/phase04_test.go` | `TestPhase4Records` gate test; walks `tests/transpiler3/beam/fixtures/phase4/` |
+| `tests/transpiler3/beam/fixtures/phase4/` | 25 fixture pairs (`300_` through `325_`) |
 
 ## Test set
 
-_Pending phase open._
+25 fixtures total:
+- Phase 4.0: 5 fixtures (`300_` through `304_`).
+- Phase 4.1: 11 fixtures (`305_` through `315_`).
+- Phase 4.2: 7 fixtures (`316_` through `322_`).
+- Phase 4.3: 3 fixtures (`323_` through `325_`).
+
+All byte-equal vs vm3.
+
+Gate test: `transpiler3/beam/build/phase04_test.go::TestPhase4Records` -- walks all fixtures in `tests/transpiler3/beam/fixtures/phase4/`, calls `runBeamFixture` on each pair.
+
+Additional unit tests:
+- `transpiler3/beam/lower/lower_record_test.go::TestLowerRecordLit` -- unit: verifies the `cerl.Module` shape for a record literal (tag atom, field pairs in declaration order, UTF-8 binary strings).
+- `transpiler3/beam/lower/lower_record_test.go::TestLowerFieldAccess` -- unit: verifies `maps:get(field, V_p)` emission.
+- `transpiler3/beam/lower/lower_record_test.go::TestLowerFieldUpdate` -- unit: verifies `c_map_update` emission.
+- `transpiler3/beam/lower/lower_record_test.go::TestLowerRecordPattern` -- unit: verifies `c_map_pattern` with `mochi_record_tag` and bound variables.
+- `transpiler3/beam/lower/lower_record_test.go::TestLowerMethodDecl` -- unit: verifies method lowers to a module-level function with the mangled name.
+
+## Deferred work
+
+- `print(p)` for records (printing the full record as a string) -- deferred to Phase 6 (strings and I/O). Phase 4 fixtures only print individual scalar fields.
+- Record field ordering in `print` output -- Phase 6.
+- `Ord` trait / record ordering (`<`, `>`) -- not in MEP-46 v1 scope.
+- Interface/trait dispatch on records -- Phase 7 (error model and traits).
+- Generic records (`type Box<T> { value: T }`) -- Phase 5.X or later.
+- BEAM's native `record` construct is not used at any point; all records are BEAM maps throughout MEP-46.
+- Dialyzer map specs for record types (narrowing `map()` to `#{mochi_record_tag := person, name := binary(), age := integer()}`) -- Phase 17.
+- Record serialisation to JSON / external format -- Phase 12 (FFI and interop).
 
 ## Closeout notes
 

--- a/website/docs/implementation/0046/phase-05-sums.md
+++ b/website/docs/implementation/0046/phase-05-sums.md
@@ -2,39 +2,315 @@
 title: "Phase 5. Sum types and pattern matching"
 sidebar_position: 7
 sidebar_label: "Phase 5. Sum types and pattern matching"
-description: "MEP-46 Phase 5. Sum types and pattern matching tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+description: "MEP-46 Phase 5 implementation spec: lowering Mochi sum types, option, and result to tagged BEAM values and c_case."
 ---
 
 # Phase 5. Sum types and pattern matching
 
 | Field          | Value |
 |----------------|-------|
-| MEP            | [MEP-46 §Phases · Phase 5. Sum types and pattern matching](/docs/mep/mep-0046#phase-5-sum-types-and-pattern-matching) |
+| MEP            | [MEP-46 §Phases · Phase 5](/docs/mep/mep-0046#phase-5-sum-types-and-pattern-matching) |
 | Status         | NOT STARTED |
 | Started        | — |
 | Landed         | — |
 | Tracking issue | — |
 | Tracking PR    | — |
 
-## Gate
-
-See [MEP-46 §Phases · Phase 5. Sum types and pattern matching](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+---
 
 ## Goal-alignment audit
 
-_Pending phase open._
+This phase directly advances the correctness gate (byte-equal stdout vs vm3)
+for programs that use sum types, which is one of the most common Mochi
+patterns. Without this phase, any program using `option<T>`, `Result<T,E>`, or
+user-defined tagged unions fails to compile to BEAM. Completing this phase
+unlocks a large fraction of real Mochi programs.
 
-## Sub-phases
+---
 
-_Pending phase open._
+## Sub-phase 5.0: Variant constructors and basic match
+
+### Representation
+
+Sum type `type Shape = Circle(float) | Rectangle(float, float) | Point` lowers
+to tagged tuples and bare atoms depending on arity:
+
+| Mochi variant | Core Erlang representation |
+|---|---|
+| `Point` (unit) | `c_atom("point")` |
+| `Circle(3.14)` (single field) | `c_tuple([c_atom("circle"), c_float(3.14)])` |
+| `Rectangle(w, h)` (multi-field) | `c_tuple([c_atom("rectangle"), V_w, V_h])` |
+
+The tag atom is always the lowercase variant name. The lowerer derives it with
+`strings.ToLower(variant.Name)`.
+
+### Constructor lowering
+
+```
+lowerVariantCtor(ctor, args):
+  tag = c_atom(strings.ToLower(ctor.Name))
+  if len(args) == 0:
+    return tag
+  cerl_args = [lowerExpr(a) for a in args]
+  return c_tuple([tag] + cerl_args)
+```
+
+### Match lowering
+
+The MEP-45 match-to-decision-tree pass (Maranget canonicalisation) runs on
+aotir **before** the BEAM lowerer sees it. The BEAM lowerer receives a
+canonical sorted match tree with unique tags and maps each canonical arm
+directly to a `c_clause`.
+
+```
+match shape {
+  Circle(r)         => expr1
+  Rectangle(w, h)   => expr2
+  Point             => expr3
+}
+```
+
+lowers to (via the cerl API):
+
+```go
+c_case(V_shape, []cerl.Clause{
+    c_clause(
+        []cerl.Expr{c_tuple([]cerl.Expr{c_atom("circle"), c_var("V_r")})},
+        c_atom("true"),
+        lowerExpr(expr1),
+    ),
+    c_clause(
+        []cerl.Expr{c_tuple([]cerl.Expr{c_atom("rectangle"), c_var("V_w"), c_var("V_h")})},
+        c_atom("true"),
+        lowerExpr(expr2),
+    ),
+    c_clause(
+        []cerl.Expr{c_atom("point")},
+        c_atom("true"),
+        lowerExpr(expr3),
+    ),
+})
+```
+
+### Non-exhaustive match catch-all
+
+For non-exhaustive matches, the lowerer appends a final catch-all clause:
+
+```go
+c_clause(
+    []cerl.Expr{c_var("_")},
+    c_atom("true"),
+    c_call(c_atom("mochi_core"), c_atom("panic_match"), []cerl.Expr{}),
+)
+```
+
+`mochi_core:panic_match/0` in the runtime raises `erlang:error(mochi_err_match)`.
+
+---
+
+## Sub-phase 5.1: Nested patterns and guard clauses
+
+### Nested patterns
+
+Nested patterns are handled structurally. The Maranget pass from MEP-45 has
+already flattened multi-level matches into a decision tree; the BEAM lowerer
+emits one `c_clause` per leaf. Each level of nesting becomes a nested pattern
+within the same `c_clause` pattern list.
+
+Example: `Some(Circle(r))` over `option<Shape>`:
+
+```go
+c_clause(
+    []cerl.Expr{
+        c_tuple([]cerl.Expr{
+            c_atom("some"),
+            c_tuple([]cerl.Expr{c_atom("circle"), c_var("V_r")}),
+        }),
+    },
+    c_atom("true"),
+    body,
+)
+```
+
+### Guard clauses
+
+`Circle(r) when r > 0.0 =>` lowers to a `c_clause` with a non-trivial guard
+expression. The guard is passed as the second argument to `c_clause`:
+
+```go
+guard_expr = c_call(
+    c_atom("erlang"), c_atom(">"),
+    []cerl.Expr{c_var("V_r"), c_float(0.0)},
+)
+
+c_clause(
+    []cerl.Expr{c_tuple([]cerl.Expr{c_atom("circle"), c_var("V_r")})},
+    guard_expr,
+    body,
+)
+```
+
+BEAM guard constraints: only pure expressions are permitted (no side effects,
+no message sends, no ETS writes). The lowerer validates guard expressions for
+purity and emits a compile-time error if an impure expression appears in a
+guard position. Permitted guard forms: arithmetic, comparison, boolean logic,
+type tests (`is_integer/1`, `is_atom/1`, etc.), `size/1`, `element/2`,
+`hd/1`, `tl/1`.
+
+### Wildcard patterns
+
+`_ =>` lowers to a fresh uniquely-named variable to avoid collisions when
+multiple wildcards appear in the same `case`:
+
+```go
+c_clause(
+    []cerl.Expr{c_var(fmt.Sprintf("V__wildcard_%d", n))},
+    c_atom("true"),
+    body,
+)
+```
+
+where `n` is a per-function monotonically increasing counter.
+
+---
+
+## Sub-phase 5.2: option\<T\> lowering
+
+`option<T>` is a Mochi built-in sum type equivalent to
+`type Option<T> = Some(T) | None`. It uses the same tagged representation as
+user-defined sum types.
+
+| Mochi | Core Erlang |
+|---|---|
+| `Some(v)` | `c_tuple([c_atom("some"), lowerExpr(v)])` |
+| `None` | `c_atom("none")` |
+
+Match lowering is identical to user-defined sum type match. The `is_some(opt)`
+builtin lowers to an inline `c_case`:
+
+```go
+c_case(V_opt, []cerl.Clause{
+    c_clause(
+        []cerl.Expr{c_tuple([]cerl.Expr{c_atom("some"), c_var("_")})},
+        c_atom("true"),
+        c_atom("true"),
+    ),
+    c_clause(
+        []cerl.Expr{c_var("_")},
+        c_atom("true"),
+        c_atom("false"),
+    ),
+})
+```
+
+---
+
+## Sub-phase 5.3: Result\<T,E\> lowering
+
+`Result<T,E>` maps to the OTP-native `ok`/`error` tuple idiom so that Mochi
+functions returning `Result` are directly composable with OTP library functions.
+
+| Mochi | Core Erlang |
+|---|---|
+| `Ok(v)` | `c_tuple([c_atom("ok"), lowerExpr(v)])` |
+| `Err(e)` | `c_tuple([c_atom("error"), lowerExpr(e)])` |
+
+Match lowering:
+
+```go
+// match r { Ok(v) => body1 | Err(e) => body2 }
+c_case(V_r, []cerl.Clause{
+    c_clause(
+        []cerl.Expr{c_tuple([]cerl.Expr{c_atom("ok"), c_var("V_v")})},
+        c_atom("true"),
+        lowerExpr(body1),
+    ),
+    c_clause(
+        []cerl.Expr{c_tuple([]cerl.Expr{c_atom("error"), c_var("V_e")})},
+        c_atom("true"),
+        lowerExpr(body2),
+    ),
+})
+```
+
+Mochi `try { ... }` blocks that can fail produce `Result` values. The lowerer
+wraps the body in a `c_try` node, maps the success path to
+`c_tuple([c_atom("ok"), V_result])`, and maps the catch path to
+`c_tuple([c_atom("error"), V_reason])`.
+
+---
+
+## Fixtures
+
+25 fixture files under `tests/dataset/slt/beam/phase05/`:
+
+| File | Tests |
+|---|---|
+| `001_sum_basic.mochi` | Shape: Circle, Rectangle, Point |
+| `002_unit_variants.mochi` | Multiple unit variants, bare-atom representation |
+| `003_nested_patterns.mochi` | Nested sum types in match arms |
+| `004_option_some_none.mochi` | option\<int\> match, is_some |
+| `005_result_ok_err.mochi` | Result\<int,string\> match |
+| `006_guard_basic.mochi` | Single guard clause on variant |
+| `007_guard_compound.mochi` | AND/OR guards |
+| `008_wildcard.mochi` | Wildcard in various positions |
+| `009_non_exhaustive.mochi` | Panic-match catch-all clause fires |
+| `010_option_chain.mochi` | Chained option operations |
+| `011_result_chain.mochi` | Chained result operations |
+| `012_nested_option.mochi` | option\<option\<T\>\> |
+| `013_sum_in_list.mochi` | List of sum type values |
+| `014_sum_in_record.mochi` | Record containing sum type field |
+| `015_match_in_fun.mochi` | Match inside anonymous function |
+| `016_match_in_loop.mochi` | Match inside loop body |
+| `017_multi_guard.mochi` | Multiple guards on same variant |
+| `018_result_try.mochi` | try block producing Result |
+| `019_option_map.mochi` | Mapping over option values |
+| `020_recursive_sum.mochi` | Recursive sum type (binary tree) |
+| `021_polymorphic_match.mochi` | Generic sum type match |
+| `022_interop_ok_error.mochi` | Interop with OTP {ok,V}/{error,R} returns |
+| `023_exhaustive_check.mochi` | All variants covered, no catch-all emitted |
+| `024_variant_in_map.mochi` | Map values are sum type |
+| `025_complex_nested.mochi` | Deeply nested patterns, 4+ levels |
+
+All fixtures are compiled with `mochi build --target=beam` and stdout is
+compared byte-for-byte against vm3 output (correctness gate).
+
+---
 
 ## Decisions made
 
-_Pending phase open._
+### Why bare atom for unit variants, not zero-tuple
 
-## Test set
+`point` (atom) vs `{point}` (zero-arity tuple): OTP idiom uses bare atoms for
+unit variants (`none`, `ok`, `error`). Pattern matching on atoms is O(1) via
+atom-table lookup; tuple dispatch requires checking tuple size and extracting
+the tag element. This matches how Erlang and Elixir developers expect to see
+these types and enables direct interop with OTP library functions that use
+`ok`, `error`, `none`, `true`, `false` as unit values.
 
-_Pending phase open._
+### Why `mochi_record_tag` for records but atom tag for sums
+
+Records are structural types: all fields are always present, and the tag
+exists only for discrimination between record types. Sum variants ARE their
+tag; the tag is definitional, not incidental. These are different
+representational patterns and both are idiomatic in BEAM. Conflating them
+would sacrifice either performance (records paying tuple overhead on every
+field access) or clarity (sums using a separate tag field that looks like a
+record field).
+
+### Why we let OTP's v3_kernel compile the pattern match decision tree
+
+OTP's `v3_kernel` pass (which runs after Core Erlang in the OTP compiler
+pipeline) performs full pattern-match compilation: it converts a flat `case`
+with one clause per arm into an optimal decision tree, including heuristics for
+minimizing test count and sharing sub-tests. We emit a flat `c_case` in
+post-Maranget canonical form (from MEP-45). OTP then compiles this to
+optimised BEAM bytecode. Re-implementing the decision tree compiler in the
+Mochi BEAM lowerer would duplicate well-tested OTP logic with no performance
+benefit since OTP's output is identical regardless of how we structure the
+input clauses.
+
+---
 
 ## Closeout notes
 

--- a/website/docs/implementation/0046/phase-06-closures.md
+++ b/website/docs/implementation/0046/phase-06-closures.md
@@ -2,40 +2,256 @@
 title: "Phase 6. Closures and higher-order functions"
 sidebar_position: 8
 sidebar_label: "Phase 6. Closures and higher-order functions"
-description: "MEP-46 Phase 6. Closures and higher-order functions tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+description: "MEP-46 Phase 6 implementation spec: lowering Mochi closures and HOFs to native BEAM funs and OTP list functions."
 ---
 
 # Phase 6. Closures and higher-order functions
 
 | Field          | Value |
 |----------------|-------|
-| MEP            | [MEP-46 §Phases · Phase 6. Closures and higher-order functions](/docs/mep/mep-0046#phase-6-closures-and-higherorder-functions) |
+| MEP            | [MEP-46 §Phases · Phase 6](/docs/mep/mep-0046#phase-6-closures-and-higherorder-functions) |
 | Status         | NOT STARTED |
 | Started        | — |
 | Landed         | — |
 | Tracking issue | — |
 | Tracking PR    | — |
 
-## Gate
-
-See [MEP-46 §Phases · Phase 6. Closures and higher-order functions](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+---
 
 ## Goal-alignment audit
 
-_Pending phase open._
+Closures and HOFs are core to Mochi's functional programming model. Without
+this phase, programs that pass functions as values (including all uses of
+`map`, `filter`, `fold`, and user-defined HOFs) fail to compile to BEAM.
+Completing this phase enables idiomatic functional-style Mochi programs and
+unlocks the query DSL (Phase 7), which internally generates HOF chains.
 
-## Sub-phases
+---
 
-_Pending phase open._
+## Sub-phase 6.0: Anonymous functions / BEAM funs
+
+### Basic anonymous function
+
+`fun(x: int) -> x * 2` lowers to a Core Erlang `c_fun` node:
+
+```go
+c_fun(
+    []cerl.Var{c_var("V_x")},
+    c_call(
+        c_atom("erlang"), c_atom("*"),
+        []cerl.Expr{c_var("V_x"), c_int(2)},
+    ),
+)
+```
+
+This produces a BEAM fun (a heap-allocated closure object containing a code
+pointer and captured bindings). If the anonymous function captures free
+variables from the enclosing scope, Core Erlang lists them explicitly in the
+fun's environment; the BEAM runtime creates the closure on the heap.
+
+### Closure-conversion interaction with MEP-45
+
+The MEP-45 closure-conversion pass runs on aotir before the BEAM lowerer and
+converts closures to explicit env-struct form (env struct + env-arg threading)
+for use by the C lowerer. The BEAM lowerer detects `FunLit` aotir nodes and
+**re-lifts** them to Core Erlang `c_fun` nodes, using native BEAM closures
+instead of the env-arg threading.
+
+Concretely:
+
+1. MEP-45 closure-conversion produces aotir `FunLit` nodes annotated with a
+   `FreeVars` list.
+2. The C lowerer reads `FreeVars` and threads an env struct through the callee.
+3. The BEAM lowerer reads `FreeVars` and emits them as captured bindings in the
+   Core Erlang `c_fun` environment, then uses `c_apply` at call sites.
+
+The env-arg threading output from step 2 is ignored by the BEAM lowerer.
+
+### Free-variable capture
+
+For each `FunLit` node with free variables `[v1, v2, ...]`, the BEAM lowerer
+emits:
+
+```go
+// The c_fun node captures V_v1, V_v2 from the enclosing scope.
+// Core Erlang handles this via the fun's environment annotation.
+c_fun(
+    []cerl.Var{c_var("V_x")},        // formal parameters
+    body_with_V_v1_and_V_v2_free,    // body referencing captured vars
+)
+// Core Erlang's cerl:ann_c_fun sets the fun's free-variable annotation.
+// The OTP compiler emits code to capture these at closure creation.
+```
+
+The free-variable annotation is set via `cerl:ann_c_fun/3` with the annotation
+list containing `{free_vars, [V_v1, V_v2]}`. OTP's `v3_kernel` pass reads this
+annotation and generates the correct closure packing code.
+
+---
+
+## Sub-phase 6.1: Higher-order functions mapping to OTP
+
+Mochi's built-in HOFs map directly to OTP `lists:` functions. The lowerer
+special-cases their `CallExpr` nodes in `lowerCallExpr`:
+
+| Mochi | Core Erlang |
+|---|---|
+| `map(xs, f)` | `c_call(c_atom("lists"), c_atom("map"), [lowerExpr(f), lowerExpr(xs)])` |
+| `filter(xs, pred)` | `c_call(c_atom("lists"), c_atom("filter"), [lowerExpr(pred), lowerExpr(xs)])` |
+| `fold(xs, init, f)` | `c_call(c_atom("lists"), c_atom("foldl"), [lowerExpr(f), lowerExpr(init), lowerExpr(xs)])` |
+
+Note the argument order: OTP's `lists:map/2` takes `(Fun, List)` while Mochi's
+`map/2` takes `(List, Fun)`. The lowerer swaps the arguments when emitting the
+`c_call`.
+
+These are native OTP functions that the BeamAsm JIT compiles to optimised
+native code. No Mochi runtime wrapper is needed.
+
+Mochi's `map`, `filter`, and `fold` builtins are registered in
+`types/check.go` with appropriate generic signatures. The lowerer identifies
+them by their resolved builtin ID in the aotir `CallExpr` node and emits the
+OTP call directly.
+
+### Additional list HOFs
+
+| Mochi | Core Erlang |
+|---|---|
+| `any(xs, pred)` | `c_call(c_atom("lists"), c_atom("any"), [lowerExpr(pred), lowerExpr(xs)])` |
+| `all(xs, pred)` | `c_call(c_atom("lists"), c_atom("all"), [lowerExpr(pred), lowerExpr(xs)])` |
+| `flat_map(xs, f)` | `c_call(c_atom("lists"), c_atom("flatmap"), [lowerExpr(f), lowerExpr(xs)])` |
+| `sort(xs, cmp)` | `c_call(c_atom("lists"), c_atom("sort"), [lowerExpr(cmp), lowerExpr(xs)])` |
+
+---
+
+## Sub-phase 6.2: Partial application
+
+### Closures over top-level functions
+
+`add5 = fun(y: int) -> add(5, y)` where `add` is a top-level function: the
+closure captures `add` as a module-level fun reference. The BEAM lowerer emits
+a `c_apply` referencing the named function atom, not a `c_call` through a
+variable:
+
+```go
+c_fun(
+    []cerl.Var{c_var("V_y")},
+    c_apply(
+        c_fname("add", 2),
+        []cerl.Expr{c_int(5), c_var("V_y")},
+    ),
+)
+```
+
+`c_fname("add", 2)` is a Core Erlang function name reference (module-local).
+This allows BeamAsm to inline the call at the call site when the target is
+statically known.
+
+### First-class function values (fun references)
+
+`let f = add` (passing a top-level function as a value) lowers to a fun
+reference:
+
+```go
+// Mochi: let f: fun(int, int) -> int = add
+// Core Erlang: F = fun add/2
+c_let(
+    [c_var("V_f")],
+    c_fname("add", 2),   // or fun mochi_module:add/2 for cross-module
+    body,
+)
+```
+
+### Curried application
+
+`let f = g(1)` where `g` returns a fun: the returned BEAM fun is stored in
+`V_f` and applied later with `c_apply`:
+
+```go
+// At the use site: f(arg)
+c_apply(c_var("V_f"), []cerl.Expr{lowerExpr(arg)})
+```
+
+`c_apply` (as opposed to `c_call`) is used when the callee is a variable
+holding a fun value. `c_call` is used only when the module and function name
+are statically known atoms.
+
+---
+
+## Sub-phase 6.3: Function type lowering
+
+Mochi function types `fun(T1, T2) -> R` are native BEAM fun types at the Core
+Erlang level; no wrapper or tag is needed. The BEAM type system does not track
+arity in the value representation; arity errors produce a `badarity` exception
+at runtime. The Mochi type checker enforces arity statically so this is not
+reachable in well-typed Mochi programs.
+
+---
+
+## Fixtures
+
+25 fixture files under `tests/dataset/slt/beam/phase06/`:
+
+| File | Tests |
+|---|---|
+| `001_anon_fun_basic.mochi` | Simple anonymous function, no captures |
+| `002_closure_capture_int.mochi` | Closure capturing an int from enclosing scope |
+| `003_closure_capture_string.mochi` | Closure capturing a string |
+| `004_closure_capture_list.mochi` | Closure capturing a list |
+| `005_closure_capture_record.mochi` | Closure capturing a record |
+| `006_map_builtin.mochi` | `map(xs, f)` over list of ints |
+| `007_filter_builtin.mochi` | `filter(xs, pred)` |
+| `008_fold_builtin.mochi` | `fold(xs, 0, f)` sum |
+| `009_hof_chain.mochi` | `map` + `filter` + `fold` chained |
+| `010_partial_app_toplevel.mochi` | Closure wrapping top-level function |
+| `011_fun_as_value.mochi` | Top-level fun passed as argument |
+| `012_curried_apply.mochi` | Function returning function, applied twice |
+| `013_any_all.mochi` | `any` and `all` builtins |
+| `014_flat_map.mochi` | `flat_map` over list of lists |
+| `015_sort_custom_cmp.mochi` | `sort` with custom comparator |
+| `016_closure_over_closure.mochi` | Closure capturing another closure |
+| `017_mutual_hof.mochi` | Two HOFs calling each other |
+| `018_closure_in_record.mochi` | Record field is a fun value |
+| `019_closure_in_list.mochi` | List of fun values |
+| `020_closure_in_map.mochi` | Map values are fun values |
+| `021_apply_from_list.mochi` | Apply each fun in a list |
+| `022_gen_adder.mochi` | Function that generates closures |
+| `023_memoize.mochi` | Higher-order memoize wrapper |
+| `024_compose.mochi` | Function composition HOF |
+| `025_pipeline.mochi` | Left-to-right pipeline operator using HOFs |
+
+All fixtures are compiled with `mochi build --target=beam` and stdout is
+compared byte-for-byte against vm3 output.
+
+---
 
 ## Decisions made
 
-_Pending phase open._
+### BEAM funs vs C closure structs
 
-## Test set
+The C target uses explicit heap-allocated env structs because C has no built-in
+closures. The BEAM target uses native BEAM funs; BeamAsm inlines fun
+applications at call sites where the target is statically known (the `c_apply`
+of a `c_fname`). This gives better performance (no indirection through an env
+struct pointer, no manual GC of the env struct) and simpler codegen (no env
+struct type definition needed).
 
-_Pending phase open._
+### Closure-conversion pass from MEP-45 is still run but its env-arg output is ignored
 
-## Closeout notes
+The MEP-45 closure-conversion pass produces two outputs: (1) a free-variable
+annotation on each `FunLit` node, and (2) env-arg threading rewrites in the
+surrounding function bodies (for the C lowerer). The BEAM lowerer uses output
+(1) to set the Core Erlang fun's free-variable annotation and ignores output
+(2). This reuse-and-override approach avoids duplicating the free-variable
+analysis (which is non-trivial for mutually recursive closures) while still
+giving the BEAM lowerer the information it needs.
 
-_Fill in after gate green._
+### `c_apply` for dynamic calls, `c_call` for static calls
+
+Core Erlang distinguishes `c_apply` (call through a fun value) from `c_call`
+(call to a statically-known module:function). BeamAsm can generate a direct
+call instruction for `c_call` but must use an indirect call through the fun's
+code pointer for `c_apply`. The BEAM lowerer uses `c_call` whenever the callee
+is a statically-known top-level Mochi function or OTP BIF, and `c_apply`
+otherwise. This distinction is important for performance: inner loops that call
+HOF arguments benefit from `c_apply` being as fast as possible, but top-level
+calls should use `c_call` for direct dispatch.

--- a/website/docs/implementation/0046/phase-07-query.md
+++ b/website/docs/implementation/0046/phase-07-query.md
@@ -2,40 +2,375 @@
 title: "Phase 7. Query DSL"
 sidebar_position: 9
 sidebar_label: "Phase 7. Query DSL"
-description: "MEP-46 Phase 7. Query DSL tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+description: "MEP-46 Phase 7 implementation spec: lowering Mochi query expressions to OTP lists: functions, ETS, and mochi_query runtime helpers."
 ---
 
 # Phase 7. Query DSL
 
 | Field          | Value |
 |----------------|-------|
-| MEP            | [MEP-46 §Phases · Phase 7. Query DSL](/docs/mep/mep-0046#phase-7-query-dsl) |
+| MEP            | [MEP-46 §Phases · Phase 7](/docs/mep/mep-0046#phase-7-query-dsl) |
 | Status         | NOT STARTED |
 | Started        | — |
 | Landed         | — |
 | Tracking issue | — |
 | Tracking PR    | — |
 
-## Gate
-
-See [MEP-46 §Phases · Phase 7. Query DSL](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+---
 
 ## Goal-alignment audit
 
-_Pending phase open._
+The query DSL is one of Mochi's headline differentiators over plain Erlang.
+Without this phase, `from`/`where`/`select`/`group_by`/`order_by` expressions
+compile only for vm3 and not for BEAM. Completing this phase validates that
+Mochi's data processing model runs on BEAM with correct output and acceptable
+performance, which is a prerequisite for the release gate.
 
-## Sub-phases
+---
 
-_Pending phase open._
+## Sub-phase 7.0: from/where/select -> list comprehension equivalent
+
+### Basic select
+
+`from x in xs select expr` lowers to a `lists:map` call:
+
+```go
+c_call(
+    c_atom("lists"), c_atom("map"),
+    []cerl.Expr{
+        c_fun([]cerl.Var{c_var("V_x")}, lowerExpr(expr)),
+        lowerExpr(xs),
+    },
+)
+```
+
+### Select with where
+
+`from x in xs where pred select expr` lowers to a filter then map chain:
+
+```go
+// lists:map(fun(X) -> Expr end, lists:filter(fun(X) -> Pred end, Xs))
+c_call(
+    c_atom("lists"), c_atom("map"),
+    []cerl.Expr{
+        c_fun([]cerl.Var{c_var("V_x")}, lowerExpr(expr)),
+        c_call(
+            c_atom("lists"), c_atom("filter"),
+            []cerl.Expr{
+                c_fun([]cerl.Var{c_var("V_x")}, lowerExpr(pred)),
+                lowerExpr(xs),
+            },
+        ),
+    },
+)
+```
+
+The lowerer combines the filter and map into a single `lists:filtermap` call
+when both `where` and `select` are present and the `select` expression does
+not access the original xs elements (no sharing). `lists:filtermap/2` (OTP
+stdlib) avoids allocating the intermediate filtered list.
+
+### Why `lists:` functions instead of native Core Erlang comprehensions
+
+`c_comp` (Core Erlang list comprehension node) support for complex
+qualification forms varies between OTP versions. Using `lists:` function calls
+is portable across OTP 27 and OTP 28 and is equivalently optimised by
+BeamAsm. The `lists:` approach also composes more predictably with the
+aggregation fusion in Sub-phase 7.1.
+
+### Multi-source query
+
+`from x in xs, y in ys select {x, y}` lowers to a nested HOF:
+
+```go
+// lists:append([lists:map(fun(Y) -> {X, Y} end, Ys) || X <- Xs])
+// Emitted as nested foldl to avoid materialising the outer list comprehension.
+c_call(
+    c_atom("lists"), c_atom("foldl"),
+    []cerl.Expr{
+        c_fun(
+            []cerl.Var{c_var("V_x"), c_var("V_acc")},
+            c_call(
+                c_atom("lists"), c_atom("append"),
+                []cerl.Expr{
+                    c_var("V_acc"),
+                    c_call(
+                        c_atom("lists"), c_atom("map"),
+                        []cerl.Expr{
+                            c_fun([]cerl.Var{c_var("V_y")},
+                                c_tuple([]cerl.Expr{c_var("V_x"), c_var("V_y")}),
+                            ),
+                            lowerExpr(ys),
+                        },
+                    ),
+                },
+            ),
+        ),
+        c_nil(),
+        lowerExpr(xs),
+    },
+)
+```
+
+---
+
+## Sub-phase 7.1: Aggregations
+
+### Aggregation fusion
+
+Aggregations are detected by the lowerer when a `CallExpr` with a builtin
+aggregate ID wraps a `QueryExpr`. The lowerer fuses them into a single-pass
+fold instead of materialising the intermediate list.
+
+| Mochi | Lowered form |
+|---|---|
+| `sum(from x in xs select x)` | `lists:foldl(fun(X, Acc) -> Acc + X end, 0, Xs)` |
+| `count(from x in xs where pred ...)` | `length(lists:filter(fun(X) -> Pred end, Xs))` |
+| `max(from x in xs select x)` | `lists:foldl(fun(X, Acc) -> erlang:max(X, Acc) end, hd(Xs), tl(Xs))` |
+| `min(from x in xs select x)` | `lists:foldl(fun(X, Acc) -> erlang:min(X, Acc) end, hd(Xs), tl(Xs))` |
+| `avg(from x in xs select x)` | sum / count via two-pass foldl or single-pass foldl accumulating {Sum, Count} |
+
+The `avg` aggregation uses a single-pass foldl accumulating a
+`{Sum, Count}` tuple to avoid traversing the list twice:
+
+```go
+// avg fused single pass
+c_let(
+    [c_var("V_sc")],
+    c_call(c_atom("lists"), c_atom("foldl"),
+        []cerl.Expr{
+            c_fun([]cerl.Var{c_var("V_x"), c_var("V_acc")},
+                c_case(c_var("V_acc"), []cerl.Clause{
+                    c_clause(
+                        []cerl.Expr{c_tuple([]cerl.Expr{c_var("V_s"), c_var("V_c")})},
+                        c_atom("true"),
+                        c_tuple([]cerl.Expr{
+                            c_call(c_atom("erlang"), c_atom("+"), []cerl.Expr{c_var("V_s"), c_var("V_x")}),
+                            c_call(c_atom("erlang"), c_atom("+"), []cerl.Expr{c_var("V_c"), c_int(1)}),
+                        }),
+                    ),
+                }),
+            ),
+            c_tuple([]cerl.Expr{c_float(0.0), c_int(0)}),
+            lowerExpr(xs),
+        },
+    ),
+    // extract and divide
+    c_case(c_var("V_sc"), ...),
+)
+```
+
+---
+
+## Sub-phase 7.2: group_by
+
+`from x in xs group_by x.dept select {x.dept, count(x)}` uses an ETS-backed
+or map-backed accumulator depending on estimated output cardinality.
+
+### Small group_by (estimate <= 10,000 rows): BEAM map accumulator
+
+```go
+// mochi_query:group_by(KeyFun, ValFun, List) -> #{Key => [Val]}
+c_call(
+    c_atom("mochi_query"), c_atom("group_by"),
+    []cerl.Expr{
+        c_fun([]cerl.Var{c_var("V_x")}, lowerExpr(keyExpr)),
+        c_fun([]cerl.Var{c_var("V_x")}, lowerExpr(valExpr)),
+        lowerExpr(xs),
+    },
+)
+```
+
+`mochi_query:group_by/3` is implemented as:
+
+```erlang
+group_by(KeyFun, ValFun, List) ->
+    lists:foldl(fun(X, Acc) ->
+        K = KeyFun(X),
+        V = ValFun(X),
+        maps:update_with(K, fun(Vs) -> [V | Vs] end, [V], Acc)
+    end, #{}, List).
+```
+
+### Large group_by (estimate > 10,000 rows): ETS accumulator
+
+When a compile-time size hint or runtime annotation indicates the list may
+exceed 10,000 rows, the lowerer emits a call to `mochi_query:group_by_ets/3`
+instead. ETS tables are off-heap and GC-transparent; large accumulations avoid
+per-process GC pauses:
+
+```erlang
+group_by_ets(KeyFun, ValFun, List) ->
+    Tab = ets:new(mochi_gb_tmp, [set, private]),
+    lists:foreach(fun(X) ->
+        K = KeyFun(X),
+        V = ValFun(X),
+        case ets:lookup(Tab, K) of
+            []        -> ets:insert(Tab, {K, [V]});
+            [{K, Vs}] -> ets:insert(Tab, {K, [V | Vs]})
+        end
+    end, List),
+    Result = ets:tab2list(Tab),
+    ets:delete(Tab),
+    Result.
+```
+
+---
+
+## Sub-phase 7.3: Joins
+
+### Inner join
+
+`from x in xs, y in ys where x.id == y.id select ...` lowers to a hash join:
+build an index map from `ys` keyed by `y.id`, then probe for each `x`.
+
+```go
+c_call(
+    c_atom("mochi_query"), c_atom("hash_join"),
+    []cerl.Expr{
+        c_fun([]cerl.Var{c_var("V_x")}, lowerExpr(x_key)),  // probe key fn
+        c_fun([]cerl.Var{c_var("V_y")}, lowerExpr(y_key)),  // build key fn
+        lowerExpr(xs),
+        lowerExpr(ys),
+    },
+)
+```
+
+`mochi_query:hash_join/4` builds a map from `ys` then probes it:
+
+```erlang
+hash_join(ProbeFun, BuildFun, Xs, Ys) ->
+    Index = lists:foldl(fun(Y, Acc) ->
+        K = BuildFun(Y),
+        maps:update_with(K, fun(Vs) -> [Y | Vs] end, [Y], Acc)
+    end, #{}, Ys),
+    lists:flatmap(fun(X) ->
+        K = ProbeFun(X),
+        case maps:get(K, Index, []) of
+            [] -> [];
+            Ys2 -> [{X, Y} || Y <- Ys2]
+        end
+    end, Xs).
+```
+
+### Left join
+
+`mochi_query:left_join/4` extends the hash join: when no matching `y` is
+found, produces `{X, none}` instead of omitting the row.
+
+---
+
+## Sub-phase 7.4: order_by, take, skip
+
+### order_by
+
+`order_by x.age desc` lowers to a `lists:sort` with a custom comparator:
+
+```go
+c_call(
+    c_atom("lists"), c_atom("sort"),
+    []cerl.Expr{
+        c_fun(
+            []cerl.Var{c_var("V_a"), c_var("V_b")},
+            c_call(
+                c_atom("erlang"), c_atom(">"),
+                []cerl.Expr{
+                    lowerFieldAccess(c_var("V_a"), "age"),
+                    lowerFieldAccess(c_var("V_b"), "age"),
+                },
+            ),
+        ),
+        lowerExpr(xs),
+    },
+)
+```
+
+### take and skip
+
+`take N` lowers to `lists:sublist(Sorted, N)`.
+`skip N` lowers to `lists:nthtail(N, Sorted)`.
+
+### Top-K optimization
+
+When `take K` immediately follows `order_by` and `K < 100`, the lowerer emits
+a call to `mochi_query:top_k/3` (heap-based partial sort, O(n log k) vs
+O(n log n) for full sort):
+
+```go
+c_call(
+    c_atom("mochi_query"), c_atom("top_k"),
+    []cerl.Expr{c_int(k), comparatorFun, lowerExpr(xs)},
+)
+```
+
+`mochi_query:top_k/3` maintains a bounded max-heap of size K, inserting each
+element and evicting the worst when the heap exceeds K.
+
+---
+
+## Fixtures
+
+30 fixture files under `tests/dataset/slt/beam/phase07/`:
+
+| File | Tests |
+|---|---|
+| `001_select_basic.mochi` | `from x in xs select x * 2` |
+| `002_where_select.mochi` | `from x in xs where x > 0 select x` |
+| `003_multi_source.mochi` | Two-source cartesian product |
+| `004_sum_agg.mochi` | `sum(from ...)` |
+| `005_count_agg.mochi` | `count(from ... where ...)` |
+| `006_max_min_agg.mochi` | `max` and `min` |
+| `007_avg_agg.mochi` | `avg` single-pass |
+| `008_group_by_basic.mochi` | Small group_by with count |
+| `009_group_by_sum.mochi` | group_by with sum aggregation |
+| `010_group_by_large.mochi` | Large group_by, ETS path |
+| `011_inner_join.mochi` | Hash join two lists |
+| `012_left_join.mochi` | Left join with none rows |
+| `013_order_by_asc.mochi` | order_by ascending |
+| `014_order_by_desc.mochi` | order_by descending |
+| `015_take.mochi` | take N |
+| `016_skip.mochi` | skip N |
+| `017_take_skip.mochi` | skip then take (pagination) |
+| `018_top_k.mochi` | order_by + take K optimization |
+| `019_nested_query.mochi` | Query inside select expression |
+| `020_query_in_fun.mochi` | Query inside anonymous function |
+| `021_query_over_records.mochi` | `from r in records select r.field` |
+| `022_query_over_maps.mochi` | `from kv in map select kv.val` |
+| `023_multi_where.mochi` | Multiple where conditions |
+| `024_select_tuple.mochi` | `select {x, y}` projection |
+| `025_filtermap_fusion.mochi` | where + select fused to filtermap |
+| `026_join_then_group.mochi` | Join followed by group_by |
+| `027_group_then_sort.mochi` | group_by followed by order_by |
+| `028_query_in_loop.mochi` | Query inside while loop |
+| `029_agg_fusion_avg.mochi` | avg fusion test |
+| `030_complex_pipeline.mochi` | Multi-step query pipeline |
+
+---
 
 ## Decisions made
 
-_Pending phase open._
+### Why `lists:` functions instead of native Core Erlang comprehensions
 
-## Test set
+`c_comp` support for qualification forms varies between OTP versions; using
+`lists:` function calls is portable across OTP 27 and OTP 28 and is
+equivalently optimised by BeamAsm. The `lists:` approach also makes
+aggregation fusion straightforward: fusing a `sum` into a `lists:foldl` is a
+simple substitution; fusing into a `c_comp` node would require understanding
+and rewriting the comprehension's qualification structure.
 
-_Pending phase open._
+### Why ETS for large group_by
 
-## Closeout notes
+BEAM maps with more than 32 keys use HAMT (hash-mapped array tries) and are
+GC-managed per-process heap. A `group_by` accumulating millions of rows causes
+major GC pauses as the HAMT grows. ETS (Erlang Term Storage) is off-heap and
+GC-transparent; it handles arbitrarily large tables without per-process GC
+involvement. The threshold for switching to the ETS path is 10,000 estimated
+output rows (detected via compile-time annotation or a conservative estimate
+based on input list type annotations).
 
-_Fill in after gate green._
+### Why hash join instead of nested loop join
+
+Nested loop join is O(n * m); hash join is O(n + m) for equi-joins. The Mochi
+type checker knows when a `where` condition is an equi-join (the form
+`x.field == y.field`) and the lowerer selects hash join in that case.
+Non-equi-join conditions fall back to nested loop (cross product then filter).

--- a/website/docs/implementation/0046/phase-08-datalog.md
+++ b/website/docs/implementation/0046/phase-08-datalog.md
@@ -2,40 +2,323 @@
 title: "Phase 8. Datalog"
 sidebar_position: 10
 sidebar_label: "Phase 8. Datalog"
-description: "MEP-46 Phase 8. Datalog tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+description: "MEP-46 Phase 8 implementation spec: lowering Mochi Datalog facts and rules to ETS tables with a semi-naive fixed-point evaluator."
 ---
 
 # Phase 8. Datalog
 
 | Field          | Value |
 |----------------|-------|
-| MEP            | [MEP-46 §Phases · Phase 8. Datalog](/docs/mep/mep-0046#phase-8-datalog) |
+| MEP            | [MEP-46 §Phases · Phase 8](/docs/mep/mep-0046#phase-8-datalog) |
 | Status         | NOT STARTED |
 | Started        | — |
 | Landed         | — |
 | Tracking issue | — |
 | Tracking PR    | — |
 
-## Gate
-
-See [MEP-46 §Phases · Phase 8. Datalog](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+---
 
 ## Goal-alignment audit
 
-_Pending phase open._
+Datalog is a distinguishing feature of Mochi that has no equivalent in standard
+Erlang. This phase validates that Mochi's Datalog programs run on BEAM with
+correct output (byte-equal vs vm3), establishing that the BEAM target is a
+viable deployment path for Mochi programs that use relational logic. It also
+produces the `mochi_datalog.erl` and `mochi_datalog_ets.erl` runtime modules
+that are shipped as part of the Mochi OTP application.
 
-## Sub-phases
+---
 
-_Pending phase open._
+## Sub-phase 8.0: Fact declarations -> ETS tables
+
+### Table creation
+
+`fact parent(string, string)` declares a relation with two string columns. Each
+relation gets its own ETS table. Tables are created in the generated
+`__datalog_init/0` function:
+
+```go
+// lowerFactDecl emits an ETS new + insert for each base fact
+// Table creation:
+c_call(
+    c_atom("ets"), c_atom("new"),
+    []cerl.Expr{
+        c_atom("mochi_datalog_parent"),
+        c_cons(c_atom("set"),
+            c_cons(c_atom("named_table"),
+                c_cons(c_atom("public"), c_nil()))),
+    },
+)
+```
+
+The table is created with `[set, named_table, public]` options. `named_table`
+allows access by atom name from any process. `public` allows any process to
+read and write (required for the semi-naive evaluator which runs in the calling
+process).
+
+### Fact insertion
+
+`parent("alice", "bob")` -> `ets:insert(mochi_datalog_parent, {alice, bob})`:
+
+```go
+c_call(
+    c_atom("ets"), c_atom("insert"),
+    []cerl.Expr{
+        c_atom("mochi_datalog_parent"),
+        c_tuple([]cerl.Expr{c_string("alice"), c_string("bob")}),
+    },
+)
+```
+
+### __datalog_init/0
+
+The lowerer collects all fact declarations and emits a single
+`__datalog_init/0` function that creates all ETS tables and inserts all base
+facts. The generated `main/0` calls `__datalog_init()` as its first statement:
+
+```go
+// Generated main/0 structure:
+c_fun([]cerl.Var{},
+    c_let([c_var("_")],
+        c_apply(c_fname("__datalog_init", 0), []cerl.Expr{}),
+        lowerExpr(mainBody),
+    ),
+)
+```
+
+---
+
+## Sub-phase 8.1: Rule declarations -> semi-naive evaluator
+
+### Rule representation
+
+`rule ancestor(X, Z) :- parent(X, Y), ancestor(Y, Z)` is a recursive rule.
+Each rule is lowered to an Erlang fun that:
+1. Queries ETS tables for matching body atoms (using ETS match specs).
+2. Inserts new derived facts into the head relation's ETS table.
+3. Returns the count of newly inserted facts.
+
+```go
+// Each rule becomes a fun() -> integer() (count of new insertions)
+c_fun([]cerl.Var{},
+    // [ets:insert(ancestor, {X, Z}) || {X, Y} <- ets:tab2list(parent),
+    //                                   {Y2, Z} <- ets:tab2list(ancestor),
+    //                                   Y =:= Y2]
+    // ...emitted as nested foldl
+    ...
+)
+```
+
+### Rule lowering details
+
+Multi-body rules are lowered as nested foldl over ETS lookups:
+
+```go
+// rule ancestor(X, Z) :- parent(X, Y), ancestor(Y, Z)
+//
+// Lowered as:
+// fun() ->
+//   lists:foldl(fun({X, Y}, Acc0) ->
+//     lists:foldl(fun({Y2, Z}, Acc1) ->
+//       case Y =:= Y2 of
+//         true ->
+//           mochi_datalog_ets:delta_insert(ancestor, {X, Z}),
+//           Acc1 + 1;
+//         false -> Acc1
+//       end
+//     end, Acc0, ets:tab2list(mochi_datalog_ancestor))
+//   end, 0, ets:tab2list(mochi_datalog_parent))
+// end
+```
+
+The lowerer generates variable names from rule body atom positions to avoid
+collisions: `V_r0_0`, `V_r0_1` for the first rule's first body atom's
+arguments, etc.
+
+### mochi_datalog_ets:delta_insert/2
+
+`mochi_datalog_ets:delta_insert(RelName, Tuple)` inserts into both the main
+table and the delta table if the fact is not already present:
+
+```erlang
+delta_insert(RelName, Tuple) ->
+    DeltaName = list_to_atom(atom_to_list(RelName) ++ "_delta"),
+    case ets:insert_new(RelName, Tuple) of
+        true  -> ets:insert(DeltaName, Tuple), true;
+        false -> false
+    end.
+```
+
+`ets:insert_new/2` is atomic and returns `false` if a duplicate exists (for
+`set` tables). This guarantees idempotency: the same fact is never inserted
+twice.
+
+---
+
+## Sub-phase 8.2: Recursive rules and fixpoint termination
+
+### Fixpoint loop
+
+`mochi_datalog:compute_fixpoint/2` takes a list of rule funs and runs them in
+a loop until no new facts are inserted:
+
+```erlang
+compute_fixpoint(Rules, _Tables) ->
+    case run_rules(Rules) of
+        0    -> ok;                          % stable: no new facts
+        _N   -> compute_fixpoint(Rules, _Tables)  % iterate again
+    end.
+
+run_rules(Rules) ->
+    lists:foldl(fun(RuleFun, Acc) -> Acc + RuleFun() end, 0, Rules).
+```
+
+### Semi-naive optimization
+
+In the naive evaluator, each iteration joins against the full relation. In the
+semi-naive evaluator, recursive body atoms join against the delta table (new
+facts from the previous iteration) rather than the full table:
+
+- Each relation `rel` has a shadow `mochi_datalog_rel_delta` ETS table.
+- At the start of each iteration, the delta tables are cleared.
+- `delta_insert` populates both the main and delta tables during an iteration.
+- Recursive body atoms in rules use `ets:tab2list(mochi_datalog_rel_delta)`
+  instead of `ets:tab2list(mochi_datalog_rel)`.
+
+The lowerer identifies recursive body atoms (atoms whose relation name matches
+the head relation of any rule in the same stratum) and emits delta-table
+lookups for them. Non-recursive body atoms use the full table.
+
+### Stratification
+
+Rules are stratified by the lowerer before emitting the fixpoint computation.
+Negation-in-rule-body requires stratification (the negated relation must be
+fully computed before the current stratum runs). The lowerer performs a
+dependency analysis:
+
+1. Build a dependency graph: relation A depends on B if B appears in a rule
+   body for A.
+2. Find SCCs (strongly connected components) using Tarjan's algorithm.
+3. Topologically sort SCCs into strata.
+4. Emit one `compute_fixpoint` call per stratum, in topological order.
+
+### Termination guarantee
+
+The Mochi type system ensures all Datalog programs are range-restricted: every
+variable that appears in a rule head also appears in at least one positive body
+atom. This guarantees that the fixpoint computation terminates (the set of
+derivable facts is bounded by the Herbrand base, which is finite for
+range-restricted programs). The lowerer validates range restriction at compile
+time and emits a clear error if a rule violates it.
+
+---
+
+## Sub-phase 8.3: Query expressions over facts and rules
+
+### ETS match object queries
+
+`query ancestor(X, "alice")` where `X` is a free variable and `"alice"` is a
+bound constant lowers to an ETS match object lookup:
+
+```go
+// ets:match_object(mochi_datalog_ancestor, {'_', alice})
+c_call(
+    c_atom("ets"), c_atom("match_object"),
+    []cerl.Expr{
+        c_atom("mochi_datalog_ancestor"),
+        c_tuple([]cerl.Expr{c_atom("_"), c_string("alice")}),
+    },
+)
+```
+
+Free variables in the query pattern become `'_'` in the ETS match spec. Bound
+constants become their lowered value. The lowerer determines which variables
+are free (not yet bound in the surrounding scope) at the query expression site.
+
+### Integration with query DSL
+
+`query from r in ancestor(_, "alice") select r` combines ETS lookup with Phase
+7's query DSL lowering. The `ancestor(_, "alice")` fact query is first lowered
+to an `ets:match_object` call, and the result (a list of tuples) is then
+treated as the source collection for the `from`/`select` expression.
+
+### mochi_datalog:query/2
+
+`mochi_datalog:query(RelName, Pattern)` is a convenience wrapper:
+
+```erlang
+query(RelName, Pattern) ->
+    TableName = list_to_atom("mochi_datalog_" ++ atom_to_list(RelName)),
+    ets:match_object(TableName, Pattern).
+```
+
+---
+
+## Fixtures
+
+20 fixture files under `tests/dataset/slt/beam/phase08/`:
+
+| File | Tests |
+|---|---|
+| `001_parent_child.mochi` | Base facts, simple query |
+| `002_transitive_closure.mochi` | Recursive ancestor rule |
+| `003_stratified.mochi` | Two strata, second depends on first |
+| `004_magic_set.mochi` | Magic set transformation (manual) |
+| `005_cycle_detection.mochi` | Cycle in relation graph |
+| `006_range_restriction.mochi` | Compile-time range restriction check |
+| `007_multi_rule_head.mochi` | Multiple rules for same relation |
+| `008_negation.mochi` | Negation-as-failure in stratified program |
+| `009_aggregation_in_rule.mochi` | Aggregate in rule body |
+| `010_ets_large_facts.mochi` | Large fact set, ETS performance |
+| `011_query_free_var.mochi` | Query with free variable |
+| `012_query_bound_const.mochi` | Query with multiple bound constants |
+| `013_query_dsl_over_facts.mochi` | `from r in query(...) select ...` |
+| `014_fixpoint_count.mochi` | Count iterations to fixpoint |
+| `015_mutual_recursion.mochi` | Mutually recursive rules (same SCC) |
+| `016_semi_naive_delta.mochi` | Verify semi-naive reduces iterations |
+| `017_string_keys.mochi` | String-keyed relations |
+| `018_int_keys.mochi` | Integer-keyed relations |
+| `019_mixed_types.mochi` | Relation with mixed column types |
+| `020_empty_base.mochi` | Rules over empty fact set |
+
+---
 
 ## Decisions made
 
-_Pending phase open._
+### Why ETS instead of in-process lists for fact tables
 
-## Test set
+ETS tables are off-heap, GC-transparent, and support O(1) lookup by key (for
+`set` tables). For recursive Datalog programs that may derive millions of
+facts, ETS avoids heap pressure on the calling process. An in-process list or
+map accumulator would trigger major GC pauses as the derived set grows.
+Additionally, ETS `named_table` allows fact tables to survive across process
+restarts and be inspected from any process during debugging.
 
-_Pending phase open._
+### Why semi-naive evaluation
 
-## Closeout notes
+Naive evaluation re-evaluates every rule against the full relation each
+iteration, costing O(|relation|^2) per iteration for binary recursive rules.
+Semi-naive tracks new (delta) facts from the previous iteration and joins
+recursive body atoms only against deltas, reducing per-iteration cost from
+O(n^2) to O(n * |delta|). For programs where `|delta|` is small relative to
+`|relation|` (the common case after the first few iterations), this is a
+significant speedup. The MEP-45 Datalog implementation uses the same strategy;
+we carry it forward to BEAM.
 
-_Fill in after gate green._
+### Why compile-time range restriction check
+
+An un-range-restricted rule (a variable appears in the rule head but not in any
+positive body atom) potentially derives an infinite set of facts, causing the
+fixpoint loop to run forever. Rather than detecting infinite loops at runtime
+(which would require a timeout heuristic), the lowerer rejects such programs at
+compile time with a clear error message identifying the offending variable and
+rule. This fail-fast approach is safer for production deployments.
+
+### Why one ETS table per relation (not a single global table with a relation-name key)
+
+Per-relation tables allow ETS `match_object` to use the table's internal index
+directly, with the match pattern matching only on the fact's columns. A single
+global table would require all match patterns to include the relation name as
+the first element, doubling the pattern complexity and halving the effective
+index selectivity. Per-relation tables also make `ets:tab2list` more efficient
+for full-table scans during fixpoint computation.

--- a/website/docs/implementation/0046/phase-09-agents.md
+++ b/website/docs/implementation/0046/phase-09-agents.md
@@ -2,40 +2,438 @@
 title: "Phase 9. Agents and gen_server"
 sidebar_position: 11
 sidebar_label: "Phase 9. Agents and gen_server"
-description: "MEP-46 Phase 9. Agents and gen_server tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+description: "MEP-46 Phase 9 implementation spec: lowering Mochi agent declarations to OTP gen_server callback modules with supervisor integration."
 ---
 
 # Phase 9. Agents and gen_server
 
 | Field          | Value |
 |----------------|-------|
-| MEP            | [MEP-46 §Phases · Phase 9. Agents and gen_server](/docs/mep/mep-0046#phase-9-agents-and-genserver) |
+| MEP            | [MEP-46 §Phases · Phase 9](/docs/mep/mep-0046#phase-9-agents-and-genserver) |
 | Status         | NOT STARTED |
 | Started        | — |
 | Landed         | — |
 | Tracking issue | — |
 | Tracking PR    | — |
 
-## Gate
-
-See [MEP-46 §Phases · Phase 9. Agents and gen_server](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+---
 
 ## Goal-alignment audit
 
-_Pending phase open._
+Agents are Mochi's concurrency primitive. This phase validates that Mochi
+agent programs run on BEAM as proper OTP processes with supervision, crash
+recovery, and correct message passing semantics. Completing this phase enables
+Mochi programs to participate in OTP supervision trees, making the BEAM target
+viable for production concurrent systems, not just batch computation.
 
-## Sub-phases
+---
 
-_Pending phase open._
+## Sub-phase 9.0: agent -> gen_server callback module
+
+### Overview
+
+Each `agent` declaration in Mochi generates a complete OTP gen_server callback
+module. The module name is derived from the agent name:
+`mochi_user_<lowercase_agent_name>.erl`.
+
+Given:
+
+```mochi
+agent Counter {
+    var count: int = 0
+    fun increment() { count = count + 1 }
+    fun get(): int { return count }
+}
+```
+
+The lowerer emits a Core Erlang representation of:
+
+```erlang
+-module(mochi_user_counter).
+-behaviour(gen_server).
+-export([start_link/1, increment/1, get/1]).
+-export([init/1, handle_call/3, handle_cast/2, terminate/2]).
+
+start_link(InitArgs) ->
+    gen_server:start_link(?MODULE, InitArgs, []).
+
+init([Count]) ->
+    {ok, #{count => Count}}.
+
+%% Public API
+
+increment(Ref) ->
+    gen_server:cast(Ref, increment).
+
+get(Ref) ->
+    gen_server:call(Ref, get).
+
+%% Callbacks
+
+handle_call(get, _From, State) ->
+    {reply, maps:get(count, State), State};
+handle_call(_Req, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(increment, State) ->
+    NewCount = maps:get(count, State) + 1,
+    {noreply, State#{count => NewCount}}.
+
+terminate(_Reason, _State) ->
+    ok.
+```
+
+### Lowering agent fields to gen_server state
+
+Agent fields are stored in the gen_server state map. The map uses field names
+as atom keys:
+
+```go
+// init/1 body: {ok, #{count => InitCount}}
+c_tuple([]cerl.Expr{
+    c_atom("ok"),
+    c_map([]cerl.Pair{
+        c_map_pair(c_atom("count"), c_var("V_InitCount")),
+    }),
+})
+```
+
+The state map does not include a `__mochi_record__` tag (unlike Mochi records
+lowered in Phase 4) because the state map is gen_server internal state, not a
+user-facing Mochi value.
+
+### Determining call vs cast
+
+The lowerer classifies each agent method:
+- Methods with return type `unit` -> `gen_server:cast` (fire-and-forget).
+- Methods with non-unit return type -> `gen_server:call` (synchronous reply).
+
+This classification drives both the public API function (`cast` vs `call` in
+the client stub) and the callback handler (`handle_cast` vs `handle_call`).
+
+### handle_call structure
+
+`handle_call` is emitted as a `c_case` over the request atom, with one clause
+per query method and a catch-all:
+
+```go
+c_case(c_var("V_Req"), []cerl.Clause{
+    // get clause
+    c_clause(
+        []cerl.Expr{c_atom("get")},
+        c_atom("true"),
+        c_tuple([]cerl.Expr{
+            c_atom("reply"),
+            c_call(c_atom("maps"), c_atom("get"),
+                []cerl.Expr{c_atom("count"), c_var("V_State")}),
+            c_var("V_State"),
+        }),
+    ),
+    // catch-all
+    c_clause(
+        []cerl.Expr{c_var("_")},
+        c_atom("true"),
+        c_tuple([]cerl.Expr{
+            c_atom("reply"), c_atom("ok"), c_var("V_State"),
+        }),
+    ),
+})
+```
+
+### handle_cast structure
+
+`handle_cast` is emitted as a `c_case` over the message atom, with one clause
+per command method:
+
+```go
+c_case(c_var("V_Msg"), []cerl.Clause{
+    // increment clause
+    c_clause(
+        []cerl.Expr{c_atom("increment")},
+        c_atom("true"),
+        c_let(
+            [c_var("V_NewState")],
+            // State#{count => maps:get(count, State) + 1}
+            c_map_update(c_var("V_State"), []cerl.Pair{
+                c_map_pair(c_atom("count"),
+                    c_call(c_atom("erlang"), c_atom("+"),
+                        []cerl.Expr{
+                            c_call(c_atom("maps"), c_atom("get"),
+                                []cerl.Expr{c_atom("count"), c_var("V_State")}),
+                            c_int(1),
+                        },
+                    ),
+                ),
+            }),
+            c_tuple([]cerl.Expr{c_atom("noreply"), c_var("V_NewState")}),
+        ),
+    ),
+})
+```
+
+---
+
+## Sub-phase 9.1: spawn -> mochi_agent_sup:start_child/2
+
+### Spawn lowering
+
+`let c = spawn Counter(0)` lowers to a call to `mochi_agent_sup:start_child/2`:
+
+```go
+c_call(
+    c_atom("mochi_agent_sup"), c_atom("start_child"),
+    []cerl.Expr{
+        c_atom("mochi_user_counter"),
+        c_cons(c_int(0), c_nil()),   // [0]
+    },
+)
+```
+
+`mochi_agent_sup:start_child/2` starts a supervised child and returns a PID.
+The lowerer wraps the PID in an opaque agent ref tuple:
+
+```go
+// Full spawn lowering:
+c_let(
+    [c_var("V_Pid")],
+    c_call(c_atom("mochi_agent_sup"), c_atom("start_child"),
+        []cerl.Expr{c_atom("mochi_user_counter"), initArgsList}),
+    c_tuple([]cerl.Expr{c_atom("mochi_agent_ref"), c_var("V_Pid")}),
+)
+```
+
+The opaque `{mochi_agent_ref, Pid}` tuple prevents the caller from using the
+PID directly (bypassing the type system), while still allowing the lowerer to
+extract the PID when emitting gen_server calls.
+
+### mochi_agent_sup implementation
+
+`mochi_agent_sup` is a `dynamic_supervisor` (OTP 25+ API) under `mochi_sup`:
+
+```erlang
+-module(mochi_agent_sup).
+-behaviour(supervisor).
+-export([start_link/0, start_child/2]).
+-export([init/1]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    SupFlags = #{strategy => one_for_one, intensity => 3, period => 5},
+    {ok, {SupFlags, []}}.
+
+start_child(Module, Args) ->
+    ChildSpec = #{
+        id      => {Module, make_ref()},
+        start   => {Module, start_link, [Args]},
+        restart => transient,
+        type    => worker,
+        modules => [Module]
+    },
+    case supervisor:start_child(?MODULE, ChildSpec) of
+        {ok, Pid}                -> Pid;
+        {ok, Pid, _Info}         -> Pid;
+        {error, Reason}          -> erlang:error({mochi_spawn_failed, Reason})
+    end.
+```
+
+---
+
+## Sub-phase 9.2: method calls -> gen_server:call/cast
+
+### Extracting PID from agent ref
+
+`unwrap_ref(V_c)` extracts the PID from `{mochi_agent_ref, Pid}`:
+
+```go
+c_case(c_var("V_c"), []cerl.Clause{
+    c_clause(
+        []cerl.Expr{c_tuple([]cerl.Expr{
+            c_atom("mochi_agent_ref"), c_var("V_Pid"),
+        })},
+        c_atom("true"),
+        c_var("V_Pid"),
+    ),
+})
+```
+
+### Query method call (gen_server:call)
+
+`c.get()` (non-unit return type) lowers to:
+
+```go
+c_call(
+    c_atom("gen_server"), c_atom("call"),
+    []cerl.Expr{
+        unwrapRef(c_var("V_c")),
+        c_atom("get"),
+        c_int(5000),   // 5 second timeout
+    },
+)
+```
+
+The 5000ms timeout is the default. A future phase may expose `@timeout`
+annotations to override it.
+
+### Command method call (gen_server:cast)
+
+`c.increment()` (unit return type) lowers to:
+
+```go
+c_call(
+    c_atom("gen_server"), c_atom("cast"),
+    []cerl.Expr{
+        unwrapRef(c_var("V_c")),
+        c_atom("increment"),
+    },
+)
+```
+
+### Method arguments
+
+Methods with arguments pass them as a tagged tuple in the message:
+`c.set(42)` -> `gen_server:call(Pid, {set, 42})`.
+
+The message pattern in `handle_call`/`handle_cast` is correspondingly a tuple:
+`{set, V_Val}`. The lowerer emits `c_tuple` for the message and clause pattern
+in this case.
+
+---
+
+## Sub-phase 9.3: on_close -> terminate/2
+
+`on_close { cleanup_code() }` is emitted into the `terminate/2` callback:
+
+```go
+// Generated terminate/2:
+c_fun(
+    []cerl.Var{c_var("V_Reason"), c_var("V_State")},
+    c_let(
+        [c_var("_")],
+        lowerExpr(cleanupCode),   // cleanup_code() body
+        c_atom("ok"),
+    ),
+)
+```
+
+The cleanup code runs for all termination reasons: `normal`, `shutdown`,
+`{shutdown, Term}`, and crash reasons. If the cleanup code throws, the
+exception is caught by the gen_server framework and logged; the process
+terminates regardless.
+
+If there is no `on_close` block, `terminate/2` is emitted as simply returning
+`ok`:
+
+```go
+c_fun(
+    []cerl.Var{c_var("_"), c_var("_")},
+    c_atom("ok"),
+)
+```
+
+---
+
+## Sub-phase 9.4: Supervised crash and restart
+
+### Supervisor configuration
+
+The `mochi_agent_sup` child spec uses `restart => transient`: the child is
+restarted only if it terminates abnormally (with a reason other than `normal`
+or `shutdown`). This matches Mochi's semantics: a normally-completed agent is
+not restarted.
+
+Restart limits: `intensity => 3, period => 5` (3 restarts within 5 seconds).
+If the limit is exceeded, `mochi_agent_sup` itself terminates and propagates
+the failure up the `mochi_sup` supervision tree.
+
+### Crash test fixture
+
+`agent_crash_restart.mochi` spawns a Counter agent. It calls an intent that
+deliberately crashes the gen_server (`erlang:error(intentional_crash)` in the
+handler). After the crash, the agent ref is used again; the lowerer must
+handle `noproc` errors gracefully (the ref points to the old Pid; the
+restarted process has a new Pid). The test verifies that:
+
+1. The crash is caught and the process is restarted by the supervisor.
+2. Calling the agent ref after restart raises a Mochi `AgentRestartedError`
+   (detected by monitoring the Pid before the call and catching `noproc`).
+
+Future sub-phase: persistent agent refs that follow the restarted Pid (via
+`via` name registration or pg groups).
+
+---
+
+## Fixtures
+
+25 fixture files under `tests/dataset/slt/beam/phase09/`:
+
+| File | Tests |
+|---|---|
+| `001_counter_basic.mochi` | Counter agent: spawn, increment, get |
+| `002_multi_field_state.mochi` | Agent with multiple state fields |
+| `003_agent_in_loop.mochi` | Spawn agent, call in loop |
+| `004_multiple_agents.mochi` | Spawn two different agent types |
+| `005_agent_with_list_state.mochi` | State field is a list |
+| `006_agent_with_map_state.mochi` | State field is a map |
+| `007_agent_method_args.mochi` | Methods with arguments |
+| `008_agent_cast_no_return.mochi` | Command method, fire-and-forget |
+| `009_agent_call_returns.mochi` | Query method, synchronous reply |
+| `010_on_close_basic.mochi` | on_close block runs on stop |
+| `011_on_close_cleanup.mochi` | on_close cleans up a resource |
+| `012_spawn_multiple.mochi` | Spawn N instances of same agent |
+| `013_agent_calls_agent.mochi` | Agent method calls another agent |
+| `014_agent_in_fun.mochi` | Agent ref passed to a function |
+| `015_agent_in_list.mochi` | List of agent refs |
+| `016_crash_restart.mochi` | Crash + supervisor restart |
+| `017_agent_with_sum_field.mochi` | State field is a sum type |
+| `018_agent_with_option_field.mochi` | State field is option\<T\> |
+| `019_concurrent_agents.mochi` | Multiple agents, interleaved calls |
+| `020_agent_accumulator.mochi` | Agent used as accumulator (replaces fold) |
+| `021_agent_pub_sub.mochi` | Two agents: publisher sends, subscriber receives |
+| `022_agent_ring.mochi` | Ring of N agents passing a token |
+| `023_agent_timeout.mochi` | Call that takes longer than default timeout |
+| `024_agent_stop.mochi` | Explicit stop/1 terminates agent normally |
+| `025_supervision_tree.mochi` | Nested supervision via agent supervisor |
+
+---
 
 ## Decisions made
 
-_Pending phase open._
+### Why gen_server:cast for unit-returning intents and gen_server:call for value-returning ones
 
-## Test set
+This is the standard OTP idiom: `call` is synchronous (blocks the caller until
+the server replies), `cast` is fire-and-forget (returns immediately). Commands
+that modify state but don't return values (like `increment`) are casts; queries
+(like `get`) are calls. Using `cast` for commands avoids blocking the caller
+for state-modifying operations that have no useful return value, improving
+throughput when the caller and agent are on different BEAM schedulers.
 
-_Pending phase open._
+### Why mochi_agent_sup is a dynamic_supervisor
 
-## Closeout notes
+`simple_one_for_one` (OTP 25 and earlier) and `dynamic_supervisor` (OTP 25+,
+preferred in OTP 27) both support dynamically started children.
+`dynamic_supervisor` is the modern OTP API and is what Phoenix Channels, Ranch
+listeners, and other production OTP frameworks use. We use
+`supervisor:start_child/2` on it, which is the standard pattern for dynamically
+adding children. Using `dynamic_supervisor` also enables future support for
+`count_children/1` and `which_children/1` for introspection.
 
-_Fill in after gate green._
+### Why agent state uses a BEAM map and not an Erlang record
+
+Erlang records are compile-time tuples with position-based access; all record
+definitions must be known at compile time in every module that accesses the
+record. BEAM maps (since OTP 17) are runtime key-value structures that support
+dynamic access (`maps:get/2`) and structural update (`Map#{key => val}`).
+Using maps allows the agent's state shape to be determined at Mochi compile
+time without requiring Erlang record definitions to be shared across modules.
+It also means the generated gen_server module has no compile-time dependency on
+any `.hrl` header, making the generated code self-contained.
+
+### Why the opaque {mochi_agent_ref, Pid} wrapper
+
+Exposing the raw Pid would allow callers to send arbitrary messages to the
+gen_server process, bypassing Mochi's type-checked method dispatch. The opaque
+wrapper enforces that all interaction goes through the generated API functions.
+It also provides a clear hook for future features (persistent refs, monitored
+refs, named agent refs) without changing the call-site syntax.

--- a/website/docs/implementation/0046/phase-10-streams.md
+++ b/website/docs/implementation/0046/phase-10-streams.md
@@ -2,7 +2,7 @@
 title: "Phase 10. Streams and pubsub"
 sidebar_position: 12
 sidebar_label: "Phase 10. Streams and pubsub"
-description: "MEP-46 Phase 10. Streams and pubsub tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+description: "MEP-46 Phase 10. Streams and pubsub — detailed implementation spec."
 ---
 
 # Phase 10. Streams and pubsub
@@ -16,25 +16,239 @@ description: "MEP-46 Phase 10. Streams and pubsub tracking stub. Filled in when 
 | Tracking issue | — |
 | Tracking PR    | — |
 
+This phase implements Mochi's `stream` type on the BEAM target using OTP's `pg` (process groups) module as the pubsub backbone. Streams are declared at module scope, published imperatively, and subscribed with a block that runs per event. The implementation spans two runtime modules (`mochi_stream.erl`, `mochi_stream_sup.erl`) and 20 fixtures covering declaration, publish, subscribe, backpressure, and cross-node scenarios.
+
+---
+
 ## Gate
 
-See [MEP-46 §Phases · Phase 10. Streams and pubsub](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+See [MEP-46 §Phases · Phase 10. Streams and pubsub](/docs/mep/mep-0046) for the normative gate. All 20 fixtures must produce byte-equal output to vm3.
+
+---
 
 ## Goal-alignment audit
 
-_Pending phase open._
+Stream publish and subscribe are user-facing Mochi primitives that unlock real-time event-driven programs on the BEAM. The gate requires 20 fixtures spanning basic pubsub, backpressure, and cross-node distribution — all directly user-visible behaviours. The `pg`-backed design avoids a broker process, meaning stream overhead scales with the number of subscribers rather than requiring a central coordinator.
+
+---
 
 ## Sub-phases
 
-_Pending phase open._
+### Sub-phase 10.0: stream declaration and publish
 
-## Decisions made
+**Stream declaration**
 
-_Pending phase open._
+`stream<int> events` declares a typed stream named `events`. On the BEAM target, a stream declaration:
+
+1. Registers the stream name as a `pg` group key under the `mochi` scope. The group name is the stream name lowercased: `mochi_stream_events`.
+2. Does **not** spawn any process for the stream itself. `pg` is purely name-based: processes register themselves as members; no central broker process exists.
+3. The lowerer emits no Erlang code for the declaration itself. The declaration is recorded in the `aotir.Program` as a `StreamDecl` node and used only to type-check `publish` and `subscribe` expressions at compile time.
+
+**Publish**
+
+`publish events v` lowers to `mochi_stream:publish(events, V)`.
+
+The `mochi_stream:publish/2` function:
+
+```erlang
+publish(Name, Value) ->
+  Members = pg:get_members(mochi, Name),
+  [Pid ! {mochi_stream_event, Name, Value} || Pid <- Members],
+  ok.
+```
+
+Semantics:
+
+- `pg:get_members/2` returns the list of subscriber PIDs currently registered under the group. This is a local read from the `pg` ETS table; it does not involve any message passing or remote calls (even in distributed mode, the local `pg` server maintains a synchronized copy of group membership).
+- The message send `Pid ! ...` is a non-blocking fire-and-forget. The publisher continues immediately after sending to all current subscribers.
+- `publish` returns `ok` (the atom), which Mochi treats as `unit`.
+- If there are zero subscribers, `pg:get_members/2` returns `[]` and the comprehension is a no-op.
+
+**pg scope initialization**
+
+The `pg` scope named `mochi` is started by `mochi_app:start/2`:
+
+```erlang
+start(_Type, _Args) ->
+  {ok, _} = pg:start_link(mochi),
+  mochi_sup:start_link().
+```
+
+The scope must be started before any `publish` or `subscribe` call. `pg:start_link/1` is idempotent if the scope is already registered under a named process; `mochi_app` owns the lifecycle.
+
+---
+
+### Sub-phase 10.1: subscribe and gen_statem subscriber
+
+**subscribe block**
+
+`subscribe e in events { body_using_e }` spawns a supervised `mochi_stream_filter` gen_statem process that:
+
+1. Calls `pg:join(mochi, events, self())` in its `init/1` callback to register as a member of the stream group.
+2. Enters a `gen_statem` state `waiting` that loops on incoming messages.
+3. Handles `{mochi_stream_event, events, E}` messages by running the compiled subscriber body with `E` bound to the event value.
+4. Ignores any message that does not match the expected stream name (safe in distributed scenarios where multiple streams share the same supervisor).
+
+**Per-subscribe module generation**
+
+The lowerer generates a dedicated Erlang module per `subscribe` block in a translation unit. The module name is `mochi_stream_filter_N` where `N` is a monotonically increasing counter per TU, reset to `0` at the start of each file's lowering pass. For example:
+
+```erlang
+-module(mochi_stream_filter_0).
+-behaviour(gen_statem).
+
+init([StreamName, Body]) ->
+  ok = pg:join(mochi, StreamName, self()),
+  {ok, waiting, #{stream => StreamName, body => Body}}.
+
+callback_mode() -> state_functions.
+
+waiting(info, {mochi_stream_event, Name, Event}, #{stream := Name, body := Body} = Data) ->
+  Body(Event),
+  {next_state, waiting, Data};
+waiting(info, _Other, Data) ->
+  {next_state, waiting, Data}.
+```
+
+**Supervision**
+
+Subscriber processes are started under `mochi_stream_sup`, a `dynamic_supervisor`:
+
+```erlang
+-module(mochi_stream_sup).
+-behaviour(supervisor).
+
+init([]) ->
+  SupFlags = #{strategy => simple_one_for_one, intensity => 10, period => 60},
+  ChildSpec = #{
+    id => mochi_stream_filter,
+    start => {gen_statem, start_link, []},
+    restart => transient,
+    type => worker
+  },
+  {ok, {SupFlags, [ChildSpec]}}.
+```
+
+`subscribe` lowering calls `supervisor:start_child(mochi_stream_sup, [mochi_stream_filter_N, [StreamName, CompiledBody]])` to spawn the subscriber under supervision.
+
+---
+
+### Sub-phase 10.2: Subscriber backpressure
+
+**Limit syntax**
+
+`subscribe e in events limit 100 { ... }` configures the subscriber's mailbox depth limit. The `limit` keyword is parsed as an optional clause on the `subscribe` expression. Default is unlimited (no checking).
+
+**Backpressure implementation**
+
+The `mochi_stream_filter` gen_statem checks mailbox depth at each event arrival:
+
+```erlang
+waiting(info, {mochi_stream_event, Name, Event}, #{stream := Name, body := Body, limit := Limit} = Data) ->
+  {message_queue_len, Len} = process_info(self(), message_queue_len),
+  case Len > Limit of
+    true ->
+      mochi_log:warn("stream ~p: dropping event, queue ~p > limit ~p", [Name, Len, Limit]),
+      {next_state, waiting, Data};
+    false ->
+      Body(Event),
+      {next_state, waiting, Data}
+  end.
+```
+
+Semantics:
+
+- The drop is lossy: the event is silently discarded from this subscriber's perspective. The publisher is unaffected.
+- `mochi_log:warn/2` writes to the OTP logger at `warning` level with structured metadata `#{stream => Name}`.
+- BEAM's process mailbox is unbounded by design; this check is an application-level guard, not an OS-level flow control mechanism. The implementation is O(1) per event because `process_info/2` for `message_queue_len` is a cheap BIF.
+
+---
+
+### Sub-phase 10.3: Cross-node streams
+
+**How pg enables distribution**
+
+Because `pg` is cluster-aware (it uses `net_kernel` and its internal replication protocol to synchronize group membership across connected nodes), `publish` and `subscribe` work across distributed BEAM nodes with zero additional code in the Mochi lowerer or runtime.
+
+When node A and node B are connected via `net_kernel:connect_node/1`:
+- `pg:join(mochi, events, Pid)` on node B is propagated to node A's `pg` server.
+- `pg:get_members(mochi, events)` on node A returns PIDs from **both** nodes.
+- Erlang's `!` operator delivers messages to remote PIDs via the distribution protocol transparently.
+
+**Test fixture: stream_distributed.mochi**
+
+The fixture uses OTP 25+'s `peer` module to start a second BEAM node within the test:
+
+```erlang
+{ok, Peer, PeerNode} = peer:start(#{name => peer1, host => "localhost"}),
+true = net_kernel:connect_node(PeerNode),
+ok = erpc:call(PeerNode, application, start, [mochi]),
+Ref = make_ref(),
+erpc:call(PeerNode, mochi_stream_filter_test, subscribe, [events, self(), Ref]),
+mochi_stream:publish(events, 42),
+receive {mochi_stream_event_forwarded, Ref, 42} -> ok
+after 1000 -> error(timeout) end,
+peer:stop(Peer).
+```
+
+---
 
 ## Test set
 
-_Pending phase open._
+20 fixtures under `tests/transpiler3/beam/fixtures/phase10/`:
+
+| # | File | Description |
+|---|------|-------------|
+| 01 | `stream_declare.mochi` | Declare stream, verify no crash on zero subscribers |
+| 02 | `stream_publish_basic.mochi` | Publish one integer, one subscriber receives it |
+| 03 | `stream_publish_string.mochi` | Publish a string value |
+| 04 | `stream_publish_float.mochi` | Publish a float value |
+| 05 | `stream_multi_subscriber.mochi` | Two subscribers on same stream both receive events |
+| 06 | `stream_multi_stream.mochi` | Two streams declared; subscribers only receive their stream's events |
+| 07 | `stream_subscribe_body.mochi` | Subscriber body runs a multi-statement computation |
+| 08 | `stream_subscribe_counter.mochi` | Subscriber accumulates a counter across events |
+| 09 | `stream_publish_many.mochi` | Publish 1000 events; subscriber counts all received |
+| 10 | `stream_unsubscribe.mochi` | Subscriber process exit removes it from pg group |
+| 11 | `stream_backpressure_drop.mochi` | Limit 1, fast publisher; subscriber logs drops |
+| 12 | `stream_backpressure_ok.mochi` | Limit 1000, slow publisher; no drops |
+| 13 | `stream_list_element.mochi` | Publish list values |
+| 14 | `stream_map_element.mochi` | Publish map values |
+| 15 | `stream_nested.mochi` | Nested subscribe (inner subscribe inside outer subscriber body) |
+| 16 | `stream_error_recovery.mochi` | Subscriber body crashes; supervisor restarts; subsequent events delivered |
+| 17 | `stream_publish_no_subscribers.mochi` | Publish with no subscribers; verify `ok` not error |
+| 18 | `stream_distributed.mochi` | Cross-node publish and subscribe via `peer` module |
+| 19 | `stream_distributed_multi.mochi` | Three nodes, round-robin publish |
+| 20 | `stream_interop_async.mochi` | `async` publish from Phase 11 combined with stream subscribe |
+
+---
+
+## Runtime modules
+
+**mochi_stream.erl** — Public API:
+
+- `publish(Name :: atom(), Value :: term()) -> ok` — fire-and-forget publish to all subscribers.
+- `subscribe(Name :: atom(), HandlerPid :: pid()) -> ok` — low-level join (used internally by gen_statem init).
+- `unsubscribe(Name :: atom(), HandlerPid :: pid()) -> ok` — leave group; called from `terminate/3` of the subscriber gen_statem.
+
+**mochi_stream_sup.erl** — Dynamic supervisor for `mochi_stream_filter_N` gen_statem instances. Strategy: `simple_one_for_one`, restart: `transient` (crashed subscribers are restarted; intentionally exiting subscribers are not).
+
+---
+
+## Decisions made
+
+**Why pg instead of Phoenix.PubSub**
+
+`pg` is part of OTP's `kernel` application (included since OTP 23) and requires zero Hex dependencies. Phoenix.PubSub is a third-party Hex package that adds several transitive dependencies. For the Mochi runtime, zero external deps is a hard constraint for phases 10 through 14. Users who need Phoenix.PubSub's adapter-based design (Redis adapter, etc.) can wrap it via FFI (Phase 12).
+
+**Why gen_statem for subscribers instead of plain receive loops**
+
+A plain `receive` loop in a `spawn`ed process is not supervisable: if it crashes, the supervisor cannot restart it because it was not started as a supervised child. `gen_statem` integrates with OTP supervision, provides `code_change/4` hooks for hot code reload (relevant for long-running Mochi services), and cleanly separates state transitions from business logic.
+
+**Why lossy drop on backpressure rather than blocking the publisher**
+
+Blocking a publisher process on a slow subscriber violates BEAM's M:N process independence and creates deadlock risk when the publisher is itself a subscriber of another stream. Streams are defined in Mochi's semantics as unreliable broadcast channels; reliable point-to-point delivery is the role of channels (a separate primitive). Lossy drop matches the stream contract and preserves publisher liveness.
+
+---
 
 ## Closeout notes
 

--- a/website/docs/implementation/0046/phase-11-async.md
+++ b/website/docs/implementation/0046/phase-11-async.md
@@ -2,7 +2,7 @@
 title: "Phase 11. async/await"
 sidebar_position: 13
 sidebar_label: "Phase 11. async/await"
-description: "MEP-46 Phase 11. async/await tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+description: "MEP-46 Phase 11. async/await — detailed implementation spec."
 ---
 
 # Phase 11. async/await
@@ -16,25 +16,249 @@ description: "MEP-46 Phase 11. async/await tracking stub. Filled in when the pha
 | Tracking issue | — |
 | Tracking PR    | — |
 
+This phase implements Mochi's `async`/`await` on the BEAM target using monitored BEAM process spawning and selective receive. Each `async expr` spawns a single BEAM process that computes the expression and sends the result back; `await f` does a selective receive on the unique reference attached to that future. OTP 24+'s recv-marker optimization ensures that awaiting N concurrent futures does not degrade to O(N^2) mailbox scanning.
+
+---
+
 ## Gate
 
-See [MEP-46 §Phases · Phase 11. async/await](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+See [MEP-46 §Phases · Phase 11. async/await](/docs/mep/mep-0046) for the normative gate. All 15 fixtures must produce byte-equal output to vm3.
+
+---
 
 ## Goal-alignment audit
 
-_Pending phase open._
+`async`/`await` is a core user-facing concurrency primitive in Mochi. The BEAM target maps it naturally to process spawning, which is the idiomatic BEAM approach to concurrent work. The 15 fixtures cover basic usage, error propagation, combinators (`await_all`, `await_any`), timeout, and interop with streams (Phase 10). All fixtures exercise directly user-visible behaviour.
+
+---
 
 ## Sub-phases
 
-_Pending phase open._
+### Sub-phase 11.0: async -> monitored spawn
 
-## Decisions made
+**Syntax and lowering**
 
-_Pending phase open._
+`let f = async expr` is a Mochi expression. The lowerer transforms it into:
+
+```erlang
+mochi_async:async(fun() -> <lowered_expr> end)
+```
+
+The lowerer emits the Core Erlang:
+
+```erlang
+c_call(c_atom(mochi_async), c_atom(async), [c_fun([], lowerExpr(expr))])
+```
+
+The zero-argument `c_fun` wraps the expression so that `mochi_async:async/1` receives a thunk (a `fun/0`) it can invoke in the spawned process.
+
+**mochi_async:async/1**
+
+```erlang
+-spec async(fun(() -> term())) -> mochi_async_ref().
+async(Fun) ->
+  Ref = make_ref(),
+  Parent = self(),
+  {Pid, _MonRef} = spawn_monitor(fun() ->
+    try
+      Result = Fun(),
+      Parent ! {mochi_async_done, Ref, {ok, Result}}
+    catch
+      Class:Reason:Stack ->
+        Parent ! {mochi_async_done, Ref, {error, {Class, Reason, Stack}}}
+    end
+  end),
+  {mochi_async_ref, Ref, Pid}.
+```
+
+The return type `mochi_async_ref()` is defined as:
+
+```erlang
+-type mochi_async_ref() :: {mochi_async_ref, reference(), pid()}.
+```
+
+**Crash safety via spawn_monitor**
+
+`spawn_monitor/1` atomically spawns the child process and establishes a monitor in one BIF call. If the spawned process crashes before it can send `{mochi_async_done, ...}` (for example, due to a BEAM-level error like `badarg` inside `Fun()`), the parent receives a `{'DOWN', MonRef, process, Pid, Reason}` message. The `await` implementation handles this DOWN message and converts it to `mochi_err_async_crash`.
+
+**Thunk ownership**
+
+The thunk captures all variables from the enclosing Mochi scope via Erlang closure. Because BEAM closures capture references (heap terms are shared via reference counting), there is no data copying for large values; only the closure environment header is copied when the thunk is sent cross-process.
+
+---
+
+### Sub-phase 11.1: await -> selective receive with recv-marker
+
+**Syntax and lowering**
+
+`await f` lowers to:
+
+```erlang
+mochi_async:await(F)
+```
+
+The lowerer emits:
+
+```erlang
+c_call(c_atom(mochi_async), c_atom(await), [V_f])
+```
+
+where `V_f` is the Core Erlang variable holding the `mochi_async_ref()` value.
+
+**mochi_async:await/1**
+
+```erlang
+-spec await(mochi_async_ref()) -> term().
+await({mochi_async_ref, Ref, Pid}) ->
+  receive
+    {mochi_async_done, Ref, {ok, Result}} ->
+      Result;
+    {mochi_async_done, Ref, {error, {_Class, Reason, _Stack}}} ->
+      erlang:error({mochi_err_async_crash, Reason});
+    {'DOWN', _MonRef, process, Pid, Reason} ->
+      erlang:error({mochi_err_async_crash, Reason})
+  end.
+```
+
+The `receive` pattern matches on `Ref` (the unique reference created in `async/1`). Because each `async` call creates a fresh `make_ref()`, the pattern is unique per future: no two concurrent futures share the same `Ref`.
+
+**OTP 24 recv-marker optimization**
+
+Without recv-markers, `receive {mochi_async_done, Ref, _} end` scans the entire mailbox from position 0 on every iteration. If a process has N concurrent outstanding futures and processes them in order, this is O(N^2) total work.
+
+OTP 24 introduced `erlang:recv_marker_reserve/0` and `erlang:recv_marker_bind/2` to allow the runtime to store a scan-start pointer per reference. The `await` implementation uses this optimization:
+
+```erlang
+await({mochi_async_ref, Ref, Pid}) ->
+  Marker = erlang:recv_marker_reserve(),
+  erlang:recv_marker_bind(Marker, Ref),
+  receive
+    {mochi_async_done, Ref, {ok, Result}} ->
+      erlang:recv_marker_clear(Marker),
+      Result;
+    {mochi_async_done, Ref, {error, {_Class, Reason, _Stack}}} ->
+      erlang:recv_marker_clear(Marker),
+      erlang:error({mochi_err_async_crash, Reason});
+    {'DOWN', _MonRef, process, Pid, Reason} ->
+      erlang:recv_marker_clear(Marker),
+      erlang:error({mochi_err_async_crash, Reason})
+  end.
+```
+
+With the marker bound to `Ref`, BEAM stores the mailbox scan pointer at the position of the message matching `Ref`, so the receive is O(1) regardless of how many other messages are in the mailbox. This is documented in OTP 24 release notes under "Selective receive optimization."
+
+The lowerer wraps `async` + `await` pairs so that the `Marker` is reserved **before** the `async` spawn, ensuring that any message arriving between spawn and await is still found at the correct position.
+
+---
+
+### Sub-phase 11.2: await_all, await_any, await_timeout
+
+**await_all**
+
+`await_all([f1, f2, f3])` waits for all futures in the list to complete and returns a list of their results in order. Lowers to `mochi_async:await_all([F1, F2, F3])`.
+
+Implementation:
+
+```erlang
+-spec await_all([mochi_async_ref()]) -> [term()].
+await_all(Futures) ->
+  lists:map(fun await/1, Futures).
+```
+
+This is sequential await: `f1` is awaited first, then `f2`, then `f3`. This is correct because BEAM selective receive allows messages to arrive in any order; awaiting `f1` first will block only until `f1`'s message arrives, regardless of whether `f2` and `f3` have already completed (their messages sit in the mailbox). The recv-marker optimization makes each individual await O(1).
+
+**await_any**
+
+`await_any([f1, f2, f3])` returns the result of whichever future completes first. Lowers to `mochi_async:await_any([F1, F2, F3])`.
+
+Implementation:
+
+```erlang
+-spec await_any([mochi_async_ref()]) -> term().
+await_any(Futures) ->
+  RefSet = maps:from_list([{Ref, true} || {mochi_async_ref, Ref, _} <- Futures]),
+  await_any_loop(RefSet, Futures).
+
+await_any_loop(RefSet, Futures) ->
+  receive
+    {mochi_async_done, Ref, {ok, Result}} when is_map_key(Ref, RefSet) ->
+      cancel_remaining(Futures, Ref),
+      Result;
+    {mochi_async_done, Ref, {error, {_Class, Reason, _Stack}}} when is_map_key(Ref, RefSet) ->
+      cancel_remaining(Futures, Ref),
+      erlang:error({mochi_err_async_crash, Reason})
+  end.
+
+cancel_remaining(Futures, WinnerRef) ->
+  [exit(Pid, cancel) || {mochi_async_ref, Ref, Pid} <- Futures, Ref =/= WinnerRef].
+```
+
+Cancelled futures receive an `exit(Pid, cancel)` signal. Since the spawned futures are monitored (not linked), the `exit` is an asynchronous kill; the parent is not affected.
+
+**await_timeout**
+
+`await f timeout 5000` lowers to `mochi_async:await_timeout(F, 5000)`.
+
+Implementation:
+
+```erlang
+-spec await_timeout(mochi_async_ref(), non_neg_integer()) -> term().
+await_timeout({mochi_async_ref, Ref, Pid}, TimeoutMs) ->
+  receive
+    {mochi_async_done, Ref, {ok, Result}} -> Result;
+    {mochi_async_done, Ref, {error, {_Class, Reason, _Stack}}} ->
+      erlang:error({mochi_err_async_crash, Reason});
+    {'DOWN', _MonRef, process, Pid, Reason} ->
+      erlang:error({mochi_err_async_crash, Reason})
+  after TimeoutMs ->
+    exit(Pid, timeout),
+    erlang:error(mochi_err_timeout)
+  end.
+```
+
+The `after` clause uses BEAM's native receive timeout, which is implemented via a timer wheel (O(1) insert and cancel). On timeout, the spawned process is killed via `exit(Pid, timeout)` to prevent resource leaks.
+
+---
 
 ## Test set
 
-_Pending phase open._
+15 fixtures under `tests/transpiler3/beam/fixtures/phase11/`:
+
+| # | File | Description |
+|---|------|-------------|
+| 01 | `async_basic.mochi` | `async` + `await` of a simple integer expression |
+| 02 | `async_string.mochi` | `async` + `await` of a string concatenation |
+| 03 | `async_computation.mochi` | `async` of a fibonacci computation |
+| 04 | `async_multiple.mochi` | Three concurrent `async` calls, each awaited independently |
+| 05 | `async_await_all.mochi` | `await_all` of 5 futures |
+| 06 | `async_await_any.mochi` | `await_any` of 3 futures with different durations |
+| 07 | `async_timeout_ok.mochi` | `await timeout 5000` completes well within timeout |
+| 08 | `async_timeout_expire.mochi` | `await timeout 1` expires; error propagated |
+| 09 | `async_crash.mochi` | Async expression crashes; `await` surfaces `mochi_err_async_crash` |
+| 10 | `async_nested.mochi` | `async` inside `async`; outer awaits inner |
+| 11 | `async_capture.mochi` | Async closure captures a large list; verify result correctness |
+| 12 | `async_ordering.mochi` | `await_all` returns results in original order, not completion order |
+| 13 | `async_stream_interop.mochi` | `async` publish to a stream from Phase 10 |
+| 14 | `async_cancel_any.mochi` | `await_any` cancels losers; verify they do not deliver results |
+| 15 | `async_recv_marker.mochi` | 100 concurrent futures, awaited in order; verify no O(N^2) degradation |
+
+---
+
+## Decisions made
+
+**Why spawn_monitor instead of plain spawn**
+
+If the spawned process crashes before sending its result, plain `spawn` leaves the awaiting process blocked indefinitely (or until timeout). `spawn_monitor` guarantees a `DOWN` message on any process termination, which `await/1` converts to `mochi_err_async_crash`. This is the standard OTP pattern for safe concurrent calls, as used by `gen_server:call/2` internally.
+
+**Why the recv-marker optimization matters**
+
+Without recv-markers, awaiting N concurrent futures where the first-awaited future is the last to complete requires scanning the entire mailbox (containing N-1 already-delivered messages) on every `receive` iteration. For N=100, this is 100+99+...+1 = 5050 message inspections for the complete await sequence. With recv-markers, each `await` is O(1) regardless of N. This is documented in the OTP 24 release notes under "Selective receive optimization" and is enabled automatically when `make_ref()` is used as the match key.
+
+**Why async/await and not Task/Promise**
+
+Mochi's `async expr` / `await f` syntax maps directly to the BEAM spawned-process model. There is no intermediary abstraction layer (no Task struct, no Promise chain). The BEAM process is the unit of concurrency; each future is exactly one process. This matches how experienced Erlang and Elixir programmers think about concurrent computation and makes the generated Erlang code readable and debuggable without knowledge of Mochi internals. Promise chaining (`.then()`) would require either a callback-based CPS transform or a trampoline, both of which obscure the generated Erlang.
+
+---
 
 ## Closeout notes
 

--- a/website/docs/implementation/0046/phase-12-ffi.md
+++ b/website/docs/implementation/0046/phase-12-ffi.md
@@ -1,11 +1,11 @@
 ---
-title: "Phase 12. FFI"
+title: "Phase 12. FFI (Erlang)"
 sidebar_position: 14
-sidebar_label: "Phase 12. FFI"
-description: "MEP-46 Phase 12. FFI tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+sidebar_label: "Phase 12. FFI (Erlang)"
+description: "MEP-46 Phase 12. FFI (Erlang) — detailed implementation spec."
 ---
 
-# Phase 12. FFI
+# Phase 12. FFI (Erlang)
 
 | Field          | Value |
 |----------------|-------|
@@ -16,25 +16,238 @@ description: "MEP-46 Phase 12. FFI tracking stub. Filled in when the phase opens
 | Tracking issue | — |
 | Tracking PR    | — |
 
+This phase implements Mochi's foreign function interface for the BEAM target. Unlike MEP-45's C FFI (which uses JSON-over-subprocess to interop with external processes), the BEAM FFI is a zero-overhead direct cross-module call within the same VM. The `extern "Erlang"` declaration form introduces a BEAM-specific binding that lowers to a plain `c_call` in Core Erlang, with no marshalling cost for most types.
+
+---
+
 ## Gate
 
-See [MEP-46 §Phases · Phase 12. FFI](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+See [MEP-46 §Phases · Phase 12. FFI](/docs/mep/mep-0046) for the normative gate. All 15 fixtures must produce byte-equal output to vm3.
+
+---
 
 ## Goal-alignment audit
 
-_Pending phase open._
+FFI is the escape hatch that lets Mochi programs access the full OTP ecosystem without waiting for Mochi-native wrappers. Phase 12 fixtures cover calls to `lists`, `maps`, `string`, `crypto`, and `erlang` stdlib modules — all directly useful in user programs. The identity-marshalling design means FFI has zero overhead for all common types, making it a first-class primitive rather than a last resort.
+
+---
 
 ## Sub-phases
 
-_Pending phase open._
+### Sub-phase 12.0: extern Erlang module declarations
 
-## Decisions made
+**Syntax**
 
-_Pending phase open._
+```mochi
+extern "Erlang" mod lists {
+  fun nth(n: int, xs: list<int>): int
+  fun sort(xs: list<int>): list<int>
+}
+```
+
+This declares FFI bindings to functions in the Erlang `lists` module. The module name after `mod` is the unquoted Erlang module atom. The function signature uses Mochi types; the type checker validates call sites against these declared signatures at compile time.
+
+**Lowering: ExternErlangDecl IR node**
+
+The parser produces an `ExternErlangDecl` AST node containing:
+
+- `TargetModule string` — the Erlang module name (e.g., `"lists"`).
+- `Bindings []ExternErlangBinding` — each binding has a Mochi name, Erlang function name, parameter types, and return type.
+
+The aotir lowerer records `ExternErlangDecl` in `aotir.Program.ExternErlang` (a new map field: Mochi qualified name -> `ExternErlangFunc`). When a call to an extern Erlang function appears in Mochi source:
+
+```mochi
+let x = nth(1, xs)
+```
+
+The call lowerer checks `ExternErlang`, finds the binding, and emits:
+
+```erlang
+c_call(c_atom(lists), c_atom(nth), [lowerExpr(1), lowerExpr(xs)])
+```
+
+This is a direct Erlang cross-module call. No wrapper function is generated; no marshalling code is emitted.
+
+**Dotted module names and `as` clause**
+
+For cases where the Mochi function name differs from the Erlang function name, or where the Erlang module differs from the `mod` alias:
+
+```mochi
+extern "Erlang" mod crypto {
+  fun hash(algo: atom, data: string): string as crypto:hash
+}
+```
+
+The `as module:function` clause overrides the default mapping. For simple cases the standard form works:
+
+```mochi
+extern "Erlang" mod crypto {
+  fun hash(algo: atom, data: string): string
+}
+```
+
+Lowers to `c_call(c_atom(crypto), c_atom(hash), [AlgoArg, DataArg])`.
+
+**BEAM-target-specific declaration**
+
+`extern "Erlang"` declarations are silently ignored by non-BEAM lowerers. The C lowerer in MEP-45 treats an `ExternErlangDecl` as a no-op and emits no code. A call site that references an extern Erlang function from a non-BEAM target produces a compile-time error: `extern "Erlang" binding 'lists.nth' is not available on target 'c'`.
+
+---
+
+### Sub-phase 12.1: Marshalling: Mochi types <-> Erlang terms
+
+The BEAM target's key advantage over the C FFI is that most Mochi types are identity-mapped to Erlang terms: there is nothing to marshal. The marshalling table lives in `transpiler3/beam/lower/ffi.go` as `func beamFFIType(t aotir.Type) beamRepr`.
+
+**Type mapping table**
+
+| Mochi type | BEAM representation | Notes |
+|------------|---------------------|-------|
+| `int` | BEAM integer | Identity. Erlang integers are arbitrary precision. |
+| `float` | BEAM float (64-bit IEEE 754) | Identity. |
+| `bool` | `true` / `false` atoms | Identity. |
+| `string` | BEAM binary (UTF-8) | Identity. Mochi strings on BEAM are always UTF-8 binaries. |
+| `list<T>` | BEAM cons-cell list | Identity. Mochi lists are BEAM proper lists. |
+| `map<K,V>` | BEAM map | Identity. Mochi maps are BEAM maps. |
+| `atom` | BEAM atom | FFI-only type; see below. |
+| `any` | Any BEAM term | FFI escape hatch; see below. |
+| User-defined record | BEAM map with atom keys | Same as Mochi's internal record representation. |
+
+**The `atom` FFI type**
+
+`atom` is a type available only in `extern "Erlang"` declarations. It represents an Erlang atom literal or a runtime atom value. In Mochi source:
+
+```mochi
+extern "Erlang" mod crypto {
+  fun hash(algo: atom, data: string): string
+}
+
+let digest = hash(#sha256, "hello")
+```
+
+The `#sha256` syntax (new for Phase 12) is an atom literal. It lowers to `c_atom(sha256)` directly. At call sites that need to produce atoms from string data at runtime, the lowerer emits `binary_to_existing_atom(Data, utf8)` (see design decisions for atom safety rationale).
+
+**The `any` FFI escape hatch**
+
+`any` in an `extern "Erlang"` signature tells the Mochi type checker to treat the argument or return value as an opaque BEAM term. The lowerer emits the term as-is with no type annotation in the generated Core Erlang:
+
+```mochi
+extern "Erlang" mod gun {
+  fun open(host: string, port: int, opts: any): any
+}
+
+let conn = open("api.example.com", 443, gun_tls_opts())
+```
+
+`any` values are opaque to the Mochi type checker after they are produced; they can only be passed to other `any`-typed FFI parameters or returned from functions with `any` return types. This prevents `any` from infecting the Mochi type system beyond FFI boundaries.
+
+**Marshalling table implementation**
+
+```go
+// transpiler3/beam/lower/ffi.go
+
+func beamFFIType(t aotir.Type) beamRepr {
+  switch t.(type) {
+  case *aotir.IntType:    return beamReprIdentity
+  case *aotir.FloatType:  return beamReprIdentity
+  case *aotir.BoolType:   return beamReprIdentity
+  case *aotir.StringType: return beamReprIdentity
+  case *aotir.ListType:   return beamReprIdentity
+  case *aotir.MapType:    return beamReprIdentity
+  case *aotir.AtomType:   return beamReprAtom
+  case *aotir.AnyType:    return beamReprAny
+  default:
+    panic(fmt.Sprintf("unsupported FFI type: %T", t))
+  }
+}
+```
+
+For `beamReprIdentity`, the lowerer passes the Core Erlang expression directly with no wrapper. For `beamReprAtom`, if the source is a string variable (not a compile-time literal), the lowerer wraps with `binary_to_existing_atom/2`.
+
+---
+
+### Sub-phase 12.2: Hex.pm dep declarations in mochi.toml -> rebar.config
+
+**mochi.toml Hex dependency syntax**
+
+A `mochi.toml` project manifest (proposed for a later MEP; referenced here for completeness) can declare Hex.pm dependencies for the BEAM target:
+
+```toml
+[beam_deps]
+gun = "2.1.0"
+cowboy = "2.10.0"
+```
+
+**Build driver: mochi.toml -> rebar.config generation**
+
+The `mochi build --target beam` command reads `mochi.toml` and generates `rebar.config`:
+
+```erlang
+{deps, [
+  {gun, "2.1.0"},
+  {cowboy, "2.10.0"}
+]}.
+```
+
+It also generates `{erl_opts, [debug_info]}` and `{profiles, [{test, [{deps, [...]}]}]}` sections. The build driver is implemented in `cmd/mochi/build_beam.go`.
+
+**FFI declarations referencing Hex deps**
+
+Once a Hex dep is declared, FFI can reference its modules:
+
+```mochi
+extern "Erlang" mod gun {
+  fun open(host: string, port: int, opts: any): any
+  fun request(conn: any, method: atom, path: string, headers: any, body: any): any
+}
+```
+
+The Mochi compiler does not verify that the referenced Erlang module exists at compile time. A missing dep causes an Erlang compile error downstream when rebar3 attempts to compile the generated `.erl` files.
+
+**Phase 12 CI scope**
+
+Phase 12 fixtures use only OTP stdlib modules (no Hex deps) to keep CI reproducible without a Hex.pm network connection. The `mochi.toml` Hex dep feature is tested in Phase 14's fetch fixtures (which require `gun`).
+
+---
 
 ## Test set
 
-_Pending phase open._
+15 fixtures under `tests/transpiler3/beam/fixtures/phase12/`:
+
+| # | File | Description |
+|---|------|-------------|
+| 01 | `ffi_lists_nth.mochi` | `lists:nth` with int list |
+| 02 | `ffi_lists_sort.mochi` | `lists:sort` with int list |
+| 03 | `ffi_lists_reverse.mochi` | `lists:reverse` |
+| 04 | `ffi_lists_map.mochi` | `lists:map` with a Mochi fun |
+| 05 | `ffi_lists_filter.mochi` | `lists:filter` |
+| 06 | `ffi_maps_merge.mochi` | `maps:merge` of two Mochi maps |
+| 07 | `ffi_maps_keys.mochi` | `maps:keys` returns a list |
+| 08 | `ffi_string_uppercase.mochi` | `string:uppercase` on a UTF-8 binary |
+| 09 | `ffi_string_split.mochi` | `string:split` |
+| 10 | `ffi_crypto_hash.mochi` | `crypto:hash(sha256, Data)` via atom literal `#sha256` |
+| 11 | `ffi_erlang_system_time.mochi` | `erlang:system_time(millisecond)` |
+| 12 | `ffi_erlang_node.mochi` | `erlang:node()` returns current node name |
+| 13 | `ffi_any_passthrough.mochi` | Pass `any`-typed value through FFI without type error |
+| 14 | `ffi_atom_literal.mochi` | Atom literals `#ok`, `#error` in FFI call |
+| 15 | `ffi_multi_module.mochi` | Multiple `extern "Erlang"` blocks in one file |
+
+---
+
+## Decisions made
+
+**Why `extern "Erlang"` syntax rather than a generic `extern fun`**
+
+MEP-45's `extern fun` is a C-direct FFI that uses a subprocess and JSON-over-stdin/stdout to communicate with Go, Python, or JavaScript programs. BEAM FFI is fundamentally different: it is a direct cross-module call in the same VM process, with no subprocess, no serialization, and no network. Using the same `extern fun` syntax for both would obscure this distinction and mislead users into expecting C FFI behavior (process isolation, JSON marshalling). The `extern "Erlang"` form is target-specific and makes the mechanism explicit.
+
+**Why identity marshalling for most types**
+
+Mochi's BEAM representation is designed to be idiomatic Erlang from the ground up: lists are cons cells, maps are BEAM maps, strings are UTF-8 binaries, booleans are atoms. This is a deliberate design choice that makes Mochi/Erlang interop cost-free for the common case. The C target's FFI requires JSON-over-subprocess precisely because C has no native representation for Mochi's high-level types. On BEAM, there is nothing to convert.
+
+**Why `binary_to_existing_atom` for string-to-atom conversion**
+
+Erlang's atom table is a fixed-size global table (default: 1,048,576 atoms). `binary_to_atom/1` creates a new atom entry if the string has not been seen before; under adversarial input (e.g., a web service that reads user-supplied field names and passes them as atoms), this can exhaust the atom table and crash the BEAM node. `binary_to_existing_atom/2` only succeeds if the atom is already registered, preventing atom table exhaustion from runtime data. The FFI layer never creates new atoms from runtime data; atom literals in Mochi source are compiled to `c_atom(...)` directly.
+
+---
 
 ## Closeout notes
 

--- a/website/docs/implementation/0046/phase-13-llm.md
+++ b/website/docs/implementation/0046/phase-13-llm.md
@@ -2,7 +2,7 @@
 title: "Phase 13. LLM (generate)"
 sidebar_position: 15
 sidebar_label: "Phase 13. LLM (generate)"
-description: "MEP-46 Phase 13. LLM (generate) tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+description: "MEP-46 Phase 13. LLM (generate) — detailed implementation spec."
 ---
 
 # Phase 13. LLM (generate)
@@ -16,25 +16,300 @@ description: "MEP-46 Phase 13. LLM (generate) tracking stub. Filled in when the 
 | Tracking issue | — |
 | Tracking PR    | — |
 
+This phase implements Mochi's `generate` expression on the BEAM target. `generate` sends a prompt to a configured LLM provider and returns a structured response validated against a Mochi record schema. The runtime uses `gun` for HTTP/2 connections to provider APIs, a per-provider gen_server for connection pooling and request throttling, and a cassette-replay system for deterministic CI testing.
+
+---
+
 ## Gate
 
-See [MEP-46 §Phases · Phase 13. LLM (generate)](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+See [MEP-46 §Phases · Phase 13. LLM (generate)](/docs/mep/mep-0046) for the normative gate. All 10 fixtures must produce byte-equal output to vm3. All 10 fixtures run against pre-recorded cassettes committed to the repo.
+
+---
 
 ## Goal-alignment audit
 
-_Pending phase open._
+`generate` is a first-class Mochi primitive for LLM-backed computation. The gate requires 10 fixtures covering basic generation, multi-field schemas, mixed types, prompt interpolation, and provider selection. All fixtures are user-facing. The cassette system ensures CI is deterministic without live API calls. Runtime schema validation catches provider errors at the point of generation rather than propagating untyped maps into Mochi code.
+
+---
 
 ## Sub-phases
 
-_Pending phase open._
+### Sub-phase 13.0: mochi_llm provider supervisor
 
-## Decisions made
+**Architecture overview**
 
-_Pending phase open._
+The LLM subsystem has three layers:
+
+1. **`mochi_llm.erl`** — Public API module. Stateless; delegates to per-provider gen_servers.
+2. **`mochi_llm_sup.erl`** — `one_for_one` supervisor. Starts one gen_server per configured provider.
+3. **`mochi_llm_<provider>.erl`** — Provider-specific gen_server (e.g., `mochi_llm_openai`, `mochi_llm_anthropic`). Manages HTTP connection pool to the provider's API endpoint.
+
+**Provider configuration**
+
+Providers are configured at application start via `application:get_env/2`:
+
+```erlang
+%% In sys.config or application env:
+{mochi, [
+  {llm_providers, [
+    {openai,    #{api_key => <<"sk-...">>, model => <<"gpt-4o">>}},
+    {anthropic, #{api_key => <<"sk-ant-...">>, model => <<"claude-opus-4-5">>}}
+  ]}
+]}
+```
+
+If `llm_providers` is not set (or is `[]`), `mochi_llm_sup` starts no children. Calls to `mochi_llm:generate/2` with an unconfigured provider return `{error, provider_not_configured}`.
+
+**mochi_llm_sup.erl**
+
+```erlang
+-module(mochi_llm_sup).
+-behaviour(supervisor).
+
+start_link() ->
+  supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+  Providers = application:get_env(mochi, llm_providers, []),
+  ChildSpecs = [provider_child_spec(Name, Opts) || {Name, Opts} <- Providers],
+  SupFlags = #{strategy => one_for_one, intensity => 5, period => 30},
+  {ok, {SupFlags, ChildSpecs}}.
+
+provider_child_spec(Name, Opts) ->
+  Module = provider_module(Name),
+  #{
+    id      => Name,
+    start   => {Module, start_link, [Name, Opts]},
+    restart => permanent,
+    type    => worker
+  }.
+
+provider_module(openai)    -> mochi_llm_openai;
+provider_module(anthropic) -> mochi_llm_anthropic;
+provider_module(Other)     -> error({unknown_llm_provider, Other}).
+```
+
+**mochi_llm_openai.erl gen_server state**
+
+```erlang
+-record(state, {
+  api_key   :: binary(),
+  model     :: binary(),
+  conn_pid  :: pid() | undefined,
+  semaphore :: integer(),      %% remaining slots (max concurrent requests)
+  max_conc  :: integer(),      %% configured max concurrent (default 10)
+  pending   :: queue:queue()   %% queued requests waiting for a slot
+}).
+```
+
+The gen_server handles:
+
+- `handle_call({generate, Opts}, From, State)` — If a slot is available (semaphore > 0), fires the HTTP request via `gun` and stores `{From, StreamRef}` in the pending map. If the semaphore is 0, enqueues the request.
+- `handle_info({gun_response, ConnPid, StreamRef, fin, Status, Headers}, State)` — Response received; deserialises JSON body; validates against schema; replies to caller.
+- `handle_info({gun_down, ...}, State)` — Connection lost; reconnects with exponential backoff (initial 100ms, max 30s, factor 2.0).
+
+Maximum concurrent requests (default 10) is configurable per-provider via `#{max_concurrent => N}` in the provider opts map.
+
+**mochi_llm.erl public API**
+
+```erlang
+-spec generate(atom(), map()) -> {ok, map()} | {error, term()}.
+generate(Provider, Opts) ->
+  case mochi_llm_cassette:lookup(Provider, Opts) of
+    {hit, Response} -> Response;
+    miss ->
+      Module = provider_module(Provider),
+      Result = gen_server:call(Module, {generate, Opts}, 30000),
+      mochi_llm_cassette:record(Provider, Opts, Result),
+      Result
+  end.
+```
+
+---
+
+### Sub-phase 13.1: generate block lowering
+
+**Syntax**
+
+```mochi
+let result = generate openai {
+  prompt: "Summarize {text}",
+  model: "gpt-4o",
+  schema: { summary: string, word_count: int }
+}
+```
+
+**Lowering steps**
+
+The lowerer processes a `GenerateExpr` AST node through the following steps:
+
+Step 1: **Prompt interpolation.** The prompt string `"Summarize {text}"` is lowered using the Phase 2.4 string interpolation pattern. If `text` is a Mochi variable holding a binary, the lowerer emits `Prompt = <<"Summarize ", Text/binary>>`. For complex interpolations with multiple variables, the lowerer emits `iolist_to_binary([...])`.
+
+Step 2: **Schema lowering.** The Mochi record schema `{ summary: string, word_count: int }` is lowered to a BEAM map literal that represents the JSON Schema types:
+
+```erlang
+Schema = #{summary => <<"string">>, word_count => <<"integer">>}
+```
+
+The lowerer maps Mochi types to JSON Schema type strings: `int` -> `"integer"`, `float` -> `"number"`, `string` -> `"string"`, `bool` -> `"boolean"`.
+
+Step 3: **generate call.** The lowerer emits:
+
+```erlang
+c_call(c_atom(mochi_llm), c_atom(generate), [
+  c_atom(openai),
+  c_map([
+    {c_atom(prompt),  V_prompt},
+    {c_atom(model),   c_binary(<<"gpt-4o">>)},
+    {c_atom(schema),  V_schema}
+  ])
+])
+```
+
+Step 4: **Result unwrapping.** The `generate/2` call returns `{ok, #{summary => <<"...">>, word_count => 42}}`. The lowerer emits a pattern match to unwrap the `{ok, _}` tuple and bind the schema fields into the Mochi scope:
+
+```erlang
+{ok, Result} = mochi_llm:generate(openai, Opts),
+Summary = maps:get(summary, Result),
+WordCount = maps:get(word_count, Result)
+```
+
+**JSON Schema construction in the provider**
+
+`mochi_llm_openai.erl` converts the Mochi schema map to an OpenAI-compatible JSON Schema:
+
+```erlang
+schema_to_json(Schema) ->
+  Properties = maps:map(fun(_Key, TypeStr) ->
+    #{<<"type">> => TypeStr}
+  end, Schema),
+  #{
+    <<"type">>                 => <<"object">>,
+    <<"properties">>           => Properties,
+    <<"required">>             => maps:keys(Schema),
+    <<"additionalProperties">> => false
+  }.
+```
+
+This map is serialised to JSON via OTP 27's `json:encode/1` and sent in the `response_format` field of the OpenAI API request body.
+
+**Response validation**
+
+`mochi_llm.erl`'s `validate_response/2` checks that the returned map contains all expected keys with the correct runtime types:
+
+```erlang
+validate_response(Response, Schema) ->
+  maps:foreach(fun(Key, TypeStr) ->
+    Value = maps:get(Key, Response, undefined),
+    case {Value, TypeStr} of
+      {undefined, _}     -> error({schema_mismatch, missing_key, Key});
+      {V, <<"string">>}  when not is_binary(V)  -> error({schema_mismatch, Key, expected_string});
+      {V, <<"integer">>} when not is_integer(V) -> error({schema_mismatch, Key, expected_integer});
+      {V, <<"number">>}  when not is_float(V), not is_integer(V) ->
+        error({schema_mismatch, Key, expected_number});
+      _ -> ok
+    end
+  end, Schema),
+  {ok, Response}.
+```
+
+---
+
+### Sub-phase 13.2: Replay-cassette test mode
+
+**Cassette directory**
+
+If the environment variable `MOCHI_LLM_CASSETTE_DIR` is set, `mochi_llm_cassette.erl` intercepts all `generate` calls. The cassette directory is read once at `mochi_app:start/2` and stored in application env.
+
+**Cassette keying**
+
+Each cassette file is named by the DJB2 hash of the tuple `{Provider, Prompt, Schema}` serialised to a canonical binary. DJB2 is chosen for its simplicity (no external dep) and low collision rate for short strings:
+
+```erlang
+djb2(Data) ->
+  lists:foldl(fun(Byte, Hash) ->
+    (Hash * 33 bxor Byte) band 16#FFFFFFFF
+  end, 5381, binary_to_list(Data)).
+```
+
+Cassette files are stored as Erlang terms (`.eterms` extension) for human readability and easy manual editing:
+
+```erlang
+%% cassettes/1234567890.eterms
+{cassette,
+  provider, openai,
+  prompt, <<"Summarize hello world">>,
+  schema, #{summary => <<"string">>},
+  response, {ok, #{summary => <<"Hello world is a greeting.">>}}
+}.
+```
+
+**Cassette modes**
+
+Two modes controlled by the `MOCHI_LLM_CASSETTE_MODE` env var:
+
+- **`replay`** (default in CI): If a cassette file exists for the key, return its recorded response. If no cassette exists, return `{error, cassette_not_found}` (never makes a live API call).
+- **`record`**: If a cassette file exists, return it (same as replay). If no cassette exists, make the live API call, save the response as a new cassette file, and return the result. Requires a live API key in the environment.
+
+**mochi_llm_cassette.erl**
+
+```erlang
+lookup(Provider, Opts) ->
+  case application:get_env(mochi, llm_cassette_dir) of
+    undefined -> miss;
+    {ok, Dir} ->
+      Key = cassette_key(Provider, Opts),
+      Path = filename:join(Dir, integer_to_list(Key) ++ ".eterms"),
+      case file:consult(Path) of
+        {ok, [{cassette, _, _, _, _, _, _, response, Response}]} -> {hit, Response};
+        _ -> miss
+      end
+  end.
+```
+
+**CI cassette management**
+
+All fixture cassettes are committed to the repository under `tests/transpiler3/beam/cassettes/`. CI always runs with:
+
+```
+MOCHI_LLM_CASSETTE_DIR=tests/transpiler3/beam/cassettes/
+MOCHI_LLM_CASSETTE_MODE=replay
+```
+
+New cassettes are recorded locally by a developer with API keys and committed. The cassette directory is tracked in `.gitattributes` as binary to prevent line-ending normalisation on Windows.
+
+---
 
 ## Test set
 
-_Pending phase open._
+10 fixtures under `tests/transpiler3/beam/fixtures/phase13/`, all with pre-recorded cassettes:
+
+| # | File | Description |
+|---|------|-------------|
+| 01 | `llm_summarize.mochi` | Summarize a short text, return `{summary: string}` |
+| 02 | `llm_classify.mochi` | Classify sentiment, return `{sentiment: string}` |
+| 03 | `llm_extract.mochi` | Extract name and age from text, return `{name: string, age: int}` |
+| 04 | `llm_translate.mochi` | Translate English to French |
+| 05 | `llm_multi_field.mochi` | Schema with 5 fields of mixed types |
+| 06 | `llm_anthropic.mochi` | Same summarize task via Anthropic provider |
+| 07 | `llm_schema_mismatch.mochi` | Provider returns wrong type; verify `schema_mismatch` error |
+| 08 | `llm_prompt_interp.mochi` | Prompt with variable interpolation |
+| 09 | `llm_nested_schema.mochi` | Schema with `map<string, string>` field |
+| 10 | `llm_async_generate.mochi` | `async (generate ...)` combined with Phase 11 |
+
+---
+
+## Decisions made
+
+**Why gun for HTTP in the LLM provider**
+
+OTP's built-in `httpc` (from the `inets` application) uses a single process per connection pool, making concurrent requests serialised per pool. For LLM use cases where a Mochi program may issue 10 or more concurrent `generate` calls, `httpc` becomes a bottleneck. `gun` supports HTTP/2 stream multiplexing: 50 concurrent requests share a single TCP connection, with BEAM receiving response frames asynchronously via `handle_info` callbacks. `gun` is also already a dependency for `mochi_fetch` (Phase 14), so using it here adds no new transitive deps.
+
+**Why schema validation in the runtime rather than compile-time**
+
+LLM responses are dynamically generated by a remote model; the schema is a hint to the provider (via JSON Schema `response_format` in OpenAI's API) but not a hard guarantee. The model may hallucinate fields, omit required fields, or return a field with the wrong type. Mochi's type checker validates that the schema expression is syntactically correct and that call sites use the correct field names and types (compile-time safety). But the actual content of the response can only be validated at runtime. `mochi_llm.erl`'s `validate_response/2` performs this runtime check and returns `{error, {schema_mismatch, Key, Reason}}` on failure, allowing Mochi programs to handle validation errors gracefully rather than crashing on a bad pattern match.
+
+---
 
 ## Closeout notes
 

--- a/website/docs/implementation/0046/phase-14-fetch.md
+++ b/website/docs/implementation/0046/phase-14-fetch.md
@@ -2,7 +2,7 @@
 title: "Phase 14. fetch (HTTP)"
 sidebar_position: 16
 sidebar_label: "Phase 14. fetch (HTTP)"
-description: "MEP-46 Phase 14. fetch (HTTP) tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+description: "MEP-46 Phase 14. fetch (HTTP) — detailed implementation spec."
 ---
 
 # Phase 14. fetch (HTTP)
@@ -16,25 +16,311 @@ description: "MEP-46 Phase 14. fetch (HTTP) tracking stub. Filled in when the ph
 | Tracking issue | — |
 | Tracking PR    | — |
 
+This phase implements Mochi's `fetch` expression on the BEAM target. `fetch` issues HTTP/HTTPS requests using `gun` for connection pooling and HTTP/2 multiplexing, with TLS 1.3 enforced via OTP 27's `ssl` application and JSON handled by OTP 27's built-in `json` stdlib module. No external Hex dependencies are required for JSON or TLS; `gun` is the single runtime dep for HTTP.
+
+---
+
 ## Gate
 
-See [MEP-46 §Phases · Phase 14. fetch (HTTP)](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+See [MEP-46 §Phases · Phase 14. fetch (HTTP)](/docs/mep/mep-0046) for the normative gate. All 10 fixtures must produce byte-equal output to vm3. Fixtures run against a local test HTTP server started during test setup.
+
+---
 
 ## Goal-alignment audit
 
-_Pending phase open._
+`fetch` is the primary mechanism for Mochi programs to call external HTTP APIs, which is one of the most common real-world use cases. The 10 fixtures cover GET, POST, JSON encoding/decoding, TLS, concurrent requests, large responses, and mixed JSON types. All fixtures are directly user-visible. The per-host connection pool design ensures that production workloads with many requests to the same host do not pay TLS handshake overhead on every request.
+
+---
 
 ## Sub-phases
 
-_Pending phase open._
+### Sub-phase 14.0: mochi_fetch wrapping gun
 
-## Decisions made
+**Syntax and lowering**
 
-_Pending phase open._
+Simple GET:
+
+```mochi
+let resp = fetch "https://api.example.com/data"
+```
+
+Lowers to:
+
+```erlang
+c_call(c_atom(mochi_fetch), c_atom(get), [c_binary(<<"https://api.example.com/data">>)])
+```
+
+POST with options:
+
+```mochi
+let resp = fetch "https://api.example.com/items" with {
+  method: "POST",
+  body: payload,
+  headers: { "Content-Type": "application/json" }
+}
+```
+
+Lowers to:
+
+```erlang
+c_call(c_atom(mochi_fetch), c_atom(request), [
+  c_map([
+    {c_atom(method),  c_atom(post)},
+    {c_atom(url),     c_binary(<<"https://api.example.com/items">>)},
+    {c_atom(body),    V_payload},
+    {c_atom(headers), c_map([{c_binary(<<"Content-Type">>), c_binary(<<"application/json">>)}])}
+  ])
+])
+```
+
+The lowerer converts the string method name `"POST"` to the atom `post` at compile time.
+
+**mochi_fetch.erl public API**
+
+```erlang
+-spec get(binary()) -> {ok, response()} | {error, term()}.
+get(Url) ->
+  request(#{method => get, url => Url}).
+
+-spec request(map()) -> {ok, response()} | {error, term()}.
+request(Opts) ->
+  {Host, Port, Path, Scheme} = parse_url(maps:get(url, Opts)),
+  ConnPid = mochi_fetch_pool:get_or_create(Host, Port, Scheme),
+  Method  = maps:get(method, Opts, get),
+  Headers = maps:to_list(maps:get(headers, Opts, #{})),
+  Body    = maps:get(body, Opts, <<>>),
+  StreamRef = gun:request(ConnPid, method_to_binary(Method), Path, Headers, Body),
+  await_response(ConnPid, StreamRef).
+```
+
+**Response type**
+
+```erlang
+-type response() :: #{
+  status  := non_neg_integer(),
+  headers := #{binary() => binary()},
+  body    := binary()
+}.
+```
+
+Non-2xx responses are returned as `{ok, Response}` with the actual status code in `response.status`. Only network-level errors (connection refused, DNS failure, TLS handshake failure) return `{error, Reason}`. Mochi programs check `resp.status` explicitly if they care about HTTP error codes. This follows the principle of least surprise: HTTP 404 is a valid HTTP response, not a protocol-level error.
+
+**URL parsing**
+
+`mochi_fetch:parse_url/1` uses `uri_string:parse/1` (OTP 23+ stdlib):
+
+```erlang
+parse_url(Url) ->
+  #{scheme := Scheme, host := Host, path := Path} = uri_string:parse(Url),
+  Port = case Scheme of
+    <<"https">> -> 443;
+    <<"http">>  -> 80
+  end,
+  {Host, Port, Path, Scheme}.
+```
+
+---
+
+### Sub-phase 14.1: Per-host connection pooling via mochi_fetch_pool
+
+**Architecture**
+
+`mochi_fetch_sup.erl` is a `simple_one_for_one` supervisor. Each child is a `mochi_fetch_pool` gen_server managing one `gun` connection to one `{Host, Port, Scheme}` tuple.
+
+```erlang
+-module(mochi_fetch_sup).
+-behaviour(supervisor).
+
+init([]) ->
+  SupFlags = #{strategy => simple_one_for_one, intensity => 10, period => 60},
+  ChildSpec = #{
+    id      => mochi_fetch_pool,
+    start   => {mochi_fetch_pool, start_link, []},
+    restart => transient,
+    type    => worker
+  },
+  {ok, {SupFlags, [ChildSpec]}}.
+```
+
+**mochi_fetch_pool.erl gen_server**
+
+State:
+
+```erlang
+-record(state, {
+  host     :: binary(),
+  port     :: inet:port_number(),
+  scheme   :: http | https,
+  conn_pid :: pid() | undefined,
+  pending  :: #{reference() => {pid(), reference()}}
+}).
+```
+
+`get_or_create/3` looks up the pool by `{Host, Port, Scheme}` in an ETS table (`mochi_fetch_pools`). If no pool exists, it starts a new gen_server child under `mochi_fetch_sup` and registers it in the ETS table. Concurrent first-request races for the same host are serialized via a `mochi_fetch_registry` gen_server that owns the ETS write.
+
+**Connection lifecycle**
+
+On `init/1`, the pool gen_server calls:
+
+```erlang
+{ok, ConnPid} = gun:open(Host, Port, gun_opts(Scheme))
+```
+
+And waits for `{gun_up, ConnPid, Protocol}` in `handle_info` before accepting requests. If the connection drops (`gun_down`), the pool gen_server re-opens with exponential backoff (initial 100ms, max 30s, factor 2.0, jitter 10%).
+
+**HTTP/2 multiplexing**
+
+`gun` uses HTTP/2 by default for HTTPS connections (negotiated via ALPN in the TLS handshake). Multiple `gun:request/5` calls on the same `ConnPid` each return a unique `StreamRef`. Responses arrive as `{gun_response, ConnPid, StreamRef, fin, Status, Headers}` and `{gun_data, ConnPid, StreamRef, fin, Body}` messages. The pool gen_server correlates each `StreamRef` to its caller and replies via `gen_server:reply/2`.
+
+---
+
+### Sub-phase 14.1: TLS via ssl (OTP 27 TLS 1.3 default)
+
+**gun TLS options**
+
+`mochi_fetch_pool` constructs gun's TLS options for HTTPS connections:
+
+```erlang
+gun_opts(https) ->
+  #{
+    transport => tls,
+    tls_opts  => [
+      {versions,          ['tlsv1.3', 'tlsv1.2']},
+      {verify,            verify_peer},
+      {cacerts,           public_key:cacerts_get()},
+      {customize_hostname_check, [
+        {match_fun, public_key:pkix_verify_hostname_match_fun(https)}
+      ]}
+    ]
+  };
+gun_opts(http) ->
+  #{transport => tcp}.
+```
+
+Key TLS settings:
+
+- `{versions, ['tlsv1.3', 'tlsv1.2']}` — explicitly excludes TLS 1.0 and TLS 1.1.
+- `{verify, verify_peer}` — server certificate is verified against the CA bundle.
+- `{cacerts, public_key:cacerts_get()}` — uses the system CA bundle (OTP 25+ API). On macOS, reads from the macOS trust store; on Linux, from `/etc/ssl/certs/ca-certificates.crt` or equivalent.
+- `customize_hostname_check` with `pkix_verify_hostname_match_fun(https)` — performs RFC 6125-compliant hostname verification.
+
+**Test mode: self-signed cert**
+
+Test fixtures use a local HTTPS server. The test setup generates a self-signed certificate at test startup:
+
+```erlang
+setup_test_tls() ->
+  {ok, _Cert, _Key} = mochi_test_tls:generate_self_signed(<<"localhost">>),
+  application:set_env(mochi, fetch_tls_opts_override, [
+    {verify, verify_none}
+  ]).
+```
+
+`mochi_fetch_pool` checks for `fetch_tls_opts_override` in application env and substitutes the provided options. This override is only available when the `mochi` application is started with `{test_mode, true}` env; it is a compile-time error to set this override in a production release build.
+
+---
+
+### Sub-phase 14.2: JSON parse via stdlib json (OTP 27)
+
+**JSON decode**
+
+`json_body = json.decode(resp.body)` lowers to:
+
+```erlang
+c_call(c_atom(json), c_atom(decode), [V_body])
+```
+
+OTP 27's `json:decode/1` returns BEAM terms with the following mapping:
+
+| JSON type | BEAM term |
+|-----------|-----------|
+| `null` | `null` atom |
+| `true` | `true` atom |
+| `false` | `false` atom |
+| Number (integer) | BEAM integer |
+| Number (float) | BEAM float |
+| String | Binary (UTF-8) |
+| Array | BEAM list |
+| Object | BEAM map with binary keys |
+
+**mochi_fetch:json/1 helper**
+
+```erlang
+-spec json(response()) -> term().
+json(#{body := Body}) ->
+  json:decode(Body).
+```
+
+This helper is lowered for the common pattern `let data = json(resp)` — the lowerer recognizes the `json(resp)` call pattern and emits `c_call(c_atom(mochi_fetch), c_atom(json), [V_resp])`.
+
+**JSON encode**
+
+For POST/PUT bodies:
+
+```mochi
+fetch url with { method: "POST", body: json_encode(payload) }
+```
+
+`json_encode` is a Mochi builtin that lowers to:
+
+```erlang
+c_call(c_atom(mochi_fetch), c_atom(json_encode), [V_payload])
+```
+
+```erlang
+-spec json_encode(term()) -> binary().
+json_encode(Term) ->
+  iolist_to_binary(json:encode(Term)).
+```
+
+OTP 27's `json:encode/1` handles all BEAM native types that have JSON equivalents. It raises `badarg` for terms with no JSON representation (e.g., PIDs, references). The Mochi type checker prevents this at compile time for typed values; `any`-typed values passed to `json_encode` are checked at runtime.
+
+**No external JSON deps**
+
+OTP 27's `json` module provides encoding and decoding. For the Mochi runtime's needs (encoding request bodies, decoding response bodies), stdlib `json` is sufficient. Projects that need JSON path queries or streaming JSON can use FFI (Phase 12) to access `jsx`, `jiffy`, or other Hex packages.
+
+---
 
 ## Test set
 
-_Pending phase open._
+10 fixtures under `tests/transpiler3/beam/fixtures/phase14/`, run against a local test HTTP server:
+
+| # | File | Description |
+|---|------|-------------|
+| 01 | `fetch_get_basic.mochi` | GET request; check status 200 |
+| 02 | `fetch_get_json.mochi` | GET JSON endpoint; decode and access field |
+| 03 | `fetch_post_json.mochi` | POST with JSON body; verify echo response |
+| 04 | `fetch_headers.mochi` | Custom request headers sent; verify server received them |
+| 05 | `fetch_404.mochi` | GET returns 404; Mochi program checks `resp.status` |
+| 06 | `fetch_tls.mochi` | HTTPS GET against local TLS server with self-signed cert in test mode |
+| 07 | `fetch_concurrent.mochi` | 10 concurrent `async (fetch ...)` calls, then `await_all` |
+| 08 | `fetch_large_body.mochi` | Response body > 1 MB; verify full body received |
+| 09 | `fetch_json_types.mochi` | JSON with mixed types (null, bool, int, float, string, array, object) |
+| 10 | `fetch_post_form.mochi` | POST with `application/x-www-form-urlencoded` body |
+
+The test helper `mochi_test_server.erl` starts a minimal Cowboy instance handling predefined routes. Cowboy is a test-only dep declared in `rebar.config` under the `test` profile:
+
+```erlang
+{profiles, [{test, [{deps, [{cowboy, "2.10.0"}]}]}]}.
+```
+
+---
+
+## Decisions made
+
+**Why per-host connection pooling in mochi_fetch_pool**
+
+HTTP/1.1 keepalive and HTTP/2 multiplexing both require a persistent TCP connection per host. Without pooling, each `fetch` call would open a new TCP connection (3-way handshake: ~1ms LAN, ~100ms WAN) and complete a TLS handshake (~100ms additional for TLS 1.3 1-RTT). With a pooled HTTP/2 connection, these costs are paid once per host per application lifetime, and subsequent requests on the same host take ~1ms round trip. For a Mochi web service making many requests per second to the same upstream, the difference is significant.
+
+**Why OTP 27 `json` stdlib instead of jsx/jiffy**
+
+The OTP 27 `json` module was contributed by the OTP team and is maintained as part of the OTP release cycle, requiring no Hex.pm dependency, no NIF compilation, and no version pinning. `jiffy` is a NIF-based JSON library: NIF crashes can bring down the entire BEAM node (unlike Erlang process crashes which are isolated). `jsx` is a pure-Erlang library but adds a transitive Hex dep and its own versioning surface area. OTP 27's `json` is the correct choice for the Mochi runtime's zero-external-dep constraint on BEAM. For use cases requiring `json` performance beyond stdlib, users can access `jiffy` or `jason` (Elixir) via FFI (Phase 12).
+
+**Why TLS 1.3 default and reject TLS 1.0/1.1**
+
+TLS 1.0 and TLS 1.1 are deprecated by RFC 8996 (March 2021) and disabled by default in Chrome 84+, Firefox 78+, Safari 13+, and all major cloud load balancers. Accepting TLS 1.0/1.1 would expose Mochi programs to known attacks: BEAST (CVE-2011-3389) against TLS 1.0's CBC mode, POODLE (CVE-2014-3566) against SSL 3.0/TLS 1.0 fallback, and RC4 vulnerabilities present in older cipher suites. OTP 27's `ssl` application sets `['tlsv1.3', 'tlsv1.2']` as its default, but `mochi_fetch` makes this explicit in `gun_opts/1` to ensure the behaviour is not accidentally changed by OTP upgrades that might loosen defaults for compatibility reasons.
+
+---
 
 ## Closeout notes
 

--- a/website/docs/implementation/0046/phase-15-release.md
+++ b/website/docs/implementation/0046/phase-15-release.md
@@ -2,7 +2,7 @@
 title: "Phase 15. Release packaging"
 sidebar_position: 17
 sidebar_label: "Phase 15. Release packaging"
-description: "MEP-46 Phase 15. Release packaging tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+description: "MEP-46 Phase 15. Release packaging: relx OTP release, rebar3 project export, mix project export, AtomVM profile, Docker base images."
 ---
 
 # Phase 15. Release packaging
@@ -18,23 +18,281 @@ description: "MEP-46 Phase 15. Release packaging tracking stub. Filled in when t
 
 ## Gate
 
-See [MEP-46 §Phases · Phase 15. Release packaging](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+`mochi build --target=beam-release hello.mochi` produces a `hello.tar.gz` OTP release that unpacks
+and passes `bin/hello eval "mochi_user_hello:main()."` with output matching vm3 on OTP 27 and 28,
+on both x86_64-linux-gnu and aarch64-darwin.
 
 ## Goal-alignment audit
 
-_Pending phase open._
+Phase 15 directly enables the user-facing goal of shipping Mochi programs to production. Without
+release packaging, users can only run Mochi programs via `erl -run` or escript in a dev environment
+that already has OTP installed. An OTP release bundles ERTS, beam files, and startup scripts into a
+self-contained tarball that can be deployed to any Linux server without a pre-installed Erlang
+runtime. This is the standard deployment unit for Erlang/OTP production software.
+
+The rebar3-project target (15.1) enables Erlang developers to receive Mochi output as a first-class
+Erlang project they can extend, maintain, and compile independently. The mix-project target (15.2)
+does the same for Elixir teams. The AtomVM target (15.3) enables embedded deployments. Docker images
+(15.4) close the CI loop for the OTP matrix in Phase 16.
+
+All four sub-phase outputs are concrete, independently useful deployment artifacts, not internal
+scaffolding.
 
 ## Sub-phases
 
-_Pending phase open._
+### 15.0 `--target=beam-release` via relx
+
+OTP releases bundle ERTS, `.beam` files, and startup scripts into a tarball. `relx` (bundled with
+rebar3) is the standard tool for building OTP releases.
+
+**Build driver flow:**
+
+1. Lower Mochi source to `.beam` files (same pipeline as `--target=beam`).
+2. Write a temporary rebar3 project to a workdir (`os.MkdirTemp`).
+3. Run `rebar3 release` in the workdir via `os/exec.Command`.
+4. Copy and compress `_build/default/rel/<name>/` into the output `<out>.tar.gz`.
+
+**Generated `rebar.config`:**
+
+```erlang
+{relx, [{release, {mochi_app_name, "0.1.0"}, [mochi_user_MODULE, mochi]},
+         {dev_mode, false}, {include_erts, true},
+         {extended_start_script, true}]}.
+{profiles, [{default, [{relx, [{include_erts, true}]}]}]}.
+```
+
+`mochi_user_MODULE` is the generated module atom for the user's Mochi source file (e.g.,
+`mochi_user_hello` for `hello.mochi`). The release boots the `mochi` OTP application which starts
+the supervision tree (gen_server agent registry, pg scope for streams, async supervisor).
+
+**Output artifact:** `<out>.tar.gz`, typically 30-80 MB including ERTS. When unpacked, the release
+provides:
+
+```
+<name>/
+├── bin/
+│   └── <name>          (startup script: start|stop|console|eval|remote_console)
+├── erts-<ver>/         (bundled ERTS)
+├── lib/
+│   ├── mochi_user_MODULE-0.1.0/ebin/
+│   └── mochi-0.1.0/ebin/
+└── releases/
+    └── 0.1.0/
+        └── sys.config
+```
+
+**Validation:** `bin/<name> eval "mochi_user_hello:main()."` runs the Mochi `main` function and
+exits. The test framework captures stdout and diffs it against the vm3 reference output.
+
+**Go files changed:**
+
+- `transpiler3/beam/build/driver.go`: add `TargetBEAMRelease` case; implement `buildRelease()`.
+- `transpiler3/beam/build/rebar3.go` (new): `WriteRebar3Project()`, `RunRebar3Release()`.
+- `transpiler3/beam/build/phase15_test.go` (new): `TestPhase15Release`.
+
+### 15.1 `--target=beam-rebar3-project`
+
+Emits a complete rebar3 project layout to the output directory, suitable for `rebar3 compile` and
+`rebar3 release` without the Mochi build driver.
+
+**Output layout:**
+
+```
+<out>/
+├── rebar.config           (deps, relx, erl_opts)
+├── src/
+│   ├── mochi_user_MODULE.erl      (pretty-printed via erl_prettypr)
+│   ├── mochi_user_MODULE.app.src
+│   └── mochi.app.src              (copied from runtime)
+├── include/               (Erlang headers, if any)
+└── priv/                  (static assets, empty for now)
+```
+
+The `.erl` source is the pretty-printed form of the generated Core Erlang, recovered via:
+
+```
+Core Erlang IR -> cerl_trees:to_abstract_format/1 -> erl_prettypr:format/1 -> .erl text
+```
+
+This gives Erlang developers a human-readable handoff. The generated project compiles
+independently with `rebar3 compile` and can be extended by Erlang developers without the Mochi
+toolchain.
+
+**`rebar.config` contents:**
+
+```erlang
+{erl_opts, [debug_info]}.
+{deps, [{mochi, "0.1.0", {pkg, mochi}}]}.
+{relx, [{release, {mochi_user_MODULE, "0.1.0"}, [mochi_user_MODULE, mochi]},
+         {dev_mode, false}, {include_erts, true}]}.
+```
+
+**Go files changed:**
+
+- `transpiler3/beam/build/driver.go`: add `TargetBEAMRebar3Project` case.
+- `transpiler3/beam/build/rebar3.go`: add `WriteRebar3ProjectDir()`, `PrettyPrintErl()`.
+- `transpiler3/beam/build/phase15_test.go`: `TestPhase15Rebar3Project`.
+
+### 15.2 `--target=beam-mix-project`
+
+Emits a `mix.exs` project for users who prefer Elixir tooling. Secondary target; rebar3 is
+canonical.
+
+**Generated `mix.exs`:**
+
+```elixir
+defmodule MochiUserApp.MixProject do
+  use Mix.Project
+  def project, do: [
+    app: :mochi_user_app,
+    version: "0.1.0",
+    elixir: "~> 1.16",
+    deps: deps()
+  ]
+  def application, do: [extra_applications: [:logger], mod: {MochiUserApp.Application, []}]
+  defp deps, do: [{:mochi, "~> 0.1"}]
+end
+```
+
+`.beam` files are placed in `_build/dev/lib/mochi_user_app/ebin/` so that `mix run` finds them.
+The target generates a thin `MochiUserApp.Application` module that calls `mochi_user_MODULE:main()`
+on start.
+
+**Go files changed:**
+
+- `transpiler3/beam/build/driver.go`: add `TargetBEAMMixProject` case.
+- `transpiler3/beam/build/mix.go` (new): `WriteMixProject()`.
+- `transpiler3/beam/build/phase15_test.go`: `TestPhase15MixProject`.
+
+### 15.3 `--target=beam-atomvm`
+
+AtomVM is a minimal BEAM runtime for microcontrollers (ESP32, STM32, Raspberry Pi Pico). It runs
+a subset of OTP without full ERTS.
+
+**Compatibility profile validation:** The build driver validates generated `.beam` files against
+the AtomVM compatibility profile. Rejected at compile time:
+
+- `pg`, `gen_statem`, `httpc`, `gun`, `ssl` module calls.
+- `crypto` calls except `crypto:hash/2` (AtomVM includes only hash functions).
+- Agents (Phase 9), streams (Phase 10), async (Phase 11), LLM (Phase 13), fetch (Phase 14).
+
+Using any rejected feature in an `atomvm`-profiled Mochi program is a compile-time error with a
+clear message: `error: 'pg:join' is not available in the atomvm profile`.
+
+**Output format:** `.avm` file (AtomVM bundle format, a zip of `.beam` files with AtomVM-specific
+headers). The build driver invokes `packbeam` (AtomVM's bundler) or assembles the `.avm` format
+directly using Go's `archive/zip`.
+
+**Command:**
+
+```
+mochi build --target=beam-atomvm --profile=atomvm hello.mochi -o hello.avm
+```
+
+**Go files changed:**
+
+- `transpiler3/beam/build/driver.go`: add `TargetBEAMAtomVM` case.
+- `transpiler3/beam/build/atomvm.go` (new): `ValidateAtomVMProfile()`, `PackAVM()`.
+- `transpiler3/beam/build/phase15_test.go`: `TestPhase15AtomVM`.
+
+### 15.4 Docker base images
+
+`docker/Dockerfile.beam-otp27` builds a base image: Ubuntu 22.04, OTP 27 installed from
+`erlang-solutions` apt repo, rebar3 installed from GitHub releases, mochi CLI installed from the
+release artifact.
+
+```dockerfile
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y curl wget libssl3 libncurses5
+RUN curl -fsSL https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb \
+    | dpkg -i - && apt-get update && apt-get install -y esl-erlang=1:27.*
+RUN wget https://github.com/erlang/rebar3/releases/download/3.23.0/rebar3 \
+    -O /usr/local/bin/rebar3 && chmod +x /usr/local/bin/rebar3
+COPY bin/mochi /usr/local/bin/mochi
+```
+
+Published as:
+- `mochilang/mochi:beam-otp27` (OTP 27.latest)
+- `mochilang/mochi:beam-otp28` (OTP 28.latest)
+
+CI Phase 16 matrix jobs use these images to avoid OTP installation overhead per-run.
+
+**Files changed:**
+
+- `docker/Dockerfile.beam-otp27` (new)
+- `docker/Dockerfile.beam-otp28` (new)
+- `.github/workflows/docker-beam.yml` (new): builds and pushes images on `v*.*.*` tags.
 
 ## Decisions made
 
-_Pending phase open._
+**Why relx via rebar3 instead of direct `systools` calls.** `relx` is the modern, widely-used
+release builder for OTP. `systools` (the older OTP tool) requires `.rel` and `.script` files and
+significantly more ceremony to produce a release. `relx` handles ERTS bundling, pruning unused OTP
+applications, and cross-platform startup scripts out of the box. rebar3 ships `relx` built-in, so
+there is no additional installation dependency. The tradeoff is that the build driver must spawn a
+`rebar3` subprocess rather than making OTP API calls directly from Go, but this is acceptable
+because release building is a one-shot operation (not hot path).
+
+**Why emit `.erl` source in the rebar3-project target.** The generated `.erl` is a handoff
+artifact for Erlang developers who want to review, extend, or maintain the generated code. Without
+readable source, the generated `.beam` files are a black box that Erlang developers cannot inspect
+or modify. `erl_prettypr:format/1` produces idiomatic-enough Erlang from the abstract format
+recovered via `cerl_trees`. The round-trip is: Core Erlang IR -> abstract format ->
+`erl_prettypr` -> `.erl`. The result is not identical to hand-written Erlang but is readable and
+compiles without modification.
+
+**Why AtomVM as a separate profile, not a separate lowering pipeline.** AtomVM runs standard
+`.beam` files; the difference is which OTP modules are available at runtime, not the format of the
+`.beam` file itself. Rather than a separate lowering pipeline (which would duplicate Phase 0-8),
+we use a validation profile that rejects calls to unsupported modules at compile time. The output
+`.beam` files are standard BEAM bytecode; only the packaging (`.avm` instead of escript/release)
+differs. This approach keeps the lowering pipeline unified and avoids duplicating the Phase 0-8
+work for a niche target.
+
+**Why Docker images are Phase 15, not Phase 16.** Phase 16 needs the images to already exist in
+Docker Hub before the matrix jobs run. Building the images is release packaging work (they package
+OTP + rebar3 + mochi), so they belong in Phase 15. Phase 16 only consumes them.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `transpiler3/beam/build/driver.go` | Add `TargetBEAMRelease`, `TargetBEAMRebar3Project`, `TargetBEAMMixProject`, `TargetBEAMAtomVM` cases |
+| `transpiler3/beam/build/rebar3.go` | New: `WriteRebar3Project()`, `RunRebar3Release()`, `PrettyPrintErl()`, `WriteRebar3ProjectDir()` |
+| `transpiler3/beam/build/mix.go` | New: `WriteMixProject()` |
+| `transpiler3/beam/build/atomvm.go` | New: `ValidateAtomVMProfile()`, `PackAVM()` |
+| `transpiler3/beam/build/phase15_test.go` | New: `TestPhase15Release`, `TestPhase15Rebar3Project`, `TestPhase15MixProject`, `TestPhase15AtomVM` |
+| `docker/Dockerfile.beam-otp27` | New |
+| `docker/Dockerfile.beam-otp28` | New |
+| `.github/workflows/docker-beam.yml` | New: build + push Docker images on release tags |
+| `tests/transpiler3/beam/fixtures/phase15/` | New: fixture Mochi programs for each target |
 
 ## Test set
 
-_Pending phase open._
+- `TestPhase15Release`: builds `hello.mochi` with `--target=beam-release`, unpacks the tarball,
+  runs `bin/hello eval "mochi_user_hello:main()."`, diffs stdout vs vm3 reference.
+- `TestPhase15Rebar3Project`: builds `hello.mochi` with `--target=beam-rebar3-project`, runs
+  `rebar3 compile` in the output directory, verifies `.beam` files are produced.
+- `TestPhase15MixProject`: builds `hello.mochi` with `--target=beam-mix-project`, verifies
+  `mix.exs` is parseable and contains the expected module name and deps.
+- `TestPhase15AtomVM`: builds `hello.mochi` with `--target=beam-atomvm`, verifies `.avm` file is
+  produced. Attempts to build a program using `pg` with `--profile=atomvm` and expects a compile
+  error.
+- `TestPhase15AtomVMReject`: confirms each Phase 9-14 feature is rejected under the atomvm profile.
+- All tests run on OTP 27 (the minimum version). The release test unpacks and runs the tarball.
+
+## Deferred work
+
+- Hot-code reload via `relup` and `appup` files (OTP rolling upgrade support): deferred post-v1.0.
+  Implementing `relup` requires versioned releases and a running node to upgrade, which adds
+  significant complexity to the build driver.
+- AtomVM hardware-in-the-loop testing (flashing to an actual ESP32 and running): deferred. CI
+  uses the AtomVM host emulator (`atomvm` binary) for Phase 15 tests.
+- Cross-compilation: building an OTP release for `aarch64-linux-gnu` from `x86_64-linux-gnu`.
+  Requires cross-compiled ERTS, which relx does not support without a custom ERTS build.
+  Deferred post-v1.0.
+- Mix project: `mix release` (Elixir releases) vs just `mix compile`. Currently the mix target
+  only supports `mix compile`. `mix release` support deferred.
 
 ## Closeout notes
 

--- a/website/docs/implementation/0046/phase-16-otp-matrix.md
+++ b/website/docs/implementation/0046/phase-16-otp-matrix.md
@@ -2,7 +2,7 @@
 title: "Phase 16. Multi-OTP-version matrix"
 sidebar_position: 18
 sidebar_label: "Phase 16. Multi-OTP-version matrix"
-description: "MEP-46 Phase 16. Multi-OTP-version matrix tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+description: "MEP-46 Phase 16. Multi-OTP-version CI matrix: OTP 27/28 x x86_64-linux/aarch64-darwin, nightly OTP 29 RC, Windows nightly."
 ---
 
 # Phase 16. Multi-OTP-version matrix
@@ -18,23 +18,259 @@ description: "MEP-46 Phase 16. Multi-OTP-version matrix tracking stub. Filled in
 
 ## Gate
 
-See [MEP-46 §Phases · Phase 16. Multi-OTP-version matrix](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+All 6 combinations in the `otp x runner` matrix (OTP 27.0, 27.latest, 28.latest) x
+(ubuntu-latest, macos-latest) pass `go test ./transpiler3/beam/build/... -run TestPhase` with zero
+failures, and output matches vm3 reference on every cell.
 
 ## Goal-alignment audit
 
-_Pending phase open._
+Mochi programs must run correctly on the OTP versions users have deployed. OTP 27 is the current
+LTS; OTP 28 is the next major release. A bug introduced in the OTP 27->28 transition (e.g., a
+change in `gen_server` call semantics, a new warning about deprecated BIFs, or a JIT regression)
+would silently break Mochi programs on OTP 28 if we only test on OTP 27. The matrix CI makes this
+failure blocking, not discovered by users after release.
+
+The platform dimension (x86_64-linux vs aarch64-darwin) catches platform-specific behavior such as
+endianness assumptions in term encoding, path separator differences, or JIT code generation
+differences between BeamAsm x86 and BeamAsm ARM64. Both are Tier-1 developer platforms with
+BeamAsm JIT support.
+
+This phase adds no new language features. Its value is entirely in the correctness guarantee it
+extends across the OTP version and platform space.
 
 ## Sub-phases
 
-_Pending phase open._
+### 16.0 CI workflow for OTP x arch matrix
+
+`.github/workflows/transpiler3-beam-matrix.yml` defines a matrix job that covers the blocking
+6-cell Tier-1 matrix.
+
+**Workflow definition (key excerpt):**
+
+```yaml
+name: transpiler3-beam-matrix
+on:
+  push:
+    branches: [main, "mep/0046-*"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  beam-matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        otp: ["27.0", "27.3", "28.0"]
+        runner: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+      - name: Run beam phase tests
+        env:
+          ERL_VERSION: ${{ matrix.otp }}
+        run: go test ./transpiler3/beam/build/... -run TestPhase -v -timeout 10m
+```
+
+`fail-fast: false` ensures all matrix cells run even if one fails, giving full cross-matrix
+failure information in a single CI run.
+
+**OTP version pinning:** The build driver reads `ERL_VERSION` from the environment and validates
+`erl +V` output against it at test startup:
+
+```go
+func validateErlVersion(t *testing.T, required string) {
+    out, err := exec.Command("erl", "+V").CombinedOutput()
+    require.NoError(t, err)
+    if !strings.Contains(string(out), required[:4]) {
+        t.Fatalf("erl version mismatch: want %s, got %s", required, out)
+    }
+}
+```
+
+This catches CI misconfiguration where `erlef/setup-beam` silently fell back to a different OTP
+version than requested.
+
+**Fixture corpus:** All Phase 1-14 fixtures run in each matrix cell. The driver diffs stdout
+against vm3 reference output stored in `tests/transpiler3/beam/fixtures/<phase>/expected/`.
+Reference output is generated once on OTP 27.0 and committed; it is authoritative across all
+matrix cells (Mochi program output must be version-independent for all supported OTP releases).
+
+**Files changed:**
+
+- `.github/workflows/transpiler3-beam-matrix.yml` (new)
+- `transpiler3/beam/build/testutil.go`: add `validateErlVersion()`, `erlVersion()` helpers.
+
+### 16.1 OTP 29 RC nightly
+
+A separate workflow runs nightly on OTP 29 RC when available from the `erlef/setup-beam` version
+matrix.
+
+```yaml
+name: transpiler3-beam-nightly-otp29
+on:
+  schedule:
+    - cron: "0 2 * * *"   # 02:00 UTC daily
+
+jobs:
+  beam-otp29-nightly:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "29"
+          version-type: latest
+        continue-on-error: true
+        id: setup-otp29
+      - name: Skip if OTP 29 not available
+        if: steps.setup-otp29.outcome == 'failure'
+        run: echo "OTP 29 RC not yet available, skipping" && exit 0
+      - name: Run beam phase tests
+        if: steps.setup-otp29.outcome == 'success'
+        run: go test ./transpiler3/beam/build/... -run TestPhase -v -timeout 10m
+      - name: Notify Slack on failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1
+        with:
+          channel-id: "mochi-beam-nightly"
+          slack-message: "OTP 29 nightly failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+```
+
+Non-blocking: failures post a Slack notification to `#mochi-beam-nightly` but do not block PRs or
+prevent merging to `main`. The OTP 29 nightly graduates to blocking Tier-1 after OTP 29 final is
+released and two weeks of green nightly runs are observed.
+
+**Files changed:**
+
+- `.github/workflows/transpiler3-beam-nightly-otp29.yml` (new)
+
+### 16.2 Windows x86-64 (OTP 27) nightly
+
+A separate nightly workflow tests on `windows-latest` with OTP 27.
+
+```yaml
+name: transpiler3-beam-nightly-windows
+on:
+  schedule:
+    - cron: "0 3 * * *"
+
+jobs:
+  beam-windows-nightly:
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+      - run: go test ./transpiler3/beam/build/... -run TestPhase -v -timeout 15m
+```
+
+**Known Windows gotchas handled in the build driver:**
+
+- `erl.exe` is in `C:\Program Files\erl-<version>\bin\`; `os/exec.LookPath("erl")` finds it if
+  on PATH. `erlef/setup-beam` adds it to PATH automatically.
+- Escript shebangs (`#!/usr/bin/env escript`) do not work on Windows (no `/usr/bin/env` resolver).
+  The `beam-escript` target generates a `<name>.bat` wrapper on Windows that calls
+  `erl -noshell -s <module> main -s init stop`. The `.bat` wrapper is generated only when
+  `GOOS=windows` or the `ERL_PLATFORM=windows` env var is set.
+- `pg` (process groups) works on Windows BEAM, but the cross-node stream test uses `epmd` on
+  a Unix socket path, which is Linux-only. The cross-node test is skipped on Windows via a
+  `//go:build !windows` build tag on the test file.
+- Path separators: the build driver uses `filepath.Join` throughout (not hardcoded `/`), and
+  Erlang path arguments are converted from `\` to `/` before passing to `erl -pa`.
+- Temp directory cleanup: `os.MkdirTemp` + `t.Cleanup(func() { os.RemoveAll(dir) })` works on
+  Windows provided no OTP process holds file handles open at cleanup time. The driver waits for
+  `erl` to exit before cleanup.
+
+Non-blocking nightly. Failures notify `#mochi-beam-nightly` via Slack.
+
+**Files changed:**
+
+- `.github/workflows/transpiler3-beam-nightly-windows.yml` (new)
+- `transpiler3/beam/build/emit_windows.go` (new): Windows `.bat` escript wrapper generation.
+- `tests/transpiler3/beam/build/phase10_crossnode_test.go`: add `//go:build !windows` build tag.
 
 ## Decisions made
 
-_Pending phase open._
+**Why OTP 27.0 specifically (not just 27.latest).** OTP 27.0 is the minimum supported version.
+Testing against it ensures we do not accidentally use APIs added in a 27.x patch release. If the
+build driver calls a function added in OTP 27.1, it would succeed on 27.1+ but fail for users on
+27.0 who have not yet upgraded. `erlef/setup-beam` supports specific OTP versions via
+`otp-version: "27.0"`.
+
+**Why x86_64-linux-gnu and aarch64-darwin as Tier-1 CI platforms.** These cover the two most
+common developer machines: Intel/AMD Linux servers and Apple silicon laptops (M1/M2/M3/M4). The
+BeamAsm JIT is fully supported and well-tested on both platforms. ARM Linux (aarch64-linux) and
+Windows are Tier-2 (nightly, best-effort) because they have lower developer adoption in the Mochi
+target audience and higher CI runner costs (ARM Linux runners are slower and more expensive on
+GitHub Actions; Windows runners have more OTP tooling rough edges).
+
+**Why block on all 6 cells, not just 1.** A single-cell CI would not catch OTP version regressions
+(e.g., a change in `maps:fold/3` behavior between OTP 27 and 28) or platform-specific bugs (e.g.,
+a race condition in `pg` that manifests only on Linux due to scheduler differences). Cross-version
+matrix blocking prevents shipping code that works on OTP 27 but silently fails on OTP 28. The
+6-cell matrix runs in parallel and takes approximately 8 minutes total, which is acceptable for a
+blocking gate.
+
+**Why `fail-fast: false` in the matrix.** With `fail-fast: true` (the GitHub Actions default),
+the first failing cell cancels all other cells. This hides the full failure picture: if OTP 27.0
+on Linux fails and OTP 28.0 on macOS also fails for a different reason, we only see the first
+failure. `fail-fast: false` runs all cells to completion, giving a complete cross-matrix view in a
+single CI run.
+
+**Why nightly for OTP 29 and Windows rather than blocking.** OTP 29 is a release candidate; its
+API may change before final release. Blocking PRs on a release candidate would be disruptive.
+Windows has known rough edges (escript shebangs, path handling, cross-node tests) that require
+ongoing fixes; making it blocking before those are fully resolved would slow development. Both
+become Tier-1 blocking targets post-v1.0 on explicit promotion criteria (two weeks of clean
+nightly runs).
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `.github/workflows/transpiler3-beam-matrix.yml` | New: blocking 6-cell matrix (OTP 27.0/27.latest/28.latest x linux/macos) |
+| `.github/workflows/transpiler3-beam-nightly-otp29.yml` | New: nightly OTP 29 RC, non-blocking |
+| `.github/workflows/transpiler3-beam-nightly-windows.yml` | New: nightly Windows OTP 27, non-blocking |
+| `transpiler3/beam/build/testutil.go` | Add `validateErlVersion()`, `erlVersion()` |
+| `transpiler3/beam/build/emit_windows.go` | New: `.bat` escript wrapper for Windows |
+| `tests/transpiler3/beam/build/phase10_crossnode_test.go` | Add `//go:build !windows` build tag |
 
 ## Test set
 
-_Pending phase open._
+Phase 16 introduces no new Go test functions. Its gate is the passing of all existing Phase 1-14
+`TestPhase*` tests in every matrix cell. The CI workflow is the test artifact.
+
+Verification steps for gate:
+1. Merge a PR that adds `.github/workflows/transpiler3-beam-matrix.yml`.
+2. Confirm all 6 matrix cells show green in the GitHub Actions UI on the next push to `main`.
+3. Introduce a deliberate OTP-version-specific failure (call a function removed in OTP 28),
+   confirm the affected cell fails while others pass.
+4. Revert the deliberate failure and confirm all 6 cells return green.
+
+## Deferred work
+
+- ARM Linux (aarch64-linux-gnu) Tier-1 promotion: deferred until GitHub Actions provides stable,
+  affordable ARM Linux runners. Currently `ubuntu-latest` is x86_64 only.
+- OTP 29 stable promotion to Tier-1 blocking: happens when OTP 29 final is released. Add `"29.0"`
+  to the blocking `otp` list in the matrix after two weeks of clean nightly runs.
+- Windows Tier-1 promotion: post-v1.0, after all Windows-specific gotchas (escript `.bat` wrapper,
+  cross-node tests on Windows) are resolved and the nightly has been clean for two weeks.
+- RISC-V BEAM (OTP 27+ supports RISC-V): deferred indefinitely; BeamAsm JIT is not available on
+  RISC-V yet and no CI runner is available for this platform.
+- OTP 26 compatibility (for users on the previous LTS): not in scope for v0.1. OTP 27 is the
+  minimum. A future MEP amendment could lower the minimum to OTP 26 if user demand warrants it.
 
 ## Closeout notes
 

--- a/website/docs/implementation/0046/phase-17-dialyzer.md
+++ b/website/docs/implementation/0046/phase-17-dialyzer.md
@@ -2,7 +2,7 @@
 title: "Phase 17. Dialyzer cleanliness"
 sidebar_position: 19
 sidebar_label: "Phase 17. Dialyzer cleanliness"
-description: "MEP-46 Phase 17. Dialyzer cleanliness tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+description: "MEP-46 Phase 17. Dialyzer cleanliness: -spec emission from Mochi types, opaque runtime refs, CI Dialyzer gate, false-positive allowlist."
 ---
 
 # Phase 17. Dialyzer cleanliness
@@ -18,23 +18,313 @@ description: "MEP-46 Phase 17. Dialyzer cleanliness tracking stub. Filled in whe
 
 ## Gate
 
-See [MEP-46 §Phases · Phase 17. Dialyzer cleanliness](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+`rebar3 dialyzer -Werror` exits 0 for every fixture in `tests/transpiler3/beam/fixtures/` on
+OTP 27, with no suppressed warnings beyond those listed in `dialyzer_allowlist.txt`.
 
 ## Goal-alignment audit
 
-_Pending phase open._
+Dialyzer is Erlang's primary static analysis tool. Users who consume Mochi-compiled libraries from
+Erlang or Elixir code will run Dialyzer on their own projects, and Dialyzer warnings about
+Mochi-generated code would appear as noise (or genuine errors) in their analysis results. A
+Dialyzer-clean transpiler output means Mochi-built libraries are first-class citizens in the
+Erlang/Elixir ecosystem: they can be depended on from Erlang without polluting the Dialyzer report.
+
+Beyond interoperability, Dialyzer cleanliness validates the correctness of the type-lowering table
+(Phase 2 sub-phase 2.1 and the type mappers in `transpiler3/beam/lower/types.go`). If the emitted
+`-spec` attributes are inconsistent with the generated function bodies, Dialyzer will flag it,
+making Dialyzer an additional compile-time correctness check on the lowerer itself.
 
 ## Sub-phases
 
-_Pending phase open._
+### 17.0 `-spec` emission for exported functions
+
+Every Mochi-exported function gets a Dialyzer `-spec` derived from its Mochi type signature. The
+spec is emitted as a Core Erlang module attribute by the lowerer.
+
+**Type mapping table:**
+
+| Mochi type | Dialyzer spec form |
+|------------|-------------------|
+| `int` | `integer()` |
+| `float` | `float()` |
+| `bool` | `boolean()` |
+| `string` | `binary()` |
+| `unit` | `ok` |
+| `list<T>` | `[lowerSpec(T)]` |
+| `map<K,V>` | `#{lowerSpec(K) => lowerSpec(V)}` |
+| `option<T>` | `{some, lowerSpec(T)} \| none` |
+| `Result<T,E>` | `{ok, lowerSpec(T)} \| {error, lowerSpec(E)}` |
+| `fun(A,B) -> C` | `fun((lowerSpec(A), lowerSpec(B)) -> lowerSpec(C))` |
+| `Record{f: T}` | `#{mochi_record_tag := atom(), f := lowerSpec(T)}` |
+| `Sum{A \| B}` | `{a, lowerSpec(A)} \| {b, lowerSpec(B)}` |
+
+**Spec emission in Core Erlang:**
+
+The lowerer adds spec attributes via the `cerl` API after emitting each exported function:
+
+```go
+// In lower/module.go, after emitting each exported function:
+func emitSpec(mod *cerl.Module, fname string, arity int, sig *types.FunctionType) {
+    spec := lowerFuncTypeToDialyzerSpec(sig)
+    mod.AddAttribute(cerl.Atom("spec"), cerl.Tuple([]cerl.Term{
+        cerl.Atom(fname), cerl.Integer(arity), cerl.List([]cerl.Term{spec}),
+    }))
+}
+```
+
+**Example:** `fun greet(p: Person): string` in Mochi, where `Person` is
+`record Person { name: string, age: int }`, emits:
+
+```erlang
+-spec greet(#{mochi_record_tag := person, name := binary(), age := integer()}) -> binary().
+```
+
+**Edge cases:**
+
+- Polymorphic functions (generics) are monomorphised before spec emission; each monomorphisation
+  gets its own spec derived from the concrete instantiated types.
+- Recursive types (e.g., `type Tree<T> = Leaf | Node { val: T, left: Tree<T>, right: Tree<T> }`)
+  use Dialyzer's user-defined type syntax: the type is emitted as a named
+  `-type mochi_tree(T) :: ...` and the spec references it by name to avoid infinite expansion.
+- Functions with more than 63 parameters are not common in Mochi but theoretically possible via
+  deeply nested currying chains. Dialyzer limits function arity in specs; the lowerer caps spec
+  emission at arity 63 and emits `any()` for functions beyond this limit.
+
+**Go files changed:**
+
+- `transpiler3/beam/lower/types.go`: add `lowerSpec()`, `lowerFuncTypeToDialyzerSpec()`.
+- `transpiler3/beam/lower/module.go`: call `emitSpec()` for each exported function.
+- `transpiler3/beam/lower/recursive_types.go` (new): handle recursive type spec emission with
+  named user-defined types to prevent infinite expansion.
+- `transpiler3/beam/build/phase17_test.go` (new): `TestPhase17SpecEmission`.
+
+### 17.1 `-opaque` for agent/stream/async refs
+
+Runtime reference types are emitted as opaque Dialyzer types in the runtime modules. This prevents
+user Erlang code from pattern-matching on their internal structure, which would create coupling to
+implementation details that may change between Mochi versions.
+
+**Opaque type declarations (emitted in runtime `.erl` files):**
+
+```erlang
+%% mochi_agent.erl
+-opaque mochi_agent_ref() :: {mochi_agent_ref, pid()}.
+-export_type([mochi_agent_ref/0]).
+
+%% mochi_stream.erl
+-opaque mochi_stream_ref() :: {mochi_stream_ref, atom()}.
+-export_type([mochi_stream_ref/0]).
+
+%% mochi_async.erl
+-opaque mochi_async_ref(T) :: {mochi_async_ref, reference(), pid()}.
+-export_type([mochi_async_ref/1]).
+```
+
+Dialyzer enforces opacity: user code that pattern-matches directly on `{mochi_agent_ref, Pid}`
+(instead of calling `mochi_agent:get_pid/1`) receives a Dialyzer warning:
+`Attempt to match against a term of an opaque type`.
+
+**Specs for runtime API functions using opaque types:**
+
+```erlang
+-spec new(fun(() -> S)) -> mochi_agent_ref().
+-spec call(mochi_agent_ref(), fun((S) -> {S, R})) -> R.
+-spec cast(mochi_agent_ref(), fun((S) -> S)) -> ok.
+```
+
+**Files changed:**
+
+- `transpiler3/beam/runtime/mochi_agent.erl`: add `-opaque`, `-export_type`, `-spec` attributes
+  for all public functions.
+- `transpiler3/beam/runtime/mochi_stream.erl`: add `-opaque`, `-export_type`, `-spec` attributes.
+- `transpiler3/beam/runtime/mochi_async.erl`: add `-opaque`, `-export_type`, `-spec` attributes.
+
+### 17.2 CI job: `rebar3 dialyzer` on every fixture project
+
+`.github/workflows/transpiler3-beam-dialyzer.yml` runs `rebar3 dialyzer -Werror` on the rebar3
+project emitted by `--target=beam-rebar3-project` for each fixture.
+
+**Workflow definition (key excerpt):**
+
+```yaml
+name: transpiler3-beam-dialyzer
+on:
+  push:
+    branches: [main, "mep/0046-*"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  dialyzer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+      - name: Restore Dialyzer PLT cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/rebar3/rebar_dialyzer_plt
+          key: dialyzer-plt-otp27-${{ hashFiles('**/rebar.lock') }}
+          restore-keys: dialyzer-plt-otp27-
+      - name: Run dialyzer on all fixtures
+        run: go test ./transpiler3/beam/build/... -run TestPhase17Dialyzer -v -timeout 20m
+```
+
+`TestPhase17Dialyzer` in `transpiler3/beam/build/phase17_test.go`:
+
+1. For each fixture directory in `tests/transpiler3/beam/fixtures/`, build the rebar3 project via
+   `--target=beam-rebar3-project` into a temp dir.
+2. Run `rebar3 dialyzer -Werror` in the temp dir.
+3. Fail the test if `rebar3 dialyzer` exits non-zero, printing Dialyzer's full output.
+
+Blocking: Dialyzer failures prevent merging. Runs on OTP 27 only (Dialyzer is OTP-version-specific;
+testing one version is sufficient for the cleanliness gate).
+
+**PLT caching:** The Dialyzer PLT (Persistent Lookup Table) is a pre-analyzed summary of the OTP
+stdlib that Dialyzer uses to type-check user code. Building the PLT from scratch takes 90-120
+seconds. The cache key `dialyzer-plt-otp27-{{hashFiles('**/rebar.lock')}}` ensures:
+
+- The PLT is rebuilt when `rebar.lock` changes (new OTP or dep version).
+- The PLT is reused across runs when deps are unchanged, reducing the Dialyzer job from 2+ minutes
+  to 15-30 seconds.
+
+**Files changed:**
+
+- `.github/workflows/transpiler3-beam-dialyzer.yml` (new)
+- `transpiler3/beam/build/phase17_test.go`: `TestPhase17SpecEmission`, `TestPhase17Dialyzer`,
+  `TestPhase17OpaqueViolation`, `TestPhase17AllowlistCoverage`.
+
+### 17.3 Dialyzer false-positive allowlist
+
+Some Dialyzer warnings are false positives due to opaque types, dynamic dispatch patterns in the
+runtime, or known Dialyzer limitations on certain type expressions.
+
+**`dialyzer_allowlist.txt` format:**
+
+```
+# Entry format:
+# WARNING: <dialyzer warning text pattern>
+# MODULE: <module where it appears>
+# MOCHI_PATTERN: <Mochi construct that generates it>
+# REASON: <why it is a false positive>
+# OTP_ISSUE: <OTP issue number or "none">
+
+WARNING: Function mochi_stream_subscribe/2 has no local return
+MODULE: mochi_stream
+MOCHI_PATTERN: stream subscription with receive loop
+REASON: Dialyzer cannot infer that the receive loop terminates because the termination
+        condition depends on a pg scope message that Dialyzer models as type 'any'.
+        The function does terminate normally; this is a Dialyzer limitation with pg messages.
+OTP_ISSUE: none
+```
+
+**Suppressions in generated code:** When the lowerer detects a known false-positive pattern at
+the call site (e.g., a `pg:get_members` call whose result is used in a way Dialyzer cannot type
+correctly), it emits a targeted suppression attribute in the generated `.erl`:
+
+```erlang
+-dialyzer({nowarn_function, subscribe_loop/2}).
+```
+
+The lowerer emits suppressions only for patterns documented in `dialyzer_allowlist.txt`. The
+allowlist is the authoritative record of known suppressions; undocumented suppressions are a
+build error (caught by `TestPhase17AllowlistCoverage`).
+
+**Files changed:**
+
+- `dialyzer_allowlist.txt` (new): machine-readable allowlist with one entry per false positive.
+- `transpiler3/beam/lower/module.go`: read allowlist at lowering time, emit `nowarn_function`
+  attributes for matched patterns.
+- `transpiler3/beam/build/phase17_test.go`: `TestPhase17AllowlistCoverage` verifies every
+  suppression in the generated code has a corresponding allowlist entry, and every allowlist entry
+  corresponds to at least one actually-generated suppression.
 
 ## Decisions made
 
-_Pending phase open._
+**Why Dialyzer-clean as a blocking gate rather than advisory.** Dialyzer silence is a quality
+signal that generated Erlang code is well-typed. If the Mochi-to-Erlang transpiler produces
+Dialyzer warnings, it means the type-lowering table has gaps or the generated code uses dynamic
+patterns Dialyzer cannot reason about. Fixing these improves the correctness guarantee for users
+who consume Mochi-built libraries from Erlang. Making it blocking (`-Werror`) ensures it stays
+clean as new features are added. An advisory Dialyzer gate would gradually accumulate warnings
+that no one fixes.
+
+**Why emit specs from Mochi types rather than inferring them from the generated Erlang.** Dialyzer
+type inference works bottom-up: it can infer types for internal functions but cannot propagate
+user-level type annotations to `-spec` attributes without explicit declaration. Emitting specs from
+Mochi's static type system gives Dialyzer more information than it could infer on its own,
+producing better warnings for callers of Mochi-built libraries. Inference-only specs would be less
+precise (Dialyzer would widen `integer()` to `number()` in some cases) and would not preserve the
+semantic intent of Mochi's type annotations.
+
+**Why PLT caching is important.** Building the Dialyzer PLT for OTP stdlib takes 90-120 seconds.
+Without caching, every CI run would rebuild the PLT. With caching (keyed on OTP version +
+`rebar.lock`), the PLT is built once and reused across runs, reducing CI time for the Dialyzer job
+from 2+ minutes to 15-30 seconds. This makes the Dialyzer gate practical as a blocking check on
+every PR.
+
+**Why opaque types for agent/stream/async refs.** Exposing the internal representation (e.g.,
+`{mochi_agent_ref, Pid}`) as a public structural type would allow Erlang callers to construct agent
+refs directly (bypassing `mochi_agent:new/1`), pattern-match on them (creating coupling to the
+internal format), and send raw messages to agent PIDs (breaking the protocol). Opacity prevents
+all three. The cost is that Erlang code cannot inspect agent refs without calling the runtime API,
+which is the intended constraint.
+
+**Why a machine-readable allowlist file rather than inline comments.** A standalone
+`dialyzer_allowlist.txt` makes it easy to audit all suppressions in one place, to detect stale
+suppressions (entries with no corresponding generated `nowarn_function` are caught by
+`TestPhase17AllowlistCoverage`), and to add suppressions without modifying the lowerer for each
+new case. An inline-comment approach would scatter suppressions across generated files and make
+auditing difficult.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `transpiler3/beam/lower/types.go` | Add `lowerSpec()`, `lowerFuncTypeToDialyzerSpec()` |
+| `transpiler3/beam/lower/module.go` | Emit `-spec` attributes for exported functions; emit `nowarn_function` for allowlist patterns |
+| `transpiler3/beam/lower/recursive_types.go` | New: recursive type spec emission via named user types |
+| `transpiler3/beam/runtime/mochi_agent.erl` | Add `-opaque mochi_agent_ref/0`, `-export_type`, `-spec` for all public functions |
+| `transpiler3/beam/runtime/mochi_stream.erl` | Add `-opaque mochi_stream_ref/0`, `-export_type`, `-spec` |
+| `transpiler3/beam/runtime/mochi_async.erl` | Add `-opaque mochi_async_ref/1`, `-export_type`, `-spec` |
+| `.github/workflows/transpiler3-beam-dialyzer.yml` | New: blocking Dialyzer CI gate on OTP 27 |
+| `dialyzer_allowlist.txt` | New: false-positive allowlist |
+| `transpiler3/beam/build/phase17_test.go` | New: `TestPhase17SpecEmission`, `TestPhase17Dialyzer`, `TestPhase17OpaqueViolation`, `TestPhase17AllowlistCoverage` |
 
 ## Test set
 
-_Pending phase open._
+- `TestPhase17SpecEmission`: compiles a fixture with a range of Mochi types (int, float, bool,
+  string, list, map, option, Result, record, sum), extracts `-spec` attributes from the generated
+  `.beam` file via `beam_lib:chunks(File, [abstract_code])`, and verifies each spec matches the
+  expected Dialyzer type form from the mapping table above.
+- `TestPhase17Dialyzer`: for each fixture, builds a rebar3 project via `--target=beam-rebar3-project`,
+  runs `rebar3 dialyzer -Werror` in the project directory, and asserts exit code 0.
+- `TestPhase17OpaqueViolation`: generates Erlang code that pattern-matches directly on
+  `{mochi_agent_ref, Pid}`, runs Dialyzer on it, and asserts Dialyzer emits an opacity violation
+  warning. (This test verifies that Dialyzer does enforce opacity, not just that we declared it.)
+- `TestPhase17AllowlistCoverage`: parses `dialyzer_allowlist.txt`, runs Dialyzer with full output
+  (without `-Werror`), and asserts every warning in the full output either is absent (i.e., the
+  generated code is clean) or has a corresponding allowlist entry. Any warning not in the allowlist
+  is a test failure (it must be either fixed in the lowerer or explicitly documented).
+- `TestPhase17RecursiveTypeSpec`: fixture with a recursive Mochi type (`Tree<int>`), verifies the
+  emitted spec uses the named type form (`mochi_tree(integer())`) and that Dialyzer accepts it
+  without an infinite type expansion error.
+
+## Deferred work
+
+- Typer integration: `typer` is an Erlang tool that infers specs from compiled `.beam` files.
+  Running `typer` on Mochi-generated modules and comparing the inferred specs with the emitted
+  specs would be a useful regression check. Deferred post-v1.0.
+- EDoc integration: generating EDoc comments from Mochi doc-comments alongside the `-spec`
+  attributes. Deferred; requires Mochi doc-comment syntax (not yet designed for v0.1).
+- Dialyzer for internal (non-exported) functions: currently only exported functions get `-spec`
+  attributes. Emitting specs for internal functions would improve Dialyzer's analysis quality
+  inside the module. Deferred due to the volume of internal functions generated by monomorphisation
+  (which would produce many specs that users never see).
+- OTP 28 Dialyzer gate: OTP 28 may introduce changes to Dialyzer's type system as part of the
+  ongoing gradual typing work. The Phase 17 gate runs on OTP 27 only. Post-v1.0, add OTP 28
+  Dialyzer to the blocking matrix.
 
 ## Closeout notes
 

--- a/website/docs/implementation/0046/phase-18-repro-perf.md
+++ b/website/docs/implementation/0046/phase-18-repro-perf.md
@@ -2,7 +2,7 @@
 title: "Phase 18. Reproducibility and perf"
 sidebar_position: 20
 sidebar_label: "Phase 18. Reproducibility and perf"
-description: "MEP-46 Phase 18. Reproducibility and perf tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+description: "MEP-46 Phase 18. Reproducible .beam output (CInf stripping, function sort order) and benchmark harness with BG kernel gate."
 ---
 
 # Phase 18. Reproducibility and perf
@@ -18,23 +18,315 @@ description: "MEP-46 Phase 18. Reproducibility and perf tracking stub. Filled in
 
 ## Gate
 
-See [MEP-46 §Phases · Phase 18. Reproducibility and perf](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+(a) Two independent builds of the same Mochi source (different `SOURCE_DATE_EPOCH` values,
+different temp directories) produce bit-for-bit identical `.beam` files, verified by SHA-256
+comparison in CI on every merge to `main`.
+(b) All 5 BG kernel benchmarks complete within 3x of the MEP-45 C target wall-clock median on
+x86_64-linux-gnu OTP 27.
 
 ## Goal-alignment audit
 
-_Pending phase open._
+Reproducible builds are a prerequisite for content-addressed caching and release verification.
+Without reproducibility, the build cache cannot reliably reuse a previously compiled `.beam` file
+(the cache key would always miss because the file hash differs on every rebuild), and a user who
+wants to verify that a shipped release was built from a known source commit cannot do so by
+recompiling from source (the hashes would differ even with identical inputs). Both are correctness
+properties that matter for production deployments.
+
+The performance gate ensures the BEAM backend is competitive for the workloads Mochi targets. The
+3x-of-C gate is a concrete, testable bound that prevents performance regressions as new lowering
+passes are added. Without a gate, a later phase could introduce a lowering transformation that
+accidentally generates inefficient Erlang (e.g., creating unnecessary intermediate lists in a loop)
+and it would not be caught until a user reports it.
 
 ## Sub-phases
 
-_Pending phase open._
+### 18.0 Strip timestamp from `CInf` chunk; relative source paths
+
+The `CInf` (compile info) chunk in a `.beam` file contains:
+
+```erlang
+[{version, "8.2.1"},
+ {options, [{outdir, "/tmp/foo"}, {source, "/abs/path/hello.erl"}]},
+ {time, {2026, 5, 26, 14, 32, 10}},
+ {source, "/abs/path/hello.erl"}]
+```
+
+Both `{time, _}` and the absolute source path in `{source, _}` and in `{options, [{source, _}]}`
+are sources of non-reproducibility: two compilations of the same source at different times or from
+different directory trees produce different `.beam` files.
+
+The `Line` chunk also stores absolute source paths in its filename table and is similarly affected.
+
+**Stripping procedure** (implemented in an Erlang helper escript invoked by the Go emit driver
+after `compile:forms/2` produces the `.beam` bytes):
+
+1. Read the current `CInf` chunk: `beam_lib:chunks(BeamFile, ['CInf'])`.
+2. Binary-decode the chunk: `binary_to_term(CInfBin)`.
+3. Remove `{time, _}` from the top-level proplist using `proplists:delete(time, CInf)`.
+4. Rewrite `{source, AbsPath}` to `{source, filename:basename(AbsPath)}`.
+5. Rewrite `{options, Opts}` to strip `{source, AbsPath}` from `Opts`.
+6. Rebuild the `CInf` chunk: `term_to_binary(ModifiedCInf)`.
+7. Rebuild the `.beam` file with the modified chunk via `beam_lib:build_file/2` (OTP 27+),
+   or via `beam_lib:all_chunks/1` + chunk list replacement + manual BEAM binary assembly for
+   pre-27 compatibility.
+8. Rewrite the `Line` chunk's filename table entries from absolute to basename-only paths.
+
+**Erlang helper:** `priv/strip_cinf.escript` is a small Erlang escript:
+
+```erlang
+#!/usr/bin/env escript
+main([BeamFile]) ->
+    {ok, _, Chunks} = beam_lib:all_chunks(BeamFile),
+    ModChunks = lists:map(fun strip_chunk/1, Chunks),
+    {ok, NewBeam} = beam_lib:build_file(ModChunks),
+    ok = file:write_file(BeamFile, NewBeam).
+```
+
+The Go emit driver invokes it after compilation:
+
+```go
+cmd := exec.Command("escript",
+    filepath.Join(mochiRoot, "priv", "strip_cinf.escript"), beamFilePath)
+```
+
+**Go files changed:**
+
+- `transpiler3/beam/emit/emit.go`: call `stripCInf()` after each `compile:forms/2` invocation.
+- `transpiler3/beam/emit/strip_cinf.go` (new): `stripCInf()` Go function that invokes the escript.
+- `priv/strip_cinf.escript` (new): the Erlang CInf stripping helper.
+- `transpiler3/beam/build/phase18_test.go` (new): `TestPhase18CInfStrip`.
+
+### 18.1 Sort exported functions by canonical IR identifier
+
+The order of functions in a `.beam` module's export table and function section affects the binary
+output. Two non-deterministic sources exist in the Go lowerer:
+
+1. **Map iteration order** after the monomorphisation pass. The monomorphisation pass collects
+   instantiated generics into a `map[string]*aotir.Function` (Go hash map), which is iterated in
+   non-deterministic order when converting back to a slice.
+2. **Import order** for OTP standard library functions called by the generated code. Imports are
+   collected into a `map[string]int` (module+function+arity -> index), with non-deterministic
+   iteration.
+
+**Fix:** Before emitting the Core Erlang module, the lowerer sorts both collections:
+
+```go
+// In lower/module.go, before cerl.NewModule():
+sort.Slice(functions, func(i, j int) bool {
+    return functions[i].MangledName < functions[j].MangledName
+})
+sort.Slice(imports, func(i, j int) bool {
+    return importKey(imports[i]) < importKey(imports[j])
+})
+```
+
+Mangled names follow the pattern `mochi_{pkg}__{mod}__{name}_{arity}`, which is globally unique
+within a compilation unit and provides a stable alphabetical ordering.
+
+`cerl:c_module` takes a `Funs` list; the list ordering determines the export table and function
+section order in the `.beam` binary. With sorted inputs, two compilations of the same source
+produce functions in the same order.
+
+**Files changed:**
+
+- `transpiler3/beam/lower/module.go`: add function and import sorting before `cerl.NewModule()`.
+- `transpiler3/beam/build/phase18_test.go`: `TestPhase18FunctionOrder`.
+
+### 18.2 Reproducibility CI workflow
+
+`.github/workflows/transpiler3-beam-repro.yml` verifies bit-for-bit reproducibility across two
+independent builds on the same runner.
+
+**Workflow definition:**
+
+```yaml
+name: transpiler3-beam-repro
+on:
+  push:
+    branches: [main]
+  release:
+    types: [created]
+
+jobs:
+  repro:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+      - name: Build corpus (run 1)
+        env:
+          SOURCE_DATE_EPOCH: "1000000000"
+          MOCHI_BUILD_OUTDIR: /tmp/repro-run1
+        run: go test ./transpiler3/beam/build/... -run TestPhase -v -timeout 10m
+      - name: Build corpus (run 2)
+        env:
+          SOURCE_DATE_EPOCH: "1700000000"
+          MOCHI_BUILD_OUTDIR: /tmp/repro-run2
+        run: go test ./transpiler3/beam/build/... -run TestPhase -v -timeout 10m
+      - name: Compare SHA-256 of .beam files
+        run: |
+          find /tmp/repro-run1 -name '*.beam' | sort | while read f; do
+            rel="${f#/tmp/repro-run1/}"
+            sha1=$(sha256sum "$f" | awk '{print $1}')
+            sha2=$(sha256sum "/tmp/repro-run2/$rel" | awk '{print $1}')
+            if [ "$sha1" != "$sha2" ]; then
+              echo "MISMATCH: $rel"
+              echo "  run1: $sha1"
+              echo "  run2: $sha2"
+              exit 1
+            fi
+          done
+          echo "All .beam files are bit-for-bit identical."
+```
+
+`SOURCE_DATE_EPOCH` is passed to the Erlang compiler via the `{compile_info, [{time, ...}]}` option.
+The `strip_cinf.escript` strips the time field regardless of input, so the output `.beam` is
+identical regardless of the `SOURCE_DATE_EPOCH` value. The CI test validates that stripping works
+correctly under two different epoch values.
+
+**Schedule:** runs on every merge to `main` and on every release tag creation. Not triggered on
+feature branches (reduces CI load; the merge-to-main run is the authoritative check).
+
+**Files changed:**
+
+- `.github/workflows/transpiler3-beam-repro.yml` (new)
+
+### 18.3 Benchmark harness with BG kernels
+
+`tests/transpiler3/beam/bench/` contains 5 BG kernel benchmark programs matching the MEP-45
+Phase 18 kernel set, adapted for Mochi source:
+
+| File | Description | Gate metric |
+|------|-------------|-------------|
+| `bench_hello.mochi` | Print "Hello, World!" and exit | 200ms absolute cap (startup-dominated) |
+| `bench_sum_loop.mochi` | Sum integers 1..10_000_000 in a loop | 3x of C median |
+| `bench_fib_iter.mochi` | Fibonacci(40) iteratively | 3x of C median |
+| `bench_fib_rec.mochi` | Fibonacci(30) recursively | 3x of C median |
+| `bench_list_sum.mochi` | Sum a list of 1_000_000 integers | 3x of C median |
+
+C target medians are loaded from `tests/transpiler3/beam/bench/c_reference.json` (committed,
+populated by the MEP-45 Phase 18 pipeline on x86_64-linux-gnu).
+
+**`TestPhase18BenchHarness`** in `transpiler3/beam/build/phase18_test.go`:
+
+1. For each kernel, build via `--target=beam-escript`.
+2. Run the escript 5 times, capture wall-clock time via `time.Now()` before and after
+   `exec.Command.Run()` (includes escript startup).
+3. Record the median of the 5 runs.
+4. Load the corresponding C reference median from `c_reference.json`.
+5. For `bench_hello`: assert `beamMedian <= 200ms`.
+6. For compute-bound kernels: subtract the escript baseline startup time (measured via a minimal
+   no-op escript) and assert `(beamMedian - startupMedian) <= 3.0 * cMedian`.
+7. Write results to `bench_report.json` in `$MOCHI_BUILD_OUTDIR`.
+
+**Benchmark report attachment:** `.github/workflows/transpiler3-beam-bench-report.yml` runs
+`TestPhase18BenchHarness` on release tag creation and uploads `bench_report.json` as a GitHub
+release asset alongside the release tarball.
+
+**Files changed:**
+
+- `tests/transpiler3/beam/bench/bench_hello.mochi` (new)
+- `tests/transpiler3/beam/bench/bench_sum_loop.mochi` (new)
+- `tests/transpiler3/beam/bench/bench_fib_iter.mochi` (new)
+- `tests/transpiler3/beam/bench/bench_fib_rec.mochi` (new)
+- `tests/transpiler3/beam/bench/bench_list_sum.mochi` (new)
+- `tests/transpiler3/beam/bench/c_reference.json` (new)
+- `transpiler3/beam/build/phase18_test.go`: `TestPhase18BenchHarness`, `TestPhase18CInfStrip`,
+  `TestPhase18FunctionOrder`, `TestPhase18ReproLocal`.
+- `.github/workflows/transpiler3-beam-bench-report.yml` (new)
 
 ## Decisions made
 
-_Pending phase open._
+**Why 3x of C as the BEAM perf gate instead of tighter.** BEAM is the concurrency and reliability
+target, not the raw-compute target. The C AOT backend (MEP-45) is the right choice for CPU-bound
+numerics. BEAM's BeamAsm JIT brings BEAM compute performance to approximately 2-5x of optimized C
+on numeric workloads; the 3x gate gives headroom for escript startup overhead (~50ms) and GC pauses
+inherent to BEAM without requiring NIF optimization for numeric loops (which would add a C
+compilation dependency to the BEAM pipeline, excluded in v0.1). Tightening to 2x is achievable for
+compute-bound loops on longer-running programs but would be violated by startup-heavy benchmarks.
+
+**Why CInf timestamp stripping matters.** A `.beam` file built at 10:00am and one built at 10:01am
+are bit-for-bit identical in content but differ in the `CInf` chunk timestamp. Without stripping,
+every rebuild produces a different `.beam` even with identical source input. This breaks: (a)
+content-addressed caching (the cache key, derived from the `.beam` SHA-256, would always miss
+because the hash differs), and (b) release verification (a user who recompiles from source to
+verify a shipped `.beam` gets a different hash and cannot confirm the binary matches the release).
+Stripping the timestamp and absolute paths makes `.beam` output a pure function of the source input.
+
+**Why sort functions rather than rely on declaration order.** The Go lowerer iterates over
+`aotir.Program.Functions` as a slice (ordered by source declaration), but the monomorphisation pass
+adds functions to a `map[string]*aotir.Function` (Go hash map, non-deterministic iteration order).
+When the lowerer converts the map back to a slice, order is undefined. Without an explicit sort,
+two compilations of the same generic Mochi source could produce functions in different orders in the
+`.beam` export table, causing non-reproducible output even without any timestamp-related changes.
+Sorting by mangled name is stable, deterministic, and makes the `.beam` binary diff-friendly.
+
+**Why run the reproducibility check on merge-to-main rather than every PR.** The reproducibility
+CI is more expensive than the regular test suite (it builds the entire corpus twice). Running it on
+every PR would double the CI cost for the corpus build step. Merge-to-main is the right checkpoint:
+it catches non-reproducibility before it enters the release artifact, and the gap between a PR merge
+and the merge-to-main check is short (seconds to minutes in practice).
+
+**Why `beam_lib:build_file/2` for chunk reconstruction instead of manual binary surgery.**
+Manual binary surgery on BEAM files requires understanding the BEAM file format at the byte level
+(4-byte chunk IDs, big-endian 4-byte lengths, 4-byte alignment padding). This is fragile and
+version-specific. `beam_lib:build_file/2` (OTP 27+) is a supported OTP API that accepts a list of
+`{ChunkId, ChunkData}` tuples and produces a valid `.beam` binary. For OTP versions before 27,
+the fallback uses `beam_lib:all_chunks/1` + chunk list replacement + a 150-line Erlang BEAM binary
+assembler that is well-tested because the BEAM format has been stable since OTP 18.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `transpiler3/beam/emit/emit.go` | Call `stripCInf()` after each compilation |
+| `transpiler3/beam/emit/strip_cinf.go` | New: `stripCInf()` Go wrapper for the escript |
+| `priv/strip_cinf.escript` | New: Erlang CInf stripping helper |
+| `transpiler3/beam/lower/module.go` | Sort functions and imports before `cerl.NewModule()` |
+| `transpiler3/beam/build/phase18_test.go` | New: `TestPhase18CInfStrip`, `TestPhase18FunctionOrder`, `TestPhase18BenchHarness`, `TestPhase18ReproLocal` |
+| `tests/transpiler3/beam/bench/*.mochi` | New: 5 BG kernel benchmark programs |
+| `tests/transpiler3/beam/bench/c_reference.json` | New: C target median wall-clock values |
+| `.github/workflows/transpiler3-beam-repro.yml` | New: reproducibility CI (blocking, merge-to-main and release tags) |
+| `.github/workflows/transpiler3-beam-bench-report.yml` | New: benchmark report attached to GitHub releases |
 
 ## Test set
 
-_Pending phase open._
+- `TestPhase18CInfStrip`: compiles `hello.mochi`, strips CInf, verifies `{time, _}` is absent
+  from the `CInf` chunk and `{source, _}` contains only the basename (not an absolute path).
+  Verification is done by invoking `beam_lib:chunks(File, ['CInf'])` in an Erlang subprocess and
+  parsing the output.
+- `TestPhase18FunctionOrder`: compiles a Mochi file with a generic function twice (from different
+  temp dirs), extracts the export table from each `.beam` via `beam_lib:chunks(F, [exports])`,
+  and asserts the export table entries are in the same order in both outputs.
+- `TestPhase18BenchHarness`: builds and runs all 5 BG kernel benchmarks 5 times each, asserts the
+  gate thresholds described in sub-phase 18.3, and writes `bench_report.json`.
+- `TestPhase18ReproLocal`: a local version of the CI reproducibility check. Builds the fixture
+  corpus twice (to different temp dirs), computes SHA-256 of each `.beam`, asserts no mismatches.
+  Slower test; only runs when `-run TestPhase18Repro` is specified (not in the standard
+  `-run TestPhase` sweep) to avoid doubling routine CI time on developer machines.
+
+## Deferred work
+
+- Hermetic builds: fully hermetic `.beam` files (no host information at all, including OTP version
+  in the `CInf` `version` field) are more aggressive than needed for our reproducibility goal
+  (we test on specific OTP versions) and would make it harder to diagnose which OTP version
+  compiled a given `.beam`. Deferred.
+- Build cache integration: using the reproducible `.beam` hashes as cache keys in a
+  content-addressed build cache (similar to Buck2 or Bazel remote cache). Deferred post-v1.0;
+  requires a caching infrastructure decision.
+- NIF optimization for numeric loops: would bring BEAM numerics closer to C performance (from 3x
+  to ~1.5x) but adds a C compilation step to the BEAM pipeline. Explicitly excluded in v0.1.
+- Benchmark dashboards: tracking benchmark results over time (e.g., via the `github-action-benchmark`
+  action or a Grafana dashboard). Deferred; the current phase only attaches a point-in-time report
+  to releases.
+- Windows and macOS benchmark gates: the 3x-of-C gate currently applies only to x86_64-linux-gnu
+  OTP 27. Windows has higher escript overhead; macOS has different JIT characteristics. Platform-
+  specific benchmark gates are deferred post-v1.0.
 
 ## Closeout notes
 

--- a/website/docs/implementation/0046/phase-19-release.md
+++ b/website/docs/implementation/0046/phase-19-release.md
@@ -2,7 +2,7 @@
 title: "Phase 19. v1.0 release"
 sidebar_position: 21
 sidebar_label: "Phase 19. v1.0 release"
-description: "MEP-46 Phase 19. v1.0 release tracking stub. Filled in when the phase opens; see MEP-46 §Phases for the gate."
+description: "MEP-46 Phase 19. v1.0 release: user docs, changelog, Hex.pm publish, MEP-46 Final status."
 ---
 
 # Phase 19. v1.0 release
@@ -18,23 +18,369 @@ description: "MEP-46 Phase 19. v1.0 release tracking stub. Filled in when the ph
 
 ## Gate
 
-See [MEP-46 §Phases · Phase 19. v1.0 release](/docs/mep/mep-0046) for the normative gate. This page is filled in when the phase opens.
+`website/docs/manual/build-beam.mdx` is published and accurate, `CHANGELOG.md` has a `[0.12.0]`
+entry, `mochi` Hex package `0.1.0` is published to Hex.pm, and `mep-0046.md` status is `Final`.
 
 ## Goal-alignment audit
 
-_Pending phase open._
+Phase 19 closes the MEP-46 BEAM pipeline. The gate has four components, each serving a distinct
+user-facing purpose:
+
+**User documentation (19.0):** Without documentation, users cannot discover or correctly use the
+BEAM targets. The `build-beam.mdx` page is the canonical user entry point for the Mochi BEAM
+backend. It must ship simultaneously with the implementation; documentation that lags the feature
+is documentation that does not exist in practice. The no-caveats rule ensures the page does not
+describe unfinished work.
+
+**Changelog (19.1):** The `CHANGELOG.md` entry gives users upgrading from v0.11 a clear,
+structured summary of what the BEAM backend provides. It also serves as the basis for the GitHub
+release notes and the Hex.pm release description.
+
+**Hex.pm publication (19.2):** Publishing the `mochi` OTP runtime to Hex.pm makes it a first-class
+Erlang/Elixir dependency. Erlang teams who want to call Mochi-compiled agents or streams from their
+own Erlang code can add `{mochi, "0.1.0"}` to their `rebar.config` and depend on it like any other
+Hex package. Without Hex publication, the runtime is only available via path reference, which is
+not usable for third-party adoption.
+
+**MEP Final (19.3):** Flipping the MEP to Final marks the specification as normative and complete.
+It signals to contributors that the design is stable and that changes to the BEAM pipeline should
+go through a new MEP or MEP amendment, not informal code changes.
 
 ## Sub-phases
 
-_Pending phase open._
+### 19.0 `website/docs/manual/build-beam.mdx`
+
+User-facing documentation page. Published on the Mochi website alongside `build.mdx` (the C/AOT
+backend docs from MEP-45 Phase 19.0).
+
+**Page structure:**
+
+```
+# Building for BEAM/OTP
+
+## Quick start
+  (two code blocks: escript hello-world, release packaging)
+
+## Tier-1 platform support
+  (table: platform x arch x OTP versions x JIT x status)
+
+## Build targets reference
+  ### --target=beam-escript
+  ### --target=beam-release
+  ### --target=beam-rebar3-project
+  ### --target=beam-mix-project
+  ### --target=beam-atomvm
+
+## OTP version requirements
+  (minimum OTP 27.0; tested on 27.0, 27.latest, 28.latest)
+
+## Packaging (escript vs release vs project export)
+  (when to use each target; size comparison table)
+
+## Erlang FFI
+  (syntax, calling conventions, type mapping)
+
+## Agents (gen_server)
+  (agent.new, agent.call, agent.cast; lifetime, supervision)
+
+## Streams (pg process groups)
+  (stream.pub, stream.sub, stream.map, stream.filter; cross-node)
+
+## Async/await
+  (async {} blocks, await, recv-marker optimization)
+
+## LLM functions
+  (mochi.llm.query, cassette mode, --cassette flag)
+
+## HTTP fetch (gun)
+  (fetch, fetch_json, error handling, TLS)
+
+## AtomVM profile
+  (--profile=atomvm, .avm output, supported OTP subset)
+
+## Reproducible builds
+  (CInf stripping, SOURCE_DATE_EPOCH, SHA-256 verification)
+
+## CLI reference
+  (full flag table for mochi build --target=beam-*)
+```
+
+**No-caveats rule:** The page describes only shipped, working features. If a feature is not yet
+implemented (e.g., `mix release` in the mix target), it does not appear on this page. The AtomVM
+section appears because Phase 15.3 shipped the AtomVM profile. The reproducible builds section
+appears because Phase 18 shipped CInf stripping.
+
+**CLI help sync:** `mochi build --help` and `mochi build --target=beam-* --help` output must match
+the CLI reference section of the docs page. This is tested by `TestPhase19DocsCliSync` which
+extracts flag names and descriptions from the CLI reference section of the MDX source and asserts
+they match `mochi build --help` output line-by-line.
+
+**Platform table:**
+
+| Platform | Architecture | OTP versions | JIT | Status |
+|----------|-------------|--------------|-----|--------|
+| Linux | x86_64 | 27.0, 27.x, 28.x | BeamAsm | Tier 1 |
+| macOS | ARM64 (Apple silicon) | 27.0, 27.x, 28.x | BeamAsm | Tier 1 |
+| Linux | ARM64 | 27.x | BeamAsm | Tier 2 (nightly) |
+| Windows | x86_64 | 27.x | BeamAsm | Tier 2 (nightly) |
+| AtomVM | ESP32/STM32/Pico | AtomVM 0.6+ | None | Profile target |
+
+**Files changed:**
+
+- `website/docs/manual/build-beam.mdx` (new)
+- `transpiler3/beam/build/phase19_test.go` (new): `TestPhase19DocsCliSync`.
+
+### 19.1 Release notes and changelog entry
+
+`CHANGELOG.md` gets a `[0.12.0]` entry immediately below the `[Unreleased]` header.
+
+**Entry structure (abbreviated):**
+
+```markdown
+## [0.12.0] - 2026-MM-DD
+
+### Added: BEAM/OTP backend (MEP-46)
+
+- `mochi build --target=beam-escript`: compile Mochi programs to self-contained OTP escripts.
+- `mochi build --target=beam-release`: OTP release tarball via relx (includes ERTS, ~30-80 MB).
+- `mochi build --target=beam-rebar3-project`: emit a complete rebar3 project with readable .erl source.
+- `mochi build --target=beam-mix-project`: emit a Mix project for Elixir tooling.
+- `mochi build --target=beam-atomvm`: compile for AtomVM microcontrollers (.avm output).
+- OTP 27.0 minimum; OTP 27.x and 28.x tested in blocking CI matrix (x86_64-linux, aarch64-darwin).
+- Agents: `agent<S>` lowers to gen_server processes; agent.new, agent.call, agent.cast.
+- Streams: `stream<T>` lowers to pg process groups; pub/sub, stream.map, stream.filter, cross-node.
+- Async/await: `async {}` blocks lower to spawn_monitor with recv-marker optimization.
+- Erlang FFI: `@erlang_module("module") fun f(x: T): R` calls native Erlang from Mochi.
+- LLM functions: cassette mode for testing; --cassette flag for reproducible LLM tests.
+- HTTP fetch: fetch(url) and fetch_json(url) via the gun HTTP client.
+- Dialyzer-clean output: -spec attributes emitted from Mochi types; CI gate with rebar3 dialyzer -Werror.
+- Reproducible .beam output: CInf timestamp stripped, functions sorted; SHA-256 reproducibility CI.
+- mochi OTP runtime published as mochi 0.1.0 on Hex.pm.
+```
+
+The changelog entry is comprehensive because users upgrading from v0.11 have not seen any BEAM
+backend features yet. Subsequent BEAM releases use incremental changelogs.
+
+The GitHub release notes for `v0.12.0` are generated from the `[0.12.0]` changelog section by
+`.github/workflows/release.yml` (existing release workflow, already reads from `CHANGELOG.md`).
+
+**Files changed:**
+
+- `CHANGELOG.md`: add `[0.12.0]` section.
+
+### 19.2 `mochi` runtime published to Hex.pm
+
+The `transpiler3/beam/runtime/` directory is packaged as the `mochi` Hex package. It contains the
+OTP runtime modules that every Mochi-compiled BEAM program depends on at runtime.
+
+**Package layout:**
+
+```
+transpiler3/beam/runtime/
+├── mix.exs                  (Hex package metadata + Mix project definition)
+├── rebar.config             (rebar3 dep compatibility)
+├── src/
+│   ├── mochi.app.src        (OTP application descriptor)
+│   ├── mochi_agent.erl      (gen_server agent runtime)
+│   ├── mochi_stream.erl     (pg stream runtime)
+│   ├── mochi_async.erl      (spawn_monitor async runtime)
+│   ├── mochi_llm.erl        (LLM + cassette runtime)
+│   └── mochi_fetch.erl      (gun HTTP client wrapper)
+└── test/                    (runtime unit tests)
+```
+
+**`mix.exs` for Hex publishing:**
+
+```elixir
+defmodule Mochi.MixProject do
+  use Mix.Project
+  def project, do: [
+    app: :mochi,
+    version: "0.1.0",
+    description: "OTP runtime library for Mochi-compiled BEAM programs",
+    package: package(),
+    deps: [{:gun, "~> 2.0"}]
+  ]
+  defp package, do: [
+    licenses: ["Apache-2.0"],
+    links: %{"GitHub" => "https://github.com/mochilang/mochi",
+             "Docs" => "https://mochilang.dev/docs/manual/build-beam"},
+    files: ~w(src rebar.config mix.exs LICENSE README.md)
+  ]
+end
+```
+
+**`rebar.config` for rebar3 users:**
+
+```erlang
+{deps, [{gun, "2.0.1"}]}.
+{erl_opts, [debug_info]}.
+{hex, [{doc, ex_doc}]}.
+```
+
+**Publication CI step** (in `.github/workflows/hex-publish.yml`):
+
+```yaml
+name: hex-publish
+on:
+  push:
+    tags: ["v*.*.*"]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+          elixir-version: "1.17"
+      - run: mix hex.publish --yes
+        working-directory: transpiler3/beam/runtime
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+```
+
+The `HEX_API_KEY` secret is the Hex.pm API key for the `mochilang` organization account,
+configured in the GitHub repository secrets by a maintainer.
+
+The `gun` 2.0 dependency is declared in both `mix.exs` and `rebar.config`. `TestPhase19HexManifest`
+verifies both files declare the same version to prevent skew.
+
+**Files changed:**
+
+- `transpiler3/beam/runtime/mix.exs` (new)
+- `transpiler3/beam/runtime/rebar.config`: add Hex metadata fields (`{hex, [...]}` block).
+- `.github/workflows/hex-publish.yml` (new)
+- `transpiler3/beam/build/phase19_test.go`: `TestPhase19HexManifest`.
+
+### 19.3 MEP-46 status flipped to Final
+
+`website/docs/mep/mep-0046.md` receives two changes:
+
+**1. Status line update:**
+
+```markdown
+| Status | Final 2026-MM-DD HH:MM (GMT+7) |
+```
+
+(Timestamp from `date` at the time of the PR merge commit.)
+
+**2. Closeout block** appended at the end of the MEP:
+
+```markdown
+## Closeout
+
+Landed: 2026-MM-DD HH:MM (GMT+7)
+
+All Phase 0-19 gates green. Shipped in Mochi v0.12.0.
+
+What shipped:
+- Phases 0-8: Core Erlang lowering, escript, primitives, collections, records, sums,
+  closures, query, Datalog.
+- Phase 9: Agents (gen_server).
+- Phase 10: Streams (pg process groups).
+- Phase 11: Async/await (spawn_monitor, recv-marker optimization).
+- Phase 12: Erlang FFI.
+- Phase 13: LLM functions (cassette mode).
+- Phase 14: HTTP fetch (gun).
+- Phase 15: Release packaging (escript, OTP release via relx, rebar3 project, mix project,
+  AtomVM profile, Docker base images).
+- Phase 16: OTP 27/28 x linux/macos CI matrix (6 cells, blocking).
+- Phase 17: Dialyzer-clean output (-spec emission, opaque runtime types, CI gate).
+- Phase 18: Reproducible .beam files (CInf stripping, function sort); benchmark gate (3x of C).
+- Phase 19: User docs (build-beam.mdx), changelog (v0.12.0), Hex.pm (mochi 0.1.0).
+
+Deferred post-v1.0: relup/appup hot reload, AtomVM hardware-in-the-loop CI,
+cross-compilation, mix release, EDoc/ExDoc, ARM Linux Tier-1, Windows Tier-1,
+OTP 29 Tier-1, build cache integration, NIF numeric optimization.
+```
+
+**Implementation tracking index** (`website/docs/implementation/0046/index.md`): Phase 15-19
+rows in the phase status table are updated from `NOT STARTED` to `LANDED`.
+
+**Files changed:**
+
+- `website/docs/mep/mep-0046.md`: Status -> Final, closeout block.
+- `website/docs/implementation/0046/index.md`: Phase 15-19 status -> LANDED.
 
 ## Decisions made
 
-_Pending phase open._
+**Why `build-beam.mdx` not `build-beam.md`.** All other Docusaurus manual pages in this project
+use `.mdx` for MDX support (JSX-in-Markdown, which enables interactive code examples and imported
+React components). Consistency with `build.mdx` (MEP-45 Phase 19.0) means the BEAM docs page can
+use the same `<CodeBlock>`, `<Tabs>`, and `<PlatformTable>` components used elsewhere in the
+manual. A `.md` file cannot use JSX, which would make the BEAM docs page look and feel different
+from the rest of the manual.
+
+**Why publish to Hex.pm at all.** The `mochi` OTP runtime library is useful independently of the
+Mochi build tool. Erlang and Elixir developers who want to call Mochi-compiled agents, streams, or
+query functions from their own Erlang code need the runtime as a dep. Publishing to Hex.pm makes it
+a first-class community dependency with versioned releases, a changelog, and discoverability via
+`hex.pm/packages/mochi`. Without Hex publication, users must add the runtime via a git path
+reference, which is not practical for production dependencies and signals that the library is not a
+stable artifact.
+
+**Why `[0.12.0]` for the BEAM backend release.** The current release is `v0.11.1`. The BEAM
+backend is a major new feature. Following semver, a new feature warrants a minor version bump:
+`0.11.1 -> 0.12.0`. The BEAM backend does not break existing Mochi programs (the C AOT backend is
+unchanged), so a major version bump is not warranted. A patch bump (`0.11.2`) would undersell the
+scope of the change.
+
+**Why Final and not Accepted.** The MEP lifecycle for this project is `Draft -> Final`. There is
+no `Accepted` or `Active` state. A MEP moves to Final when the implementation is complete and all
+phase gates are green. At that point the MEP becomes normative documentation of a shipped feature,
+not a proposal. Marking it Accepted when the implementation is already shipped would be inaccurate.
+
+**Why include all Phase 0-19 highlights in the changelog, not just Phase 15-19.** Users upgrading
+from v0.11 have not seen any BEAM backend features yet (Phases 0-14 were not shipped in v0.11
+releases; they were behind the in-progress MEP-46 flag). The changelog for the first BEAM release
+should be comprehensive: it is the primary communication channel for what the BEAM backend can do.
+A changelog that says only "Phase 15-19 landed" is not useful to a user who has never seen Phase
+0-14. Subsequent BEAM patch releases use incremental changelogs.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `website/docs/manual/build-beam.mdx` | New: user-facing BEAM backend documentation |
+| `CHANGELOG.md` | Add `[0.12.0]` section with full BEAM backend feature list |
+| `transpiler3/beam/runtime/mix.exs` | New: Hex.pm package metadata + Mix project definition |
+| `transpiler3/beam/runtime/rebar.config` | Add `{hex, [...]}` metadata block |
+| `.github/workflows/hex-publish.yml` | New: `mix hex.publish` on `v*.*.*` tags |
+| `website/docs/mep/mep-0046.md` | Status -> Final, closeout block added |
+| `website/docs/implementation/0046/index.md` | Phase 15-19 rows updated to LANDED |
+| `transpiler3/beam/build/phase19_test.go` | New: `TestPhase19DocsCliSync`, `TestPhase19HexManifest`, `TestPhase19MEPFinal`, `TestPhase19ChangelogEntry` |
 
 ## Test set
 
-_Pending phase open._
+- `TestPhase19DocsCliSync`: extracts CLI flag entries from the `## CLI reference` section of
+  `build-beam.mdx` via regex, runs `mochi build --target=beam-escript --help` and other target
+  help commands, and asserts the documented flags match the actual CLI output. Mismatched or
+  missing flags are a test failure.
+- `TestPhase19HexManifest`: reads `transpiler3/beam/runtime/mix.exs` and `rebar.config`, verifies
+  both declare the same package version (`0.1.0`) and the same `gun` dependency version, preventing
+  version skew between the two manifests.
+- `TestPhase19MEPFinal`: reads `website/docs/mep/mep-0046.md`, asserts `Status: Final` is present
+  with a timestamp, and asserts the `## Closeout` section is present with a `Landed:` line.
+  Prevents the MEP from being marked Final without the closeout block.
+- `TestPhase19ChangelogEntry`: reads `CHANGELOG.md`, asserts a `[0.12.0]` section is present and
+  contains at least the key feature keywords: `beam-escript`, `beam-release`, `gen_server`, `pg`,
+  `Dialyzer`, `Hex.pm`, `AtomVM`. A changelog entry missing key features is a test failure.
+
+## Deferred work
+
+- Interactive code examples in `build-beam.mdx` using the Mochi playground widget (embedded WASM
+  compilation in the browser). Deferred; the playground is not yet available for the BEAM target.
+- `mix release` support in the `--target=beam-mix-project` target: currently only `mix compile` is
+  supported. `mix release` requires generating a `rel/` directory and `config/runtime.exs`.
+  Deferred post-v1.0.
+- ExDoc HTML documentation uploaded to Hex.pm alongside the package: requires EDoc comments in the
+  runtime `.erl` files. Deferred until the EDoc deferred item from Phase 17 is addressed.
+- OTP 29 promotion to Tier-1 in the platform table: update `build-beam.mdx` when OTP 29 final is
+  released and the nightly has been clean for two weeks. No MEP amendment needed; this is a
+  documentation update.
+- Windows Tier-1 promotion in the platform table: same criteria as OTP 29 promotion.
+- `mochi` on other package registries (npm for WASM/WebAssembly BEAM, crates.io): no WASM BEAM
+  target is planned for v1.0. Deferred indefinitely.
 
 ## Closeout notes
 


### PR DESCRIPTION
Closes #22247

## Summary

- Replaces all 20 stub tracking pages under `website/docs/implementation/0046/` with full technical implementation specs
- 5,410 lines added across phases 0-19 of the Mochi-to-BEAM (Erlang/OTP) transpiler pipeline
- Covers Core Erlang lowering, OTP runtime module layouts, gate tests, CI matrix, and architectural decisions

## Test plan

- [ ] Docusaurus build succeeds (all 20 pages render in sidebar)
- [ ] No broken internal links (each page links to the correct MEP-46 phase anchor)
- [ ] Phase-00 through phase-19 pages match the sub-phase table in mep-0046.md