### PR TITLE
fix: Windows go build -- CRLF normalization, jit build tag, crosslang Maxrss

### DIFF
--- a/archived/jit_legacy/jit.go
+++ b/archived/jit_legacy/jit.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package jit
 
 import (

--- a/bench/crosslang/main.go
+++ b/bench/crosslang/main.go
@@ -17,10 +17,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -398,9 +396,7 @@ func runCmd(cat, prog string, n int, lang string, cmd *exec.Cmd) result {
 	err := cmd.Run()
 	_ = time.Since(start)
 	if cmd.ProcessState != nil {
-		if ru, ok := cmd.ProcessState.SysUsage().(*syscall.Rusage); ok && ru != nil {
-			r.MemoryBytes = maxrssBytes(int64(ru.Maxrss))
-		}
+		r.MemoryBytes = processMaxRSS(cmd.ProcessState)
 	}
 	if err != nil {
 		r.Err = fmt.Sprintf("%v: %s", err, strings.TrimSpace(stderr.String()))
@@ -419,13 +415,6 @@ func runCmd(cat, prog string, n int, lang string, cmd *exec.Cmd) result {
 	return r
 }
 
-// maxrssBytes normalizes getrusage maxrss across platforms.
-func maxrssBytes(raw int64) int64 {
-	if runtime.GOOS == "darwin" {
-		return raw // bytes on macOS
-	}
-	return raw * 1024 // kilobytes on Linux/BSD
-}
 
 // measure runs fn `runs` times and aggregates the results into one row.
 // We report the median because (1) it's robust to outliers from OS

--- a/bench/crosslang/mem_unix.go
+++ b/bench/crosslang/mem_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+)
+
+func processMaxRSS(ps *os.ProcessState) int64 {
+	if ps == nil {
+		return 0
+	}
+	ru, ok := ps.SysUsage().(*syscall.Rusage)
+	if !ok || ru == nil {
+		return 0
+	}
+	raw := int64(ru.Maxrss)
+	if runtime.GOOS == "darwin" {
+		return raw // bytes on macOS
+	}
+	return raw * 1024 // kilobytes on Linux/BSD
+}

--- a/bench/crosslang/mem_windows.go
+++ b/bench/crosslang/mem_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package main
+
+import "os"
+
+func processMaxRSS(_ *os.ProcessState) int64 { return 0 }

--- a/transpiler3/jvm/build/phase13_test.go
+++ b/transpiler3/jvm/build/phase13_test.go
@@ -61,8 +61,8 @@ func TestPhase13LLM(t *testing.T) {
 				t.Fatalf("java -jar: %v", err)
 			}
 
-			got := strings.TrimRight(stdout.String(), "\n")
-			wantStr := strings.TrimRight(string(want), "\n")
+			got := strings.TrimRight(stdout.String(), "\r\n")
+			wantStr := strings.TrimRight(string(want), "\r\n")
 			if got != wantStr {
 				t.Errorf("stdout mismatch\ngot:  %q\nwant: %q", got, wantStr)
 			}

--- a/transpiler3/jvm/build/phase14_test.go
+++ b/transpiler3/jvm/build/phase14_test.go
@@ -79,8 +79,8 @@ func TestPhase14Fetch(t *testing.T) {
 				t.Fatalf("java -jar: %v", err)
 			}
 
-			got := strings.TrimRight(stdout.String(), "\n")
-			wantStr := strings.TrimRight(string(want), "\n")
+			got := strings.TrimRight(stdout.String(), "\r\n")
+			wantStr := strings.TrimRight(string(want), "\r\n")
 			if got != wantStr {
 				t.Errorf("stdout mismatch\ngot:  %q\nwant: %q", got, wantStr)
 			}

--- a/transpiler3/jvm/build/phase15_test.go
+++ b/transpiler3/jvm/build/phase15_test.go
@@ -40,7 +40,7 @@ func TestPhase15UberJar(t *testing.T) {
 	}
 	elapsed := time.Since(start)
 
-	got := strings.TrimRight(stdout.String(), "\n")
+	got := strings.TrimRight(stdout.String(), "\r\n")
 	if got != "hello, world" {
 		t.Errorf("stdout mismatch: got %q want %q", got, "hello, world")
 	}
@@ -119,7 +119,7 @@ func TestPhase15JLink(t *testing.T) {
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("java (jlink image): %v", err)
 	}
-	if got := strings.TrimRight(stdout.String(), "\n"); got != "hello, world" {
+	if got := strings.TrimRight(stdout.String(), "\r\n"); got != "hello, world" {
 		t.Errorf("stdout: got %q want %q", got, "hello, world")
 	}
 }

--- a/transpiler3/jvm/build/phase16_test.go
+++ b/transpiler3/jvm/build/phase16_test.go
@@ -48,7 +48,7 @@ func TestPhase16NativeImage(t *testing.T) {
 	}
 	elapsed := time.Since(start)
 
-	got := strings.TrimRight(stdout.String(), "\n")
+	got := strings.TrimRight(stdout.String(), "\r\n")
 	if got != "hello, world" {
 		t.Errorf("stdout: got %q want %q", got, "hello, world")
 	}

--- a/transpiler3/jvm/build/phase17_test.go
+++ b/transpiler3/jvm/build/phase17_test.go
@@ -83,7 +83,7 @@ func TestPhase17Matrix(t *testing.T) {
 		t.Fatalf("java -jar: %v", err)
 	}
 
-	got := strings.TrimRight(stdout.String(), "\n")
+	got := strings.TrimRight(stdout.String(), "\r\n")
 	if got != "hello, world" {
 		t.Errorf("stdout: got %q want %q", got, "hello, world")
 	}

--- a/transpiler3/jvm/build/phase18_test.go
+++ b/transpiler3/jvm/build/phase18_test.go
@@ -65,7 +65,7 @@ public class HelloCheck {
 		t.Fatalf("java: %v", err)
 	}
 
-	got := strings.TrimRight(stdout.String(), "\n")
+	got := strings.TrimRight(stdout.String(), "\r\n")
 	if got != "hello, world" {
 		t.Errorf("stdout: got %q want %q", got, "hello, world")
 	}


### PR DESCRIPTION
Closes #22368

Three pre-existing Windows build/test failures now exposed after the checkout fix (PR #22367) landed.

## 1. JVM tests: CRLF normalization

Java's `System.out.println` uses `System.lineSeparator()` which is `\r\n` on Windows. The JVM test files used `strings.TrimRight(s, "\n")` which only strips `\n`, leaving a trailing `\r`. Changed to `strings.TrimRight(s, "\r\n")` in all six affected test files (phase13–18). Fixes `TestPhase14Fetch`, `TestPhase15UberJar`, `TestPhase15JLink`, `TestPhase17Matrix`, `TestPhase18Publish` on `windows-2022`.

## 2. archived/jit_legacy/jit.go: add `//go:build !windows`

Uses `syscall.Mmap`, `syscall.PROT_READ/WRITE/EXEC`, `syscall.MAP_ANON`, `syscall.MAP_PRIVATE` — all absent on Windows. JIT via `mmap` is a Unix-only feature; the file was missing the build constraint.

## 3. bench/crosslang: extract Maxrss into platform files

`syscall.Rusage.Maxrss` does not exist on Windows (`syscall.Rusage` is an empty struct there). Moved the memory measurement into:
- `bench/crosslang/mem_unix.go` (`!windows`): reads `ru.Maxrss`; normalises macOS (bytes) vs Linux/BSD (KB).
- `bench/crosslang/mem_windows.go` (`windows`): returns 0.
- `bench/crosslang/main.go`: calls `processMaxRSS(cmd.ProcessState)`; removed the now-unused `syscall`, `runtime` imports and the old `maxrssBytes` helper.

## Test plan
- [ ] `go build ./...` passes on Windows
- [ ] `Test (windows-latest)` passes
- [ ] `test (windows-2022, 21/25)` in JVM workflow pass
- [ ] All non-Windows jobs stay green