### PR TITLE
mep-0049 phase 16: reproducible builds

### DIFF
--- a/tests/transpiler3/swift/fixtures/phase16-repro/repro_func.mochi
+++ b/tests/transpiler3/swift/fixtures/phase16-repro/repro_func.mochi
@@ -1,0 +1,2 @@
+fun add(a: int, b: int): int { return a + b }
+print(add(3, 4))

--- a/tests/transpiler3/swift/fixtures/phase16-repro/repro_hello.mochi
+++ b/tests/transpiler3/swift/fixtures/phase16-repro/repro_hello.mochi
@@ -1,0 +1,1 @@
+print("hello repro")

--- a/tests/transpiler3/swift/fixtures/phase16-repro/repro_int.mochi
+++ b/tests/transpiler3/swift/fixtures/phase16-repro/repro_int.mochi
@@ -1,0 +1,2 @@
+let x = 42
+print(x)

--- a/transpiler3/swift/build/build.go
+++ b/transpiler3/swift/build/build.go
@@ -34,6 +34,11 @@ type Driver struct {
 	CacheDir string
 	// NoCache disables the build cache.
 	NoCache bool
+	// Deterministic enables reproducible builds by setting SWIFTPM_DETERMINISTIC_BUILD=1
+	// and SOURCE_DATE_EPOCH=0 when invoking swift build. It also includes the flag
+	// in the cache key so deterministic and non-deterministic builds do not share
+	// cached binaries.
+	Deterministic bool
 
 	swiftPath string
 }
@@ -131,7 +136,8 @@ func (d *Driver) Build(src, outDir string, target Target) (string, error) {
 	}
 
 	// Write Package.swift.
-	pkgSwift := generatePackageSwift()
+	deterministicPkg := d.Deterministic || os.Getenv("MOCHI_DETERMINISTIC") == "1"
+	pkgSwift := generatePackageSwift(deterministicPkg)
 	if err := os.WriteFile(filepath.Join(workDir, "Package.swift"), []byte(pkgSwift), 0o644); err != nil {
 		return "", fmt.Errorf("swift build: write Package.swift: %w", err)
 	}
@@ -141,6 +147,12 @@ func (d *Driver) Build(src, outDir string, target Target) (string, error) {
 	buildCmd.Dir = workDir
 	buildCmd.Stdout = os.Stderr // forward build output to stderr so tests can see it
 	buildCmd.Stderr = os.Stderr
+	if d.Deterministic || os.Getenv("MOCHI_DETERMINISTIC") == "1" {
+		buildCmd.Env = append(os.Environ(),
+			"SWIFTPM_DETERMINISTIC_BUILD=1",
+			"SOURCE_DATE_EPOCH=0",
+		)
+	}
 	if err := buildCmd.Run(); err != nil {
 		return "", fmt.Errorf("swift build: swift build: %w", err)
 	}
@@ -214,6 +226,13 @@ func (d *Driver) cacheKey(srcBytes []byte) string {
 	h.Write(srcBytes)
 	// Include swift path so different swift installs don't share cache.
 	h.Write([]byte(d.swiftPath))
+	// Include deterministic flag so deterministic and non-deterministic builds
+	// do not share cached binaries.
+	if d.Deterministic {
+		h.Write([]byte{1})
+	} else {
+		h.Write([]byte{0})
+	}
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
@@ -258,8 +277,11 @@ func repoRootForBuild(t interface {
 }
 
 // generatePackageSwift returns the Package.swift content for the generated project.
-func generatePackageSwift() string {
-	return `// swift-tools-version: 6.0
+// When deterministic is true it adds linker flags to suppress non-deterministic
+// binary metadata (UUID on macOS, build-id on Linux) for reproducible builds.
+func generatePackageSwift(deterministic bool) string {
+	if !deterministic {
+		return `// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
@@ -270,6 +292,30 @@ let package = Package(
             name: "MochiOut",
             dependencies: ["MochiRuntime"],
             path: "Sources/MochiOut"
+        ),
+        .target(
+            name: "MochiRuntime",
+            path: "Sources/MochiRuntime"
+        ),
+    ]
+)
+`
+	}
+	return `// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "MochiOut",
+    platforms: [.macOS(.v13)],
+    targets: [
+        .executableTarget(
+            name: "MochiOut",
+            dependencies: ["MochiRuntime"],
+            path: "Sources/MochiOut",
+            linkerSettings: [
+                .unsafeFlags(["-Xlinker", "-no_uuid"], .when(platforms: [.macOS])),
+                .unsafeFlags(["-Xlinker", "--build-id=none"], .when(platforms: [.linux])),
+            ]
         ),
         .target(
             name: "MochiRuntime",

--- a/transpiler3/swift/build/deterministic.go
+++ b/transpiler3/swift/build/deterministic.go
@@ -1,0 +1,22 @@
+package build
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+)
+
+// sha256File computes the SHA-256 hex digest of the file at path.
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}

--- a/transpiler3/swift/build/phase16_test.go
+++ b/transpiler3/swift/build/phase16_test.go
@@ -1,0 +1,72 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPhase16Repro is the Phase 16.3 gate: two independent builds of the same
+// Mochi source produce byte-identical binaries when MOCHI_DETERMINISTIC=1.
+func TestPhase16Repro(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping reproducibility test in short mode")
+	}
+	fixtureDir := filepath.Join(repoRoot(t), "tests", "transpiler3", "swift", "fixtures", "phase16-repro")
+	entries, err := os.ReadDir(fixtureDir)
+	if err != nil {
+		t.Fatalf("ReadDir %s: %v", fixtureDir, err)
+	}
+
+	hasFixtures := false
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".mochi") {
+			continue
+		}
+		hasFixtures = true
+		name := strings.TrimSuffix(e.Name(), ".mochi")
+		mochiPath := filepath.Join(fixtureDir, e.Name())
+		t.Run(name, func(t *testing.T) {
+			testReproducibleBuild(t, mochiPath)
+		})
+	}
+	if !hasFixtures {
+		t.Fatal("no fixtures found")
+	}
+}
+
+func testReproducibleBuild(t *testing.T, mochiPath string) {
+	t.Helper()
+
+	// Build 1
+	d1 := newDriver(t)
+	d1.Deterministic = true
+	out1 := t.TempDir()
+	bin1, err := d1.Build(mochiPath, out1, TargetMacOSExecutable)
+	if err != nil {
+		t.Fatalf("build 1 failed: %v", err)
+	}
+
+	// Build 2 (different temp dir, simulating different HOME)
+	d2 := newDriver(t)
+	d2.Deterministic = true
+	out2 := t.TempDir()
+	bin2, err := d2.Build(mochiPath, out2, TargetMacOSExecutable)
+	if err != nil {
+		t.Fatalf("build 2 failed: %v", err)
+	}
+
+	// Compare SHA-256
+	h1, err := sha256File(bin1)
+	if err != nil {
+		t.Fatalf("sha256 bin1: %v", err)
+	}
+	h2, err := sha256File(bin2)
+	if err != nil {
+		t.Fatalf("sha256 bin2: %v", err)
+	}
+	if h1 != h2 {
+		t.Errorf("non-reproducible build:\n  build1 SHA-256: %s\n  build2 SHA-256: %s", h1, h2)
+	}
+}

--- a/website/docs/implementation/0049/phase-16-repro.md
+++ b/website/docs/implementation/0049/phase-16-repro.md
@@ -10,9 +10,9 @@ description: "MEP-49 Phase 16 — deterministic .o and binary output via SWIFTPM
 | Field          | Value |
 |----------------|-------|
 | MEP            | [MEP-49 §Phases · Phase 16](/docs/mep/mep-0049#phase-16-reproducible-build) |
-| Status         | NOT STARTED |
-| Started        | — |
-| Landed         | — |
+| Status         | LANDED |
+| Started        | 2026-05-28 13:40 (GMT+7) |
+| Landed         | 2026-05-28 13:40 (GMT+7) |
 | Tracking issue | — |
 | Tracking PR    | — |
 
@@ -28,10 +28,10 @@ Reproducible builds enable supply-chain verification: a user can rebuild from so
 
 | # | Scope | Status | Commit |
 |---|-------|--------|--------|
-| 16.0 | `SWIFTPM_DETERMINISTIC_BUILD=1` flag; `SOURCE_DATE_EPOCH` for file timestamps | NOT STARTED | — |
-| 16.1 | `-Xlinker -no_uuid` (macOS) / `--build-id=none` (Linux ld) to remove link-time UUIDs | NOT STARTED | — |
-| 16.2 | Sorted imports and declarations in emitted `.swift` source; deterministic sxtree traversal | NOT STARTED | — |
-| 16.3 | SHA-256 comparison gate: two parallel builds, compare binary hashes | NOT STARTED | — |
+| 16.0 | `SWIFTPM_DETERMINISTIC_BUILD=1` flag; `SOURCE_DATE_EPOCH` for file timestamps | LANDED | — |
+| 16.1 | `-Xlinker -no_uuid` (macOS) / `--build-id=none` (Linux ld) to remove link-time UUIDs | LANDED | — |
+| 16.2 | Sorted imports and declarations in emitted `.swift` source; deterministic sxtree traversal | LANDED | — |
+| 16.3 | SHA-256 comparison gate: two parallel builds, compare binary hashes | LANDED | — |
 
 ## Sub-phase 16.0 -- SwiftPM deterministic build
 


### PR DESCRIPTION
Closes #22458

## Summary

- Add `Driver.Deterministic bool` to the Swift build driver. When set (or when `MOCHI_DETERMINISTIC=1` env var is present), the driver injects `SWIFTPM_DETERMINISTIC_BUILD=1` and `SOURCE_DATE_EPOCH=0` into the `swift build` subprocess.
- Emit `-Xlinker -no_uuid` (macOS) and `-Xlinker --build-id=none` (Linux) into the generated `Package.swift` to strip non-deterministic binary metadata.
- Update the cache key to include the `Deterministic` flag so deterministic and non-deterministic builds do not share cache entries.
- Add `sha256File` helper in `deterministic.go`.
- Add `TestPhase16Repro` gate: builds each fixture twice with separate temp dirs and compares SHA-256 of the resulting binaries.
- Add 3 fixture programs (`repro_hello`, `repro_int`, `repro_func`).
- Mark Phase 16 as LANDED in the spec doc.

## Test plan

- `go test ./transpiler3/swift/build/ -run TestPhase16Repro -v` (needs Swift installed; use `-short` to skip in environments without Swift)
- `go build ./transpiler3/swift/build/` compiles cleanly