### PR TITLE
fix: use 'escript <path>' instead of direct exec for Windows BEAM tests

### DIFF
--- a/transpiler3/beam/build/build_test.go
+++ b/transpiler3/beam/build/build_test.go
@@ -76,7 +76,10 @@ func runBeamFixture(t *testing.T, mochiPath, outPath string) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, escriptPath)
+	// On Windows the OS does not support shebang lines, so we cannot exec
+	// the escript file directly. Use `escript <path>` on all platforms for
+	// consistency; OTP's escript binary handles the archive format correctly.
+	cmd := exec.CommandContext(ctx, "escript", escriptPath)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = os.Stderr

--- a/transpiler3/beam/build/phase13_2_live_test.go
+++ b/transpiler3/beam/build/phase13_2_live_test.go
@@ -52,7 +52,8 @@ func TestPhase13_2LiveProviderRouting(t *testing.T) {
 		t.Fatalf("Driver.Build: %v", err)
 	}
 
-	cmd := exec.Command(escriptPath)
+	// Use `escript <path>` for Windows compatibility (no shebang support).
+	cmd := exec.Command("escript", escriptPath)
 	// No MOCHI_LLM_CASSETTE_DIR; inject a fake key so live path is taken.
 	cmd.Env = append(os.Environ(), "OPENAI_API_KEY=fake-key-for-routing-test",
 		"MOCHI_LLM_CASSETTE_DIR=")

--- a/transpiler3/beam/build/phase14_test.go
+++ b/transpiler3/beam/build/phase14_test.go
@@ -93,7 +93,8 @@ func runFetchFixture(t *testing.T, script, want string) {
 		t.Fatalf("Driver.Build: %v", err)
 	}
 
-	cmd := exec.Command(escriptPath)
+	// Use `escript <path>` for Windows compatibility (no shebang support).
+	cmd := exec.Command("escript", escriptPath)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Closes #22382

## Summary
- Change all BEAM test escript invocations from `exec.Command(escriptPath)` to `exec.Command("escript", escriptPath)`
- Windows doesn't support shebang lines; direct execution fails with `%1 is not a valid Win32 application`
- Using the `escript` launcher works uniformly on Windows, macOS, and Linux

## Test plan
- [ ] BEAM test (OTP 27 / windows-latest) should now pass
- [ ] BEAM test (OTP 28 / windows-latest) should now pass
- [ ] All existing Linux/macOS matrix legs continue to pass