### PR TITLE
mep-0048 docs: correct fixture counts in phase 4-8 and phase 16 docs

### DIFF
--- a/releases/v0.15.0.md
+++ b/releases/v0.15.0.md
@@ -291,9 +291,9 @@ responses throw `MochiPanic("MOCHI_ERR_HTTP", status)`.
 Three MSBuild properties make `.dll` files bit-identical across
 machines: `<Deterministic>true</Deterministic>`,
 `<PathMap>$(MSBuildProjectDirectory)=/_/</PathMap>`,
-`<DebugType>none</DebugType>`. `TestPhase16Repro` builds the same
-fixture twice in separate temp directories and compares SHA-256 of
-every PE section byte-for-byte.
+`<DebugType>none</DebugType>`. `TestPhase16Reproducible` builds all 5
+Phase 1 fixtures twice in separate temp directories and compares
+SHA-256 of every `.dll` file byte-for-byte.
 
 ### 1.17 Self-contained packaging across RIDs (Phase 17)
 
@@ -334,7 +334,7 @@ NuGet via `dotnet nuget push`:
 | `TestPhase13LLM` | 13 | cassette playback; structured output |
 | `TestPhase14Fetch` | 14 | HTTP GET; json_decode |
 | `TestPhase15NativeAot` | 15 | 6 fixtures; gated on `MOCHI_TEST_AOT=1` |
-| `TestPhase16Repro` | 16 | two builds; SHA-256 bit-identical |
+| `TestPhase16Reproducible` | 16 | 5 Phase 1 fixtures built twice; SHA-256 bit-identical |
 | `TestPhase17SelfContained` | 17 | 4 fixtures on host RID |
 | `TestPhase18Publish` | 18 | gated on `MOCHI_TEST_TRIM=1` |
 

--- a/website/docs/implementation/0048/phase-04-records.md
+++ b/website/docs/implementation/0048/phase-04-records.md
@@ -18,7 +18,7 @@ description: "MEP-48 Phase 4 — record types to sealed record class / readonly 
 
 ## Gate
 
-`TestPhase4Records`: 25 fixtures green on net8.0 and net10.0.
+`TestPhase4Records`: 14 fixtures green on net8.0 and net10.0.
 
 ## Goal-alignment audit
 
@@ -98,13 +98,12 @@ Methods on `readonly record struct` work the same way; they are `public` instanc
 | File | Purpose |
 |------|---------|
 | `transpiler3/dotnet/lower/lower.go` | Record type → `sealed record` / `readonly record struct` decision + emission; field type mapping; record literal `{ x: 1, y: 2 }` → `new Point(1L, 2L)`; update `{ r with x: 3 }` → `r with { X = 3L }` |
-| `transpiler3/dotnet/build/phase04_test.go` | `TestPhase4Records`: 25 fixtures |
-| `tests/transpiler3/dotnet/fixtures/phase04-records/` | 25 fixture directories |
+| `transpiler3/dotnet/build/phase04_test.go` | `TestPhase4Records`: 14 fixtures |
+| `tests/transpiler3/dotnet/fixtures/phase04-records/` | 14 fixture directories |
 
 ## Test set
 
-- `TestPhase4Records` -- 25 fixtures: point creation, point access, point equality, record with method, record update, record in list, record in map, nested records (record containing record), record as function argument/return, record with string field, record with bool field, record struct elision (Point → struct), struct equality, struct in list, struct array, record comparison, record destructuring in pattern (prep for Phase 5), multi-field record (5+ fields stays class), record with Option field (placeholder for Phase 5), record printed via ToString.
-- `TestRecordEqualityVm3` -- differential gate: all 25 fixtures byte-equal vs vm3.
+- `TestPhase4Records` -- 14 fixtures: record_basic, record_bool_field, record_eq_false, record_eq_true, record_field_arith, record_float_field, record_fn_arg, record_fn_return, record_in_if, record_in_list, record_single_field, record_string_field, record_two_types, record_var_reassign.
 
 ## Deferred work
 

--- a/website/docs/implementation/0048/phase-05-sums.md
+++ b/website/docs/implementation/0048/phase-05-sums.md
@@ -18,7 +18,7 @@ description: "MEP-48 Phase 5 — sum types to abstract record + sealed record va
 
 ## Gate
 
-`TestPhase5Sums`: 25 fixtures green on net8.0 and net10.0.
+`TestPhase5Sums`: 4 fixtures green on net8.0 and net10.0.
 
 ## Goal-alignment audit
 
@@ -132,12 +132,12 @@ Both diagnostics are planned as Roslyn `DiagnosticAnalyzer` in `Mochi.Analyzers`
 | `transpiler3/dotnet/runtime/Mochi.Runtime/Types/Result.cs` | `Result<T,E>`, `Ok<T,E>`, `Err<T,E>` |
 | `transpiler3/dotnet/runtime/Mochi.Runtime/Types/MochiUnionAttribute.cs` | `[MochiUnion]` attribute definition |
 | `transpiler3/dotnet/runtime/Mochi.Runtime/Errors/MochiMatchExhaustivityError.cs` | Runtime catch-all exception |
-| `transpiler3/dotnet/build/phase05_test.go` | `TestPhase5Sums`: 25 fixtures |
-| `tests/transpiler3/dotnet/fixtures/phase05-sums/` | 25 fixture directories |
+| `transpiler3/dotnet/build/phase05_test.go` | `TestPhase5Sums`: 4 fixtures |
+| `tests/transpiler3/dotnet/fixtures/phase05-sums/` | 4 fixture directories |
 
 ## Test set
 
-- `TestPhase5Sums` -- 25 fixtures: circle/rect area, option some/none, result ok/err, nested match, guard match, list pattern empty, list pattern head/tail, exhaustive shape match, option chain, result unwrap, recursive sum type (tree), json-like ADT, match on string literal, match on int literal, match with when guard, nested option, option map/flatMap (implemented as match), result map/flatMap, multi-variant match, wildcard arm, sum type in list, sum type as record field, Option<string> fast path (nullable), sum type printed via ToString, match result in loop.
+- `TestPhase5Sums` -- 4 fixtures (sum_basic, sum_function, sum_nullary, sum_string_result).
 
 ## Deferred work
 

--- a/website/docs/implementation/0048/phase-06-closures.md
+++ b/website/docs/implementation/0048/phase-06-closures.md
@@ -18,7 +18,7 @@ description: "MEP-48 Phase 6 — fun(...) => to Func<>/Action<> delegates; mutab
 
 ## Gate
 
-`TestPhase6Funs`: 25 fixtures green on net8.0 and net10.0.
+`TestPhase6Closures`: 6 fixtures green on net8.0 and net10.0.
 
 ## Goal-alignment audit
 
@@ -127,13 +127,12 @@ These are used in Phase 7 (query DSL generates partial applications of predicate
 | `transpiler3/dotnet/runtime/Mochi.Runtime/Func/MutableCell.cs` | Mutable cell for var captures |
 | `transpiler3/dotnet/runtime/Mochi.Runtime/Func/Func17.cs` | High-arity delegate types (Func17..Func32) |
 | `transpiler3/dotnet/runtime/Mochi.Runtime/Func/CurryHelpers.cs` | Curry / uncurry / partial apply |
-| `transpiler3/dotnet/build/phase06_test.go` | `TestPhase6Funs`: 25 fixtures |
-| `tests/transpiler3/dotnet/fixtures/phase06-closures/` | 25 fixture directories |
+| `transpiler3/dotnet/build/phase06_test.go` | `TestPhase6Closures`: 6 fixtures |
+| `tests/transpiler3/dotnet/fixtures/phase06-closures/` | 6 fixture directories |
 
 ## Test set
 
-- `TestPhase6Funs` -- 25 fixtures: identity function, add function, double function, closure over let, closure over var (counter), higher-order map, higher-order filter, compose, partial application, two-arg lambda, three-arg lambda, curried add, closure returned from function, callback pattern, adder factory, accumulator via mutable cell, map with closure, filter with closure, fold (reduce), function as record field, option map via closure, function composition chain, closure in match arm, lambda as argument to lambda, higher-arity (17-arg) function.
-- `TestClosureSemantics` -- unit tests verifying capture semantics: let-capture does not observe post-creation mutation; var-capture via MutableCell does.
+- `TestPhase6Closures` -- 6 fixtures (closure_capture, hof_filter, hof_map, hof_reduce, lambda_as_arg, lambda_basic).
 
 ## Deferred work
 

--- a/website/docs/implementation/0048/phase-07-query.md
+++ b/website/docs/implementation/0048/phase-07-query.md
@@ -18,7 +18,7 @@ description: "MEP-48 Phase 7 — query DSL to LINQ method syntax; group_by, join
 
 ## Gate
 
-`TestPhase7Query`: 30 fixtures green on net8.0 and net10.0.
+`TestPhase7Query`: 10 fixtures green on net8.0 and net10.0.
 
 ## Goal-alignment audit
 
@@ -145,12 +145,12 @@ Consumed with `await foreach (var x in result) { ... }`.
 |------|---------|
 | `transpiler3/dotnet/lower/lower.go` | Query DSL → LINQ method chain lowering |
 | `transpiler3/dotnet/runtime/Mochi.Runtime/Query/` | Window function helpers (Lag, Lead, RollingWindow, RowNumber) |
-| `transpiler3/dotnet/build/phase07_test.go` | `TestPhase7Query`: 30 fixtures |
-| `tests/transpiler3/dotnet/fixtures/phase07-query/` | 30 fixture directories |
+| `transpiler3/dotnet/build/phase07_test.go` | `TestPhase7Query`: 10 fixtures |
+| `tests/transpiler3/dotnet/fixtures/phase07-query/` | 10 fixture directories |
 
 ## Test set
 
-- `TestPhase7Query` -- 30 fixtures: simple filter, simple projection, chained filter+projection, group_by sum, group_by count, order_by asc, order_by desc, order_by multi-key, take, skip, take+skip, inner join, left_join, left_join missing, aggregate sum/avg/min/max, count, distinct, flat_map (SelectMany), zip, window_lag, window_lead, rolling_window, parallel filter, parallel map, parallel group, async filter, async projection, async group_by, mixed sync source with async predicate, empty source.
+- `TestPhase7Query` -- 10 fixtures (query_empty_result, query_filter, query_filter_select, query_group_by, query_no_where, query_select, query_skip, query_skip_take, query_sort, query_take).
 
 ## Deferred work
 

--- a/website/docs/implementation/0048/phase-08-datalog.md
+++ b/website/docs/implementation/0048/phase-08-datalog.md
@@ -2,7 +2,7 @@
 title: "Phase 8. Datalog"
 sidebar_position: 10
 sidebar_label: "Phase 8. Datalog"
-description: "MEP-48 Phase 8 — fact/rule/query lowering to Mochi.Runtime.Datalog; semi-naive evaluator; 20 fixtures."
+description: "MEP-48 Phase 8 — fact/rule/query lowering to Mochi.Runtime.Datalog; semi-naive evaluator; 6 fixtures."
 ---
 
 # Phase 8. Datalog
@@ -18,7 +18,7 @@ description: "MEP-48 Phase 8 — fact/rule/query lowering to Mochi.Runtime.Datal
 
 ## Gate
 
-`TestPhase8Datalog`: 20 fixtures green on net8.0 and net10.0.
+`TestPhase8Datalog`: 6 fixtures green on net8.0 and net10.0.
 
 ## Goal-alignment audit
 
@@ -87,12 +87,12 @@ The evaluator is single-threaded and in-memory (no RETE network in Phase 8). Suf
 | `transpiler3/dotnet/runtime/Mochi.Runtime/Datalog/Engine.cs` | Semi-naive evaluator, fact store, rule application |
 | `transpiler3/dotnet/runtime/Mochi.Runtime/Datalog/DatalogTerm.cs` | `Const` / `Var` term discriminated union |
 | `transpiler3/dotnet/runtime/Mochi.Runtime/Datalog/DatalogTuple.cs` | Binding environment |
-| `transpiler3/dotnet/build/phase08_test.go` | `TestPhase8Datalog`: 20 fixtures |
-| `tests/transpiler3/dotnet/fixtures/phase08-datalog/` | 20 fixture directories |
+| `transpiler3/dotnet/build/phase08_test.go` | `TestPhase8Datalog`: 6 fixtures |
+| `tests/transpiler3/dotnet/fixtures/phase08-datalog/` | 6 fixture directories |
 
 ## Test set
 
-- `TestPhase8Datalog` -- 20 fixtures: parent/ancestor, sibling, grandparent, multi-hop path, graph reachability, mutual recursion, multiple rules per head, query with multiple vars, query with all constants, rule with multiple body atoms, stratified negation (if supported), empty result, single-fact query, multi-step chain (depth 5), join in rule body, rule fan-out, same-generation, symmetric relation, transitive relation, fact retraction (if supported in Phase 8).
+- `TestPhase8Datalog` -- 6 fixtures (dl_ancestor, dl_connected, dl_facts_grandparent, dl_negation, dl_parent_basic, dl_sibling).
 
 ## Deferred work
 

--- a/website/docs/implementation/0048/phase-16-repro.md
+++ b/website/docs/implementation/0048/phase-16-repro.md
@@ -18,7 +18,7 @@ description: "MEP-48 Phase 16 — Roslyn /deterministic; Deterministic=true; Sou
 
 ## Gate
 
-`TestPhase16Reproducible`: bit-identical `.dll` files verified on 3 Phase 1 fixtures (hello, hello_bool, hello_int) using `<Deterministic>true</Deterministic>` + `<PathMap>` + `<DebugType>none</DebugType>`. Cross-host comparison, `diffoscope` sweep, and NativeAOT reproducibility (sub-phases 16.1-16.4) are deferred.
+`TestPhase16Reproducible`: bit-identical `.dll` files verified on 5 Phase 1 fixtures (hello, hello_bool, hello_fx, hello_int, hello_newline) using `<Deterministic>true</Deterministic>` + `<PathMap>` + `<DebugType>none</DebugType>`. Cross-host comparison, `diffoscope` sweep, and NativeAOT reproducibility (sub-phases 16.1-16.4) are deferred.
 
 ## Goal-alignment audit
 
@@ -124,7 +124,7 @@ func CompileInProcess(cu *csharpsrc.CompilationUnit, outDll string) error {
 
 ## Test set
 
-- `TestPhase16Reproducible` -- 3 Phase 1 fixtures (hello, hello_bool, hello_int) built twice; SHA-256 of `.dll` outputs compared.
+- `TestPhase16Reproducible` -- 5 Phase 1 fixtures (hello, hello_bool, hello_fx, hello_int, hello_newline) built twice; SHA-256 of `.dll` outputs compared.
 
 ## Deferred work
 


### PR DESCRIPTION
Closes #22438

## Summary

- Phases 4-8 Gate/Files/Test-set sections had aspirational fixture counts from the planning phase; correct them to match what actually shipped and was verified by the audit test run
- Phase 16 repro doc said 3 Phase 1 fixtures; the test reads the phase01-hello/ directory which has 5 fixtures after the audit PR added hello_fx and hello_newline
- releases/v0.15.0.md aligned to the same corrected counts

## Changes

| Phase | Doc claimed | Corrected |
|-------|------------|-----------|
| 4 (records) | 25 fixtures | 14 (list all 14 names) |
| 5 (sums) | 25 fixtures | 4 (sum_basic, sum_function, sum_nullary, sum_string_result) |
| 6 (closures) | TestPhase6Funs: 25 | TestPhase6Closures: 6 (list all 6 names) |
| 7 (query) | 30 fixtures | 10 (list all 10 query_* names) |
| 8 (datalog) | 20 fixtures | 6 (list all 6 dl_* names) |
| 16 (repro) | 3 Phase 1 fixtures | 5 (hello, hello_bool, hello_fx, hello_int, hello_newline) |

## Test plan

- No code changes; docs only
- All 119 sub-tests verified PASS on main before this branch