### PR TITLE
transpiler3/php: drop unused amphp/revolt from runtime composer.json

### DIFF
--- a/transpiler3/php/runtime/composer.json
+++ b/transpiler3/php/runtime/composer.json
@@ -6,11 +6,7 @@
     "require": {
         "php": "^8.4",
         "ext-mbstring": "*",
-        "ext-gmp": "*",
-        "amphp/amp": "^3.0",
-        "amphp/pipeline": "^1.0",
-        "revolt/event-loop": "^1.0",
-        "amphp/http-client": "^5.0"
+        "ext-gmp": "*"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.12",


### PR DESCRIPTION
## Summary

The runtime composer.json declared `amphp/amp`, `amphp/pipeline`, `revolt/event-loop`, and `amphp/http-client`, but the emitted PHP never imports any of those namespaces. Phase 11 (async/futures) ships as a synchronous value wrapper -- no event loop, no HTTP client.

Carrying the deps anyway pulls a large transitive graph on every `composer install`, misrepresents the package's public surface, and would attract false-positive CVE flags against the Mochi runtime release.

Drop the four lines. The Phase 15/18 composer-shape gates pin name / license / psr-4 / php constraint only; none pin async deps. If a future phase wires real async dispatch (with actual deferred work) the deps can come back alongside the code that uses them.

Tracking issue: #22576.

## Test plan

- [x] `go test ./transpiler3/php/build/` passes locally (Phase 15 + Phase 18 composer gates remain green).
- [ ] CI matrix green (PHP 8.4 end-to-end + Psalm + PHPStan; `composer install` should still resolve cleanly with the smaller require set).