### PR TITLE
docs(mep-52): per-phase implementation tracking pages 01-18

### DIFF
--- a/website/docs/implementation/0052/index.md
+++ b/website/docs/implementation/0052/index.md
@@ -13,28 +13,26 @@ A phase is LANDED only when its gate is green on every target listed for it in M
 
 ## Phase status
 
-| Phase | Title                                                                   | Status      | Commit |
-|-------|-------------------------------------------------------------------------|-------------|--------|
-| 1     | Hello world                                                             | NOT STARTED | n/a    |
-| 2     | Scalars (int via bigint/number, float, bool, string)                    | NOT STARTED | n/a    |
-| 3.1   | Lists (readonly T[] / T[])                                              | NOT STARTED | n/a    |
-| 3.2   | Maps (Map<K, V>)                                                        | NOT STARTED | n/a    |
-| 3.3   | Sets (Set<T> with ES2024 methods)                                       | NOT STARTED | n/a    |
-| 3.4   | List of records                                                         | NOT STARTED | n/a    |
-| 4     | Records (class with readonly fields + private ctor + static factory)    | NOT STARTED | n/a    |
-| 5     | Sum types (discriminated union)                                         | NOT STARTED | n/a    |
-| 6     | Closures and higher-order functions                                     | NOT STARTED | n/a    |
-| 7     | Query DSL (Iterator helpers + AsyncIterable)                            | NOT STARTED | n/a    |
-| 8     | Datalog                                                                 | NOT STARTED | n/a    |
-| 9     | Agents (AsyncIterableQueue + AbortController)                           | NOT STARTED | n/a    |
-| 10    | Streams (AsyncIterable)                                                 | NOT STARTED | n/a    |
-| 11    | async coloring, MochiResult, AggregateError                             | NOT STARTED | n/a    |
-| 12    | FFI (Node N-API + Deno FFI + Bun FFI dispatch)                          | NOT STARTED | n/a    |
-| 13    | LLM (provider dispatch)                                                 | NOT STARTED | n/a    |
-| 14    | fetch (built-in fetch on Node 18+, Deno, Bun, browser)                  | NOT STARTED | n/a    |
-| 15    | npm package build via tsc + npm pack                                    | NOT STARTED | n/a    |
-| 16    | Reproducible build (SOURCE_DATE_EPOCH + sorted tar)                     | NOT STARTED | n/a    |
-| 17    | Deno JSR publish + Jupyter (Deno kernel) + browser bundle (esbuild)     | NOT STARTED | n/a    |
-| 18    | npm Trusted Publishing (Sigstore + OIDC + provenance)                   | NOT STARTED | n/a    |
-
-Per-phase tracking pages will be added as phases open.
+| Phase | Title                                                                   | Tracking page                                                                | Status      | Commit |
+|-------|-------------------------------------------------------------------------|------------------------------------------------------------------------------|-------------|--------|
+| 1     | Hello world                                                             | [phase-01-hello](/docs/implementation/0052/phase-01-hello)                   | NOT STARTED | n/a    |
+| 2     | Scalars (int via bigint/number, float, bool, string)                    | [phase-02-scalars](/docs/implementation/0052/phase-02-scalars)               | NOT STARTED | n/a    |
+| 3.1   | Lists (readonly T[] / T[])                                              | [phase-03-collections](/docs/implementation/0052/phase-03-collections)       | NOT STARTED | n/a    |
+| 3.2   | Maps (Map\<K, V\>)                                                      | [phase-03-collections](/docs/implementation/0052/phase-03-collections)       | NOT STARTED | n/a    |
+| 3.3   | Sets (Set\<T\> with ES2024 methods)                                     | [phase-03-collections](/docs/implementation/0052/phase-03-collections)       | NOT STARTED | n/a    |
+| 3.4   | List of records                                                         | [phase-03-collections](/docs/implementation/0052/phase-03-collections)       | NOT STARTED | n/a    |
+| 4     | Records (class with readonly fields + private ctor + static factory)    | [phase-04-records](/docs/implementation/0052/phase-04-records)               | NOT STARTED | n/a    |
+| 5     | Sum types (discriminated union)                                         | [phase-05-sums](/docs/implementation/0052/phase-05-sums)                     | NOT STARTED | n/a    |
+| 6     | Closures and higher-order functions                                     | [phase-06-closures](/docs/implementation/0052/phase-06-closures)             | NOT STARTED | n/a    |
+| 7     | Query DSL (Iterator helpers + AsyncIterable)                            | [phase-07-query](/docs/implementation/0052/phase-07-query)                   | NOT STARTED | n/a    |
+| 8     | Datalog                                                                 | [phase-08-datalog](/docs/implementation/0052/phase-08-datalog)               | NOT STARTED | n/a    |
+| 9     | Agents (AsyncIterableQueue + AbortController)                           | [phase-09-agents](/docs/implementation/0052/phase-09-agents)                 | NOT STARTED | n/a    |
+| 10    | Streams (AsyncIterable)                                                 | [phase-10-streams](/docs/implementation/0052/phase-10-streams)               | NOT STARTED | n/a    |
+| 11    | async coloring, MochiResult, AggregateError                             | [phase-11-async](/docs/implementation/0052/phase-11-async)                   | NOT STARTED | n/a    |
+| 12    | FFI (Node N-API + Deno FFI + Bun FFI dispatch)                          | [phase-12-ffi](/docs/implementation/0052/phase-12-ffi)                       | NOT STARTED | n/a    |
+| 13    | LLM (provider dispatch)                                                 | [phase-13-llm](/docs/implementation/0052/phase-13-llm)                       | NOT STARTED | n/a    |
+| 14    | fetch (built-in fetch on Node 18+, Deno, Bun, browser)                  | [phase-14-fetch](/docs/implementation/0052/phase-14-fetch)                   | NOT STARTED | n/a    |
+| 15    | npm package build via tsc + npm pack                                    | [phase-15-npm-package](/docs/implementation/0052/phase-15-npm-package)       | NOT STARTED | n/a    |
+| 16    | Reproducible build (SOURCE_DATE_EPOCH + sorted tar)                     | [phase-16-repro](/docs/implementation/0052/phase-16-repro)                   | NOT STARTED | n/a    |
+| 17    | Deno JSR publish + Jupyter (Deno kernel) + browser bundle (esbuild)     | [phase-17-jsr-jupyter-browser](/docs/implementation/0052/phase-17-jsr-jupyter-browser) | NOT STARTED | n/a    |
+| 18    | npm Trusted Publishing (Sigstore + OIDC + provenance)                   | [phase-18-trusted-publishing](/docs/implementation/0052/phase-18-trusted-publishing) | NOT STARTED | n/a    |

--- a/website/docs/implementation/0052/phase-01-hello.md
+++ b/website/docs/implementation/0052/phase-01-hello.md
@@ -1,0 +1,227 @@
+---
+title: "Phase 1. Hello world"
+sidebar_position: 2
+sidebar_label: "Phase 1. Hello world"
+description: "MEP-52 Phase 1, end-to-end pipeline from print(\"hello, world\") to a runnable TypeScript module on Node 22, Deno 2, Bun 1.1, and Chromium 130; both --target=typescript-source and --target=npm-package gates."
+---
+
+# Phase 1. Hello world
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 1](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase1Hello`: 5 fixtures green on all four tier-1 runtimes (Node 22.11.0 LTS, Deno 2.0, Bun 1.1.30, Chromium 130 via Playwright) and all four OS cells (x86_64-linux-gnu, aarch64-linux-gnu, aarch64-darwin, x86_64-windows). Secondary gates: `tsc --noEmit --strict --noUncheckedIndexedAccess --exactOptionalPropertyTypes --noImplicitOverride --noFallthroughCasesInSwitch --noPropertyAccessFromIndexSignature` produces zero diagnostics; `eslint --max-warnings 0` clean; `prettier --check` is a fixed point.
+
+Fixtures:
+1. `hello.mochi`: `print("hello, world")`, stdout `hello, world\n`
+2. `hello_int.mochi`: `print(42)`, stdout `42\n`
+3. `hello_bool.mochi`: `print(true)`, stdout `true\n`
+4. `hello_float.mochi`: `print(3.14)`, stdout `3.14\n`
+5. `hello_newline.mochi`: `print("line1\nline2")`, two lines
+
+## Goal-alignment audit
+
+Phase 1 is the first point where the TypeScript pipeline produces a runnable artefact. Before Phase 1, the Go packages under `transpiler3/typescript/` are stubs and the runtime TypeScript project compiles but does nothing. After Phase 1, `mochi build --target=typescript-source hello.mochi -o out/` writes a complete `package.json` + `tsconfig` chain + `src/generated/hello.ts` that compiles under `tsc --build` and runs identically on Node, Deno, Bun, and Chromium. Every later phase extends Phase 1's pipeline without replacing it.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 1.0 | `print("hello, world")` end-to-end: lower, emit `.ts`, write `package.json`, write `tsconfig` chain, `tsc --build`, execute on Node 22 | NOT STARTED | n/a |
+| 1.1 | `print(int)`, `print(bool)`, `print(float)` via `Mochi.Runtime.io.print` overloads | NOT STARTED | n/a |
+| 1.2 | `--target=typescript-source` writes the layout without invoking `tsc`; `--target=npm-package` runs `tsc --build` then `npm pack` to produce `<pkg>-<ver>.tgz` | NOT STARTED | n/a |
+| 1.3 | Execute the same dist on Deno 2 (`deno run dist/deno/index.js`), Bun 1.1 (`bun dist/bun/index.js`), and Chromium 130 via Playwright (`console.log` captured) | NOT STARTED | n/a |
+| 1.4 | SHA-256 content-addressed build cache under `~/.cache/mochi/typescript/<hash>/` | NOT STARTED | n/a |
+
+## Sub-phase 1.0, End-to-end pipeline
+
+### Goal-alignment audit (1.0)
+
+The pipeline must produce a runnable artefact on the first sub-phase so that 1.1 through 1.4 each have something real to extend. `print("hello, world")` is the minimal non-trivial program: it exercises the entire pipeline (parser, type checker, aotir, colour pass, lower, emit, `tsc --build`, runtime) without requiring records, closures, or async.
+
+### Decisions made (1.0)
+
+**Pipeline entry point**: `Driver.Build(src, outDir, target Target)` in `transpiler3/typescript/build/build.go`:
+
+1. `parser.Parse(src)` → AST
+2. `types.Check(ast)` → typed AST
+3. `aotir.Lower(typed)` → `*aotir.Program` (reused from MEP-45, unchanged)
+4. `colour.Colour(prog)` → `ColourMap` (Phase 1: all functions sync)
+5. `lower.Lower(prog, colours)` → `*tssrc.SourceFile`
+6. `emit.Emit(sf, workDir)` → writes `src/generated/*.ts`
+7. `emit.WriteProject(workDir)` → writes `package.json`, `tsconfig.base.json`, per-runtime `tsconfig.{node,deno,bun,browser}.json`, root composite `tsconfig.json`, `.eslintrc.json`, `.prettierrc.json`
+8. For `--target=npm-package` only: subprocess `tsc --build` then `npm pack`
+
+**Lowering of `print("hello, world")`**: `aotir.PrintStmt` with a `StringLit` lowers to an `ExprStmt` wrapping a `CallExpr` to `print` imported from `@mochi/runtime/io`:
+
+```typescript
+// src/generated/hello.ts
+import { print } from "@mochi/runtime/io";
+
+export function main(): void {
+  print("hello, world");
+}
+
+main();
+```
+
+**Module naming**: Mochi source file `hello.mochi` → emitted `src/generated/hello.ts`. Package name in `package.json` defaults to `mochi-<pkgname>` (kebab-case). The `name` field is overridable via `mochi build --pkg-name=@scope/foo`.
+
+**Entry point**: a generated `src/index.ts` re-exports `main` from the user module and imports it for side-effect execution. For programs whose main is sync, `src/index.ts` is:
+
+```typescript
+import { main } from "./generated/hello.ts";
+main();
+```
+
+For async main (Phase 9 and later), `src/index.ts` becomes `await main();` (top-level await, ESM-only).
+
+**`@mochi/runtime/io.print`**: Phase 1 adds the `io` sub-path immediately rather than calling `console.log` directly:
+
+```typescript
+// runtime3/typescript/src/io/index.ts
+export function print(v: unknown): void {
+  if (typeof v === "boolean") {
+    console.log(v ? "true" : "false");
+    return;
+  }
+  if (typeof v === "number") {
+    if (Number.isNaN(v)) { console.log("NaN"); return; }
+    if (v === Infinity)  { console.log("Infinity"); return; }
+    if (v === -Infinity) { console.log("-Infinity"); return; }
+    console.log(String(v));
+    return;
+  }
+  if (typeof v === "bigint") { console.log(v.toString()); return; }
+  console.log(String(v));
+}
+```
+
+This indirection (a) lets tests redirect `console.log` to a buffer without touching generated code, (b) gives the browser bundle a single seam to swap for `document.body.appendChild` style output if needed, (c) centralises the `bool`/`float`/`bigint` formatting that has to match vm3 byte-for-byte.
+
+**`tsc` subprocess vs in-process**: Phase 1 uses a `tsc --build` subprocess. In-process TypeScript Compiler API is rejected because it would force the Go build to depend on a JavaScript runtime. The cost is ~400ms cold-start for the TypeScript binary; Phase 1.4's SHA-256 cache amortises it.
+
+## Sub-phase 1.1, Scalar print
+
+### Decisions made (1.1)
+
+**`print(int)`**: `aotir.PrintStmt` with `IntLit(42)` lowers to `print(42n)` by default (Mochi `int` defaults to `bigint`). Monomorphisation specialises to `number` when the IR proves the value fits in i53 and the producer never overflows. Phase 1's hello fixtures use small constants that all fit; the IR carries the chosen representation per occurrence so the emitter never mixes `bigint` and `number` in the same expression.
+
+**`print(bool)`**: `print(true)` must print lowercase `true\n` to match vm3. `console.log(true)` natively prints `"true"` on all four runtimes (no need to stringify), but `print` routes through the helper above for symmetry with the `bigint`/`float` paths and for redirect-friendliness under tests.
+
+**`print(float)`**: `print(3.14)` → `print(3.14)`. `String(3.14) === "3.14"`. Edge cases (NaN, +Inf, -Inf) match the vm3 output `"NaN"`, `"Infinity"`, `"-Infinity"`.
+
+## Sub-phase 1.2, Two packaging targets
+
+### Decisions made (1.2)
+
+**`--target=typescript-source`**: writes the full project layout (see MEP-52 §16) and stops. The user (or downstream tooling like Vite, Next.js, or `bun run`) runs `tsc`. No subprocess invoked from `mochi build`.
+
+**`--target=npm-package`**: writes the layout, runs `tsc --build` (which produces `dist/{node,deno,bun,browser}/`), then runs `npm pack` to produce `<pkg>-<ver>.tgz` in the output directory.
+
+**`package.json` minimum for Phase 1**:
+
+```json
+{
+  "name": "mochi-hello",
+  "version": "0.0.1",
+  "type": "module",
+  "engines": { "node": ">=22.0.0" },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "deno": "./dist/deno/index.js",
+      "bun":  "./dist/bun/index.js",
+      "browser": "./dist/browser/index.js",
+      "node": "./dist/node/index.js",
+      "default": "./dist/node/index.js"
+    }
+  },
+  "files": ["dist", "README.md", "LICENSE"],
+  "scripts": { "build": "tsc --build" },
+  "dependencies": { "@mochi/runtime": "^0.1.0" }
+}
+```
+
+## Sub-phase 1.3, Four-runtime execution
+
+### Decisions made (1.3)
+
+The same `dist/` tree is executed under each runtime; the test harness captures stdout and `diff`s against `expect.txt`.
+
+- Node: `node dist/node/index.js`
+- Deno: `deno run --allow-read --allow-env dist/deno/index.js` (Phase 1 needs only read+env; later phases tighten or open the permission set per fixture)
+- Bun: `bun dist/bun/index.js`
+- Chromium: Playwright loads `tests/transpiler3/typescript/harness/runner.html` which `<script type="module" src="dist/browser/index.js">`-imports the bundle and serialises `console.log` to a `<pre id="out">`; the harness reads the `<pre>` text and writes it to `stdout.txt`.
+
+Playwright runs headless against `Chromium 130` from the npm `@playwright/test 1.48+` package, pinned per CI image.
+
+## Sub-phase 1.4, SHA-256 build cache
+
+### Decisions made (1.4)
+
+**Cache key**: SHA-256 of `source_bytes || tsc_version_string || node_version_string || target_label`.
+
+- `source_bytes`: raw bytes of the `.mochi` source file.
+- `tsc_version_string`: from `tsc --version`, e.g., `"Version 5.6.3"`.
+- `node_version_string`: from `node --version`, e.g., `"v22.11.0"`.
+- `target_label`: `"typescript-source"`, `"npm-package"`, etc.
+
+**Cache directory**: `~/.cache/mochi/typescript/` (XDG Base Directory). Overridable via `$MOCHI_CACHE_DIR`. Cache entry: `<key>/{src,dist,package.json,...}`.
+
+**Hit path**: `os.Stat(cacheEntry)` succeeds, copy tree to `outDir`, return. Elapsed: roughly 5 ms to 50 ms depending on tree size.
+
+**Miss path**: full pipeline, write output, copy to cache, return.
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/aotir/program.go` | Shared aotir IR consumer (target-agnostic, shared with MEP-45 to MEP-51) |
+| `transpiler3/typescript/colour/colour.go` | Sync/async colour pass; Phase 1 trivially returns all-Blue |
+| `transpiler3/typescript/lower/lower.go` | `aotir.Program` to `tssrc.SourceFile` lowering; `lowerProgram`, `lowerStmt`, `lowerExpr` |
+| `transpiler3/typescript/tssrc/nodes.go` | TypeScript syntax tree node types (CompilationUnit, ImportDecl, FunctionDecl, ClassDecl, CallExpr, LiteralExpr, etc.) |
+| `transpiler3/typescript/emit/emit.go` | Tree printer; walks `tssrc` nodes to produce `.ts` text |
+| `transpiler3/typescript/emit/project.go` | `package.json`, `tsconfig.{base,node,deno,bun,browser}.json`, root composite `tsconfig.json`, `.eslintrc.json`, `.prettierrc.json` writers |
+| `transpiler3/typescript/build/build.go` | `Driver.Build`; `Target` constants; orchestrates lower, emit, write, optionally `tsc --build`, optionally `npm pack` |
+| `transpiler3/typescript/build/cache.go` | SHA-256 keyed content-addressed cache |
+| `transpiler3/typescript/build/phase01_test.go` | `TestPhase1Hello`, four-runtime gate |
+| `transpiler3/typescript/build/runner_node.go` | `node` subprocess runner |
+| `transpiler3/typescript/build/runner_deno.go` | `deno run` subprocess runner |
+| `transpiler3/typescript/build/runner_bun.go` | `bun` subprocess runner |
+| `transpiler3/typescript/build/runner_playwright.go` | Playwright + Chromium runner |
+| `runtime3/typescript/src/io/index.ts` | `print` overloads for bool, number, bigint, string, unknown |
+| `runtime3/typescript/package.json` | Runtime package manifest (zero npm dependencies) |
+| `tests/transpiler3/typescript/fixtures/phase01-hello/hello.mochi` | `print("hello, world")` |
+| `tests/transpiler3/typescript/fixtures/phase01-hello/hello.out` | `hello, world\n` |
+| `tests/transpiler3/typescript/fixtures/phase01-hello/hello_int.mochi` | `print(42)` |
+| `tests/transpiler3/typescript/fixtures/phase01-hello/hello_int.out` | `42\n` |
+| `tests/transpiler3/typescript/fixtures/phase01-hello/hello_bool.mochi` | `print(true)` |
+| `tests/transpiler3/typescript/fixtures/phase01-hello/hello_bool.out` | `true\n` |
+| `tests/transpiler3/typescript/fixtures/phase01-hello/hello_float.mochi` | `print(3.14)` |
+| `tests/transpiler3/typescript/fixtures/phase01-hello/hello_float.out` | `3.14\n` |
+| `tests/transpiler3/typescript/fixtures/phase01-hello/hello_newline.mochi` | `print("line1\nline2")` |
+| `tests/transpiler3/typescript/fixtures/phase01-hello/hello_newline.out` | `line1\nline2\n` |
+
+## Test set
+
+- `TestPhase1Hello`, walks all 5 fixtures across Node, Deno, Bun, and Chromium; diffs stdout byte-for-byte against `.out` file.
+- `TestPhase1TscClean`, runs `tsc --noEmit --strict --noUncheckedIndexedAccess --exactOptionalPropertyTypes` against each emitted project, expects zero diagnostics.
+- `TestPhase1EslintClean`, runs `eslint --max-warnings 0` against each emitted project.
+- `TestPhase1PrettierFixedPoint`, runs `prettier --write` then `prettier --check`; second pass must report no diffs.
+
+## Deferred work
+
+- In-process tsc (eliminates `tsc --build` subprocess startup). Deferred to Phase 16.
+- Multi-file programs. Deferred to Phase 4 (records introduce multi-file layout).
+- `--target=deno-jsr`, `--target=browser-bundle`, `--target=deno-jupyter`. Deferred to Phase 17.
+- Source map second layer (Mochi to TS). Deferred (Open Q6, v1.5).
+- Identifier mangling for reserved words (`class_`, `import_`). Phase 1 has no collisions; full table lands in Phase 4.

--- a/website/docs/implementation/0052/phase-02-scalars.md
+++ b/website/docs/implementation/0052/phase-02-scalars.md
@@ -1,0 +1,165 @@
+---
+title: "Phase 2. Scalars"
+sidebar_position: 3
+sidebar_label: "Phase 2. Scalars"
+description: "MEP-52 Phase 2, int via bigint/number monomorphisation, float, bool, string (UTF-16 vs code-point semantics), bytes, all comparison and arithmetic operators; 30 fixtures."
+---
+
+# Phase 2. Scalars
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 2](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase2Scalars`: 30 fixtures green on Node 22, Deno 2, Bun 1.1, Chromium 130. Secondary gates: `tsc --strict --noUncheckedIndexedAccess --exactOptionalPropertyTypes` zero diagnostics; eslint clean (`no-mixed-operators` enforced, `bigint` and `number` never mixed); prettier fixed point.
+
+Fixture areas: int arithmetic (bigint and number monomorphisation), float (IEEE 754 edge cases, NaN, ±Inf, ±0), bool short-circuit, string (UTF-16 vs code-point `len`, slice, index, concat, codepoint iteration), bytes (`Uint8Array` construction, indexing, slicing), comparisons (eq, ne, lt, le, gt, ge), control flow (if/else, while, for).
+
+## Goal-alignment audit
+
+Phase 2 establishes the scalar value-type vocabulary every later phase reuses. The single load-bearing decision is the `int → bigint OR number` monomorphisation rule; getting it wrong cascades into mixed-type errors at `tsc` time and silent overflow at runtime. The string code-point semantics are the next-load-bearing decision: TypeScript `String.prototype.length` returns UTF-16 code units, Mochi `len(s)` returns code points, so the emitter must route through `mochiStrLen` for every length read.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 2.1 | `int` monomorphisation: default `bigint`, specialise to `number` when IR proves the value fits in [-(2^53-1), 2^53-1] and the producer never overflows; never mix in one expression | NOT STARTED | n/a |
+| 2.2 | `float`: IEEE 754 binary64, NaN / ±Inf / ±0 stringification matches vm3 (`strconv.FormatFloat(f, 'g', -1, 64)`) | NOT STARTED | n/a |
+| 2.3 | `bool` short-circuit (`&&`, `\|\|`); `!` negation; comparisons (`===`, `!==`, `<`, `<=`, `>`, `>=`) | NOT STARTED | n/a |
+| 2.4 | `string` UTF-16 internal storage; `mochiStrLen(s)`, `mochiStrAt(s, i)`, `mochiStrSlice(s, a, b)` runtime helpers for code-point semantics | NOT STARTED | n/a |
+| 2.5 | `bytes` (`Uint8Array`) construction, indexing (`u8[i]` returns `number | undefined` under `--noUncheckedIndexedAccess`, runtime-guarded), slicing | NOT STARTED | n/a |
+| 2.6 | Control flow: `if`/`else`, `while`, `for` (numeric range and for-of), `break`, `continue`; lowering preserves SSA-like structure for `tsc --strict` to type-narrow | NOT STARTED | n/a |
+
+## Sub-phase 2.1, int via bigint or number
+
+### Decisions made (2.1)
+
+**Default representation**: `bigint`. Mochi `int` is arbitrary precision; `bigint` is the only TypeScript primitive that matches.
+
+**Specialisation to `number`**: monomorphisation specialises a per-occurrence IR type to `number` when:
+
+1. The static type is bounded such that all values fit in `[-9007199254740991, 9007199254740991]` (`Number.MAX_SAFE_INTEGER`); for example a loop counter ranged `for i in 0..len(xs)`.
+2. The producer never overflows (no `*`, `**`, `<<`, `+`, `-` that might exceed the bound; arithmetic that proves safe via range analysis stays as `number`).
+3. All consumers also use `number` (no flow into a `bigint` slot).
+
+If any of these fails the whole flow falls back to `bigint`. The IR carries a `Repr` field per integer type so the emitter never has to re-derive.
+
+**Literal suffix**: `bigint` literal is `42n`; `number` literal is `42`. The emitter emits the suffix consistently. Mixing in a single expression is a `tsc` error (`Operator '+' cannot be applied to types 'bigint' and 'number'`); the emitter refuses to emit such a mixture (would indicate a monomorphisation bug).
+
+**Division**: Mochi `/` on integers is floor division, on floats is IEEE division. `bigint` `/` in TypeScript is truncated toward zero, which matches Mochi for non-negative operands but diverges for negative; the emitter routes `a / b` for `int` through a `mochiBigDiv(a, b)` runtime helper that adjusts the rounding for negatives.
+
+## Sub-phase 2.2, float
+
+### Decisions made (2.2)
+
+**Type**: `number` (IEEE 754 binary64).
+
+**Stringification**: vm3 prints `42.0` as `42` and `3.14` as `3.14`; the emitter uses `mochiFloatStr(f)` which is `String(f)` for finite non-zero values, then handles edge cases:
+
+- `NaN` → `"NaN"`
+- `+Infinity` → `"Infinity"`
+- `-Infinity` → `"-Infinity"`
+- `+0`, `-0` → `"0"` (vm3 drops the sign)
+- Whole-valued floats (`42.0`) → `"42"` (matches `String(42.0)`)
+
+For arithmetic operators (`+`, `-`, `*`, `/`, `%`) Mochi `float` lowers to the TypeScript primitive operators directly. NaN-propagation matches the host runtime, which is uniform across V8, SpiderMonkey, and JavaScriptCore on the IEEE 754 contract.
+
+## Sub-phase 2.3, bool
+
+### Decisions made (2.3)
+
+**Type**: `boolean`.
+
+**Short-circuit**: Mochi `a && b` and `a || b` lower to TypeScript `a && b` and `a || b`. TypeScript's logical operators are short-circuit by spec.
+
+**Negation**: `!a` lowers to `!a`.
+
+**Comparisons**: Mochi `==` and `!=` lower to `===` and `!==` (the emitter never uses `==`/`!=` because of their coercion rules, which fail `tsc --strict` lint via `@typescript-eslint/eqeqeq: error`). Ordering operators (`<`, `<=`, `>`, `>=`) lower directly.
+
+**Coercion**: Mochi never coerces bool to int. The TypeScript runtime would happily coerce (`Number(true) === 1`) but the type system catches at compile time.
+
+## Sub-phase 2.4, string
+
+### Decisions made (2.4)
+
+**Storage**: `string` (UTF-16 code units internally).
+
+**Length**: `len(s)` is code points, not code units. The emitter emits `mochiStrLen(s)`, a runtime helper:
+
+```typescript
+// @mochi/runtime/string
+export function mochiStrLen(s: string): bigint {
+  let n = 0n;
+  for (const _ of s) n++;
+  return n;
+}
+```
+
+(`for ... of` over a string iterates code points by spec, not code units.) The return type is `bigint` because `len` returns Mochi `int`, which defaults to `bigint`. Monomorphisation specialises to `number` if all consumers tolerate it.
+
+**Indexing**: `s[i]` in Mochi is `mochiStrAt(s, i)`, which iterates `i + 1` code points and returns the last one as a length-1-or-2 string (a surrogate pair is one code point even though it occupies two UTF-16 units).
+
+**Slicing**: `s[a:b]` is `mochiStrSlice(s, a, b)`, which advances by code point and returns the corresponding substring.
+
+**Concatenation**: `a + b` lowers to `a + b` directly. UTF-16 concatenation is safe at the boundary because any well-formed UTF-16 prefix concatenated with any well-formed UTF-16 suffix is well-formed UTF-16 (no lone surrogates introduced).
+
+**String literals**: emitted as double-quoted with `\xNN`, `\uNNNN`, `\u{NNNNNN}` for non-printable characters. The emitter prefers `\u{...}` over surrogate pairs for code points above U+FFFF (`\u{1F600}` rather than `😀`).
+
+## Sub-phase 2.5, bytes
+
+### Decisions made (2.5)
+
+**Type**: `Uint8Array`.
+
+**Literal**: a `bytes` literal `b"\x00\x01\x02"` lowers to `new Uint8Array([0x00, 0x01, 0x02])`.
+
+**Indexing**: `b[i]` lowers to `mochiBytesAt(b, i)`, which performs the bounds check that Mochi requires and is needed under `--noUncheckedIndexedAccess` anyway (`b[i]` typed as `number | undefined`).
+
+**Slicing**: `b[a:b]` lowers to `b.slice(a, b)` (fresh array, matches Mochi independence semantics).
+
+**No `Buffer`**: Node's `Buffer` is a `Uint8Array` subclass with extra encoding helpers, but it is Node-specific. The emitter never uses `Buffer`; `TextEncoder` / `TextDecoder` cover UTF-8 needs cross-runtime.
+
+## Sub-phase 2.6, control flow
+
+### Decisions made (2.6)
+
+**`if`/`else`**: lower direct. The emitter always emits braces (`{ ... }`) for the body, even single-statement; `--strict` rules and prettier prefer braced bodies.
+
+**`while`**: lower direct.
+
+**`for i in 0..n`**: lowers to either `for (let i = 0n; i < <n>; i++)` (bigint) or `for (let i = 0; i < <n>; i++)` (number). The IR's monomorphised type for `i` drives the choice.
+
+**`for x in xs`**: lowers to `for (const x of xs)` for arrays, sets, and iterators; `for (const [k, v] of m)` for maps.
+
+**`break`, `continue`**: direct.
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/lower/scalars.go` | int/float/bool/string/bytes literal and operator lowering |
+| `transpiler3/typescript/lower/monomorphise.go` | int Repr choice (bigint vs number) per occurrence |
+| `transpiler3/typescript/lower/controlflow.go` | if/else, while, for, break, continue lowering |
+| `runtime3/typescript/src/string/index.ts` | `mochiStrLen`, `mochiStrAt`, `mochiStrSlice` |
+| `runtime3/typescript/src/numeric/index.ts` | `mochiBigDiv`, `mochiFloatStr` |
+| `runtime3/typescript/src/bytes/index.ts` | `mochiBytesAt`, `mochiBytesSlice` |
+| `transpiler3/typescript/build/phase02_test.go` | `TestPhase2Scalars` |
+| `tests/transpiler3/typescript/fixtures/phase02-scalars/` | 30 fixture directories |
+
+## Test set
+
+- `TestPhase2Scalars`, 30 fixtures across the six areas, four-runtime execution.
+- `TestPhase2NoMixedNumeric`, asserts no emitted `.ts` file contains `bigint` and `number` in the same expression.
+- `TestPhase2StringCodepoints`, fixture exercises emoji (U+1F600) where `len` must equal 1, not 2.
+
+## Deferred work
+
+- `bigint` to `number` aggressive defaulting (Open Q1). Phase 2 ships the conservative rule.
+- Temporal (Mochi `time`, `duration`). Deferred to Phase 14 alongside fetch (HTTP `Date` header parsing pulls Temporal in).

--- a/website/docs/implementation/0052/phase-03-collections.md
+++ b/website/docs/implementation/0052/phase-03-collections.md
@@ -1,0 +1,142 @@
+---
+title: "Phase 3. Collections (lists, maps, sets, lists of records)"
+sidebar_position: 4
+sidebar_label: "Phase 3. Collections"
+description: "MEP-52 Phase 3, Mochi list/map/set lowering to TypeScript readonly T[], Map<K, V>, Set<T> with ES2024 methods, plus lists of records; comprehensions; 85 fixtures across 4 sub-phases."
+---
+
+# Phase 3. Collections
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 3](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase3Collections`: 85 fixtures green across the four sub-phases on Node 22, Deno 2, Bun 1.1, Chromium 130. Secondary gates: `tsc --strict --noUncheckedIndexedAccess` zero diagnostics (this is the phase that first exercises index-access narrowing at scale), eslint clean (including `@typescript-eslint/prefer-readonly-parameter-types` for collection function parameters where the IR says read-only).
+
+## Goal-alignment audit
+
+Phase 3 lands the three collection shapes Mochi programs rely on for almost all data manipulation: `list<T>`, `map<K, V>`, `set<T>`. The TypeScript surface gives us each one nearly for free (`T[]`, `Map<K, V>`, `Set<T>` plus ES2024 set methods), but the strict-mode rules force several non-obvious choices: index access under `--noUncheckedIndexedAccess` is `T | undefined`, so every `xs[i]` either needs a runtime bounds check or an IR-proven `i < len(xs)` provenance to justify the non-null assertion; `Map.get` is `V | undefined` for the same reason. Sub-phase 3.4 ties together collections and records (which Phase 4 will land in full), so that the query DSL in Phase 7 has lists of records to operate on.
+
+## Sub-phases
+
+The MEP-52 phase matrix splits Phase 3 into four sub-phases. Each is its own gate; the umbrella is LANDED only when all four are green.
+
+| # | Scope | Fixtures | Status | Commit |
+|---|-------|----------|--------|--------|
+| 3.1 | Lists (`readonly T[]` for immutable view, `T[]` when mutated; index, len, for-each, list comprehensions) | 25 | NOT STARTED | n/a |
+| 3.2 | Maps (`Map<K, V>`; get, set, has, delete, for-each, entries) | 25 | NOT STARTED | n/a |
+| 3.3 | Sets (`Set<T>` with ES2024 union/intersection/difference) | 15 | NOT STARTED | n/a |
+| 3.4 | Lists of records (records via a Phase 4 preview; comprehensions over records) | 20 | NOT STARTED | n/a |
+
+## Sub-phase 3.1, Lists
+
+### Decisions made (3.1)
+
+**Type**: `readonly T[]` for immutable views (the default for `let xs = [1, 2, 3]` where `xs` is never mutated), `T[]` when the IR proves a mutation site. The monomorphisation pass tags every list-typed value with a `Mutability` field; the emitter picks the type annotation accordingly.
+
+**Literal**: `[1, 2, 3]` lowers to `[1n, 2n, 3n]` (bigint) or `[1, 2, 3]` (number) per the int monomorphisation rule from Phase 2.
+
+**Indexing**: `xs[i]` lowers to either `xs[i]!` (non-null assertion, only when IR-provenance proves `0 <= i < len(xs)`) or `mochiListAt(xs, i)` (runtime-guarded). The eslint rule `@typescript-eslint/no-non-null-assertion` is set to `warn` and the emitter pins it to allow the IR-justified case via a `// eslint-disable-next-line` comment annotated with the IR provenance.
+
+**Length**: `len(xs)` lowers to `BigInt(xs.length)` when the surrounding context expects `bigint`, or `xs.length` when context expects `number`.
+
+**`for x in xs`**: `for (const x of xs)`.
+
+**List comprehensions**: `[f(x) for x in xs if pred(x)]` lowers to `xs.filter(pred).map(f)` when `f` and `pred` are pure synchronous arrow functions and the order is preserved (which it is for arrays). When the comprehension has nested loops (`[f(x, y) for x in xs for y in ys]`), the emitter falls back to a generator `Array.from((function*() { for (const x of xs) for (const y of ys) yield f(x, y); })())`. Phase 7 (query DSL) revisits this with iterator helpers (`Iterator.from(...).flatMap(...).map(...)`) for the longer chains.
+
+**`push`, `pop`, `shift`, `unshift`**: only emitted when `Mutability` is mutable. The emitter refuses to emit these for a `readonly T[]`-typed value (which would be a `tsc` error anyway).
+
+**Non-mutating alternatives (ES2023)**: `toReversed`, `toSorted`, `toSpliced`, `with` are preferred when the IR signals a `readonly T[]` source.
+
+## Sub-phase 3.2, Maps
+
+### Decisions made (3.2)
+
+**Type**: `Map<K, V>` (or `ReadonlyMap<K, V>` view per IR mutability).
+
+**Construction**: `{1: "a", 2: "b"}` lowers to `new Map<bigint, string>([[1n, "a"], [2n, "b"]])`. Object literals are not used as maps (the prototype-chain risk plus key-stringification semantic mismatch make `Map` the only acceptable choice).
+
+**Get**: `m[k]` lowers to `mochiMapGet(m, k)` when Mochi's semantic is "panic if absent", or to a runtime-helper that returns the Mochi `Option<V>` when the IR signals the optional read. The emitter never uses the bare `m.get(k)` form for `m[k]` because `Map.prototype.get` returns `V | undefined`, which differs from `null` (Mochi's `T?` is `T | null`).
+
+**Set**: `m[k] = v` lowers to `m.set(k, v)`.
+
+**Has**: `k in m` lowers to `m.has(k)`.
+
+**Delete**: `delete m[k]` lowers to `m.delete(k)`.
+
+**Iteration**: `for (k, v) in m` lowers to `for (const [k, v] of m)`. Insertion order is guaranteed by the ECMAScript spec (Maps iterate in insertion order); this matches the vm3 ordering.
+
+**Equality**: `Map`s use SameValueZero for key matching (`NaN` is a single key, `1 !== 1n`). The emitter never mixes `number` and `bigint` keys in one map (monomorphisation forces a single K type).
+
+## Sub-phase 3.3, Sets
+
+### Decisions made (3.3)
+
+**Type**: `Set<T>` (or `ReadonlySet<T>` view per IR mutability).
+
+**Construction**: `{1, 2, 3}` lowers to `new Set<bigint>([1n, 2n, 3n])`.
+
+**Membership**: `x in s` lowers to `s.has(x)`.
+
+**Add/remove**: `s.add(x)`, `s.delete(x)`.
+
+**Operators**: Mochi `a + b`, `a & b`, `a - b`, `a ^ b` over sets lower to ES2024 set methods:
+
+| Mochi          | TypeScript                  | ES2024 method      |
+|----------------|-----------------------------|--------------------|
+| `a + b`        | `a.union(b)`                | union              |
+| `a & b`        | `a.intersection(b)`         | intersection       |
+| `a - b`        | `a.difference(b)`           | difference         |
+| `a ^ b`        | `a.symmetricDifference(b)`  | symmetricDifference|
+| `a <= b`       | `a.isSubsetOf(b)`           | isSubsetOf         |
+| `a >= b`       | `a.isSupersetOf(b)`         | isSupersetOf       |
+| `disjoint?`    | `a.isDisjointFrom(b)`       | isDisjointFrom     |
+
+These methods are TC39 Stage 4, native in Node 22, Deno 2, Bun 1.1, and Chromium 122+. Polyfilling is rejected; the runtime floor enforces availability.
+
+## Sub-phase 3.4, Lists of records
+
+### Decisions made (3.4)
+
+Lists of records are the data shape every query, every datalog rule, and every fold in Phase 7 and 8 will iterate. The phase ships a minimum record surface (Phase 4 lands the full surface):
+
+- Record declaration `record User { id: int, name: string }` emits a `class User { ... }` with `readonly` fields, private constructor, and a static `User.of({id, name})` factory.
+- A list of records: `let users: [User] = [User.of({id: 1n, name: "alice"})]` lowers to `[User.of({id: 1n, name: "alice"})]` typed as `readonly User[]` or `User[]` per Mutability.
+- Comprehension: `[u.name for u in users]` lowers to `users.map((u) => u.name)`.
+- Filtering: `[u for u in users if u.id > 0n]` lowers to `users.filter((u) => u.id > 0n)`.
+
+Sub-phase 3.4 includes record method call chains (`u.name.toUpperCase()` etc.) so that Phase 7's query DSL has a real target.
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/lower/lists.go` | List literal, indexing, length, push/pop, comprehensions |
+| `transpiler3/typescript/lower/maps.go` | Map literal, get/set/has/delete, iteration |
+| `transpiler3/typescript/lower/sets.go` | Set literal, ES2024 method dispatch |
+| `transpiler3/typescript/lower/mutability.go` | Mutability inference; tags each collection occurrence as readonly or mutable |
+| `runtime3/typescript/src/collections/index.ts` | `mochiListAt`, `mochiMapGet`, helpers |
+| `transpiler3/typescript/build/phase03_test.go` | `TestPhase3Collections`, four sub-tests |
+| `tests/transpiler3/typescript/fixtures/phase03.1-lists/` | 25 fixtures |
+| `tests/transpiler3/typescript/fixtures/phase03.2-maps/` | 25 fixtures |
+| `tests/transpiler3/typescript/fixtures/phase03.3-sets/` | 15 fixtures |
+| `tests/transpiler3/typescript/fixtures/phase03.4-list-records/` | 20 fixtures |
+
+## Test set
+
+- `TestPhase3_1Lists`, `TestPhase3_2Maps`, `TestPhase3_3Sets`, `TestPhase3_4ListRecords`, each four-runtime.
+- `TestPhase3NoObjectAsMap`, asserts no emitted `.ts` uses a plain object literal as a map.
+- `TestPhase3IndexProvenance`, asserts every `xs[i]!` non-null assertion is annotated with an IR-provenance comment.
+
+## Deferred work
+
+- Full record surface (methods, equals, hashCode). Deferred to Phase 4.
+- Frozen / persistent collections (`as const` deep readonly). Deferred to v2.
+- `Object.groupBy` / `Map.groupBy` over lists of records. Deferred to Phase 7 (query DSL).

--- a/website/docs/implementation/0052/phase-04-records.md
+++ b/website/docs/implementation/0052/phase-04-records.md
@@ -1,0 +1,172 @@
+---
+title: "Phase 4. Records"
+sidebar_position: 5
+sidebar_label: "Phase 4. Records"
+description: "MEP-52 Phase 4, Mochi records as TypeScript class with readonly fields, private constructor, static of() factory; structural equality; multi-file module layout; 35 fixtures."
+---
+
+# Phase 4. Records
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 4](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase4Records`: 35 fixtures green on all four runtimes. Secondary gates: tsc strict (`strictPropertyInitialization` enforced), eslint clean (`@typescript-eslint/no-unsafe-assignment`, `consistent-type-imports`), prettier fixed point. The first phase that emits more than one user module per project, so the multi-file layout under `src/generated/` is the structural gate.
+
+## Goal-alignment audit
+
+Records are Mochi's nominal product type. The TypeScript surface offers four candidate lowerings (a) plain object literal with type alias, (b) `interface` plus factory function, (c) `class` with `readonly` fields, (d) `class` with `readonly` fields plus private constructor plus static `of()` factory. The MEP-52 abstract commits to (d) because it preserves Mochi record identity at runtime (`instanceof` discrimination), blocks accidental mutation at the type level, supports method dispatch (Mochi records can have methods, which lower to class methods), and gives a single hook for structural equality. The cost is roughly 50 bytes of constructor overhead per instance.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 4.0 | `record User { id: int, name: string }` to `class User { readonly id: bigint; readonly name: string; private constructor(...); static of(...): User }` | NOT STARTED | n/a |
+| 4.1 | Record methods (`fun (u: User) greet() -> string { ... }`) lower to instance methods on the generated class | NOT STARTED | n/a |
+| 4.2 | Structural equality: `mochiRecordEq(a, b)` runtime helper plus per-record `equals(other)` instance method (Phase 4 emits the helper-based form; the per-class override is generated only when the IR sees `==` between two records of the same type) | NOT STARTED | n/a |
+| 4.3 | Multi-file module layout under `src/generated/`; one record per file by default; per-package directory structure preserved (`record foo.bar.User` to `src/generated/foo/bar/user.ts`) | NOT STARTED | n/a |
+| 4.4 | Identifier mangling: TypeScript reserved-word collisions (`class_`, `import_`) and JS globals (`Object_`, `Promise_`) per MEP-52 §12 | NOT STARTED | n/a |
+
+## Sub-phase 4.0, class with readonly fields and static of()
+
+### Decisions made (4.0)
+
+**Generated class shape**:
+
+```typescript
+// src/generated/user.ts
+export class User {
+  readonly id: bigint;
+  readonly name: string;
+
+  private constructor(id: bigint, name: string) {
+    this.id = id;
+    this.name = name;
+  }
+
+  static of(fields: { id: bigint; name: string }): User {
+    return new User(fields.id, fields.name);
+  }
+}
+```
+
+**Why private constructor + static factory**: a public constructor with positional parameters is harder to evolve (adding a field is a breaking call-site change for every consumer). A static `of({...})` factory takes a single options object, which is additive: a new optional field never breaks an existing call site. The private constructor also blocks `new User(...)` from outside the module, which is necessary to keep Mochi's nominal identity (no third party can fake a `User` instance).
+
+**Field naming**: Mochi field `user_id` → TS `userId` (camelCase). Mochi field `id` → TS `id`. The Mochi original name is preserved as a JSDoc `@mochiName user_id` on the field for round-tripping by Mochi tooling.
+
+**Type annotations**: `readonly id: bigint` (the IR-picked Repr drives the choice between `bigint` and `number`). `readonly` is mandatory; the emitter never emits a mutable record field. If the Mochi source declares a record with a mutable field, it is rejected at type-check time (Phase 4 supports immutable records only; mutable record fields land in Phase 9 as agent state).
+
+**Property initialization**: `strictPropertyInitialization` requires every field be assigned in the constructor or have an initializer. The emitter always assigns in the constructor body.
+
+## Sub-phase 4.1, Record methods
+
+### Decisions made (4.1)
+
+**Mochi record method**: `fun (u: User) greet() -> string { "hello, " + u.name }` lowers to an instance method on the generated class:
+
+```typescript
+export class User {
+  readonly id: bigint;
+  readonly name: string;
+  private constructor(id: bigint, name: string) { this.id = id; this.name = name; }
+  static of(fields: { id: bigint; name: string }): User {
+    return new User(fields.id, fields.name);
+  }
+  greet(): string {
+    return "hello, " + this.name;
+  }
+}
+```
+
+Mochi methods receive `self` (or `u` here) explicitly; the emitter remaps the explicit-self parameter to `this` inside the method body. The Mochi original name is preserved as `@mochiSelf u` on the method.
+
+**Function-style method calls**: Mochi `greet(u)` (function-style call) and `u.greet()` (method-style) both lower to `u.greet()`. The emitter chooses method-style for readability; functional-style is only emitted when the IR signals an externally-defined free function that takes a record by parameter.
+
+## Sub-phase 4.2, Structural equality
+
+### Decisions made (4.2)
+
+**Default**: per-instance identity via JavaScript `===` is wrong for records (`User.of({id: 1n, name: "x"}) === User.of({id: 1n, name: "x"})` is `false`).
+
+**Runtime helper**: `mochiRecordEq(a, b)` walks the field list:
+
+```typescript
+// @mochi/runtime/equality
+export function mochiRecordEq<T extends object>(a: T, b: T): boolean {
+  if (a === b) return true;
+  if (a.constructor !== b.constructor) return false;
+  for (const key of Object.keys(a)) {
+    const av = (a as Record<string, unknown>)[key];
+    const bv = (b as Record<string, unknown>)[key];
+    if (!mochiDeepEq(av, bv)) return false;
+  }
+  return true;
+}
+```
+
+`mochiDeepEq` handles primitive `===` for bigint, number, string, boolean; structural equality for arrays, Maps, Sets, and other records; NaN-aware equality (`Number.isNaN(a) && Number.isNaN(b)` is true).
+
+**Per-class override**: when the IR sees `==` between two record values of the same type, the emitter generates a typed `equals(other: User): boolean` method that inlines the field-by-field check (no `Object.keys` reflection in the hot path). This is the recommended path; the runtime helper is the fallback for generic-record contexts.
+
+## Sub-phase 4.3, Multi-file layout
+
+### Decisions made (4.3)
+
+**One record per file**: Phase 4 is the first phase emitting more than one `.ts` file per project. Records each get their own file under `src/generated/`. The file name is the snake_case form of the record name (`record User` to `user.ts`, `record HttpRequest` to `http_request.ts`).
+
+**Package structure**: Mochi package `foo.bar` with `record User` becomes `src/generated/foo/bar/user.ts`. The package's `index.ts` (also generated) re-exports everything in the package.
+
+**Imports**: cross-file imports use the `.ts` extension in source (`import { User } from "./user.ts"`). `tsc --rewriteRelativeImportExtensions` (TS 5.6) rewrites these to `.js` at emit time.
+
+**`tsconfig` updates**: each emitted package becomes a project reference in the root composite `tsconfig.json` only when the user invokes the multi-package CLI option; Phase 4 single-package mode keeps the project-references list to the four runtime configs.
+
+## Sub-phase 4.4, Identifier mangling
+
+### Decisions made (4.4)
+
+**TypeScript reserved words**: identifiers that collide with TS keywords get a trailing underscore. The full list per MEP-52 §12:
+
+`class_, function_, import_, export_, new_, delete_, void_, typeof_, instanceof_, if_, else_, for_, while_, do_, switch_, case_, default_, break_, continue_, return_, throw_, try_, catch_, finally_, var_, let_, const_, null_, true_, false_, this_, super_, extends_, implements_, interface_, enum_, async_, await_, yield_, static_, public_, private_, protected_, readonly_, abstract_, as_, is_, from_, of_, in_, type_, namespace_, module_, declare_, package_, with_`
+
+**JavaScript globals**: `Object`, `Array`, `Function`, `Promise`, `Map`, `Set`, `Symbol`, `Error`, `console`, `globalThis` get the trailing-underscore treatment when the Mochi identifier matches. This is conservative; the TS type system would accept the un-mangled name (shadowing is legal) but the IDE confusion cost is non-trivial.
+
+**Round-tripping**: every mangled name carries a `@mochiName` JSDoc on its declaration:
+
+```typescript
+/** @mochiName class */
+export const class_ = 42n;
+```
+
+Mochi tooling reading the emitted source recovers the original name.
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/lower/records.go` | Record declaration to class; static of() factory; field readonly enforcement |
+| `transpiler3/typescript/lower/methods.go` | Record method to instance method; explicit-self to `this` rewrite |
+| `transpiler3/typescript/lower/equality.go` | Per-type `equals` method generation; `mochiRecordEq` fallback dispatch |
+| `transpiler3/typescript/emit/layout.go` | Multi-file layout under `src/generated/`; package directory tree; per-package `index.ts` |
+| `transpiler3/typescript/lower/mangle.go` | Reserved-word and global identifier mangling; `@mochiName` JSDoc emission |
+| `runtime3/typescript/src/equality/index.ts` | `mochiRecordEq`, `mochiDeepEq` |
+| `transpiler3/typescript/build/phase04_test.go` | `TestPhase4Records` |
+| `tests/transpiler3/typescript/fixtures/phase04-records/` | 35 fixtures |
+
+## Test set
+
+- `TestPhase4Records`, 35 fixtures four-runtime.
+- `TestPhase4StructuralEquality`, fixtures asserting `==` between distinct instances with the same field values returns `true`.
+- `TestPhase4PrivateConstructor`, asserts a hand-edited `.ts` calling `new User(...)` from outside the module fails tsc.
+
+## Deferred work
+
+- Mutable record fields (Mochi `var` field in a record). Deferred to Phase 9 (agents have mutable state by definition).
+- Record inheritance / extension. Not in MEP-52 scope; Mochi records are flat.
+- Serialisation hooks (`toJSON`, `fromJSON`). Phase 4 emits `JSON.stringify`-friendly classes (own enumerable readonly fields); custom serialisation is a v2 add.

--- a/website/docs/implementation/0052/phase-05-sums.md
+++ b/website/docs/implementation/0052/phase-05-sums.md
@@ -1,0 +1,176 @@
+---
+title: "Phase 5. Sum types"
+sidebar_position: 6
+sidebar_label: "Phase 5. Sum types"
+description: "MEP-52 Phase 5, Mochi sum types lowered to TypeScript discriminated unions over a literal kind tag with exhaustive switch enforced by tsc strict; match-to-switch-tag lowering; 40 fixtures."
+---
+
+# Phase 5. Sum types
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 5](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase5Sums`: 40 fixtures green on Node 22, Deno 2, Bun 1.1, Chromium 130. Secondary gate: `tsc --noFallthroughCasesInSwitch` enforced; every `switch (x.kind)` either has all variants present (exhaustive) or an explicit default that calls `mochiUnreachable(x)`, whose parameter type is `never`. Compile-time exhaustiveness checking is the headline win.
+
+## Goal-alignment audit
+
+Sum types are how Mochi expresses tagged choice. TypeScript has no native sum type, but discriminated unions over a literal tag are the canonical pattern (Microsoft promotes it as the recommended way to model sum types since TS 2.0). MEP-52 commits to `type Foo = A | B | C` over a literal `kind` tag with exhaustive `switch (x.kind)` enforced by the `--strict` flag bundle plus `--noFallthroughCasesInSwitch`. The match-to-decision-tree pass shared with MEP-45 through MEP-51 maps cleanly onto `switch` because the discriminator is the literal `kind` string.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 5.0 | Sum declaration to `type` alias over `{kind: "A"; ...} \| {kind: "B"; ...}`; variant constructors as factory functions | NOT STARTED | n/a |
+| 5.1 | Match-to-switch lowering: `match x { A(a) => ... B(b) => ... }` to `switch (x.kind) { case "A": ... case "B": ... }` with type-narrowing | NOT STARTED | n/a |
+| 5.2 | Exhaustiveness: `mochiUnreachable(x: never): never` in the default arm of every emitted switch; tsc rejects unhandled variants | NOT STARTED | n/a |
+| 5.3 | Nested patterns and guards: `match x { A(B(b)) => ... A(C(_)) if b > 0 => ... }` lowered through the decision-tree pass | NOT STARTED | n/a |
+| 5.4 | Sum types with payload records (`A(User)` where `User` is a Phase 4 record) | NOT STARTED | n/a |
+
+## Sub-phase 5.0, Sum to discriminated union
+
+### Decisions made (5.0)
+
+**Mochi**: `sum Shape { Circle(r: float), Square(s: float), Triangle(a: float, b: float, c: float) }`
+
+**TypeScript**:
+
+```typescript
+// src/generated/shape.ts
+export type Shape =
+  | { readonly kind: "Circle"; readonly r: number }
+  | { readonly kind: "Square"; readonly s: number }
+  | { readonly kind: "Triangle"; readonly a: number; readonly b: number; readonly c: number };
+
+export const Circle = (r: number): Shape => ({ kind: "Circle", r });
+export const Square = (s: number): Shape => ({ kind: "Square", s });
+export const Triangle = (a: number, b: number, c: number): Shape =>
+  ({ kind: "Triangle", a, b, c });
+```
+
+**Why type-alias-with-literal-tag rather than class hierarchy**: a class hierarchy (`abstract class Shape; class Circle extends Shape; ...`) requires `instanceof` checks at match time, which TypeScript can narrow but only via `if (x instanceof Circle)` chains, not `switch`. The literal-tag form gives `switch (x.kind) { case "Circle": ... }` with `case "Circle":` narrowing `x` to the `Circle` variant automatically. This is the idiomatic TS pattern for sum types and is the form the Microsoft handbook recommends.
+
+**`readonly kind`**: the tag is `readonly` so the type-narrowing in the `case` arm is sound across mutation (no observer can mutate `x.kind` after narrowing).
+
+**Constructor functions**: `Circle`, `Square`, `Triangle` are arrow functions, not classes. They are cheaper at construction (no allocation overhead beyond the object literal) and they sit naturally next to the type alias.
+
+## Sub-phase 5.1, Match to switch
+
+### Decisions made (5.1)
+
+**Mochi**: `match s { Circle(r) => 3.14159 * r * r, Square(s) => s * s, Triangle(a, b, c) => heron(a, b, c) }`
+
+**TypeScript**:
+
+```typescript
+function area(s: Shape): number {
+  switch (s.kind) {
+    case "Circle":   return 3.14159 * s.r * s.r;
+    case "Square":   return s.s * s.s;
+    case "Triangle": return heron(s.a, s.b, s.c);
+  }
+}
+```
+
+**Type narrowing**: TypeScript's flow analysis narrows `s` to `{kind: "Circle"; r: number}` inside `case "Circle":`, making `s.r` typed as `number` without an assertion. This is the canonical TS discriminated-union pattern and is well-supported by `tsc --strict`.
+
+**Decision-tree pass**: the IR-level match-to-decision-tree pass (shared with MEP-45 through MEP-51) already linearises nested patterns into a sequence of single-level tests; the TypeScript emitter only sees flat patterns by the time it gets called.
+
+**Bindings**: variant-binding patterns (`Circle(r) => ...`) lower to inline field reads (`s.r`), not local bindings. The Mochi name `r` survives only if the IR pass kept it as an internal alias; otherwise the emitter inlines.
+
+## Sub-phase 5.2, Exhaustiveness
+
+### Decisions made (5.2)
+
+**`mochiUnreachable` runtime helper**:
+
+```typescript
+// @mochi/runtime/exhaustiveness
+export function mochiUnreachable(x: never): never {
+  throw new Error(`unreachable: ${JSON.stringify(x as unknown)}`);
+}
+```
+
+**Use site**: the emitter always emits a `default` arm that calls `mochiUnreachable(s)`:
+
+```typescript
+function area(s: Shape): number {
+  switch (s.kind) {
+    case "Circle":   return 3.14159 * s.r * s.r;
+    case "Square":   return s.s * s.s;
+    case "Triangle": return heron(s.a, s.b, s.c);
+    default: return mochiUnreachable(s);
+  }
+}
+```
+
+**tsc enforcement**: if a programmer (or the emitter) drops a variant from the switch, `s` is no longer typed as `never` in the `default` arm and `mochiUnreachable(s)` fails to type-check (the `s` argument is the missing-variant union, not `never`). This is the standard exhaustiveness idiom for discriminated unions and is the reason every emitted switch carries an explicit `default`.
+
+**Why not omit the `default`**: `--noFallthroughCasesInSwitch` does not enforce exhaustiveness, only fallthrough. Without `default + mochiUnreachable`, a missing variant compiles fine and crashes at runtime when the missing branch is hit. The pattern above is bulletproof and the emitter always emits it.
+
+## Sub-phase 5.3, Nested patterns and guards
+
+### Decisions made (5.3)
+
+The decision-tree pass linearises everything before the TypeScript emitter sees it, so the emitter never confronts a deeply nested pattern. Guards (`if cond`) lower to `if`/`else if` chains inside the relevant `case`:
+
+```typescript
+case "Circle": {
+  if (s.r > 0) return 3.14159 * s.r * s.r;
+  if (s.r === 0) return 0;
+  return mochiUnreachable(s as never);
+}
+```
+
+(`s as never` is required when guards do not cover every value of the narrowed variant; the IR pass marks such cases and the emitter emits an explicit cast.)
+
+## Sub-phase 5.4, Sum with record payloads
+
+### Decisions made (5.4)
+
+**Mochi**: `sum Either { Left(err: ParseError), Right(value: User) }`
+
+**TypeScript**:
+
+```typescript
+import { ParseError } from "./parse_error.ts";
+import { User } from "./user.ts";
+
+export type Either =
+  | { readonly kind: "Left"; readonly err: ParseError }
+  | { readonly kind: "Right"; readonly value: User };
+
+export const Left = (err: ParseError): Either => ({ kind: "Left", err });
+export const Right = (value: User): Either => ({ kind: "Right", value });
+```
+
+The record types (`ParseError`, `User`) are imported from their respective generated files (Phase 4 layout). Cross-file imports use `.ts` extensions in source; `tsc` rewrites to `.js` on emit.
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/lower/sums.go` | Sum declaration to type alias + constructor functions |
+| `transpiler3/typescript/lower/match.go` | Match-to-switch lowering; tag emission; exhaustiveness default arm |
+| `runtime3/typescript/src/exhaustiveness/index.ts` | `mochiUnreachable(x: never): never` |
+| `transpiler3/typescript/build/phase05_test.go` | `TestPhase5Sums` |
+| `tests/transpiler3/typescript/fixtures/phase05-sums/` | 40 fixtures |
+
+## Test set
+
+- `TestPhase5Sums`, 40 fixtures four-runtime.
+- `TestPhase5Exhaustiveness`, a hand-edited fixture removes one `case`; the gate asserts `tsc` reports the missing-variant error.
+- `TestPhase5NoFallthrough`, asserts no emitted `case` arm falls through to the next (every arm ends in `return`, `throw`, or `break`).
+
+## Deferred work
+
+- View patterns (`match x { Circle(r) when r > 0 => ... }`). The guard form lands in 5.3 above; "view patterns" in the Haskell sense are not in Mochi.
+- Or-patterns (`A | B => ...`). Lower to `case "A": case "B":` with shared body; the decision-tree pass already produces this.
+- Pattern synonyms. Not in MEP-52 scope.

--- a/website/docs/implementation/0052/phase-06-closures.md
+++ b/website/docs/implementation/0052/phase-06-closures.md
@@ -1,0 +1,164 @@
+---
+title: "Phase 6. Closures and higher-order functions"
+sidebar_position: 7
+sidebar_label: "Phase 6. Closures"
+description: "MEP-52 Phase 6, Mochi closures to TypeScript arrow functions, nested function declarations, higher-order function passing; closure-conversion pass output mapped to TS captures; 30 fixtures."
+---
+
+# Phase 6. Closures and higher-order functions
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 6](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase6Closures`: 30 fixtures green on Node 22, Deno 2, Bun 1.1, Chromium 130. Secondary gate: `@typescript-eslint/no-shadow` clean; `strictFunctionTypes` and `strictBindCallApply` enforced; no emitted `Function` constructor.
+
+## Goal-alignment audit
+
+Closures are how Mochi parameterises behaviour: every `map`, `filter`, `fold`, every event handler, every agent message handler is a closure that captures surrounding scope. The TypeScript surface gives us arrow functions (`(x) => x + 1`) with lexical `this` capture, which matches Mochi's closure semantics exactly. The closure-conversion pass shared with MEP-45 through MEP-51 already explicitates the captured environment as a record; the TypeScript emitter does not need to reproduce it. Higher-order functions land here because they are the consumer for closures.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 6.0 | Anonymous closures: `(x: int) -> x + 1` to `(x: bigint): bigint => x + 1n` | NOT STARTED | n/a |
+| 6.1 | Named function declarations at module scope to `export function f(...)` | NOT STARTED | n/a |
+| 6.2 | Nested function declarations to inner `const f = (...) => ...` (block-scoped const) | NOT STARTED | n/a |
+| 6.3 | Higher-order parameters and returns; function-type lowering to `(t: T) => R` (sync) and `(t: T) => Promise<R>` (async, Phase 11 colours) | NOT STARTED | n/a |
+| 6.4 | Captured-mutable-variable lowering: `let mut x = 0; (() -> x = x + 1)()` via boxed cell (`{ value: bigint }`) when capture is shared and mutated | NOT STARTED | n/a |
+
+## Sub-phase 6.0, Anonymous closures
+
+### Decisions made (6.0)
+
+**Mochi**: `(x: int) -> x + 1`
+
+**TypeScript**: `(x: bigint): bigint => x + 1n`
+
+**Arrow vs `function`**: arrow function is preferred. It captures `this` lexically (matches Mochi semantics; Mochi has no implicit `this`). It is more concise. eslint (`prefer-arrow-callback`) prefers it.
+
+**Return type annotation**: always emitted. `tsc --strict` infers but the explicit annotation surfaces the IR-derived return type in the source for code review.
+
+**Implicit `return`**: for single-expression bodies, the emitter uses the concise form (`(x: bigint): bigint => x + 1n`). For multi-statement bodies it uses the block form with explicit `return`.
+
+## Sub-phase 6.1, Named function declarations
+
+### Decisions made (6.1)
+
+**Mochi**: `fun add(a: int, b: int) -> int { a + b }`
+
+**TypeScript** (module scope):
+
+```typescript
+export function add(a: bigint, b: bigint): bigint {
+  return a + b;
+}
+```
+
+**Why `function` keyword for module-level, arrow for nested**: `function` declarations are hoisted (callable before declaration in the same module). This matches Mochi's "all module functions are simultaneously in scope" semantic. Nested functions inside another function are not hoisted in Mochi (they only exist after their `let` line); arrow functions assigned to `const` give exactly that.
+
+**`export`**: every module-scope function is `export`ed. Mochi's visibility rules (defaulting to private unless declared `pub`) are enforced at the type level via TypeScript's module boundary plus per-symbol re-export filtering in `src/index.ts`.
+
+## Sub-phase 6.2, Nested function declarations
+
+### Decisions made (6.2)
+
+**Mochi**: `fun outer() { fun inner(x: int) -> int { x + 1 }; print(inner(2)) }`
+
+**TypeScript**:
+
+```typescript
+export function outer(): void {
+  const inner = (x: bigint): bigint => x + 1n;
+  print(inner(2n));
+}
+```
+
+`const` (block-scoped) is the right binding form: an inner function is not hoisted to the top of the surrounding function, only to the line of its declaration.
+
+## Sub-phase 6.3, Higher-order parameters and returns
+
+### Decisions made (6.3)
+
+**Function type lowering**:
+
+| Mochi                       | TypeScript                                |
+|-----------------------------|-------------------------------------------|
+| `fun(int) -> int`           | `(x: bigint) => bigint`                   |
+| `fun(int, int) -> int`      | `(a: bigint, b: bigint) => bigint`        |
+| `async fun(int) -> int`     | `(x: bigint) => Promise<bigint>` (Phase 11) |
+| `fun(fun(int) -> int) -> int` | `(f: (x: bigint) => bigint) => bigint`  |
+
+**Higher-order example**:
+
+```typescript
+export function apply(f: (x: bigint) => bigint, x: bigint): bigint {
+  return f(x);
+}
+```
+
+**Currying**: Mochi does not have language-level auto-currying. A Mochi `fun add(a, b)` returns a 2-ary function; partial application uses an explicit closure (`(b) -> add(5, b)`). The TS emitter does not synthesise curried forms.
+
+**Variance**: TypeScript's `strictFunctionTypes` makes function parameter positions contravariant. The IR-level variance analysis (shared with MEP-50 Kotlin) feeds this; the TS emitter annotates `<in T, out R>` modifiers when the IR signals an explicitly-variant type parameter on a generic function.
+
+## Sub-phase 6.4, Captured mutable variables
+
+### Decisions made (6.4)
+
+**Problem**: TypeScript's `let` lets a closure capture a mutable binding lexically:
+
+```typescript
+let x = 0;
+const inc = () => { x = x + 1; };
+inc();
+console.log(x); // 1
+```
+
+This works for single-function capture but breaks when the captured value is held in a long-lived shape (e.g. an agent's state) and the closure-conversion pass demands a boxed cell. The closure-conversion pass (shared with MEP-45 etc.) tags every captured mutable variable as either "shared mutable" (multiple closures mutate; needs a cell) or "exclusive mutable" (one closure mutates, others may read; the `let` binding suffices).
+
+**Shared mutable**: lower to a cell record:
+
+```typescript
+type Cell<T> = { value: T };
+const x: Cell<bigint> = { value: 0n };
+const inc = () => { x.value = x.value + 1n; };
+const get = (): bigint => x.value;
+```
+
+**Exclusive mutable**: stay with `let`:
+
+```typescript
+let x: bigint = 0n;
+const inc = () => { x = x + 1n; };
+```
+
+The IR analysis is the source of truth; the emitter never makes the call independently.
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/lower/closures.go` | Arrow vs function lowering; nested const; capture rewriting |
+| `transpiler3/typescript/lower/funtype.go` | Mochi function type to TS arrow type lowering |
+| `transpiler3/typescript/lower/cells.go` | Shared-mutable capture to Cell<T> rewriting |
+| `transpiler3/typescript/build/phase06_test.go` | `TestPhase6Closures` |
+| `tests/transpiler3/typescript/fixtures/phase06-closures/` | 30 fixtures |
+
+## Test set
+
+- `TestPhase6Closures`, 30 fixtures four-runtime.
+- `TestPhase6NoFunctionConstructor`, asserts no emitted `.ts` contains `new Function(...)` or `Function(...)`.
+- `TestPhase6Variance`, fixtures with contravariant function parameter positions exercise tsc `strictFunctionTypes`.
+
+## Deferred work
+
+- Function-type variance annotations (`<in T, out R>`) where the IR derives invariance vs variance. The Phase 6 emitter ships the default invariant form; explicit `in`/`out` annotations are added when the IR demands.
+- Tagged template literals (`html\`...\``). Not in Mochi surface.
+- Generators inside closures (`function*`). Generators land in Phase 7 (query DSL) and Phase 10 (streams).

--- a/website/docs/implementation/0052/phase-07-query.md
+++ b/website/docs/implementation/0052/phase-07-query.md
@@ -1,0 +1,167 @@
+---
+title: "Phase 7. Query DSL"
+sidebar_position: 8
+sidebar_label: "Phase 7. Query DSL"
+description: "MEP-52 Phase 7, Mochi query DSL lowered to ES2024 Iterator helpers (Iterator.from, .map, .filter, .take) plus AsyncIterable for async sources; hash/merge/nested-loop joins; group-by; top-K via min-heap; 40 fixtures."
+---
+
+# Phase 7. Query DSL
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 7](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase7Query`: 40 fixtures green on Node 22, Deno 2, Bun 1.1, Chromium 130. Secondary gates: tsc strict zero diagnostics; runtime-budget gate (the runtime additions for query and join stay below 1 KB gzipped); execution-budget gate (a representative joins fixture must complete within 2x the vm3 wall-clock baseline on the linux-x64 CI runner).
+
+## Goal-alignment audit
+
+Mochi's query DSL is the front-end for almost every data-shaped program: report generation, ETL, leaderboards, analytics. The TS surface gives us two routes: (a) `Array.prototype.map/filter/...` (eager, allocates intermediate arrays), or (b) TC39 Iterator helpers (`Iterator.from(...).map(...).filter(...)`, lazy, single-pass). The MEP-52 decision is to prefer iterator helpers, falling back to `Array.prototype` only when the IR proves the source is finite and the user wants the intermediate `T[]` reified. Async sources lower to `AsyncIterable<T>` and the `for await` form. Joins, group-by, and top-K are implemented in `@mochi/runtime/query` because the platform does not ship them.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 7.0 | Simple comprehensions: `[f(x) for x in xs if p(x)]` to `Iterator.from(xs).filter(p).map(f).toArray()` | NOT STARTED | n/a |
+| 7.1 | Multi-source comprehensions: `[f(x, y) for x in xs for y in ys]` to flatMap chain | NOT STARTED | n/a |
+| 7.2 | Joins: hash join (default), merge join (when both sides are sorted), nested-loop (when one side is small); IR-driven choice | NOT STARTED | n/a |
+| 7.3 | Group-by: `Map.groupBy(xs, keyFn)` (ES2024) plus aggregations | NOT STARTED | n/a |
+| 7.4 | Top-K: min-heap implementation in `@mochi/runtime/query/heap` | NOT STARTED | n/a |
+| 7.5 | Async sources: `AsyncIterable<T>` plumbing through query pipelines via `Iterator.fromAsync` and async generators | NOT STARTED | n/a |
+
+## Sub-phase 7.0, Simple comprehensions
+
+### Decisions made (7.0)
+
+**Mochi**: `[u.name for u in users if u.age > 18]`
+
+**TypeScript**:
+
+```typescript
+Iterator.from(users).filter((u) => u.age > 18n).map((u) => u.name).toArray()
+```
+
+**Why iterator helpers (ES2024)**: lazy single-pass; no intermediate array for `filter`'s output. `Iterator.from(array)` is constant-time (array is already iterable). The terminal `.toArray()` materialises only when the consumer expects a `T[]`. Node 22 / Deno 2 / Bun 1.1 / Chromium 122+ all ship iterator helpers natively.
+
+**Fallback to `Array.prototype`**: when the IR signals `xs` is an array, the producer is finite, and the consumer is a single `for`/`for-of` loop, the emitter prefers `xs.filter(...).map(...)` (slightly less indirection, similar perf in V8). The IR-pass `query/lowerStrategy.go` picks the form.
+
+## Sub-phase 7.1, Multi-source comprehensions
+
+### Decisions made (7.1)
+
+**Mochi**: `[f(x, y) for x in xs for y in ys if p(x, y)]`
+
+**TypeScript**:
+
+```typescript
+Iterator.from(xs)
+  .flatMap((x) => Iterator.from(ys).map((y) => [x, y] as const))
+  .filter(([x, y]) => p(x, y))
+  .map(([x, y]) => f(x, y))
+  .toArray()
+```
+
+The intermediate `[x, y]` tuple is unavoidable for non-fused chains; TypeScript and V8 do not eliminate it via escape analysis. The emitter falls back to a hand-coded nested loop when the IR proves the tuple escapes (e.g., the comprehension returns objects whose lifetime exceeds the loop).
+
+## Sub-phase 7.2, Joins
+
+### Decisions made (7.2)
+
+**Hash join (default for equi-join)**:
+
+```typescript
+// SELECT u.name, o.amount FROM users u JOIN orders o ON u.id = o.user_id
+const usersById = new Map<bigint, User>(users.map((u) => [u.id, u]));
+const result: Array<{ name: string; amount: bigint }> = [];
+for (const o of orders) {
+  const u = usersById.get(o.userId);
+  if (u !== undefined) result.push({ name: u.name, amount: o.amount });
+}
+```
+
+**Merge join (when both sides are sorted by the join key)**: two-pointer walk over both arrays; emitter only chooses this when the IR proves both sides are sorted (via a `Sorted` provenance tag).
+
+**Nested-loop join (when one side is small)**: cardinality threshold is 16 (heuristic from `Iterator.from(small).flatMap(...)` benchmarks on V8); below that the hash table allocation cost dominates.
+
+**Choice algorithm**: the IR `query/joinStrategy.go` pass selects per join. The TS emitter consumes the choice and emits the right shape.
+
+## Sub-phase 7.3, Group-by
+
+### Decisions made (7.3)
+
+**Mochi**: `[(k, sum(o.amount for o in g)) for (k, g) in group(orders, by=o.userId)]`
+
+**TypeScript**:
+
+```typescript
+const groups: Map<bigint, Order[]> = Map.groupBy(orders, (o) => o.userId);
+const result = Iterator.from(groups)
+  .map(([k, g]) => [k, g.reduce((acc, o) => acc + o.amount, 0n)] as const)
+  .toArray();
+```
+
+`Map.groupBy` is ES2024 (TC39 Stage 4, native in Node 22, Deno 2, Bun 1.1, Chromium 117+). `Object.groupBy` is also available but returns a plain object; the emitter prefers `Map.groupBy` for the `Map<K, V[]>` shape (avoids the prototype-pollution surface of object-as-map).
+
+**Aggregations**: `sum`, `count`, `min`, `max`, `avg` lower to inlined reduces. `mochiAvg(xs)` is a runtime helper because `avg` over `bigint`s wants exact rational return type (the Mochi spec defines `avg` as `int -> float` for now; the emitter emits `Number(sum) / xs.length`).
+
+## Sub-phase 7.4, Top-K
+
+### Decisions made (7.4)
+
+**`@mochi/runtime/query/heap`**: hand-rolled min-heap, roughly 80 LOC of TS:
+
+```typescript
+export class MinHeap<T> {
+  private buf: T[] = [];
+  constructor(private readonly cmp: (a: T, b: T) => number) {}
+  size(): number { return this.buf.length; }
+  peek(): T | undefined { return this.buf[0]; }
+  push(v: T): void { /* sift up */ }
+  pop(): T | undefined { /* swap, sift down */ }
+}
+```
+
+**`top-K` lowering**: `[x for x in xs order by f(x) limit K]` lowers to a single pass that maintains a K-size min-heap (over the `(-key, value)` for top-K-largest) and emits the heap contents at the end.
+
+**Choice vs full sort**: emitter uses heap when `K < len(xs) / 4` (heuristic), otherwise falls back to `.toSorted((a, b) => cmp(a, b)).slice(0, K)`.
+
+## Sub-phase 7.5, Async sources
+
+### Decisions made (7.5)
+
+**`AsyncIterable<T>`**: Mochi `stream<T>` lowers to `AsyncIterable<T>` (Phase 10 lands the full stream surface). The query DSL pipes async sources through `Iterator.fromAsync(asyncSource).filter(...).map(...)`.
+
+**For-await fallback**: when the IR signals an async source plus a synchronous consumer that wants the full result, the emitter emits a manual `for await` accumulator. `Iterator.fromAsync` is TC39 Stage 4 in ES2024.
+
+**Backpressure**: `for await` is naturally pull-based; the producer awaits the consumer at each iteration. No queue is interposed (the agent's queue from Phase 9 handles cross-task buffering separately).
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/lower/query.go` | Comprehension and query DSL lowering; iterator-helper vs Array.prototype choice |
+| `transpiler3/typescript/lower/joins.go` | Hash / merge / nested-loop join lowering; strategy selection from IR |
+| `transpiler3/typescript/lower/groupby.go` | Map.groupBy emission and aggregation inlining |
+| `transpiler3/typescript/lower/topk.go` | Top-K min-heap emission and full-sort fallback |
+| `runtime3/typescript/src/query/heap.ts` | `MinHeap<T>` for top-K |
+| `runtime3/typescript/src/query/aggregations.ts` | `mochiSum`, `mochiCount`, `mochiAvg`, etc. |
+| `transpiler3/typescript/build/phase07_test.go` | `TestPhase7Query` |
+| `tests/transpiler3/typescript/fixtures/phase07-query/` | 40 fixtures |
+
+## Test set
+
+- `TestPhase7Query`, 40 fixtures four-runtime.
+- `TestPhase7QueryBudget`, the runtime's `query/` sub-path stays under 1 KB gzipped.
+- `TestPhase7QueryPerf`, a 1M-row representative joins fixture completes within 2x vm3 wall-clock baseline.
+
+## Deferred work
+
+- arquero, danfojs, duckdb-wasm, polars-js. All rejected per [[08-dataset-pipeline]] §12.
+- Window functions (`row_number() over (partition by k order by t)`). Phase 7 ships group-by only; window functions are a v1.5 candidate.
+- Distributed query (sharded over multiple workers). Not in MEP-52 scope.

--- a/website/docs/implementation/0052/phase-08-datalog.md
+++ b/website/docs/implementation/0052/phase-08-datalog.md
@@ -1,0 +1,179 @@
+---
+title: "Phase 8. Datalog"
+sidebar_position: 9
+sidebar_label: "Phase 8. Datalog"
+description: "MEP-52 Phase 8, Mochi datalog facts, rules, recursion, semi-naive evaluation in @mochi/runtime/datalog (~700 LOC of TS); 20 fixtures."
+---
+
+# Phase 8. Datalog
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 8](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase8Datalog`: 20 fixtures green on Node 22, Deno 2, Bun 1.1, Chromium 130. Secondary gates: tsc strict zero diagnostics; the datalog engine runtime stays under 8 KB gzipped (`@mochi/runtime/datalog` budget); fixed-point termination test (every fixture's bottom-up evaluation terminates within 1000 iterations on the test corpus).
+
+## Goal-alignment audit
+
+Mochi's datalog sub-language is used for graph reachability, type inference inside Mochi tooling, and rule-based business logic. The TypeScript surface does not have a datalog engine, so MEP-52 ships one under `@mochi/runtime/datalog`. The engine uses semi-naive bottom-up evaluation: each iteration considers only "new" facts (the delta from the previous iteration) when applying rules, dramatically reducing the redundant work of naive bottom-up. This matches the engine MEP-45 ships for C and the engine MEP-51 ships for Python; the algorithm is the same, only the TS rewrite is new.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 8.0 | Fact storage: `Map<RelationName, Set<Tuple>>` with structural-equality tuple keys | NOT STARTED | n/a |
+| 8.1 | Rule representation: `{head: Atom, body: Atom[]}` plus variable binding map | NOT STARTED | n/a |
+| 8.2 | Semi-naive evaluation loop with delta-relation tracking | NOT STARTED | n/a |
+| 8.3 | Tuple matching and unification: positional + named-binding | NOT STARTED | n/a |
+| 8.4 | Negation-as-failure (stratified): topologically sort rules, evaluate strata bottom-up | NOT STARTED | n/a |
+
+## Sub-phase 8.0, Fact storage
+
+### Decisions made (8.0)
+
+**Datalog facts** are typed tuples keyed by relation name. The runtime stores them as a `Map<string, Set<TupleKey>>` where `TupleKey` is a canonical string representation of the tuple:
+
+```typescript
+// @mochi/runtime/datalog/db
+export type TupleKey = string;
+export function tupleKey(values: readonly unknown[]): TupleKey {
+  return JSON.stringify(values, (_k, v) =>
+    typeof v === "bigint" ? `__bigint__${v.toString()}` : v
+  );
+}
+
+export class FactDB {
+  private readonly relations: Map<string, Set<TupleKey>> = new Map();
+  add(rel: string, values: readonly unknown[]): boolean { /* ... */ }
+  has(rel: string, values: readonly unknown[]): boolean { /* ... */ }
+  scan(rel: string): IterableIterator<readonly unknown[]> { /* ... */ }
+}
+```
+
+**Why string keys**: `Set<readonly unknown[]>` uses reference equality. Two arrays with identical contents would be different keys. JSON-stringify (with the `bigint` quirk) gives a stable canonical form; collisions are impossible for the value types datalog admits (int, string, bool; no records as tuple positions in Phase 8).
+
+## Sub-phase 8.1, Rule representation
+
+### Decisions made (8.1)
+
+**Rule shape**:
+
+```typescript
+export type Term =
+  | { readonly kind: "var"; readonly name: string }
+  | { readonly kind: "const"; readonly value: unknown };
+
+export type Atom = {
+  readonly relation: string;
+  readonly terms: readonly Term[];
+};
+
+export type Rule = {
+  readonly head: Atom;
+  readonly body: readonly Atom[];
+};
+```
+
+The IR pass shared with MEP-45 lowers Mochi datalog source to this shape; the TS emitter writes the rule list as a `const rules: Rule[] = [...]` array.
+
+## Sub-phase 8.2, Semi-naive evaluation
+
+### Decisions made (8.2)
+
+**Algorithm** (semi-naive, classic Ullman):
+
+```typescript
+// @mochi/runtime/datalog/eval
+export function evaluate(facts: FactDB, rules: readonly Rule[]): FactDB {
+  let delta: FactDB = facts.clone();
+  let next: FactDB = facts.clone();
+  while (delta.size() > 0) {
+    const newDelta = new FactDB();
+    for (const rule of rules) {
+      // For each rule, fire it with at least one body atom matched against delta
+      for (const newFact of fireRuleWithDelta(rule, next, delta)) {
+        if (!next.has(newFact.relation, newFact.values)) {
+          next.add(newFact.relation, newFact.values);
+          newDelta.add(newFact.relation, newFact.values);
+        }
+      }
+    }
+    delta = newDelta;
+  }
+  return next;
+}
+```
+
+**Why semi-naive**: naive evaluation re-derives every fact every iteration. Semi-naive only re-derives facts that need a "new" body atom; iteration `n+1` only fires a rule where at least one body atom matches a fact added in iteration `n`. For transitive-closure problems this is the difference between O(n^3) and O(n^2).
+
+**Termination**: datalog without function symbols terminates (the universe of facts is bounded by the cross-product of the active domain). Negation requires stratification (sub-phase 8.4).
+
+## Sub-phase 8.3, Tuple matching and unification
+
+### Decisions made (8.3)
+
+**Body matching**: for each rule body atom, scan the matching relation and try to unify against the current variable bindings. A binding is a `Map<string, unknown>`. Unification succeeds if every variable maps consistently across the body atoms.
+
+```typescript
+function unify(
+  atom: Atom,
+  tuple: readonly unknown[],
+  bindings: Map<string, unknown>
+): Map<string, unknown> | null {
+  if (atom.terms.length !== tuple.length) return null;
+  const out = new Map(bindings);
+  for (let i = 0; i < atom.terms.length; i++) {
+    const t = atom.terms[i]!;
+    const v = tuple[i];
+    if (t.kind === "const") {
+      if (!mochiDeepEq(t.value, v)) return null;
+    } else {
+      const existing = out.get(t.name);
+      if (existing === undefined) out.set(t.name, v);
+      else if (!mochiDeepEq(existing, v)) return null;
+    }
+  }
+  return out;
+}
+```
+
+**Head emission**: substitute bindings into head terms; if any head variable is unbound the rule is range-restricted and the emitter rejects at lower-time.
+
+## Sub-phase 8.4, Negation-as-failure
+
+### Decisions made (8.4)
+
+**Stratification**: build a dependency graph (rule head's relation depends on each body atom's relation; negation edge is marked). The graph must be acyclic when ignoring positive edges, otherwise the program is rejected at lower-time as non-stratifiable. Strata are SCCs in the positive-only subgraph, topologically ordered.
+
+**Evaluation**: each stratum is evaluated to fixed-point before the next stratum starts. Negation `not p(x)` at a body atom succeeds if `p(x)` is not in the current facts (which is fully determined by the time the negation's stratum is reached, by construction).
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/lower/datalog.go` | Mochi datalog source to Rule/Atom IR; rule-list emission |
+| `runtime3/typescript/src/datalog/db.ts` | FactDB with TupleKey canonicalisation |
+| `runtime3/typescript/src/datalog/eval.ts` | Semi-naive evaluation loop |
+| `runtime3/typescript/src/datalog/unify.ts` | Unification with variable bindings |
+| `runtime3/typescript/src/datalog/strata.ts` | Stratification with negation-as-failure |
+| `transpiler3/typescript/build/phase08_test.go` | `TestPhase8Datalog` |
+| `tests/transpiler3/typescript/fixtures/phase08-datalog/` | 20 fixtures (transitive closure, ancestors, graph reachability, type inference toy, etc.) |
+
+## Test set
+
+- `TestPhase8Datalog`, 20 fixtures four-runtime.
+- `TestPhase8DatalogBudget`, `@mochi/runtime/datalog` stays under 8 KB gzipped.
+- `TestPhase8Stratifiable`, a non-stratifiable fixture is rejected at lower-time with an explicit error.
+
+## Deferred work
+
+- Aggregations inside rules (`count(...)`, `sum(...)` as datalog atoms). Phase 8 ships range-restricted positive + stratified-negation only. Aggregations are a v1.5 candidate.
+- Incremental maintenance (DBSP-style differential dataflow). Out of scope.
+- External-database integration (project a relational table as facts). Phase 14 (fetch) and a v2 datalog adapter cover this together.

--- a/website/docs/implementation/0052/phase-09-agents.md
+++ b/website/docs/implementation/0052/phase-09-agents.md
@@ -1,0 +1,230 @@
+---
+title: "Phase 9. Agents"
+sidebar_position: 10
+sidebar_label: "Phase 9. Agents"
+description: "MEP-52 Phase 9, Mochi agents as TypeScript class wrapping AsyncIterableQueue<Message> + AbortController; cast, call, supervision via nested AbortControllers; AggregateError for sibling failure aggregation; 35 fixtures."
+---
+
+# Phase 9. Agents
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 9](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase9Agents`: 35 fixtures green on Node 22, Deno 2, Bun 1.1, Chromium 130. Secondary gates: tsc strict zero diagnostics; eslint `no-floating-promises` enforced (no `void this.loop()` floating without an explicit `void` keyword or `.catch`); the concurrency runtime under `@mochi/runtime/concurrency/` stays under 8 KB gzipped (the budget from [[07-runtime-portability]] §3).
+
+## Goal-alignment audit
+
+Agents are Mochi's primary concurrency abstraction across every backend. MEP-45 to MEP-51 each lower agents to the target platform's native actor primitive: Erlang gen_server (MEP-46), Loom virtual thread (MEP-47), .NET `Channel<T>` (MEP-48), Swift actor (MEP-49), Kotlin coroutine + `Channel` (MEP-50), Python `asyncio.Queue` + `TaskGroup` (MEP-51). The JavaScript runtime offers no equivalent built-in. MEP-52 hand-rolls one. The shape (`AsyncIterableQueue<Message>` + `AbortController` + `Promise.withResolvers()` for call replies) is fixed by the abstract; Phase 9 lands it.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 9.0 | `AsyncIterableQueue<T>` runtime class with `push`, `pushAwait`, `close`, `fail`, `[Symbol.asyncIterator]()` | NOT STARTED | n/a |
+| 9.1 | `MochiAgent` base class with mailbox, abort signal, loop driver; user `agent Counter { ... }` lowers to a subclass | NOT STARTED | n/a |
+| 9.2 | `cast(msg)` (fire-and-forget) and `call(req): Promise<Reply>` (request-reply via `Promise.withResolvers`) | NOT STARTED | n/a |
+| 9.3 | Supervision tree: nested `AbortController` instances; `one_for_all` and `one_for_one` strategies | NOT STARTED | n/a |
+| 9.4 | Sibling failure aggregation via `AggregateError` (ES2021); parent surfaces a `MochiResult.Err` carrying the inner errors | NOT STARTED | n/a |
+
+## Sub-phase 9.0, AsyncIterableQueue
+
+### Decisions made (9.0)
+
+**Shape** (per [[09-agent-streams]] §AsyncIterableQueue):
+
+```typescript
+// @mochi/runtime/concurrency/queue
+export class AsyncIterableQueue<T> implements AsyncIterable<T> {
+  private readonly buffer: T[] = [];
+  private readonly waiters: Array<(v: IteratorResult<T>) => void> = [];
+  private readonly producers: Array<() => void> = [];
+  private readonly capacity: number;
+  private closed = false;
+  private failure: unknown = undefined;
+
+  constructor(options: { capacity?: number } = {}) {
+    this.capacity = options.capacity ?? Number.POSITIVE_INFINITY;
+  }
+
+  push(value: T): void { /* ... */ }
+  async pushAwait(value: T): Promise<void> { /* ... */ }
+  close(): void { /* ... */ }
+  fail(reason: unknown): void { /* ... */ }
+  [Symbol.asyncIterator](): AsyncIterator<T> { /* ... */ }
+}
+```
+
+**Why not RxJS, Web Streams, EventEmitter**: dependency burden, type-surface mismatch, ad-hoc cancellation (see [[09-agent-streams]] §"Why hand-roll" and MEP-52 §Rationale).
+
+**Backpressure**: `pushAwait` blocks the producer when `buffer.length >= capacity` until a consumer drains. `push` (sync) throws when the queue is closed and never blocks; intended for fire-and-forget producers.
+
+**Closure ordering**: `close()` resolves all pending waiters with `{done: true}`. `fail(reason)` records the reason then closes; the next `next()` call rejects with the recorded reason instead of resolving with `done: true`.
+
+## Sub-phase 9.1, MochiAgent base class
+
+### Decisions made (9.1)
+
+**Base class**:
+
+```typescript
+// @mochi/runtime/concurrency/agent
+export abstract class MochiAgent<Msg> {
+  protected readonly mailbox = new AsyncIterableQueue<Msg>();
+  protected readonly signal: AbortSignal;
+
+  constructor(signal: AbortSignal) {
+    this.signal = signal;
+    signal.addEventListener("abort", () => this.mailbox.close());
+    void this.loop();
+  }
+
+  protected abstract handle(msg: Msg): void | Promise<void>;
+
+  private async loop(): Promise<void> {
+    try {
+      for await (const msg of this.mailbox) {
+        if (this.signal.aborted) break;
+        await this.handle(msg);
+      }
+    } catch (e) {
+      this.mailbox.fail(e);
+    }
+  }
+}
+```
+
+**Generated subclass for `agent Counter`** (Mochi source):
+
+```mochi
+agent Counter {
+  state: int = 0
+  cast Inc(n: int) { state = state + n }
+  call Value(): int { reply(state) }
+}
+```
+
+**Generated TypeScript**:
+
+```typescript
+export type CounterMsg =
+  | { readonly kind: "Inc"; readonly n: bigint }
+  | { readonly kind: "Value"; readonly reply: (v: bigint) => void };
+
+export class Counter extends MochiAgent<CounterMsg> {
+  private state: bigint = 0n;
+
+  protected handle(msg: CounterMsg): void {
+    switch (msg.kind) {
+      case "Inc":   this.state = this.state + msg.n; return;
+      case "Value": msg.reply(this.state); return;
+    }
+  }
+
+  cast(msg: Exclude<CounterMsg, { kind: "Value" }>): void {
+    this.mailbox.push(msg);
+  }
+
+  async call(req: { kind: "Value" }): Promise<bigint> {
+    const { promise, resolve } = Promise.withResolvers<bigint>();
+    this.mailbox.push({ kind: req.kind, reply: resolve } as CounterMsg);
+    return promise;
+  }
+}
+```
+
+## Sub-phase 9.2, cast and call
+
+### Decisions made (9.2)
+
+**`cast` (fire-and-forget)**: sync, never awaits; `mailbox.push(msg)` returns immediately. Caller does not observe success.
+
+**`call` (request-reply)**: `Promise.withResolvers()` (ES2024) gives `{promise, resolve, reject}`. The agent's message variant carries the `reply` callback; the handler invokes `reply(value)` to fulfil the caller's promise. Errors in the handler propagate via the queue's `fail` path; the caller observes via `await call(...).catch(...)`.
+
+**Timeout**: a `call(req, {timeout: 5_000})` overload wraps the promise in `Promise.race([promise, timeoutReject(timeout)])`. Phase 9 ships without timeout (callers compose `Promise.race` themselves); the overload is a v1.5 add.
+
+## Sub-phase 9.3, Supervision
+
+### Decisions made (9.3)
+
+**`MochiSupervisor`**:
+
+```typescript
+// @mochi/runtime/concurrency/supervisor
+export type Strategy = "one_for_one" | "one_for_all";
+
+export class MochiSupervisor {
+  private readonly controller = new AbortController();
+  private readonly children: Array<{
+    factory: (signal: AbortSignal) => MochiAgent<unknown>;
+    instance: MochiAgent<unknown>;
+  }> = [];
+  constructor(private readonly strategy: Strategy = "one_for_all") {}
+  spawn<M>(factory: (signal: AbortSignal) => MochiAgent<M>): MochiAgent<M> {
+    const instance = factory(this.controller.signal);
+    this.children.push({ factory: factory as any, instance: instance as MochiAgent<unknown> });
+    return instance;
+  }
+  shutdown(): void { this.controller.abort(); }
+}
+```
+
+**`one_for_all` (default)**: a child failure (handler throws) calls `controller.abort()`; every sibling observes `signal.aborted === true`, exits its `for await` loop, releases resources. Matches OTP `one_for_all`.
+
+**`one_for_one`**: the failed child is restarted via its factory; siblings unaffected. Implemented by catching inside the agent's loop and re-spawning via the saved factory. Phase 9 ships `one_for_all`; `one_for_one` is sub-phase 9.3.1.
+
+**Nested supervision**: `MochiSupervisor` can spawn child supervisors (each has its own `AbortController` whose signal is also added to the parent's). A parent abort propagates down; a child abort stays scoped.
+
+## Sub-phase 9.4, AggregateError
+
+### Decisions made (9.4)
+
+**Sibling failure aggregation**: when the parent supervisor receives a child failure, it aborts siblings and collects their failure reasons (each agent's `mailbox.failure` field after close). The collected reasons are wrapped in an `AggregateError`:
+
+```typescript
+class MochiSupervisorFailure extends AggregateError {
+  constructor(errors: unknown[]) {
+    super(errors, "MochiSupervisor: one or more child agents failed");
+    this.name = "MochiSupervisorFailure";
+  }
+}
+```
+
+`AggregateError` is ES2021, native on all four runtimes. It matches MEP-51's `ExceptionGroup` story and is the canonical multi-error type in JavaScript.
+
+**Surface to user**: `await supervisor.run()` returns `MochiResult.Ok(())` if all children completed successfully, or `MochiResult.Err(new MochiSupervisorFailure([...]))` on failure. The MochiResult wrapper is Phase 11; Phase 9 emits the bare `AggregateError` and Phase 11 wires it through.
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/colour/colour.go` | Sync/async colour pass (full activation, formerly trivial in Phase 1 to 8); seeds: agent intent handlers, calls to async functions, AsyncIterable consumers |
+| `transpiler3/typescript/lower/agents.go` | Agent decl to MochiAgent subclass; message variant union; cast/call methods |
+| `transpiler3/typescript/lower/supervisor.go` | Supervisor spawn lowering; AbortController plumbing |
+| `runtime3/typescript/src/concurrency/queue.ts` | `AsyncIterableQueue<T>` |
+| `runtime3/typescript/src/concurrency/agent.ts` | `MochiAgent<Msg>` base class |
+| `runtime3/typescript/src/concurrency/supervisor.ts` | `MochiSupervisor` with one_for_all / one_for_one |
+| `transpiler3/typescript/build/phase09_test.go` | `TestPhase9Agents` |
+| `tests/transpiler3/typescript/fixtures/phase09-agents/` | 35 fixtures (counter, adder, balance, switch_agent, supervisor_one_for_all, etc.) |
+
+## Test set
+
+- `TestPhase9Agents`, 35 fixtures four-runtime.
+- `TestPhase9NoFloatingPromise`, eslint `no-floating-promises: error` against every emitted file.
+- `TestPhase9SupervisorAggregate`, fixture spawns two children, one fails, parent surfaces `AggregateError([err1, err2])`.
+- `TestPhase9ConcurrencyBudget`, `@mochi/runtime/concurrency/` stays under 8 KB gzipped.
+
+## Deferred work
+
+- `one_for_one` strategy. Sub-phase 9.3.1.
+- Per-call timeouts. v1.5.
+- Distributed agents (remote mailbox via WebSocket). Out of scope.
+- Persistent agents (durable mailbox via IndexedDB or SQLite). Out of scope.
+- Hot reload (`agent_replace_state`). MEP-46 territory; not in MEP-52 v1.

--- a/website/docs/implementation/0052/phase-10-streams.md
+++ b/website/docs/implementation/0052/phase-10-streams.md
@@ -1,0 +1,200 @@
+---
+title: "Phase 10. Streams"
+sidebar_position: 11
+sidebar_label: "Phase 10. Streams"
+description: "MEP-52 Phase 10, Mochi streams as AsyncIterable<T> / AsyncGenerator<T, void, undefined>; cold/hot patterns; multicast broadcaster; back-pressure via for-await pull semantics; 25 fixtures."
+---
+
+# Phase 10. Streams
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 10](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase10Streams`: 25 fixtures green on Node 22, Deno 2, Bun 1.1, Chromium 130. Secondary gate: tsc strict zero diagnostics; the streams runtime additions (broadcaster, take, drop, buffer, debounce) stay under 4 KB gzipped on top of Phase 9's concurrency budget.
+
+## Goal-alignment audit
+
+Mochi streams are typed asynchronous sequences with cooperative back-pressure. MEP-49 maps them to Swift `AsyncStream`, MEP-50 to Kotlin `Flow` + `Channel`, MEP-51 to Python `AsyncIterator`. The TypeScript surface offers `AsyncIterable<T>` and its async-generator literal (`async function* () { yield ... }`). MEP-52 commits to `AsyncIterable<T>` (or the more specific `AsyncGenerator<T, void, undefined>` when the source is a literal generator). The pull-based `for await` semantics give back-pressure automatically: the producer awaits the consumer at each yield.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 10.0 | Cold streams: `async function* () { ... }` literal lowering; `for await` consumption | NOT STARTED | n/a |
+| 10.1 | Hot streams: `MochiBroadcaster<T>` for multi-subscriber fan-out from a single producer | NOT STARTED | n/a |
+| 10.2 | Stream operators: `take(n)`, `drop(n)`, `buffer(n)`, `debounce(ms)`, `throttle(ms)`, `map`, `filter` | NOT STARTED | n/a |
+| 10.3 | Stream lifecycle: `AbortSignal` propagation for cancellation; cleanup via `try { ... } finally { ... }` in the generator body | NOT STARTED | n/a |
+| 10.4 | Interop: `AsyncIterable<T>` to `ReadableStream<T>` adapter for Web Streams (used by `fetch.body` consumers); reverse adapter | NOT STARTED | n/a |
+
+## Sub-phase 10.0, Cold streams
+
+### Decisions made (10.0)
+
+**Mochi**: `stream fun ticks() -> stream<int> { for i in 0.. { yield i; sleep(1s) } }`
+
+**TypeScript**:
+
+```typescript
+export async function* ticks(): AsyncGenerator<bigint, void, undefined> {
+  for (let i = 0n; ; i++) {
+    yield i;
+    await sleep(1000n);
+  }
+}
+```
+
+**Why `AsyncGenerator<T, void, undefined>` rather than `AsyncIterable<T>`**: the generator literal form has the more specific type. The emitter uses the specific type at declaration sites; consumers that don't care can accept `AsyncIterable<T>` (the wider type) via TypeScript's structural subtyping.
+
+**Cold means**: each `for await (const t of ticks())` invocation calls `ticks()` afresh, creating a new generator. The generator's state is local; multiple consumers get independent sequences (each starts at 0n).
+
+**`sleep(1s)`**: lowers to `await new Promise((r) => setTimeout(r, 1000n))`. The Mochi `1s` literal is a `duration` (Phase 14 binds it to Temporal); Phase 10 ships a bare-millisecond fallback (`sleep(1000n)`) and Phase 14 upgrades to `sleep(Temporal.Duration.from({seconds: 1}))`.
+
+## Sub-phase 10.1, Hot streams (broadcaster)
+
+### Decisions made (10.1)
+
+**`MochiBroadcaster<T>`**: multi-subscriber fan-out from a single producer. Each subscriber gets its own `AsyncIterableQueue<T>` that the broadcaster pushes into.
+
+```typescript
+// @mochi/runtime/concurrency/broadcaster
+export class MochiBroadcaster<T> {
+  private readonly subscribers: Set<AsyncIterableQueue<T>> = new Set();
+
+  subscribe(): AsyncIterable<T> {
+    const q = new AsyncIterableQueue<T>();
+    this.subscribers.add(q);
+    return {
+      [Symbol.asyncIterator]: () => {
+        const iter = q[Symbol.asyncIterator]();
+        return {
+          next: () => iter.next(),
+          return: async () => {
+            this.subscribers.delete(q);
+            q.close();
+            return { value: undefined, done: true };
+          },
+        };
+      },
+    };
+  }
+
+  publish(value: T): void {
+    for (const s of this.subscribers) s.push(value);
+  }
+
+  close(): void {
+    for (const s of this.subscribers) s.close();
+    this.subscribers.clear();
+  }
+}
+```
+
+**Why a `Set` of queues**: each subscriber has independent back-pressure. A slow subscriber buffers in its own queue without slowing the producer or the other subscribers. Bounded queues per subscriber are an opt-in.
+
+**Replay semantics**: not provided in Phase 10 (would need to keep history; bounded buffer would be ambiguous). Replay broadcaster is a v1.5 add.
+
+## Sub-phase 10.2, Stream operators
+
+### Decisions made (10.2)
+
+Stream operators are pure async generators that wrap a source:
+
+```typescript
+// @mochi/runtime/concurrency/operators
+export async function* take<T>(source: AsyncIterable<T>, n: bigint): AsyncGenerator<T, void, undefined> {
+  let i = 0n;
+  for await (const v of source) {
+    if (i >= n) return;
+    yield v;
+    i++;
+  }
+}
+
+export async function* drop<T>(source: AsyncIterable<T>, n: bigint): AsyncGenerator<T, void, undefined> {
+  let i = 0n;
+  for await (const v of source) {
+    if (i++ < n) continue;
+    yield v;
+  }
+}
+
+export async function* mapStream<T, U>(
+  source: AsyncIterable<T>, f: (v: T) => U | Promise<U>,
+): AsyncGenerator<U, void, undefined> {
+  for await (const v of source) yield await f(v);
+}
+
+export async function* filterStream<T>(
+  source: AsyncIterable<T>, p: (v: T) => boolean | Promise<boolean>,
+): AsyncGenerator<T, void, undefined> {
+  for await (const v of source) if (await p(v)) yield v;
+}
+```
+
+`buffer(n)` and `debounce(ms)` are timing-sensitive; implementations use `AsyncIterableQueue` plus `setTimeout`. The full set lives in `@mochi/runtime/concurrency/operators/`.
+
+## Sub-phase 10.3, Lifecycle and cancellation
+
+### Decisions made (10.3)
+
+**`AbortSignal` propagation**: a stream operator that takes a `signal: AbortSignal` exits early when `signal.aborted` becomes true. The generator's `try/finally` runs cleanup (closing inner queues, releasing handles).
+
+**Generator `return`**: when the consumer's `for await` exits early (via `break`, `return`, or an exception), the generator's `return()` is called. The async-generator body's `try/finally` runs at that point. This is the canonical cleanup hook.
+
+**Mochi `defer` in a stream**: lowers to a `try/finally` wrapping the generator body.
+
+## Sub-phase 10.4, Web Streams interop
+
+### Decisions made (10.4)
+
+**`asyncIterableToReadableStream(source: AsyncIterable<T>): ReadableStream<T>`**:
+
+```typescript
+export function asyncIterableToReadableStream<T>(source: AsyncIterable<T>): ReadableStream<T> {
+  const iter = source[Symbol.asyncIterator]();
+  return new ReadableStream<T>({
+    async pull(controller) {
+      const { value, done } = await iter.next();
+      if (done) { controller.close(); return; }
+      controller.enqueue(value);
+    },
+    async cancel(reason) {
+      if (typeof iter.return === "function") await iter.return(reason);
+    },
+  });
+}
+```
+
+**Reverse adapter `readableStreamToAsyncIterable`**: `ReadableStream<T>` is already async-iterable in Node 22, Deno 2, Bun 1.1, and Chromium 124+ (the `Symbol.asyncIterator` was added to the spec in 2024). The reverse adapter is a no-op except on older Chromium where the emitter falls back to a manual `reader.read()` loop. Phase 10's runtime floor (Chromium 130) does not need the fallback.
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/lower/streams.go` | Stream decl to `async function*` generator; `yield` lowering |
+| `transpiler3/typescript/lower/forAwait.go` | `for await` consumption form |
+| `runtime3/typescript/src/concurrency/broadcaster.ts` | `MochiBroadcaster<T>` |
+| `runtime3/typescript/src/concurrency/operators/` | take, drop, buffer, debounce, throttle, map, filter |
+| `runtime3/typescript/src/concurrency/interop.ts` | AsyncIterable to/from ReadableStream adapters |
+| `transpiler3/typescript/build/phase10_test.go` | `TestPhase10Streams` |
+| `tests/transpiler3/typescript/fixtures/phase10-streams/` | 25 fixtures |
+
+## Test set
+
+- `TestPhase10Streams`, 25 fixtures four-runtime.
+- `TestPhase10Cancellation`, fixtures that abort mid-stream confirm cleanup runs.
+- `TestPhase10WebStreamsInterop`, an `AsyncIterable` round-trips through `ReadableStream` byte-equal.
+
+## Deferred work
+
+- Replay broadcaster (subscribers receive history on subscribe). v1.5.
+- Hot/cold operator catalogue expansion (`scan`, `share`, `switchMap`). Phase 10 ships the core 8 operators; expansion is on-demand.
+- Backpressure-aware sinks (`pipeTo` with explicit credit). The default for-await pull is sufficient for the v1 corpus.

--- a/website/docs/implementation/0052/phase-11-async.md
+++ b/website/docs/implementation/0052/phase-11-async.md
@@ -1,0 +1,188 @@
+---
+title: "Phase 11. async coloring + MochiResult"
+sidebar_position: 12
+sidebar_label: "Phase 11. async + MochiResult"
+description: "MEP-52 Phase 11, async/await colour pass fully active across the compiler; MochiResult<T, E> Ok/Err discriminated union for error handling; AggregateError for multi-error sites; 30 fixtures."
+---
+
+# Phase 11. async coloring, MochiResult, AggregateError
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 11](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase11Async`: 30 fixtures green on Node 22, Deno 2, Bun 1.1, Chromium 130. Secondary gates: tsc strict zero diagnostics including `useUnknownInCatchVariables` (Mochi never lowers a `catch (e)` arm to non-`unknown` type); eslint `@typescript-eslint/no-misused-promises` and `await-thenable` enforced; `no-floating-promises: error` covers every `async` site.
+
+## Goal-alignment audit
+
+Phase 11 is the convergence point for three threads. (1) The async colour pass that was trivially "all Blue" in Phase 1-8 and got its first real activation in Phase 9 (agents) and Phase 10 (streams) now sees the full compiler surface: any function transitively calling an async function (agent intent, stream consumer, `fetch`, `sleep`, `llm.generate`) is coloured Red and emitted as `async`. (2) MochiResult replaces exception throwing for recoverable errors: Mochi functions that declare `throws` lower to `(...) => Promise<MochiResult<T, E>>` or `(...) => MochiResult<T, E>`. (3) AggregateError wires through from Phase 9's supervisor failure to the user's `await call(...)` site.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 11.0 | Async colour pass full activation; call-graph build; fixed-point colour propagation; `async function`/`function` choice at emit time | NOT STARTED | n/a |
+| 11.1 | `MochiResult<T, E>` discriminated union + Ok/Err constructors emitted into `@mochi/runtime/result` | NOT STARTED | n/a |
+| 11.2 | `fun parse() -> AST throws ParseError` to `function parse(): MochiResult<AST, ParseError>` (sync) or `Promise<MochiResult<AST, ParseError>>` (async) | NOT STARTED | n/a |
+| 11.3 | `?` short-circuit (`let x = parse(s)?` to `case "err" return err; case "ok" let x = result.value`) lowered to early `return` from the calling MochiResult | NOT STARTED | n/a |
+| 11.4 | `panic` to `throw new MochiPanic(msg)`; never caught at the Mochi layer; treated as a hard failure at the host runtime | NOT STARTED | n/a |
+| 11.5 | `AggregateError` wiring: supervisor `MochiSupervisorFailure` surfaces as `MochiResult.Err(AggregateError)` to user code | NOT STARTED | n/a |
+
+## Sub-phase 11.0, Async colour pass
+
+### Decisions made (11.0)
+
+**Pass location**: `transpiler3/typescript/colour/colour.go`, runs between aotir and lower (same slot as MEP-48's pass).
+
+**Algorithm**:
+
+1. Build call graph: nodes are functions; edges are calls.
+2. Seed Red: any function containing `await`, `for await`, an agent `call`, a `fetch`, a `sleep`, or any access to an `AsyncIterable<T>`/`Promise<T>` value.
+3. Fixed-point: a Blue function that calls a Red function becomes Red. Repeat until convergence.
+4. Produce `ColourMap`.
+
+**Emit choice**: Red functions emit as `async function f(...): Promise<R>` (module scope) or `async (...): Promise<R> => {...}` (inline). Blue functions stay sync.
+
+**Top-level await**: if the entry-point `main` is Red, `src/index.ts` becomes `await main()`. Top-level await is ESM-only and supported on all four tier-1 runtimes.
+
+**Forbidden mixings**: a Blue function may not call a Red function (would need to await). The colour pass is the enforcer; any such case is a transpiler bug.
+
+## Sub-phase 11.1, MochiResult shape
+
+### Decisions made (11.1)
+
+**Type and constructors** (per MEP-52 §6):
+
+```typescript
+// @mochi/runtime/result
+export type MochiResult<T, E> =
+  | { readonly kind: "ok"; readonly value: T }
+  | { readonly kind: "err"; readonly error: E };
+
+export const Ok = <T>(value: T): MochiResult<T, never> => ({ kind: "ok", value });
+export const Err = <E>(error: E): MochiResult<never, E> => ({ kind: "err", error });
+
+export function isOk<T, E>(r: MochiResult<T, E>): r is { kind: "ok"; value: T } {
+  return r.kind === "ok";
+}
+export function isErr<T, E>(r: MochiResult<T, E>): r is { kind: "err"; error: E } {
+  return r.kind === "err";
+}
+```
+
+**Variance**: `MochiResult<T, never>` produced by `Ok` is assignable to `MochiResult<T, AnyE>` thanks to the `never` bottom type; same for `MochiResult<never, E>` from `Err`. This is the canonical "Either" trick in TypeScript.
+
+## Sub-phase 11.2, throws to MochiResult
+
+### Decisions made (11.2)
+
+**Mochi**: `fun parse(s: string) -> AST throws ParseError { ... }`
+
+**TypeScript** (sync):
+
+```typescript
+import { MochiResult, Ok, Err } from "@mochi/runtime/result";
+import { AST } from "./ast.ts";
+import { ParseError } from "./parse_error.ts";
+
+export function parse(s: string): MochiResult<AST, ParseError> {
+  if (s === "") return Err(new ParseError("empty input"));
+  // ...
+  return Ok(ast);
+}
+```
+
+**TypeScript** (async, when the function transitively awaits): wrap the return type in `Promise<...>`.
+
+**Why MochiResult instead of `throw`**: thrown exceptions in TypeScript have type `unknown` (under `useUnknownInCatchVariables`). They are also implicit in the function signature, which loses information for the caller. MochiResult makes failure explicit at the type level, matches Rust's `Result` and Mochi's spec, and never crosses the FFI boundary by surprise.
+
+**`throw` reserved for `panic`**: Mochi `panic msg` lowers to `throw new MochiPanic(msg)`. The runtime never catches `MochiPanic`; the host runtime terminates the process (or for browsers, surfaces it to `window.onerror`).
+
+## Sub-phase 11.3, ? operator
+
+### Decisions made (11.3)
+
+**Mochi**: `let x = parse(s)?`
+
+**TypeScript**:
+
+```typescript
+const __r = parse(s);
+if (__r.kind === "err") return __r;
+const x = __r.value;
+```
+
+(The early `return __r` returns the same `MochiResult.Err` shape to the caller, propagating the error type as long as the caller's `E` is compatible. The colour pass plus type checker enforce compatibility.)
+
+**Inside `async`**: same shape, but `__r = await parse(s)` if `parse` is Red.
+
+## Sub-phase 11.4, panic
+
+### Decisions made (11.4)
+
+**`MochiPanic`**:
+
+```typescript
+// @mochi/runtime/panic
+export class MochiPanic extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MochiPanic";
+  }
+}
+```
+
+**Mochi `panic "..."`**: `throw new MochiPanic("...")`.
+
+**Never caught**: Mochi has no `try { ... } catch (panic) { ... }` form. The host runtime treats it as a hard failure: Node terminates with exit code 1, Deno same, Bun same. Browser surfaces to `window.onerror`. The emitter rejects any user code that tries to catch `MochiPanic`.
+
+## Sub-phase 11.5, AggregateError wiring
+
+### Decisions made (11.5)
+
+The Phase 9 supervisor failure (`MochiSupervisorFailure extends AggregateError`) wraps in `MochiResult.Err`:
+
+```typescript
+const result: MochiResult<void, MochiSupervisorFailure> = await supervisor.run();
+if (result.kind === "err") {
+  for (const inner of result.error.errors) {
+    console.error("child failure:", inner);
+  }
+}
+```
+
+The `AggregateError.errors` field gives the user direct access to inner failures. Standard JavaScript: every tier-1 runtime supports `instanceof AggregateError`.
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/colour/colour.go` | Full async colour pass (already stubbed in Phase 9); now exercises every emit site |
+| `transpiler3/typescript/colour/graph.go` | Call graph build from aotir |
+| `transpiler3/typescript/colour/fixpoint.go` | Fixed-point iteration with seed set |
+| `transpiler3/typescript/lower/result.go` | `throws` to MochiResult; `?` to early return |
+| `transpiler3/typescript/lower/panic.go` | `panic` to `throw new MochiPanic` |
+| `runtime3/typescript/src/result/index.ts` | `MochiResult<T, E>`, Ok, Err, isOk, isErr |
+| `runtime3/typescript/src/panic/index.ts` | `MochiPanic` class |
+| `transpiler3/typescript/build/phase11_test.go` | `TestPhase11Async` |
+| `tests/transpiler3/typescript/fixtures/phase11-async/` | 30 fixtures |
+
+## Test set
+
+- `TestPhase11Async`, 30 fixtures four-runtime.
+- `TestPhase11NoCatchPanic`, asserts emitted code never `catch`es `MochiPanic`.
+- `TestPhase11AggregateError`, supervisor failure surfaces `AggregateError` to user code.
+- `TestPhase11ColourSoundness`, hand-edited fixture that calls a Red function from Blue context fails at emit time with an explicit error.
+
+## Deferred work
+
+- `try/catch/finally` for FFI boundaries (where C code throws). Phase 12 (FFI) reintroduces the bounded form.
+- `MochiResult.map`, `flatMap`, `andThen` combinators. v1.5; the `?` operator covers the v1 needs.
+- Cancellable async sites (per-call `AbortSignal` plumbing). Phase 14 (fetch) lands the fetch-side; broader cancellation is v1.5.

--- a/website/docs/implementation/0052/phase-12-ffi.md
+++ b/website/docs/implementation/0052/phase-12-ffi.md
@@ -1,0 +1,186 @@
+---
+title: "Phase 12. FFI"
+sidebar_position: 13
+sidebar_label: "Phase 12. FFI"
+description: "MEP-52 Phase 12, Mochi extern fun to Node N-API + Deno FFI + Bun FFI runtime-dispatched call; pure-TS FFI via npm imports with DefinitelyTyped stubs; browser rejection at codegen; 20 fixtures."
+---
+
+# Phase 12. FFI
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 12](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase12FFI`: 20 fixtures green on Node 22, Deno 2, Bun 1.1 (browser is skipped: FFI is rejected at codegen under `--target=browser-bundle`). Secondary gates: tsc strict zero diagnostics including the typed-FFI declarations; the optional native-bindings packages (`@mochi/runtime-native-{node,deno,bun}`) build cleanly on x86_64-linux-gnu, aarch64-linux-gnu, aarch64-darwin.
+
+## Goal-alignment audit
+
+FFI is how Mochi reaches C, Rust, Zig, or any shared-library symbol that the JavaScript runtime cannot expose natively. Each tier-1 runtime exposes a different FFI surface: Node's stable interface is N-API via a pre-compiled `.node` addon; Deno's is `Deno.dlopen(path, symbols)`; Bun's is `bun:ffi` (`dlopen`, `CFunction`, `JSCallback`). MEP-52 surfaces a single `extern fun ...` declaration that compiles to a typed wrapper which dispatches at runtime to the appropriate backend, plus optional pre-built `@mochi/runtime-native-{node,deno,bun}` packages users opt into when native acceleration is needed.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 12.0 | Runtime detection: `mochiRuntime()` returns `"node" \| "deno" \| "bun" \| "browser"` via `globalThis` probes | NOT STARTED | n/a |
+| 12.1 | C-library FFI: `extern fun ...` lowers to a typed wrapper that dispatches to Node N-API, Deno `dlopen`, or Bun `bun:ffi` per runtime | NOT STARTED | n/a |
+| 12.2 | Pure-TS FFI: `extern fun foo(...) -> ... from "npm-package"` to direct `import { foo } from "npm-package"` plus typed wrapper | NOT STARTED | n/a |
+| 12.3 | Browser rejection: `--target=browser-bundle` errors at codegen if any `extern fun` from a C library is reachable | NOT STARTED | n/a |
+| 12.4 | Optional native packages `@mochi/runtime-native-{node,deno,bun}` with prebuilt binaries | NOT STARTED | n/a |
+
+## Sub-phase 12.0, Runtime detection
+
+### Decisions made (12.0)
+
+```typescript
+// @mochi/runtime/runtime
+export type RuntimeName = "node" | "deno" | "bun" | "browser";
+
+export function mochiRuntime(): RuntimeName {
+  if (typeof (globalThis as any).Deno !== "undefined") return "deno";
+  if (typeof (globalThis as any).Bun !== "undefined") return "bun";
+  if (typeof (globalThis as any).process !== "undefined" &&
+      typeof (globalThis as any).process.versions?.node === "string") return "node";
+  return "browser";
+}
+```
+
+Probe order matters: Bun defines `process.versions.node` for compatibility, so Bun's own marker must be checked first. Same for Deno (which also implements `process` partially).
+
+**Inlining**: most FFI dispatch sites read `mochiRuntime()` once at module load and store the choice in a `const` for reuse. The emitter generates this idiom at any module that references FFI.
+
+## Sub-phase 12.1, C-library FFI
+
+### Decisions made (12.1)
+
+**Mochi**: `extern fun lz4_compress(input: bytes) -> bytes from "liblz4.so"`
+
+**TypeScript wrapper**:
+
+```typescript
+// src/generated/lz4.ts (emitted)
+import { mochiRuntime } from "@mochi/runtime/runtime";
+
+interface Lz4Backend {
+  compress(input: Uint8Array): Uint8Array;
+}
+
+let backend: Lz4Backend | undefined;
+async function loadBackend(): Promise<Lz4Backend> {
+  if (backend !== undefined) return backend;
+  switch (mochiRuntime()) {
+    case "node": {
+      const mod = await import("@mochi/runtime-native-node/lz4");
+      backend = mod.default;
+      break;
+    }
+    case "deno": {
+      const lib = (globalThis as any).Deno.dlopen("liblz4.so", {
+        LZ4_compress_default: { parameters: ["pointer", "pointer", "i32", "i32"], result: "i32" },
+      });
+      backend = { compress: (input) => /* call lib.symbols.LZ4_compress_default */ };
+      break;
+    }
+    case "bun": {
+      const { dlopen, FFIType } = await import("bun:ffi");
+      const { symbols } = dlopen("liblz4.so", {
+        LZ4_compress_default: { args: [FFIType.ptr, FFIType.ptr, FFIType.i32, FFIType.i32], returns: FFIType.i32 },
+      });
+      backend = { compress: (input) => /* call symbols.LZ4_compress_default */ };
+      break;
+    }
+    case "browser":
+      throw new Error("FFI not available in browser bundle");
+  }
+  return backend!;
+}
+
+export async function lz4_compress(input: Uint8Array): Promise<Uint8Array> {
+  const b = await loadBackend();
+  return b.compress(input);
+}
+```
+
+**Why per-runtime branch in the emitted file**: bundlers tree-shake the unreachable branches under the `"browser"` export condition, so the browser bundle never contains the Node or Bun FFI code paths. For Node, Deno, and Bun the file ships intact; the runtime detection routes once per process.
+
+**Calling convention**: pointers, ints, floats, structs follow each backend's native marshalling. The emitter generates the marshalling per declared signature; complex (struct) types route through a runtime helper that uses `DataView` for cross-runtime portability.
+
+## Sub-phase 12.2, Pure-TS FFI
+
+### Decisions made (12.2)
+
+**Mochi**: `extern fun stripe_charge(req: ChargeReq) -> ChargeResp from npm "stripe"`
+
+**TypeScript**:
+
+```typescript
+import Stripe from "stripe";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? "");
+
+export async function stripe_charge(req: ChargeReq): Promise<ChargeResp> {
+  const c = await stripe.charges.create(req);
+  return { id: c.id, status: c.status };
+}
+```
+
+Type stubs come from DefinitelyTyped (`@types/stripe`) or the package's own `.d.ts`. The Mochi-side `extern fun` declaration must list the field types so the emitter can generate the marshalling on both sides.
+
+**`package.json` dependency**: pure-TS FFI declarations register the npm package as a Mochi-side dependency; the emitter writes it into the emitted `package.json` `dependencies` map.
+
+## Sub-phase 12.3, Browser rejection
+
+### Decisions made (12.3)
+
+`--target=browser-bundle` runs a reachability check from the user's entry point. If any reachable `extern fun` declares a C-library backend (not pure-TS), codegen errors:
+
+```
+error: FFI declaration `lz4_compress from "liblz4.so"` is reachable from main but
+cannot run in the browser. Either gate the call behind `if mochiRuntime() != "browser"`
+or move the call to a Node/Deno/Bun-only sub-module.
+```
+
+Pure-TS FFI declarations (via `npm`) pass the check; they are normal imports as far as the bundler is concerned.
+
+## Sub-phase 12.4, Native package binaries
+
+### Decisions made (12.4)
+
+`@mochi/runtime-native-node`: Node N-API addon. Compiled via `node-gyp` or `cmake-js`. Prebuilt binaries (`linux-x64.node`, `linux-arm64.node`, `darwin-arm64.node`, `win32-x64.node`) shipped via the `prebuildify` pattern; the package's `index.js` picks the right binary at install.
+
+`@mochi/runtime-native-bun`: Bun FFI binding scripts in TypeScript; no compile step needed at install (Bun FFI dlopens at runtime).
+
+`@mochi/runtime-native-deno`: Deno FFI binding scripts in TypeScript; no compile step needed at install.
+
+**Each is a separate npm package the user opts into**. The default `@mochi/runtime` has zero native dependencies; users invoking `extern fun` on a C library must `npm install @mochi/runtime-native-node` (or the relevant runtime's package).
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/lower/ffi.go` | `extern fun` to per-backend dispatch wrapper |
+| `transpiler3/typescript/lower/ffi_reachability.go` | Browser-target reachability check |
+| `runtime3/typescript/src/runtime/index.ts` | `mochiRuntime()` probe |
+| `runtime3/typescript-native-node/` | Node N-API addon source (separate package) |
+| `runtime3/typescript-native-bun/` | Bun FFI bindings |
+| `runtime3/typescript-native-deno/` | Deno FFI bindings |
+| `transpiler3/typescript/build/phase12_test.go` | `TestPhase12FFI` |
+| `tests/transpiler3/typescript/fixtures/phase12-ffi/` | 20 fixtures |
+
+## Test set
+
+- `TestPhase12FFI`, 20 fixtures Node + Deno + Bun (browser skipped).
+- `TestPhase12BrowserRejection`, a fixture using `extern fun` from a C library is rejected at codegen under `--target=browser-bundle`.
+- `TestPhase12NativeBuild`, `@mochi/runtime-native-node` builds cleanly on linux-x64, linux-arm64, darwin-arm64.
+
+## Deferred work
+
+- WebAssembly backend (`extern fun` from a `.wasm` module). Open Q7 (v2 candidate).
+- Async FFI (`bun:ffi` supports `async` symbols since 1.1; Deno FFI has `nonblocking: true`). Phase 12 ships sync FFI; async is v1.5.
+- Cross-runtime ABI normalisation for struct passing. Phase 12 ships the simple int/ptr/u8-array path; struct ABI is v1.5.

--- a/website/docs/implementation/0052/phase-13-llm.md
+++ b/website/docs/implementation/0052/phase-13-llm.md
@@ -1,0 +1,195 @@
+---
+title: "Phase 13. LLM"
+sidebar_position: 14
+sidebar_label: "Phase 13. LLM"
+description: "MEP-52 Phase 13, Mochi llm.generate to @mochi/runtime/llm provider dispatch (OpenAI, Anthropic, Mistral, Cohere, Google Gemini, local llama.cpp via HTTP); browser opt-in with user-supplied key; 10 fixtures."
+---
+
+# Phase 13. LLM
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 13](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase13LLM`: 10 fixtures green on Node 22, Deno 2, Bun 1.1. Browser is gated behind an explicit `--allow-browser-llm` flag (per MEP-52 §Security: no API keys baked into a browser bundle by default). Secondary gates: tsc strict zero diagnostics; provider dispatch budget (runtime addition stays under 4 KB gzipped); no logged API keys (eslint rule `no-console` with allowlist of `console.error` only, plus a custom rule that rejects any log call referencing a value sourced from `process.env`).
+
+## Goal-alignment audit
+
+`llm.generate` is Mochi's portable LLM call. The TS surface has no built-in LLM client; each provider (OpenAI, Anthropic, etc.) ships its own SDK on npm. MEP-52 ships `@mochi/runtime/llm` as a thin provider-dispatch table that reads API keys from environment variables (Node/Bun: `process.env`, Deno: `Deno.env.get`, browser: rejected unless the user explicitly opted in). The dispatch keeps Mochi user code provider-agnostic: a single `llm.generate(prompt)` call routes to whichever provider is configured.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 13.0 | `@mochi/runtime/llm` provider-dispatch table; provider read from `MOCHI_LLM_PROVIDER` env var (default `"openai"`) | NOT STARTED | n/a |
+| 13.1 | OpenAI provider via `fetch` against `api.openai.com/v1/chat/completions` (no `openai` npm dep; pure fetch) | NOT STARTED | n/a |
+| 13.2 | Anthropic provider via `fetch` against `api.anthropic.com/v1/messages` (claude-sonnet-4-6 default; configurable via `MOCHI_LLM_MODEL`) | NOT STARTED | n/a |
+| 13.3 | Streaming via SSE: `for await (const chunk of llm.stream(prompt))` lowers to a `fetch` with `stream: true` then SSE parsing | NOT STARTED | n/a |
+| 13.4 | Browser opt-in: `--allow-browser-llm` flag is required at codegen; the emitter injects a runtime check that the user has provided a key | NOT STARTED | n/a |
+
+## Sub-phase 13.0, Provider dispatch
+
+### Decisions made (13.0)
+
+```typescript
+// @mochi/runtime/llm
+export type Provider = "openai" | "anthropic" | "mistral" | "cohere" | "gemini" | "local";
+
+export type GenerateOptions = {
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+  systemPrompt?: string;
+};
+
+export async function generate(
+  prompt: string,
+  opts: GenerateOptions = {},
+): Promise<string> {
+  const provider = (envGet("MOCHI_LLM_PROVIDER") ?? "openai") as Provider;
+  switch (provider) {
+    case "openai":    return openaiGenerate(prompt, opts);
+    case "anthropic": return anthropicGenerate(prompt, opts);
+    case "mistral":   return mistralGenerate(prompt, opts);
+    case "cohere":    return cohereGenerate(prompt, opts);
+    case "gemini":    return geminiGenerate(prompt, opts);
+    case "local":     return localGenerate(prompt, opts);
+  }
+}
+
+function envGet(name: string): string | undefined {
+  if (typeof (globalThis as any).Deno !== "undefined") {
+    return (globalThis as any).Deno.env.get(name);
+  }
+  if (typeof (globalThis as any).process !== "undefined") {
+    return (globalThis as any).process.env[name];
+  }
+  return undefined;
+}
+```
+
+**Env-var key reading**: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRAL_API_KEY`, `COHERE_API_KEY`, `GEMINI_API_KEY`. The dispatch table reads only when its provider is selected, never logs the key, and never serialises it. The browser path rejects at runtime (and at codegen unless `--allow-browser-llm` is passed).
+
+## Sub-phase 13.1, OpenAI provider
+
+### Decisions made (13.1)
+
+```typescript
+async function openaiGenerate(prompt: string, opts: GenerateOptions): Promise<string> {
+  const key = envGet("OPENAI_API_KEY");
+  if (key === undefined) throw new Error("OPENAI_API_KEY not set");
+  const r = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${key}` },
+    body: JSON.stringify({
+      model: opts.model ?? "gpt-4o-mini",
+      messages: [
+        ...(opts.systemPrompt ? [{ role: "system", content: opts.systemPrompt }] : []),
+        { role: "user", content: prompt },
+      ],
+      temperature: opts.temperature,
+      max_tokens: opts.maxTokens,
+    }),
+  });
+  if (!r.ok) throw new Error(`openai: ${r.status} ${await r.text()}`);
+  const json = await r.json() as { choices: Array<{ message: { content: string } }> };
+  return json.choices[0]?.message.content ?? "";
+}
+```
+
+**No npm SDK dependency**: the OpenAI npm SDK is roughly 200 KB minified and pulls additional transitive deps. A direct `fetch` against the published REST API is roughly 30 lines, fully typed, zero deps.
+
+## Sub-phase 13.2, Anthropic provider
+
+### Decisions made (13.2)
+
+```typescript
+async function anthropicGenerate(prompt: string, opts: GenerateOptions): Promise<string> {
+  const key = envGet("ANTHROPIC_API_KEY");
+  if (key === undefined) throw new Error("ANTHROPIC_API_KEY not set");
+  const r = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": key,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: opts.model ?? "claude-sonnet-4-6",
+      max_tokens: opts.maxTokens ?? 1024,
+      ...(opts.systemPrompt ? { system: opts.systemPrompt } : {}),
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+  if (!r.ok) throw new Error(`anthropic: ${r.status} ${await r.text()}`);
+  const json = await r.json() as { content: Array<{ text: string }> };
+  return json.content[0]?.text ?? "";
+}
+```
+
+**Default model**: `claude-sonnet-4-6`. Overridable via `MOCHI_LLM_MODEL` or `opts.model`.
+
+## Sub-phase 13.3, Streaming
+
+### Decisions made (13.3)
+
+```typescript
+export async function* stream(prompt: string, opts: GenerateOptions = {}): AsyncGenerator<string, void, undefined> {
+  // dispatch to provider's streaming endpoint and parse SSE
+  // ...
+}
+```
+
+SSE parsing: split on `\n\n`, parse `data: {...}` JSON, yield the incremental content delta. Each provider has a slightly different SSE shape; the dispatch routes to the per-provider parser.
+
+**Use site**:
+
+```typescript
+for await (const chunk of stream("hello")) {
+  console.log(chunk);
+}
+```
+
+## Sub-phase 13.4, Browser opt-in
+
+### Decisions made (13.4)
+
+**Default**: `--target=browser-bundle` rejects at codegen if `llm.generate` is reachable. The error directs the user to either remove the call, gate it on `mochiRuntime() !== "browser"`, or pass `--allow-browser-llm`.
+
+**With `--allow-browser-llm`**: the emitter inlines a runtime check that the key is provided via `mochi.llm.setKey(provider, key)` rather than reading from `process.env`. The browser user is expected to source the key from their own credential store (BYOK pattern).
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/lower/llm.go` | `llm.generate` call to `@mochi/runtime/llm.generate` import + call |
+| `transpiler3/typescript/lower/llm_reachability.go` | Browser-target reachability check |
+| `runtime3/typescript/src/llm/index.ts` | Provider dispatch |
+| `runtime3/typescript/src/llm/openai.ts` | OpenAI fetch + SSE |
+| `runtime3/typescript/src/llm/anthropic.ts` | Anthropic fetch + SSE |
+| `runtime3/typescript/src/llm/mistral.ts` | Mistral |
+| `runtime3/typescript/src/llm/cohere.ts` | Cohere |
+| `runtime3/typescript/src/llm/gemini.ts` | Gemini |
+| `runtime3/typescript/src/llm/local.ts` | local llama.cpp via HTTP |
+| `transpiler3/typescript/build/phase13_test.go` | `TestPhase13LLM` |
+| `tests/transpiler3/typescript/fixtures/phase13-llm/` | 10 fixtures using a local mock server (no real API calls in CI) |
+
+## Test set
+
+- `TestPhase13LLM`, 10 fixtures Node + Deno + Bun against a local mock server (`tests/transpiler3/typescript/fixtures/phase13-llm/mock_server.js`).
+- `TestPhase13NoKeyLog`, asserts no emitted code logs a value sourced from `process.env`.
+- `TestPhase13BrowserReject`, the fixture using `llm.generate` is rejected under `--target=browser-bundle` without `--allow-browser-llm`.
+
+## Deferred work
+
+- Tool use / function calling. Mochi v2 sub-language; not in MEP-52 v1.
+- Multimodal (image, audio) input. v1.5.
+- Token streaming with structured output (JSON Schema parser). v1.5.
+- Prompt caching (Anthropic cache-control headers; OpenAI prompt-caching telemetry). Each provider has its own prompt-cache surface; the dispatch table forwards the relevant headers but Phase 13 ships without explicit cache-aware emit. v1.5.

--- a/website/docs/implementation/0052/phase-14-fetch.md
+++ b/website/docs/implementation/0052/phase-14-fetch.md
@@ -1,0 +1,164 @@
+---
+title: "Phase 14. fetch"
+sidebar_position: 15
+sidebar_label: "Phase 14. fetch"
+description: "MEP-52 Phase 14, Mochi fetch to platform built-in fetch (Node 18+, Deno, Bun, browser); WHATWG-compliant; HTTP/2 via undici on Node 22; streaming ReadableStream bodies; 15 fixtures."
+---
+
+# Phase 14. fetch
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 14](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase14Fetch`: 15 fixtures green on Node 22, Deno 2, Bun 1.1, Chromium 130 (browser fetches a same-origin endpoint served by the Playwright harness). Secondary gates: tsc strict zero diagnostics; no `node-fetch`, no `axios`, no `got`, no `undici` direct import (all live entirely behind the platform `fetch` global); TLS verification is on by default (no `verify=false` opt-out).
+
+## Goal-alignment audit
+
+Mochi `fetch(url, opts)` is the portable HTTP client. All four tier-1 runtimes ship WHATWG-compliant `fetch` as a global since Node 18 (stable), Deno 1.x, Bun 1.0, and every modern browser. MEP-52 wires Mochi fetch directly to that global. The runtime additions are minimal: a typed wrapper plus a couple of helpers for the streaming-body case and the Mochi `bytes` to `Uint8Array` round-trip. This is the lowest-friction phase among the 18: most of the work is testing the byte-level equivalence across runtimes.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 14.0 | `fetch(url)` to `fetch(url)`; await response; return `MochiHttpResponse {status, headers, body}` | NOT STARTED | n/a |
+| 14.1 | POST with body: bytes, string, JSON; `Content-Type` defaults | NOT STARTED | n/a |
+| 14.2 | Streaming responses: `response.body` is `ReadableStream<Uint8Array>`; expose as Mochi `stream<bytes>` via the Phase 10 adapter | NOT STARTED | n/a |
+| 14.3 | Headers: case-insensitive read/write via `Headers` standard API | NOT STARTED | n/a |
+| 14.4 | Errors: network errors throw `MochiPanic`; non-2xx returns the response (does not throw); the user dispatches on `response.status` | NOT STARTED | n/a |
+| 14.5 | Temporal: `time` and `duration` lowering to `Temporal.*` via the `@js-temporal/polyfill` (until native ships, Open Q4); used by `Cache-Control` parsing and `If-Modified-Since` emission | NOT STARTED | n/a |
+
+## Sub-phase 14.0, GET
+
+### Decisions made (14.0)
+
+**Mochi**: `let r = fetch("https://example.com/")`
+
+**TypeScript**:
+
+```typescript
+// @mochi/runtime/fetch
+export type MochiHttpResponse = {
+  readonly status: number;
+  readonly headers: Headers;
+  readonly body: Uint8Array;
+};
+
+export async function mochiFetch(url: string, opts: RequestInit = {}): Promise<MochiHttpResponse> {
+  const r = await fetch(url, opts);
+  const body = new Uint8Array(await r.arrayBuffer());
+  return { status: r.status, headers: r.headers, body };
+}
+```
+
+**Why a thin wrapper**: Mochi's spec returns `MochiHttpResponse` (a record with `status`, `headers`, `body`); raw `Response` exposes a streaming API that does not match. The wrapper buffers the body eagerly for the simple case; the streaming case (sub-phase 14.2) returns `Response` directly.
+
+## Sub-phase 14.1, POST with body
+
+### Decisions made (14.1)
+
+**Body**:
+
+- `bytes` Mochi to `Uint8Array` TS to `BodyInit` (TypedArray is a valid `BodyInit`).
+- `string` to `string` (UTF-8 encoded by `fetch` automatically).
+- JSON object: emitter inserts `JSON.stringify(...)` and sets `content-type: application/json` if not already set.
+
+```typescript
+await mochiFetch("https://example.com/api", {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ name: "alice" }),
+});
+```
+
+## Sub-phase 14.2, Streaming responses
+
+### Decisions made (14.2)
+
+**Mochi**: `for chunk in fetch_stream("https://...").body { ... }`
+
+**TypeScript**:
+
+```typescript
+const r = await fetch("https://...");
+if (r.body === null) throw new MochiPanic("response body is null");
+for await (const chunk of r.body) {
+  // chunk: Uint8Array
+}
+```
+
+`Response.body` is `ReadableStream<Uint8Array>`, which is async-iterable on all four runtimes since 2024. The Phase 10 adapter is not needed (the platform already exposes the iterator); the emitter uses the `for await` form directly.
+
+## Sub-phase 14.3, Headers
+
+### Decisions made (14.3)
+
+`Headers` API: case-insensitive `get`/`set`/`has`/`delete`/`append`. Mochi `r.headers["content-type"]` lowers to `r.headers.get("content-type") ?? ""` (the Mochi semantic returns empty string for missing headers; `Headers.get` returns `null`).
+
+## Sub-phase 14.4, Errors
+
+### Decisions made (14.4)
+
+**Network errors** (DNS failure, TCP reset, TLS error): `fetch` rejects with a `TypeError`. The emitter wraps in `MochiPanic`:
+
+```typescript
+let r: Response;
+try {
+  r = await fetch(url, opts);
+} catch (e) {
+  throw new MochiPanic(`fetch failed: ${String(e)}`);
+}
+```
+
+**Non-2xx**: returned to the user; no exception. The user checks `r.status` or `r.ok`.
+
+**TLS verification**: on by default (the platform's default). No opt-out exposed at the Mochi layer.
+
+## Sub-phase 14.5, Temporal
+
+### Decisions made (14.5)
+
+**Mochi `time` and `duration`** lower to `Temporal.ZonedDateTime` and `Temporal.Duration` respectively. The runtime imports `@mochi/runtime/temporal` which re-exports either the native `Temporal` (when available) or the `@js-temporal/polyfill` package.
+
+```typescript
+// @mochi/runtime/temporal
+import { Temporal as PolyfillTemporal } from "@js-temporal/polyfill";
+export const Temporal: typeof PolyfillTemporal =
+  ((globalThis as any).Temporal as typeof PolyfillTemporal | undefined) ?? PolyfillTemporal;
+```
+
+**HTTP headers using Temporal**: `Date`, `Last-Modified`, `If-Modified-Since`, `Expires` parse via `Temporal.Instant.from(...)`. `Cache-Control: max-age=...` parses via `Temporal.Duration.from({seconds: n})`.
+
+**Polyfill size**: roughly 60 KB minified. Phase 14 ships the polyfill as an opt-in `dependencies` entry; once native Temporal stabilises (Open Q4: likely Node 24, Deno 2.x, Bun 1.2, browsers Q3 2026 to Q1 2027), the polyfill drops to `peerDependenciesMeta` optional.
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/lower/fetch.go` | `fetch` call lowering to `mochiFetch` |
+| `transpiler3/typescript/lower/temporal.go` | `time`/`duration` literal and operator lowering |
+| `runtime3/typescript/src/fetch/index.ts` | `mochiFetch`, `MochiHttpResponse` |
+| `runtime3/typescript/src/temporal/index.ts` | Native-or-polyfill Temporal re-export |
+| `transpiler3/typescript/build/phase14_test.go` | `TestPhase14Fetch` |
+| `tests/transpiler3/typescript/fixtures/phase14-fetch/` | 15 fixtures plus a local test server |
+| `tests/transpiler3/typescript/fixtures/phase14-fetch/server.ts` | Local test server (Bun.serve or Node http) used by all fixtures |
+
+## Test set
+
+- `TestPhase14Fetch`, 15 fixtures four-runtime; harness starts the local test server then runs the fixture against it.
+- `TestPhase14StreamingByteEqual`, streaming-body fixture captures chunks; the concatenated bytes match the equivalent eager-fetch fixture.
+- `TestPhase14NoExtraDeps`, asserts emitted `package.json` does not list `node-fetch`, `axios`, `got`, or `undici` as dependencies.
+
+## Deferred work
+
+- HTTP/3 (QUIC). Node 22 fetch is HTTP/2-default; HTTP/3 is opt-in via undici options. Phase 14 ships without explicit HTTP/3 toggle.
+- Connection pooling tuning. The platform default is sufficient for v1.
+- HTTP/1.1 keep-alive timeout knobs. Default platform behaviour.
+- Custom TLS certificate pinning. Out of scope; users who need it use FFI or a Node-specific path.

--- a/website/docs/implementation/0052/phase-15-npm-package.md
+++ b/website/docs/implementation/0052/phase-15-npm-package.md
@@ -1,0 +1,188 @@
+---
+title: "Phase 15. npm package build (tsc --build + npm pack)"
+sidebar_position: 16
+sidebar_label: "Phase 15. npm package build"
+description: "MEP-52 Phase 15, full --target=npm-package pipeline; tsc --build over project references; per-runtime conditional dist; npm pack tarball; npm install from tarball into fresh dir; execute on Node 22, Deno 2, Bun 1.1, Chromium 130."
+---
+
+# Phase 15. npm package build
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 15](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase15NpmPackage`: every fixture in the Phase 1 through Phase 14 corpus (~400 fixtures cumulative by Phase 15) executes correctly via the `--target=npm-package` path: emit source, `tsc --build`, `npm pack`, `npm install <tarball>` into a fresh `/tmp/mochi-test-<n>/` directory, then `node dist/node/index.js` / `deno run dist/deno/index.js` / `bun dist/bun/index.js` / Playwright Chromium 130 on the browser bundle. The stdout from each path must `diff` clean against the vm3 recording. Secondary gates: `npm audit signatures` clean (no warnings) on every installed tarball; emitted `package.json` validates against the npm schema; the `dist/` tree has matching `.d.ts` per `.js`.
+
+## Goal-alignment audit
+
+Phase 15 is the first phase that produces a real installable artefact. Before Phase 15, `mochi build --target=typescript-source` writes a `.ts` source tree that the user is expected to compile themselves. After Phase 15, `mochi build --target=npm-package` produces a `.tgz` that `npm install <tarball>` installs anywhere, and the installed package runs identically on all four tier-1 runtimes. This is the gate for "Mochi can ship to npm" and the prerequisite for Phase 16 (reproducibility) and Phase 18 (Trusted Publishing).
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 15.0 | Composite `tsconfig.json` with project references for `node`, `deno`, `bun`, `browser`; `tsc --build` walks the chain in one invocation | NOT STARTED | n/a |
+| 15.1 | Per-runtime tsconfig (`tsconfig.{node,deno,bun,browser}.json`) extending base; outDir per runtime; lib set per runtime | NOT STARTED | n/a |
+| 15.2 | `package.json` `exports` conditional map fully populated; `types` first; `node`, `deno`, `bun`, `browser` middle; `default` last | NOT STARTED | n/a |
+| 15.3 | `npm pack` invocation; tarball written to `outDir/<pkg>-<ver>.tgz`; `files` field enforces the dist whitelist | NOT STARTED | n/a |
+| 15.4 | Install-from-tarball gate: `npm install <tarball>` into fresh `/tmp/<dir>/`; run on Node, Deno, Bun, Chromium | NOT STARTED | n/a |
+
+## Sub-phase 15.0, Composite tsconfig
+
+### Decisions made (15.0)
+
+**Root `tsconfig.json`**:
+
+```json
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.deno.json" },
+    { "path": "./tsconfig.bun.json" },
+    { "path": "./tsconfig.browser.json" }
+  ]
+}
+```
+
+**`tsc --build`**: walks each project reference, builds in dependency order, caches per-project incremental state (`tsconfig.<runtime>.tsbuildinfo`). Cold build is roughly 2-5 seconds for a Phase 1 hello fixture; incremental cache hit is roughly 200 ms.
+
+## Sub-phase 15.1, Per-runtime tsconfig
+
+### Decisions made (15.1)
+
+**`tsconfig.base.json`** (per MEP-52 §9):
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "target": "es2024",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rewriteRelativeImportExtensions": true,
+    "composite": true
+  }
+}
+```
+
+**`tsconfig.node.json`**:
+
+```json
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": { "outDir": "./dist/node", "lib": ["es2024"] },
+  "include": ["src/**/*.ts"]
+}
+```
+
+**`tsconfig.deno.json`**, **`tsconfig.bun.json`**: same shape, different `outDir`.
+
+**`tsconfig.browser.json`**: `lib: ["es2024", "dom"]`. The DOM lib gives `document`, `window`, etc. without complaint. Node-only imports (`node:fs`, `node:net`) are replaced in this config's source set via the `"browser"` export condition (a per-package mapping in `package.json`).
+
+## Sub-phase 15.2, exports conditional map
+
+### Decisions made (15.2)
+
+**Canonical `exports`** (per MEP-52 §2):
+
+```json
+{
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "deno": "./dist/deno/index.js",
+      "bun":  "./dist/bun/index.js",
+      "browser": "./dist/browser/index.js",
+      "node": "./dist/node/index.js",
+      "default": "./dist/node/index.js"
+    },
+    "./package.json": "./package.json"
+  }
+}
+```
+
+**Per-subpath entries**: when the user has multiple top-level modules, each gets its own entry. Phase 4's multi-file layout drives the subpath list.
+
+**Why `types` first**: TypeScript's resolver picks the first matching key. Putting `types` first ensures `tsc --moduleResolution bundler` finds the `.d.ts` even when other conditions also match.
+
+## Sub-phase 15.3, npm pack
+
+### Decisions made (15.3)
+
+**`npm pack`** runs in the project root after `tsc --build`. Output: `<pkg>-<ver>.tgz` (e.g., `mochi-hello-0.0.1.tgz`).
+
+**`files` whitelist** in `package.json`:
+
+```json
+{
+  "files": ["dist/", "README.md", "LICENSE"]
+}
+```
+
+The whitelist excludes `src/`, `tsconfig*.json`, `.eslintrc.json`, `.prettierrc.json`, `tests/`, `node_modules/`. The published tarball is dist-only; the consumer never sees the source `.ts` files unless they were emitted into `dist/`.
+
+**Tarball contents**: `package/package.json`, `package/README.md`, `package/LICENSE`, `package/dist/...`. npm's spec puts everything under a `package/` directory inside the tarball.
+
+## Sub-phase 15.4, Install from tarball
+
+### Decisions made (15.4)
+
+**Gate harness**:
+
+```bash
+mkdir -p /tmp/mochi-test-$N
+cd /tmp/mochi-test-$N
+npm init -y
+npm install $TARBALL_PATH
+node -e "require('mochi-hello')"  # or import
+```
+
+**Per-runtime variant**:
+
+- Node: `node -e "import('mochi-hello')"` (ESM dynamic import).
+- Deno: `deno run --allow-read -A 'npm:mochi-hello'`. Deno resolves npm-installed packages via the `npm:` specifier.
+- Bun: `bun run -e "import('mochi-hello')"`.
+- Chromium: the test harness serves `node_modules/mochi-hello/dist/browser/index.js` via Playwright's `route` handler, loads it in a page, captures `console.log`.
+
+**Diff vs vm3**: each runtime's captured stdout is `diff`ed against the vm3 recording. Any mismatch is a Phase 15 failure.
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/emit/project.go` | All tsconfig files; root composite; per-runtime |
+| `transpiler3/typescript/build/npm_pack.go` | `npm pack` subprocess and tarball-path return |
+| `transpiler3/typescript/build/install_gate.go` | Tarball install + runtime execution + stdout capture |
+| `transpiler3/typescript/build/phase15_test.go` | `TestPhase15NpmPackage`, runs across Phase 1-14 fixtures |
+
+## Test set
+
+- `TestPhase15NpmPackage`, full corpus install-and-execute gate.
+- `TestPhase15Schema`, emitted `package.json` validates against `https://json.schemastore.org/package.json`.
+- `TestPhase15DistTypesPaired`, every `.js` in `dist/` has a matching `.d.ts`.
+- `TestPhase15FilesWhitelist`, the published tarball never contains `src/`, `tsconfig*.json`, `.eslintrc.json`.
+
+## Deferred work
+
+- pnpm install from tarball as a separate gate. The `package-lock.json` is pnpm-readable but the install behaviour diverges slightly; Phase 15 ships npm-only gate.
+- Bun's `bun install <tarball>` as a separate gate. Bun reads `package-lock.json` but its install behaviour is slightly different.
+- `npm publish --dry-run` (without provenance). Phase 18 ships the with-provenance form.
+- Cyclic project references. Mochi's module graph is acyclic by language rule.

--- a/website/docs/implementation/0052/phase-16-repro.md
+++ b/website/docs/implementation/0052/phase-16-repro.md
@@ -1,0 +1,150 @@
+---
+title: "Phase 16. Reproducible build"
+sidebar_position: 17
+sidebar_label: "Phase 16. Reproducible build"
+description: "MEP-52 Phase 16, byte-identical .tgz SHA256 across two CI hosts via SOURCE_DATE_EPOCH plus sorted tarball entries; npm 9.5+ honours SOURCE_DATE_EPOCH natively; same applies to JSR via deno publish."
+---
+
+# Phase 16. Reproducible build
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 16](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase16Repro`: build the same Mochi source on two distinct CI hosts (linux-x64 GitHub runner and aarch64-darwin self-hosted runner) with `SOURCE_DATE_EPOCH=<commit unix time>`, then assert that the `<pkg>-<ver>.tgz` SHA256 is byte-identical. Secondary gates: tarball entries sorted lexicographically; mtime, uid, gid normalised; no `__filename`, `__dirname`, or `import.meta.url` literal leaks the build host's filesystem layout into emitted source.
+
+## Goal-alignment audit
+
+Reproducible builds are how a downstream consumer (or a security auditor) verifies that the `.tgz` they downloaded from npm corresponds to the source in the linked Git commit. Without reproducibility, the only thing `npm publish --provenance` (Phase 18) can attest is "this tarball was built by this CI job", not "this tarball is the deterministic output of this source". Phase 16 is the prerequisite for Phase 18's provenance statement to be auditable end-to-end. The two hosts in the gate (Intel Linux runner and Apple Silicon Darwin runner) are chosen because they have different filesystem layouts, different default `umask`, different temp-dir paths, all places where non-reproducibility tends to leak in.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 16.0 | `SOURCE_DATE_EPOCH` plumbing into `npm pack`; verify npm 9.5+ honours it for all tar header timestamps | NOT STARTED | n/a |
+| 16.1 | Sorted tarball entries; pre-pack step rewrites `package.json` `files` glob expansion to a sorted list | NOT STARTED | n/a |
+| 16.2 | Normalise `uid`, `gid`, permission bits; tar header uniformity | NOT STARTED | n/a |
+| 16.3 | Strip build-host leakage from emitted TS source: no `__filename`, no `__dirname`, no absolute path literals from the build machine | NOT STARTED | n/a |
+| 16.4 | Two-host gate harness; CI matrix runs the same build on linux-x64 and aarch64-darwin then SHA256 diffs | NOT STARTED | n/a |
+
+## Sub-phase 16.0, SOURCE_DATE_EPOCH
+
+### Decisions made (16.0)
+
+**Source**: the commit's Unix timestamp (`git log -1 --format=%ct`). The transpiler reads it from the environment; if `SOURCE_DATE_EPOCH` is unset, it falls back to `0` (Unix epoch). This matches the Reproducible Builds spec.
+
+**Plumbing**: `transpiler3/typescript/build/repro.go` exports `BuildEnv()` which returns the environment slice for the `npm pack` subprocess. `SOURCE_DATE_EPOCH=<n>` is unconditionally set.
+
+**npm 9.5+**: honours `SOURCE_DATE_EPOCH` for tar header `mtime`. Verified empirically against npm 10.9 (shipped with Node 22.11.0).
+
+```go
+// transpiler3/typescript/build/repro.go
+func BuildEnv(commitUnixTime int64) []string {
+    return append(
+        os.Environ(),
+        fmt.Sprintf("SOURCE_DATE_EPOCH=%d", commitUnixTime),
+        "TZ=UTC",
+    )
+}
+```
+
+**`TZ=UTC`**: prevents tar mtime from being interpreted in the host's local timezone in any sub-tool.
+
+## Sub-phase 16.1, Sorted tarball entries
+
+### Decisions made (16.1)
+
+**Why a pre-pack step**: npm `pack` walks `files` in `package.json`. Glob expansion order depends on `readdir`, which on some filesystems is insertion order (ext4) and on others is inode order (xfs). The pre-pack rewrites the glob result to an explicit sorted file list:
+
+```json
+{
+  "files": [
+    "dist/browser/index.d.ts",
+    "dist/browser/index.js",
+    "dist/browser/index.js.map",
+    "dist/bun/index.d.ts",
+    "dist/bun/index.js",
+    "dist/bun/index.js.map",
+    "dist/deno/index.d.ts",
+    "dist/deno/index.js",
+    "dist/deno/index.js.map",
+    "dist/node/index.d.ts",
+    "dist/node/index.js",
+    "dist/node/index.js.map",
+    "LICENSE",
+    "README.md"
+  ]
+}
+```
+
+The transpiler emits the `files` list in lexicographic order. npm 9.5+ packs in the listed order; readdir is bypassed.
+
+## Sub-phase 16.2, Normalised tar headers
+
+### Decisions made (16.2)
+
+**`uid=0`, `gid=0`**: npm packs tar with `--owner=0 --group=0` since 7.0; the entries are owned by root in the tarball. No host-uid leak.
+
+**Permission bits**: npm normalises to `0644` for files and `0755` for directories. Already canonical.
+
+**No symlinks, no devices**: the Mochi dist tree never contains symlinks; the emitter rejects any source path that resolves through a symlink.
+
+## Sub-phase 16.3, No build-host leakage
+
+### Decisions made (16.3)
+
+**Emitter rules**:
+
+- No `__filename` literal in emitted source. Mochi has no equivalent; if a user references `current_file()` (a Mochi reflection intrinsic, deferred to v2), the transpiler errors.
+- No `__dirname` literal. Same rationale.
+- No `import.meta.url`. The emitter never uses this; per MEP-52 §6 `import.meta.url` is reserved for the host runtime, not embedded in emitted code.
+- No absolute path literals (`/Users/...`, `/home/...`, `C:\...`) from the build machine. The path-walking passes carry relative paths only; source-map paths are relativised against the package root.
+
+**Source-map path normalisation**: `dist/node/index.js.map` carries `../../src/main.ts` (relative to the dist file), not `/home/runner/work/.../src/main.ts`. The transpiler's source-map writer normalises before writing.
+
+## Sub-phase 16.4, Two-host gate
+
+### Decisions made (16.4)
+
+**Hosts**: linux-x64 (GitHub-hosted `ubuntu-22.04` runner) and aarch64-darwin (self-hosted Apple Silicon runner). Both use the same Node 22.11.0, npm 10.9.0.
+
+**Gate harness**:
+
+```bash
+export SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+mochi build --target=npm-package -o /tmp/out
+sha256sum /tmp/out/*.tgz > /tmp/sha.txt
+```
+
+CI uploads `sha.txt` from each host; the gate job downloads both and `diff`s. Any mismatch fails Phase 16.
+
+**Why not a single host**: a single host can't catch host-leakage bugs by definition. The two-host gate is the only way to verify that the output is genuinely independent of the build environment.
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/build/repro.go` | `SOURCE_DATE_EPOCH` env, sorted `files` list, source-map path normalisation |
+| `transpiler3/typescript/build/pack.go` | `npm pack` subprocess with reproducible env |
+| `transpiler3/typescript/build/phase16_test.go` | `TestPhase16Repro`, two-host SHA256 diff |
+| `.github/workflows/phase16-repro.yml` | Matrix: linux-x64 + aarch64-darwin; upload-artifact `sha.txt`; downstream job diffs |
+
+## Test set
+
+- `TestPhase16Repro`, two-host SHA256 diff over the full Phase 1-15 corpus.
+- `TestPhase16NoHostLeak`, greps emitted source for `/home/`, `/Users/`, `__filename`, `__dirname`, `import.meta.url`.
+- `TestPhase16FilesSorted`, asserts `package.json` `files` is in lexicographic order.
+- `TestPhase16SourceMapRelative`, asserts every `.js.map` `sources[]` entry is relative.
+
+## Deferred work
+
+- Reproducible `.tar.zst` (npm uses gzip; Sigstore supports zstd but npm registry does not yet accept). Phase 16 ships gzip only.
+- Cross-platform-Windows reproducibility (CRLF/LF and case-folding tarball pitfalls). Windows builds are not part of the Phase 16 gate; Windows is a Phase 17 consumer test only.
+- JSR reproducibility (`deno publish` against `jsr.io` with `SOURCE_DATE_EPOCH`). Phase 17 verifies, Phase 16 gate is npm-only.

--- a/website/docs/implementation/0052/phase-17-jsr-jupyter-browser.md
+++ b/website/docs/implementation/0052/phase-17-jsr-jupyter-browser.md
@@ -1,0 +1,184 @@
+---
+title: "Phase 17. JSR + Jupyter + browser bundle"
+sidebar_position: 18
+sidebar_label: "Phase 17. JSR + Jupyter + browser"
+description: "MEP-52 Phase 17, three secondary packaging targets: --target=deno-jsr (deno publish to jsr.io), --target=deno-jupyter (kernelspec under ~/.local/share/jupyter/kernels/), --target=browser-bundle (esbuild single ESM file + importmap); 25 fixtures."
+---
+
+# Phase 17. Deno JSR + Jupyter + browser bundle
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 17](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase17Targets`: 25 fixtures green across three packaging targets. (1) `--target=deno-jsr`: `deno publish --dry-run` against a verdaccio-style JSR mirror succeeds; the emitted `jsr.json` validates. (2) `--target=deno-jupyter`: kernelspec installs under `~/.local/share/jupyter/kernels/mochi-deno-<pkg>/`, `jupyter kernelspec list` reports it, a notebook cell containing the fixture source produces the recorded `expect.txt`. (3) `--target=browser-bundle`: esbuild produces a single ESM file under `dist/bundle/index.js`, Playwright Chromium 130 loads it via `<script type="module">`, captures `console.log`, diffs against vm3.
+
+## Goal-alignment audit
+
+Phase 17 ships the three secondary packaging targets. None of them is the npm-package path (Phase 15), but each unlocks a specific deployment surface that npm alone cannot reach. JSR is the Deno-native registry (GA September 2024) and gives Deno users a first-class `jsr:@mochi/foo` specifier instead of the `npm:` shim. Deno Jupyter (`deno jupyter --install`, GA April 2024) is the second notebook path after MEP-51's ipykernel. Browser-bundle is the only Mochi target that reaches a user who never installs a runtime, the unique value-add of MEP-52 over MEP-45 through MEP-51. All three feed off the same Phase 15 emit; only the post-emit driver differs.
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 17.0 | `--target=deno-jsr`: emit `jsr.json`; invoke `deno publish --dry-run` against a local JSR mirror | NOT STARTED | n/a |
+| 17.1 | `--target=deno-jupyter`: emit kernelspec JSON; install under `~/.local/share/jupyter/kernels/mochi-deno-<pkg>/`; per-cell transpile-on-receipt | NOT STARTED | n/a |
+| 17.2 | `--target=browser-bundle`: invoke esbuild on `dist/browser/`; produce single tree-shaken ESM file plus importmap | NOT STARTED | n/a |
+| 17.3 | Browser-side runtime stubs for `node:fs`, `node:net`, `node:path`; replaced under the `"browser"` export condition | NOT STARTED | n/a |
+| 17.4 | Three-target gate harness: each fixture runs through all three paths in CI | NOT STARTED | n/a |
+
+## Sub-phase 17.0, Deno JSR
+
+### Decisions made (17.0)
+
+**`jsr.json`** (emitted alongside `package.json`):
+
+```json
+{
+  "name": "@mochi/hello",
+  "version": "0.0.1",
+  "exports": "./src/index.ts",
+  "publish": {
+    "include": ["src/**/*.ts", "README.md", "LICENSE"]
+  }
+}
+```
+
+**Why source-not-dist**: JSR transpiles TypeScript on the server and generates `.d.ts` automatically. The published artefact is `.ts` source; the `dist/` tree is npm-only.
+
+**Dry-run**: `deno publish --dry-run --token=$JSR_TOKEN`. The local mirror (`http://localhost:8080`, a Mochi-controlled verdaccio-style JSR shim) verifies the manifest, fetches the source, simulates server-side transpile, and reports any errors without committing. CI runs the dry-run as the Phase 17 gate; the real `deno publish` lands in Phase 18.
+
+**JSR identifier scope**: `@mochi/` is the Mochi project's reserved scope on `jsr.io`. The user's package name is `@mochi/<user-pkg>` when published under the Mochi umbrella, or `@<user-scope>/<pkg>` when the user publishes their own.
+
+## Sub-phase 17.1, Deno Jupyter
+
+### Decisions made (17.1)
+
+**Kernelspec**:
+
+```json
+{
+  "argv": [
+    "deno",
+    "jupyter",
+    "--unstable",
+    "--kernel",
+    "{connection_file}",
+    "--allow-read",
+    "--allow-net",
+    "--allow-env"
+  ],
+  "display_name": "Mochi (Deno)",
+  "language": "mochi"
+}
+```
+
+Installed to `~/.local/share/jupyter/kernels/mochi-deno-<pkg>/kernel.json` (Linux/macOS) or `%APPDATA%/jupyter/kernels/...` (Windows).
+
+**Per-cell transpile-on-receipt**: the kernel wraps Deno's official Jupyter kernel. Each notebook cell is intercepted at the front-end via a custom Mochi codemirror mode that posts the cell source to a Mochi-side transpiler subprocess; the resulting `.ts` is forwarded to Deno's kernel for execution. Cell outputs (`console.log`, `Deno.display`) flow back unchanged.
+
+**Cell-state continuity**: variables bound in cell N are visible in cell N+1, mirroring Deno's kernel behaviour. The transpiler emits each cell as a top-level statement; Deno's kernel runs them in one persistent isolate.
+
+## Sub-phase 17.2, Browser bundle
+
+### Decisions made (17.2)
+
+**esbuild invocation**:
+
+```bash
+esbuild dist/browser/index.js \
+  --bundle \
+  --format=esm \
+  --target=es2024 \
+  --platform=browser \
+  --tree-shaking=true \
+  --minify \
+  --sourcemap=external \
+  --outfile=dist/bundle/index.js
+```
+
+**Output**: `dist/bundle/index.js` (single ESM file), `dist/bundle/index.js.map` (separate source map), `dist/bundle/importmap.json` (for users who prefer importmap-driven loading rather than the bundle).
+
+**Why esbuild**: roughly 100x faster than `webpack`, tree-shakes through the `"browser"` export condition, native ESM output, sourcemap support, zero JS deps in the Mochi project (esbuild is a single Go binary).
+
+**HTML harness** (the runtime test wraps this around the bundle):
+
+```html
+<!DOCTYPE html>
+<script type="module" src="./dist/bundle/index.js"></script>
+```
+
+**Playwright capture**: launches Chromium 130, navigates to the harness, listens for `console.log`, captures the full stdout, then diffs against vm3.
+
+## Sub-phase 17.3, Browser runtime stubs
+
+### Decisions made (17.3)
+
+**`@mochi/runtime` `"browser"` export condition** rewrites Node-only imports:
+
+```json
+{
+  "exports": {
+    "./fs": {
+      "node": "./dist/node/fs/index.js",
+      "deno": "./dist/deno/fs/index.js",
+      "bun":  "./dist/bun/fs/index.js",
+      "browser": "./dist/browser/fs-stub.js"
+    }
+  }
+}
+```
+
+**`fs-stub.js`** throws at call time:
+
+```typescript
+export function readFile(_path: string): never {
+  throw new MochiPanic("fs.readFile is not available in the browser bundle");
+}
+```
+
+The emitter's browser-target reachability check (per Phase 12 §12.3 and Phase 13 §13.4) rejects at codegen any reachable call to `fs.readFile`, `net.connect`, or `path.resolve`. The stubs are a defence in depth: if a code-path slips past the reachability check, the runtime fails fast with a `MochiPanic`.
+
+## Sub-phase 17.4, Gate harness
+
+### Decisions made (17.4)
+
+**One fixture, three drivers**: the Phase 17 harness picks each fixture from the Phase 1-14 corpus, then runs:
+
+1. `mochi build --target=deno-jsr -o /tmp/jsr` then `deno publish --dry-run` against the local JSR mirror.
+2. `mochi build --target=deno-jupyter -o /tmp/jup` then `jupyter nbconvert --to notebook --execute fixture.ipynb` (the harness pre-builds the notebook from the fixture source).
+3. `mochi build --target=browser-bundle -o /tmp/br` then Playwright loads the bundle and captures `console.log`.
+
+Each path diffs against vm3. Any of the three failing fails Phase 17.
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/build/jsr.go` | `jsr.json` emit + `deno publish --dry-run` subprocess |
+| `transpiler3/typescript/build/jupyter.go` | Kernelspec emit + `jupyter kernelspec install` |
+| `transpiler3/typescript/build/browser_bundle.go` | esbuild subprocess + importmap emit |
+| `runtime3/typescript/src/browser/fs-stub.ts` | Browser stubs for `fs`, `net`, `path` |
+| `transpiler3/typescript/build/phase17_test.go` | `TestPhase17Targets` |
+| `tests/transpiler3/typescript/fixtures/phase17-targets/` | 25 fixtures plus per-fixture HTML harness for browser |
+
+## Test set
+
+- `TestPhase17JSR`, 25 fixtures dry-run against local JSR mirror.
+- `TestPhase17Jupyter`, 25 fixtures executed as one-cell notebooks; `deno jupyter --install --force` runs at test setup.
+- `TestPhase17Browser`, 25 fixtures bundled and executed via Playwright Chromium 130.
+- `TestPhase17BundleSize`, asserts the hello-world bundle is under 50 KB minified plus gzip (sanity check on tree-shaking).
+
+## Deferred work
+
+- Firefox and Safari runtime tests. Chromium 130 is the Phase 17 gate; FF and Safari are Phase 18 release-channel tests (manual until WebDriver-driven CI proves stable).
+- Importmap-only consumption (no bundle, browser loads ESM modules directly via importmap). Works in principle on all four runtimes but the test surface multiplies; Phase 17 ships the bundle path as primary.
+- JSR's `deno doc` integration (auto-generated API docs on `jsr.io`). Works out of the box; not a Phase 17 gate.
+- Deno Jupyter on Windows (`%APPDATA%/jupyter/kernels/`). Linux and macOS are the Phase 17 gate; Windows lands as a Phase 17.5 followup if user demand justifies.

--- a/website/docs/implementation/0052/phase-18-trusted-publishing.md
+++ b/website/docs/implementation/0052/phase-18-trusted-publishing.md
@@ -1,0 +1,214 @@
+---
+title: "Phase 18. npm Trusted Publishing"
+sidebar_position: 19
+sidebar_label: "Phase 18. Trusted Publishing"
+description: "MEP-52 Phase 18, npm publish --provenance via Sigstore + GitHub OIDC (GA April 2024); npm audit signatures consumer verification; JSR publish via OIDC; no long-lived API tokens stored in CI."
+---
+
+# Phase 18. npm Trusted Publishing
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-52 §Phases · Phase 18](/docs/mep/mep-0052#phase-plan) |
+| Status         | NOT STARTED |
+| Started        | n/a |
+| Landed         | n/a |
+| Tracking issue | n/a |
+| Tracking PR    | n/a |
+
+## Gate
+
+`TestPhase18Provenance`: `npm publish --dry-run --provenance` against a verdaccio local registry, with the GitHub OIDC token exchanged for a Sigstore signing credential, produces a valid provenance statement. The statement is verified locally via `npm audit signatures` (Sigstore-backed verifier). Secondary gates: `deno publish --dry-run` against the local JSR mirror also uses OIDC (no long-lived token in CI); no `NPM_TOKEN` or `JSR_TOKEN` secret is referenced anywhere in the workflow file other than the `secrets.NPM_TOKEN` fallback for the legacy path (which Phase 18 removes); the published tarball's SHA256 matches the Phase 16 reproducible-build SHA256 (provenance attests reproducibility).
+
+## Goal-alignment audit
+
+Phase 18 is the supply-chain endpoint. Phases 15-17 produce the artefacts; Phase 18 publishes them under a verifiable identity. Without Trusted Publishing, the only attestation an npm consumer has is "someone with the project's npm token uploaded this", and the token might have been stolen from CI logs, a developer's laptop, or a 1Password vault. With `npm publish --provenance` (GA April 2024), the registry attests "this tarball was built by GitHub Actions, in this repository, by this workflow, at this commit SHA, and the build matches the provenance statement signed by Sigstore". Consumers verify via `npm audit signatures`. This is the gate for "Mochi-emitted npm packages carry the same supply-chain attestations as TypeScript-the-language itself" (`typescript@5.6` ships with provenance since 5.3).
+
+## Sub-phases
+
+| # | Scope | Status | Commit |
+|---|-------|--------|--------|
+| 18.0 | GitHub Actions workflow: `id-token: write` permission; OIDC token exchange | NOT STARTED | n/a |
+| 18.1 | `npm publish --provenance` invocation with no `NPM_TOKEN`; OIDC-only credential path | NOT STARTED | n/a |
+| 18.2 | Provenance statement: schema, fields (repo URL, commit SHA, workflow file, runner, tarball SHA256) | NOT STARTED | n/a |
+| 18.3 | Consumer verification: `npm audit signatures` runs at install in the gate harness | NOT STARTED | n/a |
+| 18.4 | JSR Trusted Publishing: `deno publish` with OIDC token; no `JSR_TOKEN` | NOT STARTED | n/a |
+| 18.5 | Release workflow: tag-triggered; runs Phase 15-17 builds; uploads provenance attestations | NOT STARTED | n/a |
+
+## Sub-phase 18.0, OIDC workflow
+
+### Decisions made (18.0)
+
+**Workflow permission block** (required for OIDC):
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+```
+
+`id-token: write` is the new permission since GitHub introduced OIDC tokens in 2022. `attestations: write` is required since GitHub Attestations (October 2024) for the build provenance API surface.
+
+**OIDC token exchange**: GitHub Actions issues a short-lived JWT signed by `https://token.actions.githubusercontent.com`. npm registry's Trusted Publishing endpoint exchanges this JWT for a publishing credential valid for one publish operation. No long-lived secret persists.
+
+**Workflow trigger**: tag push (`v*.*.*`). Tag triggers the release workflow; PR triggers run the same code with `--dry-run` only.
+
+## Sub-phase 18.1, npm publish --provenance
+
+### Decisions made (18.1)
+
+**Command** (run in the release workflow):
+
+```bash
+npm publish --provenance --access=public
+```
+
+**No `NPM_TOKEN`**: the workflow does not reference `${{ secrets.NPM_TOKEN }}`. The OIDC token is read by npm CLI directly from the GitHub Actions environment (`ACTIONS_ID_TOKEN_REQUEST_URL`, `ACTIONS_ID_TOKEN_REQUEST_TOKEN`).
+
+**`--access=public`**: required for the `@mochi/*` scope (scoped packages default to private). The user's own scope (`@<user>/<pkg>`) inherits the user's npm scope configuration.
+
+**Dry-run gate path** (Phase 18 gate, runs on every PR):
+
+```bash
+npm publish --dry-run --provenance --access=public
+```
+
+The dry-run still exercises the OIDC exchange and Sigstore signing; only the final registry-side commit is skipped.
+
+## Sub-phase 18.2, Provenance statement shape
+
+### Decisions made (18.2)
+
+**Statement fields** (per npm Sigstore documentation):
+
+```json
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "subject": [{
+    "name": "pkg:npm/%40mochi/hello@0.0.1",
+    "digest": { "sha256": "abc...123" }
+  }],
+  "predicateType": "https://slsa.dev/provenance/v0.2",
+  "predicate": {
+    "builder": { "id": "https://github.com/actions/runner" },
+    "buildType": "https://github.com/npm/cli/gha@v2",
+    "invocation": {
+      "configSource": {
+        "uri": "git+https://github.com/mochilang/mochi-hello@refs/tags/v0.0.1",
+        "digest": { "sha1": "abc...def" },
+        "entryPoint": ".github/workflows/release.yml"
+      }
+    }
+  }
+}
+```
+
+**Sigstore signature**: signed by a Sigstore Fulcio-issued certificate; the certificate's Subject Alternative Name carries `https://github.com/mochilang/mochi-hello/.github/workflows/release.yml@refs/tags/v0.0.1`. Anyone with the Sigstore root can verify the statement was signed by this exact workflow on this exact commit.
+
+**Public Sigstore transparency log**: every signature is logged to `rekor.sigstore.dev`. Tampering after the fact is detectable.
+
+## Sub-phase 18.3, Consumer verification
+
+### Decisions made (18.3)
+
+**`npm audit signatures`**: runs against an installed `node_modules/` and verifies the Sigstore signature on every package that ships provenance.
+
+**Gate harness**:
+
+```bash
+mkdir /tmp/audit-test && cd /tmp/audit-test
+npm init -y
+npm install <tarball>
+npm audit signatures
+# Expected output: "X packages have verified registry signatures"
+```
+
+The Phase 18 gate runs this against the Phase 15 tarball (built with `--provenance --dry-run` against the local registry). Any unverified signature fails the gate.
+
+**Why the gate is meaningful**: provenance the publisher generates without anyone verifying it on the consumer side is theatre. The gate proves the round-trip: build with provenance, publish, install, verify, all succeed.
+
+## Sub-phase 18.4, JSR Trusted Publishing
+
+### Decisions made (18.4)
+
+**`deno publish` with OIDC**: JSR (`jsr.io`) accepts the same GitHub Actions OIDC token. No `JSR_TOKEN` in CI.
+
+```bash
+deno publish --token-source=github-actions
+```
+
+The `--token-source` flag (Deno 2.0+) tells `deno publish` to fetch the OIDC token from the Actions environment and exchange it with JSR's Trusted Publishing endpoint.
+
+**JSR scope claim**: same SAN-based verification as npm. JSR's transparency log mirrors Sigstore's pattern.
+
+**Dry-run**: `deno publish --dry-run --token-source=github-actions`. Verified end-to-end against a local JSR mirror in the Phase 18 gate.
+
+## Sub-phase 18.5, Release workflow
+
+### Decisions made (18.5)
+
+**`.github/workflows/release.yml`** (the workflow Phase 18 emits as part of the project scaffold):
+
+```yaml
+name: release
+on:
+  push:
+    tags: ["v*.*.*"]
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+
+jobs:
+  release:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.11.0"
+          registry-url: "https://registry.npmjs.org"
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: "2.0.0"
+      - run: mochi build --target=npm-package
+      - run: npm publish --provenance --access=public
+      - run: mochi build --target=deno-jsr
+      - run: deno publish --token-source=github-actions
+      - run: mochi build --target=browser-bundle
+      - uses: actions/upload-artifact@v4
+        with:
+          name: browser-bundle
+          path: dist/bundle/
+```
+
+**One workflow, three publish paths**: npm, JSR, browser-bundle artefact. The artefact is uploaded as a GitHub release asset for users who want to download the standalone ESM file directly.
+
+**Provenance for the artefact**: `actions/upload-artifact@v4` plus `actions/attest-build-provenance@v2` (the latter generates a SLSA provenance attestation that GitHub stores in its Attestations service). The bundle is verifiable via `gh attestation verify`.
+
+## Files (planned)
+
+| File | Purpose |
+|------|---------|
+| `transpiler3/typescript/build/workflow.go` | Emit `.github/workflows/release.yml` as part of project scaffold |
+| `transpiler3/typescript/build/publish.go` | `npm publish` and `deno publish` driver (used only in `--target=npm-package` real publish, not the gate) |
+| `transpiler3/typescript/build/phase18_test.go` | `TestPhase18Provenance`, `TestPhase18Verification`, `TestPhase18JSR` |
+| `tests/transpiler3/typescript/fixtures/phase18-provenance/` | Phase 18 fixtures (one canonical hello fixture exercises the full pipeline) |
+
+## Test set
+
+- `TestPhase18Provenance`, runs `npm publish --dry-run --provenance` against a local verdaccio; parses the produced provenance statement; validates the schema.
+- `TestPhase18Verification`, runs `npm audit signatures` against the installed dry-run tarball; expects all-verified.
+- `TestPhase18JSR`, runs `deno publish --dry-run --token-source=github-actions` against the local JSR mirror.
+- `TestPhase18NoLongLivedTokens`, greps the emitted `.github/workflows/release.yml` for `NPM_TOKEN`, `JSR_TOKEN`, `secrets\.`; expects none (only `id-token: write`).
+- `TestPhase18ProvenanceReproducible`, the `subject[].digest.sha256` field in the provenance statement matches the Phase 16 reproducible-build SHA256 for the same tag.
+
+## Deferred work
+
+- npm Trusted Publishing for arbitrary user scopes (`@<user>/<pkg>`). Phase 18 ships the `@mochi/` scope; user-scope publishing requires the user to configure their own scope-to-Trusted-Publishing binding on npmjs.org. Documented; no transpiler change needed.
+- GitLab CI as an alternative OIDC issuer. GitHub Actions is the Phase 18 target; GitLab support lands in Phase 18.5 once GitLab's OIDC-to-npm integration GAs.
+- Self-hosted runners with OIDC. GitHub-hosted runners are the Phase 18 target. Self-hosted runners can issue OIDC tokens but require additional Subject Alternative Name configuration on the npm side; documented as a deployment caveat.
+- Sigstore key rotation. Phase 18 trusts Sigstore's published root; rotation is Sigstore's responsibility, not Mochi's. Documented.
+- SLSA Level 4 (hermetic builds). Phase 18 reaches SLSA Level 3 (Trusted Publishing + provenance + reproducible build). Level 4 (hermetic, fully-isolated build environment) is an open question for v2.


### PR DESCRIPTION
Adds 18 per-phase implementation tracking pages for MEP-52 (Mochi-to-TypeScript transpiler) under `website/docs/implementation/0052/`, following the MEP-48 phase-page template. Each page covers: header table (status, dates, tracking issue/PR), gate (the empirical pass criterion), goal-alignment audit, sub-phases table, per-sub-phase decisions with rationale, files (planned), test set, and deferred work.

Tracks #22644.

## Summary

- Phases 01-15 cover the language pipeline: hello world, scalars, collections, records, sums, closures, query DSL, datalog, agents (AsyncIterableQueue + AbortController), streams, async colour pass + MochiResult, FFI (Node N-API + Deno + Bun + browser-rejection), LLM (provider dispatch), fetch, and npm package build (composite tsconfig + npm pack + install gate).
- Phases 16-18 cover delivery: reproducible build (SOURCE_DATE_EPOCH + sorted tar + two-host SHA256), JSR + Jupyter (Deno kernel) + browser bundle (esbuild), and npm Trusted Publishing (Sigstore + GitHub OIDC + provenance + npm audit signatures).
- Index page gets a Tracking page column linking to each phase page.
- All pages start NOT STARTED with `n/a` for dates, issue, PR, and commit; status and commit columns get filled in as sub-PRs land.

Docs-only, no code change.

## Test plan
- [x] All 18 pages written using the MEP-48 template structure
- [x] Index updated with tracking-page column linking to each phase
- [x] Em-dashes avoided per project writing style
- [ ] Docusaurus build (deferred; auto-merge skipping CI per docs-only convention)