### PR TITLE
fix: filepath.ToSlash in cerl_test evalETF for Windows

### DIFF
--- a/transpiler3/beam/cerl/cerl_test.go
+++ b/transpiler3/beam/cerl/cerl_test.go
@@ -35,8 +35,9 @@ func evalETF(t *testing.T, erl string, etfBytes []byte) error {
 	if err := os.WriteFile(etfPath, etfBytes, 0o644); err != nil {
 		return err
 	}
+	etfFwd := filepath.ToSlash(etfPath)
 	script := `
-{ok, B} = file:read_file("` + etfPath + `"),
+{ok, B} = file:read_file("` + etfFwd + `"),
 _ = binary_to_term(B),
 halt(0).`
 	cmd := exec.Command(erl, "-noshell", "-eval", script)


### PR DESCRIPTION
Closes the cerl_test Windows path issue.

## Summary
- Apply `filepath.ToSlash` before embedding temp-file path in Erlang eval expression
- Without this, Windows backslash paths become corrupted escape sequences inside Erlang double-quoted strings

## Test plan
- [ ] TestCerlETFRoundTrip should pass on Windows OTP 27/28