### PR TITLE
fix: CI green -- BEAM BIF clash, native-image --main-class, Windows sparse checkout

### DIFF
--- a/.github/workflows/jvm.yml
+++ b/.github/workflows/jvm.yml
@@ -21,7 +21,18 @@ jobs:
         java: ['21', '25']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        if: runner.os != 'Windows'
+      - uses: actions/checkout@v6
+        if: runner.os == 'Windows'
+        with:
+          sparse-checkout: |
+            transpiler3/jvm
+            transpiler3/c
+            tests/transpiler3/jvm
+            parser
+            types
+          sparse-checkout-cone-mode: true
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
@@ -39,7 +50,7 @@ jobs:
   native-image:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
@@ -57,7 +68,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'

--- a/.github/workflows/transpiler3-beam-test.yml
+++ b/.github/workflows/transpiler3-beam-test.yml
@@ -58,6 +58,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        if: runner.os != 'Windows'
+      - name: Checkout (Windows sparse)
+        uses: actions/checkout@v6
+        if: runner.os == 'Windows'
+        with:
+          sparse-checkout: |
+            transpiler3/beam
+            transpiler3/c
+            tests/transpiler3/beam
+            parser
+            types
+          sparse-checkout-cone-mode: true
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/transpiler3/beam/runtime/src/mochi_fetch.erl
+++ b/transpiler3/beam/runtime/src/mochi_fetch.erl
@@ -1,5 +1,6 @@
 -module(mochi_fetch).
 -export([get/1]).
+-compile({no_auto_import,[get/1]}).
 
 %% get/1 performs an HTTP GET on URL and returns the response body as a binary.
 %% Uses OTP's built-in httpc client (part of the inets application).

--- a/transpiler3/jvm/build/native.go
+++ b/transpiler3/jvm/build/native.go
@@ -17,12 +17,6 @@ func BuildNativeImage(outJar, outExe string) error {
 		return fmt.Errorf("native-image not found (install GraalVM or Liberica NIK): %w", err)
 	}
 
-	// Determine main class from jar manifest (we know the pattern: dev.mochi.user.XxxMochi).
-	mainClass, err := jarMainClass(outJar)
-	if err != nil {
-		return fmt.Errorf("native-image: %w", err)
-	}
-
 	args := []string{
 		"-jar", outJar,
 		"-H:Name=" + filepath.Base(outExe),
@@ -30,7 +24,6 @@ func BuildNativeImage(outJar, outExe string) error {
 		"--no-fallback",
 		"--initialize-at-build-time",
 		"-H:+ReportExceptionStackTraces",
-		"--main-class", mainClass,
 	}
 	cmd := exec.Command(niPath, args...)
 	cmd.Stdout = os.Stdout
@@ -51,18 +44,3 @@ func MeasureStartup(exe string) (time.Duration, error) {
 	return time.Since(start), err
 }
 
-// jarMainClass reads the Main-Class from a jar's manifest.
-func jarMainClass(jarPath string) (string, error) {
-	out, err := exec.Command("unzip", "-p", jarPath, "META-INF/MANIFEST.MF").Output()
-	if err != nil {
-		return "", fmt.Errorf("read manifest: %w", err)
-	}
-	for _, line := range splitLines(string(out)) {
-		line = trimSpace(line)
-		const prefix = "Main-Class:"
-		if len(line) > len(prefix) && line[:len(prefix)] == prefix {
-			return trimSpace(line[len(prefix):]), nil
-		}
-	}
-	return "", fmt.Errorf("Main-Class not found in manifest of %s", jarPath)
-}


### PR DESCRIPTION
Closes #22361

## Changes

- `transpiler3/beam/runtime/src/mochi_fetch.erl`: add `-compile({no_auto_import,[get/1]}).` to suppress pre-OTP-R14 auto-import clash with `erlang:get/1` BIF
- `transpiler3/jvm/build/native.go`: remove `--main-class` flag (invalid with `-jar`; manifest already specifies the main class)
- `.github/workflows/jvm.yml`: sparse checkout on Windows to avoid `tests/rosetta/` filenames with trailing `...` (invalid on Windows); bump all checkout steps to `actions/checkout@v6`
- `.github/workflows/transpiler3-beam-test.yml`: same sparse-checkout pattern for Windows matrix cells

## Test plan

- [ ] BEAM test matrix passes on all platforms (OTP 27/28/29 × linux/macos/windows)
- [ ] JVM native-image job passes
- [ ] JVM test matrix passes on all platforms (JDK 21/25 × 4 OS)