### PR TITLE
transpiler3/php: pin Phase 2 float-compare strict-equality shape

### DIFF
--- a/transpiler3/php/build/phase02_test.go
+++ b/transpiler3/php/build/phase02_test.go
@@ -91,6 +91,22 @@ func TestPhase2EmitFragments(t *testing.T) {
 			},
 		},
 		{
+			// Float equality must lower to PHP's strict `===` (same as
+			// int/string), not the loose `==` that performs numeric
+			// coercion on string/null/bool operands. The only other
+			// float-touching fragment cases (arith_float, float_nan_inf,
+			// float_neg_inf) exercise arithmetic and printing; without
+			// this entry, a regression that swapped `===` for `==` in
+			// the float-compare path would only fail under end-to-end
+			// PHP runs and silently pass on hosts without `php`.
+			fixture: "compare_float.mochi",
+			wants: []string{
+				`($a < $b)`,
+				`($a === $b)`,
+				`($b > $a)`,
+			},
+		},
+		{
 			fixture: "float_nan_inf.mochi",
 			wants: []string{
 				`fdiv(1, 0)`,


### PR DESCRIPTION
## Summary

- Adds the missing fragment-table row for \`compare_float.mochi\`.
- Pins the strict \`===\` shape for float equality so a regression swapping it for loose \`==\` fails on PHP-less hosts.

Closes #22605.

## Test plan

- [x] \`go test ./transpiler3/php/build/ -run TestPhase2EmitFragments/compare_float -v -count=1\`
- [x] \`go test ./transpiler3/php/... -count=1\`