### PR TITLE
mep-0047 audit cleanup: version strings + stale index

### DIFF
--- a/transpiler3/jvm/build/phase00_test.go
+++ b/transpiler3/jvm/build/phase00_test.go
@@ -25,10 +25,16 @@ func TestPhase0Skeleton(t *testing.T) {
 		// The runtime jar is built by Maven. In CI it is pre-built.
 		// In a local dev checkout, run: mvn -f transpiler3/jvm/runtime/pom.xml package -DskipTests
 		repoRoot := repoRootForTest(t)
-		jarPath := filepath.Join(repoRoot, "transpiler3", "jvm", "runtime",
-			"target", "mochi-runtime-0.10.0-SNAPSHOT.jar")
-		if _, err := os.Stat(jarPath); err != nil {
-			t.Skipf("runtime jar not built yet (run mvn package): %v", err)
+		found := false
+		for _, name := range []string{"mochi-runtime-0.14.0.jar", "mochi-runtime-0.10.0-SNAPSHOT.jar"} {
+			jarPath := filepath.Join(repoRoot, "transpiler3", "jvm", "runtime", "target", name)
+			if _, err := os.Stat(jarPath); err == nil {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Skip("runtime jar not built yet (run: mvn -f transpiler3/jvm/runtime/pom.xml package -DskipTests -Dgpg.skip=true)")
 		}
 	})
 

--- a/transpiler3/jvm/build/uberjar.go
+++ b/transpiler3/jvm/build/uberjar.go
@@ -54,7 +54,7 @@ func PackUberJar(classDir, runtimeJar, outJar, mainClass string) error {
 	defer w.Close()
 
 	// Write MANIFEST.MF with fixed timestamp.
-	manifest := "Manifest-Version: 1.0\nMain-Class: " + mainClass + "\nImplementation-Version: 0.10.0\nBuilt-By: Mochi Transpiler\n"
+	manifest := "Manifest-Version: 1.0\nMain-Class: " + mainClass + "\nImplementation-Version: 0.14.0\nBuilt-By: Mochi Transpiler\n"
 	mfHeader := &zip.FileHeader{
 		Name:     "META-INF/MANIFEST.MF",
 		Method:   zip.Deflate,

--- a/website/docs/implementation/0047/index.md
+++ b/website/docs/implementation/0047/index.md
@@ -19,13 +19,13 @@ A phase is LANDED only when its gate is green on every target listed for it in M
 | 1 | Hello world | LANDED | — | [phase-01](/docs/implementation/0047/phase-01-hello) |
 | 2 | Primitives and control flow | LANDED | — | [phase-02](/docs/implementation/0047/phase-02-scalars) |
 | 3 | Collections | LANDED | — | [phase-03](/docs/implementation/0047/phase-03-collections) |
-| 4 | Records | NOT STARTED | — | [phase-04](/docs/implementation/0047/phase-04-records) |
-| 5 | Sum types and pattern matching | NOT STARTED | — | [phase-05](/docs/implementation/0047/phase-05-sums) |
-| 6 | Closures and higher-order functions | NOT STARTED | — | [phase-06](/docs/implementation/0047/phase-06-closures) |
-| 7 | Query DSL | NOT STARTED | — | [phase-07](/docs/implementation/0047/phase-07-query) |
-| 8 | Datalog | NOT STARTED | — | [phase-08](/docs/implementation/0047/phase-08-datalog) |
-| 9 | Agents (virtual threads, Loom) | NOT STARTED | — | [phase-09](/docs/implementation/0047/phase-09-agents) |
-| 10 | Streams | NOT STARTED | — | [phase-10](/docs/implementation/0047/phase-10-streams) |
+| 4 | Records | LANDED | — | [phase-04](/docs/implementation/0047/phase-04-records) |
+| 5 | Sum types and pattern matching | LANDED | — | [phase-05](/docs/implementation/0047/phase-05-sums) |
+| 6 | Closures and higher-order functions | LANDED | — | [phase-06](/docs/implementation/0047/phase-06-closures) |
+| 7 | Query DSL | LANDED | — | [phase-07](/docs/implementation/0047/phase-07-query) |
+| 8 | Datalog | LANDED | — | [phase-08](/docs/implementation/0047/phase-08-datalog) |
+| 9 | Agents (virtual threads, Loom) | LANDED | — | [phase-09](/docs/implementation/0047/phase-09-agents) |
+| 10 | Streams | LANDED | — | [phase-10](/docs/implementation/0047/phase-10-streams) |
 | 11 | async (Loom-backed) | LANDED | — | [phase-11](/docs/implementation/0047/phase-11-async) |
 | 12 | FFI (JVM interop) | LANDED | — | [phase-12](/docs/implementation/0047/phase-12-ffi) |
 | 13 | LLM (generate) | LANDED | — | [phase-13](/docs/implementation/0047/phase-13-llm) |

--- a/website/docs/implementation/0047/phase-18-maven-central.md
+++ b/website/docs/implementation/0047/phase-18-maven-central.md
@@ -18,7 +18,7 @@ description: "MEP-47 Phase 18 — publish mochi-runtime to Maven Central; PGP si
 
 ## Gate
 
-`TestPhase18Publish` (nightly): fetch `dev.mochi:mochi-runtime:0.10.0` from Maven Central, compile a test program against it, run, verify stdout. Performance dashboard updated with vm3 comparison.
+`TestPhase18Publish` (nightly): fetch `dev.mochi:mochi-runtime:0.14.0` from Maven Central, compile a test program against it, run, verify stdout. Performance dashboard updated with vm3 comparison.
 
 ## Goal-alignment audit
 
@@ -48,10 +48,10 @@ Maven Central is the default resolution repository for all Maven and Gradle buil
 2. **Deployment token**: Generate an API key in the Central portal's account settings. Store as `MAVEN_CENTRAL_TOKEN` CI secret.
 
 3. **Artifact bundle**: ZIP file containing:
-   - `dev/mochi/mochi-runtime/0.10.0/mochi-runtime-0.10.0.jar`
-   - `dev/mochi/mochi-runtime/0.10.0/mochi-runtime-0.10.0-sources.jar`
-   - `dev/mochi/mochi-runtime/0.10.0/mochi-runtime-0.10.0-javadoc.jar`
-   - `dev/mochi/mochi-runtime/0.10.0/mochi-runtime-0.10.0.pom`
+   - `dev/mochi/mochi-runtime/0.14.0/mochi-runtime-0.14.0.jar`
+   - `dev/mochi/mochi-runtime/0.14.0/mochi-runtime-0.14.0-sources.jar`
+   - `dev/mochi/mochi-runtime/0.14.0/mochi-runtime-0.14.0-javadoc.jar`
+   - `dev/mochi/mochi-runtime/0.14.0/mochi-runtime-0.14.0.pom`
    - `.asc` signatures for each (Phase 18.1)
 
 4. **Upload**: `POST https://central.sonatype.com/api/v1/publisher/upload` with `Authorization: Bearer $MAVEN_CENTRAL_TOKEN` and the bundle as a multipart form.
@@ -155,7 +155,7 @@ echo "$GPG_PRIVATE_KEY" | gpg --batch --import
 
 The key's fingerprint is published to `keys.openpgp.org` for user verification.
 
-**`.asc` files**: Each artifact gets a detached signature: `mochi-runtime-0.10.0.jar.asc`, `mochi-runtime-0.10.0.pom.asc`, etc. These are included in the deployment bundle.
+**`.asc` files**: Each artifact gets a detached signature: `mochi-runtime-0.14.0.jar.asc`, `mochi-runtime-0.14.0.pom.asc`, etc. These are included in the deployment bundle.
 
 ## Sub-phase 18.2 -- Performance benchmarks
 
@@ -230,12 +230,12 @@ Add LANDED rows to all phase tables in the MEP spec:
 - Agents on Loom virtual threads: 100K concurrent agents tested.
 - Full JDK 21+25 matrix across linux/amd64, linux/arm64, darwin/arm64, windows/amd64.
 
-**`TestPhase18Publish`** (nightly): Fetches `dev.mochi:mochi-runtime:0.10.0` from Maven Central (not the local build), compiles a minimal Mochi program against it, runs it, verifies stdout:
+**`TestPhase18Publish`** (nightly): Fetches `dev.mochi:mochi-runtime:0.14.0` from Maven Central (not the local build), compiles a minimal Mochi program against it, runs it, verifies stdout:
 
 ```go
 func TestPhase18Publish(t *testing.T) {
     if testing.Short() { t.Skip("skipping network test in -short mode") }
-    // Write a pom.xml that depends on dev.mochi:mochi-runtime:0.10.0
+    // Write a pom.xml that depends on dev.mochi:mochi-runtime:0.14.0
     // mvn compile exec:java -Dmain.class=dev.mochi.user.HelloMochi
     // Assert stdout == "hello, world\n"
 }


### PR DESCRIPTION
Closes #22359

Fixes found during post-implementation spec/code audit:

1. `uberjar.go:57` — manifest `Implementation-Version: 0.10.0` -> `0.14.0`
2. `phase00_test.go:29` — now checks `mochi-runtime-0.14.0.jar` first, falls back to `0.10.0-SNAPSHOT`
3. `index.md` — phases 4-10 corrected from NOT STARTED to LANDED (were implemented in earlier sessions, index was not updated)
4. `phase-18-maven-central.md` — replaced all remaining `0.10.0` artifact references with `0.14.0` (Gate, artifact bundle, .asc filenames, TestPhase18Publish docstring)

No logic changes. Build clean.