### PR TITLE
fix: normalize CRLF in BEAM golden-file comparisons for Windows

### DIFF
--- a/transpiler3/beam/build/build_test.go
+++ b/transpiler3/beam/build/build_test.go
@@ -10,6 +10,12 @@ import (
 	"time"
 )
 
+// normalizeLF strips carriage returns so golden-file comparisons work on
+// Windows, where git checks out text files with CRLF line endings.
+func normalizeLF(b []byte) []byte {
+	return bytes.ReplaceAll(b, []byte("\r\n"), []byte("\n"))
+}
+
 // repoRoot walks up from the test binary's working directory until
 // it finds go.mod, then returns that directory. Failing to find
 // go.mod is fatal: the build cannot proceed without the repo root.
@@ -95,7 +101,8 @@ func runBeamFixture(t *testing.T, mochiPath, outPath string) {
 		t.Fatalf("run escript %s: %v", escriptPath, err)
 	}
 
-	got := stdout.Bytes()
+	got := normalizeLF(stdout.Bytes())
+	want = normalizeLF(want)
 	if !bytes.Equal(got, want) {
 		t.Errorf("stdout mismatch for %s\ngot:  %q\nwant: %q", mochiPath, got, want)
 	}


### PR DESCRIPTION
Closes #22384

## Summary
- Add `normalizeLF` helper in `build_test.go` that strips `\r` from bytes
- Apply it to both `got` (escript stdout) and `want` (`.out` file) before `bytes.Equal`
- Windows git checks out text files as CRLF; escript emits LF — this mismatch caused every BEAM phase test to fail on Windows OTP 27/28

## Test plan
- [ ] BEAM test (OTP 27 / windows-latest) should now pass all phase tests
- [ ] BEAM test (OTP 28 / windows-latest) should now pass all phase tests
- [ ] All Linux/macOS matrix legs unaffected (LF → LF, no change)