### PR TITLE
fix: normalize backslash paths in golden normalizeOutput for Windows

### DIFF
--- a/golden/golden.go
+++ b/golden/golden.go
@@ -344,6 +344,9 @@ func normalizeOutput(root string, b []byte) []byte {
 	out := string(b)
 	// Normalize Windows line endings so golden files check out identically on all platforms.
 	out = strings.ReplaceAll(out, "\r\n", "\n")
+	// Normalize path separators: backslash → forward slash so path stripping
+	// works uniformly on Windows (where error messages embed native paths).
+	out = strings.ReplaceAll(out, `\`, "/")
 	// Strip absolute paths for stable diffs.
 	out = strings.ReplaceAll(out, filepath.ToSlash(root)+"/", "")
 	out = strings.ReplaceAll(out, filepath.ToSlash(root), "")


### PR DESCRIPTION
Closes #22374

On Windows, parser error messages embed native paths with backslashes (`D:\a\mochi\mochi\tests\...`). The existing `filepath.ToSlash(root)` stripping in `normalizeOutput` only handles forward-slash paths, so the absolute prefix was left in place and mismatched the golden files.

**Fix**: normalize `\` → `/` before the path stripping, so both `got` and `want` resolve to relative test paths on all platforms.