### PR TITLE
fix: normalize backslash paths in soundness_test for Windows CI

### DIFF
--- a/types/soundness_test.go
+++ b/types/soundness_test.go
@@ -85,6 +85,8 @@ func formatErrs(errs []error) string {
 var soundnessPathRE = regexp.MustCompile(`[^ \n\t]*tests/types/soundness/`)
 
 func normalizeSoundness(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, `\`, "/")
 	s = soundnessPathRE.ReplaceAllString(s, "tests/types/soundness/")
 	s = strings.TrimRight(s, "\n") + "\n"
 	return s


### PR DESCRIPTION
Closes the issue above. Adds `strings.ReplaceAll(s, `\\`, "/")` and `\r\n` normalization to `normalizeSoundness` in `types/soundness_test.go`.