### PR TITLE
transpiler3/php: silence Psalm UnusedClass on runtime IO

### DIFF
--- a/transpiler3/php/runtime/src/Mochi/Runtime/IO.php
+++ b/transpiler3/php/runtime/src/Mochi/Runtime/IO.php
@@ -10,6 +10,11 @@ namespace Mochi\Runtime;
  * \\println behaviour. The lowerer routes calls through these helpers
  * so the runtime owns formatting (e.g. \\NaN / \\+Inf / \\-Inf and the
  * Go-style \\strconv.FormatFloat 'g' -1 64 round-trip).
+ *
+ * @api  Public runtime entry point. Lowered Mochi programs live
+ *       outside `src/`, so Psalm's UnusedClass check would otherwise
+ *       flag this. The @api tag tells Psalm this is intentionally an
+ *       externally-consumed surface.
  */
 final class IO
 {


### PR DESCRIPTION
## Summary

- Annotate `Mochi\Runtime\IO` with the `@api` Psalm doc-tag.
- Required after the psalm 5 -> 6 bump in #22551 because Psalm 6 enforces UnusedClass under `findUnusedCode="true"`. IO's real callers are the lowered Mochi `main.php` programs, which live outside the Psalm project root.

Tracking issue: #22556

## Test plan

- [ ] CI: `php-runtime (8.4)` flips from red to green
- [ ] CI: `php-runtime (8.4.0)` flips from red to green
- [ ] CI: `php-runtime (8.5)` stays green (already passed; allow-failure)