### PR TITLE
MEP-55 Phase 14: fetch via file_get_contents stream wrapper

### DIFF
--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_basic.mochi
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_basic.mochi
@@ -1,0 +1,3 @@
+writeFile("/tmp/mochi_swift_fetch1.txt", "hello from file")
+let body = fetch("file:///tmp/mochi_swift_fetch1.txt")
+print(body)

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_basic.out
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_basic.out
@@ -1,0 +1,1 @@
+hello from file

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_concat.mochi
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_concat.mochi
@@ -1,0 +1,3 @@
+writeFile("/tmp/mochi_swift_fc.txt", "world")
+let r = fetch("file:///tmp/mochi_swift_fc.txt")
+print("hello " + r)

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_concat.out
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_concat.out
@@ -1,0 +1,1 @@
+hello world

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_empty.mochi
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_empty.mochi
@@ -1,0 +1,3 @@
+writeFile("/tmp/mochi_swift_fe.txt", "empty test")
+let r = fetch("file:///tmp/mochi_swift_fe.txt")
+print(r)

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_empty.out
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_empty.out
@@ -1,0 +1,1 @@
+empty test

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_json_string.mochi
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_json_string.mochi
@@ -1,0 +1,3 @@
+writeFile("/tmp/mochi_swift_fetch4.txt", "status-ok")
+let body = fetch("file:///tmp/mochi_swift_fetch4.txt")
+print(body)

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_json_string.out
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_json_string.out
@@ -1,0 +1,1 @@
+status-ok

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_multiline.mochi
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_multiline.mochi
@@ -1,0 +1,3 @@
+writeFile("/tmp/mochi_swift_fetch3.txt", "line1\nline2\nline3")
+let body = fetch("file:///tmp/mochi_swift_fetch3.txt")
+print(body)

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_multiline.out
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_multiline.out
@@ -1,0 +1,3 @@
+line1
+line2
+line3

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_newlines.mochi
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_newlines.mochi
@@ -1,0 +1,3 @@
+writeFile("/tmp/mochi_swift_fn.txt", "line1\nline2\nline3")
+let r = fetch("file:///tmp/mochi_swift_fn.txt")
+print(r)

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_newlines.out
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_newlines.out
@@ -1,0 +1,3 @@
+line1
+line2
+line3

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_overwrite_fetch.mochi
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_overwrite_fetch.mochi
@@ -1,0 +1,6 @@
+writeFile("/tmp/mochi_swift_fof.txt", "first")
+let r1 = fetch("file:///tmp/mochi_swift_fof.txt")
+writeFile("/tmp/mochi_swift_fof.txt", "second")
+let r2 = fetch("file:///tmp/mochi_swift_fof.txt")
+print(r1)
+print(r2)

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_overwrite_fetch.out
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_overwrite_fetch.out
@@ -1,0 +1,2 @@
+first
+second

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_reuse.mochi
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_reuse.mochi
@@ -1,0 +1,5 @@
+writeFile("/tmp/mochi_swift_fre.txt", "reused")
+let r1 = fetch("file:///tmp/mochi_swift_fre.txt")
+let r2 = fetch("file:///tmp/mochi_swift_fre.txt")
+print(r1)
+print(r2)

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_reuse.out
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_reuse.out
@@ -1,0 +1,2 @@
+reused
+reused

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_string.mochi
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_string.mochi
@@ -1,0 +1,4 @@
+writeFile("/tmp/mochi_swift_fetch2.txt", "fetch content here")
+let r = fetch("file:///tmp/mochi_swift_fetch2.txt")
+let result = "Got: " + r
+print(result)

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_string.out
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_string.out
@@ -1,0 +1,1 @@
+Got: fetch content here

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_use_result.mochi
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_use_result.mochi
@@ -1,0 +1,4 @@
+writeFile("/tmp/mochi_swift_fetch5.txt", "hello fetch")
+let r1 = fetch("file:///tmp/mochi_swift_fetch5.txt")
+let r2 = fetch("file:///tmp/mochi_swift_fetch5.txt")
+print(r1 + " " + r2)

--- a/tests/transpiler3/php/fixtures/phase14-fetch/fetch_use_result.out
+++ b/tests/transpiler3/php/fixtures/phase14-fetch/fetch_use_result.out
@@ -1,0 +1,1 @@
+hello fetch hello fetch

--- a/transpiler3/php/build/phase14_test.go
+++ b/transpiler3/php/build/phase14_test.go
@@ -1,0 +1,164 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPhase14Fetch walks the Phase 14 fetch fixtures and exercises
+// each through the full PHP transpiler. Tests skip when PHP is not
+// installed; CI uses shivammathur/setup-php@v2 to drive the end-to-end
+// gate.
+func TestPhase14Fetch(t *testing.T) {
+	fixtureDir := filepath.Join(repoRoot(t), "tests", "transpiler3", "php", "fixtures", "phase14-fetch")
+	entries, err := os.ReadDir(fixtureDir)
+	if err != nil {
+		t.Fatalf("ReadDir %s: %v", fixtureDir, err)
+	}
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".mochi") {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".mochi")
+		t.Run(name, func(t *testing.T) {
+			runPhpFixture(t,
+				filepath.Join(fixtureDir, e.Name()),
+				filepath.Join(fixtureDir, name+".out"))
+		})
+	}
+}
+
+// TestPhase14EmitFragments asserts that `fetch(url)` lowers to
+// `file_get_contents($url)`. PHP's file_get_contents accepts both
+// `file://` and `http(s)://` URLs natively through its stream wrappers,
+// so a single mapping covers all Phase 14 fixtures (all of which use
+// `file://` for offline determinism).
+//
+// No runtime helpers are needed; the PHP stdlib subsumes the fetch
+// semantics directly. If a future fixture exercises HTTP-specific
+// behaviour (headers, methods, status codes), a richer helper would
+// live alongside the LLM cassette helper from Phase 13.
+func TestPhase14EmitFragments(t *testing.T) {
+	cases := []struct {
+		fixture string
+		wants   []string
+	}{
+		{
+			fixture: "fetch_basic.mochi",
+			wants: []string{
+				// fetch + file:// URL flows through the same stream
+				// wrapper as a plain readFile path; the result is the
+				// raw bytes of the file.
+				`$body = file_get_contents("file:///tmp/mochi_swift_fetch1.txt");`,
+				`mochi_print_str($body);`,
+			},
+		},
+		{
+			fixture: "fetch_concat.mochi",
+			wants: []string{
+				// fetched body flows into a `+` concat at the print
+				// site, which lowers to PHP's `.` operator.
+				`$r = file_get_contents("file:///tmp/mochi_swift_fc.txt");`,
+			},
+		},
+		{
+			fixture: "fetch_empty.mochi",
+			wants: []string{
+				// "empty" here is the fixture name; the cassette
+				// contains literal bytes "empty test". No special
+				// handling for empty results is needed.
+				`$r = file_get_contents("file:///tmp/mochi_swift_fe.txt");`,
+			},
+		},
+		{
+			fixture: "fetch_json_string.mochi",
+			wants: []string{
+				// JSON-shaped payload is just bytes from PHP's
+				// perspective; no parser is invoked here.
+				`$body = file_get_contents("file:///tmp/mochi_swift_fetch4.txt");`,
+			},
+		},
+		{
+			fixture: "fetch_multiline.mochi",
+			wants: []string{
+				// Embedded \n round-trip: the file_put_contents call
+				// writes the literal newline bytes, the fetch reads
+				// them back unchanged.
+				`file_put_contents("/tmp/mochi_swift_fetch3.txt", "line1\nline2\nline3");`,
+				`$body = file_get_contents("file:///tmp/mochi_swift_fetch3.txt");`,
+			},
+		},
+		{
+			fixture: "fetch_newlines.mochi",
+			wants: []string{
+				`$r = file_get_contents("file:///tmp/mochi_swift_fn.txt");`,
+			},
+		},
+		{
+			fixture: "fetch_overwrite_fetch.mochi",
+			wants: []string{
+				// Two writes interleaved with two fetches: each fetch
+				// reads the bytes present on disk at that point.
+				`file_put_contents("/tmp/mochi_swift_fof.txt", "first");`,
+				`$r1 = file_get_contents("file:///tmp/mochi_swift_fof.txt");`,
+				`file_put_contents("/tmp/mochi_swift_fof.txt", "second");`,
+				`$r2 = file_get_contents("file:///tmp/mochi_swift_fof.txt");`,
+			},
+		},
+		{
+			fixture: "fetch_reuse.mochi",
+			wants: []string{
+				// Same URL fetched twice: both calls reach the same
+				// file_get_contents site (PHP doesn't cache stream
+				// reads, so r1 and r2 are independent reads).
+				`$r1 = file_get_contents("file:///tmp/mochi_swift_fre.txt");`,
+				`$r2 = file_get_contents("file:///tmp/mochi_swift_fre.txt");`,
+			},
+		},
+		{
+			fixture: "fetch_string.mochi",
+			wants: []string{
+				// Fetched body bound to a let, then concatenated into
+				// a result string before print.
+				`$r = file_get_contents("file:///tmp/mochi_swift_fetch2.txt");`,
+				`$result = ("Got: " . $r);`,
+			},
+		},
+		{
+			fixture: "fetch_use_result.mochi",
+			wants: []string{
+				// Two fetches plus a three-way `.` concat at print
+				// time; each fetched result keeps its own variable.
+				`$r1 = file_get_contents("file:///tmp/mochi_swift_fetch5.txt");`,
+				`$r2 = file_get_contents("file:///tmp/mochi_swift_fetch5.txt");`,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(strings.TrimSuffix(c.fixture, ".mochi"), func(t *testing.T) {
+			mochiPath := filepath.Join(repoRoot(t), "tests", "transpiler3", "php", "fixtures", "phase14-fetch", c.fixture)
+			if _, err := os.Stat(mochiPath); err != nil {
+				t.Skipf("fixture missing: %v", err)
+			}
+			outDir := t.TempDir()
+			d := &Driver{CacheDir: t.TempDir(), NoCache: true}
+			p, err := d.Build(mochiPath, outDir, TargetPhpSource)
+			if err != nil {
+				t.Fatalf("Build(%s): %v", c.fixture, err)
+			}
+			data, err := os.ReadFile(p)
+			if err != nil {
+				t.Fatalf("read %s: %v", p, err)
+			}
+			src := string(data)
+			for _, want := range c.wants {
+				if !strings.Contains(src, want) {
+					t.Errorf("%s: emitted source missing %q\n---\n%s", c.fixture, want, src)
+				}
+			}
+		})
+	}
+}

--- a/transpiler3/php/lower/lower.go
+++ b/transpiler3/php/lower/lower.go
@@ -1605,6 +1605,20 @@ func (l *lowerer) lowerExpr(e aotir.Expr) (ptree.Expr, error) {
 			Callee: &ptree.IdentExpr{Name: "mochi_sub_recv"},
 			Args:   []ptree.Expr{s},
 		}, nil
+	case *aotir.HttpGetExpr:
+		// Phase 14: `fetch(url)` maps to PHP's `file_get_contents`,
+		// which natively supports both `http://` and `file://` URLs
+		// via PHP's stream wrappers. All Phase 14 fixtures use
+		// `file://` schemes so the dependency surface is the same as
+		// Phase 12; HTTP wrappers ship with the default PHP build.
+		url, err := l.lowerExpr(v.URL)
+		if err != nil {
+			return nil, err
+		}
+		return &ptree.CallExpr{
+			Callee: &ptree.IdentExpr{Name: "file_get_contents"},
+			Args:   []ptree.Expr{url},
+		}, nil
 	case *aotir.LLMGenerateExpr:
 		// Phase 13: `generate openai { prompt: ... }` lowers to a
 		// runtime helper that reads a cassette file keyed by the DJB2


### PR DESCRIPTION
Tracks #22534.

## Summary

- Lowers `fetch(url)` to PHP's `file_get_contents($url)`.
- PHP's stream wrappers natively support both `file://` and `http(s)://` URLs, so the stdlib subsumes Phase 14's semantics directly. No runtime helpers needed.
- All 10 Phase 14 fixtures use `file://` for offline determinism.

## Test plan

- [x] `go test ./transpiler3/php/build/ -run TestPhase14` passes locally (runners skip without PHP, fragments pass).
- [ ] CI gate via shivammathur/setup-php@v2 runs the runners against real PHP.