### PR TITLE
fix: Windows CI (NTFS illegal dirs), remove fragile sparse-checkout, fix mochi_llm Dialyzer

### DIFF
--- a/.github/workflows/jvm.yml
+++ b/.github/workflows/jvm.yml
@@ -22,18 +22,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-        if: runner.os != 'Windows'
-      - uses: actions/checkout@v6
-        if: runner.os == 'Windows'
-        with:
-          filter: tree:0
-          sparse-checkout: |
-            transpiler3/jvm
-            transpiler3/c
-            tests/transpiler3/jvm
-            parser
-            types
-          sparse-checkout-cone-mode: true
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'

--- a/.github/workflows/transpiler3-beam-test.yml
+++ b/.github/workflows/transpiler3-beam-test.yml
@@ -58,19 +58,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        if: runner.os != 'Windows'
-      - name: Checkout (Windows sparse)
-        uses: actions/checkout@v6
-        if: runner.os == 'Windows'
-        with:
-          filter: tree:0
-          sparse-checkout: |
-            transpiler3/beam
-            transpiler3/c
-            tests/transpiler3/beam
-            parser
-            types
-          sparse-checkout-cone-mode: true
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/transpiler3/beam/runtime/src/mochi_llm.erl
+++ b/transpiler3/beam/runtime/src/mochi_llm.erl
@@ -44,7 +44,7 @@ openai_or_anthropic(openai, Model, Prompt, Key) ->
         _    -> Model
     end,
     Body = json_encode_openai(EModel, Prompt),
-    Hdrs = [{"Authorization", "Bearer " ++ binary_to_list(Key)},
+    Hdrs = [{"Authorization", "Bearer " ++ Key},
             {"Content-Type", "application/json"}],
     case httpc:request(post,
             {"https://api.openai.com/v1/chat/completions", Hdrs,
@@ -70,7 +70,7 @@ openai_or_anthropic(anthropic, Model, Prompt, Key) ->
         _    -> Model
     end,
     Body = json_encode_anthropic(EModel, Prompt),
-    Hdrs = [{"x-api-key", binary_to_list(Key)},
+    Hdrs = [{"x-api-key", Key},
             {"anthropic-version", "2023-06-01"},
             {"Content-Type", "application/json"}],
     case httpc:request(post,


### PR DESCRIPTION
Closes #22365

## Three fixes in two commits

### Commit 1: rename NTFS-illegal directories + add filter:tree:0
- `tests/rosetta/x/Python/Eulers-constant-0.5772...` → `Eulers-constant-0.5772`
- `tests/rosetta/x/Python/Four-is-the-number-of-letters-in-the-...` → `Four-is-the-number-of-letters-in-the`

Windows NTFS forbids path components ending with `.`. Both directories end with `...`. This caused `git checkout` to fail with `invalid path` on every Windows CI job.

### Commit 2: remove Windows sparse-checkout + fix Dialyzer
**Sparse-checkout removal**: The sparse-checkout was only added as a workaround for the NTFS issue. After the rename it is no longer needed, and it introduced new failures (`mochi/diagnostic not in std`, `mochi/ast not in std`) because the transitive dependency list was incomplete and fragile to maintain. Both `jvm.yml` and `transpiler3-beam-test.yml` now do a full checkout on all platforms.

**Dialyzer fix** (`mochi_llm.erl`): `os:getenv/1` returns `string()` (a char list), not `binary()`. The code was calling `binary_to_list(Key)` on the API key on both the OpenAI path (line 47) and Anthropic path (line 73). `binary_to_list/1` expects `binary()` -- passing a `string()` breaks the contract. The key is already a list; use it directly in the header tuple. This fixes 4 Dialyzer warnings:
- 2× "will never return since it differs in the 4th argument"
- 2× "breaks the contract"
- Plus the derived "will never be called" warnings on `parse_openai_response` and `parse_anthropic_response`

## Test plan
- [ ] `Test (windows-latest)` passes
- [ ] `test (windows-2022, 21/25)` in JVM workflow pass
- [ ] BEAM transpiler tests pass on all platforms
- [ ] BEAM Dialyzer passes (zero warnings)