### PR TITLE
ci: upgrade GitHub Actions to v6 + fix APE cosmocc install

### DIFF
--- a/.github/workflows/jvm-publish.yml
+++ b/.github/workflows/jvm-publish.yml
@@ -12,7 +12,7 @@ jobs:
   publish:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v4
         with:
           java-version: '21'
@@ -37,8 +37,8 @@ jobs:
     needs: publish
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
       - uses: actions/setup-java@v4

--- a/.github/workflows/jvm-repro.yml
+++ b/.github/workflows/jvm-repro.yml
@@ -9,8 +9,8 @@ jobs:
   diffoscope:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
       - uses: actions/setup-java@v4

--- a/.github/workflows/jvm.yml
+++ b/.github/workflows/jvm.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
       - uses: actions/setup-java@v4
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
       - uses: graalvm/setup-graalvm@v1
@@ -58,7 +58,7 @@ jobs:
     if: github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
       - uses: actions/setup-java@v4

--- a/.github/workflows/transpiler3-c-apex.yml
+++ b/.github/workflows/transpiler3-c-apex.yml
@@ -54,21 +54,18 @@ jobs:
           path: ~/.mochi/cache/cosmocc
           key: cosmocc-3.9.5
 
-      - name: Download cosmocc via Ensure()
-        env:
-          MOCHI_COSMOCC_VENDOR_TEST: '1'
-        run: |
-          go test -vet=off -v -count=1 -timeout=600s \
-            ./transpiler3/c/build/ -run TestPhase13CosmoVendor/ensure_cached
-
-      - name: Resolve cosmocc path
+      - name: Download and install cosmocc
         id: cosmocc
         run: |
-          BIN=$(ls ~/.mochi/cache/cosmocc/3.9.5/bin/cosmocc 2>/dev/null || true)
-          if [ -z "$BIN" ]; then
-            echo "cosmocc binary not found after Ensure(); aborting"
-            exit 1
+          DEST="$HOME/.mochi/cache/cosmocc/3.9.5"
+          BIN="$DEST/bin/cosmocc"
+          if [ ! -f "$BIN" ]; then
+            mkdir -p "$DEST"
+            curl -fsSL https://cosmo.zip/pub/cosmocc/cosmocc-3.9.5.zip -o /tmp/cosmocc.zip
+            unzip -q /tmp/cosmocc.zip -d "$DEST"
+            chmod +x "$BIN"
           fi
+          echo "cosmocc installed at $BIN"
           echo "path=$BIN" >> "$GITHUB_OUTPUT"
 
       - name: Build APE binary (add_ints)

--- a/.github/workflows/transpiler3-c-bench-report.yml
+++ b/.github/workflows/transpiler3-c-bench-report.yml
@@ -21,9 +21,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/transpiler3-c-release-sha256.yml
+++ b/.github/workflows/transpiler3-c-release-sha256.yml
@@ -30,9 +30,9 @@ jobs:
             runner: macos-13
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -68,7 +68,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download all checksum artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Closes #22394

## Summary
- Upgrade `actions/checkout@v4` → `@v6` and `actions/setup-go@v5` → `@v6` across all workflows (fixes Node.js 20 deprecation warnings)
- Replace fragile `TestPhase13CosmoVendor/ensure_cached` cosmocc download in `transpiler3-c-apex.yml` with direct `curl -fsSL ... | unzip` so the binary is reliably present before the build step

## Test plan
- CI passes on all matrix legs for each affected workflow
- APE build step finds cosmocc at `~/.mochi/cache/cosmocc/3.9.5/bin/cosmocc`