### PR TITLE
transpiler3/php: fix CI red on MEP-55 (readonly + psalm)

### DIFF
--- a/transpiler3/php/build/phase05_test.go
+++ b/transpiler3/php/build/phase05_test.go
@@ -31,9 +31,11 @@ func TestPhase5Sums(t *testing.T) {
 }
 
 // TestPhase5EmitFragments asserts the lowerer emits the expected PHP
-// shape for the sealed-hierarchy sum-type lowering: one abstract base
-// class plus one final readonly variant subclass, with match arms
-// becoming an `instanceof` discriminator chain. The fragments cover
+// shape for the sealed-hierarchy sum-type lowering: one abstract
+// readonly base class plus one final readonly variant subclass, with
+// match arms becoming an `instanceof` discriminator chain. The base
+// must be `abstract readonly` because PHP 8.4 forbids a readonly
+// subclass from extending a non-readonly parent. The fragments cover
 // the four feature shapes Phase 5.0 ships: variant with int field,
 // nullary variants, match-as-expression result temp, and string
 // arm bodies.
@@ -45,7 +47,7 @@ func TestPhase5EmitFragments(t *testing.T) {
 		{
 			fixture: "sum_basic.mochi",
 			wants: []string{
-				`abstract class Shape`,
+				`abstract readonly class Shape`,
 				`final readonly class Shape_Circle extends Shape`,
 				`final readonly class Shape_Square extends Shape`,
 				`public int $r,`,
@@ -74,7 +76,7 @@ func TestPhase5EmitFragments(t *testing.T) {
 		{
 			fixture: "sum_nullary.mochi",
 			wants: []string{
-				`abstract class Color`,
+				`abstract readonly class Color`,
 				`final readonly class Color_Red extends Color`,
 				`final readonly class Color_Green extends Color`,
 				`final readonly class Color_Blue extends Color`,

--- a/transpiler3/php/ptree/nodes.go
+++ b/transpiler3/php/ptree/nodes.go
@@ -733,7 +733,10 @@ func (d *ClassDecl) PhpString(ind int) string {
 	sb.WriteString(pad)
 	switch {
 	case d.Abstract:
-		sb.WriteString("abstract class ")
+		// PHP 8.4: a readonly subclass can only extend a readonly base,
+		// so sum-type bases must be `abstract readonly` to admit
+		// `final readonly` variants.
+		sb.WriteString("abstract readonly class ")
 	case d.Mutable:
 		sb.WriteString("final class ")
 	default:

--- a/transpiler3/php/runtime/composer.json
+++ b/transpiler3/php/runtime/composer.json
@@ -16,7 +16,7 @@
         "phpstan/phpstan": "^1.12",
         "phpstan/phpstan-strict-rules": "^1.6",
         "phpstan/phpstan-deprecation-rules": "^1.2",
-        "vimeo/psalm": "^5.26",
+        "vimeo/psalm": "^6.0",
         "friendsofphp/php-cs-fixer": "^3.65",
         "phpunit/phpunit": "^11.3"
     },


### PR DESCRIPTION
## Summary

- Sum-type bases emit `abstract readonly class` instead of `abstract class`. PHP 8.4 rejects `final readonly class X extends non-readonly Base`, breaking all four Phase 5 sum fixtures.
- Bump `vimeo/psalm` from `^5.26` to `^6.0` in `runtime/composer.json`. Psalm 5 does not support PHP 8.4 and was failing every job in the php-runtime matrix.

Tracking issue: #22550

## Test plan

- [x] `go test ./transpiler3/php/build/ -run TestPhase5EmitFragments -count=1` (passes locally)
- [x] `go test ./transpiler3/php/... -count=1` (all green)
- [ ] CI: transpiler3-php matrix turns green
- [ ] CI: php-runtime matrix turns green