### PR TITLE
transpiler3/php: lock Phase 13 stderr-diagnostic branches in LLM helper

### DIFF
--- a/transpiler3/php/build/phase13_test.go
+++ b/transpiler3/php/build/phase13_test.go
@@ -104,6 +104,16 @@ func TestPhase13EmitFragments(t *testing.T) {
 				`$dir = getenv('MOCHI_LLM_CASSETTE_DIR');`,
 				`$path = rtrim($dir, '/') . '/' . $key . '.txt';`,
 				`$data = @file_get_contents($path);`,
+				// Both failure branches must emit a stderr note and
+				// short-circuit with `return '';`. Neither runtime
+				// test exercises the failing path (they all run with
+				// the env var set and cassettes present), so the
+				// fragment gate is the only thing pinning the
+				// diagnostic contract.
+				`fwrite(STDERR, "mochi_llm_generate: MOCHI_LLM_CASSETTE_DIR not set; live mode not yet implemented for PHP\n");`,
+				`fwrite(STDERR, "mochi_llm_generate: cassette not found: $path\n");`,
+				`if ($dir === false || $dir === '') {`,
+				`if ($data === false) {`,
 				// User call-site: provider literal flows in as a
 				// string arg; empty model means provider default.
 				`$r = mochi_llm_generate("openai", "", "Say hello.");`,


### PR DESCRIPTION
## Summary

- Pins the two stderr-diagnostic branches in \`mochi_llm_generate\`: env-var-unset and cassette-not-found.
- TestPhase13LLM always runs with the env set and matching cassettes present, so neither branch had any gate. A regression that dropped the \`fwrite(STDERR, ...)\` or skipped \`return '';\` would have shipped silently.

Closes #22600.

## Test plan

- [x] \`go test ./transpiler3/php/... -count=1\`