### PR TITLE
fix: BEAM lower + mochi_str runtime for string/math builtins

### DIFF
--- a/transpiler3/beam/lower/lower.go
+++ b/transpiler3/beam/lower/lower.go
@@ -1518,6 +1518,100 @@ func lowerExpr(l *lowerer, expr aotir.Expr) (cerl.Expr, error) {
 	case *aotir.StrConvertExpr:
 		return lowerStrConvertExpr(l, e)
 
+	// String operations backed by mochi_str runtime.
+	case *aotir.StrIndexExpr:
+		recv, err := lowerExpr(l, e.Receiver)
+		if err != nil {
+			return nil, err
+		}
+		idx, err := lowerExpr(l, e.Index)
+		if err != nil {
+			return nil, err
+		}
+		return cerl.CCall(cerl.CAtom("mochi_str"), cerl.CAtom("index"), []cerl.Expr{recv, idx}), nil
+	case *aotir.StrSubstringExpr:
+		recv, err := lowerExpr(l, e.Receiver)
+		if err != nil {
+			return nil, err
+		}
+		start, err := lowerExpr(l, e.Start)
+		if err != nil {
+			return nil, err
+		}
+		end, err := lowerExpr(l, e.End)
+		if err != nil {
+			return nil, err
+		}
+		return cerl.CCall(cerl.CAtom("mochi_str"), cerl.CAtom("substring"), []cerl.Expr{recv, start, end}), nil
+	case *aotir.StrReverseExpr:
+		recv, err := lowerExpr(l, e.Receiver)
+		if err != nil {
+			return nil, err
+		}
+		return cerl.CCall(cerl.CAtom("mochi_str"), cerl.CAtom("reverse"), []cerl.Expr{recv}), nil
+	case *aotir.StrSplitExpr:
+		str, err := lowerExpr(l, e.Str)
+		if err != nil {
+			return nil, err
+		}
+		sep, err := lowerExpr(l, e.Sep)
+		if err != nil {
+			return nil, err
+		}
+		return cerl.CCall(cerl.CAtom("mochi_str"), cerl.CAtom("split"), []cerl.Expr{str, sep}), nil
+	case *aotir.StrJoinExpr:
+		list, err := lowerExpr(l, e.List)
+		if err != nil {
+			return nil, err
+		}
+		sep, err := lowerExpr(l, e.Sep)
+		if err != nil {
+			return nil, err
+		}
+		return cerl.CCall(cerl.CAtom("mochi_str"), cerl.CAtom("join"), []cerl.Expr{list, sep}), nil
+
+	// Phase 13.0 builtins: string length, case, contains.
+	case *aotir.StrLenExpr:
+		recv, err := lowerExpr(l, e.Receiver)
+		if err != nil {
+			return nil, err
+		}
+		return cerl.CCall(cerl.CAtom("mochi_str"), cerl.CAtom("len"), []cerl.Expr{recv}), nil
+	case *aotir.StrUpperExpr:
+		recv, err := lowerExpr(l, e.Receiver)
+		if err != nil {
+			return nil, err
+		}
+		return cerl.CCall(cerl.CAtom("mochi_str"), cerl.CAtom("upper"), []cerl.Expr{recv}), nil
+	case *aotir.StrLowerExpr:
+		recv, err := lowerExpr(l, e.Receiver)
+		if err != nil {
+			return nil, err
+		}
+		return cerl.CCall(cerl.CAtom("mochi_str"), cerl.CAtom("lower"), []cerl.Expr{recv}), nil
+	case *aotir.StrContainsExpr:
+		recv, err := lowerExpr(l, e.Receiver)
+		if err != nil {
+			return nil, err
+		}
+		sub, err := lowerExpr(l, e.Sub)
+		if err != nil {
+			return nil, err
+		}
+		return cerl.CCall(cerl.CAtom("mochi_str"), cerl.CAtom("contains"), []cerl.Expr{recv, sub}), nil
+
+	// Phase 13.0 builtins: abs, floor, ceil via MathCallExpr.
+	case *aotir.MathCallExpr:
+		return lowerMathCallExpr(l, e)
+
+	// int(x) cast: float → integer truncation toward zero.
+	case *aotir.NumCastExpr:
+		operand, err := lowerExpr(l, e.Operand)
+		if err != nil {
+			return nil, err
+		}
+		return cerl.CCall(cerl.CAtom("erlang"), cerl.CAtom("trunc"), []cerl.Expr{operand}), nil
+
 	// Phase 11.0: async expr → mochi_async:async(fun() -> Body end)
 	case *aotir.AsyncExpr:
 		return lowerAsyncExpr(l, e)
@@ -1550,6 +1644,28 @@ func lowerAwaitExpr(l *lowerer, e *aotir.AwaitExpr) (cerl.Expr, error) {
 		return nil, fmt.Errorf("beam/lower: await future: %w", err)
 	}
 	return cerl.CCall(cerl.CAtom("mochi_async"), cerl.CAtom("await"), []cerl.Expr{fut}), nil
+}
+
+// lowerMathCallExpr lowers abs/floor/ceil to Erlang built-ins.
+//   abs_i64  → erlang:abs(X)         (integer)
+//   abs_f64  → erlang:abs(X)         (float)
+//   floor    → math:floor(X)         (float → float)
+//   ceil     → math:ceil(X)          (float → float)
+func lowerMathCallExpr(l *lowerer, e *aotir.MathCallExpr) (cerl.Expr, error) {
+	arg, err := lowerExpr(l, e.Arg)
+	if err != nil {
+		return nil, fmt.Errorf("beam/lower: math call %s arg: %w", e.Func, err)
+	}
+	switch e.Func {
+	case "abs_i64", "abs_f64":
+		return cerl.CCall(cerl.CAtom("erlang"), cerl.CAtom("abs"), []cerl.Expr{arg}), nil
+	case "floor":
+		return cerl.CCall(cerl.CAtom("math"), cerl.CAtom("floor"), []cerl.Expr{arg}), nil
+	case "ceil":
+		return cerl.CCall(cerl.CAtom("math"), cerl.CAtom("ceil"), []cerl.Expr{arg}), nil
+	default:
+		return nil, fmt.Errorf("beam/lower: unknown MathCallExpr func %q", e.Func)
+	}
 }
 
 // lowerStrConvertExpr lowers str(x) to erlang:integer_to_binary/1,

--- a/transpiler3/beam/runtime/src/mochi_str.erl
+++ b/transpiler3/beam/runtime/src/mochi_str.erl
@@ -1,5 +1,6 @@
 -module(mochi_str).
--export([print_float/1, concat/2, index/2, substring/3, reverse/1, convert/1, split/2, join/2]).
+-export([print_float/1, concat/2, index/2, substring/3, reverse/1, convert/1, split/2, join/2,
+         len/1, upper/1, lower/1, contains/2]).
 
 %% print_float/1 prints a float using Go-compatible shortest-round-trip
 %% formatting, matching vm3's fmt.Println(f) output exactly.
@@ -100,3 +101,18 @@ split(S, Sep) ->
 join([], _Sep) -> <<>>;
 join([H | T], Sep) ->
     lists:foldl(fun(X, Acc) -> <<Acc/binary, Sep/binary, X/binary>> end, H, T).
+
+%% len/1 — byte length of a binary string (matches C strlen semantics).
+len(S) when is_binary(S) -> byte_size(S).
+
+%% upper/1 — convert binary string to uppercase.
+upper(S) when is_binary(S) ->
+    unicode:characters_to_binary(string:uppercase(unicode:characters_to_list(S))).
+
+%% lower/1 — convert binary string to lowercase.
+lower(S) when is_binary(S) ->
+    unicode:characters_to_binary(string:lowercase(unicode:characters_to_list(S))).
+
+%% contains/2 — true if binary S contains substring Sub.
+contains(S, Sub) when is_binary(S), is_binary(Sub) ->
+    binary:match(S, Sub) =/= nomatch.


### PR DESCRIPTION
Closes #22378

## What was missing

`transpiler3/beam/lower/lower.go` had no `case` for:
- `*aotir.StrLenExpr` → `mochi_str:len/1`
- `*aotir.StrUpperExpr` → `mochi_str:upper/1`
- `*aotir.StrLowerExpr` → `mochi_str:lower/1`
- `*aotir.StrContainsExpr` → `mochi_str:contains/2`
- `*aotir.MathCallExpr` → `erlang:abs/1` or `math:floor|ceil`
- `*aotir.NumCastExpr` (int() cast) → `erlang:trunc/1`

Also wired up preemptively: `StrIndexExpr`, `StrSubstringExpr`, `StrReverseExpr`, `StrSplitExpr`, `StrJoinExpr` (all backed by existing mochi_str exports).

## Runtime additions (`mochi_str.erl`)

Added `len/1`, `upper/1`, `lower/1`, `contains/2` functions and exported them.