### PR TITLE
docs(mep-57): round 4 fixes (error registry + research-07 + phase-17 platform scope)

### DIFF
--- a/website/docs/implementation/0057/errors.md
+++ b/website/docs/implementation/0057/errors.md
@@ -53,6 +53,7 @@ Conventions:
 | M057_RESOLVE_E007 | 2.2 | Cold-cache sentinel (internal) | internal |
 | M057_RESOLVE_E008 | 2.3 | Cache lock contention exceeded timeout | "another mochi process holds the lock" |
 | M057_RESOLVE_E009 | 2.3 | Cache integrity check failed | "run `mochi pkg cache verify`" |
+| M057_RESOLVE_E010 | 2.0 | Both `mochi.toml` and `mochi.workspace.toml` in the same directory | "rename or delete one" |
 
 ## WORKSPACE (Phase 3)
 
@@ -181,6 +182,7 @@ specific target failed").
 | M057_SBOM_E001 | 15.6 | CycloneDX schema validation failed | "see emitted message for field" |
 | M057_SBOM_E002 | 15.6 | SPDX schema validation failed | "see emitted message for field" |
 | M057_SBOM_E003 | 15.3 | in-toto Statement does not match resolved tree | "re-run publish from a clean tree" |
+| M057_SBOM_E004 | 15.4 | PURL malformed (invalid scope, version, or qualifier) | "fix the manifest field surfaced in the message" |
 
 ## ADV (Phase 16 advisory)
 

--- a/website/docs/implementation/0057/errors.md
+++ b/website/docs/implementation/0057/errors.md
@@ -152,6 +152,18 @@ Phase 18's verify mismatch is `BLOB_E006`.
 | M057_SIG_E008 | 13.10 | TUF root expired or signature invalid | "refresh TUF root from pinned source" |
 | M057_SIG_E009 | 13.10 | TUF metadata rollback detected | "abort; report to registry operator" |
 
+## TUF (Phase 13 metadata client)
+
+`SIG_E008` and `SIG_E009` cover root + rollback at the trust-root layer.
+`TUF_E*` codes cover the targets-metadata client used per fetch (separate
+sentinels so callers can distinguish "trust root broken" from "this
+specific target failed").
+
+| Code | Owner | Trigger | Recovery hint |
+|------|-------|---------|---------------|
+| M057_TUF_E001 | 13.10 | TUF targets metadata expired or signature invalid | "refresh metadata; check clock skew" |
+| M057_TUF_E002 | 13.10 | TUF target hash/length disagrees with metadata | "treat as untrusted; report to operator" |
+
 ## FAN (Phase 14 polyglot fan-out)
 
 | Code | Owner | Trigger | Recovery hint |
@@ -179,6 +191,16 @@ Phase 18's verify mismatch is `BLOB_E006`.
 | M057_ADV_E003 | 16.0 | Advisory YAML schema invalid | "advisory author / registry bug" |
 | M057_ADV_E004 | 16.6 | `[ignore-advisories]` references unknown ID | "remove or update the ignore" |
 
+## REPRO (Phase 17)
+
+| Code | Owner | Trigger | Recovery hint |
+|------|-------|---------|---------------|
+| M057_REPRO_E001 | 17.2 | Tarball contains non-deterministic metadata (xattr, PAX record) | "drop the xattr; rebuild" |
+| M057_REPRO_E002 | 17.5 | Twice-built tarball hashes differ | "see [phase 17](./phase-17-repro) repro harness" |
+| M057_REPRO_E003 | 17.6 | Consumer rebuild does not match registry hash | "report to publisher; treat as untrusted" |
+| M057_REPRO_E004 | 17.7 | Source repository tag missing or moved | "publisher must re-tag commit" |
+| M057_REPRO_E005 | 17.0 | `SOURCE_DATE_EPOCH` not a valid integer | "unset or set to seconds since epoch" |
+
 ## OFFLINE (Phase 18)
 
 | Code | Owner | Trigger | Recovery hint |
@@ -194,6 +216,18 @@ Phase 18's verify mismatch is `BLOB_E006`.
 | M057_CACHE_E001 | 19.6 | GC raced a concurrent build | "the build will retry transparently" |
 | M057_CACHE_E002 | 19.0 | Hardlink installer hit per-inode limit | "fallback to copy is automatic" |
 | M057_CACHE_E003 | 19.6 | `mochi pkg cache verify` found tampering | "run `mochi pkg cache prune`" |
+
+## PERF (Phase 19)
+
+`CACHE_*` covers correctness of the on-disk cache. `PERF_*` covers
+bench-gate and operational failures of GC/install paths, which are
+recoverable but user-visible.
+
+| Code | Owner | Trigger | Recovery hint |
+|------|-------|---------|---------------|
+| M057_PERF_E001 | 19.5 | Bench result exceeds rolling baseline beyond threshold | "see `bench/baseline.json`; investigate regression" |
+| M057_PERF_E002 | 19.6 | Cache GC failed (filesystem permissions, disk full) | "free disk space; check `$MOCHI_HOME` permissions" |
+| M057_PERF_E003 | 19.0 | Hardlink failed across filesystems; fell back to copy | "internal; logged at debug, not surfaced to user" |
 
 ## Localization policy
 

--- a/website/docs/implementation/0057/phase-00-skeleton.md
+++ b/website/docs/implementation/0057/phase-00-skeleton.md
@@ -402,6 +402,15 @@ Conventions used across the phase tracking pages:
   no separate config root; `config/` is a subtree of `$MOCHI_HOME` because
   registries.toml is read every command and the OS-defined config root adds
   a second lookup path that is rarely useful in CI containers.
+- **Schema key naming**: two conventions coexist by design.
+  Index JSONL entries (Phase 8) use compact short keys (`v`, `r`, `b3`,
+  `s2`, `deps`, `y`, `cap`, `tgt`) because each line is shipped over the
+  wire on every solve and the bytes add up. Manifests (`mochi.toml`,
+  Phase 1) and lockfiles (`mochi.lock`, Phase 4) use long keys (`version`,
+  `released`, `blake3`, `sha256`, `dependencies`, `yanked`, `capabilities`,
+  `targets`) because both are human-edited and reviewed in PRs. The
+  long-key form is canonical; the JSONL form is a wire encoding. Phase 8
+  documents the bidirectional mapping table.
 
 | File | Purpose | Owner |
 |------|---------|-------|

--- a/website/docs/implementation/0057/phase-02-local-resolution.md
+++ b/website/docs/implementation/0057/phase-02-local-resolution.md
@@ -25,8 +25,8 @@ Pass criteria:
 1. Specifier classifier. `pkgresolve.Classify(spec)` returns the right kind for every entry in `tests/pkgsystem/local-resolve/classify/cases.json` (250+ rows covering path, scoped, unscoped, FFI-tagged, mixed-shape, and degenerate inputs).
 2. Manifest discovery. Given a working directory, `pkgresolve.DiscoverManifest(cwd)` walks parents and returns either a manifest path (preferring `mochi.workspace.toml` over `mochi.toml`) or a "manifest-less" verdict. Both outcomes are covered by separate fixtures.
 3. Cache lookup. For every scoped import in `tests/pkgsystem/local-resolve/scoped-cached/`, the resolver returns a `ResolvedModule` whose source path lives under the test cache root (`tests/pkgsystem/local-resolve/scoped-cached/cache/`). The resolved tree is dumped as canonical JSON and compared against `golden.json`.
-4. Manifest-less mode. Path-form and FFI imports work without a manifest. Any scoped import in manifest-less mode raises `M057_NO_MANIFEST` and the error message contains the literal hint `did you forget mochi init?`.
-5. Version mismatch. When the in-source `@req` disagrees with the manifest pin, `pkgresolve.Resolve` raises `M057_VERSION_MISMATCH` and the error message shows both the in-source and in-manifest specs.
+4. Manifest-less mode. Path-form and FFI imports work without a manifest. Any scoped import in manifest-less mode raises `M057_RESOLVE_E002` and the error message contains the literal hint `did you forget mochi init?`.
+5. Version mismatch. When the in-source `@req` disagrees with the manifest pin, `pkgresolve.Resolve` raises `M057_RESOLVE_E003` and the error message shows both the in-source and in-manifest specs.
 6. Regression. Every `examples/v0.7/**/*.mochi` still resolves without changes; the test harness reuses `tests/examples_test.go` for the regression sweep.
 
 ## Goal-alignment audit
@@ -42,7 +42,7 @@ The scoped-import surface is purely additive: no existing token is repurposed, n
 | 2.0 | Specifier classifier (path / scoped / unscoped / FFI / ambiguous) | NOT STARTED | — |
 | 2.1 | Manifest discovery (walk parents for `mochi.workspace.toml` / `mochi.toml`) | NOT STARTED | — |
 | 2.2 | Cache lookup at `$MOCHI_HOME/store/extracted/<blake3>/` (see [layout](./phase-00-skeleton#sub-phase-06--ci-workflow)) | NOT STARTED | — |
-| 2.3 | Manifest-less mode: path + FFI work; scoped fails with M057_NO_MANIFEST | NOT STARTED | — |
+| 2.3 | Manifest-less mode: path + FFI work; scoped fails with M057_RESOLVE_E002 | NOT STARTED | — |
 | 2.4 | In-source `@req` vs manifest `version` mismatch detection | NOT STARTED | — |
 | 2.5 | Resolver dispatch wired into `parser/import.go` | NOT STARTED | — |
 | 2.6 | Regression: every existing example under `examples/v0.7/` still resolves | NOT STARTED | — |
@@ -110,7 +110,7 @@ func Classify(stmt parser.ImportStmt) (Classification, error) {
 }
 ```
 
-The mixed-shape case (`import "./util@^1" as x`) raises `M057_AMBIGUOUS_SPEC`. The classifier does no I/O.
+The mixed-shape case (`import "./util@^1" as x`) raises `M057_RESOLVE_E001`. The classifier does no I/O.
 
 ## Sub-phase 2.1 — Manifest discovery
 
@@ -150,7 +150,7 @@ func DiscoverManifest(startDir string) (DiscoveryResult, error) {
 
 Filesystem stop conditions: filesystem root (`/`), volume root on Windows, or the user home directory (configurable via `MOCHI_DISCOVERY_STOP_AT`). Symlinks are resolved but not followed across volume boundaries.
 
-A directory containing both `mochi.toml` and `mochi.workspace.toml` is rejected with `M057_AMBIGUOUS_MANIFEST` to avoid ambiguity (research note 04 §8).
+A directory containing both `mochi.toml` and `mochi.workspace.toml` is rejected with `M057_RESOLVE_E010` to avoid ambiguity (research note 04 §8).
 
 ## Sub-phase 2.2 — Cache lookup
 
@@ -187,7 +187,7 @@ func (r *PkgResolver) Resolve(c Classification, ctx *Context) (ResolvedModule, e
     }
     if c.Req != "" {
         if err := assertReqMatches(c.Req, locked.Version); err != nil {
-            return ResolvedModule{}, err  // M057_VERSION_MISMATCH
+            return ResolvedModule{}, err  // M057_RESOLVE_E003
         }
     }
 
@@ -216,7 +216,7 @@ When `DiscoverManifest` returns `ManifestLess: true`:
 
 - Path imports work. The existing `runtime/mod/mod.go` resolver is used unchanged.
 - FFI imports work. The per-language driver is dispatched unchanged.
-- Scoped imports raise `M057_NO_MANIFEST`:
+- Scoped imports raise `M057_RESOLVE_E002`:
 
 ```
 error: scoped import "@mochi/strings@^0.4" requires a manifest
@@ -249,7 +249,7 @@ func assertReqMatches(sourceReq, lockedVersion string) error {
 
 If the in-source `@req` is absent, the locked version wins (research note 01 §2).
 
-If the in-manifest version range and the in-source `@req` disagree (e.g. manifest says `^0.4`, source says `@^0.5`), the parser raises `M057_VERSION_MISMATCH` regardless of which one matches the locked version.
+If the in-manifest version range and the in-source `@req` disagree (e.g. manifest says `^0.4`, source says `@^0.5`), the parser raises `M057_RESOLVE_E003` regardless of which one matches the locked version.
 
 ## Sub-phase 2.5 — Resolver dispatch wired in
 
@@ -332,7 +332,7 @@ Sorted by `(scope, name, version)`. Compared against `golden.json` byte-for-byte
 | `pkg/pkgresolve/resolve.go` | Top-level `Resolve` dispatch (extended by Phase 3) | Owner |
 | `pkg/pkgresolve/cache.go` | Cache lookup + integrity verification | Owner |
 | `pkg/pkgresolve/dump.go` | Canonical JSON dump | Owner |
-| `pkg/pkgresolve/errors.go` | Sentinel errors (M057_AMBIGUOUS_SPEC, etc.) | Owner |
+| `pkg/pkgresolve/errors.go` | Sentinel errors (M057_RESOLVE_E001, etc.) | Owner |
 | `parser/import.go` | Dispatch hook | Extends |
 | `tests/pkgsystem/local-resolve/path-only/*.mochi` | Path regression corpus | Owner |
 | `tests/pkgsystem/local-resolve/scoped-cached/*.mochi` | Scoped cache-hit corpus | Owner |
@@ -342,15 +342,18 @@ Sorted by `(scope, name, version)`. Compared against `golden.json` byte-for-byte
 
 ## Error code surface
 
+Sources (see [error registry](./errors)). Verbal aliases used in early
+drafts are renamed to the canonical `M057_RESOLVE_E<NNN>` form:
+
 | Code | Trigger |
 |------|---------|
-| `M057_NO_MANIFEST` | Scoped import without a discoverable manifest. |
-| `M057_AMBIGUOUS_SPEC` | Mixed-shape specifier (e.g. `./foo@^1`). |
-| `M057_AMBIGUOUS_MANIFEST` | Both `mochi.toml` and `mochi.workspace.toml` in the same directory. |
-| `M057_VERSION_MISMATCH` | In-source `@req` disagrees with manifest or lockfile. |
-| `M057_LOCKED_PKG_MISSING` | Resolved import is not in the lockfile. |
-| `M057_CACHE_POISONED` | Cache entry exists but BLAKE3 does not match the lockfile. |
-| `M057_COLD_CACHE` | Phase 2 only: cache miss for a scoped import; Phase 8 will resolve this. |
+| `M057_RESOLVE_E002` | Scoped import without a discoverable manifest. |
+| `M057_RESOLVE_E001` | Mixed-shape specifier (e.g. `./foo@^1`). |
+| `M057_RESOLVE_E010` | Both `mochi.toml` and `mochi.workspace.toml` in the same directory. |
+| `M057_RESOLVE_E003` | In-source `@req` disagrees with manifest or lockfile. |
+| `M057_RESOLVE_E004` | Resolved import is not in the lockfile (or 404 at registry). |
+| `M057_RESOLVE_E009` | Cache entry exists but BLAKE3 does not match the lockfile. |
+| `M057_RESOLVE_E007` | Phase 2 only: cold-cache sentinel for a scoped import; Phase 8 resolves it. |
 
 ## Fixtures
 
@@ -366,8 +369,8 @@ Sorted by `(scope, name, version)`. Compared against `golden.json` byte-for-byte
 - `TestPhase2Classify` — classifier `cases.json`.
 - `TestPhase2Discover` — manifest discovery.
 - `TestPhase2CacheHit` — scoped imports against pre-populated cache.
-- `TestPhase2ManifestLess` — scoped raises `M057_NO_MANIFEST`.
-- `TestPhase2VersionMismatch` — `M057_VERSION_MISMATCH`.
+- `TestPhase2ManifestLess` — scoped raises `M057_RESOLVE_E002`.
+- `TestPhase2VersionMismatch` — `M057_RESOLVE_E003`.
 - `TestPhase2Regression` — `examples/v0.7/**/*.mochi` still resolves.
 
 ## Open questions

--- a/website/docs/implementation/0057/phase-03-workspaces.md
+++ b/website/docs/implementation/0057/phase-03-workspaces.md
@@ -131,7 +131,7 @@ func LoadWorkspace(rootDir string) (*WorkspaceState, error) {
 Edge cases:
 
 - Empty workspace (`members = []`) is allowed; the umbrella is a degenerate case.
-- A member with the same `package.name` as another member raises `M057_DUPLICATE_MEMBER`.
+- A member with the same `package.name` as another member raises `M057_WORKSPACE_E001`.
 - A member listed under `members` whose directory has no `mochi.toml` is silently skipped (matches Cargo).
 
 ## Sub-phase 3.2 — Cross-member short-circuit
@@ -238,7 +238,7 @@ The workspace root can be one of two shapes (research note 04 §8):
 |------------------------------|---------------------|-----------------------------------------|
 | `mochi.workspace.toml` only  | required            | Umbrella only; root is not a package    |
 | `mochi.toml` only            | required            | Combined: root is also a member         |
-| both                         | -                   | `M057_AMBIGUOUS_MANIFEST`               |
+| both                         | -                   | `M057_RESOLVE_E010`               |
 
 In the combined case the root manifest's `[package]` produces a member; its sources live in the workspace root directory.
 
@@ -272,7 +272,7 @@ func DetectCycles(ws *WorkspaceState) error {
 }
 ```
 
-Cycles raise `M057_WORKSPACE_CYCLE` with the full cycle path in the error message.
+Cycles raise `M057_WORKSPACE_E003` with the full cycle path in the error message.
 
 ## Files changed
 
@@ -292,13 +292,16 @@ Cycles raise `M057_WORKSPACE_CYCLE` with the full cycle path in the error messag
 
 ## Error code surface
 
+Sources (see [error registry](./errors)). Verbal aliases from early
+drafts are renamed to the canonical `M057_WORKSPACE_E<NNN>` form:
+
 | Code | Trigger |
 |------|---------|
-| `M057_DUPLICATE_MEMBER` | Two members share `package.name`. |
-| `M057_AMBIGUOUS_MANIFEST` | Both `mochi.toml` and `mochi.workspace.toml` at the root. |
-| `M057_WORKSPACE_CYCLE` | Cross-member imports form a cycle. |
+| `M057_WORKSPACE_E001` | Two members share `package.name`. |
+| `M057_RESOLVE_E010` | Both `mochi.toml` and `mochi.workspace.toml` at the root (shared with Phase 2). |
+| `M057_WORKSPACE_E003` | Cross-member imports form a cycle. |
+| `M057_WORKSPACE_E004` | Member glob escapes workspace root. |
 | `M057_MANIFEST_E009` | Member's `workspace = true` dep is not in `[workspace.dependencies]`. |
-| `M057_GLOB_OUT_OF_BOUNDS` | Member glob escapes the workspace root. |
 
 ## Fixtures
 
@@ -320,7 +323,7 @@ Cycles raise `M057_WORKSPACE_CYCLE` with the full cycle path in the error messag
 
 ## Open questions
 
-- Whether to support nested workspaces (a member that is itself a workspace root); current plan: reject with `M057_NESTED_WORKSPACE` at v1.
+- Whether to support nested workspaces (a member that is itself a workspace root); current plan: reject with `M057_WORKSPACE_E005` at v1.
 - Whether `workspace = "name"` (named workspace reference) is useful for cross-repo workspaces; deferred to v2.
 
 ## Cross-references

--- a/website/docs/implementation/0057/phase-04-lockfile.md
+++ b/website/docs/implementation/0057/phase-04-lockfile.md
@@ -377,9 +377,13 @@ No hand-merging. Most conflicts touch separate package blocks, but `--refresh` i
 | `M057_LOCK_E002` | Resolution mismatch (drift). |
 | `M057_LOCK_E003` | Lock version too new. |
 | `M057_LOCK_E004` | Invalid lockfile syntax. |
-| `M057_LOCK_E005` | Unknown registry referenced. |
+| `M057_LOCK_E005` | Missing required lock field. |
 | `M057_LOCK_E006` | New capability without `--accept-capabilities`. |
-| `M057_LOCK_E007` | Hash mismatch on cached blob. |
+
+Hash mismatch on cached blob surfaces as `M057_BLOB_E001` (BLAKE3
+mismatch, owner Phase 9.4) rather than a Phase 4 sentinel; the lockfile
+contains the expected hash but the mismatch is detected by the content
+store. Phase 4 re-raises with `%w` rather than redeclaring a code.
 
 ## Test set
 

--- a/website/docs/implementation/0057/phase-04-lockfile.md
+++ b/website/docs/implementation/0057/phase-04-lockfile.md
@@ -398,7 +398,7 @@ store. Phase 4 re-raises with `%w` rather than redeclaring a code.
 ## Open questions
 
 - Whether to expose `provenance.registry_etag` to `mochi pkg why` for debug; current plan: yes, but only when `--verbose`.
-- Whether to record `[provenance].solver_decision_count` as a perf metric; deferred.
+- Whether to record `[provenance].solver_decision_count` as a perf metric; landed in [Phase 19 §19.3](./phase-19-cache-perf) (solver memo), which is the natural home for solver-timing counters.
 - Whether `capabilities-seen` should be per-version or per-package; current plan: per-package, taking the union (keeps the delta noise low).
 
 ## Cross-references

--- a/website/docs/implementation/0057/phase-05-pubgrub.md
+++ b/website/docs/implementation/0057/phase-05-pubgrub.md
@@ -397,13 +397,16 @@ PubGrub's correctness guarantee says it always terminates on finite registries; 
 
 ## Error code surface
 
+Sources (see [error registry](./errors)). Verbal aliases from early
+drafts are renamed to the canonical `M057_SOLVER_E<NNN>` form:
+
 | Code | Trigger |
 |------|---------|
 | `M057_SOLVER_E001` | Solver exceeded wall-clock or iteration limit. |
-| `M057_SOLVER_UNSAT` | No solution exists. Phase 6 produces the explanation. |
-| `M057_CAPABILITY_DENIED` | Candidate version requires capabilities not in consumer pin. |
-| `M057_TARGET_UNSUPPORTED` | Candidate version's target set is not a superset. |
-| `M057_COMPILER_INCOMPAT` | Candidate version's `mochi` range excludes running compiler. |
+| `M057_SOLVER_E002` | No solution exists. Phase 6 produces the explanation. |
+| `M057_SOLVER_E003` | Candidate version requires capabilities not in consumer pin. |
+| `M057_SOLVER_E004` | Candidate version's target set is not a superset. |
+| `M057_SOLVER_E005` | Candidate version's `mochi` range excludes running compiler. |
 
 ## Test set
 

--- a/website/docs/implementation/0057/phase-07-local-registry.md
+++ b/website/docs/implementation/0057/phase-07-local-registry.md
@@ -25,8 +25,8 @@ Pass criteria:
 1. URL parity. The `Registry` interface implemented by `pkg/pkgregistry/local` returns identical bytes to the planned `pkg/pkgregistry/sparse` (HTTP) backend, given identical on-disk content. The harness compares `Versions(name)` and `Manifest(name, ver)` outputs across both backends.
 2. Solver parity. Running `mochi pkg lock` with `[registry] default = "file:///opt/mochi-cache"` produces a lockfile byte-identical to the same lock against the HTTP backend (`https://index.mochi.dev`) seeded with the same fixture content.
 3. Blob retrieval. `Blob(blake3)` returns the byte-identical tarball whether sourced from disk or HTTPS.
-4. Init helper. `mochi registry init <root>` populates a usable filesystem registry from a set of input manifests + tarballs.
-5. Serve helper. `mochi registry serve --local=<root> --port=N` opens an HTTPS reverse proxy that fronts a local root with the sparse URL scheme; the test harness uses this to verify the local backend matches the HTTP shape.
+4. Init helper. `mochi pkg registry init <root>` populates a usable filesystem registry from a set of input manifests + tarballs.
+5. Serve helper. `mochi pkg registry serve --local=<root> --port=N` opens an HTTPS reverse proxy that fronts a local root with the sparse URL scheme; the test harness uses this to verify the local backend matches the HTTP shape.
 
 ## Goal-alignment audit
 
@@ -43,8 +43,8 @@ Phase 7 deliberately does *not* implement HTTP semantics (ETag, conditional GET,
 | 7.0 | `pkg/pkgregistry/local` package: parse `file://` URL, walk filesystem | NOT STARTED | — |
 | 7.1 | URL scheme on disk: `<root>/<bucket>/<scope>/<name>` | NOT STARTED | — |
 | 7.2 | Blob lookup: `<root>/blobs/<blake3-hex>` | NOT STARTED | — |
-| 7.3 | `mochi registry serve --local=<root>` debug command | NOT STARTED | — |
-| 7.4 | `mochi registry init <root>` for populating a test root from manifests | NOT STARTED | — |
+| 7.3 | `mochi pkg registry serve --local=<root>` debug command | NOT STARTED | — |
+| 7.4 | `mochi pkg registry init <root>` for populating a test root from manifests | NOT STARTED | — |
 | 7.5 | Cross-backend parity tests | NOT STARTED | — |
 | 7.6 | Negative paths (missing pkg -> 404 analog, malformed JSONL -> M057_INDEX_E002) | NOT STARTED | — |
 
@@ -166,7 +166,7 @@ func (r *FilesystemRegistry) blobPath(blake3 string) string {
 
 Two-character pair sharding keeps any single directory bounded for popular projects.
 
-## Sub-phase 7.3 — `mochi registry serve`
+## Sub-phase 7.3 — `mochi pkg registry serve`
 
 A debug HTTPS server that fronts a local root with the URL scheme. Used to integration-test Phase 8 (sparse HTTPS) against a local backend:
 
@@ -194,9 +194,9 @@ func cmdRegistryServe(c *cli.Context) error {
 
 `serveBlob` streams the tarball with `Content-Type: application/vnd.mochi.tarball+zstd` and `ETag` equal to the BLAKE3 hex (matches blobs.mochi.dev convention).
 
-This server is the test-time alternative to mocking `net/http` in unit tests; integration tests against `mochi registry serve` exercise the same code path used in production HTTPS.
+This server is the test-time alternative to mocking `net/http` in unit tests; integration tests against `mochi pkg registry serve` exercise the same code path used in production HTTPS.
 
-## Sub-phase 7.4 — `mochi registry init`
+## Sub-phase 7.4 — `mochi pkg registry init`
 
 Populates a registry root from a set of manifests + tarballs:
 
@@ -220,7 +220,7 @@ The output tree is a complete sparse index ready to be served.
 
 ## Sub-phase 7.5 — Cross-backend parity tests
 
-The test harness runs each solver fixture twice: once against the local filesystem registry and once against `mochi registry serve` over HTTPS:
+The test harness runs each solver fixture twice: once against the local filesystem registry and once against `mochi pkg registry serve` over HTTPS:
 
 ```go
 // tests/pkgsystem/local-registry/parity_test.go
@@ -284,7 +284,7 @@ row was a collision with Phase 9's hash-mismatch code and is removed.
 - `TestPhase7ManifestFetch` — `Manifest` returns the parsed manifest for a version.
 - `TestPhase7Blob` — `Blob` streams tarball.
 - `TestPhase7Parity` — local vs HTTPS-serve parity.
-- `TestPhase7Init` — `mochi registry init` produces a usable tree.
+- `TestPhase7Init` — `mochi pkg registry init` produces a usable tree.
 
 ## Open questions
 

--- a/website/docs/implementation/0057/phase-07-local-registry.md
+++ b/website/docs/implementation/0057/phase-07-local-registry.md
@@ -246,7 +246,7 @@ This is the cheap insurance against Phase 8 protocol drift.
 
 Cases:
 
-- `Versions("@nonexistent/pkg")` returns `M057_PKG_NOT_FOUND`.
+- `Versions("@nonexistent/pkg")` returns `M057_INDEX_E008` (package not found in local index).
 - A JSONL file with a malformed line raises `M057_INDEX_E002` and the error mentions the line number.
 - A file whose JSONL contains an unknown field (forward-compat) is *accepted* with a warning under `Manifest.Warnings`; old clients must not refuse to parse new fields (research note 07 §14, E003 reserved but not used at v1).
 - A `Blob(notfound)` returns `M057_BLOB_E007` (local registry 404). The

--- a/website/docs/implementation/0057/phase-09-content-store.md
+++ b/website/docs/implementation/0057/phase-09-content-store.md
@@ -342,11 +342,19 @@ A mismatch is a P0 forensic signal.
 
 | Code | Trigger |
 |------|---------|
-| `M057_BLOB_E001` | BLAKE3 of downloaded bytes does not match URL hex. |
-| `M057_BLOB_E002` | SHA-256 of downloaded bytes does not match index `s2`. |
-| `M057_BLOB_E003` | Tar entry violates safety policy. |
-| `M057_BLOB_NOT_FOUND` | 404 from blob endpoint. |
-| `M057_CACHE_LOCKED` | Could not acquire per-blob lock (timeout). |
+Sources (see [error registry](./errors)). The Phase 9 BLOB_E002
+mapping is registry-name reuse: the registry's `M057_BLOB_E002` is the
+generic "fetch partial / connection reset" sentinel. SHA-256 disagreement
+falls under `M057_BLOB_E001` (dual-hash family) plus the integrity
+sidecar. Verbal aliases used in early drafts:
+
+| Code | Trigger |
+|------|---------|
+| `M057_BLOB_E001` | BLAKE3 (or SHA-256 sidecar) of downloaded bytes does not match URL hex / index `s2`. |
+| `M057_BLOB_E002` | Blob fetch partial / connection reset (auto-retried). |
+| `M057_BLOB_E003` | Tar entry violates safety policy (path escape, absolute path). |
+| `M057_BLOB_E007` | 404 from local registry blob endpoint. |
+| `M057_RESOLVE_E008` | Could not acquire per-blob lock (timeout). |
 
 ## Test set
 

--- a/website/docs/implementation/0057/phase-09-content-store.md
+++ b/website/docs/implementation/0057/phase-09-content-store.md
@@ -186,6 +186,8 @@ func (l *BlobLock) Release() error {
 
 The lock path is per `(name, version)` because two concurrent installs of distinct blobs should not serialise on each other. Windows uses `LockFileEx`; the abstraction lives behind `pkg/pkgblob/lock_unix.go` and `lock_windows.go`.
 
+This lock is internal to the `mochi` CLI process group sharing one `$MOCHI_HOME`; it is not a capability that downstream packages can request or grant. The Phase 10 capability whitelist does not list `fs.lock`; packages have no syscall surface to acquire OS-level file locks. The `fcntl` / `LockFileEx` calls happen inside the CLI binary before any package code runs.
+
 The flow:
 
 1. Acquire shared lock to check extracted dir exists.

--- a/website/docs/implementation/0057/phase-10-capabilities.md
+++ b/website/docs/implementation/0057/phase-10-capabilities.md
@@ -413,7 +413,7 @@ The VM3 trace tag is used in `mochi run --trace-capabilities`, which logs every 
 
 ## Open questions
 
-- Whether `clock` and `random` should be in the closed set at all (both are present in research note 10 §1; the argument is that deterministic-replay tools want to see them as effects).
+- Whether `clock` and `random` should be in the closed set at all (both are present in research note 10 §1; the argument is that deterministic-replay tools want to see them as effects). Decision: keep both. The reproducibility surface that consumes them lives in [Phase 17](./phase-17-repro): `SOURCE_DATE_EPOCH` shadows `clock` so reproducible builds are unaffected; deterministic-RNG seeding for `random` is tracked under Phase 17 open question 4.
 - Whether to support a per-target capability override (e.g., `net.dial` allowed on the server target but denied on the wasm target); current plan: per-target overrides live in the consumer pin, not the publisher declaration.
 - Whether the suspicious detector should fail the build or only warn; current plan: warn by default, `--suspicious-as-error` opts in.
 

--- a/website/docs/implementation/0057/phase-16-advisory.md
+++ b/website/docs/implementation/0057/phase-16-advisory.md
@@ -345,10 +345,14 @@ Implementation lives outside the Mochi binary (it is an external Go script that 
 
 | Code | Trigger |
 |------|---------|
-| `M057_AUDIT_E001` | Vulnerability found (exit code 1). |
-| `M057_AUDIT_E002` | Advisory feed unreachable AND no cache. |
-| `M057_AUDIT_E003` | Advisory YAML malformed. |
-| `M057_AUDIT_E004` | CVSS vector unparseable. |
+| `M057_ADV_E001` | Vulnerability found at or above `--fail-on` threshold (exit code 1). |
+| `M057_ADV_E002` | Advisory feed refresh failed AND no cache. |
+| `M057_ADV_E003` | Advisory YAML schema invalid. |
+| `M057_ADV_E004` | `[workspace.audit] ignore` references unknown ID. |
+
+CVSS-vector parse failure surfaces as `M057_ADV_E003` (schema invalid)
+since the CVSS string is a schema field; phase 16 does not declare a
+separate code. See the [error registry](./errors) for owners.
 
 ## Test set
 

--- a/website/docs/implementation/0057/phase-17-repro.md
+++ b/website/docs/implementation/0057/phase-17-repro.md
@@ -20,12 +20,22 @@ description: "MEP-57 Phase 17 — SOURCE_DATE_EPOCH respect, sorted tar entries,
 
 `TestPhase17Reproducible`: for every fixture under `tests/pkgsystem/repro/`, building the package twice in different temp directories with different umasks and TZ produces byte-identical tarballs and identical BLAKE3 + SHA-256 hashes.
 
+The reproducibility gate runs on linux-x86_64 and macos-arm64 (the two
+hosts that share POSIX tar + zstd semantics). Windows-x86_64 runs the
+gate in *consume* mode only: it verifies that a tarball built upstream
+on linux/mac extracts and hashes identically, but it does not act as a
+build origin because Windows file-attribute and CRLF handling would
+require a separate normalization pass. This is a deliberate scope cut
+documented as Phase 17 open question 4; consumer rebuilds (criterion 6)
+on Windows still pass because the source tag plus a linux/mac builder
+produces the registry's `<b3>`.
+
 Pass criteria:
 
 1. Cross-TZ. Building in `TZ=UTC` and `TZ=Asia/Ho_Chi_Minh` produces byte-identical tarballs.
 2. Cross-umask. `umask 022` vs `umask 077` produces byte-identical tarballs.
 3. Cross-locale. `LC_ALL=C` vs `LC_ALL=en_US.UTF-8` vs `LC_ALL=ja_JP.UTF-8` produces byte-identical tarballs.
-4. Cross-filesystem. ext4 vs APFS vs NTFS source mounts produce byte-identical tarballs (case-sensitive; case-folding fs is out of scope).
+4. Cross-filesystem. ext4 vs APFS source mounts produce byte-identical tarballs (case-sensitive; case-folding fs is out of scope; NTFS deferred per the Windows scope cut above).
 5. SOURCE_DATE_EPOCH. With `SOURCE_DATE_EPOCH=1700000000`, every tar entry has `mtime=1700000000`; every zstd frame is independent of wall clock.
 6. Rebuild script. `mochi pkg rebuild --from-source <repo>@<tag>` reproduces the registry's `<b3>` from a fresh git clone with no machine-specific environment.
 7. Diffoscope-clean. For a fixture where reproducibility fails, `diffoscope` output is the test diagnostic; the harness asserts no diff at the byte level.
@@ -317,6 +327,7 @@ Network access during rebuild: git clone of source repo. No registry access (the
 - Whether to require reproducibility for publishes (refuse to publish if `--verify-reproducible` fails); current plan: warn at v1, require at v2.
 - Whether to support a wider rebuild matrix (e.g., across mochi compiler versions); deferred to v1.1 with explicit compatibility windows.
 - Whether to publish rebuild attestations from third parties (cross-rebuilders like Debian's); current plan: yes, post v1.0, accept rebuild signatures from a configured trust list.
+- Windows-x86_64 as a build origin (currently consumer-only per Gate). Adding it requires a tar-builder pass that normalizes CRLF line endings, strips Windows file attributes, and forces case-sensitive sort order for paths that case-fold on NTFS. Tracked for v1.1.
 
 ## Cross-references
 

--- a/website/docs/mep/mep-0057.md
+++ b/website/docs/mep/mep-0057.md
@@ -423,6 +423,8 @@ Member packages share the workspace lockfile (`mochi.lock` at the workspace root
 
 Per [[02-design-philosophy]] §10:
 
+Primary surface (verbs every user touches):
+
 ```
 mochi pkg new <name> [--lib | --bin]
 mochi pkg init
@@ -441,6 +443,21 @@ mochi pkg search <term>
 mochi pkg info <pkg>
 mochi pkg mirror serve|sync
 mochi pkg workspace ls|add|remove
+```
+
+Phase-specific surface (verbs introduced by a single phase; same
+`mochi pkg <verb>` namespace):
+
+```
+mochi pkg pack [--verify-reproducible]      # Phase 17
+mochi pkg rebuild --from-source <repo>@<tag>  # Phase 17
+mochi pkg sbom show|verify|convert <pkg>    # Phase 15
+mochi pkg bench [--baseline=<file>]         # Phase 19
+mochi pkg cache verify|prune|gc             # Phase 19
+mochi pkg config registry default <url>     # Phase 0 / Phase 11
+mochi pkg publish register                  # Phase 13 (publisher binding)
+mochi pkg audit mirror <name>               # Phase 11
+mochi pkg audit fix                         # Phase 16
 ```
 
 `mochi get` keeps its current meaning (Go-module FFI fetch) for backward compatibility; `mochi pkg fetch` is the new pure-Mochi command.
@@ -552,6 +569,26 @@ MEP-57 is purely additive at the source-language layer. The existing `import "./
 The legacy `import "github.com/foo/bar"` bare-Go-import form is deprecated with a warning in v1; the manifest-driven equivalent (`mochi.toml` lists `github-bar = { git = "..." }` and code writes `import "github-bar" as B`) is the preferred path. The deprecated form is removed in v2 (no earlier than 12 months after MEP-57 v1 ships).
 
 Existing transpiler MEPs (MEP-45 through MEP-53) consume the resolved module graph through their existing `aotir` IR input; no changes to their lowering passes. Per-target publishing flows (Maven, npm, PyPI, NuGet, JSR, crates.io, Hex, Swift Package Index) are preserved; the polyglot fan-out wraps them.
+
+**Legacy projects (no `mochi.toml`).** Existing Mochi codebases that
+predate MEP-57 do not need a manifest to keep working: path imports,
+FFI imports, and the deprecated bare-Go-import form continue to
+resolve. There is no automatic conversion tool in v1. Users opt in by
+running `mochi pkg init` in the project root and authoring
+`[dependencies]` entries by hand; the manifest then unlocks scoped
+imports, lockfile, audit, and publish. A `mochi pkg init --convert`
+tool that scans `import go "..."` calls and seeds the manifest is
+tracked for v1.1.
+
+**Lockfile format evolution.** The `version = 1` envelope (see [§3
+Lockfile](#3-lockfile-mochilock)) reserves the right to extend the
+hash set in v2 (for example, adding BLAKE3+SHA3-256 as the dual hash
+if BLAKE3 or SHA-256 is deprecated by NIST). v1 clients reject any
+lockfile with `version > 1` rather than partially parse it; v2
+clients are expected to read v1 lockfiles transparently and rewrite
+on the next `mochi pkg lock`. The dual-hash family used by Phase 9's
+content store and Phase 11's mirror tampering check is paired with
+the lockfile envelope, so a hash rotation is a coordinated v2 cut.
 
 ## Reference Implementation
 

--- a/website/docs/mep/mep-0057.md
+++ b/website/docs/mep/mep-0057.md
@@ -458,6 +458,8 @@ mochi pkg config registry default <url>     # Phase 0 / Phase 11
 mochi pkg publish register                  # Phase 13 (publisher binding)
 mochi pkg audit mirror <name>               # Phase 11
 mochi pkg audit fix                         # Phase 16
+mochi pkg registry init <root>              # Phase 7 (filesystem registry seed)
+mochi pkg registry serve --local=<root>     # Phase 7 (HTTPS debug front-end)
 ```
 
 `mochi get` keeps its current meaning (Go-module FFI fetch) for backward compatibility; `mochi pkg fetch` is the new pure-Mochi command.

--- a/website/docs/research/0057/07-registry-index.md
+++ b/website/docs/research/0057/07-registry-index.md
@@ -9,7 +9,7 @@ sidebar_position: 7
 **Status**: research note. **Date**: 2026-05-29 (GMT+7).
 **Mirrors**: deployed to `/docs/research/0057/registry-index`.
 
-This note specifies the sparse HTTPS registry index protocol Mochi-57 ships in `pkg/pkgindex/`. The choice of sparse-over-git is in [02-design-philosophy](./02-design-philosophy) §4; the comparison with Cargo's 2023 GA migration is in [03-prior-art-registries](./03-prior-art-registries) §1.
+This note specifies the sparse HTTPS registry index protocol Mochi-57 ships in `pkg/pkgregistry/sparse/` (the working name in early drafts was `pkg/pkgindex/`; phase docs 0, 2, 7, 8, 11, 18 canonicalize the implementation under `pkg/pkgregistry/` and there is no `pkg/pkgindex/` directory at v1). The choice of sparse-over-git is in [02-design-philosophy](./02-design-philosophy) §4; the comparison with Cargo's 2023 GA migration is in [03-prior-art-registries](./03-prior-art-registries) §1.
 
 ## 1. Why a sparse index
 


### PR DESCRIPTION
## Summary

Round 4 + round 5 deep audit of the MEP-57 package system docs after PR #22548 landed. This PR consolidates the verified-defect subsets of both rounds.

## Commits

| Commit | Scope | Round | Closes |
|---|---|---|---|
| `0a2446b75b` | Error registry completeness (REPRO, TUF, PERF) + Phase 16 ADV mismatch | 4 | #22621 |
| `cffffff2f3` | Research-07 pkgindex/pkgregistry staleness + Phase 17 build-origin scope | 4 | #22621 |
| `d604458285` | Canonicalize 16 verbal error code aliases to M057_<CAT>_E<NNN> | 5 | #22621 |
| `68d5951323` | Close CLI verb spec gap + legacy migration + lockfile v2 hash rotation + open Q landing | 5 | #22621 |

## Round 4 findings landed

- **Error registry holes** — `M057_TUF_E*`, `M057_REPRO_E*`, `M057_PERF_E*` declared in phase docs but missing from errors.md. Phase 16's surface table used `M057_AUDIT_E*` while round 3 had committed them as `M057_ADV_E*`. Phase doc now matches registry; CVSS-vector parse failures fold into ADV_E003.
- **Research-07 staleness** — opening paragraph now names `pkg/pkgregistry/sparse/` as canonical and identifies `pkg/pkgindex/` as the pre-implementation working name.
- **Phase 17 platform scope** — gate scopes "build origin" to linux-x86_64 and macos-arm64, "consume + verify" to Windows. Added Phase 17 open question 4 for v1.1 Windows build-origin support.

## Round 5 findings landed

- **Verbal code aliases** — phase docs carried 16 non-canonical names (e.g. `M057_NO_MANIFEST`, `M057_VERSION_MISMATCH`, `M057_WORKSPACE_CYCLE`, `M057_CACHE_LOCKED`) from early drafts. All renamed to canonical `M057_<CAT>_E<NNN>` form. Two new registry codes added: `RESOLVE_E010` (manifest + workspace.toml ambiguity), `SBOM_E004` (PURL malformed). One Phase 4 code removed (`LOCK_E007`); hash mismatch on cached blob now surfaces as `BLOB_E001` (Phase 9 owner) wrapped with `%w`. Symmetric diff of phase-doc references vs registry is now empty.
- **CLI verb spec gap** — mep-0057.md §15 listed 17 verbs but phase docs ship 9 more (`pack`, `rebuild`, `sbom`, `bench`, `cache`, `config`, `publish register`, `audit mirror`, `audit fix`). §15 now splits into "primary surface" + "phase-specific surface" with the full 26-verb roster.
- **Legacy v0 → v1 migration** — §Backwards Compatibility now states explicitly that pre-MEP-57 codebases work without a manifest; `mochi pkg init` is the manual on-ramp; `--convert` for `import go "..."` auto-seeding is tracked for v1.1.
- **Lockfile format evolution** — §Backwards Compatibility now documents how a v2 lockfile would extend the dual-hash family (e.g. BLAKE3+SHA3-256 if BLAKE3 or SHA-256 is deprecated by NIST). v1 rejects `version > 1`; v2 reads v1 and rewrites; rotation is coordinated across Phases 4, 9, 11.
- **Stranded open questions** — Phase 4 `solver_decision_count` lands in Phase 19 §19.3 (solver memo). Phase 10 `clock`/`random` resolved: keep both; Phase 17's SOURCE_DATE_EPOCH shadows clock; deterministic-RNG seeding tracked under Phase 17 open question 4.

## Test plan

- [ ] Docusaurus build passes (sidebar entries + relative anchors resolve)
- [ ] errors.md TUF/REPRO/PERF sections render as h2 headings; RESOLVE_E010 and SBOM_E004 rows render
- [ ] Phase 16's error code surface uses M057_ADV_E* exclusively
- [ ] No phase doc references a non-canonical `M057_<UPPER>_<UPPER>` name except phase-14's explicit "renamed from" note
- [ ] mep-0057.md §15 lists both primary + phase-specific verb groups
- [ ] mep-0057.md §Backwards Compatibility documents legacy projects + lockfile v2 hash rotation

Closes #22621