### PR TITLE
fix: C sanitizer nightly - abs name collision + query_join MapPutStmt

### DIFF
--- a/transpiler3/c/aotir/program.go
+++ b/transpiler3/c/aotir/program.go
@@ -603,11 +603,12 @@ func (*ListSetStmt) isStmt() {}
 // helper receives a pointer to the local struct so it can
 // resize the table when a new key is inserted.
 type MapPutStmt struct {
-	Name      string
-	Key       Expr
-	Value     Expr
-	KeyType   Type
-	ValueType Type
+	Name              string
+	Key               Expr
+	Value             Expr
+	KeyType           Type
+	ValueType         Type
+	ListValueElemType Type // valid when ValueType==TypeList (Phase 3.4e)
 }
 
 func (*MapPutStmt) isStmt() {}

--- a/transpiler3/c/build/phase12_3_test.go
+++ b/transpiler3/c/build/phase12_3_test.go
@@ -90,12 +90,8 @@ func TestPhase12WasmCorpus(t *testing.T) {
 		runFixtureSuiteWasmExclude(t, "shutdown", wasmtime, []string{"shutdown_sched"})
 	})
 
-	// Functions suite: exclude fun_early_return which defines a Mochi function
-	// named "abs". wasm-wasi-musl's __math.h declares extern int abs(int), which
-	// conflicts with the emitter's static int64_t abs(...). Pre-existing issue;
-	// the same fixture compiles fine on LP64 targets where __math.h is not pulled in.
 	t.Run("functions", func(t *testing.T) {
-		runFixtureSuiteWasmExclude(t, "functions", wasmtime, []string{"fun_early_return"})
+		runFixtureSuiteWasm(t, "functions", wasmtime)
 	})
 }
 

--- a/transpiler3/c/emit/emit.go
+++ b/transpiler3/c/emit/emit.go
@@ -1862,6 +1862,10 @@ func walkStmtMapOfList(st aotir.Stmt, add func(aotir.Type, aotir.Type, aotir.Typ
 		walkExprMapOfList(s.Init, add)
 	case *aotir.AssignStmt:
 		walkExprMapOfList(s.Value, add)
+	case *aotir.MapPutStmt:
+		add(s.KeyType, s.ValueType, s.ListValueElemType)
+		walkExprMapOfList(s.Key, add)
+		walkExprMapOfList(s.Value, add)
 	case *aotir.CallStmt:
 		for _, a := range s.Args {
 			walkExprMapOfList(a, add)
@@ -2119,6 +2123,37 @@ func emitMapOfListHelpers(b *strings.Builder, pairs []mapOfListPair) error {
 		fmt.Fprintf(b, "        %s *e = &m.table[pos];\n", entryName)
 		b.WriteString("        if (e->hash == 0) return 0;\n")
 		fmt.Fprintf(b, "        if (e->hash == h && %s) return 1;\n", eqFn("e->key", "k"))
+		b.WriteString("        pos = (pos + 1) & mask;\n")
+		b.WriteString("    }\n")
+		b.WriteString("}\n\n")
+
+		// _grow_ (internal resize helper for _put)
+		fmt.Fprintf(b, "static void %s_grow_(%s *m) {\n", name, name)
+		fmt.Fprintf(b, "    int64_t new_cap = m->cap ? m->cap * 2 : 8;\n")
+		fmt.Fprintf(b, "    %s *nt = (%s *)calloc((size_t)new_cap, sizeof(%s));\n", entryName, entryName, entryName)
+		b.WriteString("    if (nt == NULL) mochi_panic_index();\n")
+		b.WriteString("    uint64_t mask = (uint64_t)(new_cap - 1);\n")
+		b.WriteString("    for (int64_t i = 0; i < m->cap; i++) {\n")
+		fmt.Fprintf(b, "        %s *e = &m->table[i];\n", entryName)
+		b.WriteString("        if (e->hash == 0) continue;\n")
+		b.WriteString("        uint64_t pos = e->hash & mask;\n")
+		b.WriteString("        while (nt[pos].hash != 0) pos = (pos + 1) & mask;\n")
+		b.WriteString("        nt[pos] = *e;\n")
+		b.WriteString("    }\n")
+		b.WriteString("    free(m->table);\n")
+		b.WriteString("    m->table = nt; m->cap = new_cap;\n")
+		b.WriteString("}\n\n")
+
+		// _put
+		fmt.Fprintf(b, "static void %s_put(%s *m, %s k, %s v) {\n", name, name, keyC, valC)
+		fmt.Fprintf(b, "    if (m->nLive * 2 >= m->cap) %s_grow_(m);\n", name)
+		fmt.Fprintf(b, "    uint64_t h = %s(k);\n", hashFn)
+		b.WriteString("    uint64_t mask = (uint64_t)(m->cap - 1);\n")
+		b.WriteString("    uint64_t pos = h & mask;\n")
+		b.WriteString("    while (1) {\n")
+		fmt.Fprintf(b, "        %s *e = &m->table[pos];\n", entryName)
+		b.WriteString("        if (e->hash == 0) { e->hash = h; e->key = k; e->value = v; m->nLive++; return; }\n")
+		fmt.Fprintf(b, "        if (e->hash == h && %s) { e->value = v; return; }\n", eqFn("e->key", "k"))
 		b.WriteString("        pos = (pos + 1) & mask;\n")
 		b.WriteString("    }\n")
 		b.WriteString("}\n\n")
@@ -3032,7 +3067,7 @@ func emitListSetStmt(b *strings.Builder, s *aotir.ListSetStmt, indent string) er
 }
 
 func emitMapPutStmt(b *strings.Builder, s *aotir.MapPutStmt, indent string) error {
-	suf, err := mapSuffix(s.KeyType, s.ValueType, aotir.TypeInvalid)
+	suf, err := mapSuffix(s.KeyType, s.ValueType, s.ListValueElemType)
 	if err != nil {
 		return fmt.Errorf("map-put: %w", err)
 	}

--- a/transpiler3/c/lower/lower.go
+++ b/transpiler3/c/lower/lower.go
@@ -560,7 +560,7 @@ func Lower(prog *parser.Program) (*aotir.Program, error) {
 			}
 		}
 		out.Functions = append(out.Functions, &aotir.Function{
-			Name:                    fn.Name,
+			Name:                    "mochi__" + fn.Name,
 			Params:                  sig.params,
 			ReturnType:              sig.returnType,
 			ReturnRecordName:        sig.returnRecordName,
@@ -1122,7 +1122,7 @@ func (l *lowerer) lowerExprStmt(out *aotir.Block, es *parser.ExprStmt) error {
 	}
 	_ = sig.returnType // discarded
 	out.Statements = append(out.Statements, &aotir.CallStmt{
-		Func: call.Func,
+		Func: "mochi__" + call.Func,
 		Args: args,
 	})
 	return nil
@@ -2019,11 +2019,12 @@ func (l *lowerer) lowerIndexAssign(out *aotir.Block, as *parser.AssignStmt) erro
 			return fmt.Errorf("map-put %q: binding value %s, got %s", as.Name, b.value, valExpr.Type())
 		}
 		out.Statements = append(out.Statements, &aotir.MapPutStmt{
-			Name:      as.Name,
-			Key:       keyExpr,
-			Value:     valExpr,
-			KeyType:   b.key,
-			ValueType: b.value,
+			Name:              as.Name,
+			Key:               keyExpr,
+			Value:             valExpr,
+			KeyType:           b.key,
+			ValueType:         b.value,
+			ListValueElemType: b.listValElem,
 		})
 		return nil
 	case aotir.TypeOMap:
@@ -4077,13 +4078,13 @@ func (l *lowerer) lowerFunRef(funcName string, sig *funcSig) (aotir.Expr, error)
 		body := &aotir.Block{}
 		if sig.returnType == aotir.TypeUnit {
 			body.Statements = append(body.Statements, &aotir.CallStmt{
-				Func: funcName,
+				Func: "mochi__" + funcName,
 				Args: args,
 			})
 		} else {
 			body.Statements = append(body.Statements, &aotir.ReturnStmt{
 				Value: &aotir.CallExpr{
-					Func:   funcName,
+					Func:   "mochi__" + funcName,
 					Args:   args,
 					Result: sig.returnType,
 				},
@@ -4890,7 +4891,7 @@ func (l *lowerer) lowerUserCallExpr(call *parser.CallExpr) (aotir.Expr, error) {
 		return nil, err
 	}
 	return &aotir.CallExpr{
-		Func:                    call.Func,
+		Func:                    "mochi__" + call.Func,
 		Args:                    args,
 		Result:                  sig.returnType,
 		ResultRecordName:        sig.returnRecordName,
@@ -5900,13 +5901,13 @@ func (l *lowerer) lowerPartialApply(call *parser.CallExpr, sig *funcSig) (aotir.
 
 	// Build the closure body: a single return statement calling the original function.
 	bodyCallExpr := &aotir.CallExpr{
-		Func:   call.Func,
+		Func:   "mochi__" + call.Func,
 		Args:   bodyCallArgs,
 		Result: sig.returnType,
 	}
 	var bodyStmt aotir.Stmt
 	if sig.returnType == aotir.TypeUnit {
-		bodyStmt = &aotir.CallStmt{Func: call.Func, Args: bodyCallArgs}
+		bodyStmt = &aotir.CallStmt{Func: "mochi__" + call.Func, Args: bodyCallArgs}
 	} else {
 		bodyStmt = &aotir.ReturnStmt{Value: bodyCallExpr}
 	}
@@ -6105,9 +6106,10 @@ func (l *lowerer) buildHashJoin(
 		},
 		&aotir.MapPutStmt{
 			Name: idxName, Key: hkRef(),
-			Value:     &aotir.AppendExpr{Receiver: hvRef(), Value: innerVarRef, ElemType: srcElemType},
-			KeyType:   hj.keyType,
-			ValueType: aotir.TypeList,
+			Value:             &aotir.AppendExpr{Receiver: hvRef(), Value: innerVarRef, ElemType: srcElemType},
+			KeyType:           hj.keyType,
+			ValueType:         aotir.TypeList,
+			ListValueElemType: srcElemType,
 		},
 	}}
 	l.currentBlock.Statements = append(l.currentBlock.Statements, &aotir.ForEachStmt{


### PR DESCRIPTION
Closes #22471

## Summary

- **Bug A (abs collision):** user-defined `fun abs` was emitted as `static int64_t abs(int64_t)`, conflicting with stdlib's `int abs(int)`. Fix: prefix all user-defined Mochi function names with `mochi__` in lower.go (definitions, call statements, call expressions, shim bodies, partial apply). Removes the WASM fun_early_return exclusion in phase12_3_test.go since the prefix works on all targets.
- **Bug B (query_join):** inner join lower pass built `MapPutStmt` with `ValueType==TypeList` but `ListValueElemType==TypeInvalid`; and `emitMapOfListHelpers` had no `_put` function. Fix: add `ListValueElemType` field to `MapPutStmt`, propagate it from lower pass, use it in emitMapPutStmt, add `MapPutStmt` case to `walkStmtMapOfList`, add `_grow_`/`_put` to `emitMapOfListHelpers`.

## Test plan

- [x] `TestPhase16ASan` full suite passes (all 30+ suites including functions/fun_early_return and query_join)
- [x] `TestPhase2Functions` passes (recursive and mutual-recursive user functions)
- [x] `TestPhase5FreeFunctionShim` passes (shim functions call mochi__-prefixed user fns)
- [x] `TestPhase5Closures` passes
- [x] `go vet ./transpiler3/c/...` clean