### PR TITLE
transpiler3/php: strengthen MEP-55 test assertions (audit follow-up)

### DIFF
--- a/transpiler3/php/build/phase04_test.go
+++ b/transpiler3/php/build/phase04_test.go
@@ -108,31 +108,50 @@ func TestPhase4EmitFragments(t *testing.T) {
 		{
 			fixture: "record_single_field.mochi",
 			wants: []string{
-				`final readonly class`,
+				// Lock the class name and the lone field so a
+				// regression that dropped either is caught.
+				`final readonly class Box`,
+				`public int $value,`,
+				`new Box(value: 42);`,
 			},
 		},
 		{
 			fixture: "record_bool_field.mochi",
 			wants: []string{
-				`public bool`,
+				`final readonly class Flag`,
+				`public bool $active,`,
+				`public int $count,`,
+				`new Flag(active: true, count: 5);`,
 			},
 		},
 		{
 			fixture: "record_float_field.mochi",
 			wants: []string{
-				`public float`,
+				`final readonly class Vec`,
+				`public float $dx,`,
+				`public float $dy,`,
+				`new Vec(dx: 1.5, dy: 2.5);`,
 			},
 		},
 		{
 			fixture: "record_string_field.mochi",
 			wants: []string{
-				`public string`,
+				`final readonly class Msg`,
+				`public string $text,`,
+				`public int $count,`,
+				`new Msg(text: "hello", count: 3);`,
 			},
 		},
 		{
 			fixture: "record_field_arith.mochi",
 			wants: []string{
-				`($`,
+				// Lock the actual arithmetic shapes so a regression
+				// that swapped the operands or dropped the field
+				// reference would surface. A bare `($` substring is
+				// too loose; any binary expression in any record
+				// program would satisfy it.
+				`$area = ($r->w * $r->h);`,
+				`mochi_print_i64(($r->w + $r->h));`,
 			},
 		},
 	}

--- a/transpiler3/php/build/phase07_test.go
+++ b/transpiler3/php/build/phase07_test.go
@@ -142,6 +142,61 @@ func TestPhase7EmitFragments(t *testing.T) {
 				`$__query1 = array_slice($__query1, 2, ((2 + 4) - 2));`,
 			},
 		},
+		{
+			fixture: "query_bool_filter.mochi",
+			wants: []string{
+				// Bare bool predicate `where f` lowers to a raw
+				// truthiness check, not `=== true`.
+				`foreach ($flags as $f) {`,
+				`if ($f) {`,
+				`$__query1 = [...$__query1, $f];`,
+			},
+		},
+		{
+			fixture: "query_order_by_strings.mochi",
+			wants: []string{
+				// `order by w` over strings goes through the same
+				// spaceship-backed helper as ints/floats. Locks the
+				// type-agnostic sort path.
+				`$words = ["banana", "apple", "cherry", "date"];`,
+				`foreach ($words as $w) {`,
+				`$__query1 = [...$__query1, $w];`,
+				`$__query1 = mochi_list_sort_asc($__query1);`,
+				`$sorted = $__query1;`,
+			},
+		},
+		{
+			fixture: "query_order_filter.mochi",
+			wants: []string{
+				// `where n % 2 == 0 order by n` composes a filtered
+				// gather and a sort, in that order.
+				`foreach ($nums as $n) {`,
+				`if ((($n % 2) === 0)) {`,
+				`$__query1 = [...$__query1, $n];`,
+				`$__query1 = mochi_list_sort_asc($__query1);`,
+				`$evens_sorted = $__query1;`,
+			},
+		},
+		{
+			fixture: "query_order_take.mochi",
+			wants: []string{
+				// `order by n take 3` produces gather → sort → slice
+				// (with the zero-skip canonical form).
+				`$__query1 = mochi_list_sort_asc($__query1);`,
+				`$__query1 = array_slice($__query1, 0, ((0 + 3) - 0));`,
+				`$top3 = $__query1;`,
+			},
+		},
+		{
+			fixture: "query_string_map.mochi",
+			wants: []string{
+				// `select len(w)` invokes the StrLenExpr lowering
+				// inside the per-row push expression.
+				`foreach ($words as $w) {`,
+				`$__query1 = [...$__query1, strlen($w)];`,
+				`$lengths = $__query1;`,
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/transpiler3/php/build/phase08_test.go
+++ b/transpiler3/php/build/phase08_test.go
@@ -112,6 +112,26 @@ func TestPhase8EmitFragments(t *testing.T) {
 				`$results = ["a", "d"];`,
 			},
 		},
+		{
+			fixture: "dl_chain.mochi",
+			wants: []string{
+				// Length-4 transitive closure exercises the
+				// semi-naive evaluator's iterate-until-fixpoint loop
+				// (lower/datalog.go:dlDeriveRule). The result order
+				// is the derivation order, so a regression that
+				// re-ordered tuples in dlTupleIn would surface here.
+				`$xs = ["n2", "n3", "n4", "n5"];`,
+			},
+		},
+		{
+			fixture: "dl_filter_const.mochi",
+			wants: []string{
+				// Query with a constant LHS argument (`like("alice", Y)`)
+				// locks the binding/unification path where one query
+				// arg is a literal and the other is the binder.
+				`$xs = ["cats", "birds"];`,
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/transpiler3/php/build/phase13_test.go
+++ b/transpiler3/php/build/phase13_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -186,4 +187,72 @@ func TestPhase13EmitFragments(t *testing.T) {
 			}
 		})
 	}
+}
+
+// djb2CassetteKey is a Go reimplementation of the PHP
+// mochi_llm_cassette_key helper. Both must agree: any divergence here
+// means a regression in the emitter that no end-to-end PHP run would
+// catch on hosts without `php`. The PHP version uses GMP because the
+// uint64 product can exceed PHP_INT_MAX; Go's uint64 already wraps
+// modulo 2^64 so the result is the same without GMP.
+func djb2CassetteKey(provider, model, prompt string) string {
+	buf := provider + "\x00" + model + "\x00" + prompt
+	var h uint64 = 5381
+	for i := 0; i < len(buf); i++ {
+		h = (h * 33) ^ uint64(buf[i])
+	}
+	return strconv.FormatUint(h, 10)
+}
+
+// TestPhase13DJB2HashMatchesCassetteFilenames pins the cassette
+// lookup algorithm: every (provider, model, prompt) tuple used by a
+// Phase 13 fixture must hash to a filename that actually exists in
+// that fixture's cassette/ directory. The test runs without PHP - it
+// only needs the fixture directory. It catches a regression in the
+// PHP DJB2 implementation (wrong concat order, missing NUL, wrong
+// mask, signed-int overflow), a wrong default model passed by the
+// lowerer, or a renamed cassette file.
+func TestPhase13DJB2HashMatchesCassetteFilenames(t *testing.T) {
+	cases := []struct {
+		fixture, provider, model, prompt, wantHash string
+	}{
+		{"generate_text", "openai", "", "Say hello.", "15023835511162652990"},
+		{"generate_anthropic", "anthropic", "", "Count to 3.", "2324397449310383700"},
+		{"generate_concat", "openai", "", "Capital of France?", "13416524672896750544"},
+		{"generate_confirm", "anthropic", "", "Reply with only the word: yes", "7071908178434434007"},
+		{"generate_in_var", "openai", "", "What color is the sky?", "9323966891408970643"},
+		{"generate_math", "openai", "", "What is 6 times 7?", "7500588262126349073"},
+		{"generate_prime", "openai", "", "Is 7 prime?", "16185609923679915080"},
+	}
+	for _, c := range cases {
+		t.Run(c.fixture, func(t *testing.T) {
+			got := djb2CassetteKey(c.provider, c.model, c.prompt)
+			if got != c.wantHash {
+				t.Errorf("djb2(%q, %q, %q) = %s; want %s", c.provider, c.model, c.prompt, got, c.wantHash)
+			}
+			path := filepath.Join(repoRoot(t), "tests", "transpiler3", "php", "fixtures", "phase13-llm", c.fixture, "cassette", got+".txt")
+			if _, err := os.Stat(path); err != nil {
+				t.Errorf("cassette file %s does not exist: %v", path, err)
+			}
+		})
+	}
+
+	// generate_multiple issues two distinct prompts in one program;
+	// both must resolve. This pins the path that hashes per call
+	// rather than carrying state across calls.
+	t.Run("generate_multiple", func(t *testing.T) {
+		for prompt, want := range map[string]string{
+			"Say foo.":        "14733925101528638458",
+			"Is Mochi great?": "16198809129143077817",
+		} {
+			got := djb2CassetteKey("openai", "", prompt)
+			if got != want {
+				t.Errorf("djb2(openai, \"\", %q) = %s; want %s", prompt, got, want)
+			}
+			path := filepath.Join(repoRoot(t), "tests", "transpiler3", "php", "fixtures", "phase13-llm", "generate_multiple", "cassette", got+".txt")
+			if _, err := os.Stat(path); err != nil {
+				t.Errorf("cassette file %s does not exist: %v", path, err)
+			}
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Closes #22566. Deep audit of MEP-55 phases 0..18 surfaced weak or missing test assertions in four phases. This PR tightens all of them without changing any runtime/lowering code.

- **Phase 4** records: replace 5 substring-only assertions with full shape assertions (class name + field decls + constructor-call shape). The worst offender (\`record_field_arith\` wanting \`(\$\`) is now pinned to \`(\$r->w * \$r->h)\` and \`(\$r->w + \$r->h)\`.
- **Phase 7** query: add fragment rows for 5 fixtures that previously had only end-to-end PHP coverage (\`query_bool_filter\`, \`query_order_by_strings\`, \`query_order_filter\`, \`query_order_take\`, \`query_string_map\`). 31% of Phase 7 fixtures had no shape coverage; this drops the gap to zero.
- **Phase 8** datalog: add fragment rows for \`dl_chain\` (length-4 transitive closure) and \`dl_filter_const\` (literal LHS arg).
- **Phase 13** LLM: add \`TestPhase13DJB2HashMatchesCassetteFilenames\` - a Go reimplementation of the PHP \`mochi_llm_cassette_key\` helper that verifies every fixture's (provider, model, prompt) tuple hashes to a filename that exists in that fixture's cassette dir. Catches DJB2 regressions without needing PHP on PATH.

## Test plan

- [x] \`go test ./transpiler3/php/build/ -run TestPhase4EmitFragments\` (all 14 subtests pass)
- [x] \`go test ./transpiler3/php/build/ -run TestPhase7EmitFragments\` (now 16 subtests, all pass)
- [x] \`go test ./transpiler3/php/build/ -run TestPhase8EmitFragments\` (now 11 subtests, all pass)
- [x] \`go test ./transpiler3/php/build/ -run TestPhase13\` (DJB2 + emit fragments, all pass)
- [x] \`go test ./transpiler3/php/...\` (full PHP transpiler suite green)
- [ ] CI: PHP matrix stays green