### PR TITLE
fix: Windows CI -- NTFS paths, CRLF, jit_legacy build tags, crosslang Maxrss

### DIFF
--- a/archived/jit_legacy/cmd/testprog/main.go
+++ b/archived/jit_legacy/cmd/testprog/main.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package main
 
 import (

--- a/archived/jit_legacy/exec.go
+++ b/archived/jit_legacy/exec.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package jit
 
 /*


### PR DESCRIPTION
Closes #22370

## What this fixes

Four independent Windows CI failures, fixed in sequence:

**1. NTFS-illegal directory names** (`tests/rosetta/x/Python/`)
Two dirs had names ending with `...` which Windows rejects as trailing-period paths. Renamed both via `git mv`.

**2. Dialyzer: `mochi_llm.erl`**
`os:getenv/1` returns `string()` (char list), not `binary()`. Removed `binary_to_list(Key)` wrapping that broke the Dialyzer contract.

**3. JVM Windows CRLF** (phase13–18 tests)
Java `System.out.println` uses `\r\n` on Windows. Changed `TrimRight(s, "\n")` → `TrimRight(s, "\r\n")` in all six JVM test files.

**4. `archived/jit_legacy` + `bench/crosslang` Windows build**
- `jit.go`, `exec.go`, `cmd/testprog/main.go`: added `//go:build !windows` (uses Unix-only `syscall.Mmap` and CGo)
- `bench/crosslang`: split `Maxrss` access into `mem_unix.go` / `mem_windows.go` (stub)