### PR TITLE
ci(php-publish): close four Phase 18 trust-chain holes

### DIFF
--- a/.github/workflows/transpiler3-php-publish.yml
+++ b/.github/workflows/transpiler3-php-publish.yml
@@ -24,6 +24,15 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-24.04
+    # Hoist the optional secrets to job level so step-level `if:`
+    # expressions see them. Step-level `env:` is merged into the
+    # command environment after `if:` is evaluated, so referencing
+    # `env.PACKAGIST_API_TOKEN` from a step's own `if:` block when
+    # the env is declared in the same step always reads as empty.
+    env:
+      PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}
+      PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+      PHP_SIGNIFY_SECRET_KEY: ${{ secrets.PHP_SIGNIFY_SECRET_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -59,19 +68,9 @@ jobs:
             exit 1
           }
 
-      - name: Composer install (no-dev)
-        working-directory: transpiler3/php/runtime
-        run: composer install --no-interaction --no-dev --prefer-dist --classmap-authoritative
-
-      - name: Composer audit
-        working-directory: transpiler3/php/runtime
-        # composer audit (Composer 2.4+) reports known-vulnerable deps
-        # from the FriendsOfPHP advisory database. Phase 18 requires a
-        # clean audit before tag publication.
-        run: composer audit --no-interaction
-
       - name: Stage release tarball
         id: stage
+        if: steps.check.outputs.configured == 'true' && startsWith(github.ref, 'refs/tags/')
         working-directory: transpiler3/php/runtime
         run: |
           mkdir -p ../../../dist
@@ -82,25 +81,42 @@ jobs:
               composer.json src
           echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
 
+      - name: Composer audit (against staged tarball)
+        if: steps.check.outputs.configured == 'true' && startsWith(github.ref, 'refs/tags/')
+        # composer audit (Composer 2.4+) reports known-vulnerable deps
+        # from the FriendsOfPHP advisory database. Phase 18 requires a
+        # clean audit before tag publication. We extract the staged
+        # tarball into a temp dir and audit *that*: auditing the source
+        # tree at transpiler3/php/runtime/ could read a different
+        # composer.lock/vendor state than what users will install.
+        run: |
+          audit_dir="$(mktemp -d)"
+          tar -xzf "${{ steps.stage.outputs.tarball }}" -C "$audit_dir"
+          (cd "$audit_dir" && \
+            composer install --no-interaction --no-dev --prefer-dist --classmap-authoritative && \
+            composer audit --no-interaction)
+
       - name: Attest build provenance
         # GitHub Actions OIDC attestation (GA April 2024). Attaches a
         # Sigstore-backed provenance statement to the release tarball.
         # Consumers verify with `gh attestation verify <tarball>`.
-        if: startsWith(github.ref, 'refs/tags/')
+        # Gated on the GPG check so an unsigned-tag push cannot attach
+        # an attestation that downstream consumers might mistake for a
+        # full trust-root assertion.
+        if: steps.check.outputs.configured == 'true' && startsWith(github.ref, 'refs/tags/')
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: ${{ steps.stage.outputs.tarball }}
 
       - name: php-signify (optional Ed25519 signature)
-        if: steps.check.outputs.configured == 'true' && env.PHP_SIGNIFY_SECRET_KEY != ''
-        env:
-          PHP_SIGNIFY_SECRET_KEY: ${{ secrets.PHP_SIGNIFY_SECRET_KEY }}
+        if: steps.check.outputs.configured == 'true' && startsWith(github.ref, 'refs/tags/') && env.PHP_SIGNIFY_SECRET_KEY != ''
         run: |
           # Drupal's php-signify ports OpenBSD signify(1) to PHP. The
           # signature file is published alongside the tarball; key
-          # fingerprint is in SECURITY.md.
+          # fingerprint is in SECURITY.md. Pin the major to avoid a
+          # publish-time supply-chain swap.
           echo "$PHP_SIGNIFY_SECRET_KEY" > /tmp/release.key
-          composer global require drupal/php-signify
+          composer global require --no-interaction 'drupal/php-signify:^1.0'
           ~/.composer/vendor/bin/signify -S \
             -s /tmp/release.key \
             -m "${{ steps.stage.outputs.tarball }}"
@@ -109,11 +125,9 @@ jobs:
       - name: Notify Packagist
         # Packagist auto-discovers tags via the GitHub webhook the user
         # configured in their Packagist account settings. This step is
-        # a defensive ping in case the webhook was disabled.
-        if: startsWith(github.ref, 'refs/tags/') && env.PACKAGIST_API_TOKEN != ''
-        env:
-          PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}
-          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+        # a defensive ping in case the webhook was disabled. Gated on
+        # GPG so unsigned tags do not trigger a Packagist update.
+        if: steps.check.outputs.configured == 'true' && startsWith(github.ref, 'refs/tags/') && env.PACKAGIST_API_TOKEN != ''
         run: |
           curl -X POST \
             -H 'content-type:application/json' \
@@ -121,9 +135,11 @@ jobs:
             -d '{"repository":{"url":"https://github.com/mochilang/mochi"}}'
 
   verify-gate:
-    # Defensive: independent job re-runs composer install + audit from
-    # a fresh checkout so a publish-job-side credential leak cannot mask
-    # a broken release.
+    # Defensive: independent job re-stages the release tarball from a
+    # fresh checkout, then runs composer install + audit against the
+    # extracted artifact. A publish-job-side credential leak or in-place
+    # composer.lock tamper cannot mask a broken release because this
+    # job's checkout, stage, and audit all run on a clean runner.
     runs-on: ubuntu-24.04
     needs: publish
     if: startsWith(github.ref, 'refs/tags/')
@@ -135,9 +151,21 @@ jobs:
           extensions: mbstring, gmp
           coverage: none
           tools: composer:v2
-      - name: Composer install (no-dev, fresh)
+      - name: Re-stage release tarball
+        id: restage
         working-directory: transpiler3/php/runtime
-        run: composer install --no-interaction --no-dev --prefer-dist
-      - name: Composer audit (fresh)
-        working-directory: transpiler3/php/runtime
-        run: composer audit --no-interaction
+        run: |
+          mkdir -p ../../../dist
+          tarball="../../../dist/mochi-runtime-${GITHUB_REF#refs/tags/}.tar.gz"
+          tar --sort=name --owner=0 --group=0 --numeric-owner \
+              --mtime='2024-01-01 00:00:00 UTC' \
+              -czf "$tarball" \
+              composer.json src
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+      - name: Composer install + audit (against re-staged tarball)
+        run: |
+          audit_dir="$(mktemp -d)"
+          tar -xzf "${{ steps.restage.outputs.tarball }}" -C "$audit_dir"
+          (cd "$audit_dir" && \
+            composer install --no-interaction --no-dev --prefer-dist && \
+            composer audit --no-interaction)

--- a/transpiler3/php/runtime/TRUST.md
+++ b/transpiler3/php/runtime/TRUST.md
@@ -72,9 +72,13 @@ trust root and demote the others to secondary.
 ## composer audit
 
 Every release is published after a clean `composer audit` against the
-FriendsOfPHP advisory database. The publish workflow re-runs the audit
-in an independent `verify-gate` job after publish, so a leaked credential
-in the publish job alone cannot mask a vulnerable release.
+FriendsOfPHP advisory database. The audit runs against the **extracted
+release tarball** (not the in-tree source), so an out-of-band
+`composer.lock` or `vendor/` directory in the working tree cannot mask
+a vulnerable artifact. The publish workflow re-runs the audit in an
+independent `verify-gate` job after publish, which re-stages the
+tarball from a fresh checkout and audits the result, so a leaked
+credential in the publish job alone cannot mask a vulnerable release.
 
 ## Release key fingerprint
 


### PR DESCRIPTION
## Summary
- Closes #22626
- Round 6 audit caught four soft spots in the Phase 18 release workflow at `.github/workflows/transpiler3-php-publish.yml`.

1. Unsigned-tag publish: attest, php-signify, and Packagist-notify steps had no dependency on the GPG-configured output. A tag push without `GPG_PRIVATE_KEY` would still attach a Sigstore attestation and ping Packagist. Every publish-side step now requires `steps.check.outputs.configured == 'true'`.
2. Composer audit against source tree: audit ran in `transpiler3/php/runtime/` where a stray `composer.lock` or `vendor/` could differ from what ships in the tarball. Audit now extracts the staged `dist/mochi-runtime-<tag>.tar.gz` into a temp dir and audits the extract. The defensive `verify-gate` job re-stages from its own fresh checkout and audits the same way.
3. Unpinned `drupal/php-signify`: pinned to `^1.0`.
4. Step-level env in step-level if: `env.PACKAGIST_API_TOKEN` and `env.PHP_SIGNIFY_SECRET_KEY` were declared in the same step's env block. GitHub evaluates `if:` before merging step env, so these read empty. Hoist both to job-level env where step ifs can read them.

`transpiler3/php/runtime/TRUST.md` updated to reflect that audit runs against the release tarball, not the in-tree source.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI on the umbrella publish workflow exercises the new gates (drives only via release tag pushes; the verify-gate path will run when a `v0.*` or `v1.*` tag is pushed)
- [x] All four soft spots traced through the new file