### PR TITLE
mep-0049 docs: comprehensive per-phase implementation tracking pages

### DIFF
--- a/website/docs/implementation/0049/index.md
+++ b/website/docs/implementation/0049/index.md
@@ -37,4 +37,26 @@ A phase is LANDED only when its gate is green on every target listed for it in M
 | 17    | Static Linux SDK single binary                   | NOT STARTED | n/a    |
 | 18    | App Store / Mac App Store validation             | NOT STARTED | n/a    |
 
-Per-phase tracking pages will be added as phases open.
+Per-phase tracking pages:
+
+- [Phase 1. Hello world](phase-01-hello.md)
+- [Phase 2. Scalars](phase-02-scalars.md)
+- [Phase 3.1. Lists](phase-03-lists.md)
+- [Phase 3.2. Maps](phase-03-maps.md)
+- [Phase 3.3. Sets](phase-03-sets.md)
+- [Phase 3.4. List of records](phase-03-list-of-records.md)
+- [Phase 4. Records](phase-04-records.md)
+- [Phase 5. Sum types and pattern matching](phase-05-sums.md)
+- [Phase 6. Closures and higher-order functions](phase-06-closures.md)
+- [Phase 7. Query DSL](phase-07-query.md)
+- [Phase 8. Datalog](phase-08-datalog.md)
+- [Phase 9. Agents (actor + AsyncStream)](phase-09-agents.md)
+- [Phase 10. Streams (AsyncSequence)](phase-10-streams.md)
+- [Phase 11. Async colouring and typed throws](phase-11-async.md)
+- [Phase 12. FFI (module maps, @_silgen_name)](phase-12-ffi.md)
+- [Phase 13. LLM (FoundationModels on Apple)](phase-13-llm.md)
+- [Phase 14. fetch (URLSession)](phase-14-fetch.md)
+- [Phase 15. iOS app bundle (.ipa via xcodebuild)](phase-15-ios.md)
+- [Phase 16. Reproducible build](phase-16-repro.md)
+- [Phase 17. Static Linux SDK single binary](phase-17-static-linux.md)
+- [Phase 18. App Store / Mac App Store validation](phase-18-appstore.md)

--- a/website/docs/implementation/0049/phase-01-hello.md
+++ b/website/docs/implementation/0049/phase-01-hello.md
@@ -1,0 +1,188 @@
+---
+title: "Phase 1. Hello world"
+sidebar_position: 2
+sidebar_label: "Phase 1. Hello world"
+description: "MEP-49 Phase 1 — end-to-end pipeline from print(\"hello, world\") to a runnable Swift binary on Linux x64; sxtree shadow AST; swiftc invocation."
+---
+
+# Phase 1. Hello world
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 1](/docs/mep/mep-0049#phase-1-hello-world) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase1Hello`: 5 fixtures green on Swift 6.0 and 6.1, linux-x64. Secondary gate: `TestSwiftcClean` (zero warnings under `-strict-concurrency=complete -warnings-as-errors -swift-version 6`). `TestSwiftFormatFixedPoint` (swift-format idempotent on emitted source).
+
+Fixtures:
+1. `hello.mochi`: `print("hello, world")` → stdout `hello, world\n`
+2. `hello_int.mochi`: `print(42)` → stdout `42\n`
+3. `hello_bool.mochi`: `print(true)` → stdout `true\n`
+4. `hello_float.mochi`: `print(3.14)` → stdout `3.14\n`
+5. `hello_newline.mochi`: `print("line1\nline2")` → two lines
+
+## Goal-alignment audit
+
+Phase 1 is the first point where the Swift transpiler produces a real runnable binary. Before Phase 1, the Go packages are stubs. After Phase 1, a user can run `mochi build --target=swift-linux hello.mochi` and get a binary that prints text and exits 0. This proves the pipeline (parser → typechecker → aotir → lower → sxtree → swift-format → swiftc) works end-to-end. Every later phase extends Phase 1's pipeline without replacing it.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 1.0 | `print("hello, world")` end-to-end: aotir → sxtree nodes → `.swift` source → `swift build` → binary | NOT STARTED | — |
+| 1.1 | `print(int)`, `print(bool)`, `print(float)` -- scalar types via `MochiRuntime.Print` | NOT STARTED | — |
+| 1.2 | `swift-format --in-place` post-processing; `TestSwiftFormatFixedPoint` gate | NOT STARTED | — |
+| 1.3 | `TestSwiftcClean` gate: zero warnings under `-strict-concurrency=complete -warnings-as-errors` | NOT STARTED | — |
+
+## Sub-phase 1.0 -- End-to-end pipeline
+
+### Decisions made (1.0)
+
+**Pipeline entry point**: `Driver.Build(src, outDir string, target Target)` in `transpiler3/swift/build/build.go`:
+1. `parser.Parse(src)` → AST
+2. `types.Check(ast)` → typed AST
+3. `aotir.Lower(typed)` → `*aotir.Program` (reused from MEP-45, unchanged)
+4. `lower.Lower(prog)` → `*sxtree.SourceFile` (Go shadow AST for Swift)
+5. `emit.Emit(sf, workDir)` → writes `.swift` source files
+6. `swift.Format(workDir)` → runs `swift-format --in-place` on every `.swift`
+7. `swift.Build(workDir, outDir, target)` → calls `swift build` subprocess via generated `Package.swift`
+
+**sxtree -- Go shadow AST for Swift**: package `github.com/mochilang/mochi/transpiler3/swift/sxtree`. Each node has a `Render(w *Writer)` method that writes canonical Swift. No dependency on Apple's `swift-syntax` library at Go compilation time. Example node:
+
+```go
+// in transpiler3/swift/sxtree/decl.go
+type FunctionDecl struct {
+    Attributes   []Attribute
+    Modifiers    []Modifier
+    Name         Identifier
+    Generics     *GenericParameterClause
+    Params       ParameterClause
+    Effects      EffectSpecifiers
+    ReturnType   *TypeSyntax
+    WhereClause  *GenericWhereClause
+    Body         *CodeBlock
+}
+
+func (f *FunctionDecl) Render(w *Writer) {
+    for _, a := range f.Attributes { a.Render(w) }
+    // ...
+}
+```
+
+**Lowering of `print("hello, world")`**: `aotir.PrintStmt` with a `StringLit` lowers to a `FunctionCallExpr` targeting `MochiRuntime.print`:
+
+```swift
+// Emitted for hello.mochi:
+import MochiRuntime
+
+@main
+struct HelloMochi {
+    static func main() {
+        MochiRuntime.print("hello, world")
+    }
+}
+```
+
+**Module naming**: Mochi source file `hello.mochi` → Swift file `Hello.swift` containing `struct HelloMochi` (snake_case → PascalCase, `Mochi` suffix avoids collision with Swift stdlib `Hello`). The `@main` entry struct is emitted in the top-level module file; sub-files for records and functions are separate `.swift` files in the same SwiftPM target.
+
+**`MochiRuntime.print`**: Phase 1 wraps `Swift.print` to match vm3's output format:
+
+```swift
+// in MochiRuntime/Sources/MochiRuntime/IO.swift
+public func print(_ value: String) { Swift.print(value) }
+public func print(_ value: Int64)  { Swift.print(value) }
+public func print(_ value: Double) { Swift.print(value) }
+public func print(_ value: Bool)   { Swift.print(value ? "true" : "false") }
+```
+
+**`swift build` subprocess**: Phase 1 uses a `swift build` subprocess. The driver generates a minimal `Package.swift` and calls `swift build -c release`. The SwiftPM build graph handles compilation and linking. Build time: ~5s first build, ~200ms incremental.
+
+**Generated `Package.swift`** in `transpiler3/swift/build/package.go`:
+
+```swift
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "MochiOut",
+    platforms: [.macOS(.v15)],
+    dependencies: [
+        .package(url: "https://github.com/mochilang/swift-runtime", from: "0.1.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "MochiOut",
+            dependencies: [
+                .product(name: "MochiRuntime", package: "swift-runtime"),
+            ],
+            path: "Sources/MochiOut",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .unsafeFlags(["-strict-concurrency=complete"]),
+            ]
+        ),
+    ]
+)
+```
+
+## Sub-phase 1.1 -- Scalar print
+
+### Decisions made (1.1)
+
+**`print(int)`**: `aotir.PrintStmt` with `IntLit(42)` lowers to `MochiRuntime.print(Int64(42))`. All Mochi `int` literals are `Int64`, not `Int`. The `Int64(...)` cast is explicit in emitted code to prevent Mochi from accidentally promoting to `Int` on 32-bit platforms.
+
+**`print(bool)`**: Swift's `String(describing: true)` returns `"true"` (lowercase), which matches vm3. However, direct `Swift.print(true)` also emits `"true"`. `MochiRuntime.print(_ value: Bool)` calls `Swift.print(value ? "true" : "false")` for explicitness and to guard against Swift version-dependent changes.
+
+**`print(float)`**: Mochi `float` is `Double`. `print(3.14)` lowers to `MochiRuntime.print(3.14)`. `MochiRuntime.print(_ value: Double)` calls `Swift.print(value)` which uses Swift's `Double` description, matching vm3's `strconv.FormatFloat(f, 'g', -1, 64)`. Edge cases: `Double.nan` → `"nan"`, `Double.infinity` → `"inf"`, `-Double.infinity` → `"-inf"`. These must match vm3; MochiRuntime has explicit checks.
+
+## Sub-phase 1.2 -- swift-format post-processing
+
+### Decisions made (1.2)
+
+**swift-format version**: locked to the minor version matching the Swift toolchain (Swift 6.0 → swift-format 600.x.y). The formatter is invoked as a subprocess: `swift-format --in-place Sources/**/*.swift`.
+
+**`TestSwiftFormatFixedPoint`**: the gate runs swift-format twice and diffs the output. If the second run produces any change, the test fails. This prevents the lowerer from emitting code that swift-format reformats in a way that reveals hidden structural issues (e.g., nested ternaries that format differently on each pass).
+
+**Style decisions baked into sxtree Render()**: sxtree nodes produce canonical Swift that swift-format is expected to leave unchanged. Known divergences: swift-format prefers trailing commas in multi-line argument lists; the sxtree `ParameterClause` renderer emits them. This prevents spurious diffs.
+
+## Sub-phase 1.3 -- TestSwiftcClean gate
+
+### Decisions made (1.3)
+
+**Gate command**: `swift build -Xswiftc -warnings-as-errors -Xswiftc -strict-concurrency=complete -swift-version 6`. This runs as a separate CI step from the fixture test. A build can pass fixtures (correct output) but fail this gate (warnings present). Both gates must be green before a phase is LANDED.
+
+**`-strict-concurrency=complete`**: Swift 6.0 default in `swiftLanguageModes: [.v6]` already enables complete checking. The explicit flag is belt-and-suspenders. Phase 1 emits only `@main struct` + synchronous `main()`, so no concurrency issues arise. The gate is established in Phase 1 so it runs on every subsequent phase automatically.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/lower/lower.go` | `Lower` entry; `lowerProgram`, `lowerStmt`, `lowerExpr` for Phase 1 surface |
+| `transpiler3/swift/sxtree/` | Go shadow AST package: all Swift node types with `Render()` methods |
+| `transpiler3/swift/emit/emit.go` | Walks sxtree → writes `.swift` source files |
+| `transpiler3/swift/build/build.go` | `Driver.Build`; `Target` constants |
+| `transpiler3/swift/build/package.go` | `Package.swift` generator |
+| `transpiler3/swift/build/swift.go` | `swift build` / `swift-format` subprocess wrappers |
+| `transpiler3/swift/build/phase01_test.go` | `TestPhase1Hello`: 5 fixtures + clean + format gates |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/IO.swift` | `print()` overloads for all scalar types |
+| `transpiler3/swift/runtime/Package.swift` | MochiRuntime SwiftPM package definition |
+| `tests/transpiler3/swift/fixtures/phase01-hello/` | 5 fixture directories |
+
+## Test set
+
+- `TestPhase1Hello` -- 5 fixtures (hello, hello_int, hello_bool, hello_float, hello_newline); diffs stdout byte-for-byte against `.out`.
+- `TestSwiftcClean` -- runs `swift build -warnings-as-errors -strict-concurrency=complete` on emitted source; asserts zero warnings.
+- `TestSwiftFormatFixedPoint` -- runs swift-format twice; asserts second pass produces no diff.
+
+## Deferred work
+
+- SHA-256 build cache. Deferred to Phase 16 (reproducible builds).
+- Multi-file programs. Deferred to Phase 4 (records introduce multi-file structure).
+- macOS/Windows/arm64 CI runners. Phase 1 targets linux-x64 only; full matrix in Phase 17.
+- `print(float)` NaN/Inf edge cases. Deferred to Phase 2.

--- a/website/docs/implementation/0049/phase-02-scalars.md
+++ b/website/docs/implementation/0049/phase-02-scalars.md
@@ -1,0 +1,128 @@
+---
+title: "Phase 2. Scalars"
+sidebar_position: 3
+sidebar_label: "Phase 2. Scalars"
+description: "MEP-49 Phase 2 — complete scalar type lowering: int→Int64, float→Double, bool→Bool, string→String; arithmetic, comparison, string ops; MOCHI003 overflow analyzer."
+---
+
+# Phase 2. Scalars
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 2](/docs/mep/mep-0049#phase-2-scalars) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase2Scalars`: 20 fixtures green on Swift 6.0 and 6.1, linux-x64. `TestSwiftcClean` remains green.
+
+## Goal-alignment audit
+
+Scalars are the foundation everything else rests on. The critical decision here is `int` → `Int64` (not Swift's platform-width `Int`). Getting this wrong would make Mochi programs produce different results on 32-bit vs 64-bit platforms, and would break the byte-equality guarantee against vm3. Phase 2 locks in all scalar semantics and makes them explicit in generated code.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 2.0 | `int` → `Int64`: arithmetic, comparison, negation; wrapping operators `&+` / `&-` / `&*` | NOT STARTED | — |
+| 2.1 | `float` → `Double`: arithmetic, comparison, math functions via `Swift.Glibc`/`Darwin` | NOT STARTED | — |
+| 2.2 | `bool` → `Bool`: `&&`, `\|\|`, `!`; short-circuit evaluation | NOT STARTED | — |
+| 2.3 | `string` → `String`: concatenation, length, `substr`, comparison, `startsWith`/`endsWith` | NOT STARTED | — |
+| 2.4 | NaN/Inf/overflow edge cases; `TestScalarEdgeCases` differential against vm3 | NOT STARTED | — |
+
+## Sub-phase 2.0 -- int → Int64
+
+### Decisions made (2.0)
+
+**`Int64` not `Int`**: Swift's `Int` is 64-bit on 64-bit platforms but 32-bit on 32-bit targets (Embedded Swift, old watchOS). Using `Int64` explicitly makes Mochi programs portable and byte-identical to vm3 across all targets. Every integer literal in emitted Swift has an explicit `Int64(...)` cast or `as Int64` annotation when inference would produce `Int`.
+
+**Arithmetic operators**: `+`, `-`, `*`, `/`, `%` lower directly to Swift `Int64` operators. Division is truncating (matches vm3's Go integer division). Modulo sign follows the dividend (Swift matches Go here).
+
+**Overflow behavior**: Mochi integer arithmetic traps on overflow by default (matches Go's behavior on overflow check builds, and the Mochi spec). Swift's default `+`/`-`/`*` trap on overflow for fixed-width types. The lowerer emits standard operators, not wrapping `&+`/`&-`/`&*`. Wrapping operators are only emitted when the Mochi source explicitly uses the `wrapping_add`/`wrapping_sub`/`wrapping_mul` builtins.
+
+**Integer literals**: All `IntLit(n)` → `Int64(n)` in sxtree. Negative literals: `-42` → `Int64(-42)` (not `-(Int64(42))`) to avoid the overflow trap on `Int64.min`.
+
+**Comparison**: `==`, `!=`, `<`, `>`, `<=`, `>=` → same Swift operators on `Int64`. Return type is `Bool`.
+
+**Bitwise**: `&`, `|`, `^`, `~`, `<<`, `>>` → Swift bitwise operators on `Int64`. Right shift is arithmetic (sign-extending), matching vm3.
+
+**Conversions**: `int_to_float(n)` → `Double(n)`. `float_to_int(f)` → `Int64(f)` (truncating, traps on NaN or out-of-range, matching vm3).
+
+## Sub-phase 2.1 -- float → Double
+
+### Decisions made (2.1)
+
+**`Double` not `Float`**: Mochi `float` is always 64-bit IEEE 754, matching Go's `float64`. Swift `Double` is 64-bit IEEE 754. Swift `Float` is 32-bit. `Float` is never used.
+
+**Float literals**: `FloatLit(3.14)` → `3.14` (undecorated; Swift infers `Double` from context). When context is ambiguous, explicit `Double(3.14)` cast is emitted.
+
+**Math functions**: `sqrt(x)` → `Double.squareRoot()` method or `Foundation.sqrt(x)`. Platform-conditional import: on Apple platforms, `import Darwin`; on Linux, `import Glibc`. MochiRuntime provides a `mochiSqrt`, `mochiPow`, etc. facade to avoid the import duplication in user code.
+
+**NaN/Inf**: `Double.nan`, `Double.infinity`, `-Double.infinity`. String output must match vm3: `nan`, `inf`, `-inf`. `MochiRuntime.print(_ value: Double)` handles these with explicit checks before calling `Swift.print`.
+
+**Comparison with NaN**: `nan == nan` → `false`, `nan != nan` → `true`, `nan < 1.0` → `false`. All comparisons involving NaN return the IEEE 754-correct result naturally in Swift, which matches vm3.
+
+## Sub-phase 2.2 -- bool → Bool
+
+### Decisions made (2.2)
+
+**Short-circuit evaluation**: `a && b` → Swift `a && b` (already short-circuits). `a || b` → Swift `a || b` (already short-circuits). The lowerer does not expand these into `if` chains; Swift's natural semantics match Mochi.
+
+**`not` keyword**: Mochi `not x` → Swift `!x`. The `!` prefix operator on `Bool` is emitted directly.
+
+**`bool_to_string`**: `string(b)` on a bool → `b ? "true" : "false"`. This is emitted inline, not via a function call.
+
+## Sub-phase 2.3 -- string → String
+
+### Decisions made (2.3)
+
+**Swift `String` is UTF-8 since Swift 5.7**: `String` stores UTF-8 natively. `String.count` returns the number of Unicode scalar values (not bytes). Mochi `string.length` maps to `str.unicodeScalars.count` to match vm3's rune-count semantics (Go `len([]rune(s))`).
+
+**Byte length**: `string.byte_length` → `str.utf8.count`. Not exposed in Phase 2 (Phase 2 covers the Mochi surface, which has no `byte_length`). Added to runtime for FFI use in Phase 12.
+
+**Concatenation**: Mochi `s1 + s2` (string concat) → Swift `s1 + s2`. The `+` operator on `String` returns a new `String` (value semantics, COW).
+
+**Comparison**: `s1 == s2` → Swift `==` (Unicode scalar comparison, matches vm3's byte comparison when both strings are valid UTF-8 in NFC).
+
+**`substr(s, start, end)`**: `String(s.unicodeScalars[s.unicodeScalars.index(s.unicodeScalars.startIndex, offsetBy: start) ..< s.unicodeScalars.index(s.unicodeScalars.startIndex, offsetBy: end)])`. This O(n) subscript is correct; optimised slicing deferred to Phase 12 (FFI/performance).
+
+**`starts_with` / `ends_with`**: `s.hasPrefix(prefix)` and `s.hasSuffix(suffix)`.
+
+**String → Int/Float**: `int_of_string(s)` → `Int64(s) ?? { throw MochiError.parseFail }`. Phase 11 handles the `throws` colouring; Phase 2 emits the failable form and wraps in `try`.
+
+**String interpolation**: Mochi `"hello, \(name)"` syntax is identical to Swift's. The lowerer emits Swift string interpolation directly: `"hello, \(name)"`.
+
+## Sub-phase 2.4 -- Edge cases
+
+### Decisions made (2.4)
+
+**Differential testing vs vm3**: `TestPhase2ScalarEdgeCases` runs each fixture through both the Swift transpiler and vm3, diffs stdout. Any divergence is a Phase 2 bug. Edge cases covered: `Int64.max + 1` (trap), `Int64.min / -1` (trap), `0 / 0` (trap), `1.0 / 0.0` (`inf`), `0.0 / 0.0` (`nan`), `sqrt(-1.0)` (`nan`).
+
+**Overflow traps**: Swift traps via `_preconditionFailure` → process exits with signal 4 (SIGILL) or 5 (SIGTRAP). vm3 (Go) panics with `runtime error: integer overflow`. Both are non-zero exits but different signals. The test gate only checks stdout for non-trapping cases; trap cases are excluded from the fixture corpus (they'd need signal-assertion logic).
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/lower/lower.go` | Scalar arithmetic, comparison, string ops lowering |
+| `transpiler3/swift/lower/literals.go` | `IntLit`, `FloatLit`, `BoolLit`, `StringLit` → sxtree literal nodes |
+| `transpiler3/swift/lower/builtins.go` | `sqrt`, `pow`, `abs`, `string`, `int_of_string` → Swift calls |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/Math.swift` | `mochiSqrt`, `mochiPow`, `mochiAbs` platform facades |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/String.swift` | `mochiSubstr`, `mochiLength`, `mochiByteLength` |
+| `transpiler3/swift/build/phase02_test.go` | `TestPhase2Scalars`: 20 fixtures |
+| `tests/transpiler3/swift/fixtures/phase02-scalars/` | 20 fixture directories |
+
+## Test set
+
+- `TestPhase2Scalars` -- 20 fixtures covering: `int_arith`, `int_compare`, `int_bitwise`, `int_max_min`, `float_arith`, `float_compare`, `float_nan`, `float_inf`, `float_sqrt`, `bool_and_or`, `bool_not`, `string_concat`, `string_compare`, `string_length`, `string_substr`, `string_starts_ends`, `string_interp`, `scalar_conversions`, `scalar_edge_int`, `scalar_edge_float`.
+
+## Deferred work
+
+- Integer wrapping semantics for explicit wrapping builtins. Deferred to Phase 12 (FFI needs `wrapping_add` for bit manipulation).
+- `Decimal` type (arbitrary precision). Out of v1 scope.
+- `Complex<Double>` (swift-numerics). Deferred to Phase 12 (FFI/math library bindings).
+- Locale-sensitive string comparison. MochiRuntime uses unicode-scalar comparison always; locale support is out of scope.

--- a/website/docs/implementation/0049/phase-03-list-of-records.md
+++ b/website/docs/implementation/0049/phase-03-list-of-records.md
@@ -1,0 +1,139 @@
+---
+title: "Phase 3.4. List of records"
+sidebar_position: 7
+sidebar_label: "Phase 3.4. List of records"
+description: "MEP-49 Phase 3.4 — nested collections with struct elements; monomorphisation of generic collection operations over record types."
+---
+
+# Phase 3.4. List of records
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 3.4](/docs/mep/mep-0049#phase-3-collections) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase3ListOfRecords`: 20 fixtures green on Swift 6.0 and 6.1, linux-x64. `TestSwiftcClean` remains green.
+
+## Goal-alignment audit
+
+Phase 3.4 proves that the collection operations from 3.1-3.3 compose correctly with record types from Phase 4. Because Swift generics are reified (not erased), `[MyRecord].map(f)` works without monomorphisation in the Go lowerer -- Swift's type system handles specialisation at the compiler level. Phase 3.4 validates this end-to-end. This is the bridge from "collections of scalars" to "collections of structured data."
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 3.4.0 | `list<Record>` literals; `map`, `filter` over record lists; record fields in closures | NOT STARTED | — |
+| 3.4.1 | `map<string, Record>` literals; map access returning a record; record update in map | NOT STARTED | — |
+| 3.4.2 | Typed empty literals: `[] as [MyRecord]`, `OrderedDictionary<String, MyRecord>()` | NOT STARTED | — |
+| 3.4.3 | Nested collections: `list<list<T>>`, `map<K, list<V>>`, `list<map<K,V>>` | NOT STARTED | — |
+
+## Sub-phase 3.4.0 -- List of records
+
+### Decisions made (3.4.0)
+
+**No monomorphisation in Go lowerer**: Swift's generics are reified. `[MyRecord].map { $0.field }` is compiled by swiftc with full type information; the lowerer does not need to generate specialised Go code per element type. This contrasts with the C backend (which hand-expands templates) and the JVM backend (which needs boxing for primitive types).
+
+**Record type in list literal**: `[MyRecord]` type annotation is explicit in the `let` binding when the list is the first expression containing records. Subsequent references infer from context.
+
+```swift
+// Mochi: let users = [{ name: "alice", age: 30 }, { name: "bob", age: 25 }]
+let users: [User] = [User(name: "alice", age: Int64(30)), User(name: "bob", age: Int64(25))]
+```
+
+**`map` over record list**: The closure receives the full record struct. Fields are accessed via `.field` (dot notation on the Swift struct).
+
+```swift
+// Mochi: let names = users.map(fun(u) => u.name)
+let names: [String] = users.map { u in u.name }
+```
+
+**`filter` over record list**: The closure receives the record and returns `Bool`.
+
+```swift
+// Mochi: let adults = users.filter(fun(u) => u.age >= 18)
+let adults: [User] = users.filter { u in u.age >= Int64(18) }
+```
+
+**Nested field access in sort**: `sort_by` on a list of records, sorting by a nested field.
+
+```swift
+// Mochi: let sorted = users.sort_by(fun(u) => u.age)
+let sorted: [User] = users.sorted(by: { a, b in a.age < b.age })
+```
+
+## Sub-phase 3.4.1 -- Map of records
+
+### Decisions made (3.4.1)
+
+**`map<string, Record>` literal**: Similar to plain map literals but with record values.
+
+```swift
+// Mochi: let db = { "alice": { age: 30 }, "bob": { age: 25 } }
+let db: OrderedDictionary<String, User> = OrderedDictionary(uniqueKeysWithValues: [
+    ("alice", User(name: "alice", age: Int64(30))),
+    ("bob", User(name: "bob", age: Int64(25))),
+])
+```
+
+**Map access returning a record**: `db.get_or("alice", default_user)` → `db["alice"] ?? default_user`.
+
+**Record update in map**: Functional update of a record stored in a map requires extracting, updating, and reinserting:
+
+```swift
+// Mochi: let db2 = db.set("alice", { db.get_or("alice", default_user) with age: 31 })
+var __tmp_db2 = db
+let __alice = db["alice"] ?? defaultUser
+__tmp_db2["alice"] = User(name: __alice.name, age: Int64(31))
+let db2 = __tmp_db2
+```
+
+The `with` update syntax for records is lowered in Phase 4; Phase 3.4 covers the map wrapping around it.
+
+## Sub-phase 3.4.2 -- Typed empty literals
+
+### Decisions made (3.4.2)
+
+**Typed empty list**: Mochi `[]` in a context expecting `list<MyRecord>` → `[MyRecord]()` with the explicit type. The lowerer determines the expected type from the `let` binding annotation or function parameter type.
+
+**Typed empty map**: Mochi `{}` in a `map<K, Record>` context → `OrderedDictionary<K, Record>()`.
+
+**Typed empty set**: Mochi `{}` in a `set<Record>` context → `OrderedSet<Record>()`.
+
+**Inference failure**: If the context type is not determinable (e.g., passed to a generic function without type annotation), the lowerer emits a type-annotated form with a compiler comment. The `TestSwiftcClean` gate catches any resulting ambiguity warnings.
+
+## Sub-phase 3.4.3 -- Nested collections
+
+### Decisions made (3.4.3)
+
+**`list<list<T>>`**: → `[[T]]`. All collection operations compose naturally. `xs.map { inner in inner.filter { x in ... } }` works without special handling.
+
+**`map<K, list<V>>`**: → `OrderedDictionary<K, [V]>`. Building such a map from a list (group-by) is deferred to Phase 7 (query DSL `group by`). Phase 3.4 only covers direct literals and access.
+
+**`list<map<K,V>>`**: → `[OrderedDictionary<K, V>]`. Each element is an `OrderedDictionary`. Indexing into the list gives an `OrderedDictionary`; subscripting that gives `V?`.
+
+**Nesting depth**: Phase 3.4 tests up to two levels of nesting. Deeper nesting is theoretically unlimited but not explicitly tested; `TestSwiftcClean` catches any type inference issues.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/lower/lower.go` | Typed empty literal lowering; nested collection type annotation |
+| `transpiler3/swift/lower/types.go` | `swiftTypeOf(mochiType)` helper: translates Mochi type → sxtree TypeSyntax |
+| `transpiler3/swift/build/phase03_records_test.go` | `TestPhase3ListOfRecords`: 20 fixtures |
+| `tests/transpiler3/swift/fixtures/phase03-list-of-records/` | 20 fixture directories |
+
+## Test set
+
+- `TestPhase3ListOfRecords` -- 20 fixtures covering: `list_of_record_literal`, `list_of_record_map`, `list_of_record_filter`, `list_of_record_sort`, `list_of_record_fold`, `list_of_record_contains`, `map_of_record_literal`, `map_of_record_get`, `map_of_record_update`, `map_of_record_map_values`, `set_of_record`, `typed_empty_list`, `typed_empty_map`, `typed_empty_set`, `nested_list_list`, `nested_map_list`, `nested_list_map`, `nested_list_of_list_map`, `record_in_multiple_collections`, `collection_of_option_record`.
+
+## Deferred work
+
+- `group_by` on record lists (builds `map<K, list<V>>`). Deferred to Phase 7.
+- `list<option<Record>>`. Deferred to Phase 5 (option types).
+- `list<union_type>`. Deferred to Phase 5 (sum types).

--- a/website/docs/implementation/0049/phase-03-lists.md
+++ b/website/docs/implementation/0049/phase-03-lists.md
@@ -1,0 +1,136 @@
+---
+title: "Phase 3.1. Lists"
+sidebar_position: 4
+sidebar_label: "Phase 3.1. Lists"
+description: "MEP-49 Phase 3.1 — list<T> to Swift Array with COW; map, filter, reduce, sort; list literals; structural equality."
+---
+
+# Phase 3.1. Lists
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 3.1](/docs/mep/mep-0049#phase-3-collections) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase3Lists`: 25 fixtures green on Swift 6.0 and 6.1, linux-x64. `TestSwiftcClean` remains green.
+
+## Goal-alignment audit
+
+Lists are Mochi's primary sequential collection. The lowering to Swift `Array<T>` is natural: Swift arrays are value types with copy-on-write semantics, exactly matching Mochi's immutable-by-default list model. Phase 3.1 ships `map`, `filter`, `reduce`, `sort`, and structural equality so that Phases 4+ can use lists of records without additional work.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 3.1.0 | `list<T>` → `[T]`; list literals `[1, 2, 3]`; `list.length` → `.count`; indexing `xs[i]` → `xs[Int(i)]` | NOT STARTED | — |
+| 3.1.1 | `list.map(f)` → `.map(f)`; `list.filter(p)` → `.filter(p)`; `list.foldl(f, init)` → `.reduce(init, f)` | NOT STARTED | — |
+| 3.1.2 | `list.sort()` → `.sorted()`; `list.sort_by(f)` → `.sorted(by: f)`; stable sort guaranteed | NOT STARTED | — |
+| 3.1.3 | Structural equality: `xs == ys` on `[T]` where `T: Equatable`; `list.contains(x)` → `.contains(x)` | NOT STARTED | — |
+| 3.1.4 | `list.concat(ys)` → `xs + ys`; `list.append(x)` → `xs + [x]` (returns new list, value semantics) | NOT STARTED | — |
+
+## Sub-phase 3.1.0 -- List literals and indexing
+
+### Decisions made (3.1.0)
+
+**`list<T>` → `[T]`**: Swift array literal `[T]` is the natural target. It is a value type with COW, matching Mochi's value semantics. No `ImmutableList` wrapper needed (unlike .NET where `ImmutableList<T>` was required).
+
+**List literals**: `[1, 2, 3]` in Mochi → `[Int64(1), Int64(2), Int64(3)]` in Swift. Element types are explicit when the array type annotation is needed:
+
+```swift
+// Mochi: let xs: list<int> = [1, 2, 3]
+let xs: [Int64] = [Int64(1), Int64(2), Int64(3)]
+```
+
+**Empty list**: `[]` → `[T]()` or `[] as [T]` with explicit type. The lowerer always annotates the type when the list is empty to help the Swift type checker.
+
+**Indexing**: Mochi `xs[i]` (where `i: int`) → `xs[Int(i)]`. Swift `Array` subscript takes `Int` (platform-width). The `Int(i)` cast is explicit to convert from Mochi's `Int64`. The lowerer always emits `Int(i)` to avoid platform-width confusion.
+
+**`list.length`**: → `xs.count` (returns `Int`). The result is cast to `Int64` immediately: `Int64(xs.count)`, so Mochi code sees an `int` result, not a platform-width integer.
+
+**`list.first` / `list.last`**: → `xs.first` / `xs.last` (returns `T?`, which is Mochi `option<T>`). Lowered in Phase 5 after option types are available.
+
+## Sub-phase 3.1.1 -- Higher-order list operations
+
+### Decisions made (3.1.1)
+
+**`list.map(f)`**: → `xs.map(f)`. Swift's `Array.map` returns a new `[U]`. The function `f` is `(T) -> U`. No materialization needed; Swift `map` already returns an `Array`.
+
+**`list.filter(p)`**: → `xs.filter(p)`. Returns `[T]`.
+
+**`list.foldl(f, init)`**: Mochi `foldl` is left-fold. → `xs.reduce(init, f)`. Swift's `reduce` is left-to-right, matching Mochi `foldl`.
+
+**`list.foldr(f, init)`**: Mochi `foldr` is right-fold. → `xs.reversed().reduce(init, { acc, x in f(x, acc) })`. The argument order swap is required because Mochi `foldr f init [a,b,c]` = `f a (f b (f c init))` while Swift's `reduce` threads the accumulator as the first argument.
+
+**`list.for_each(f)`**: → `xs.forEach(f)`. `f` is `(T) -> Void` (Mochi `unit`).
+
+**`list.flat_map(f)`**: → `xs.flatMap(f)`. `f` returns `[U]`.
+
+**`list.zip(ys)`**: → `zip(xs, ys).map { ($0, $1) }`. Returns `[(T, U)]`. Truncates to the shorter list, matching Mochi semantics.
+
+## Sub-phase 3.1.2 -- Sort
+
+### Decisions made (3.1.2)
+
+**Stability**: Swift 5.8+ `Array.sort` and `sorted()` are stable (guaranteed by the stdlib). This matches Mochi's specification that `sort` is stable.
+
+**`list.sort()`**: → `xs.sorted()`. Requires `T: Comparable`. The lowerer adds the `Comparable` conformance constraint when emitting generic functions over sorted lists.
+
+**`list.sort_by(f)`**: → `xs.sorted(by: f)`. `f` is `(T, T) -> bool`, lowered to `(T, T) -> Bool`. The function must be a strict weak ordering; the lowerer trusts the programmer here (no static verification in Phase 3).
+
+**`list.sort_desc()`**: → `xs.sorted(by: >)`. Descending sort using the `>` operator.
+
+**Multi-key sort**: Not directly supported in Phase 3. Phase 7 (query DSL) handles `order_by k1 asc, k2 desc` via chained `.sorted`.
+
+## Sub-phase 3.1.3 -- Structural equality
+
+### Decisions made (3.1.3)
+
+**`[T]: Equatable` when `T: Equatable`**: Swift arrays conform to `Equatable` automatically when their element type does. Mochi `xs == ys` → Swift `xs == ys`. Element-wise comparison is structural, matching Mochi's value equality.
+
+**`list.contains(x)`**: → `xs.contains(x)`. Requires `T: Equatable`. Always emitted with the method form, not `xs.contains(where: { $0 == x })`.
+
+**`list.index_of(x)`**: → `xs.firstIndex(of: x).map { Int64($0) }`. Returns `option<int>`. Lowered in Phase 5 after option types are available.
+
+## Sub-phase 3.1.4 -- Concat and append
+
+### Decisions made (3.1.4)
+
+**Value semantics**: Mochi lists are immutable. `list.append(x)` returns a new list; it does not mutate the original. Swift's `+` operator on arrays returns a new array, matching this.
+
+**`list.concat(ys)`**: Mochi `xs.concat(ys)` → Swift `xs + ys`. Returns `[T]`.
+
+**`list.append(x)`**: Mochi `xs.append(x)` → Swift `xs + [x]`. The `[x]` singleton is cheap (one allocation) for small types; for large payloads, the lowerer could emit `{ var tmp = xs; tmp.append(x); return tmp }` but this is deferred to a performance pass.
+
+**`list.prepend(x)`**: Mochi `xs.prepend(x)` → Swift `[x] + xs`. O(n) copy; acceptable for Phase 3.
+
+**`list.drop(n)`**: → `Array(xs.dropFirst(Int(n)))`. The `Array(...)` materialization is required because `dropFirst` returns a `Slice`, not an `Array`.
+
+**`list.take(n)`**: → `Array(xs.prefix(Int(n)))`.
+
+**`list.reverse()`**: → `xs.reversed()` (returns `ReversedCollection<[T]>`). Materialized to `[T]` via `Array(xs.reversed())` when the result is bound to a `list<T>` variable.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/lower/lower.go` | List literal, indexing, `length` lowering |
+| `transpiler3/swift/lower/builtins.go` | `map`, `filter`, `foldl`, `foldr`, `sort`, `sort_by`, `concat`, `append`, `prepend`, `drop`, `take`, `reverse`, `contains`, `zip` |
+| `transpiler3/swift/build/phase03_lists_test.go` | `TestPhase3Lists`: 25 fixtures |
+| `tests/transpiler3/swift/fixtures/phase03-lists/` | 25 fixture directories |
+
+## Test set
+
+- `TestPhase3Lists` -- 25 fixtures covering: `list_empty`, `list_literal`, `list_index`, `list_length`, `list_map`, `list_filter`, `list_foldl`, `list_foldr`, `list_for_each`, `list_flat_map`, `list_zip`, `list_sort`, `list_sort_by`, `list_sort_desc`, `list_contains`, `list_concat`, `list_append`, `list_prepend`, `list_drop`, `list_take`, `list_reverse`, `list_nested`, `list_equality`, `list_of_string`, `list_of_float`.
+
+## Deferred work
+
+- `list.index_of`, `list.first`, `list.last` (require option types from Phase 5).
+- `list.partition` (returns two lists; deferred to Phase 5 for tuple support).
+- Lazy evaluation via `LazySequence`. Deferred to Phase 7 (query DSL).
+- Parallel map via `withTaskGroup`. Deferred to Phase 9 (agents/concurrency).

--- a/website/docs/implementation/0049/phase-03-maps.md
+++ b/website/docs/implementation/0049/phase-03-maps.md
@@ -1,0 +1,123 @@
+---
+title: "Phase 3.2. Maps"
+sidebar_position: 5
+sidebar_label: "Phase 3.2. Maps"
+description: "MEP-49 Phase 3.2 — map<K,V> to OrderedDictionary (swift-collections); insertion-order iteration; merge, filter_map, keys, values."
+---
+
+# Phase 3.2. Maps
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 3.2](/docs/mep/mep-0049#phase-3-collections) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase3Maps`: 25 fixtures green on Swift 6.0 and 6.1, linux-x64. `TestSwiftcClean` remains green.
+
+## Goal-alignment audit
+
+Mochi maps are insertion-ordered, which is a semantic guarantee. Swift's stdlib `Dictionary` does not preserve insertion order. `OrderedDictionary` from `swift-collections` does, and it matches the semantics Mochi programs expect. Phase 3.2 establishes the dependency on `swift-collections` that Phases 3.3 (sets) and Phase 7 (query group_by) will also use.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 3.2.0 | `map<K,V>` → `OrderedDictionary<K,V>`; map literals; `map.get(k)` → `[k]`; `map.set(k,v)` → functional update | NOT STARTED | — |
+| 3.2.1 | `map.keys` → `.keys`; `map.values` → `.values`; `map.length` → `.count`; `map.contains_key(k)` → `.keys.contains(k)` | NOT STARTED | — |
+| 3.2.2 | `map.map_values(f)` → `.mapValues(f)`; `map.filter(p)` → `.filter(p)`; `map.merge(m2)` → `.merging(m2, uniquingKeysWith: { _, new in new })` | NOT STARTED | — |
+| 3.2.3 | Structural equality: `m1 == m2` when `K: Hashable & Equatable, V: Equatable` | NOT STARTED | — |
+
+## Sub-phase 3.2.0 -- Map literals and access
+
+### Decisions made (3.2.0)
+
+**`OrderedDictionary<K,V>` from swift-collections**: Mochi map semantics require insertion-order iteration. `OrderedDictionary` preserves insertion order and exposes the same subscript and mutation APIs as `Dictionary`. It is `Hashable` when `K: Hashable & Equatable, V: Hashable`, `Equatable` when `V: Equatable`.
+
+**MochiRuntime dependency**: `swift-collections` is declared as a MochiRuntime dependency in `Package.swift`:
+```swift
+.package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
+```
+User `Package.swift` files get this transitively through `MochiRuntime`.
+
+**Map literals**: `{ "a": 1, "b": 2 }` in Mochi → `OrderedDictionary(uniqueKeysWithValues: [("a", Int64(1)), ("b", Int64(2))])`. The pairs array preserves insertion order. The lowerer emits this form (not the `[:]` dict literal) because `OrderedDictionary` does not support the `[k: v]` Swift dict literal syntax.
+
+**Empty map**: `{}` with explicit type annotation → `OrderedDictionary<K, V>()`.
+
+**`map.get(k)`**: Mochi `m.get(k)` returns `option<V>` (present or absent). → `m[k]` (returns `V?`). In Phase 5, `V?` maps to `option<V>`. In Phase 3.2, fixtures avoid the option return; `get` is tested via direct subscript that is known to be present, and the `?? default` operator handles missing keys.
+
+**`map.get_or(k, default)`**: → `m[k] ?? default`.
+
+**`map.set(k, v)`**: Mochi maps are value-typed. `m.set(k, v)` returns a new map. → `{ var tmp = m; tmp[k] = v; return tmp }` emitted as a closure call or inline block. The lowerer emits the block form for `let` bindings:
+
+```swift
+// Mochi: let m2 = m.set("c", 3)
+var __tmp_m2 = m
+__tmp_m2["c"] = Int64(3)
+let m2 = __tmp_m2
+```
+
+**`map.delete(k)`**: → `{ var tmp = m; tmp.removeValue(forKey: k); return tmp }` (same block pattern as `set`).
+
+## Sub-phase 3.2.1 -- Keys, values, length
+
+### Decisions made (3.2.1)
+
+**`map.keys`**: → `Array(m.keys)` materialized to `[K]`, preserving insertion order. `OrderedDictionary.keys` returns `OrderedDictionary<K,V>.Keys` (a typed collection slice). Materializing to `Array` gives a `list<K>` in Mochi.
+
+**`map.values`**: → `Array(m.values)` → `[V]`.
+
+**`map.length`**: → `Int64(m.count)`.
+
+**`map.contains_key(k)`**: → `m.keys.contains(k)`. `OrderedDictionary.keys` is a `Hashable`-indexed collection; `.contains` is O(1) via the hash table.
+
+**`map.to_list()`**: → `m.map { ($0.key, $0.value) }` → `[(K, V)]`. Returns an array of key-value tuples in insertion order.
+
+## Sub-phase 3.2.2 -- Higher-order map operations
+
+### Decisions made (3.2.2)
+
+**`map.map_values(f)`**: → `m.mapValues(f)`. Returns `OrderedDictionary<K, U>`. Preserves insertion order. Keys unchanged.
+
+**`map.filter(p)`**: `p` is `(K, V) -> bool`. → `m.filter { p($0.key, $0.value) }`. Returns `OrderedDictionary<K,V>`.
+
+**`map.merge(m2)`**: Right-biased merge (m2 wins on duplicate keys). → `m.merging(m2, uniquingKeysWith: { _, new in new })`. Returns a new `OrderedDictionary`. The merged map preserves the order of `m` for keys present in `m`, then appends keys from `m2` that are not in `m`.
+
+**`map.merge_with(m2, f)`**: Custom conflict resolution. → `m.merging(m2, uniquingKeysWith: f)`.
+
+**`map.for_each(f)`**: → `m.forEach { f($0.key, $0.value) }`.
+
+## Sub-phase 3.2.3 -- Structural equality
+
+### Decisions made (3.2.3)
+
+**`OrderedDictionary: Equatable`**: `OrderedDictionary` conforms to `Equatable` when `K: Hashable & Equatable, V: Equatable`. The comparison is order-sensitive: two maps are equal only if they have the same keys in the same insertion order with the same values. This matches Mochi's map equality semantics (maps are ordered, so order matters for equality).
+
+**`m1 == m2`**: → Swift `m1 == m2`.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/lower/lower.go` | Map literal lowering → `OrderedDictionary(uniqueKeysWithValues:...)` |
+| `transpiler3/swift/lower/builtins.go` | `get`, `get_or`, `set`, `delete`, `keys`, `values`, `length`, `contains_key`, `to_list`, `map_values`, `filter`, `merge`, `merge_with`, `for_each` |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/Map.swift` | Map helper extensions (type aliases, convenience inits) |
+| `transpiler3/swift/runtime/Package.swift` | `swift-collections` dependency (added in 3.2.0) |
+| `transpiler3/swift/build/phase03_maps_test.go` | `TestPhase3Maps`: 25 fixtures |
+| `tests/transpiler3/swift/fixtures/phase03-maps/` | 25 fixture directories |
+
+## Test set
+
+- `TestPhase3Maps` -- 25 fixtures covering: `map_empty`, `map_literal`, `map_get`, `map_get_or`, `map_set`, `map_delete`, `map_keys`, `map_values`, `map_length`, `map_contains_key`, `map_to_list`, `map_map_values`, `map_filter`, `map_merge`, `map_merge_with`, `map_for_each`, `map_equality`, `map_insertion_order`, `map_nested`, `map_of_list`, `map_string_keys`, `map_int_values`, `map_overwrite`, `map_from_list`, `map_large`.
+
+## Deferred work
+
+- `map.get(k)` returning `option<V>`. Deferred to Phase 5 (option types).
+- `map.index_of(k)` (insertion-order index). Deferred to Phase 5.
+- Persistent/persistent-update map (HAMT). Out of v1 scope.
+- `map.sort_by_key()` / `map.sort_by_value()`. Deferred to Phase 7 (query order_by).

--- a/website/docs/implementation/0049/phase-03-sets.md
+++ b/website/docs/implementation/0049/phase-03-sets.md
@@ -1,0 +1,123 @@
+---
+title: "Phase 3.3. Sets"
+sidebar_position: 6
+sidebar_label: "Phase 3.3. Sets"
+description: "MEP-49 Phase 3.3 — set<T> to OrderedSet (swift-collections); union, intersection, difference; set literals."
+---
+
+# Phase 3.3. Sets
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 3.3](/docs/mep/mep-0049#phase-3-collections) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase3Sets`: 20 fixtures green on Swift 6.0 and 6.1, linux-x64. `TestSwiftcClean` remains green.
+
+## Goal-alignment audit
+
+Mochi sets are insertion-ordered (like maps). Swift's stdlib `Set` is unordered. `OrderedSet` from `swift-collections` preserves insertion order, gives O(1) membership test, and conforms to `SetAlgebra`. Phase 3.3 builds on the `swift-collections` dependency introduced in Phase 3.2.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 3.3.0 | `set<T>` → `OrderedSet<T>`; set literals; `set.contains(x)` → `.contains(x)`; `set.length` → `.count` | NOT STARTED | — |
+| 3.3.1 | `set.add(x)` → functional update; `set.remove(x)` → functional update | NOT STARTED | — |
+| 3.3.2 | `set.union(s2)` → `.union(s2)`; `set.intersection(s2)` → `.intersection(s2)`; `set.difference(s2)` → `.subtracting(s2)` | NOT STARTED | — |
+| 3.3.3 | `set.to_list()` → `Array(s)`; `set.from_list(xs)` → `OrderedSet(xs)`; structural equality | NOT STARTED | — |
+
+## Sub-phase 3.3.0 -- Set literals and membership
+
+### Decisions made (3.3.0)
+
+**`OrderedSet<T>` from swift-collections**: same dependency as Phase 3.2 (`swift-collections` 1.1.x). `OrderedSet` is `Hashable` when `T: Hashable`, `Equatable` when `T: Hashable`. Membership is O(1) via the backing hash table. Iteration is insertion-order.
+
+**Set literals**: Mochi `{1, 2, 3}` (set literal, distinct from map `{k:v}`) → `OrderedSet([Int64(1), Int64(2), Int64(3)])`. The `OrderedSet(_ sequence:)` initializer is used because `OrderedSet` does not support the `Set` literal syntax directly.
+
+**Empty set**: `set<int>{}` → `OrderedSet<Int64>()`.
+
+**`set.contains(x)`**: → `s.contains(x)`. O(1).
+
+**`set.length`**: → `Int64(s.count)`.
+
+## Sub-phase 3.3.1 -- Add and remove (functional)
+
+### Decisions made (3.3.1)
+
+**Value semantics**: Mochi sets are immutable. `set.add(x)` returns a new set. The lowerer emits a block that copies, mutates, and returns:
+
+```swift
+// Mochi: let s2 = s.add(42)
+var __tmp_s2 = s
+__tmp_s2.append(Int64(42))  // OrderedSet.append is a no-op if already present
+let s2 = __tmp_s2
+```
+
+`OrderedSet.append` adds the element at the end if not already present (maintaining insertion order), no-ops if present. This matches Mochi set semantics.
+
+**`set.remove(x)`**: → copy-mutate-return using `remove(_ member:)`:
+
+```swift
+var __tmp_s3 = s
+__tmp_s3.remove(Int64(42))
+let s3 = __tmp_s3
+```
+
+## Sub-phase 3.3.2 -- Set algebra
+
+### Decisions made (3.3.2)
+
+**`OrderedSet` and `SetAlgebra`**: `OrderedSet` conforms to `SetAlgebra` (via `swift-collections` 1.1+). This gives `.union`, `.intersection`, `.subtracting`, `.symmetricDifference` for free.
+
+**`set.union(s2)`**: → `s.union(s2)`. Result is a new `OrderedSet` containing all elements of both sets. Elements from `s` come first in iteration order, then elements from `s2` not in `s`.
+
+**`set.intersection(s2)`**: → `s.intersection(s2)`. Elements present in both sets, preserving order from `s`.
+
+**`set.difference(s2)`**: Mochi `s.difference(s2)` = elements in `s` not in `s2`. → `s.subtracting(s2)`.
+
+**`set.symmetric_difference(s2)`**: → `s.symmetricDifference(s2)`. Elements in exactly one of the two sets.
+
+**`set.is_subset_of(s2)`**: → `s.isSubset(of: s2)`.
+
+**`set.is_superset_of(s2)`**: → `s.isSuperset(of: s2)`.
+
+## Sub-phase 3.3.3 -- Conversion and equality
+
+### Decisions made (3.3.3)
+
+**`set.to_list()`**: → `Array(s)`. Preserves insertion order. Returns `[T]`.
+
+**`set.from_list(xs)`**: → `OrderedSet(xs)`. Duplicate elements in `xs` are silently dropped (first occurrence wins). This matches Mochi's set-from-list semantics.
+
+**`s1 == s2`**: `OrderedSet` conforms to `Equatable`. Equality is order-sensitive: same elements in same insertion order. Two sets built from the same elements in different insertion orders are not equal. This is the correct Mochi semantics for ordered sets.
+
+**`set.map(f)`**: → `OrderedSet(s.map(f))`. The `map` result is re-deduplicated by `OrderedSet` init (last occurrence wins in case of collision after `f`). Mochi documents that `set.map` may reduce size if `f` is not injective.
+
+**`set.filter(p)`**: → `s.filter(p)`. Returns `OrderedSet<T>` directly (swift-collections 1.1 supports this).
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/lower/lower.go` | Set literal lowering → `OrderedSet([...])` |
+| `transpiler3/swift/lower/builtins.go` | `contains`, `length`, `add`, `remove`, `union`, `intersection`, `difference`, `symmetric_difference`, `is_subset_of`, `is_superset_of`, `to_list`, `from_list`, `map`, `filter` |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/Set.swift` | Set helper extensions |
+| `transpiler3/swift/build/phase03_sets_test.go` | `TestPhase3Sets`: 20 fixtures |
+| `tests/transpiler3/swift/fixtures/phase03-sets/` | 20 fixture directories |
+
+## Test set
+
+- `TestPhase3Sets` -- 20 fixtures covering: `set_empty`, `set_literal`, `set_contains`, `set_length`, `set_add`, `set_remove`, `set_union`, `set_intersection`, `set_difference`, `set_symmetric_difference`, `set_is_subset`, `set_is_superset`, `set_to_list`, `set_from_list`, `set_map`, `set_filter`, `set_equality`, `set_order`, `set_dedup`, `set_nested`.
+
+## Deferred work
+
+- `set.find(p)` → `s.first(where: p)` (returns `option<T>`). Deferred to Phase 5.
+- `set.partition(p)`. Deferred to Phase 5.
+- Set of sets (requires `OrderedSet: Hashable`; available in swift-collections 1.1).

--- a/website/docs/implementation/0049/phase-04-records.md
+++ b/website/docs/implementation/0049/phase-04-records.md
@@ -1,0 +1,203 @@
+---
+title: "Phase 4. Records"
+sidebar_position: 8
+sidebar_label: "Phase 4. Records"
+description: "MEP-49 Phase 4 — record types to @frozen public struct: Sendable, Hashable, Codable; functional update with(); Equatable; generic records."
+---
+
+# Phase 4. Records
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 4](/docs/mep/mep-0049#phase-4-records) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase4Records`: 25 fixtures green on Swift 6.0 and 6.1, linux-x64. `TestSwiftcClean` remains green.
+
+## Goal-alignment audit
+
+Records are Mochi's primary data aggregation. On Swift, they lower to `@frozen struct` with `Sendable`, `Hashable`, and `Codable` conformances. The `@frozen` attribute is critical for library evolution: it tells the Swift compiler that no new fields will be added, enabling optimal layout and exhaustive switch. `Sendable` conformance ensures records can cross actor boundaries (Phase 9). `Codable` (Phase 4 sub-phase) enables JSON serialisation without extra runtime metadata.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 4.0 | `record User { name: string; age: int }` → `@frozen public struct User: Sendable, Hashable` | NOT STARTED | — |
+| 4.1 | Memberwise init: `User(name: "alice", age: 30)` → Swift memberwise initializer with labeled params | NOT STARTED | — |
+| 4.2 | Functional update `{ u with age: 31 }` → `with()` extension method pattern | NOT STARTED | — |
+| 4.3 | `Codable` conformance for JSON; `Equatable` for structural equality | NOT STARTED | — |
+| 4.4 | Generic records `record Pair<A, B> { first: A; second: B }` → generic Swift struct | NOT STARTED | — |
+
+## Sub-phase 4.0 -- Struct declaration
+
+### Decisions made (4.0)
+
+**`@frozen public struct`**: every Mochi record lowers to a `@frozen public struct`. `@frozen` means the struct's stored properties are stable; clients compiled against the module can access properties directly without an indirection layer. Since Mochi programs are compiled as a single SwiftPM module (or a library + executable pair), `@frozen` is always safe and gives the best code generation.
+
+**Protocol conformances**: every record gets `Sendable, Hashable` synthesised by the Swift compiler. `Sendable` enables crossing actor isolation boundaries (Phase 9). `Hashable` enables use in `Set<Record>` and as `Dictionary` keys.
+
+**`Equatable`** is implied by `Hashable` (Swift requires `Equatable` for `Hashable`). Structural equality is synthesised.
+
+**Field ordering**: Mochi record fields are declared in source order. Swift struct fields are emitted in the same order. Swift's synthesised memberwise init follows field declaration order.
+
+**Naming**: Mochi field names are snake_case (e.g., `user_name`). Swift convention is camelCase. The lowerer converts snake_case to camelCase: `user_name` → `userName`. This is a one-way mapping; Mochi programs access fields via snake_case; the generated Swift uses camelCase.
+
+```swift
+// Mochi: record User { name: string; age: int }
+@frozen
+public struct User: Sendable, Hashable {
+    public let name: String
+    public let age: Int64
+}
+```
+
+**Stored properties**: all fields are `let` (immutable). Mochi records are value-typed and immutable. Mutation is via functional update (Phase 4.2).
+
+**One file per record**: each Mochi record type generates a dedicated `.swift` file (e.g., `User.swift`). Functions defined over a record are placed in extension blocks in the same file. This makes the generated Swift navigable in IDE source trees.
+
+## Sub-phase 4.1 -- Memberwise init
+
+### Decisions made (4.1)
+
+**Swift synthesises memberwise init automatically**: for a struct with all `let` stored properties, Swift synthesises a memberwise initializer with labeled arguments in field-declaration order. No explicit `init` is emitted.
+
+**External label form**: `User(name: "alice", age: Int64(30))`. All arguments are labeled. The Mochi lowerer emits the labeled form always (not positional).
+
+**Nil-safe init**: if a Mochi record field has type `option<T>` (Phase 5), the corresponding Swift type is `T?`. The memberwise init takes `T?` directly.
+
+**Nested record init**: a Mochi record field that is itself a record type → the Swift struct field is the inner struct type. The init takes the inner struct as a labeled argument.
+
+```swift
+// Mochi:
+// record Address { city: string; zip: string }
+// record User { name: string; address: Address }
+// let u = { name: "alice", address: { city: "SF", zip: "94105" } }
+
+let u = User(
+    name: "alice",
+    address: Address(city: "SF", zip: "94105")
+)
+```
+
+## Sub-phase 4.2 -- Functional update with()
+
+### Decisions made (4.2)
+
+**`with()` extension method**: Mochi `{ u with age: 31 }` produces a new record with one field changed. Swift structs do not have a built-in `with` syntax. The lowerer generates a `with` extension method for each record:
+
+```swift
+// Emitted in User.swift:
+extension User {
+    func with(
+        name: String? = nil,
+        age: Int64? = nil
+    ) -> User {
+        User(
+            name: name ?? self.name,
+            age: age ?? self.age
+        )
+    }
+}
+```
+
+Usage:
+
+```swift
+// Mochi: let u2 = { u with age: 31 }
+let u2 = u.with(age: Int64(31))
+```
+
+**Type collision**: if a field is already `Optional<T>` (from `option<T>` in Mochi), the `with()` parameter cannot be `T??` to distinguish "not provided" from "provided as nil". The lowerer uses a sentinel enum instead for optional fields:
+
+```swift
+// For an option<T> field:
+enum __WithSentinel<T> { case unchanged; case set(T?) }
+```
+
+This is generated per-field when needed; not emitted for non-optional fields.
+
+**Performance**: each `with()` call creates a new struct value. Swift's COW does not apply here (structs are not COW by default); the copy is trivially cheap for small structs and is inlined by the Swift compiler's optimizer.
+
+## Sub-phase 4.3 -- Codable and Equatable
+
+### Decisions made (4.3)
+
+**`Codable` synthesis**: the Swift compiler synthesises `Codable` for a struct when all stored properties are `Codable`. `String`, `Int64`, `Double`, `Bool`, `[T]`, `OrderedDictionary` are all `Codable` (via `swift-collections` 1.1). The synthesised implementation uses field names as JSON keys. Since Mochi fields are converted to camelCase in Swift, the JSON output uses camelCase keys. A `CodingKeys` enum is NOT emitted by default (the synthesised behaviour is camelCase-to-camelCase, which is the Swift/JavaScript convention).
+
+**`Hashable` implies `Equatable`**: structural equality is synthesised. `u1 == u2` compares all fields.
+
+**`Codable` declared in struct**: the protocol conformance list becomes `Sendable, Hashable, Codable`:
+
+```swift
+@frozen
+public struct User: Sendable, Hashable, Codable {
+    public let name: String
+    public let age: Int64
+}
+```
+
+## Sub-phase 4.4 -- Generic records
+
+### Decisions made (4.4)
+
+**Generic struct**: Mochi `record Pair<A, B> { first: A; second: B }` → Swift generic struct:
+
+```swift
+@frozen
+public struct Pair<A, B>: Sendable, Hashable, Codable
+where A: Sendable & Hashable & Codable, B: Sendable & Hashable & Codable {
+    public let first: A
+    public let second: B
+}
+```
+
+**Where clause**: the lowerer emits `where` constraints for every type parameter to propagate `Sendable & Hashable & Codable`. This is required for the synthesised conformances to work.
+
+**Monomorphisation**: Swift's generics are reified. `Pair<String, Int64>` is a concrete type; the Swift compiler specialises it. The Go lowerer does NOT need to monomorphise generic records (unlike the C backend). This is one of the main ergonomic advantages of the Swift target.
+
+**Recursive generic records** (e.g., `record Tree<A> { value: A; children: list<Tree<A>> }`): require `indirect` for the recursive field. Swift structs cannot contain themselves directly. The lowerer emits the field as a computed property backed by an `@inline(never)` heap allocation:
+
+```swift
+// Lowered as a class-based box to break the recursive layout:
+@frozen
+public struct Tree<A>: Sendable, Hashable, Codable where A: Sendable & Hashable & Codable {
+    public let value: A
+    private let _children: _Box<[Tree<A>]>
+    public var children: [Tree<A>] { _children.value }
+    public init(value: A, children: [Tree<A>]) {
+        self.value = value
+        self._children = _Box(children)
+    }
+}
+private final class _Box<T>: @unchecked Sendable { let value: T; init(_ v: T) { value = v } }
+```
+
+Recursive records are uncommon; the `indirect enum` pattern (from Phase 5) is the idiomatic Swift way to handle recursive types.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/lower/lower.go` | `RecordDecl` → `@frozen public struct` with conformances |
+| `transpiler3/swift/lower/record.go` | `with()` extension method generation; recursive field boxing |
+| `transpiler3/swift/lower/generics.go` | Generic type parameter mapping; `where` clause emission |
+| `transpiler3/swift/lower/types.go` | Updated `swiftTypeOf` for record types |
+| `transpiler3/swift/build/phase04_test.go` | `TestPhase4Records`: 25 fixtures |
+| `tests/transpiler3/swift/fixtures/phase04-records/` | 25 fixture directories |
+
+## Test set
+
+- `TestPhase4Records` -- 25 fixtures covering: `record_basic`, `record_nested`, `record_equality`, `record_in_list`, `record_in_map`, `record_update_single`, `record_update_multi`, `record_update_nested`, `record_generic_pair`, `record_generic_triple`, `record_generic_nested`, `record_codable_json`, `record_hashable`, `record_function_field`, `record_recursive_tree`, `record_list_field`, `record_map_field`, `record_option_field`, `record_variant_field`, `record_multiple_types`, `record_large_fields`, `record_snake_camel`, `record_init_labeled`, `record_structural_eq`, `record_in_set`.
+
+## Deferred work
+
+- `@dynamicMemberLookup` for duck-typed record access. Out of v1 scope.
+- `Codable` with custom `CodingKeys` for snake_case JSON output. Deferred to Phase 14 (fetch/JSON).
+- `NSCopying` for Objective-C bridging. Deferred to Phase 12 (FFI).
+- `description` / `CustomStringConvertible` synthesisation. Deferred -- `print(record)` uses `MochiRuntime.print` which calls `String(reflecting:)` for now.

--- a/website/docs/implementation/0049/phase-05-sums.md
+++ b/website/docs/implementation/0049/phase-05-sums.md
@@ -1,0 +1,229 @@
+---
+title: "Phase 5. Sum types and pattern matching"
+sidebar_position: 9
+sidebar_label: "Phase 5. Sum types and pattern matching"
+description: "MEP-49 Phase 5 — Mochi union types to Swift enum with associated values; match to exhaustive switch; Option<T> to T?; Result<T,E> to Result<T,E>."
+---
+
+# Phase 5. Sum types and pattern matching
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 5](/docs/mep/mep-0049#phase-5-sum-types) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase5Sums`: 25 fixtures green on Swift 6.0 and 6.1, linux-x64. `TestSwiftcClean` remains green (exhaustiveness warnings become errors).
+
+## Goal-alignment audit
+
+Sum types are the primary abstraction over `option<T>`, `result<T,E>`, and user-defined variants. Swift `enum` with associated values is the natural and idiomatic target -- it gives compile-time exhaustiveness checking via the Swift compiler's switch exhaustiveness analysis, readable generated code, and full `Sendable` / `Hashable` / `Codable` support when all associated values conform.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 5.0 | `type Shape = Circle(r: float) \| Rect(w: float, h: float)` → `public enum Shape` with associated values | NOT STARTED | — |
+| 5.1 | `match` → Swift `switch` with exhaustive case pattern; `indirect` for recursive variants | NOT STARTED | — |
+| 5.2 | `option<T>` → `T?`; `some(x)` → `x`; `none` → `nil`; `match opt { some(v) => ..., none => ... }` | NOT STARTED | — |
+| 5.3 | `result<T,E>` → `Result<T,E>`; `ok(v)` → `.success(v)`; `err(e)` → `.failure(e)` | NOT STARTED | — |
+| 5.4 | `Sendable`, `Hashable`, `Codable` conformances synthesised by Swift for all enum variants | NOT STARTED | — |
+
+## Sub-phase 5.0 -- Enum declaration
+
+### Decisions made (5.0)
+
+**`public enum`**: every Mochi union type lowers to a `public enum`. Swift enums with associated values are the canonical sum type representation. Unlike the .NET target which needs an abstract record hierarchy, Swift enums have built-in discriminant + associated data.
+
+**Associated value labels**: Mochi `Circle(r: float)` → Swift `case circle(r: Double)`. Labels are preserved (Swift associated values support labels). The label is lowercase (matching Mochi's snake_case) to keep the case name and label consistent.
+
+**Case name**: Mochi variant names are PascalCase (`Circle`). Swift enum case names are lowerCamelCase (`circle`). The lowerer converts: `Circle` → `.circle`, `Rect` → `.rect`. This matches Swift API Design Guidelines.
+
+```swift
+// Mochi: type Shape = Circle(r: float) | Rect(w: float, h: float)
+public enum Shape: Sendable, Hashable, Codable {
+    case circle(r: Double)
+    case rect(w: Double, h: Double)
+}
+```
+
+**Nullary variants**: Mochi `type Color = Red | Green | Blue` → enum cases with no associated values:
+
+```swift
+public enum Color: Sendable, Hashable, Codable {
+    case red
+    case green
+    case blue
+}
+```
+
+**`indirect` for recursive variants**: Mochi `type List<T> = Nil | Cons(head: T, tail: List<T>)` requires `indirect` because `Cons` contains the enum itself. The lowerer marks the whole enum `indirect`:
+
+```swift
+public indirect enum MochiList<T>: Sendable, Hashable, Codable
+where T: Sendable & Hashable & Codable {
+    case `nil`
+    case cons(head: T, tail: MochiList<T>)
+}
+```
+
+**`nil` keyword conflict**: Mochi `Nil` variant cannot be named `nil` in Swift (reserved keyword). The lowerer uses a backtick escape: `` case `nil` ``.
+
+**One file per union type**: same as records. Each Mochi union type gets its own `.swift` file.
+
+## Sub-phase 5.1 -- Match to switch
+
+### Decisions made (5.1)
+
+**Swift `switch` is exhaustive by default**: the Swift compiler requires all cases to be covered (or a `default` arm). Since Mochi's `match` is always exhaustive, the lowerer never emits a `default` arm unless the Mochi source has a wildcard `_` arm.
+
+**Pattern lowering**:
+
+```swift
+// Mochi:
+// match shape {
+//   Circle(r) => 3.14159 * r * r,
+//   Rect(w, h) => w * h
+// }
+
+let area: Double
+switch shape {
+case .circle(let r):
+    area = 3.14159 * r * r
+case .rect(let w, let h):
+    area = w * h
+}
+```
+
+**Switch as expression**: Swift `switch` is a statement by default (not an expression). For Mochi `match` used as an expression, the lowerer assigns to a temp variable:
+
+```swift
+let __area: Double
+switch shape {
+case .circle(let r): __area = 3.14159 * r * r
+case .rect(let w, let h): __area = w * h
+}
+let area = __area
+```
+
+In Swift 5.9+ (`if` and `switch` expressions via SE-0380), the lowerer can emit `switch` as an expression directly. The lowerer targets Swift 6.0 (which includes SE-0380), so the expression form is preferred when the switch result is used immediately:
+
+```swift
+let area = switch shape {
+case .circle(let r): 3.14159 * r * r
+case .rect(let w, let h): w * h
+}
+```
+
+**Guard clauses**: Mochi `Circle(r) if r > 0.0 => ...` → `case .circle(let r) where r > 0.0:`.
+
+**Nested patterns**: `Pair(Some(x), _)` → `case .pair(.some(let x), _):`.
+
+**Wildcard**: Mochi `_ =>` → `default:`.
+
+## Sub-phase 5.2 -- option<T> → T?
+
+### Decisions made (5.2)
+
+**`T?` not `Option<T>`**: Mochi `option<T>` maps to Swift `Optional<T>` (written `T?`). Swift `Optional` is a stdlib enum with `.some(T)` and `.none` cases. This avoids a custom `Option` type in `MochiRuntime` and integrates with Swift's `??`, `if let`, `guard let`, optional chaining, and `map`/`flatMap` on optionals.
+
+**`some(x)` → `Optional.some(x)` → just `x` in context**: in Swift, wrapping a value in `Optional` is implicit when the type context is `T?`. So `some(x)` in Mochi lowers to just `x` when assigned to a `T?` variable. When a `none` is needed, the lowerer emits `Optional<T>.none` or `nil` depending on context.
+
+**`match opt { some(v) => f(v), none => g() }`**: lowered to:
+
+```swift
+switch opt {
+case .some(let v): f(v)
+case .none: g()
+}
+```
+
+Or with the `if let` idiom when the `none` branch is trivial:
+
+```swift
+if let v = opt {
+    f(v)
+} else {
+    g()
+}
+```
+
+The lowerer prefers `switch` for exhaustive multi-arm matches and `if let` for simple `some/none` pairs.
+
+**`opt ?? default`**: Mochi `opt.get_or(default)` → `opt ?? default`.
+
+**`opt.map(f)`**: → `opt.map(f)`. Swift `Optional.map` applies `f` to the wrapped value if present.
+
+**`opt.flat_map(f)`**: → `opt.flatMap(f)`.
+
+**Optional chaining**: `user?.address?.city` in Mochi → `user?.address?.city` in Swift. The lowerer recognises optional field chains and emits optional chaining directly.
+
+## Sub-phase 5.3 -- result<T,E> → Result<T,E>
+
+### Decisions made (5.3)
+
+**Swift stdlib `Result<T,E>`**: Mochi `result<T,E>` maps to Swift's `Result<Success, Failure>` where `Failure: Error`. `ok(v)` → `.success(v)`. `err(e)` → `.failure(e)`.
+
+**Error type**: Mochi error types in `result<T,E>` are Mochi union types or record types. They are lowered to Swift types that also conform to `Error`. The lowerer adds `Error` conformance to the error enum/struct when it appears as the `E` in `result<T,E>`:
+
+```swift
+// Mochi: type MyError = NotFound | Unauthorized
+public enum MyError: Error, Sendable, Hashable, Codable {
+    case notFound
+    case unauthorized
+}
+```
+
+**`match res { ok(v) => ..., err(e) => ... }`**:
+
+```swift
+switch res {
+case .success(let v): ...
+case .failure(let e): ...
+}
+```
+
+**`result.map(f)`**: → `res.map(f)`.
+
+**`result.flat_map(f)`**: → `res.flatMap(f)`.
+
+**Typed throws bridge** (Phase 11): `result<T,E>` and `throws(E)` are interconvertible. `Result.get()` throws the error; `Result(catching:)` wraps a throwing call. The bridge is fully established in Phase 11.
+
+## Sub-phase 5.4 -- Synthesised conformances
+
+### Decisions made (5.4)
+
+**`Sendable`**: Swift synthesises `Sendable` for enums when all associated values are `Sendable`. Since all Mochi types are `Sendable` by construction (records, scalars, collections), the synthesis always succeeds.
+
+**`Hashable`**: synthesised when all associated values are `Hashable`. Same reasoning.
+
+**`Codable`**: synthesised when all associated values are `Codable`. Nullary cases encode as a string of the case name. Associated-value cases encode as an object `{ "type": "circle", "r": 1.5 }` by default. Custom encoding keys can be specified in Phase 14 (JSON customisation).
+
+**`CustomStringConvertible`**: NOT synthesised by Swift for enums with associated values. `MochiRuntime.print` uses `String(reflecting:)` for enum values in Phase 5. A proper `description` implementation is deferred.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/lower/lower.go` | `UnionDecl` → `public enum`; variant lowering; `indirect` detection |
+| `transpiler3/swift/lower/match.go` | `MatchStmt`/`MatchExpr` → `switch` statement/expression; pattern deconstruction |
+| `transpiler3/swift/lower/option.go` | `option<T>` → `T?`; `some`/`none` literal lowering; optional chain lowering |
+| `transpiler3/swift/lower/result.go` | `result<T,E>` → `Result<T,E>`; `ok`/`err` lowering; `Error` conformance injection |
+| `transpiler3/swift/build/phase05_test.go` | `TestPhase5Sums`: 25 fixtures |
+| `tests/transpiler3/swift/fixtures/phase05-sums/` | 25 fixture directories |
+
+## Test set
+
+- `TestPhase5Sums` -- 25 fixtures covering: `sum_basic`, `sum_nullary`, `sum_recursive`, `sum_generic`, `sum_nested_match`, `sum_guard`, `sum_wildcard`, `sum_as_expression`, `sum_in_list`, `sum_in_map`, `sum_codable`, `sum_hashable`, `sum_multi_variant`, `option_some_none`, `option_map`, `option_flat_map`, `option_chain`, `option_get_or`, `option_in_list`, `result_ok_err`, `result_map`, `result_flat_map`, `result_error_type`, `result_typed_throws_bridge`, `sum_string_result`.
+
+## Deferred work
+
+- `CustomStringConvertible` for enums. Deferred (low priority; `String(reflecting:)` is a working fallback).
+- `Codable` custom encoding keys for sum types. Deferred to Phase 14.
+- Pattern matching on string literals in `match`. Deferred to Phase 2 extension.
+- Non-copyable (`~Copyable`) enum variants for unique-ownership types. Out of v1 scope.

--- a/website/docs/implementation/0049/phase-06-closures.md
+++ b/website/docs/implementation/0049/phase-06-closures.md
@@ -1,0 +1,172 @@
+---
+title: "Phase 6. Closures and higher-order functions"
+sidebar_position: 10
+sidebar_label: "Phase 6. Closures and higher-order functions"
+description: "MEP-49 Phase 6 — fun(...)=>expr to Swift closures; @escaping, @Sendable at actor boundaries; capture lists; partial application; Func<> protocol."
+---
+
+# Phase 6. Closures and higher-order functions
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 6](/docs/mep/mep-0049#phase-6-closures) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase6Closures`: 25 fixtures green on Swift 6.0 and 6.1, linux-x64. `TestSwiftcClean` remains green (no `@Sendable` / `@escaping` inference failures).
+
+## Goal-alignment audit
+
+Closures are Mochi's primary abstraction for higher-order programming, callbacks, and the function argument to collection operations. Phase 6 ships the closure ABI conventions that Phase 9 (actor message handlers receive closures) and Phase 10 (stream producers are closures) depend on. The `@Sendable` annotation is required by Swift 6's strict concurrency for closures that cross actor boundaries.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 6.0 | `fun(a: int, b: int): int => a + b` → Swift closure `{ (a: Int64, b: Int64) -> Int64 in a + b }` | NOT STARTED | — |
+| 6.1 | `@escaping` annotation: closures stored in variables or passed to functions that outlive the call | NOT STARTED | — |
+| 6.2 | `@Sendable` annotation: closures passed across actor boundaries (detected in Phase 9) | NOT STARTED | — |
+| 6.3 | Capture lists: `[weak self]`, `[capturedVar]` for explicit capture semantics | NOT STARTED | — |
+| 6.4 | Partial application; curried functions; `fun(T)->R` as first-class value | NOT STARTED | — |
+
+## Sub-phase 6.0 -- Closure literals
+
+### Decisions made (6.0)
+
+**Swift closure syntax**: Mochi `fun(a: int, b: int): int => a + b` → Swift closure:
+
+```swift
+let add: (Int64, Int64) -> Int64 = { (a: Int64, b: Int64) -> Int64 in
+    return a + b
+}
+```
+
+The lowerer always emits explicit parameter types and return type in the closure signature. Trailing closure syntax is only used when the closure is the last argument of a function call (Swift convention).
+
+**`unit` → `Void`**: Mochi `fun(s: string): unit => print(s)` → `(String) -> Void`. The return type annotation is emitted as `Void` (not omitted) to make the closure type explicit in generated code.
+
+**Multi-line closures**: Mochi closures with a block body (`fun(x) => { let y = x + 1; y * 2 }`) → Swift closures with a multi-statement body:
+
+```swift
+let f: (Int64) -> Int64 = { (x: Int64) -> Int64 in
+    let y: Int64 = x + Int64(1)
+    return y * Int64(2)
+}
+```
+
+**Named function as closure**: a named Mochi function passed as a first-class value → Swift function reference using the identifier directly:
+
+```swift
+// Mochi: list.map(double)  (where double is a top-level function)
+let results = xs.map(double)
+```
+
+When the function is a method on a type, the lowerer uses a closure wrapper: `{ x in MyType.method(x) }`.
+
+**Function type in variable declarations**: Mochi `let f: fun(int) -> int = ...` → Swift `let f: (Int64) -> Int64 = ...`. The function type is part of the `let` binding annotation.
+
+## Sub-phase 6.1 -- @escaping
+
+### Decisions made (6.1)
+
+**When `@escaping` is required**: a closure is `@escaping` in Swift when it outlives the function call that receives it -- i.e., it is stored in a variable, returned, or passed to another `@escaping` parameter. The Swift compiler enforces this.
+
+**Escape analysis in the lowerer**: the lowerer conservatively marks closures `@escaping` when they are passed to:
+- A function parameter that stores the closure (determined by the callee's signature in the `aotir`).
+- A `var` binding (closures stored in mutable variables escape by definition).
+- Any `list.map`/`filter`/`reduce` (these return new collections containing transformed values; the closure must not outlive the operation, so it is NOT `@escaping` here).
+- Actor mailbox continuation enqueue (Phase 9, always `@escaping @Sendable`).
+
+**Trailing closures**: `xs.map { x in f(x) }` -- the closure is not `@escaping` here. `xs.map` takes `@escaping` in stdlib but the Swift compiler's liveness analysis handles this. The lowerer does not add `@escaping` to the closure literal itself; it is part of the `map` function's parameter signature.
+
+**`@escaping` in generated function signatures**:
+
+```swift
+// Mochi: fun register(callback: fun(int) -> unit): unit
+public func register(callback: @escaping (Int64) -> Void) {
+    // stores callback
+}
+```
+
+## Sub-phase 6.2 -- @Sendable
+
+### Decisions made (6.2)
+
+**`@Sendable` requirement**: in Swift 6, closures that cross actor isolation boundaries must be `@Sendable`. This means all captured variables must be `Sendable` (or the closure must not capture non-Sendable state). The `@Sendable` attribute is added by the lowerer when:
+- The closure is passed as an argument to an `async` function.
+- The closure is stored in an `actor`'s property (Phase 9).
+- The closure is submitted to `Task { }` or `withTaskGroup`.
+
+**Static determination**: the lowerer determines `@Sendable` requirement from the callee's parameter type in the `aotir`. If the callee's type system says the parameter is `@Sendable`, the lowerer emits `@Sendable` on the closure.
+
+**Combined**: `@escaping @Sendable` for closures stored in actor fields:
+
+```swift
+// Mochi: agent handler with a stored closure
+func onMessage(_ handler: @escaping @Sendable (Message) async -> Void) { ... }
+```
+
+**`Sendable` conformance of captured vars**: all Mochi `let` bindings are `Sendable` (their types conform). Mochi `var` bindings captured in `@Sendable` closures require the variable's type to be `Sendable`. The lowerer emits a capture list with `captureVar` (value capture) for `var` captures in `@Sendable` closures to avoid shared mutable state:
+
+```swift
+// Captures `count` by value at closure creation time:
+let f: @Sendable () -> Int64 = { [count] in count }
+```
+
+## Sub-phase 6.3 -- Capture lists
+
+### Decisions made (6.3)
+
+**`[weak self]` for actor references**: closures inside actor methods that capture `self` use `[weak self]` when the closure outlives the actor's message processing loop. The lowerer detects this pattern in Phase 9 and emits the capture list.
+
+**`[capturedVar]` (value copy)**: Mochi closures capture `let` bindings by value semantics (the binding is immutable). Swift closures capture by reference by default. For `let` bindings, the difference is immaterial (the value cannot change). For `var` bindings captured in a `@Sendable` closure, the lowerer explicitly captures by value: `{ [count] in ... }`. This makes the capture explicit and avoids `@Sendable` violations.
+
+**Mochi `let` → always safe**: since Mochi `let` bindings are immutable, their Swift counterparts can be captured by reference (the Swift default) without correctness issues. The lowerer does not emit explicit capture lists for `let` captures.
+
+**No `unowned`**: the lowerer never emits `unowned`. `weak` is sufficient and safer (no crash on dangling reference). `unowned` is an optimisation deferred to a future pass.
+
+## Sub-phase 6.4 -- Partial application and currying
+
+### Decisions made (6.4)
+
+**Partial application**: Mochi `fun add3(a: int): fun(b: int): int => fun(b: int): int => a + b` lowers to a closure returning a closure:
+
+```swift
+let add3: (Int64) -> (Int64) -> Int64 = { (a: Int64) -> (Int64) -> Int64 in
+    return { (b: Int64) -> Int64 in
+        return a + b
+    }
+}
+```
+
+**Curried functions**: Mochi allows curried syntax `fun add(a: int)(b: int): int => a + b`. The lowerer flattens this to the nested closure form above.
+
+**`list.map(f)` with a partially applied function**: `users.map(get_name)` where `get_name` is a top-level function → `users.map(getName)` (direct function reference). `users.map(add(3))` where `add(3)` returns a closure → `users.map(add3)` where `add3 = add(Int64(3))`.
+
+**First-class functions as values**: Mochi `fun(T) -> R` type → Swift `(T) -> R`. Swift function types are first-class. No boxing or delegate wrapper needed (unlike .NET which needed `Func<T,R>`).
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/lower/lower.go` | `FunLit` → Swift closure; `FunCallExpr` → call expression |
+| `transpiler3/swift/lower/closure.go` | `@escaping` / `@Sendable` annotation logic; capture list emission |
+| `transpiler3/swift/lower/types.go` | `TypeFun` → `(T1,...,Tn) -> R` Swift function type |
+| `transpiler3/swift/build/phase06_test.go` | `TestPhase6Closures`: 25 fixtures |
+| `tests/transpiler3/swift/fixtures/phase06-closures/` | 25 fixture directories |
+
+## Test set
+
+- `TestPhase6Closures` -- 25 fixtures covering: `closure_basic`, `closure_capture_let`, `closure_capture_var`, `closure_multi_param`, `closure_unit_return`, `closure_as_arg`, `closure_stored`, `closure_returning_closure`, `closure_escaping`, `closure_sendable`, `closure_capture_list`, `hof_map`, `hof_filter`, `hof_reduce`, `hof_flat_map`, `hof_for_each`, `lambda_basic`, `lambda_as_arg`, `partial_apply`, `curried`, `first_class_func`, `closure_in_list`, `closure_over_record`, `closure_nested`, `closure_recursive`.
+
+## Deferred work
+
+- Async closures (`async fun() => ...`). Deferred to Phase 11 (async colouring).
+- Generator closures (`yield`-based). Deferred to Phase 10 (streams).
+- `[DynamicallyAccessedMembers]`-equivalent for NativeAOT-style trimming. Not applicable to Swift (no reflection trimming concerns; ARC is static).
+- High-arity closures (>8 parameters). Swift supports unlimited parameters; no `Func17` equivalent needed. Out of scope.

--- a/website/docs/implementation/0049/phase-07-query.md
+++ b/website/docs/implementation/0049/phase-07-query.md
@@ -1,0 +1,229 @@
+---
+title: "Phase 7. Query DSL"
+sidebar_position: 11
+sidebar_label: "Phase 7. Query DSL"
+description: "MEP-49 Phase 7 — query DSL to Swift lazy Sequence chain; group_by to OrderedDictionary; join via hash join; order_by via sorted(by:); top-K via Heap."
+---
+
+# Phase 7. Query DSL
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 7](/docs/mep/mep-0049#phase-7-query-dsl) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase7Query`: 30 fixtures green on Swift 6.0 and 6.1, linux-x64. `TestSwiftcClean` remains green.
+
+## Goal-alignment audit
+
+The Mochi query DSL is the primary data-wrangling surface. On Swift, it lowers to `lazy` sequence chains from stdlib + `swift-algorithms` + `swift-async-algorithms`. The lowering is isomorphic: `from x in xs where p(x) select f(x)` → `xs.lazy.filter(p).map(f)`. Group-by, join, and top-K use `swift-collections` and `swift-algorithms` -- the same dependencies already pulled in by Phase 3. Phase 7 adds `swift-algorithms` as a new MochiRuntime dependency.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 7.0 | `from x in xs where p(x) select f(x)` → `xs.lazy.filter { p($0) }.map { f($0) }` | NOT STARTED | — |
+| 7.1 | `order_by`, `skip`, `take` → `sorted(by:)`, `dropFirst`, `prefix` | NOT STARTED | — |
+| 7.2 | `group_by k select { key: key, items: items }` → `OrderedDictionary` grouping via `swift-algorithms` | NOT STARTED | — |
+| 7.3 | `join` (inner, hash join) → `Dictionary(uniqueKeysWithValues:)` + `compactMap`; `left_join` | NOT STARTED | — |
+| 7.4 | Aggregates: `count`, `sum`, `avg`, `min`, `max` → stdlib `reduce` / `min(by:)` / `max(by:)` | NOT STARTED | — |
+| 7.5 | Top-K: `take N order_by k` → `Heap<T>` from `swift-collections` (O(N log K) vs O(N log N)) | NOT STARTED | — |
+| 7.6 | Async query pipeline over `AsyncSequence`; `for await` consumption | NOT STARTED | — |
+
+## Sub-phase 7.0 -- from / where / select
+
+### Decisions made (7.0)
+
+**`lazy` chain preferred over eager**: the Mochi query pipeline is lazy. `xs.lazy.filter { ... }.map { ... }` produces a `LazyFilterSequence<LazyMapSequence<...>>`. The result is materialized to `[T]` via `Array(...)` only when the Mochi source binds the result to a `list<T>` variable. When flowing directly into a `for` loop, no materialization is emitted.
+
+**`LazySequence` vs `AsyncSequence`**: synchronous queries lower to the `lazy` synchronous sequence chain. Async queries (Phase 7.6) lower to `AsyncSequence` operators from `swift-async-algorithms`.
+
+**Generated code form**:
+
+```swift
+// Mochi: from x in users where x.age > 18 select x.name
+let result: [String] = users.lazy
+    .filter { x in x.age > Int64(18) }
+    .map { x in x.name }
+    |> Array.init
+```
+
+The `|> Array.init` is sxtree shorthand for `Array(...)`. In practice, the lowerer emits `Array(users.lazy.filter { ... }.map { ... })`.
+
+**Variable shadowing**: the `from x in ...` binding introduces `x` as the iteration variable. The lowerer generates a unique name if `x` conflicts with an outer scope binding (uses `__qx0`, `__qx1`, etc.).
+
+## Sub-phase 7.1 -- order_by, skip, take
+
+### Decisions made (7.1)
+
+**`order_by k asc`**: → `sorted(by: { a, b in a.k < b.k })`. Multi-key: chained `sorted(by:)` calls with secondary comparator.
+
+**Stable sort**: Swift 5.8+ `sorted(by:)` is stable. Documented in stdlib. The lowerer relies on this guarantee.
+
+**`order_by k desc`**: → `sorted(by: { a, b in a.k > b.k })`.
+
+**Multi-key**: Mochi `order_by k1 asc, k2 desc` → a single `sorted(by:)` with a composite comparator:
+
+```swift
+.sorted(by: { a, b in
+    if a.k1 != b.k1 { return a.k1 < b.k1 }
+    return a.k2 > b.k2
+})
+```
+
+**`skip n`**: → `.dropFirst(Int(n))`. Returns a `Sequence` slice; materialized to `Array` when needed.
+
+**`take n`**: → `.prefix(Int(n))`.
+
+**`skip n take m`**: → `.dropFirst(Int(n)).prefix(Int(m))`. Applied to the ordered sequence.
+
+## Sub-phase 7.2 -- group_by
+
+### Decisions made (7.2)
+
+**`swift-algorithms` `chunked(by:)` vs manual grouping**: `swift-algorithms` provides `chunked(by:)` and `grouped(by:)` operations. `grouped(by:)` returns `[K: [V]]` (a stdlib `Dictionary`), which is unordered. For Mochi's ordered-map semantics, the lowerer uses a manual fold into `OrderedDictionary`:
+
+```swift
+// Mochi: from o in orders group_by o.customerId select { id: key, items: items }
+var __groups = OrderedDictionary<Int64, [Order]>()
+for o in orders {
+    __groups[o.customerId, default: []].append(o)
+}
+let result: [GroupResult] = __groups.map { key, items in
+    GroupResult(id: key, items: items)
+}
+```
+
+**Insertion order**: groups appear in the order their first element was encountered. This matches Mochi's `group_by` semantics and `OrderedDictionary` behavior.
+
+**Aggregate in select**: `select { id: key, total: sum(items, fun(o) => o.amount) }` → the aggregate is applied to the group's item array using `reduce`:
+
+```swift
+total: items.reduce(Int64(0)) { acc, o in acc + o.amount }
+```
+
+## Sub-phase 7.3 -- join and left_join
+
+### Decisions made (7.3)
+
+**Hash join (inner)**: Mochi `from o in orders join c in customers on o.customerId == c.id select ...` → hash join:
+
+```swift
+// Build phase: hash customers by id
+let __customerById = Dictionary(uniqueKeysWithValues: customers.map { c in (c.id, c) })
+
+// Probe phase:
+let result = orders.compactMap { o -> JoinResult? in
+    guard let c = __customerById[o.customerId] else { return nil }
+    return JoinResult(order: o, customer: c)
+}
+```
+
+`Dictionary` (stdlib, unordered) is used for the hash table because the join result order is determined by the left (probe) side -- `orders`. `OrderedDictionary` is not needed here.
+
+**`compactMap` for inner join**: `compactMap` naturally implements the "skip unmatched rows" semantics of an inner join.
+
+**Left join**: Mochi `from o in orders left_join c in customers on ...` → same hash build, but using `map` with `Optional<Customer>`:
+
+```swift
+let result = orders.map { o -> LeftJoinResult in
+    let c: Customer? = __customerById[o.customerId]
+    return LeftJoinResult(order: o, customer: c)
+}
+```
+
+The right-side element is `Customer?` (Mochi `option<Customer>`).
+
+**Merge join**: used when both sides are already sorted on the join key (detected by the query planner when both sides have an `order_by` on the join key). Merge join emits a two-pointer algorithm. Deferred to a future query optimiser phase.
+
+**Cross join**: `from a in xs from b in ys select ...` → nested `flatMap`:
+
+```swift
+let result = xs.flatMap { a in ys.map { b in (a, b) } }
+```
+
+## Sub-phase 7.4 -- Aggregates
+
+### Decisions made (7.4)
+
+**`count()`**: → `xs.count` (materializes if lazy) or `xs.reduce(0) { acc, _ in acc + 1 }` (stays lazy). For simple count-all, `.count` is emitted after materializing.
+
+**`sum(f)`**: → `xs.reduce(Int64(0)) { acc, x in acc + f(x) }`. For `float` fields: `xs.reduce(0.0) { acc, x in acc + f(x) }`.
+
+**`avg(f)`**: → `xs.reduce((Int64(0), Int64(0))) { acc, x in (acc.0 + f(x), acc.1 + 1) }` then `Double(acc.0) / Double(acc.1)`. Returns `Double`.
+
+**`min(f)` / `max(f)`**: → `xs.min(by: { a, b in f(a) < f(b) })!.field` (the `!` is safe post-filter when the list is non-empty; a guard is emitted). Alternatively, `xs.map(f).min()!` when extracting a scalar.
+
+**`distinct()`**: → `Array(OrderedSet(xs))` (from Phase 3.3). Preserves first-occurrence order.
+
+**`distinct(f)` (distinct by key)**: → `swift-algorithms` `.uniqued(on: f)`. Requires `swift-algorithms` as a dependency (added in Phase 7).
+
+## Sub-phase 7.5 -- Top-K
+
+### Decisions made (7.5)
+
+**`take N order_by k asc` → Heap**: for large datasets, sorting all elements to take the top N is O(M log M). A min-heap of size N gives O(M log N). The lowerer detects `take N order_by k` and emits the heap pattern:
+
+```swift
+import Collections  // Heap<T> from swift-collections
+
+var __heap = Heap<(Int64, Record)>()  // (key, value)
+for x in xs {
+    let k = x.someField
+    if __heap.count < Int(n) {
+        __heap.insert((k, x))
+    } else if let top = __heap.min, k > top.0 {
+        _ = __heap.popMin()
+        __heap.insert((k, x))
+    }
+}
+let result = __heap.unordered.sorted(by: { a, b in a.0 > b.0 }).map(\.1)
+```
+
+**When to use heap**: the lowerer uses the heap path when the `take` limit N is a compile-time constant and the source is not already sorted. The threshold for switching from `sorted + prefix` to heap is N < M/log(M), approximated as N < 1000 for unknown M (conservative). The exact threshold is configurable via a compiler flag.
+
+## Sub-phase 7.6 -- Async query pipeline
+
+### Decisions made (7.6)
+
+**`AsyncSequence` source**: when the source `xs` is an `AsyncSequence` (e.g., from Phase 10 streams), `where` → `.filter`, `select` → `.map` using `swift-async-algorithms` operators.
+
+**`swift-async-algorithms` dependency**: added to MochiRuntime `Package.swift` in Phase 7.6.
+
+```swift
+// Mochi: from x in asyncStream where pred(x) select f(x)
+let result = asyncStream
+    .filter { x in pred(x) }
+    .map { x in f(x) }
+// Consumed with: for await x in result { ... }
+```
+
+**Aggregates on async sequence**: `await result.count()`, `await result.reduce(0, +)` using `swift-async-algorithms` async reduce. These are `async throws` and require the enclosing function to be `async` (Phase 11).
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/lower/query.go` | Query DSL lowering: `QueryScopeStmt`, `GroupByExpr`, `JoinExpr`, aggregates |
+| `transpiler3/swift/lower/lower.go` | `ListSortExpr`, `ListSliceExpr`, `ListFilterExpr`, `ListMapExpr` updates for query context |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/Query.swift` | Heap-based top-K helpers; `mochiDistinct` |
+| `transpiler3/swift/runtime/Package.swift` | `swift-algorithms`, `swift-async-algorithms` dependencies added |
+| `transpiler3/swift/build/phase07_test.go` | `TestPhase7Query`: 30 fixtures |
+| `tests/transpiler3/swift/fixtures/phase07-query/` | 30 fixture directories |
+
+## Test set
+
+- `TestPhase7Query` -- 30 fixtures covering: `query_filter`, `query_select`, `query_where_select`, `query_no_where`, `query_empty_result`, `query_sort_asc`, `query_sort_desc`, `query_multi_sort`, `query_skip`, `query_take`, `query_skip_take`, `query_group_by`, `query_group_by_aggregate`, `query_sum`, `query_avg`, `query_min_max`, `query_count`, `query_distinct`, `query_distinct_by`, `query_inner_join`, `query_left_join`, `query_cross_join`, `query_top_k`, `query_nested`, `query_chained`, `query_lazy_no_materialize`, `query_async_filter`, `query_async_map`, `query_async_group`, `query_async_aggregate`.
+
+## Deferred work
+
+- `IQueryable<T>` / database query integration. Deferred to Phase 12 (FFI).
+- Query plan optimiser (predicate pushdown, merge join). Deferred to a future sub-MEP.
+- Window functions (`ROW_NUMBER`, `LAG`, `LEAD`). Deferred to Phase 12.
+- `from x in asyncStream group_by` (streaming aggregation). Deferred to Phase 10 extension.

--- a/website/docs/implementation/0049/phase-08-datalog.md
+++ b/website/docs/implementation/0049/phase-08-datalog.md
@@ -1,0 +1,179 @@
+---
+title: "Phase 8. Datalog"
+sidebar_position: 12
+sidebar_label: "Phase 8. Datalog"
+description: "MEP-49 Phase 8 — fact/rule/query lowering to MochiRuntime.Datalog; compile-time semi-naive evaluation; struct facts; 20 fixtures."
+---
+
+# Phase 8. Datalog
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 8](/docs/mep/mep-0049#phase-8-datalog) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase8Datalog`: 20 fixtures green on Swift 6.0 and 6.1, linux-x64. `TestSwiftcClean` remains green.
+
+## Goal-alignment audit
+
+Datalog is Mochi's relational reasoning surface. Phase 8 ships the Swift backend for Datalog, reusing the same compile-time semi-naive evaluator strategy as the BEAM and JVM targets. The gate is byte-equal stdout against vm3, which uses the same evaluation algorithm. Unlike the .NET backend (which generated `Engine.Assert/AddRule/Query` calls at runtime), the Swift backend evaluates Datalog at transpile time and emits the results as static Swift arrays -- no runtime evaluator needed for the common case.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 8.0 | `fact parent(alice, bob)` → Swift struct fact; compile-time evaluation; emitted as `let __dl_parent: [ParentFact] = [...]` | NOT STARTED | — |
+| 8.1 | `rule ancestor(X,Y) :- parent(X,Y)` → semi-naive fixed-point evaluation at compile time | NOT STARTED | — |
+| 8.2 | `query ancestor(alice, ?Z)` → static lookup against precomputed `[AncestorFact]`; print results | NOT STARTED | — |
+| 8.3 | `MochiRuntime.Datalog.Engine` for dynamic fact assertion (non-static case) | NOT STARTED | — |
+
+## Sub-phase 8.0 -- Fact declarations
+
+### Decisions made (8.0)
+
+**Compile-time evaluation strategy**: when all facts are declared as `fact` literals (no runtime-dynamic facts), the Go lowerer evaluates the Datalog program at transpile time using the same semi-naive algorithm as vm3. The derived relation (e.g., `ancestor`) is materialized as a Swift array literal. This produces the smallest and fastest generated code: zero runtime overhead, direct array iteration.
+
+**Typed fact structs**: each Mochi `fact` relation becomes a Swift struct:
+
+```swift
+// Mochi: fact parent(alice, bob)
+struct ParentFact: Equatable, Hashable {
+    let arg0: String
+    let arg1: String
+}
+
+let __dl_parent: [ParentFact] = [
+    ParentFact(arg0: "alice", arg1: "bob"),
+    ParentFact(arg0: "bob", arg1: "carol"),
+]
+```
+
+**Naming**: `fact parent(...)` → struct `ParentFact` (relation name PascalCase + "Fact"), array `__dl_parent` (relation name with `__dl_` prefix to avoid user name collision).
+
+**Heterogeneous fact arities**: each relation has a fixed arity (determined at declaration). The struct has `arg0`, `arg1`, ..., `argN` fields. Phase 8 uses positional names; labeled names are deferred to Phase 12 (typed Datalog schema).
+
+## Sub-phase 8.1 -- Rule evaluation at compile time
+
+### Decisions made (8.1)
+
+**Semi-naive fixed-point in the Go lowerer**: `transpiler3/swift/lower/datalog.go` implements the semi-naive evaluator in Go (same as the BEAM backend's Go evaluator). It runs at transpile time and produces the complete derived relation.
+
+**Algorithm**:
+1. Parse `fact` and `rule` declarations from `aotir`.
+2. Initialize each relation's set from `fact` declarations.
+3. Run bottom-up semi-naive fixed-point: for each rule, compute new tuples using `Δ` (new-in-last-iteration) sets. Halt when all `Δ` are empty.
+4. Emit the final derived sets as Swift array literals.
+
+**Complexity**: the Go evaluator handles the fixture corpus (transitive closure, ancestry, reachability) efficiently. For the 20 fixtures, evaluation completes in <1ms per program.
+
+**Stratified negation**: rules with negation (`not parent(X, Y)`) require stratified evaluation. The Go evaluator detects negation in rule bodies and partitions rules into strata. Each stratum evaluates to fixpoint before the next. Deferred to Phase 8.3 (runtime engine handles dynamic negation).
+
+**Recursive rules**: transitive closure rules (`ancestor(X,Z) :- ancestor(X,Y), parent(Y,Z)`) are handled by the fixed-point iteration. No special treatment needed.
+
+## Sub-phase 8.2 -- Query expressions
+
+### Decisions made (8.2)
+
+**Static lookup**: `query ancestor(alice, ?Z)` → a linear scan over the precomputed `__dl_ancestor` array, filtering on the bound argument and collecting the unbound variable:
+
+```swift
+// Mochi: query ancestor(alice, ?Z)
+let __q_ancestor_alice_Z: [String] = __dl_ancestor
+    .filter { $0.arg0 == "alice" }
+    .map { $0.arg1 }
+for z in __q_ancestor_alice_Z {
+    MochiRuntime.print(z)
+}
+```
+
+**Multiple bound variables**: `query ancestor(?X, carol)` → filter on `arg1`, collect `arg0`.
+
+**Multiple free variables**: `query connected(?X, ?Y)` → collect all `(arg0, arg1)` tuples, print each pair.
+
+**Output format**: matching vm3's output: one result per line, variables printed in order of appearance in the query.
+
+## Sub-phase 8.3 -- Runtime Datalog engine
+
+### Decisions made (8.3)
+
+**When the runtime engine is needed**: for programs that assert facts dynamically at runtime (from user input, network data, or FFI calls), the compile-time evaluator cannot precompute the derived relations. The lowerer detects dynamic fact assertions and falls back to `MochiRuntime.Datalog.Engine`.
+
+**`MochiRuntime.Datalog.Engine`**: pure Swift implementation in `MochiRuntime/Sources/MochiRuntime/Datalog/Engine.swift`. The evaluator:
+
+```swift
+public actor DatalogEngine {
+    private var facts: [String: Set<DatalogTuple>] = [:]
+    private var rules: [DatalogRule] = []
+    
+    public func assert(_ relation: String, _ args: String...) {
+        facts[relation, default: []].insert(DatalogTuple(args))
+    }
+    
+    public func addRule(_ rule: DatalogRule) {
+        rules.append(rule)
+    }
+    
+    public func query(_ relation: String, _ pattern: DatalogPattern) async -> [DatalogTuple] {
+        // Run semi-naive evaluation, then filter by pattern
+        await evaluate()
+        return facts[relation]?.filter { pattern.matches($0) } ?? []
+    }
+    
+    private func evaluate() async {
+        // Semi-naive fixed-point
+        var changed = true
+        while changed {
+            changed = false
+            for rule in rules {
+                let newFacts = rule.derive(from: facts)
+                for (rel, tuples) in newFacts {
+                    let before = facts[rel]?.count ?? 0
+                    facts[rel, default: []].formUnion(tuples)
+                    if (facts[rel]?.count ?? 0) > before { changed = true }
+                }
+            }
+        }
+    }
+}
+```
+
+**`actor`**: the engine is an `actor` to satisfy Swift 6's Sendable requirements when the engine is shared across tasks.
+
+**Generated code for dynamic case**:
+
+```swift
+// Mochi: fact parent(alice, bob) (when dynamic)
+let __engine = DatalogEngine()
+await __engine.assert("parent", "alice", "bob")
+await __engine.addRule(DatalogRule(...))
+let results = await __engine.query("ancestor", DatalogPattern(bound: [0: "alice"], free: [1]))
+```
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/lower/datalog.go` | Compile-time semi-naive evaluator; `DatalogQueryExpr` → static array literal |
+| `transpiler3/swift/lower/lower.go` | `FactDecl`, `RuleDecl`, `DatalogQueryExpr` dispatch |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/Datalog/Engine.swift` | Runtime `DatalogEngine` actor |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/Datalog/DatalogTuple.swift` | Tuple and pattern types |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/Datalog/DatalogRule.swift` | Rule representation and derivation |
+| `transpiler3/swift/build/phase08_test.go` | `TestPhase8Datalog`: 20 fixtures |
+| `tests/transpiler3/swift/fixtures/phase08-datalog/` | 20 fixture directories |
+
+## Test set
+
+- `TestPhase8Datalog` -- 20 fixtures covering: `dl_parent_basic`, `dl_ancestor`, `dl_sibling`, `dl_grandparent`, `dl_connected`, `dl_reachability`, `dl_transitive_closure`, `dl_negation`, `dl_stratified`, `dl_multi_rule`, `dl_multi_query`, `dl_bound_free`, `dl_all_free`, `dl_all_bound`, `dl_facts_only`, `dl_large_closure`, `dl_cycle`, `dl_path_query`, `dl_dynamic_assert`, `dl_dynamic_query`.
+
+## Deferred work
+
+- RETE network for large-scale dynamic Datalog. Deferred to a Phase 8 sub-MEP.
+- Persistent fact storage (SQLite via FFI). Deferred to Phase 12.
+- Datalog with typed schemas (relation fields named, typed). Deferred to Phase 12.
+- Probabilistic Datalog. Out of v1 scope.

--- a/website/docs/implementation/0049/phase-09-agents.md
+++ b/website/docs/implementation/0049/phase-09-agents.md
@@ -1,0 +1,238 @@
+---
+title: "Phase 9. Agents (actor + AsyncStream)"
+sidebar_position: 13
+sidebar_label: "Phase 9. Agents"
+description: "MEP-49 Phase 9 — Mochi agent to Swift actor with AsyncStream<Message> mailbox; cast (fire-and-forget); call (request-reply via CheckedContinuation); OTP-style supervision."
+---
+
+# Phase 9. Agents (actor + AsyncStream)
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 9](/docs/mep/mep-0049#phase-9-agents) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase9Agents`: 25 fixtures green on Swift 6.0 and 6.1, linux-x64. `TestSwiftcClean` remains green (all actor isolation violations surfaced as errors).
+
+## Goal-alignment audit
+
+Mochi agents are the primary concurrency primitive. Swift `actor` is the direct semantic match: isolated mutable state, cooperative scheduling, Sendable message passing. The `AsyncStream<Message>` mailbox gives back-pressure and ordering guarantees. This is one of the five load-bearing decisions in MEP-49: actor+AsyncStream rather than raw GCD or Combine gives a clean mental model, explicit message types, and structural supervision.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 9.0 | `agent Counter { var n = 0; ... }` → `public actor Counter` with `AsyncStream<Message>` mailbox + `runLoop()` | NOT STARTED | — |
+| 9.1 | `cast(counter, inc)` → fire-and-forget `continuation.yield(.inc)` | NOT STARTED | — |
+| 9.2 | `call(counter, value)` → request-reply via `withCheckedContinuation` | NOT STARTED | — |
+| 9.3 | Agent `init` → `Task { await self.runLoop() }` spawned in `init` | NOT STARTED | — |
+| 9.4 | Supervision: `MochiRuntime.Supervisor` actor with `one_for_one`, `rest_for_one`, `one_for_all` | NOT STARTED | — |
+| 9.5 | `@ui` annotation → `@MainActor` isolation; UIKit/SwiftUI message dispatch | NOT STARTED | — |
+
+## Sub-phase 9.0 -- Actor declaration
+
+### Decisions made (9.0)
+
+**Full agent lowering pattern**: a Mochi `agent Counter { var n: int = 0; ... }` lowers to:
+
+```swift
+public actor Counter {
+    private var n: Int64
+    private let mailbox: AsyncStream<Message>
+    private let continuation: AsyncStream<Message>.Continuation
+
+    private enum Message: Sendable {
+        case inc
+        case value(CheckedContinuation<Int64, Never>)
+    }
+
+    public init(n: Int64 = Int64(0)) {
+        self.n = n
+        let (stream, cont) = AsyncStream<Message>.makeStream(
+            bufferingPolicy: .bufferingNewest(1024)
+        )
+        self.mailbox = stream
+        self.continuation = cont
+        Task { [weak self] in
+            await self?.runLoop()
+        }
+    }
+
+    private func runLoop() async {
+        for await msg in mailbox {
+            switch msg {
+            case .inc:
+                n += Int64(1)
+            case .value(let k):
+                k.resume(returning: n)
+            }
+        }
+    }
+}
+```
+
+**`AsyncStream.makeStream(bufferingPolicy:)`**: SE-0388 (Swift 5.9+). The `.bufferingNewest(1024)` policy drops oldest messages when the buffer is full and the loop is behind. The buffer size of 1024 is the MochiRuntime default; it is configurable per-agent via an annotation `@buffer(size: N)`.
+
+**`Task { [weak self] in await self?.runLoop() }`**: the unstructured task spawns the message loop. `[weak self]` prevents the actor from being pinned by the task if the actor is released by all external references.
+
+**`Message` enum**: each agent method that can receive messages becomes a `case` in the `Message` enum. Fire-and-forget methods (no return value) are simple cases (`.inc`). Request-reply methods carry a `CheckedContinuation` case (`.value(CheckedContinuation<Int64, Never>)`).
+
+**Actor isolation**: Swift 6 enforces that `n` is only accessed from within the actor. The `runLoop()` method is `private` and only called from the `Task` spawned in `init`. All external interactions go through the public API methods (cast and call).
+
+## Sub-phase 9.1 -- cast (fire-and-forget)
+
+### Decisions made (9.1)
+
+**`cast(counter, inc)` in Mochi** → `counter.inc()` in Swift (a synchronous actor method that enqueues the message):
+
+```swift
+// Generated actor method for cast:
+public nonisolated func inc() {
+    continuation.yield(.inc)
+}
+```
+
+**`nonisolated`**: the `inc()` method is `nonisolated` because `continuation.yield` is itself a synchronous, `Sendable`-safe operation. This allows `inc()` to be called from any context without `await`. From the caller's perspective, `cast(counter, inc)` is a non-async call -- fire and forget.
+
+**`AsyncStream.Continuation` is `Sendable`**: `continuation.yield` can be called from any isolation context. The `continuation` property must be accessible from the `nonisolated` method. It is stored as a `let` property (immutable after `init`), so it is accessible nonisolated.
+
+**Back-pressure**: if the mailbox buffer is full, `continuation.yield(.inc)` returns `.dropped`. The lowerer wraps this in a discardable result; dropped messages are silent by default. A `@failOnDrop` annotation can make the drop a runtime error.
+
+## Sub-phase 9.2 -- call (request-reply)
+
+### Decisions made (9.2)
+
+**`call(counter, value)` in Mochi** → `await counter.value()` in Swift:
+
+```swift
+// Generated actor method for call:
+public func value() async -> Int64 {
+    await withCheckedContinuation { k in
+        continuation.yield(.value(k))
+    }
+}
+```
+
+**`withCheckedContinuation`**: SE-0300. The continuation is passed as the associated value of the `.value` message. The `runLoop` resumes it with `k.resume(returning: n)`. The `await` at the call site suspends until the reply arrives.
+
+**`withCheckedThrowingContinuation`**: used when the agent method can throw (Mochi `call` with an error type). The `Message` case carries `CheckedContinuation<T, Error>`.
+
+**Deadlock prevention**: the `call` pattern can deadlock if an agent calls another agent that calls back synchronously. Mochi's type system tracks agent call graphs (Phase 11) and flags cycles. In Phase 9, the programmer is responsible for avoiding deadlocks.
+
+**Timeout**: `withCheckedContinuation` has no built-in timeout. `MochiRuntime` provides a `callWithTimeout` helper:
+
+```swift
+public func valueWithTimeout(_ deadline: Duration) async throws -> Int64 {
+    try await withTimeout(deadline) {
+        await self.value()
+    }
+}
+```
+
+`withTimeout` is implemented in `MochiRuntime` using `withThrowingTaskGroup`.
+
+## Sub-phase 9.3 -- Agent init and lifecycle
+
+### Decisions made (9.3)
+
+**`init` spawns the run loop**: the `Task { [weak self] in await self?.runLoop() }` in `init` is the run loop's unstructured task. It runs until the actor is deallocated (at which point `[weak self]` resolves to `nil`, `self?.runLoop()` is a no-op, and the loop exits naturally because the `AsyncStream` is terminated by ARC when `continuation` is released).
+
+**Actor deallocation**: when all external references to the actor drop, ARC deallocates it. The `Continuation`'s deinit calls `continuation.finish()`, which terminates the `AsyncStream`, causing the `for await` loop in `runLoop` to exit.
+
+**Explicit shutdown**: Mochi `stop(counter)` → a dedicated `.stop` message case:
+
+```swift
+case stop
+```
+
+The `runLoop` handles `.stop` by returning from the loop (breaking the `for await`). The actor can then be collected.
+
+## Sub-phase 9.4 -- Supervision
+
+### Decisions made (9.4)
+
+**`MochiRuntime.Supervisor` actor**: implements OTP-style supervision:
+
+```swift
+public actor Supervisor {
+    public enum Strategy { case oneForOne, restForOne, oneForAll }
+    public enum RestartPolicy { case permanent, transient, temporary }
+
+    public struct ChildSpec: Sendable {
+        public let id: String
+        public let start: @Sendable () async -> any MochiAgent
+        public let restart: RestartPolicy
+        public let maxRestarts: Int
+        public let within: Duration
+    }
+
+    private var children: [String: ChildEntry] = [:]
+    private let strategy: Strategy
+
+    public init(strategy: Strategy) { self.strategy = strategy }
+
+    public func startChild(_ spec: ChildSpec) async { ... }
+    public func terminateChild(_ id: String) async { ... }
+    public func handleCrash(_ id: String, error: Error) async { ... }
+}
+```
+
+**`MochiAgent` protocol**: all generated agents conform to a `MochiAgent` protocol with `func stop() async` and a stable `id: String`.
+
+**Restart strategies**:
+- `one_for_one`: restart only the crashed child.
+- `rest_for_one`: restart the crashed child and all children started after it.
+- `one_for_all`: restart all children when any one crashes.
+
+**Max restarts**: if a child crashes more than `maxRestarts` times within `within` duration, the supervisor terminates itself (escalates to its own supervisor). This implements the OTP max-restarts circuit breaker.
+
+**Linking**: `MochiRuntime.Supervisor.startChild` registers the child. The supervisor monitors the child's `Task` using structured `withTaskGroup`. If the child's task completes with an error, the supervisor's `handleCrash` is called.
+
+## Sub-phase 9.5 -- @ui annotation → @MainActor
+
+### Decisions made (9.5)
+
+**`@ui`-annotated Mochi agents** → `@MainActor`-isolated actors:
+
+```swift
+// Mochi: @ui agent ViewModel { ... }
+@MainActor
+public final class ViewModel: ObservableObject {
+    // Not an actor -- @MainActor classes can conform to ObservableObject
+    // for SwiftUI integration
+}
+```
+
+**`class` not `actor`**: SwiftUI's `ObservableObject` + `@Published` requires a `class`. `@MainActor` provides the isolation guarantee. Mochi `@ui` agents lower to `@MainActor class` rather than `actor` to enable SwiftUI integration.
+
+**Non-`@ui` agents**: lower to `actor` (the standard case in 9.0).
+
+**`@MainActor` dispatch**: `cast(viewModel, updateTitle("hello"))` from a non-`@MainActor` context → `await viewModel.updateTitle("hello")` (async dispatch to main actor). The `await` is mandatory in Swift 6 strict concurrency.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/lower/agent.go` | `AgentDecl` → `actor` declaration; `Message` enum generation; `runLoop` body |
+| `transpiler3/swift/lower/lower.go` | `CastExpr`, `CallExpr` (agent) → nonisolated/async method calls |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/Supervisor.swift` | `Supervisor` actor; `MochiAgent` protocol; restart strategies |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/Timeout.swift` | `withTimeout` helper |
+| `transpiler3/swift/build/phase09_test.go` | `TestPhase9Agents`: 25 fixtures |
+| `tests/transpiler3/swift/fixtures/phase09-agents/` | 25 fixture directories |
+
+## Test set
+
+- `TestPhase9Agents` -- 25 fixtures covering: `agent_basic_counter`, `agent_cast_fire_forget`, `agent_call_reply`, `agent_state_mutation`, `agent_multiple_messages`, `agent_init_args`, `agent_stop`, `agent_two_agents`, `agent_ping_pong`, `agent_chain`, `agent_spawn_in_loop`, `agent_backpressure`, `agent_timeout`, `agent_supervisor_one_for_one`, `agent_supervisor_rest_for_one`, `agent_supervisor_one_for_all`, `agent_restart_permanent`, `agent_restart_transient`, `agent_restart_temporary`, `agent_max_restarts`, `agent_ui_main_actor`, `agent_sendable_message`, `agent_record_message`, `agent_enum_message`, `agent_large_state`.
+
+## Deferred work
+
+- Distributed actors (Swift Distributed Actors framework). Deferred to a Phase 9 sub-MEP.
+- `@cluster` annotation for distributed deployment. Out of v1 scope.
+- Agent hot-code reload. Out of v1 scope.
+- `select` receive (multiple mailboxes). Deferred to Phase 9.1.

--- a/website/docs/implementation/0049/phase-10-streams.md
+++ b/website/docs/implementation/0049/phase-10-streams.md
@@ -1,0 +1,165 @@
+---
+title: "Phase 10. Streams (AsyncSequence)"
+sidebar_position: 14
+sidebar_label: "Phase 10. Streams"
+description: "MEP-49 Phase 10 — stream<T> to AsyncStream<T>; producer closures; debounce, throttle, merge, zip via swift-async-algorithms; for-await consumption."
+---
+
+# Phase 10. Streams (AsyncSequence)
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 10](/docs/mep/mep-0049#phase-10-streams) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase10Streams`: 20 fixtures green on Swift 6.0 and 6.1, linux-x64. `TestSwiftcClean` remains green.
+
+## Goal-alignment audit
+
+Mochi streams are the primary abstraction for push-based data pipelines: sensor data, network events, user input events, agent output sequences. Swift `AsyncSequence` is the semantic match. The `swift-async-algorithms` package (already pulled in for Phase 7's async queries) provides `debounce`, `throttle`, `merge`, `zip`, and `AsyncChannel` -- the building blocks for Mochi's stream operators.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 10.0 | `stream<T>` → `AsyncStream<T>`; producer closure via `AsyncStream.Continuation`; `for await` consumption | NOT STARTED | — |
+| 10.1 | `stream.map(f)` → `.map(f)`; `stream.filter(p)` → `.filter(p)`; `stream.flat_map(f)` → `.flatMap(f)` | NOT STARTED | — |
+| 10.2 | `stream.debounce(interval)` → `swift-async-algorithms` `.debounce(for:clock:)`; `throttle` | NOT STARTED | — |
+| 10.3 | `stream.merge(s2)` → `merge(s, s2)`; `stream.zip(s2)` → `zip(s, s2)` | NOT STARTED | — |
+| 10.4 | `AsyncChannel<T>` from `swift-async-algorithms` for multi-producer streams | NOT STARTED | — |
+| 10.5 | Determinism gate: `TestStreamDeterminism` -- multiple runs produce identical output | NOT STARTED | — |
+
+## Sub-phase 10.0 -- Stream creation
+
+### Decisions made (10.0)
+
+**`AsyncStream<T>` as the backing type**: Mochi `stream<T>` lowers to Swift `AsyncStream<T>`. `AsyncStream` (SE-0314, Swift 5.5+) is the stdlib async sequence type with a producer continuation. It is `Sendable` and safe across actor boundaries.
+
+**Producer closure lowering**: a Mochi stream producer `stream { emit -> ... }` lowers to `AsyncStream<T>` with a continuation:
+
+```swift
+// Mochi: let s = stream { emit -> stream<int>
+//     for i in 1..10 { emit(i) }
+// }
+let s = AsyncStream<Int64> { continuation in
+    for i in Int64(1)...Int64(10) {
+        continuation.yield(i)
+    }
+    continuation.finish()
+}
+```
+
+**`AsyncStream.makeStream`**: for streams shared between a producer and consumer in different tasks (e.g., a sensor driver feeding an agent), the `makeStream` pattern (SE-0388) is used:
+
+```swift
+let (stream, continuation) = AsyncStream<Int64>.makeStream(
+    bufferingPolicy: .bufferingNewest(256)
+)
+```
+
+**`for await` consumption**: Mochi `for x in s { ... }` where `s: stream<T>` → Swift `for await x in s { ... }`. The `for await` loop is the primary consumption pattern.
+
+**Cancellation**: Swift structured concurrency cancels the `AsyncStream` producer task when the consuming task is cancelled. The `continuation.onTermination` callback is set in the producer to clean up resources.
+
+## Sub-phase 10.1 -- Stream operators
+
+### Decisions made (10.1)
+
+**`stream.map(f)`**: `AsyncSequence.map` is in the Swift stdlib. `s.map { x in f(x) }` returns `AsyncMapSequence<AsyncStream<T>, U>`.
+
+**`stream.filter(p)`**: `s.filter { x in p(x) }` returns `AsyncFilterSequence<AsyncStream<T>>`.
+
+**`stream.flat_map(f)`**: `s.flatMap { x in f(x) }` where `f` returns an `AsyncSequence`. Requires the async-algorithms `flatMap` overload that works on `AsyncSequence` sources; the stdlib `flatMap` on `AsyncSequence` is available in Swift 5.7+.
+
+**`stream.reduce(init, f)`**: `await s.reduce(init, f)`. Terminal operator; suspends until the stream finishes.
+
+**`stream.first(where:)`**: `await s.first(where: p)`. Returns `T?`.
+
+**`stream.take(n)`**: → `s.prefix(n)` (AsyncPrefixSequence from stdlib).
+
+**`stream.drop(n)`**: → `s.dropFirst(n)` (AsyncDropFirstSequence from stdlib).
+
+## Sub-phase 10.2 -- Debounce and throttle
+
+### Decisions made (10.2)
+
+**`swift-async-algorithms` dependency**: already declared in MochiRuntime `Package.swift` for Phase 7. Phase 10 uses the time-based operators.
+
+**`stream.debounce(interval)`**: → `s.debounce(for: .seconds(interval), clock: .suspending)`. Uses `swift-async-algorithms`'s `debounce` operator (SE-0230 + AsyncAlgorithms). The `.suspending` clock is used (matches wall time; `.continuous` for CPU time). `interval` is a Mochi `float` in seconds, converted to `Swift.Duration` via `.seconds(interval)`.
+
+**`stream.throttle(interval)`**: → `s.throttle(for: .seconds(interval), clock: .suspending, reducing: { _, new in new })`. The `reducing` closure controls how simultaneous events within the window are combined; default is to take the latest.
+
+**`stream.chunk(size: n)`**: → `s.chunks(ofCount: Int(n))`. From `swift-async-algorithms`. Buffers elements into arrays of up to `n` elements.
+
+**`stream.chunk(duration: t)`**: → `s.chunked(by: .repeating(every: .seconds(t), clock: .suspending))`. Time-windowed chunking. Returns `AsyncStream<[T]>`.
+
+## Sub-phase 10.3 -- Merge and zip
+
+### Decisions made (10.3)
+
+**`stream.merge(s2)`**: → `merge(s, s2)` from `swift-async-algorithms`. Returns an async sequence that yields elements from both streams as they arrive, in arrival order. The merged sequence finishes when both input streams finish.
+
+**`stream.zip(s2)`**: → `zip(s, s2)` from `swift-async-algorithms`. Returns pairs `(T, U)`. Finishes when either stream finishes (truncating semantics, matching Mochi's `list.zip`).
+
+**`stream.combine_latest(s2)`**: yields the latest value from each stream whenever either produces a new value. Uses `swift-async-algorithms` `combineLatest` function. Returns `(T, U)`.
+
+**`merge` with more than 2 streams**: `merge(s1, s2, s3)` -- `swift-async-algorithms` supports variadic `merge` up to some arity. For more than 3 streams, the lowerer nests: `merge(merge(s1, s2), merge(s3, s4))`.
+
+## Sub-phase 10.4 -- AsyncChannel for multi-producer
+
+### Decisions made (10.4)
+
+**`AsyncChannel<T>` from `swift-async-algorithms`**: `AsyncChannel` is a bounded channel where multiple producers can `send` and a single consumer iterates with `for await`. It provides back-pressure: `send` suspends when the channel is full.
+
+**Mochi `channel<T>` type**: maps to `AsyncChannel<T>`. Used when multiple agents or tasks produce events into a shared stream.
+
+**Producer**: `channel.send(x)` → `await ch.send(x)`. `send` is `async`; it suspends if the channel buffer is at capacity.
+
+**Consumer**: `for await x in channel { ... }`. The channel finishes when `channel.finish()` is called on the producer side.
+
+**`AsyncStream` vs `AsyncChannel`**: `AsyncStream` is single-producer with a fire-and-forget continuation (non-suspending `yield`). `AsyncChannel` is multi-producer with suspending `send`. The lowerer chooses based on Mochi source: `stream { emit -> ... }` → `AsyncStream`; `channel<T>()` → `AsyncChannel`.
+
+## Sub-phase 10.5 -- Determinism gate
+
+### Decisions made (10.5)
+
+**Non-determinism risk**: `merge(s1, s2)` can yield elements in any interleaved order. Tests that assert exact output order would be flaky. The test gate for merge fixtures checks that the multiset of output elements is correct (order-independent), not the exact sequence.
+
+**`TestStreamDeterminism`**: runs each stream fixture 5 times and asserts that all 5 runs produce identical stdout. This catches timing-dependent bugs (e.g., a `Task.yield()` call that produces different scheduling outcomes). For merge fixtures, only the sorted output is compared.
+
+**Determinism strategy for tests**: stream fixtures that involve merge or non-deterministic ordering use a `sort` step before comparison:
+
+```swift
+// In test harness:
+let results = await s.reduce([]) { acc, x in acc + [x] }
+let sorted = results.sorted()
+XCTAssertEqual(sorted, expected.sorted())
+```
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/lower/stream.go` | `StreamExpr`, `ForStreamStmt` → `AsyncStream`; producer closure; `for await` |
+| `transpiler3/swift/lower/lower.go` | `stream.map`, `filter`, `flat_map`, `reduce`, `take`, `drop` operators |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/Stream.swift` | `mochiDebounce`, `mochiThrottle`, `mochiChunk` wrappers |
+| `transpiler3/swift/runtime/Package.swift` | `swift-async-algorithms` already added in Phase 7 |
+| `transpiler3/swift/build/phase10_test.go` | `TestPhase10Streams`: 20 fixtures; `TestStreamDeterminism` |
+| `tests/transpiler3/swift/fixtures/phase10-streams/` | 20 fixture directories |
+
+## Test set
+
+- `TestPhase10Streams` -- 20 fixtures covering: `stream_basic`, `stream_finite`, `stream_map`, `stream_filter`, `stream_flat_map`, `stream_reduce`, `stream_take`, `stream_drop`, `stream_debounce`, `stream_throttle`, `stream_chunk_count`, `stream_chunk_time`, `stream_merge`, `stream_zip`, `stream_combine_latest`, `stream_channel_single`, `stream_channel_multi`, `stream_from_list`, `stream_to_list`, `stream_cancel`.
+
+## Deferred work
+
+- `stream<T>` from HTTP SSE (Server-Sent Events). Deferred to Phase 14 (fetch).
+- `stream<T>` from WebSocket. Deferred to Phase 14.
+- Backpressure control protocol (`AsyncBackpressuredStream`, proposed). Deferred pending SE acceptance.
+- `stream.window(size: n)` sliding window. Deferred -- `swift-async-algorithms` does not yet have this.

--- a/website/docs/implementation/0049/phase-11-async.md
+++ b/website/docs/implementation/0049/phase-11-async.md
@@ -1,0 +1,150 @@
+---
+title: "Phase 11. Async colouring and typed throws"
+sidebar_position: 15
+sidebar_label: "Phase 11. Async / typed throws"
+description: "MEP-49 Phase 11 — async colour pass adds async/await throughout the call graph; SE-0413 typed throws fun foo(): T throws E → func foo() throws(E) -> T."
+---
+
+# Phase 11. Async colouring and typed throws
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 11](/docs/mep/mep-0049#phase-11-async-colour) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase11Async`: 15 fixtures green on Swift 6.0 and 6.1, linux-x64. `TestSwiftcClean` remains green.
+
+## Goal-alignment audit
+
+Swift's strict concurrency model requires every async call to be explicitly `await`ed, and every function that calls an async function must itself be `async`. This "colour" propagation must be done globally over the Mochi program's call graph before code generation. Phase 11 ships the colour pass and typed-throws lowering, which unblocks all async features (agent calls, stream consumption, fetch, LLM) from being usable in arbitrary function positions.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 11.0 | Async colour pass over `aotir.Program`: propagate `async` upward through the call graph | NOT STARTED | — |
+| 11.1 | `async func` emission; `await` at every async call site; `async let` for concurrent bindings | NOT STARTED | — |
+| 11.2 | SE-0413 typed throws: `fun foo(): T throws E` → `func foo() throws(E) -> T` | NOT STARTED | — |
+| 11.3 | `result<T,E>` / `throws(E)` interconversion bridge: `Result.get()`, `Result(catching:)` | NOT STARTED | — |
+| 11.4 | `try await` at combined async-throwing call sites | NOT STARTED | — |
+
+## Sub-phase 11.0 -- Async colour pass
+
+### Decisions made (11.0)
+
+**Colour analysis**: a function is "red" (async) if it contains any of:
+- An `await agent_call` expression.
+- A `for await` loop over a stream.
+- A `try await` expression (async throws).
+- Any call to another red function.
+- An `async let` binding.
+
+The colour pass performs a topological traversal of the `aotir` call graph, marking functions red bottom-up. The pass runs after `aotir.Lower` and before `lower.Lower`.
+
+**`ColourMap`**: a `map[FunctionID]bool` stored in the lowerer context. The lowerer checks `ColourMap[fnID]` when emitting a function declaration or call.
+
+**`main` is always red if any top-level code is async**: if `main` contains any red call (including spawning agents), the lowerer emits `@main struct { static func main() async { ... } }`.
+
+**`Task { }` wrapping**: synchronous callers of red functions cannot call them directly in Swift 6. The lowerer detects this pattern (a "blue" function that logically should call a red function) and wraps the call in `Task { await f() }`. For agent casts (fire-and-forget), `Task.detached { await ... }` is used if the context is synchronous.
+
+## Sub-phase 11.1 -- async func emission
+
+### Decisions made (11.1)
+
+**`async func` keyword**: functions marked red in `ColourMap` → `func name(...) async -> T`. The `async` keyword is placed before `->`.
+
+**`await` at call sites**: every call to a red function from another red function → `await f(args)`. The sxtree `FunctionCallExpr` node has an `IsAsync bool` field; the emitter adds `await ` prefix when true.
+
+**`async let` for concurrent bindings**: Mochi `let (x, y) = concurrent { (f(), g()) }` (parallel bindings) → Swift `async let`:
+
+```swift
+async let x = f()
+async let y = g()
+let (xVal, yVal) = await (x, y)
+```
+
+`async let` starts both tasks concurrently; the `await` at the tuple collects both results.
+
+**`withTaskGroup` for dynamic concurrency**: Mochi `let results = parallel { xs.map(f) }` (parallel map over a list where `f` is async) → Swift:
+
+```swift
+let results: [U] = await withTaskGroup(of: U.self) { group in
+    for x in xs {
+        group.addTask { await f(x) }
+    }
+    var out: [U] = []
+    for await r in group { out.append(r) }
+    return out
+}
+```
+
+## Sub-phase 11.2 -- Typed throws (SE-0413)
+
+### Decisions made (11.2)
+
+**SE-0413** (Swift 6.0): `func foo() throws(E) -> T` where `E: Error`. Previously, Swift only supported untyped `throws` (which erases the error type to `any Error`). With typed throws, the error type is statically known.
+
+**Mochi `fun foo(): T throws E` mapping**:
+
+```swift
+// Mochi: fun parse(s: string): int throws ParseError
+public func parse(_ s: String) throws(ParseError) -> Int64 {
+    // ...
+}
+```
+
+**Untyped throws bridge**: when Mochi code calls a Swift FFI function that uses untyped `throws`, the lowerer wraps it in a `do { ... } catch { throw MochiError.wrap(error) }` to convert to a typed throw. `MochiError` is a catch-all error type in MochiRuntime.
+
+**Re-throw**: `fun foo(): T throws E` that calls `bar(): U throws E` can re-throw directly. Functions that call multiple throwing functions with different error types must use `throws` (untyped) or a union error type.
+
+**`rethrows`**: Mochi HOFs like `list.map_throwing(f)` where `f` is a throwing closure → `func mapThrowing<E>(_ f: (T) throws(E) -> U) throws(E) -> [U]`. The Swift compiler handles `rethrows` for this pattern.
+
+## Sub-phase 11.3 -- Result / throws bridge
+
+### Decisions made (11.3)
+
+**`Result.get()` → throws**: `res.get()` in Mochi → `try res.get()` in Swift. Swift's `Result<T,E>.get()` throws the failure value when the result is `.failure`.
+
+**`Result(catching:)`**: Mochi `result_of { f() }` → `Result { try f() }`. Wraps a throwing call in a `Result`.
+
+**Async result**: `async_result_of { await f() }` → `await Result { try await f() }`. Both `async` and `throws` at the same call site.
+
+**`flatMap` bridge**: `res.flat_map(f)` where `f` returns `result<U,E>` → `res.flatMap(f)`. Swift's `Result.flatMap` handles this.
+
+## Sub-phase 11.4 -- try await
+
+### Decisions made (11.4)
+
+**Combined async + throws call sites**: agent calls that can throw (e.g., `call(agent, fetch_data)` where `fetch_data` throws a network error) → `try await agent.fetchData()`.
+
+**Error propagation**: in a `func foo() async throws(NetworkError)`, a `try await agent.fetchData()` that throws `NetworkError` propagates the error automatically. No explicit re-throw needed.
+
+**`for try await`**: a stream that can throw (e.g., a network stream that terminates with an error) → `for try await x in stream { ... }`. The loop is wrapped in `do { ... } catch { }`.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/colour/colour.go` | `ColourPass`: propagates async colour upward through call graph |
+| `transpiler3/swift/lower/lower.go` | Checks `ColourMap`; emits `async func`, `await`, `async let`, typed throws |
+| `transpiler3/swift/lower/throws.go` | Typed throws emission; `Result`/`throws` bridge; `rethrows` analysis |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/Error.swift` | `MochiError` catch-all; `withTimeout`; error wrapping |
+| `transpiler3/swift/build/phase11_test.go` | `TestPhase11Async`: 15 fixtures |
+| `tests/transpiler3/swift/fixtures/phase11-async/` | 15 fixture directories |
+
+## Test set
+
+- `TestPhase11Async` -- 15 fixtures covering: `async_basic`, `async_chain`, `async_agent_call`, `async_stream_for_await`, `async_let_parallel`, `async_task_group`, `throws_basic`, `throws_propagate`, `throws_typed`, `throws_result_bridge`, `try_await_basic`, `try_await_agent`, `async_throws_rethrow`, `async_throws_for_try_await`, `async_colour_propagation`.
+
+## Deferred work
+
+- `async throws` functions with multiple error types (requires error union or untyped throws). Deferred to a Phase 11 extension.
+- Swift Concurrency structured task tree visualization. Out of scope.
+- Deadlock detection in the colour pass (cycle detection in the async call graph). Deferred.
+- `@discardableResult` for fire-and-forget async functions. Deferred to a linting pass.

--- a/website/docs/implementation/0049/phase-12-ffi.md
+++ b/website/docs/implementation/0049/phase-12-ffi.md
@@ -1,0 +1,183 @@
+---
+title: "Phase 12. FFI (module maps, @_silgen_name)"
+sidebar_position: 16
+sidebar_label: "Phase 12. FFI"
+description: "MEP-49 Phase 12 — C FFI via @_silgen_name and module.modulemap; Swift library import via @_implementationOnly; Objective-C bridging header."
+---
+
+# Phase 12. FFI (module maps, @_silgen_name)
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 12](/docs/mep/mep-0049#phase-12-ffi) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase12FFI`: 25 fixtures green on Swift 6.0 and 6.1, linux-x64. `TestSwiftcClean` remains green.
+
+## Goal-alignment audit
+
+FFI is the escape hatch that makes Mochi practical for real iOS/macOS/Linux applications. Phase 12 ships the three FFI paths: (1) calling C functions via `module.modulemap`, (2) calling Swift libraries directly as SwiftPM dependencies, (3) exporting Mochi functions to C callers via `@_cdecl`. This enables the ecosystem integrations (SQLite, OpenSSL, system APIs) that the other phases depend on.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 12.0 | C FFI: `module.modulemap` → ClangImporter; `@_silgen_name` for name mangling; unsafe pointer bridging | NOT STARTED | — |
+| 12.1 | Swift library FFI: `external module "github.com/..."` → SwiftPM `.package` + `.product` dependency | NOT STARTED | — |
+| 12.2 | Export to C: `@export fun foo()` → `@_cdecl("foo") public func foo()` | NOT STARTED | — |
+| 12.3 | Objective-C bridging: `@objc` annotation; bridging header; `NSObject` subclassing | NOT STARTED | — |
+| 12.4 | Unsafe Swift: `UnsafePointer<T>`, `UnsafeMutablePointer<T>`, `UnsafeRawPointer`; pointer arithmetic | NOT STARTED | — |
+
+## Sub-phase 12.0 -- C FFI via module map
+
+### Decisions made (12.0)
+
+**`module.modulemap`**: Mochi `@c_import "sqlite3"` → generates a `module.modulemap` file and adds it to the SwiftPM target's `CSettings`:
+
+```
+// Generated: Sources/CModuleSqlite3/module.modulemap
+module CSqlite3 {
+    header "sqlite3.h"
+    export *
+}
+```
+
+The SwiftPM target includes a system library target:
+
+```swift
+// In Package.swift:
+.systemLibrary(
+    name: "CSqlite3",
+    path: "Sources/CModuleSqlite3",
+    pkgConfig: "sqlite3",
+    providers: [.brew(["sqlite"]), .apt(["libsqlite3-dev"])]
+)
+```
+
+**`@_silgen_name`**: for calling C functions with non-Swift-mangled names:
+
+```swift
+// Mochi: @c_func extern fun sqlite3_open(filename: string, db: ptr<ptr<sqlite3>>): int
+@_silgen_name("sqlite3_open")
+public func sqlite3Open(_ filename: UnsafePointer<CChar>?, _ db: UnsafeMutablePointer<OpaquePointer?>?) -> Int32
+```
+
+The lowerer emits `@_silgen_name` when the Mochi FFI declaration specifies the exact C symbol name.
+
+**ClangImporter**: SwiftPM uses ClangImporter to import C headers into Swift. This is automatic when a `.systemLibrary` or `.target` with `publicHeadersPath` is declared in `Package.swift`. The Mochi lowerer generates the necessary SwiftPM target declarations.
+
+**Type bridging at FFI boundary**:
+- Mochi `string` → C `const char*`: `s.withCString { ptr in cFunc(ptr) }` (safe, no copy).
+- Mochi `int` → C `int32_t`: `Int32(n)`.
+- Mochi `list<int>` → C array: `xs.map { Int32($0) }.withUnsafeBufferPointer { buf in cFunc(buf.baseAddress!, Int32(buf.count)) }`.
+- C `int` return → Mochi `int`: `Int64(cReturn)`.
+
+## Sub-phase 12.1 -- Swift library FFI
+
+### Decisions made (12.1)
+
+**`external module` in Mochi**: `external module "https://github.com/apple/swift-crypto" version: "3.0.0"` → SwiftPM dependency added to the generated `Package.swift`:
+
+```swift
+.package(url: "https://github.com/apple/swift-crypto", from: "3.0.0"),
+```
+
+And the product added to the executable target's dependencies:
+
+```swift
+.product(name: "Crypto", package: "swift-crypto"),
+```
+
+**Mochi `use` declaration**: `use Crypto.SHA256` → `import Crypto` in the emitted `.swift` file. The lowerer generates the import statement.
+
+**Type forwarding**: Swift types from the external library are used directly in Mochi via type annotations: `let hash: Crypto.SHA256.Digest = SHA256.hash(data: ...)`. The Mochi type system treats imported Swift types as opaque `extern<T>` types.
+
+**`@_implementationOnly import`**: for internal implementation dependencies that should not be re-exported from the Mochi module, the lowerer emits `@_implementationOnly import ExternalLib`. This is the swift-evolution approved way to hide transitive dependencies.
+
+## Sub-phase 12.2 -- Export to C
+
+### Decisions made (12.2)
+
+**`@export fun foo()`**: Mochi `@export fun add(a: int, b: int): int => a + b` → Swift with `@_cdecl`:
+
+```swift
+@_cdecl("mochi_add")
+public func mochiAdd(_ a: Int64, _ b: Int64) -> Int64 {
+    return add(a, b)
+}
+```
+
+The C symbol name is `mochi_` + the Mochi function name by default. The Mochi source can override with `@export("my_symbol_name") fun foo()`.
+
+**Generated C header**: the lowerer generates a `MochiExports.h` header for C callers:
+
+```c
+// MochiExports.h (auto-generated)
+#pragma once
+#include <stdint.h>
+int64_t mochi_add(int64_t a, int64_t b);
+```
+
+**Thread safety**: `@_cdecl` functions are called from C, potentially from non-Swift threads. They are `nonisolated` by nature. The lowerer adds a `Task` wrapper when the function needs to interact with actors.
+
+## Sub-phase 12.3 -- Objective-C bridging
+
+### Decisions made (12.3)
+
+**`@objc` annotation**: Mochi `@objc record MyView { ... }` → Swift class with `@objc`:
+
+```swift
+@objc
+public final class MyView: NSObject {
+    @objc public var title: String
+    @objc public init(title: String) { self.title = title }
+}
+```
+
+Records become `NSObject` subclasses when `@objc` is applied. The `@frozen struct` from Phase 4 is converted to a `final class` for Objective-C compatibility.
+
+**Bridging header**: for mixed Obj-C/Swift targets (iOS projects using storyboards), the lowerer generates a bridging header `Mochi-Bridging-Header.h` and adds it to the `xcodebuild` settings.
+
+**`NSCopying`**: `@objc` records that need to be stored in `NSArray` or `NSDictionary` get a `copy(with:)` implementation synthesised by the lowerer.
+
+## Sub-phase 12.4 -- Unsafe pointer operations
+
+### Decisions made (12.4)
+
+**`UnsafePointer<T>`**: Mochi `unsafe_ptr<T>` type → Swift `UnsafePointer<T>`. Used for passing buffers to C APIs.
+
+**`UnsafeMutablePointer<T>`**: Mochi `unsafe_mut_ptr<T>` → Swift `UnsafeMutablePointer<T>`.
+
+**`UnsafeRawPointer`**: Mochi `raw_ptr` → Swift `UnsafeRawPointer`. For untyped memory (e.g., `malloc` return).
+
+**`withUnsafePointer(to:_:)` scope**: all unsafe pointer access is scoped. The lowerer emits `withUnsafePointer(to: &val) { ptr in ... }` to ensure the pointer is only valid within the scope.
+
+**`UnsafeBufferPointer<T>`**: `withUnsafeBufferPointer` for accessing array storage as a C-style pointer + length pair.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/lower/ffi.go` | `@c_import`, `external module`, `@export`, `@objc` lowering |
+| `transpiler3/swift/build/package.go` | External SwiftPM dependency injection from `external module` declarations |
+| `transpiler3/swift/lower/unsafe.go` | `unsafe_ptr` / `raw_ptr` type lowering; `withUnsafePointer` scoping |
+| `transpiler3/swift/emit/emit.go` | `module.modulemap` file generation; bridging header generation; `MochiExports.h` |
+| `transpiler3/swift/build/phase12_test.go` | `TestPhase12FFI`: 25 fixtures |
+| `tests/transpiler3/swift/fixtures/phase12-ffi/` | 25 fixture directories |
+
+## Test set
+
+- `TestPhase12FFI` -- 25 fixtures covering: `ffi_c_open_close`, `ffi_c_string_to_cstring`, `ffi_c_int_roundtrip`, `ffi_c_buffer`, `ffi_c_callback`, `ffi_c_struct`, `ffi_c_opaque_pointer`, `ffi_swift_lib_import`, `ffi_swift_type_use`, `ffi_export_basic`, `ffi_export_string`, `ffi_export_int64`, `ffi_objc_class`, `ffi_objc_method`, `ffi_objc_nsobject`, `ffi_unsafe_pointer`, `ffi_unsafe_buffer`, `ffi_unsafe_raw`, `ffi_unsafe_scope`, `ffi_c_errno`, `ffi_c_malloc_free`, `ffi_module_map_system`, `ffi_clang_import`, `ffi_mixed_swift_c`, `ffi_pkg_config`.
+
+## Deferred work
+
+- Swift-to-JVM interop (Android via KMP). Out of v1 scope.
+- COM interface export (Windows). Deferred to a Phase 12 sub-MEP.
+- Swift Package Index registry resolution. Deferred (manually specified URLs for now).
+- `@convention(c)` function pointer type. Deferred to a Phase 12 extension.

--- a/website/docs/implementation/0049/phase-13-llm.md
+++ b/website/docs/implementation/0049/phase-13-llm.md
@@ -1,0 +1,175 @@
+---
+title: "Phase 13. LLM (FoundationModels on Apple)"
+sidebar_position: 17
+sidebar_label: "Phase 13. LLM"
+description: "MEP-49 Phase 13 — @llm annotation using Apple FoundationModels framework (on-device); cassette playback for deterministic tests; cloud fallback via URLSession."
+---
+
+# Phase 13. LLM (FoundationModels on Apple)
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 13](/docs/mep/mep-0049#phase-13-llm) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase13LLM`: 10 fixtures green on Swift 6.0 and 6.1, macOS arm64 only (FoundationModels requires Apple Neural Engine). Cassette playback mode for linux-x64 CI. `TestSwiftcClean` remains green.
+
+## Goal-alignment audit
+
+LLM integration is a first-class Mochi feature, not an afterthought via FFI. On Apple platforms (macOS 15+, iOS 18+), Apple's `FoundationModels` framework provides on-device LLM inference with no API key, no network latency, and no data leaving the device. Phase 13 ships the `@llm` annotation that routes to `FoundationModels` on Apple and to a cloud LLM via `URLSession` on Linux/Windows. Test determinism is achieved via cassette playback (pre-recorded responses).
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 13.0 | `@llm fun summarise(text: string): string` → `FoundationModels.LanguageModel.complete(prompt:)` on Apple | NOT STARTED | — |
+| 13.1 | Structured output: `@llm fun extract(text: string): Person` → `FoundationModels` with `Generable` protocol | NOT STARTED | — |
+| 13.2 | Cassette playback for deterministic CI: record LLM calls to `.cassette` files; replay in test | NOT STARTED | — |
+| 13.3 | Cloud fallback: `@llm(provider: cloud) fun foo()` → `URLSession` HTTP call to configured LLM API | NOT STARTED | — |
+
+## Sub-phase 13.0 -- FoundationModels text generation
+
+### Decisions made (13.0)
+
+**`FoundationModels` framework availability**: `import FoundationModels` (Apple SDK, macOS 15+, iOS 18+, Xcode 16+). The framework provides on-device Apple Intelligence inference. It is NOT available on Linux or Windows.
+
+**Platform guard**: the lowerer wraps `FoundationModels` usage in `#if canImport(FoundationModels)` ... `#else` (cloud fallback). This compiles on all platforms.
+
+**`@llm fun summarise(text: string): string` lowering**:
+
+```swift
+// Generated:
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+public func summarise(_ text: String) async throws -> String {
+    #if canImport(FoundationModels)
+    let session = LanguageModelSession()
+    let response = try await session.respond(to: Prompt(text))
+    return response.content
+    #else
+    return try await __llmCloudFallback(prompt: text, model: "default")
+    #endif
+}
+```
+
+**`LanguageModelSession`**: the primary entry point into FoundationModels. Sessions maintain conversation context. For stateless `@llm` functions, a new session is created per call. For stateful Mochi agents with LLM state, the session is stored in the actor's state.
+
+**`async throws`**: all LLM calls are async (network or on-device inference is non-blocking) and can throw (model unavailable, token limit exceeded, content policy). The enclosing Mochi function must be coloured red (Phase 11).
+
+**`FoundationModels` opacity**: Apple's FoundationModels API is intentionally opaque about which model it uses internally. The lowerer cannot predict output tokens, which is why cassette playback is essential for deterministic tests.
+
+## Sub-phase 13.1 -- Structured output
+
+### Decisions made (13.1)
+
+**`Generable` protocol**: FoundationModels supports structured output via the `@Generable` macro (Xcode 26 / Swift 6.1). A Swift struct annotated with `@Generable` can be used as the target type for structured generation.
+
+**Mochi `@llm fun extract(text: string): Person`**: the return type is a Mochi record. The lowerer emits `@Generable` on the corresponding Swift struct and uses FoundationModels structured generation:
+
+```swift
+// In Person.swift (augmented):
+@Generable
+@frozen
+public struct Person: Sendable, Hashable, Codable {
+    @Guide(description: "The person's full name")
+    public let name: String
+    @Guide(description: "Age in years")
+    public let age: Int64
+}
+
+// Generated function:
+public func extract(_ text: String) async throws -> Person {
+    #if canImport(FoundationModels)
+    let session = LanguageModelSession()
+    let response = try await session.respond(
+        to: Prompt(text),
+        generating: Person.self
+    )
+    return response.content
+    #else
+    return try await __llmStructuredCloudFallback(prompt: text, type: Person.self)
+    #endif
+}
+```
+
+**`@Guide` annotations**: Mochi record field doc-comments (`/// The person's full name`) are converted to `@Guide(description:)` annotations in the generated Swift. This guides the model's structured output.
+
+**Fallback JSON parsing**: on Linux (cloud fallback), structured output is requested as JSON from the cloud API and decoded via `Codable`.
+
+## Sub-phase 13.2 -- Cassette playback
+
+### Decisions made (13.2)
+
+**Cassette pattern**: same as the BEAM backend (MEP-46 Phase 13). Pre-recorded LLM responses are stored in `.cassette` JSON files alongside fixtures. In test mode, the lowerer injects a `MockLanguageModelSession` that replays recorded responses instead of calling FoundationModels.
+
+**`MockLanguageModelSession`**: in `MochiRuntime/Sources/MochiRuntime/LLM/Mock.swift`:
+
+```swift
+#if DEBUG
+public final class MockLanguageModelSession {
+    private let cassette: [String: String]
+    public init(cassette: [String: String]) { self.cassette = cassette }
+    public func respond(to prompt: String) async -> String {
+        cassette[prompt] ?? "<<no cassette entry for: \(prompt)>>"
+    }
+}
+#endif
+```
+
+**Test injection**: the generated code checks `ProcessInfo.processInfo.environment["MOCHI_LLM_CASSETTE"]`. If set, it loads the cassette file and uses `MockLanguageModelSession`. This allows CI (linux-x64) to run LLM tests without FoundationModels.
+
+**Cassette recording**: `MOCHI_LLM_RECORD=1` mode runs the real FoundationModels and writes responses to the cassette file. Recording only works on macOS arm64 with Apple Intelligence enabled.
+
+## Sub-phase 13.3 -- Cloud fallback
+
+### Decisions made (13.3)
+
+**`@llm(provider: cloud)` annotation**: forces cloud LLM even on Apple platforms (useful when the Mochi program needs a larger model than on-device Apple Intelligence provides).
+
+**Cloud provider**: Mochi ships a default cloud provider configuration via `MochiRuntime`. The API key is read from environment variable `MOCHI_LLM_API_KEY`. The default endpoint is configurable. No specific LLM provider is hard-coded (the interface is OpenAI-compatible).
+
+**`URLSession`-based HTTP call**:
+
+```swift
+public func __llmCloudFallback(prompt: String, model: String) async throws -> String {
+    var request = URLRequest(url: URL(string: ProcessInfo.processInfo.environment["MOCHI_LLM_ENDPOINT"]!)!)
+    request.httpMethod = "POST"
+    request.httpBody = try JSONEncoder().encode(["prompt": prompt, "model": model])
+    request.addValue("Bearer \(ProcessInfo.processInfo.environment["MOCHI_LLM_API_KEY"]!)", forHTTPHeaderField: "Authorization")
+    let (data, _) = try await URLSession.shared.data(for: request)
+    return try JSONDecoder().decode(LLMResponse.self, from: data).text
+}
+```
+
+**Streaming responses**: `@llm(stream: true) fun chat(msg: string): stream<string>` → `URLSession.bytes(for:)` async byte stream, split on SSE `data:` lines.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/lower/llm.go` | `@llm` annotation lowering; `#if canImport(FoundationModels)` guard; `@Generable` emission |
+| `transpiler3/swift/lower/lower.go` | `@Guide` annotation from record field comments |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/LLM/FoundationModels.swift` | `LanguageModelSession` wrapper; cloud fallback |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/LLM/Mock.swift` | `MockLanguageModelSession`; cassette loader |
+| `transpiler3/swift/build/phase13_test.go` | `TestPhase13LLM`: 10 fixtures with cassette playback |
+| `tests/transpiler3/swift/fixtures/phase13-llm/` | 10 fixture directories with `.cassette` files |
+
+## Test set
+
+- `TestPhase13LLM` -- 10 fixtures (all with cassette playback, runnable on linux-x64 CI): `llm_summarise`, `llm_classify`, `llm_extract_person`, `llm_extract_list`, `llm_translate`, `llm_code_gen`, `llm_streaming`, `llm_cloud_fallback`, `llm_structured_output`, `llm_error_handling`.
+
+## Deferred work
+
+- FoundationModels conversation history (multi-turn chat). Deferred to Phase 13.1.
+- FoundationModels tool use (function calling). Deferred to Phase 13.2.
+- Whisper-based speech-to-text (separate `SpeechAnalyzer` API). Deferred to Phase 13.3.
+- Embeddings API. Out of v1 scope.
+- Local Ollama / LLaMA.cpp integration for Linux. Deferred to Phase 12 (FFI).

--- a/website/docs/implementation/0049/phase-14-fetch.md
+++ b/website/docs/implementation/0049/phase-14-fetch.md
@@ -1,0 +1,201 @@
+---
+title: "Phase 14. fetch (URLSession)"
+sidebar_position: 18
+sidebar_label: "Phase 14. fetch"
+description: "MEP-49 Phase 14 — HTTP fetch via URLSession; JSON decode/encode via Codable; SSE streaming; WebSocket via URLSessionWebSocketTask."
+---
+
+# Phase 14. fetch (URLSession)
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 14](/docs/mep/mep-0049#phase-14-fetch) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase14Fetch`: 10 fixtures green on Swift 6.0 and 6.1, linux-x64 (with mock HTTP server). `TestSwiftcClean` remains green.
+
+## Goal-alignment audit
+
+Mochi `fetch` is the HTTP client primitive. On Swift, it lowers to `URLSession` which is the system HTTP stack on all Apple platforms and is available (via Foundation) on Linux. Using `URLSession` (not a third-party HTTP library) minimises dependencies, uses system TLS (SecureTransport on Apple, BoringSSL on Linux via swift-cmark), and integrates with the platform's network stack including App Transport Security on iOS.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 14.0 | `fetch(url, method, headers, body)` → `URLSession.data(for:)` async; JSON decode via `Codable` | NOT STARTED | — |
+| 14.1 | Streaming responses → `URLSession.bytes(for:)` → `AsyncStream<String>`; SSE parsing | NOT STARTED | — |
+| 14.2 | WebSocket → `URLSessionWebSocketTask`; `send` / `receive` messages | NOT STARTED | — |
+| 14.3 | Mock HTTP server for tests (`MOCHI_FETCH_MOCK=1` environment flag) | NOT STARTED | — |
+
+## Sub-phase 14.0 -- HTTP fetch
+
+### Decisions made (14.0)
+
+**`URLSession.shared`**: all Mochi `fetch` calls use `URLSession.shared` by default. The session is configurable via `MochiRuntime.configure(urlSession: mySession)` for testing or proxy configuration.
+
+**`URLSession.data(for:)` async**: SE-0296 (Swift 5.5+). Returns `(Data, URLResponse)`. Available on all platforms (macOS 12+, iOS 15+, Linux via Foundation).
+
+**Mochi `fetch` lowering**:
+
+```swift
+// Mochi: let res = fetch("https://api.example.com/users", method: "GET")
+public func mochiGet(_ urlString: String, headers: OrderedDictionary<String, String> = [:]) async throws -> Data {
+    guard let url = URL(string: urlString) else { throw MochiFetchError.invalidURL(urlString) }
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+    for (key, value) in headers { request.addValue(value, forHTTPHeaderField: key) }
+    let (data, response) = try await URLSession.shared.data(for: request)
+    guard let httpResponse = response as? HTTPURLResponse,
+          (200...299).contains(httpResponse.statusCode) else {
+        throw MochiFetchError.httpError((response as? HTTPURLResponse)?.statusCode ?? -1)
+    }
+    return data
+}
+```
+
+**JSON decode**: `fetch` + decode in Mochi → `URLSession.data` + `JSONDecoder().decode(T.self, from: data)`:
+
+```swift
+// Mochi: let user: User = fetch_json("https://api.example.com/user/1")
+let data = try await mochiGet("https://api.example.com/user/1")
+let user = try JSONDecoder().decode(User.self, from: data)
+```
+
+Since Mochi records conform to `Codable` (Phase 4.3), this works without additional code.
+
+**JSON keys**: by default, Swift `Codable` synthesis uses the Swift property name (camelCase). The JSON API may use snake_case. `MochiRuntime` provides a `SnakeCaseDecoder` that sets `.keyDecodingStrategy = .convertFromSnakeCase` on `JSONDecoder`.
+
+**POST with body**:
+
+```swift
+// Mochi: let res = fetch("https://api.example.com/users", method: "POST", body: new_user)
+var request = URLRequest(url: url)
+request.httpMethod = "POST"
+request.httpBody = try JSONEncoder().encode(newUser)
+request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+```
+
+**`MochiFetchError`**: a `MochiRuntime` error type covering `invalidURL`, `httpError(statusCode)`, `decodeFailed`, `networkError(underlying)`.
+
+## Sub-phase 14.1 -- Streaming responses
+
+### Decisions made (14.1)
+
+**`URLSession.bytes(for:)`**: SE-0310 (Swift 5.5+). Returns `(URLSession.AsyncBytes, URLResponse)`. `AsyncBytes` is an `AsyncSequence<UInt8>`.
+
+**SSE (Server-Sent Events) parsing**: SSE streams emit lines of the form `data: <payload>\n\n`. The lowerer generates an SSE parser using `swift-async-algorithms`'s `.lines()` operator:
+
+```swift
+// Mochi: let stream = fetch_stream("https://api.example.com/events")
+let (asyncBytes, _) = try await URLSession.shared.bytes(for: request)
+let sseStream = asyncBytes.lines
+    .filter { $0.hasPrefix("data: ") }
+    .map { String($0.dropFirst(6)) }
+    .compactMap { line -> Event? in
+        guard line != "[DONE]" else { return nil }
+        return try? JSONDecoder().decode(Event.self, from: Data(line.utf8))
+    }
+// Consumed as AsyncStream<Event>
+```
+
+**`AsyncBytes.lines`**: `swift-async-algorithms` provides `.lines` on `AsyncSequence<UInt8>` that splits by newline, returning `AsyncLineSequence`. This handles `\n`, `\r\n`, and `\r` line endings.
+
+**LLM streaming**: Mochi `@llm(stream: true)` on Linux uses this SSE path (Phase 13.3).
+
+## Sub-phase 14.2 -- WebSocket
+
+### Decisions made (14.2)
+
+**`URLSessionWebSocketTask`**: available on macOS 10.15+, iOS 13+, Linux via Foundation. Provides `send(_ message: URLSessionWebSocketTask.Message) async throws` and `receive() async throws -> URLSessionWebSocketTask.Message`.
+
+**Mochi WebSocket lowering**:
+
+```swift
+// Mochi: let ws = websocket("wss://api.example.com/chat")
+let session = URLSession.shared
+let task = session.webSocketTask(with: URL(string: "wss://api.example.com/chat")!)
+task.resume()
+
+// Mochi: ws.send("hello")
+try await task.send(.string("hello"))
+
+// Mochi: let msg = ws.receive()
+let message = try await task.receive()
+switch message {
+case .string(let text): ...
+case .data(let bytes): ...
+@unknown default: break
+}
+```
+
+**WebSocket as stream**: `MochiRuntime` provides a `webSocketStream(url:)` helper that wraps the receive loop into an `AsyncStream<String>`:
+
+```swift
+public func webSocketStream(url: URL) -> AsyncStream<String> {
+    AsyncStream { continuation in
+        Task {
+            let task = URLSession.shared.webSocketTask(with: url)
+            task.resume()
+            while true {
+                guard let msg = try? await task.receive() else { break }
+                if case .string(let text) = msg { continuation.yield(text) }
+            }
+            continuation.finish()
+        }
+    }
+}
+```
+
+## Sub-phase 14.3 -- Mock HTTP for tests
+
+### Decisions made (14.3)
+
+**`URLProtocol` mock**: `MochiRuntime` registers a `MockURLProtocol` when `MOCHI_FETCH_MOCK=1` is set. The mock reads request URLs and returns pre-configured responses from a JSON fixture file:
+
+```swift
+// mock_responses.json:
+{
+    "https://api.example.com/users": {
+        "status": 200,
+        "body": "[{\"name\":\"alice\",\"age\":30}]"
+    }
+}
+```
+
+**`URLProtocol`**: `URLSession` routes all requests through registered `URLProtocol` subclasses. `MockURLProtocol` intercepts all HTTP requests in test mode and returns the fixture response synchronously.
+
+**Test fixture structure**: each fetch fixture directory contains:
+- `main.mochi`: the Mochi source
+- `main.out`: expected stdout
+- `mock_responses.json`: HTTP mock responses
+
+**Linux CI**: the mock server runs in `URLProtocol` (in-process), so no external HTTP server is needed on linux-x64 CI.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/lower/fetch.go` | `fetch`, `fetch_json`, `fetch_stream`, `websocket` lowering |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/Fetch.swift` | `mochiGet`, `mochiPost`, `webSocketStream`, SSE parser |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/FetchError.swift` | `MochiFetchError` enum |
+| `transpiler3/swift/runtime/Sources/MochiRuntime/Mock/MockURLProtocol.swift` | Test mock URLProtocol |
+| `transpiler3/swift/build/phase14_test.go` | `TestPhase14Fetch`: 10 fixtures with HTTP mock |
+| `tests/transpiler3/swift/fixtures/phase14-fetch/` | 10 fixture directories with `mock_responses.json` |
+
+## Test set
+
+- `TestPhase14Fetch` -- 10 fixtures: `fetch_get_string`, `fetch_get_json`, `fetch_post_json`, `fetch_headers`, `fetch_error_404`, `fetch_error_network`, `fetch_stream_sse`, `fetch_stream_bytes`, `fetch_websocket_send_receive`, `fetch_websocket_stream`.
+
+## Deferred work
+
+- HTTP/2 push streams. Deferred -- `URLSession` handles HTTP/2 transparently.
+- gRPC. Deferred to Phase 12 (FFI via grpc-swift).
+- OAuth 2.0 token refresh. Deferred to Phase 14.1.
+- Download task with progress reporting. Deferred to Phase 14.2.
+- Background URLSession for iOS background fetch. Deferred to Phase 15 (iOS packaging).

--- a/website/docs/implementation/0049/phase-15-ios.md
+++ b/website/docs/implementation/0049/phase-15-ios.md
@@ -1,0 +1,193 @@
+---
+title: "Phase 15. iOS app bundle (.ipa via xcodebuild)"
+sidebar_position: 19
+sidebar_label: "Phase 15. iOS (.ipa)"
+description: "MEP-49 Phase 15 — xcodebuild archive + exportArchive pipeline; XcodeGen project generation; codesign; notarytool; .ipa for TestFlight."
+---
+
+# Phase 15. iOS app bundle (.ipa via xcodebuild)
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 15](/docs/mep/mep-0049#phase-15-ios-bundle) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase15iOS`: iOS App Bundle gate -- `xcodebuild archive` completes without error on `macos-15` runner; `.ipa` validates via `xcrun altool --validate-app --platform ios`. 20 fixtures green on iOS 18 Simulator (arm64).
+
+## Goal-alignment audit
+
+The iOS `.ipa` is the primary deliverable for mobile Mochi apps. Phase 15 ships the full pipeline from Mochi source to a distributable `.ipa` that can be uploaded to TestFlight. This requires generating an Xcode project (via XcodeGen), archiving, code signing, and package export -- all driven from the Mochi build driver.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 15.0 | `mochi build --target=swift-ios` → SwiftPM source + `XcodeGen` `.yml` → `xcodegen generate` → `project.xcodeproj` | NOT STARTED | — |
+| 15.1 | `xcodebuild archive -scheme MochiOut -destination generic/platform=iOS` → `.xcarchive` | NOT STARTED | — |
+| 15.2 | `xcodebuild -exportArchive` with `ExportOptions.plist` → `.ipa` | NOT STARTED | — |
+| 15.3 | Code signing: `codesign --options runtime --timestamp --sign "Apple Development: ..."` | NOT STARTED | — |
+| 15.4 | TestFlight upload: `xcrun notarytool submit --wait` + `stapler staple` | NOT STARTED | — |
+
+## Sub-phase 15.0 -- XcodeGen project generation
+
+### Decisions made (15.0)
+
+**XcodeGen (Apache-2.0)**: generates `project.xcodeproj` from a `project.yml` specification. The Mochi build driver generates `project.yml` and calls `xcodegen generate`. XcodeGen is preferred over raw `xcodeproj` Ruby gem because it is actively maintained, supports Swift Package Manager integration, and produces reproducible Xcode projects (no UUIDs in YAML, UUIDs in `.xcodeproj` are deterministically derived from paths).
+
+**Generated `project.yml`**:
+
+```yaml
+name: MochiOut
+options:
+  bundleIdPrefix: com.mochi
+  deploymentTarget:
+    iOS: "18.0"
+  xcodeVersion: "16.0"
+  swiftVersion: "6.0"
+
+packages:
+  MochiRuntime:
+    url: https://github.com/mochilang/swift-runtime
+    from: 0.1.0
+
+targets:
+  MochiOut:
+    type: application
+    platform: iOS
+    sources: Sources/MochiOut
+    dependencies:
+      - package: MochiRuntime
+        product: MochiRuntime
+    settings:
+      SWIFT_VERSION: 6.0
+      SWIFT_STRICT_CONCURRENCY: complete
+      IPHONEOS_DEPLOYMENT_TARGET: "18.0"
+      INFOPLIST_FILE: Sources/MochiOut/Info.plist
+```
+
+**`Info.plist`**: the Mochi build driver generates a minimal `Info.plist` with `CFBundleName`, `CFBundleIdentifier`, `CFBundleVersion`, `CFBundleShortVersionString`, `UILaunchScreen`. The bundle ID is set via `mochi build --bundle-id com.example.myapp`.
+
+**Core/App split**: for iOS compatibility, the SwiftPM package has two targets: `MochiOutCore` (library, the transpiled Mochi logic) and `MochiOut` (executable, the `@main` entry). XcodeGen links both into the iOS app target.
+
+## Sub-phase 15.1 -- xcodebuild archive
+
+### Decisions made (15.1)
+
+**Archive command**:
+
+```bash
+xcodebuild archive \
+  -project MochiOut.xcodeproj \
+  -scheme MochiOut \
+  -destination "generic/platform=iOS" \
+  -archivePath build/MochiOut.xcarchive \
+  -allowProvisioningUpdates \
+  CODE_SIGN_STYLE=Automatic
+```
+
+**`-allowProvisioningUpdates`**: allows xcodebuild to automatically update provisioning profiles from the Apple Developer portal. Requires the machine to be authenticated with `xcodebuild -downloadAllPlatforms` or an existing provisioning profile in the keychain.
+
+**iOS Simulator gate**: the `TestPhase15iOS` gate runs on iOS Simulator (not device) to avoid provisioning requirements in CI. The simulator build uses `-destination "platform=iOS Simulator,name=iPhone 16 Pro"` and does not produce a `.ipa` (simulators use unpackaged `.app`).
+
+**`-destination "generic/platform=iOS"`**: device archive. Only runs in the "release" CI pipeline, not per-PR.
+
+## Sub-phase 15.2 -- .ipa export
+
+### Decisions made (15.2)
+
+**`ExportOptions.plist`**: required by `xcodebuild -exportArchive`. The Mochi build driver generates it:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store-connect</string>
+    <key>destination</key>
+    <string>export</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+    <key>uploadBitcode</key>
+    <false/>
+</dict>
+</plist>
+```
+
+**Export command**:
+
+```bash
+xcodebuild -exportArchive \
+  -archivePath build/MochiOut.xcarchive \
+  -exportPath build/ \
+  -exportOptionsPlist ExportOptions.plist
+```
+
+**Output**: `build/MochiOut.ipa` -- the distributable iOS app package.
+
+## Sub-phase 15.3 -- Code signing
+
+### Decisions made (15.3)
+
+**Automatic signing in CI**: `CODE_SIGN_STYLE=Automatic` with a valid Apple Developer account. The xcodebuild manages provisioning profile selection.
+
+**Manual signing for automation**: `CODE_SIGN_STYLE=Manual`, `PROVISIONING_PROFILE_SPECIFIER` set to the profile UUID, `CODE_SIGN_IDENTITY` set to the certificate common name. The Mochi build driver reads these from environment variables (`MOCHI_CODESIGN_IDENTITY`, `MOCHI_PROVISIONING_PROFILE`).
+
+**`codesign` for libraries**: embedded frameworks within the `.ipa` must be individually signed before the app bundle is signed. xcodebuild handles this automatically.
+
+**`--options runtime`**: required for notarization. Applied to all binaries in the archive.
+
+**`--timestamp`**: required for notarization. Signs with a secure timestamp from Apple's timestamp server.
+
+## Sub-phase 15.4 -- TestFlight upload
+
+### Decisions made (15.4)
+
+**`xcrun notarytool submit`**: replaced `altool` for notarization in November 2023. The Mochi build driver calls:
+
+```bash
+xcrun notarytool submit build/MochiOut.ipa \
+  --apple-id "$APPLE_ID" \
+  --password "$APP_SPECIFIC_PASSWORD" \
+  --team-id "$TEAM_ID" \
+  --wait
+```
+
+`--wait` blocks until notarization completes (or fails). Typical time: 30-120 seconds.
+
+**`xcrun altool --validate-app`**: the test gate uses `altool --validate-app` (not `--upload-app`) to verify the `.ipa` structure without actually uploading. This is the gate for `TestPhase15iOS`.
+
+**`xcrun stapler staple`**: for macOS distribution, staples the notarization ticket to the binary. Not required for iOS `.ipa` (App Store handles this).
+
+**TestFlight automation**: after notarization, the `.ipa` is automatically distributed to internal testers via the App Store Connect API. The Mochi build driver supports `mochi publish --testflight` which calls the App Store Connect REST API.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/build/ios.go` | `xcodegen generate`, `xcodebuild archive`, `xcodebuild -exportArchive`, notarytool invocation |
+| `transpiler3/swift/build/xcodegen.go` | `project.yml` + `Info.plist` generation |
+| `transpiler3/swift/build/codesign.go` | `codesign` and `xcrun notarytool submit` wrappers |
+| `transpiler3/swift/build/phase15_test.go` | `TestPhase15iOS`: 20 simulator fixtures + App Bundle gate |
+| `tests/transpiler3/swift/fixtures/phase15-ios/` | 20 fixture directories |
+
+## Test set
+
+- `TestPhase15iOS` -- 20 fixtures on iOS 18 Simulator: `ios_hello`, `ios_print`, `ios_agent`, `ios_fetch`, `ios_stream`, `ios_record`, `ios_list`, `ios_map`, `ios_query`, `ios_match`, `ios_closure`, `ios_datalog`, `ios_llm_mock`, `ios_websocket_mock`, `ios_mainactor`, `ios_lifecycle`, `ios_backgroundtask`, `ios_notificationcenter`, `ios_userdefaults`, `ios_filesystemaccess`.
+- App Bundle gate: `xcodebuild archive` + `xcrun altool --validate-app` on `macos-15`.
+
+## Deferred work
+
+- SwiftUI layer. Deferred to a Phase 15 sub-MEP.
+- SwiftData integration. Deferred to a Phase 15 sub-MEP.
+- iPadOS split-view / multi-window. Deferred.
+- WatchKit / watchOS packaging. Deferred to Phase 15.1.
+- App Clips. Out of v1 scope.

--- a/website/docs/implementation/0049/phase-16-repro.md
+++ b/website/docs/implementation/0049/phase-16-repro.md
@@ -1,0 +1,143 @@
+---
+title: "Phase 16. Reproducible build"
+sidebar_position: 20
+sidebar_label: "Phase 16. Reproducible build"
+description: "MEP-49 Phase 16 — deterministic .o and binary output via SWIFTPM_DETERMINISTIC_BUILD, SOURCE_DATE_EPOCH, -Xlinker -no_uuid; SHA-256 comparison across machines."
+---
+
+# Phase 16. Reproducible build
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 16](/docs/mep/mep-0049#phase-16-reproducible-build) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase16Repro`: SHA-256 of the final binary matches across two independent builds (different machine timestamps, different `$HOME`, different `$TMPDIR`). Gate runs on linux-x64. 10 fixture programs.
+
+## Goal-alignment audit
+
+Reproducible builds enable supply-chain verification: a user can rebuild from source and verify the binary matches the published one bit-for-bit. This is increasingly required by enterprise security policies. For Mochi's iOS target, reproducible archives enable App Store submission verification. The gate is strict: byte-identical output across two independent builds.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 16.0 | `SWIFTPM_DETERMINISTIC_BUILD=1` flag; `SOURCE_DATE_EPOCH` for file timestamps | NOT STARTED | — |
+| 16.1 | `-Xlinker -no_uuid` (macOS) / `--build-id=none` (Linux ld) to remove link-time UUIDs | NOT STARTED | — |
+| 16.2 | Sorted imports and declarations in emitted `.swift` source; deterministic sxtree traversal | NOT STARTED | — |
+| 16.3 | SHA-256 comparison gate: two parallel builds, compare binary hashes | NOT STARTED | — |
+
+## Sub-phase 16.0 -- SwiftPM deterministic build
+
+### Decisions made (16.0)
+
+**`SWIFTPM_DETERMINISTIC_BUILD=1`**: an environment variable recognised by SwiftPM (introduced in Swift 5.8). When set, SwiftPM:
+- Uses a fixed seed for any random identifiers in generated code.
+- Passes `-Xfrontend -enable-experimental-feature -Xfrontend StrictConcurrency` deterministically.
+- Suppresses timestamp-based cache invalidation.
+
+The Mochi build driver always sets `SWIFTPM_DETERMINISTIC_BUILD=1` when `--deterministic` flag is passed (or `MOCHI_DETERMINISTIC=1` env var is set). The `TestPhase16Repro` gate always sets it.
+
+**`SOURCE_DATE_EPOCH`**: the Unix timestamp used for all file modification times in the build output. Set to a fixed value (e.g., `0` for epoch) when `--deterministic` is active:
+
+```bash
+export SOURCE_DATE_EPOCH=0
+swift build -c release
+```
+
+The Swift compiler and linker respect `SOURCE_DATE_EPOCH` when building for release.
+
+**Compiler flags**: the generated `Package.swift` passes these Swift settings in deterministic mode:
+
+```swift
+.unsafeFlags([
+    "-Xfrontend", "-disable-reflection-metadata",
+    "-whole-module-optimization",
+])
+```
+
+`-whole-module-optimization` forces single-file compilation, which produces identical output regardless of file processing order.
+
+## Sub-phase 16.1 -- Linker UUID removal
+
+### Decisions made (16.1)
+
+**macOS (`-Xlinker -no_uuid`)**: the macOS linker (`ld64`) embeds a UUID in each binary by default. This UUID is derived from the link timestamp and is non-deterministic. `-Xlinker -no_uuid` removes it. The generated `Package.swift` adds this flag in deterministic mode:
+
+```swift
+linkerSettings: [
+    .unsafeFlags(["-Xlinker", "-no_uuid"], .when(platforms: [.macOS])),
+]
+```
+
+**Linux (`-Xlinker --build-id=none`)**: the Linux linker (`lld` or `gold`) embeds a `.note.gnu.build-id` section derived from the binary content (content-addressed, not time-based). This is actually deterministic for the same input. For strict reproducibility, `--build-id=none` removes it:
+
+```swift
+linkerSettings: [
+    .unsafeFlags(["-Xlinker", "--build-id=none"], .when(platforms: [.linux])),
+]
+```
+
+**Object file timestamps**: Swift's `-c release` mode does not embed timestamps in `.o` files. No additional flag needed.
+
+## Sub-phase 16.2 -- Deterministic source emission
+
+### Decisions made (16.2)
+
+**Sorted imports**: the emitter sorts `import` statements alphabetically. Swift imports in the sxtree `SourceFile` node are sorted before `Render()` is called. This prevents import order from depending on the order types were encountered during lowering.
+
+**Sorted declarations**: within a `.swift` file, top-level declarations are emitted in a canonical order:
+1. `import` statements (sorted alphabetically)
+2. Type declarations (sorted by name)
+3. Extension blocks (sorted by extended type name, then by method name)
+4. Top-level functions (sorted by name)
+5. `@main` entry struct (always last)
+
+This ordering is enforced in the sxtree `SourceFile.Render()` method.
+
+**Closure names**: anonymous closures (lifted functions) are named by a BLAKE3 hash of their source location (file + line + column in the original Mochi source). This makes closure names stable across refactors that don't touch the closure itself. BLAKE3 is chosen for speed (no crypto needed; just naming stability).
+
+**Source maps**: the `.mochi.map` sidecar files (Phase 17.1, deferred) are written in deterministic order (sorted by source location).
+
+## Sub-phase 16.3 -- SHA-256 comparison gate
+
+### Decisions made (16.3)
+
+**Gate procedure**:
+
+1. Build `fixture.mochi` in `build_1/` with `MOCHI_DETERMINISTIC=1 SOURCE_DATE_EPOCH=0`.
+2. Build the same `fixture.mochi` in `build_2/` with `MOCHI_DETERMINISTIC=1 SOURCE_DATE_EPOCH=0`, but with `TMPDIR=/tmp/build2` and `HOME=/tmp/home2` to simulate different machine environment.
+3. SHA-256 both output binaries.
+4. Assert SHA-256 hashes are equal.
+
+**What is being compared**: the final linked binary (`.elf` on Linux, `Mach-O` on macOS). Not the intermediate `.o` files (which may contain debug paths that differ by build directory).
+
+**Release mode**: only `-c release` builds are tested for reproducibility. `-c debug` builds embed debug info with absolute paths, making them inherently non-reproducible across machines.
+
+**Known non-reproducibilities**: if any are discovered, they are logged and a flag `--accept-nondeterminism=<reason>` is added for that specific fixture until fixed. The gate fails by default if any nondeterminism is detected.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/build/deterministic.go` | `--deterministic` flag handling; `SWIFTPM_DETERMINISTIC_BUILD`, `SOURCE_DATE_EPOCH` injection |
+| `transpiler3/swift/build/package.go` | `-Xlinker -no_uuid` / `--build-id=none` in deterministic mode |
+| `transpiler3/swift/emit/emit.go` | Sorted imports, sorted declarations, BLAKE3-named closures |
+| `transpiler3/swift/build/phase16_test.go` | `TestPhase16Repro`: 10 fixtures, two-build SHA-256 comparison |
+| `tests/transpiler3/swift/fixtures/phase16-repro/` | 10 fixture directories |
+
+## Test set
+
+- `TestPhase16Repro` -- 10 fixtures: `repro_hello`, `repro_scalars`, `repro_list`, `repro_record`, `repro_sum`, `repro_closure`, `repro_agent`, `repro_query`, `repro_ffi`, `repro_multifile`.
+
+## Deferred work
+
+- Reproducible iOS `.ipa` (archive timestamps). Deferred to Phase 16.1.
+- SBOM (Software Bill of Materials) generation. Deferred to a future tooling phase.
+- Reproducibility on macOS (Mach-O UUID). Tested but macOS CI is slower; tracked separately.

--- a/website/docs/implementation/0049/phase-17-static-linux.md
+++ b/website/docs/implementation/0049/phase-17-static-linux.md
@@ -1,0 +1,165 @@
+---
+title: "Phase 17. Static Linux SDK single binary"
+sidebar_position: 21
+sidebar_label: "Phase 17. Static Linux SDK"
+description: "MEP-49 Phase 17 — Swift Static Linux SDK (musl libc); single self-contained binary with no runtime dependencies; cross-compilation from macOS to linux-x64 and linux-arm64."
+---
+
+# Phase 17. Static Linux SDK single binary
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 17](/docs/mep/mep-0049#phase-17-static-linux) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase17StaticLinux`: `ldd binary` outputs "not a dynamic executable" (or equivalent on musl). Binary runs on vanilla Alpine Linux (no Swift runtime installed). 20 fixtures green on linux-x64 and linux-arm64. Cross-compilation from macOS arm64 to linux-x64 and linux-arm64.
+
+## Goal-alignment audit
+
+The single static binary is Mochi's server deployment story. Deploying a Swift server application typically requires either installing the Swift runtime on the target machine or bundling it with the app. The Static Linux SDK eliminates both requirements: the binary contains the full Swift runtime statically linked, making it a true zero-dependency deployment artifact. This is the "ship it anywhere" capability that makes Mochi competitive with Go for server workloads.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 17.0 | Static Linux SDK install: `swift sdk install` + `--checksum` verification | NOT STARTED | — |
+| 17.1 | Cross-compile from macOS arm64 → linux-x64: `swift build --swift-sdk x86_64-swift-linux-musl` | NOT STARTED | — |
+| 17.2 | Cross-compile from macOS arm64 → linux-arm64: `swift build --swift-sdk aarch64-swift-linux-musl` | NOT STARTED | — |
+| 17.3 | `ldd` gate: verify binary is statically linked; cold-start on Alpine Linux Docker container | NOT STARTED | — |
+| 17.4 | Binary size measurement: target ~10MB for release binary (hello world program) | NOT STARTED | — |
+
+## Sub-phase 17.0 -- Static Linux SDK install
+
+### Decisions made (17.0)
+
+**Swift Static Linux SDK**: Apple provides a prebuilt musl-based static SDK for cross-compilation to Linux. Introduced in Swift 5.9 (SE-0387: Swift SDK bundles). The SDK bundles:
+- Swift standard library (statically linked)
+- Foundation framework (open-source reimplementation for Linux)
+- All other Swift runtime libraries
+- musl libc
+- Linux kernel headers
+
+**Installation**:
+
+```bash
+swift sdk install \
+  https://download.swift.org/swift-6.0-release/static-sdk/swift-6.0-RELEASE/swift-6.0-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
+  --checksum <sha256>
+```
+
+The Mochi build driver installs the SDK automatically if not present (`~/.swiftpm/swift-sdks/`). The checksum is pinned in `transpiler3/swift/build/sdk.go` per Swift version.
+
+**CI setup**: the `ubuntu-24.04` GitHub Actions runner pre-installs the Swift toolchain. The Static Linux SDK is installed as a CI setup step (cached by `~/.swiftpm/swift-sdks/` path).
+
+**SDK identifier**: the SDK is referenced by its triple: `x86_64-swift-linux-musl` and `aarch64-swift-linux-musl`.
+
+## Sub-phase 17.1 -- Cross-compile to linux-x64
+
+### Decisions made (17.1)
+
+**Build command** (from macOS arm64):
+
+```bash
+swift build \
+  -c release \
+  --swift-sdk x86_64-swift-linux-musl \
+  --static-swift-stdlib
+```
+
+**`--static-swift-stdlib`**: explicitly requests static linking of the Swift standard library. With the musl SDK, this is the default; the flag is added for clarity.
+
+**Output location**: `.build/x86_64-swift-linux-musl/release/MochiOut`. A statically linked ELF binary.
+
+**MochiRuntime compilation for musl**: `swift-collections`, `swift-algorithms`, `swift-async-algorithms`, and other MochiRuntime dependencies must compile for the musl target. All Apple-provided packages support the Static Linux SDK. Third-party packages may not; the Mochi build driver checks compatibility during `swift package resolve` and warns.
+
+**`swift-cmark` / BoringSSL**: Foundation on Linux uses BoringSSL for TLS (for `URLSession`). BoringSSL is statically linked into the binary when using the Static Linux SDK. This means `URLSession` (Phase 14) works in the static binary without requiring OpenSSL on the target machine.
+
+## Sub-phase 17.2 -- Cross-compile to linux-arm64
+
+### Decisions made (17.2)
+
+**Build command** (from macOS arm64 or linux-x64):
+
+```bash
+swift build \
+  -c release \
+  --swift-sdk aarch64-swift-linux-musl \
+  --static-swift-stdlib
+```
+
+**CI runner**: `ubuntu-24.04-arm` GitHub Actions runner (Graviton 2, arm64). Native compilation is used on arm64 runners; cross-compilation from macOS is available for local development.
+
+**Output**: `.build/aarch64-swift-linux-musl/release/MochiOut`. A statically linked AArch64 ELF binary.
+
+**Binary size target**: ~10MB for a release hello-world binary (Swift runtime + Foundation + MochiRuntime). A complex program with full query DSL, agents, and streams may reach 15-20MB. This is acceptable for server deployment.
+
+## Sub-phase 17.3 -- ldd gate
+
+### Decisions made (17.3)
+
+**`ldd` verification**:
+
+```bash
+# On the build machine:
+ldd .build/x86_64-swift-linux-musl/release/MochiOut
+# Expected output: "not a dynamic executable"
+# or: "statically linked"
+```
+
+On Alpine Linux (musl libc), `ldd` on a musl-linked binary outputs the musl dynamic linker path. Static binaries output "not a dynamic executable" regardless of the host libc.
+
+**Alpine Linux container test**: the CI gate runs the binary inside a Docker container from `alpine:3.20` (no Swift installed):
+
+```bash
+docker run --rm \
+  -v "$(pwd)/.build/x86_64-swift-linux-musl/release/MochiOut:/app/MochiOut" \
+  alpine:3.20 \
+  /app/MochiOut
+```
+
+The binary must produce the expected output with exit code 0.
+
+**Cold-start measurement**: the CI gate records the time from process start to first output. Target: < 20ms for a release hello-world binary on a c5.xlarge (4 vCPU). The measurement is recorded in CI artifacts for trend tracking; it is not a hard gate.
+
+## Sub-phase 17.4 -- Binary size measurement
+
+### Decisions made (17.4)
+
+**Measurement**: `wc -c .build/x86_64-swift-linux-musl/release/MochiOut`. Recorded in CI artifacts.
+
+**Size reduction techniques applied**:
+- `-c release` (optimisations enabled, debug info disabled).
+- `--static-swift-stdlib` (single copy of stdlib, not multiple).
+- `-Xswiftc -Osize` (size-optimised build, if binary correctness is maintained).
+- Linker stripping: `strip -S` to remove debug symbols.
+
+**`-Osize` consideration**: `-Osize` (introduced in Swift 5.1) optimises for binary size over speed. The trade-off: up to 20% size reduction, up to 10% performance regression for CPU-bound code. Enabled by default in `--target=swift-linux-static` builds; can be disabled with `--no-optimize-size`.
+
+**Compression**: static binaries for distribution can be compressed with `upx --lzma`. This is optional and not applied by default (it makes the binary non-standard and slower to start). Available via `mochi build --compress`.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/build/sdk.go` | Static Linux SDK install/verify; SDK identifier constants; `--swift-sdk` flag injection |
+| `transpiler3/swift/build/static.go` | `swift build --static-swift-stdlib` invocation; ldd gate; Alpine Docker test |
+| `transpiler3/swift/build/package.go` | `--swift-sdk` dependency filtering for musl-compatible packages |
+| `transpiler3/swift/build/phase17_test.go` | `TestPhase17StaticLinux`: 20 fixtures + ldd gate + Alpine container test |
+| `tests/transpiler3/swift/fixtures/phase17-static-linux/` | 20 fixture directories |
+
+## Test set
+
+- `TestPhase17StaticLinux` -- 20 fixtures (subset of phase 1-14 fixtures recompiled for linux-x64 static): `static_hello`, `static_scalars`, `static_list`, `static_map`, `static_record`, `static_sum`, `static_closure`, `static_query`, `static_agent`, `static_stream`, `static_async`, `static_ffi_c`, `static_fetch_mock`, `static_datalog`, `static_llm_mock`, `static_arm64_hello`, `static_arm64_agent`, `static_arm64_query`, `static_alpine_hello`, `static_alpine_agent`.
+
+## Deferred work
+
+- Windows cross-compilation from macOS. Deferred to Phase 17.1.
+- Embedded Swift (bare-metal). Out of v1 scope.
+- WASI (WebAssembly System Interface). Out of v1 scope.
+- Container image generation (`docker build` with the static binary in FROM scratch). Deferred to a future tooling phase.

--- a/website/docs/implementation/0049/phase-18-appstore.md
+++ b/website/docs/implementation/0049/phase-18-appstore.md
@@ -1,0 +1,223 @@
+---
+title: "Phase 18. App Store / Mac App Store validation"
+sidebar_position: 22
+sidebar_label: "Phase 18. App Store"
+description: "MEP-49 Phase 18 — App Store Connect API automated submission; Mac App Store .pkg via productbuild; notarization stapling; xcrun altool --validate-app gate."
+---
+
+# Phase 18. App Store / Mac App Store validation
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-49 §Phases · Phase 18](/docs/mep/mep-0049#phase-18-app-store) |
+| Status         | NOT STARTED |
+| Started        | — |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+
+## Gate
+
+`TestPhase18AppStore`: `xcrun altool --validate-app --platform ios` passes for the `.ipa` produced in Phase 15. `xcrun altool --validate-app --platform osx` passes for the macOS `.pkg`. App Store Connect API upload succeeds in integration test (with a test bundle ID). 15 fixtures validate cleanly.
+
+## Goal-alignment audit
+
+App Store submission is the final delivery gate for Mochi iOS and macOS apps. Phase 18 automates the full submission pipeline: validate, upload, and confirm receipt via the App Store Connect API. Without this phase, users would need to manually run xcodebuild, notarize, and upload from Xcode. With Phase 18, `mochi publish --app-store` does the complete submission from the command line.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 18.0 | macOS `.app` packaging: `codesign --deep`, `.dmg` creation via `create-dmg` or `hdiutil` | NOT STARTED | — |
+| 18.1 | Mac App Store `.pkg` via `productbuild --component .app /Applications`; `pkgbuild` for installer | NOT STARTED | — |
+| 18.2 | Notarization: `xcrun notarytool submit --wait`; `xcrun stapler staple` for offline Gatekeeper | NOT STARTED | — |
+| 18.3 | App Store Connect API upload: `xcrun altool --upload-app` or REST API; build processing wait | NOT STARTED | — |
+| 18.4 | `xcrun altool --validate-app` gate in CI; validation without upload | NOT STARTED | — |
+
+## Sub-phase 18.0 -- macOS .app and .dmg
+
+### Decisions made (18.0)
+
+**macOS `.app` bundle**: a macOS application is distributed as a `.app` bundle (a directory with a specific structure). The Mochi build driver (`mochi build --target=swift-macos`) produces:
+
+```
+MochiOut.app/
+  Contents/
+    MacOS/
+      MochiOut          (compiled binary, codesigned)
+    Resources/
+      Assets.xcassets/  (icons, if provided)
+    Info.plist
+    _CodeSignature/     (codesign database)
+```
+
+**`codesign --deep`**: signs all embedded binaries (frameworks, dylibs) within the `.app` bundle before signing the outer bundle:
+
+```bash
+codesign \
+  --deep \
+  --options runtime \
+  --timestamp \
+  --sign "Developer ID Application: Your Name (TEAMID)" \
+  MochiOut.app
+```
+
+**`create-dmg` (Apache-2.0)**: creates a distributable `.dmg` from the `.app`. Used for direct download distribution (not Mac App Store). The Mochi build driver calls `create-dmg` if available, else falls back to `hdiutil create` + `hdiutil convert` for a basic read-only `.dmg`.
+
+**`hdiutil` flow**:
+
+```bash
+hdiutil create -srcfolder MochiOut.app -volname "MochiOut" -fs HFS+ \
+  -fsargs "-c c=64,a=16,b=16" -format UDRW -size 100m MochiOut_rw.dmg
+hdiutil convert MochiOut_rw.dmg -format UDZO -o MochiOut.dmg
+```
+
+## Sub-phase 18.1 -- Mac App Store .pkg
+
+### Decisions made (18.1)
+
+**Mac App Store requires a `.pkg`**: unlike direct download (`.dmg`), Mac App Store submissions use a `.pkg` installer.
+
+**`productbuild`**: creates the final `.pkg`:
+
+```bash
+productbuild \
+  --component MochiOut.app /Applications \
+  --sign "3rd Party Mac Developer Installer: Your Name (TEAMID)" \
+  MochiOut.pkg
+```
+
+**App Sandbox**: Mac App Store apps must have the App Sandbox entitlement. The Mochi build driver generates an `entitlements.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "...">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <!-- other entitlements from mochi.toml -->
+</dict>
+</plist>
+```
+
+Entitlements are declared in `mochi.toml` under `[macos.entitlements]`. The build driver reads them and generates the plist.
+
+**`pkgbuild`**: for headless tools (command-line utilities distributed via Mac App Store), `pkgbuild` is used instead of `productbuild`:
+
+```bash
+pkgbuild --root staging/ --identifier com.example.mochitool \
+  --version 1.0 --install-location /usr/local/bin \
+  MochiTool.pkg
+```
+
+## Sub-phase 18.2 -- Notarization and stapling
+
+### Decisions made (18.2)
+
+**`xcrun notarytool submit`**: for both `.dmg` (direct download) and `.pkg` (Mac App Store):
+
+```bash
+xcrun notarytool submit MochiOut.dmg \
+  --apple-id "$APPLE_ID" \
+  --password "$APP_SPECIFIC_PASSWORD" \
+  --team-id "$TEAM_ID" \
+  --wait \
+  --output-format json
+```
+
+The `--wait` flag blocks until Apple's notarization service completes. The JSON output contains the status and any issues found.
+
+**`xcrun stapler staple`**: staples the notarization ticket to the file so Gatekeeper can verify it offline:
+
+```bash
+xcrun stapler staple MochiOut.dmg
+xcrun stapler validate MochiOut.dmg  # verification step
+```
+
+Stapling is required for `.dmg` and `.pkg`. It is NOT available for `.ipa` (iOS apps are verified online by the App Store).
+
+**Notarization credentials**: stored in the macOS Keychain profile (`--keychain-profile mochinotary`) instead of environment variables in production:
+
+```bash
+xcrun notarytool store-credentials mochinotary \
+  --apple-id "$APPLE_ID" \
+  --password "$APP_SPECIFIC_PASSWORD" \
+  --team-id "$TEAM_ID"
+# Then:
+xcrun notarytool submit MochiOut.dmg --keychain-profile mochinotary --wait
+```
+
+## Sub-phase 18.3 -- App Store Connect API upload
+
+### Decisions made (18.3)
+
+**`xcrun altool --upload-app`**: the traditional upload mechanism. Still supported but App Store Connect REST API is preferred for automation.
+
+**App Store Connect REST API**: Apple's REST API (api.appstoreconnect.apple.com) allows uploading builds, managing TestFlight, and reading build status without Xcode. The Mochi build driver uses the API via JWT authentication (API key + key ID + issuer ID, configured in `mochi.toml`).
+
+**JWT auth**: App Store Connect API uses JWT with ES256 (ECDSA P-256). The Mochi driver generates the JWT from the API key file (`.p8`):
+
+```go
+// in transpiler3/swift/build/appstoreconnect.go:
+func newJWT(keyID, issuerID string, key *ecdsa.PrivateKey) (string, error) {
+    // ES256 JWT with 20-minute expiry, aud: "appstoreconnect-v1"
+}
+```
+
+**Upload flow**:
+1. Create a new build via `POST /v1/builds` (or `xcrun altool --upload-app`).
+2. Poll `GET /v1/builds/{id}` until `processingState == "VALID"`.
+3. Add build to TestFlight group via `POST /v1/betaBuildLocalizations`.
+4. Submit for review via `POST /v1/appStoreVersionSubmissions`.
+
+**`mochi publish --app-store` command**: drives the full upload flow. Requires `mochi.toml` with `[app-store]` section containing bundle ID, version, API key path.
+
+## Sub-phase 18.4 -- xcrun altool validate gate
+
+### Decisions made (18.4)
+
+**`xcrun altool --validate-app`**: validates the `.ipa` or `.pkg` structure against App Store requirements without uploading:
+
+```bash
+xcrun altool --validate-app \
+  --file MochiOut.ipa \
+  --type ios \
+  --apiKey "$API_KEY_ID" \
+  --apiIssuer "$ISSUER_ID"
+```
+
+**CI gate**: the `TestPhase18AppStore` gate runs `--validate-app` in CI on `macos-15`. This does not require a real App Store account for structure validation (the `--validate-app` flag checks the binary structure and entitlements, not App Store-specific metadata). The API key is only needed for online validation (checking signing certificate revocation, etc.).
+
+**Offline validation via `codesign -vvv`**: for fixtures that don't need the full App Store validation, `codesign -vvv --deep MochiOut.app` verifies the code signature structure locally:
+
+```bash
+codesign -vvv --deep --strict MochiOut.app
+```
+
+**15 fixture gate**: 15 programs that cover the App Store submission requirements are validated: correct bundle structure, Info.plist completeness, entitlements, code signature, embedded frameworks properly signed.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/swift/build/macos.go` | `.app` packaging, `codesign --deep`, `.dmg` creation |
+| `transpiler3/swift/build/macasstore.go` | `productbuild`, `pkgbuild`, entitlements plist generation |
+| `transpiler3/swift/build/notarize.go` | `xcrun notarytool submit`, `xcrun stapler staple` wrappers |
+| `transpiler3/swift/build/appstoreconnect.go` | App Store Connect REST API client; JWT generation |
+| `transpiler3/swift/build/phase18_test.go` | `TestPhase18AppStore`: 15 fixtures + `xcrun altool --validate-app` gate |
+| `tests/transpiler3/swift/fixtures/phase18-appstore/` | 15 fixture directories |
+
+## Test set
+
+- `TestPhase18AppStore` -- 15 fixtures: `appstore_hello_ios`, `appstore_hello_macos`, `appstore_dmg_structure`, `appstore_pkg_structure`, `appstore_entitlements_network`, `appstore_entitlements_sandbox`, `appstore_codesign_verify`, `appstore_notarize_structure`, `appstore_staple_verify`, `appstore_info_plist_complete`, `appstore_embedded_framework`, `appstore_bitcode_disabled`, `appstore_symbols_stripped`, `appstore_validate_ios`, `appstore_validate_macos`.
+
+## Deferred work
+
+- App Store Connect API full automation (submit for review, phased release). Deferred to Phase 18.1.
+- In-app purchases and StoreKit integration. Out of v1 scope.
+- App Store screenshots and metadata upload. Out of v1 scope.
+- Privacy manifest (`PrivacyInfo.xcprivacy`) generation. Deferred to Phase 18.1 (required for new App Store submissions from Spring 2024).
+- visionOS App Store submission. Deferred to Phase 18.2.


### PR DESCRIPTION
Closes #22440

## Summary

- 21 new files under `website/docs/implementation/0049/` covering all 18 phases (phases 3.1/3.2/3.3/3.4 for collections each get their own file)
- Updated `index.md` with links to all phase pages
- Each page follows the MEP-48 phase doc pattern: gate, goal-alignment audit, sub-phases, decisions with Swift code examples, files changed, test set, deferred work

## Key design decisions documented

Each page captures the "why" behind the Swift lowering:

- **int → Int64** (not platform-width `Int`): cross-platform determinism, byte-equality with vm3
- **OrderedDictionary / OrderedSet** from swift-collections: insertion-order semantics are a Mochi guarantee
- **@frozen struct** for records: library evolution, exhaustive switch, optimal layout
- **public enum** for unions: native sum type, exhaustiveness enforced by swiftc, `indirect` for recursive variants
- **option<T> → T?**: integrates with Swift optional chaining, `??`, `if let`, no custom runtime type
- **actor + AsyncStream<Message> mailbox**: SE-0306/SE-0314, CheckedContinuation for request-reply, nonisolated cast methods
- **Async colour pass**: propagates `async` upward before codegen, same strategy as MEP-48
- **SE-0413 typed throws**: `fun foo(): T throws E → func foo() throws(E) -> T`
- **Static Linux SDK** (musl): self-contained binary, zero runtime deps on target, ~10MB
- **xcodebuild + XcodeGen + notarytool** pipeline for iOS .ipa and Mac App Store .pkg

## Test plan

- Docs-only change; no code changed
- Docusaurus build will catch any broken markdown on the CI docs job