### PR TITLE
ci: skip Maven publish gracefully when GPG key is present but invalid

### DIFF
--- a/.github/workflows/jvm-publish.yml
+++ b/.github/workflows/jvm-publish.yml
@@ -17,20 +17,18 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Check secrets configured
+      - name: Check secrets and import GPG key
         id: check
         run: |
           if [ -z "$GPG_PRIVATE_KEY" ]; then
             echo "configured=false" >> "$GITHUB_OUTPUT"
             echo "::warning::GPG_PRIVATE_KEY not configured; skipping publish"
-          else
+          elif echo "$GPG_PRIVATE_KEY" | gpg --batch --import 2>/dev/null; then
             echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::GPG_PRIVATE_KEY is not valid GPG data; skipping publish"
           fi
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-      - name: Import GPG key
-        if: steps.check.outputs.configured == 'true'
-        run: echo "$GPG_PRIVATE_KEY" | gpg --batch --import
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
       - name: Publish to Maven Central


### PR DESCRIPTION
Fixes #22473

## Problem

The nightly `Publish mochi-runtime to Maven Central` job kept failing with:

```
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
##[error]Process completed with exit code 2.
```

PR #22470 added an empty-string guard, but `GPG_PRIVATE_KEY` is set as a non-empty invalid/placeholder value in repo secrets. The check `[ -z "$GPG_PRIVATE_KEY" ]` returned false, so `configured=true` was set and the import ran and failed.

## Fix

Combine the `Check secrets configured` and `Import GPG key` steps into one. Attempt `gpg --batch --import` and set `configured=false` (with a warning) if it fails. This covers both cases: missing secret and present-but-invalid secret. The nightly schedule run now exits green instead of erroring.