### PR TITLE
mep-0049 phase 16: fill in tracking issue/PR links in spec

### DIFF
--- a/website/docs/implementation/0049/phase-16-repro.md
+++ b/website/docs/implementation/0049/phase-16-repro.md
@@ -13,8 +13,8 @@ description: "MEP-49 Phase 16 — deterministic .o and binary output via SWIFTPM
 | Status         | LANDED |
 | Started        | 2026-05-28 13:40 (GMT+7) |
 | Landed         | 2026-05-28 13:40 (GMT+7) |
-| Tracking issue | — |
-| Tracking PR    | — |
+| Tracking issue | [#22458](https://github.com/mochilang/mochi/issues/22458) |
+| Tracking PR    | [#22459](https://github.com/mochilang/mochi/pull/22459) |
 
 ## Gate
 


### PR DESCRIPTION
Follow-up to #22459. Adds issue #22458 and PR #22459 links to the Phase 16 spec table.