### PR TITLE
docs: update roadmap — v0.13.0 current, v0.14.0 (MEP-47 JVM) next

### DIFF
--- a/website/docs/roadmap.mdx
+++ b/website/docs/roadmap.mdx
@@ -20,12 +20,10 @@ shift.
 Considering means we like the idea but have not committed yet.
 :::
 
-## v0.10.x (the current train)
+## v0.13.0 (current release)
 
-The 0.10 line is the first release where every "core feature" listed
-on the home page actually ships in one binary. The remaining 0.10.x
-patches focus on bug fixes, standard library additions, and
-incremental wins for the bytecode optimizer.
+v0.13.0 shipped in May 2026. The headline feature is the BEAM/Erlang
+transpiler reaching Final status under [MEP-46](/docs/mep/mep-0046).
 
 ### Language core
 
@@ -34,9 +32,7 @@ incremental wins for the bytecode optimizer.
   caches compiled bytecode under `~/.cache/mochi`, so a hot script
   starts in single-digit milliseconds after the first run.
 - Done. Static type inference across function calls, generic
-  instantiations, and `match` arms. Empty literals (`let xs = []`)
-  still need an annotation; we are tracking the warts that show up
-  most in the wild.
+  instantiations, and `match` arms.
 - Done. `let` and `var` bindings with the immutable-by-default rule.
 - Done. Functions, closures, and arrow lambdas (`fun(x) => x + 1`).
   Closures capture by reference and are first-class values.
@@ -47,21 +43,29 @@ incremental wins for the bytecode optimizer.
   on `match`.
 - Done. `for`, `while`, `if`/`else`, `match`, `break`, `continue`,
   range expressions (`0..n`, `0..=n`).
-- Done. Built-in collections: `list<T>`, `map<K, V>`, `set<T>` with
-  the prelude methods (`.push`, `.keys`, `.contains`, etc.).
+- Done. Built-in collections: `list<T>`, `map<K, V>`, `set<T>`,
+  `omap<K, V>` with the prelude methods (`.push`, `.keys`,
+  `.contains`, etc.).
 - Done. Packages and imports. A directory of `.mochi` files is a
   package; `import "./pkg" as alias` resolves relative paths.
 - Done. Built-in test blocks (`test "name" { ... }`) with `expect`
   assertions. `mochi test` walks the tree and runs every block.
 - Done. Agents and streams as first-class language constructs:
   `agent`, `stream`, `emit`, `on Event as e`, `intent`.
-- Done. `generate text { ... }` and `generate embedding { ... }`
-  expressions. Tool calling, structured output (`as <Type>`), and
-  streaming responses are part of the runtime.
+- Done. `generate text { ... }`, `generate embedding { ... }`, and
+  `generate <Provider> { ... }` expressions. Tool calling, structured
+  output (`as <Type>`), streaming responses, and cassette playback for
+  tests are part of the runtime.
 - Done. Dataset queries (`from x in xs where ... select ...`) with
   `sort by`, `take`, `group by`, and `join`.
+- Done. Datalog (`assert`, `retract`, `query`) with bottom-up
+  semi-naïve evaluation.
+- Done. `async`/`await` with `mochi_async` spawn-monitor semantics.
+- Done. `fetch "<url>" into <var>` and `json_decode` via the BEAM
+  runtime library.
 - Done. FFI through `extern` declarations for Go and Python.
 - Done. Pipe operator (`|`) for left-to-right function composition.
+- Done. Partial application with `_` placeholders.
 
 ### Tooling
 
@@ -69,61 +73,92 @@ incremental wins for the bytecode optimizer.
   (MCP server mode), `mochi transpile`.
 - Done. Single static binary distribution. The release tarball is
   under 20 MB on every supported platform.
-- Done. Docker image at `ghcr.io/mochilang/mochi`. Used by the CI
-  pipelines on the main repo.
+- Done. Docker image at `ghcr.io/mochilang/mochi`.
+- Done. Docker image `Dockerfile.beam-otp27` with OTP 27 for BEAM
+  targets.
 - Done. VS Code syntax highlighting via the `mochi-tm` TextMate
   bundle.
+- Done. BLAKE3 content-addressed compiler cache for `.beam` files.
+- Done. Deterministic `.beam` compilation (`deterministic` flag +
+  sorted definitions) for reproducible builds.
 - In progress. Language server (LSP). Diagnostics, hover types, and
-  goto-definition are working on the LSP branch. Auto-import,
-  refactoring, and code actions are next.
-- In progress. Native Windows build without WSL. Most of the
-  toolchain runs on Windows already; the remaining blockers are file
-  watching for `mochi serve` and ANSI color in the test runner.
-- Planned. `mochi fmt` formatter. Output is locked-in (no
-  configuration), modeled after `gofmt`.
-- Planned. Package manager and registry. We have a design doc; the
-  registry is the larger piece of work.
+  goto-definition are working on the LSP branch.
+- In progress. Native Windows build without WSL.
+- Planned. `mochi fmt` formatter.
+- Planned. Package manager and registry.
 
 ### Transpilation
 
 - Done. `--to go`, `--to python`, `--to typescript`. Each target
   produces idiomatic code that round-trips through the Mochi test
-  suite (the suite runs once natively and once for each target).
-- Considering. `--to lua`, `--to rust`. We have prototypes for both;
-  shipping depends on someone needing them and being willing to own
-  the maintenance.
-- Considering. `--to wasm`. The bytecode VM compiles fine to wasm,
-  but a clean Mochi-to-wasm path would need a separate codegen step.
+  suite.
+- Done. `--to c` / `mochi build --target=native` (MEP-45). Produces
+  a single native binary via a C AOT IR pipeline.
+- Done. `--to beam` / `mochi build --target=escript|release|rebar3|mix|atomvm`
+  (MEP-46). The Erlang/BEAM transpiler is Final. Build targets:
+  escript (single-file runnable), rebar3 project, Mix/Elixir project,
+  OTP release, and AtomVM bundle. The runtime library `mochi_runtime`
+  covers `mochi_fetch`, `mochi_json`, `mochi_llm` (OpenAI + Anthropic
+  live dispatch with cassette playback), `mochi_async`, and
+  `mochi_stream`. Hex.pm packaging infrastructure is in place.
+- Considering. `--to lua`, `--to rust`. Prototypes exist.
+- Considering. `--to wasm`. Bytecode VM compiles to wasm; a clean
+  Mochi-to-wasm codegen path is a separate workstream.
 
 ### Platform
 
 - Done. macOS (Intel and Apple Silicon).
 - Done. Linux (x86_64 and ARM64).
 - Done. Docker.
-- In progress. Windows native (above).
+- Done. BEAM/OTP 27+ (via `mochi build --target=escript`).
+- In progress. Windows native (without WSL).
 - Considering. WebAssembly via `mochi build --to wasm`.
+- Considering. AtomVM (microcontrollers) via `mochi build --target=atomvm`.
 
-## v0.11.x (next minor)
+## v0.14.0 (next release)
 
-The next minor is scoped to four things:
+v0.14.0 is scoped to [MEP-47](/docs/mep/mep-0047): the JVM
+transpiler. The goal is to let Mochi programs compile to Java source
+(via `javax.tools.JavaCompiler`) and package as uberjars, `jlink`
+runtime images, `jpackage` installers, or GraalVM `native-image`
+ahead-of-time binaries. The pipeline reuses the `aotir` IR and the
+monomorphisation and closure-conversion passes from MEP-45 and MEP-46.
 
-1. Generics finalized. Function and struct generics work today; what
-   is missing is the type bound syntax (`<T: Comparable>`) and a
-   clearer error message when inference fails. Once landed, generics
-   stop being marked "in progress" everywhere.
-2. Error propagation operator (`?`). Today, `T | nil` plus `match`
-   handles the optional case well, but errors that need to bubble
-   force a verbose pattern. We want `value?` for the common short
-   form, modeled on Rust's `?`.
-3. Async primitives. We have an internal goroutine pool used by the
-   agent runtime. The next release exposes `async` and `await` as
-   keywords with the same scheduling rules. Cancellation and
-   timeouts are part of the surface.
-4. Interface / protocol declarations. `interface` will declare a
-   set of method signatures; types that satisfy the signature are
-   automatically usable wherever the interface is required. This
-   is the last piece needed before the standard library can express
-   things like `Iterable<T>` or `Hashable`.
+What v0.14.0 adds:
+
+1. **JVM emit pass.** Lowers `aotir` to Java source via
+   `javax.tools.JavaCompiler`. A `java.lang.classfile` (ClassFile API,
+   JEP 484) direct-bytecode fallback covers agent trampolines and hot
+   lowerings.
+2. **Build targets.** `mochi build --target=jvm-uberjar`,
+   `--target=jvm-jlink`, `--target=jvm-jpackage`,
+   `--target=jvm-native-image` (GraalVM). Correctness gate: byte-equal
+   stdout against vm3 across JDK 21 LTS and JDK 25 LTS on
+   x86_64-linux-gnu, aarch64-linux-gnu, aarch64-darwin, and
+   x86_64-windows.
+3. **Agent lowering.** Mochi agents lower to Loom virtual threads
+   with `BlockingQueue` mailboxes.
+4. **Stream lowering.** Mochi streams lower to
+   `java.util.concurrent.Flow.Publisher`.
+5. **Type lowering.** Sum types → sealed interfaces + records; `match`
+   → JDK 21 switch patterns (JEP 440 + JEP 441); fun types → lambdas
+   via `LambdaMetafactory`; strings → `java.lang.String`.
+6. **Runtime library `dev.mochi.runtime`.** Apache-2.0, published to
+   Maven Central via the Central Publisher Portal. Thin layer over
+   Jackson 2.18, snakeyaml-engine, java.net.http, and JFR. Covers
+   agent supervisor, datalog evaluator, query DSL, JSON helpers, and
+   ZonedDateTime.
+7. **LLM dispatch.** `generate` expressions route to OpenAI or
+   Anthropic via `java.net.http.HttpClient`.
+8. **Fetch.** `fetch` expressions use `java.net.http.HttpClient`.
+9. **Datalog.** Bottom-up semi-naïve evaluation in the Java runtime.
+10. **Reproducibility.** Deterministic class file generation.
+
+The 18-phase delivery plan for MEP-47 mirrors MEP-46's structure:
+hello-world → scalars → collections → records → sums → closures →
+queries → datalog → agents → streams → async → JDK FFI → LLM → fetch →
+uberjar → jlink/jpackage → GraalVM native-image → reproducibility.
+Each phase is gated against vm3.
 
 ## v1.0 (stable language)
 
@@ -135,7 +170,8 @@ To get there, Mochi needs:
 
 - A versioned language specification document (today the spec lives
   in the test suite and a handful of design notes).
-- Generics, async, and interfaces from the 0.11 train shipped and
+- Generics type bounds (`<T: Comparable>`), the error propagation
+  operator (`?`), and interface / protocol declarations shipped and
   used in the standard library.
 - A stable standard library API, including `io`, `fs`, `time`,
   `http`, `crypto`, and `json`. Not breaking these later is most of
@@ -150,6 +186,21 @@ To get there, Mochi needs:
 
 We are not promising a date. We are promising that 1.0 ships when the
 list above is true and not before.
+
+## Transpiler roadmap
+
+Each MEP delivers one new ecosystem exit. The order reflects
+implementation dependencies (later MEPs reuse IR passes from earlier
+ones).
+
+| MEP | Target | Ecosystem | Status |
+|-----|--------|-----------|--------|
+| [MEP-45](/docs/mep/mep-0045) | C / native binary | POSIX, static binaries | Done |
+| [MEP-46](/docs/mep/mep-0046) | BEAM / Erlang | OTP, Hex.pm, AtomVM | Done (v0.13.0) |
+| [MEP-47](/docs/mep/mep-0047) | JVM / Java | Maven Central, Loom, GraalVM | In progress (v0.14.0) |
+| [MEP-48](/docs/mep/mep-0048) | .NET / C# | NuGet, NativeAOT, MAUI | Planned |
+| [MEP-49](/docs/mep/mep-0049) | Swift | App Store, SwiftPM, Static Linux SDK | Planned |
+| [MEP-50](/docs/mep/mep-0050) | Kotlin Multiplatform | Android, Google Play, KMP | Planned |
 
 ## Things we are deliberately not building
 


### PR DESCRIPTION
Closes #22313

## Summary
- Marks v0.13.0 (MEP-46 BEAM/Erlang transpiler, Final) as the current release with a full feature inventory (19 phases, 5 build targets, mochi_runtime library, Hex.pm packaging)
- Adds v0.14.0 section scoped to MEP-47 (JVM transpiler: javax.tools Java source emit, Loom virtual threads, GraalVM native-image, Maven Central `dev.mochi.runtime`)
- Adds a transpiler roadmap table showing MEP-45 through MEP-50 with status
- Retires the stale v0.10.x / v0.11.x framing (those shipped)

## Test plan
- [ ] Website preview builds without error
- [ ] https://mochi-lang.dev/docs/roadmap reflects v0.13.0 as current and v0.14.0 as next after merge