### PR TITLE
mep-0046 phase 1.0: hello world escript pipeline

### DIFF
--- a/tests/transpiler3/beam/fixtures/phase01/001_hello/001_hello.mochi
+++ b/tests/transpiler3/beam/fixtures/phase01/001_hello/001_hello.mochi
@@ -1,0 +1,1 @@
+print("hello, mochi!")

--- a/tests/transpiler3/beam/fixtures/phase01/001_hello/expect.txt
+++ b/tests/transpiler3/beam/fixtures/phase01/001_hello/expect.txt
@@ -1,0 +1,1 @@
+hello, mochi!

--- a/transpiler3/beam/build/build.go
+++ b/transpiler3/beam/build/build.go
@@ -1,5 +1,17 @@
 package build
 
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"mochi/parser"
+	beamlower "mochi/transpiler3/beam/lower"
+	"mochi/transpiler3/beam/emit"
+	clower "mochi/transpiler3/c/lower"
+	"mochi/types"
+)
+
 // Target selects the output artifact produced by Driver.Build.
 type Target int
 
@@ -28,23 +40,74 @@ type Driver struct {
 	CacheDir string
 }
 
+// escriptShebang is the two-line header that makes a .beam file
+// directly executable as an escript. The escript VM reads the
+// module name from the .beam binary metadata and calls ModName:main/1.
+const escriptShebang = "#!/usr/bin/env escript\n%%!\n"
+
 // Build compiles the Mochi source at src, writes the output artifact
 // to out, and returns any error. The pipeline is:
 //
 //  1. Parse + type-check (compiler3 frontend, shared with MEP-45).
-//  2. Monomorphise + lower to aotir (transpiler3/c passes, reused).
+//  2. Lower to aotir (transpiler3/c/lower, reused from MEP-45).
 //  3. beam/lower: aotir -> cerl.Module.
-//  4. beam/emit: cerl.Module -> .beam files via compile:forms/2.
-//  5. Pack as escript (TargetEscript) or release (TargetRelease).
+//  4. beam/emit: cerl.Module -> .beam file via compile:forms/2.
+//  5. Pack as escript (TargetEscript) or return error for other targets.
 //
-// Phase 0 ships the stub. Each later phase implements the stages
-// required by its gate test.
+// Phase 1 supports TargetEscript only. TargetRelease and TargetAtomVM
+// return an error until their respective phases land.
 func (d *Driver) Build(src, out string, target Target) error {
-	// Stub: implemented in Phase 1.
-	return errNotImplemented("Driver.Build not yet implemented (Phase 1)")
+	if target != TargetEscript {
+		return fmt.Errorf("beam/build: only TargetEscript is supported in Phase 1 (got %d)", target)
+	}
+
+	prog, err := parser.Parse(src)
+	if err != nil {
+		return fmt.Errorf("beam/build: parse %s: %w", src, err)
+	}
+	if errs := types.Check(prog, types.NewEnv(nil)); len(errs) > 0 {
+		return fmt.Errorf("beam/build: type-check %s: %w", src, errs[0])
+	}
+	ir, err := clower.Lower(prog)
+	if err != nil {
+		return fmt.Errorf("beam/build: lower %s: %w", src, err)
+	}
+
+	// Phase 1 uses a fixed module name. Phase N will derive the name
+	// from the source file's package path.
+	const modName = "mochi_main"
+
+	mod, err := beamlower.Lower(ir, modName)
+	if err != nil {
+		return fmt.Errorf("beam/build: beam lower %s: %w", src, err)
+	}
+
+	workDir, err := os.MkdirTemp("", "mochi-beam-")
+	if err != nil {
+		return fmt.Errorf("beam/build: mkdtemp: %w", err)
+	}
+	defer os.RemoveAll(workDir)
+
+	beamFiles, err := emit.Emit(mod, workDir)
+	if err != nil {
+		return fmt.Errorf("beam/build: emit %s: %w", src, err)
+	}
+	if len(beamFiles) == 0 {
+		return fmt.Errorf("beam/build: emit produced no .beam files")
+	}
+
+	beamBytes, err := os.ReadFile(beamFiles[0].Path)
+	if err != nil {
+		return fmt.Errorf("beam/build: read %s: %w", beamFiles[0].Path, err)
+	}
+
+	// Write escript: shebang header + raw .beam bytes.
+	// escript reads the module name from the .beam binary and calls main/1.
+	content := append([]byte(escriptShebang), beamBytes...)
+	if err := os.WriteFile(out, content, 0o755); err != nil {
+		return fmt.Errorf("beam/build: write escript %s: %w", out, err)
+	}
+
+	_ = filepath.Dir(out) // ensure import used
+	return nil
 }
-
-type notImplementedError string
-
-func errNotImplemented(msg string) error { return notImplementedError(msg) }
-func (e notImplementedError) Error() string { return string(e) }

--- a/transpiler3/beam/build/phase01_test.go
+++ b/transpiler3/beam/build/phase01_test.go
@@ -1,0 +1,50 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPhase1Hello walks tests/transpiler3/beam/fixtures/phase01/ and
+// asserts that each fixture's escript stdout matches expect.txt
+// byte-for-byte. This is the Phase 1 gate test.
+func TestPhase1Hello(t *testing.T) {
+	root := repoRoot(t)
+	fixturesDir := filepath.Join(root, "tests", "transpiler3", "beam", "fixtures", "phase01")
+
+	entries, err := os.ReadDir(fixturesDir)
+	if err != nil {
+		t.Fatalf("read fixtures dir %s: %v", fixturesDir, err)
+	}
+
+	ran := 0
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		dir := filepath.Join(fixturesDir, name)
+
+		mochiPath := filepath.Join(dir, name+".mochi")
+		expectPath := filepath.Join(dir, "expect.txt")
+
+		if _, err := os.Stat(mochiPath); err != nil {
+			t.Logf("skip %s: no .mochi file", name)
+			continue
+		}
+		if _, err := os.Stat(expectPath); err != nil {
+			t.Logf("skip %s: no expect.txt", name)
+			continue
+		}
+
+		t.Run(name, func(t *testing.T) {
+			runBeamFixture(t, mochiPath, expectPath)
+		})
+		ran++
+	}
+
+	if ran == 0 {
+		t.Fatal("no fixtures found in phase01/")
+	}
+}

--- a/transpiler3/beam/cerl/cerl.go
+++ b/transpiler3/beam/cerl/cerl.go
@@ -397,10 +397,11 @@ func (m *Module) MarshalBinary() ([]byte, error) {
 }
 
 // toTerm builds the {c_module, Anno, Name, Exports, Attrs, Defs} tuple.
+// Exports must be c_var nodes with {Name, Arity} tuples, not plain tuples.
 func (m *Module) toTerm() Term {
 	exports := make(EList, len(m.Exports))
 	for i, e := range m.Exports {
-		exports[i] = ETuple{EAtom(e.Name), EInt(int64(e.Arity))}
+		exports[i] = CVarFunc(e.Name, e.Arity)
 	}
 
 	attrs := make(EList, len(m.Attrs))

--- a/transpiler3/beam/emit/emit.go
+++ b/transpiler3/beam/emit/emit.go
@@ -1,23 +1,64 @@
 package emit
 
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"mochi/transpiler3/beam/cerl"
+)
+
 // BeamFile holds the result of compiling one cerl.Module.
 type BeamFile struct {
-	// ModName is the Erlang module name (e.g. "mochi_user__main").
+	// ModName is the Erlang module name (e.g. "mochi_main").
 	ModName string
 	// Path is the absolute path to the generated .beam file.
 	Path string
 }
 
-// Emit serialises mod to ETF, drives compile:forms/2 via an
-// erl -noshell subprocess, and writes the resulting .beam file
-// to outDir/<ModName>.beam.
+// Emit serialises mod to ETF, drives compile:forms/2 [from_core] via an
+// erl -noshell subprocess, and writes the resulting .beam file to
+// outDir/<ModName>.beam.
 //
-// Phase 0 ships the stub. Phase 1 implements the full pipeline.
-func Emit() ([]BeamFile, error) {
-	return nil, errNotImplemented("Emit not yet implemented (Phase 1)")
+// The erl binary must be on PATH. OTP 27 or later is required.
+func Emit(mod *cerl.Module, outDir string) ([]BeamFile, error) {
+	if mod == nil {
+		return nil, fmt.Errorf("beam/emit: nil module")
+	}
+	if outDir == "" {
+		return nil, fmt.Errorf("beam/emit: empty outDir")
+	}
+
+	etfBytes, err := mod.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("beam/emit: marshal %s: %w", mod.Name, err)
+	}
+
+	etfPath := filepath.Join(outDir, mod.Name+".core.etf")
+	if err := os.WriteFile(etfPath, etfBytes, 0o644); err != nil {
+		return nil, fmt.Errorf("beam/emit: write etf %s: %w", etfPath, err)
+	}
+
+	beamPath := filepath.Join(outDir, mod.Name+".beam")
+
+	// compile:forms/2 with from_core compiles a Core Erlang form
+	// (as produced by MarshalBinary's c_module tuple) to a .beam binary.
+	// return_warnings ensures a 4-tuple {ok,Mod,Bin,Warnings} on success.
+	erlExpr := fmt.Sprintf(
+		`{ok,B}=file:read_file("%s"),`+
+			`Form=binary_to_term(B),`+
+			`case compile:forms(Form,[from_core,debug_info,return_errors,return_warnings]) of `+
+			`{ok,_,BeamBin,_}->file:write_file("%s",BeamBin),halt(0);`+
+			`{error,Es,_}->io:format(standard_error,"compile error: ~p~n",[Es]),halt(1)`+
+			`end.`,
+		etfPath, beamPath,
+	)
+
+	cmd := exec.Command("erl", "-noshell", "-eval", erlExpr)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("beam/emit: compile:forms for %s: %w\n%s", mod.Name, err, out)
+	}
+
+	return []BeamFile{{ModName: mod.Name, Path: beamPath}}, nil
 }
-
-type notImplementedError string
-
-func errNotImplemented(msg string) error { return notImplementedError(msg) }
-func (e notImplementedError) Error() string { return string(e) }

--- a/transpiler3/beam/lower/lower.go
+++ b/transpiler3/beam/lower/lower.go
@@ -1,18 +1,122 @@
 package lower
 
-// Lower is the entry point for the aotir -> cerl lowering pass.
-// Phase 0 ships the stub; the pass is implemented incrementally
-// starting in Phase 1.
+import (
+	"fmt"
+
+	"mochi/transpiler3/beam/cerl"
+	"mochi/transpiler3/c/aotir"
+)
+
+// Lower converts an aotir.Program to a cerl.Module ready for
+// compile:forms/2 [from_core].
 //
-// The function signature is intentionally left as a forward
-// declaration here so that callers in beam/build can import this
-// package without a circular dependency. The actual aotir and cerl
-// types are wired up in Phase 1.
-func Lower() error {
-	return errNotImplemented("Lower not yet implemented (Phase 1)")
+// modName is the Erlang module name for the produced module (e.g.
+// "mochi_main"). The module exports main/1 which escript invokes
+// as the entry point.
+//
+// Phase 1 supports: print(<string>) at the top level (via
+// io:put_chars). Each later phase extends lowerStmt/lowerExpr
+// with the surface its gate requires.
+func Lower(prog *aotir.Program, modName string) (*cerl.Module, error) {
+	if prog == nil {
+		return nil, fmt.Errorf("beam/lower: nil program")
+	}
+	if modName == "" {
+		return nil, fmt.Errorf("beam/lower: empty module name")
+	}
+
+	mod := &cerl.Module{
+		Name:    modName,
+		Exports: []cerl.FuncRef{{Name: "main", Arity: 1}},
+	}
+
+	if prog.Main < 0 || prog.Main >= len(prog.Functions) {
+		return nil, fmt.Errorf("beam/lower: invalid main index %d (len=%d)", prog.Main, len(prog.Functions))
+	}
+
+	mainFn := prog.Functions[prog.Main]
+	body, err := lowerBlock(mainFn.Body)
+	if err != nil {
+		return nil, fmt.Errorf("beam/lower: lower main: %w", err)
+	}
+
+	mod.Defs = append(mod.Defs, cerl.FuncDef{
+		Name:  "main",
+		Arity: 1,
+		Vars:  []string{"V__args"},
+		Body:  body,
+	})
+
+	return mod, nil
 }
 
-type notImplementedError string
+// lowerBlock lowers a straight-line block to a cerl expression.
+// Multiple statements are chained with c_seq; an empty block
+// returns the atom ok.
+func lowerBlock(block *aotir.Block) (cerl.Expr, error) {
+	if block == nil || len(block.Statements) == 0 {
+		return cerl.CAtom("ok"), nil
+	}
 
-func errNotImplemented(msg string) error { return notImplementedError(msg) }
-func (e notImplementedError) Error() string { return string(e) }
+	exprs := make([]cerl.Expr, 0, len(block.Statements))
+	for _, stmt := range block.Statements {
+		e, err := lowerStmt(stmt)
+		if err != nil {
+			return nil, err
+		}
+		exprs = append(exprs, e)
+	}
+
+	if len(exprs) == 1 {
+		return exprs[0], nil
+	}
+	// Right-fold into c_seq so that later statements use the result
+	// of earlier ones: seq(s1, seq(s2, s3)).
+	result := exprs[len(exprs)-1]
+	for i := len(exprs) - 2; i >= 0; i-- {
+		result = cerl.CSeq(exprs[i], result)
+	}
+	return result, nil
+}
+
+// lowerStmt lowers one aotir statement to a cerl expression.
+func lowerStmt(stmt aotir.Stmt) (cerl.Expr, error) {
+	switch s := stmt.(type) {
+	case *aotir.CallStmt:
+		return lowerCallStmt(s)
+	default:
+		return nil, fmt.Errorf("beam/lower: unsupported statement %T (Phase 1 only)", stmt)
+	}
+}
+
+// lowerCallStmt lowers a CallStmt. Phase 1 handles the mochi_print_*
+// builtins (produced by the aotir lowerer for Mochi's print() builtin)
+// by emitting direct io:put_chars calls.
+func lowerCallStmt(s *aotir.CallStmt) (cerl.Expr, error) {
+	switch s.Func {
+	case "mochi_print_str":
+		if len(s.Args) != 1 {
+			return nil, fmt.Errorf("beam/lower: mochi_print_str wants 1 arg, got %d", len(s.Args))
+		}
+		arg, err := lowerExpr(s.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		// io:put_chars([Bin, $\n]) to match vm3's print output.
+		// The newline is appended as the integer 10 in a cons cell.
+		argWithNewline := cerl.CCons(arg, cerl.CCons(cerl.CInt(10), cerl.CNil()))
+		return cerl.CCall(cerl.CAtom("io"), cerl.CAtom("put_chars"), []cerl.Expr{argWithNewline}), nil
+	default:
+		return nil, fmt.Errorf("beam/lower: unsupported call %q (Phase 1 only supports print)", s.Func)
+	}
+}
+
+// lowerExpr lowers one aotir expression to a cerl expression.
+func lowerExpr(expr aotir.Expr) (cerl.Expr, error) {
+	switch e := expr.(type) {
+	case *aotir.StringLit:
+		return cerl.CBin([]byte(e.Value)), nil
+	default:
+		return nil, fmt.Errorf("beam/lower: unsupported expression %T (Phase 1 only)", expr)
+	}
+}

--- a/website/docs/implementation/0046/phase-01-hello.md
+++ b/website/docs/implementation/0046/phase-01-hello.md
@@ -10,9 +10,9 @@ description: "MEP-46 Phase 1 tracking: end-to-end pipeline from print(\"hello, m
 | Field          | Value |
 |----------------|-------|
 | MEP            | [MEP-46 §Phases · Phase 1](/docs/mep/mep-0046#phase-1-hello-world) |
-| Status         | NOT STARTED |
-| Started        | — |
-| Landed         | — |
+| Status         | LANDED 2026-05-26 13:01 (GMT+7) |
+| Started        | 2026-05-26 12:47 (GMT+7) |
+| Landed         | 2026-05-26 13:01 (GMT+7) |
 | Tracking issue | — |
 | Tracking PR    | — |
 
@@ -28,7 +28,7 @@ Phase 1 is the first point where the BEAM transpiler produces a *real* runnable 
 
 | #   | Scope | Status | Commit | PR |
 |-----|-------|--------|--------|----|
-| 1.0 | End-to-end pipeline: `lower.go`, `emit.go`, `driver.go`, `mochi_str.erl` stub; `001_hello.mochi` fixture green | NOT STARTED | — | — |
+| 1.0 | End-to-end pipeline: `lower.go`, `emit.go`, `build.go`, fixture green | LANDED 2026-05-26 13:01 (GMT+7) | — | — |
 | 1.1 | CLI flags `--target=beam-escript`, `--out`, `--emit=core\|erl\|beam` wired in `cmd/mochi/main.go` | NOT STARTED | — | — |
 | 1.2 | `.mochi/cache/beam/` BLAKE3 cache; hit/miss paths | NOT STARTED | — | — |
 | 1.3 | `mochi_str.erl` fully implemented: binary, integer, float, bool, atom, list | NOT STARTED | — | — |
@@ -227,4 +227,16 @@ The `float_to_binary/1` helper is defined in `mochi_str` rather than calling `io
 
 ## Closeout notes
 
-_Fill in after gate green._
+Phase 1.0 COMPLETE 2026-05-26 13:01 (GMT+7). Sub-phase 1.0 gate green.
+
+`TestPhase1Hello/001_hello` passes: `print("hello, mochi!")` compiles end-to-end to a runnable escript whose stdout is `hello, mochi!\n`, matching `expect.txt` byte-for-byte.
+
+Three deviations from the spec that are worth noting:
+
+1. The escript is a simple shebang-prefixed raw .beam file rather than an archive escript created with `escript:create/2`. This works because escript recognizes the `FOR1` BEAM magic bytes after reading the shebang and flags lines. The archive format (for bundling multiple .beam files) is needed in a later phase when mochi_str.erl runtime functions are required at runtime.
+
+2. `print("str")` lowers to `io:put_chars([<<bin>>, 10])` directly rather than `mochi_str:print(<<bin>>)`. The aotir lowerer renames `print` to `mochi_print_str` (for string args); the beam lower pass handles `mochi_print_str` and inlines the io call. mochi_str runtime module is deferred to Phase 1.3.
+
+3. The Core Erlang export list uses `c_var` nodes `{c_var,[],{Name,Arity}}` as required by `core_lint`, not plain `{Name,Arity}` tuples as initially coded. This was caught by the compile:forms error and fixed.
+
+Sub-phases 1.1, 1.2, 1.3 are pending (CLI flags, BLAKE3 cache, full mochi_str).


### PR DESCRIPTION
closes #22253

## What

Phase 1.0 of MEP-46: end-to-end pipeline from `print("hello, mochi!")` to a runnable escript.

## Changes

- `transpiler3/beam/lower/lower.go`: `mochi_print_str` -> `io:put_chars([Bin, 10])` (the aotir lowerer renames `print` to `mochi_print_str` for string args)
- `transpiler3/beam/emit/emit.go`: serialise cerl Module to ETF, drive `compile:forms/2 [from_core, debug_info, return_errors, return_warnings]` via `erl -noshell`, write `.beam` to workdir
- `transpiler3/beam/build/build.go`: full pipeline -- parse, typecheck, lower to aotir, lower to cerl, emit, write escript (shebang + raw .beam bytes)
- `transpiler3/beam/cerl/cerl.go`: fix `toTerm()` to use `c_var` nodes for exports (plain `{Name,Arity}` tuples fail `core_lint` with `invalid_exports`)
- `transpiler3/beam/build/phase01_test.go`: `TestPhase1Hello` gate test
- `tests/transpiler3/beam/fixtures/phase01/001_hello/`: source + expected output

## Gate

`TestPhase1Hello/001_hello` passes: escript stdout is `hello, mochi!\n`, matches `expect.txt` byte-for-byte.

## Deviations from spec

- Escript is shebang + raw .beam (not `escript:create/2` archive). Works because escript recognizes `FOR1` BEAM magic bytes after the shebang lines. Archive format needed later when runtime modules are required.
- `print` inlined as `io:put_chars` directly, no `mochi_str:print`. mochi_str deferred to Phase 1.3.