### PR TITLE
fix: normalize CRLF in golden.go for Windows CI

### DIFF
--- a/golden/golden.go
+++ b/golden/golden.go
@@ -342,6 +342,8 @@ func findRepoRoot(t *testing.T) string {
 // normalizeOutput strips paths for clean diffing.
 func normalizeOutput(root string, b []byte) []byte {
 	out := string(b)
+	// Normalize Windows line endings so golden files check out identically on all platforms.
+	out = strings.ReplaceAll(out, "\r\n", "\n")
 	// Strip absolute paths for stable diffs.
 	out = strings.ReplaceAll(out, filepath.ToSlash(root)+"/", "")
 	out = strings.ReplaceAll(out, filepath.ToSlash(root), "")


### PR DESCRIPTION
Closes #22372

On Windows, git `autocrlf` causes `.golden` files to be checked out with `\r\n` line endings. The parser produces output with `\n` only. `bytes.Equal` in `normalizeOutput` was failing on every `TestParser_ValidPrograms` subtest as a result.

**Fix**: add `strings.ReplaceAll(out, "\r\n", "\n")` at the start of `normalizeOutput` so both `got` and `want` are normalized before comparison.