### PR TITLE
transpiler3/php: lock Phase 1 emit shapes for int/float/bool/newline

### DIFF
--- a/transpiler3/php/build/phase01_test.go
+++ b/transpiler3/php/build/phase01_test.go
@@ -65,3 +65,76 @@ func TestPhase1EmitWithoutPhp(t *testing.T) {
 		}
 	}
 }
+
+// TestPhase1EmitFragments locks the lowered PHP shape for each of the
+// four print families (str / i64 / f64 / bool) plus the embedded-newline
+// hello fixture. Phase 2 separately exercises these helpers as part of
+// the scalar feature surface; this test pins them against the Phase 1
+// "hello world" deliverable specifically, so a regression that breaks
+// the i64 / f64 / bool entry points fails at Phase 1 (where the
+// promise lives) instead of leaking into Phase 2's scalar coverage.
+func TestPhase1EmitFragments(t *testing.T) {
+	cases := []struct {
+		fixture string
+		wants   []string
+	}{
+		{
+			fixture: "hello_int.mochi",
+			wants: []string{
+				"function mochi_print_i64(int $value): void",
+				`mochi_print_i64(42);`,
+			},
+		},
+		{
+			fixture: "hello_float.mochi",
+			wants: []string{
+				"function mochi_print_f64(float $value): void",
+				`mochi_print_f64(3.14);`,
+			},
+		},
+		{
+			fixture: "hello_bool.mochi",
+			wants: []string{
+				"function mochi_print_bool(bool $value): void",
+				`echo $value ? "true\n" : "false\n";`,
+				`mochi_print_bool(true);`,
+			},
+		},
+		{
+			// Embedded newlines inside the source string lower to a
+			// PHP double-quoted literal containing the escape \n.
+			// Pinning this keeps the lexer from accidentally
+			// dropping the embedded line break or emitting it raw,
+			// which would break the .out diff under php main.php.
+			fixture: "hello_newline.mochi",
+			wants: []string{
+				`mochi_print_str("line1\nline2");`,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(strings.TrimSuffix(c.fixture, ".mochi"), func(t *testing.T) {
+			mochiPath := filepath.Join(repoRoot(t), "tests", "transpiler3", "php", "fixtures", "phase01-hello", c.fixture)
+			if _, err := os.Stat(mochiPath); err != nil {
+				t.Skipf("fixture missing: %v", err)
+			}
+			outDir := t.TempDir()
+			d := &Driver{CacheDir: t.TempDir(), NoCache: true}
+			p, err := d.Build(mochiPath, outDir, TargetPhpSource)
+			if err != nil {
+				t.Fatalf("Build(%s): %v", c.fixture, err)
+			}
+			data, err := os.ReadFile(p)
+			if err != nil {
+				t.Fatalf("read %s: %v", p, err)
+			}
+			src := string(data)
+			for _, want := range c.wants {
+				if !strings.Contains(src, want) {
+					t.Errorf("%s: emitted source missing %q\n---\n%s", c.fixture, want, src)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `TestPhase1EmitFragments` to pin the lowered PHP shape for the four non-string Phase 1 fixtures.
- Closes a gap where the int / float / bool helper paths and the embedded-newline literal had no static-shape gate; the only emit-only assertion covered the string fixture, so PHP-less hosts could regress these silently until Phase 2's scalar suite picked it up.

Closes #22595.

## Test plan

- [x] `go test ./transpiler3/php/... -count=1`
- [x] `go vet ./transpiler3/php/...`