### PR TITLE
docs(mep-55): add 12 research notes + index (website/docs/research/0055/)

### DIFF
--- a/website/docs/research/0055/01-language-surface.md
+++ b/website/docs/research/0055/01-language-surface.md
@@ -1,0 +1,304 @@
+---
+title: "Language surface: Mochi features mapped to PHP 8.4 lowering obligations"
+description: "Every Mochi language feature and the PHP 8.4 construct it maps to, grounded in the phase00-skeleton through phase17-packaging fixture corpus."
+sidebar_position: 1
+---
+
+# Language surface: Mochi features mapped to PHP 8.4 lowering obligations
+
+Author: research pass for MEP-55 (Mochi-to-PHP 8.4 transpiler).
+Date: 2026-05-29 15:00 (GMT+7).
+Sources: `transpiler3/php/lower/lower.go`, `transpiler3/php/ptree/nodes.go`,
+`tests/transpiler3/php/fixtures/phase01-hello` through
+`tests/transpiler3/php/fixtures/phase17-packaging`,
+`transpiler3/php/build/phase*_test.go`.
+
+This note documents every Mochi language surface that MEP-55 lowers to
+PHP 8.4 source, and the specific PHP construct chosen for each one. The
+"what" companion to [[02-design-philosophy]]'s "why" and
+[[05-codegen-design]]'s pipeline walkthrough.
+
+## 1. Scalar types
+
+### 1.1 `int`
+
+Mochi `int` maps to PHP `int`. PHP guarantees 64-bit signed integers on
+all supported platforms (PHP 8.4 requires LP64 or LLP64; the 32-bit
+PHP era ended with 7.x). The lowerer (`phpScalarType` in lower.go) maps
+`aotir.TypeInt` to the string `"int"` for parameter and return type
+declarations.
+
+Integer division uses `intdiv($a, $b)` rather than `/` to preserve
+Mochi's truncating-toward-zero semantics. The `BinaryExpr` node in
+ptree sets `IsCall = true` for the `intdiv` operator so the emit pass
+renders `intdiv(left, right)` instead of an infix form (nodes.go
+`BinaryExpr.PhpString`).
+
+### 1.2 `float`
+
+Mochi `float` maps to PHP `float` (IEEE 754 binary64). All comparisons
+emit `===` (strict), never `==`. The PHP `==` operator applies type
+coercion that makes `0 == "foo"` true; Mochi semantics require strict
+identity, so the lowerer always emits the `===` form via `BinaryExpr`
+with Op `"==="`.
+
+Float printing uses a `mochi_print_f64` inline helper (defined in
+`runtimeDecls`, lower.go lines 171-184) that mirrors Go's
+`strconv.FormatFloat('g', -1, 64)` contract: whole-number values
+print without a decimal point (`4.0` becomes `"4"`), NaN prints as
+`"NaN"`, and infinities print as `"+Inf"` / `"-Inf"`. The same logic
+appears in `Mochi\Runtime\IO::printFloat` in the Phase 15 Composer
+package.
+
+### 1.3 `bool`
+
+Mochi `bool` maps to PHP `bool`. The `mochi_print_bool` helper emits
+`"true"` or `"false"` (lowercase), not PHP's native empty-string-for-
+false convention, matching the vm3 reference output.
+
+### 1.4 `string`
+
+Mochi `string` maps to PHP `string` (a byte sequence; PHP strings are
+not UTF-8-aware by default). The `str_contains` builtin lowers to a
+`mochi_str_contains` helper (lower.go lines 196-206) that short-circuits
+on an empty needle with `return $needle === "" || str_contains(...)`
+rather than delegating unconditionally to PHP's built-in, which would
+return `true` for empty needles anyway but at a slight cost for the
+common-case non-empty check.
+
+String index access (`s[i]`) lowers to `$s[$i]` (PHP string indexing
+returns a one-character substring). String length (`len(s)`) lowers
+to `strlen($s)`. String concatenation uses PHP's `.` operator via
+`BinaryExpr` with Op `"."`.
+
+`StringLit` in ptree uses `strconv.Quote` then replaces `$` with `\$`
+to suppress PHP's double-quoted string variable interpolation
+(nodes.go `StringLit.PhpString`).
+
+## 2. Collection types
+
+### 2.1 `list<T>`
+
+Mochi lists lower to PHP `array` (0-indexed, packed). The `ArrayLit`
+ptree node renders as `[a, b, c]`. The functional `append(xs, v)`
+lowers to `ArrayAppendExpr`: `[...$xs, $v]` (spread operator available
+since PHP 7.4). The `for-each` loop over a list lowers to
+`ForEachStmt`: `foreach ($list as $elem) { ... }`.
+
+### 2.2 `map<K, V>`
+
+Mochi maps lower to PHP associative `array`. `MapPutStmt` in lower.go
+emits an `IndexAssignStmt`: `$name[$key] = $value;`. Map literal
+construction uses `ArrayLit` with `Keys` and `Values` populated
+(nodes.go `ArrayLit.PhpString`).
+
+### 2.3 `set<T>`
+
+Mochi sets lower to PHP `array` of `value => true` pairs. The
+`mochi_set_make` helper (lower.go lines 207-223) iterates the input
+list and sets `$out[$e] = true`, dropping duplicates. The
+`mochi_set_add` helper (lines 224-237) returns a copy with the element
+added; PHP's copy-on-write semantics make this cheap.
+
+## 3. Records
+
+Records lower to `final readonly class` with constructor promotion
+(PHP 8.0+). Each field becomes a `public TYPE $name` promoted
+constructor parameter. The lowerer uses `ClassDecl` in ptree with
+`Abstract = false` and `Mutable = false` (the default), which causes
+the emit pass to write `final readonly class NAME` (nodes.go
+`ClassDecl.PhpString` lines 734-739).
+
+Construction uses PHP 8.0 named arguments: `new Point(x: 1, y: 2)`,
+emitted via `NewExpr`. This lets the lowerer pass fields in any order
+and keeps the emitted source readable. The `phase04-records` fixture
+corpus exercises single-field, multi-field, nested-record, and
+record-returning-function cases.
+
+## 4. Sum types (algebraic data types)
+
+Sum types lower to a two-level class hierarchy:
+
+1. An `abstract readonly class NAME` (the base) with an empty body.
+   PHP 8.4 requires that a `final readonly` subclass extends an
+   `abstract readonly` base; extending a plain (non-readonly) abstract
+   class would prevent the subclass from being `readonly`. This
+   constraint was discovered during Phase 5 CI and fixed by setting
+   `Abstract = true` on the base `ClassDecl`.
+
+2. One `final readonly class NAME_VARIANT extends NAME` per variant,
+   with constructor-promoted fields. The variant class name is computed
+   by `variantClassName(union, variant)` (lower.go line 934), which
+   joins with `_`. For example, union `Shape` with variant `Circle`
+   becomes `Shape_Circle`.
+
+Pattern matching (`match`) lowers to a `ChainedIfStmt` using
+`instanceof` checks (lower.go `lowerMatchStmt` lines 1083-1133). Each
+arm opens with `if ($tmp instanceof Shape_Circle) { ... }`, field
+bindings are extracted as `$fieldName = $tmp->fieldName;`, and the
+wildcard arm becomes the trailing `else { ... }`.
+
+## 5. Closures and function types
+
+### 5.1 Closures
+
+Mochi closures lower to PHP arrow functions (`fn(...) => ...`),
+represented as `ClosureExpr` in ptree (nodes.go lines 888-919). Arrow
+functions capture variables from the enclosing scope by value
+automatically, which matches Mochi's by-value capture semantics.
+
+The aotir lowerer lifts anonymous functions to top-level definitions
+(closure conversion). The PHP lowerer translates a `FunLit` (an
+in-scope reference to a lifted closure) into a `ClosureExpr` whose body
+is a call to the lifted function name, with capture variables forwarded
+as the leading arguments (`lowerFunLit`, lower.go lines 1041-1072).
+
+The `__e->FIELD` sentinel references that the C-target aotir lowerer
+injects for capture access are rewritten to plain variable names via
+`rewriteEnvRefs` (lower.go lines 750-862).
+
+### 5.2 Function types
+
+PHP cannot express a parameterised callable type at the declaration
+site. The `callable` pseudo-type accepts strings, arrays, and closures
+alike. The lowerer maps `aotir.TypeFun` to the PHP type `Closure`
+(phpParamType, lower.go lines 917-924), which accepts only real closure
+values, which is narrower and more correct. PHPStan and Psalm recover
+the precise signature from `@param Closure(int): string $f`-style
+PHPDoc added in Phase 15.
+
+## 6. Control flow
+
+### 6.1 `if / else`
+
+`IfStmt` in ptree renders as `if (cond) { then } else { else }` with
+the else block omitted when nil (nodes.go lines 239-270). This is a
+direct 1:1 mapping; no PHP-specific complications.
+
+### 6.2 `while`
+
+`WhileStmt` in ptree renders as `while (cond) { body }`. Mochi's
+`while` is direct-mapped (nodes.go lines 272-294).
+
+### 6.3 `for x in start..end`
+
+Range loops lower to `ForRangeStmt`: `for ($x = start; $x < end; $x++)`
+(nodes.go lines 296-325). The `<` boundary matches Mochi's exclusive
+upper bound.
+
+### 6.4 `for x in collection`
+
+Collection iteration lowers to `ForEachStmt`: `foreach ($coll as $x)`
+(nodes.go lines 640-665). Used for list, map (over values), and set
+(over keys).
+
+### 6.5 `break` / `continue`
+
+Direct 1:1 mappings: `BreakStmt` and `ContinueStmt` in ptree
+(nodes.go lines 328-339).
+
+## 7. User functions
+
+User functions lower to top-level PHP functions prefixed with `mochi__`.
+This prefix prevents collisions with the inline runtime helpers
+(`mochi_print_i64`, `mochi_str_contains`, `mochi_llm_generate`, and so
+on) which all use a single-underscore `mochi_` prefix. The distinction
+is deliberate and documented in the MEP-55 spec.
+
+The `lowerFunction` path (lower.go lines 699-744) handles parameter
+types including scalars, records, sum-type bases, lists, maps, closures,
+and futures. Lifted closures get their capture variables prepended as
+leading parameters before the declared parameter list.
+
+Function return types go through `phpParamType` for the same type
+vocabulary.
+
+## 8. Query DSL
+
+The query DSL (`from X in list where ... select ...`) is desugared by
+the shared aotir lowerer into `LetStmt + ForEachStmt + ArrayAppendExpr`
+(imperative gather) plus optional `ListSortAscExpr` and
+`ListSliceExpr`. The PHP lowerer drops the C-specific
+`QueryScopeStmt` arena wrapper (`lowerStmt` case `*aotir.QueryScopeStmt`
+at lower.go lines 473-475) and inlines the body directly, since PHP
+relies on reference-counting and cycle collection rather than an arena
+allocator.
+
+Query temp variables use the name `$__query1`, `$__query2`, etc.,
+minted by the shared aotir desugaring pass.
+
+Order-by lowers to the `mochi_list_sort_asc` helper, which uses PHP's
+spaceship operator (`<=>`) for type-agnostic natural ordering. Skip and
+take lower to `array_slice`. See [[08-dataset-pipeline]] for details.
+
+## 9. Agents
+
+Phase 9 agents lower to `final class` (no `readonly`, since intent
+bodies mutate fields). Each agent field becomes a promoted public
+constructor parameter; each `intent` becomes a public instance method.
+The aotir `__self->FIELD` sentinel is rewritten to `$this->FIELD` in
+both reads (`lowerExpr` VarRef case) and writes (`lowerAssignStmt`).
+
+`spawn AgentType()` constructs a new agent instance with zero-value
+fields synthesised from the `AgentDecl` (lower.go `lookupAgentDecl`,
+`phpZeroLit`). Agent class names that collide with PHP reserved words
+are suffixed with `_` by `phpClassName` (lower.go lines 965-972).
+
+## 10. Streams
+
+Phase 10 streams lower to the `MochiStream` / `MochiSub` inline runtime
+classes. `MochiStream` holds a `$subs` array of per-subscriber queues and
+a `$limits` array of per-subscriber drop thresholds. `MochiSub` holds a
+reference to the parent stream and a subscriber index. See
+[[09-agent-streams]] for the full stream design.
+
+## 11. Async (`async` / `await`)
+
+Phase 11 async functions lower to synchronous wrappers. `mochi_future_make`
+wraps a value in a `MochiFuture` object; `mochi_future_await` unwraps
+it; `mochi_future_await_all` maps over a list of futures. No PHP fibers
+or Amp/Revolt are involved. See [[09-agent-streams]] and
+[[02-design-philosophy]] for the choice rationale.
+
+## 12. LLM generation
+
+Phase 13 LLM calls lower to `mochi_llm_generate(provider, model, prompt)`.
+The inline runtime performs DJB2 hashing via GMP and reads a cassette
+file from `MOCHI_LLM_CASSETTE_DIR`. See [[08-dataset-pipeline]] for the
+Datalog side and [[12-risks-and-alternatives]] for risks.
+
+## 13. File I/O
+
+Phase 12 `writeFile(path, content)` lowers to `file_put_contents($path,
+$content)` (creates or truncates). `appendFile(path, content)` lowers to
+`file_put_contents($path, $content, FILE_APPEND)`. These are direct
+mappings to PHP built-in functions.
+
+## 14. `panic`
+
+Mochi `panic` lowers to `throw new \RuntimeException($message)`, a
+direct PHP exception throw. PHP's `\RuntimeException` is in the global
+namespace and requires no import.
+
+## Phase corpus at a glance
+
+| Phase | Fixture directory | Core feature added |
+|-------|-------------------|--------------------|
+| 00 | `phase00-skeleton` | Empty `mochi_main()` stub + trailing call |
+| 01 | `phase01-hello` | `mochi_print_str`, `mochi_print_i64`, `mochi_print_f64`, `mochi_print_bool` |
+| 02 | `phase02-scalars` | Literals, let/var, binary/unary ops, `if`, `while`, `for`-range, `break`, `continue` |
+| 03 | `phase03-collections` | `list`, `map`, `set`, `for-each`, `append`, index access |
+| 04 | `phase04-records` | `final readonly class`, constructor promotion, named args |
+| 05 | `phase05-sums` | `abstract readonly class` base, `final readonly class` variants, `match` / `instanceof` |
+| 06 | `phase06-closures` | Arrow functions, lifted closures, `mochi__` prefix, function types |
+| 07 | `phase07-query` | Query DSL desugaring, `mochi_list_sort_asc`, `array_slice` |
+| 08 | `phase08-datalog` | Compile-time Datalog semi-naive evaluation, static array literal |
+| 09 | `phase09-agents` | Mutable agent classes, intent methods, `spawn` zero-init |
+| 10 | `phase10-streams` | `MochiStream` / `MochiSub`, fan-out, backpressure |
+| 11 | `phase11-async` | `MochiFuture` sync wrappers, all-Blue colour pass |
+| 12 | `phase12-ffi` | FFI extension, `file_put_contents`, `appendFile` |
+| 13 | `phase13-llm` | DJB2 cassette dispatch, GMP hash, `MOCHI_LLM_CASSETTE_DIR` |
+| 14 | `phase14-fetch` | `curl_exec` HTTP fetch |
+| 15 | `phase15-composer` | PSR-4 autoload, Composer sandbox staging |
+| 16 | `phase16-repro` | Byte-equal reproducible builds, `Driver.Deterministic` |
+| 17 | `phase17-packaging` | Phar stager, FrankenPHP Caddyfile+Dockerfile, RoadRunner `.rr.yaml`+`worker.php` |

--- a/website/docs/research/0055/02-design-philosophy.md
+++ b/website/docs/research/0055/02-design-philosophy.md
@@ -1,0 +1,236 @@
+---
+title: "Design philosophy: why PHP 8.4, why strict_types, why sync wrappers, why final readonly, why DJB2/GMP, why Phar"
+description: "The 'why' behind every load-bearing MEP-55 design choice: PHP 8.4 floor, strict_types=1, abstract readonly bases, sync wrappers, GMP DJB2 hashing, and Phar packaging."
+sidebar_position: 2
+---
+
+# Design philosophy: why PHP 8.4, why `declare(strict_types=1)`, why sync wrappers not Amp/Revolt, why `final readonly class` for records, why `abstract readonly class` for sum-type bases, why DJB2/GMP for cassette keys, why Phar over box/humbug for the Phase 17 gate
+
+Author: research pass for MEP-55 (Mochi-to-PHP 8.4 transpiler).
+Date: 2026-05-29 15:00 (GMT+7).
+Sources: `transpiler3/php/lower/lower.go`, `transpiler3/php/ptree/nodes.go`,
+`transpiler3/php/colour/colour.go`, `transpiler3/php/build/packaging.go`,
+`transpiler3/php/runtime/composer.json`, `website/docs/mep/mep-0055.md`.
+
+This note explains the load-bearing design choices behind MEP-55 and
+the constraints they impose. It is the "why" companion to
+[[01-language-surface]]'s "what" and [[05-codegen-design]]'s "how".
+
+## 1. Why a PHP target
+
+Mochi already covers ten lowering targets: vm3 (reference tree-walker),
+MEP-45 (C, AOT), MEP-46 (BEAM), MEP-47 (JVM bytecode), MEP-48 (.NET),
+MEP-49 (Swift), MEP-50 (Kotlin), MEP-51 (Python), MEP-52 (TypeScript),
+MEP-53 (Rust), MEP-54 (Erlang/OTP). Each picks up an ecosystem Mochi
+cannot reach from the others.
+
+PHP is the outlier in the list above: it is the server-side language
+running the largest installed base of web applications. WordPress powers
+approximately 43% of the public web as of 2026-Q1. Laravel, Symfony,
+Drupal, MediaWiki, and Magento together cover most of the remainder of
+the PHP-powered web tier. Packagist hosts over 400,000 Composer packages.
+
+Every other Mochi target can run web workloads, but none of them
+integrates with the Composer package registry, none deploys as a Phar
+archive on a shared hosting tier, and none runs in a FrankenPHP or
+RoadRunner worker pool managed by the existing PHP app-server
+ecosystem. MEP-55 closes that gap.
+
+## 2. Why PHP 8.4 as the minimum
+
+The `require` constraint in `transpiler3/php/runtime/composer.json` is
+`"php": "^8.4"`. This is not arbitrary:
+
+**Readonly inheritance (PHP 8.4, Nov 2024).** Mochi sum types require
+that `final readonly class Shape_Circle` extends an `abstract readonly
+class Shape` base. PHP 8.4 introduced the rule that a `final readonly`
+class can extend an `abstract readonly` base. PHP 8.3 and earlier have
+no `abstract readonly` combination. In those versions, the base would
+need to be a plain `abstract class`, but then the subclass cannot be
+`readonly`. The entire sum-type lowering strategy depends on PHP 8.4.
+
+**PHP 8.3.** No `abstract readonly class` syntax. Sum-type bases would
+need a different encoding (perhaps a sealed interface plus a trait), which
+would add complexity and lose the property that `instanceof` pattern
+matching is a single `if ($x instanceof Shape_Circle)` check.
+
+**PHP 8.2.** Same problem, plus readonly classes (`final readonly class`)
+are new in 8.2, so records would also need a different encoding.
+
+**PHP 8.1.** Readonly properties exist but not readonly classes.
+Constructor promotion exists (8.0) but the `readonly` modifier on a
+class is unavailable.
+
+**PHP 8.0.** `match` expression and named arguments are available, but
+readonly properties and classes are not. Records would need custom
+`__construct` bodies with manual `$this->x = $x;` assignments.
+
+**PHP 7.x.** No `match`, no named arguments, no `fn(...)` arrow
+functions. The entire surface used by MEP-55's lowering would need
+workarounds.
+
+The conclusion is that PHP 8.4 is the earliest version where all five
+Mochi type-system constructs (records, sum types, closures, streams,
+agents) lower cleanly without workarounds.
+
+## 3. Why `declare(strict_types=1)`
+
+Every emitted PHP file opens with `declare(strict_types=1);` emitted by
+`ptree.PhpFile.PhpSource()` (nodes.go lines 40-42). This flag:
+
+- Prevents PHP from silently coercing `"42"` to `42` when an `int`
+  parameter receives a string. Without it, `mochi_print_i64("hello")`
+  would not fail at the call site.
+- Makes `===` the only form of equality that matches Mochi's strict
+  type identity semantics. The `==` operator in PHP with loose types
+  applies coercions that have no Mochi equivalent.
+- Makes PHPStan level-9 analysis more precise. Many PHPStan rules are
+  only fully actionable under strict mode.
+
+The flag applies per-file in PHP. Since the emitter writes exactly one
+file per Mochi module, every emitted file gets it unconditionally.
+
+## 4. Why `final readonly class` for records
+
+Mochi records are structurally immutable value types. The PHP encoding
+needs:
+
+1. Immutability: fields cannot be reassigned after construction.
+2. Value semantics: two records with the same fields are equal.
+3. No subclassing: records are not open for extension in Mochi.
+
+`final readonly class` satisfies all three: `readonly` enforces (1),
+PHP's value-by-copy semantics for objects passed to typed parameters
+satisfies (2) for the purposes of the lowerer, and `final` enforces (3).
+Constructor promotion (PHP 8.0) eliminates the boilerplate
+`$this->x = $x;` pattern.
+
+The alternative would be a plain `class` with `readonly` properties on
+each field. That works but requires explicit `public function
+__construct(public readonly int $x) {}` syntax, which constructor
+promotion already achieves more concisely.
+
+## 5. Why `abstract readonly class` for sum-type bases
+
+Mochi sum types need a base class that:
+
+1. Can be the parent of a `final readonly class` variant.
+2. Is not directly instantiable.
+3. Carries no fields of its own (the fields live on variants).
+
+PHP 8.4's `abstract readonly class` satisfies all three. The base body
+is intentionally empty (nodes.go `ClassDecl.PhpString` line 754 comment).
+Attempting to use `abstract class` (without `readonly`) for the base
+breaks in PHP 8.4 because `final readonly` cannot extend a non-readonly
+base (the `readonly` modifier must be consistent across the hierarchy).
+The CI failure during Phase 5 of the umbrella PR confirmed this
+constraint and drove the `Abstract = true` flag on `ClassDecl` to emit
+`abstract readonly class` specifically.
+
+## 6. Why `===` for all comparisons including float
+
+PHP's `==` operator applies type coercion. For floats, `0 == false`,
+`0 == ""`, and `0.0 == 0` are all true under `==`. Mochi's equality
+semantics require strict type identity: `0.0 == 0` is false in Mochi
+(different types), and `0.0 == 0.0` is true. The `===` operator in PHP
+performs no coercion and matches Mochi's semantics exactly.
+
+The `BinaryExpr` ptree node always uses `===` for the Mochi `==`
+operator (lower.go, `lowerBinaryExpr`). This is enforced by the lowerer
+regardless of the operand types.
+
+## 7. Why sync wrappers for async, not Amp/Revolt
+
+PHP has no preemptive scheduler in the standard library. Two
+third-party options exist: `amphp/amp` (a coroutine-based event loop)
+and `revolt/event-loop` (the spiritual successor). Both require
+adding Composer runtime dependencies and change the function signature
+conventions (Amp functions return `Future<T>` instead of `T`).
+
+Phase 11 chose sync wrappers instead:
+
+- `mochi_future_make($v)` wraps an already-computed value in a
+  `MochiFuture` object.
+- `mochi_future_await($f)` unwraps it by returning `$f->value`.
+- `mochi_future_await_all($fs)` maps over a list of `MochiFuture`
+  objects.
+
+No PHP fibers, no event loop, no runtime dependency. The
+`colour/colour.go` package documents this explicitly: every function is
+permanently Blue (synchronous); the Red colour constant is reserved but
+never produced. The `transpiler3/php/runtime/composer.json` originally
+drafted `amphp/revolt` in `require`; audit round 1 removed it after
+Phase 11 confirmed sync-only operation.
+
+This choice has a cost: Mochi agents and streams are synchronous on PHP.
+Phase 11 fixtures all use emit-before-recv patterns (no interleaving
+needed) specifically because the sync model cannot support blocking
+recv-before-emit. The trade-off buys zero external dependencies and
+full compatibility with every PHP deployment environment, including
+shared hosting that disallows fibers.
+
+## 8. Why DJB2 and GMP for cassette keys
+
+Phase 13 LLM cassette keys must be byte-equal across the PHP and C
+(MEP-45) targets so the same cassette directory can be shared. The C
+runtime uses DJB2 (hash = 5381, then `h = (h * 33) ^ c` for each
+byte, modulo 2^64). PHP's native integer is 63-bit signed on 64-bit
+platforms (PHP_INT_MAX = 9223372036854775807). Some DJB2 hash values
+for real prompts exceed PHP_INT_MAX, causing PHP's integer overflow
+to produce the wrong (negative or truncated) result.
+
+GMP (`ext-gmp`) solves this: the `mochi_llm_cassette_key` helper
+initialises the hash as a GMP integer, applies `gmp_and(gmp_mul($h,
+33), $mask)` with a 64-bit mask `FFFFFFFFFFFFFFFF`, then calls
+`gmp_strval($h, 10)` to produce the decimal string key. The GMP
+operations keep the value in 64-bit unsigned space throughout. Both
+`ext-gmp` and `ext-mbstring` are listed as required extensions in
+`runtime/composer.json` (lines 8-9).
+
+The Go-side `djb2CassetteKey` reimplementation in
+`build/phase13_test.go` (lines 219-226) uses Go's native `uint64`
+which wraps modulo 2^64 correctly, confirming equivalence with the
+GMP path without needing PHP to be installed.
+
+## 9. Why Phar over humbug/box for the Phase 17 gate
+
+The Phase 17 packaging gate tests that a runnable Phar archive can be
+produced from any emitted `main.php`. Two tools can produce Phars:
+
+1. **humbug/box** (also called box): a Composer package that compiles,
+   compresses, and optionally GPG-signs a Phar. Production builds
+   prefer it. But requiring `humbug/box` as a CI dependency adds a
+   `composer global require humbug/box` step and network access to
+   every test run.
+
+2. **PHP's built-in `Phar` class**: available in every PHP 8.4
+   installation, no extra tools required. Less featureful (no
+   compression, no GPG signing), but sufficient for structural
+   validation.
+
+The Phase 17 gate uses a generated stager script (emitted by
+`emitPharStager` in `build/packaging.go` lines 53-74) that calls
+`Phar::startBuffering()`, `addFile()`, `setStub()`, and
+`stopBuffering()`. The stager runs under `php -d phar.readonly=0`
+because `phar.readonly` defaults to `1` on many distributions. The
+gate confirms the resulting `.phar` runs and produces the correct
+stdout.
+
+Production deployments can substitute `humbug/box compile` for the
+stager; the gate's job is purely structural validation.
+
+## 10. Why a direct aotir → ptree → emit approach
+
+MEP-55 reuses the aotir IR from MEP-45 (C target) rather than
+introducing a new IR or piping through a different PHP-generating tool.
+The aotir represents the shared lowering obligations (monomorphisation,
+closure conversion, match exhaustiveness) that are target-independent.
+Below aotir, the PHP lowerer builds a PHP-specific syntax tree (ptree)
+that maps 1:1 to PHP source constructs, then the emit pass renders
+ptree to text by calling `ptree.PhpFile.PhpSource()`.
+
+This two-level architecture (aotir → ptree → text) mirrors MEP-45, -46,
+-47, -48, -49, -50, -51, -52, and -54. It ensures that all targets
+share the same front-end guarantees (type-checking, exhaustiveness, no
+unbound variables) while each target's lowerer can make PHP-specific
+choices without affecting the shared path.

--- a/website/docs/research/0055/03-prior-art-transpilers.md
+++ b/website/docs/research/0055/03-prior-art-transpilers.md
@@ -1,0 +1,170 @@
+---
+title: "Prior art: source-to-PHP tools, PHP version history, and why aotir→ptree→emit"
+description: "Survey of compile-to-PHP tools (Hack/HHVM, Haxe PHP target, Dart2PHP), PHP version history by relevant feature, and why MEP-55 chose a direct aotir→ptree→emit pipeline."
+sidebar_position: 3
+---
+
+# Prior art: source-to-PHP tools, PHP version history, and why aotir→ptree→emit
+
+Author: research pass for MEP-55 (Mochi-to-PHP 8.4 transpiler).
+Date: 2026-05-29 15:00 (GMT+7).
+Sources: `transpiler3/php/runtime/composer.json`,
+`website/docs/mep/mep-0055.md`, PHP release notes (php.net/ChangeLog),
+Haxe PHP target documentation, Hack/HHVM documentation,
+Dart2PHP deprecation announcement (2015).
+
+This note surveys the prior art in source-to-PHP compilation and explains
+why MEP-55 chose a direct aotir→ptree→emit approach rather than reusing
+any existing tool or IR.
+
+## 1. Hack / HHVM
+
+Facebook's Hack language (2014) is the most prominent "compile a typed
+language to PHP-compatible runtime" project. Hack added gradual typing,
+generics, async/await, algebraic data types, and enums on top of PHP
+syntax. HHVM (HipHop Virtual Machine) is the runtime that executes Hack
+and PHP.
+
+**What Hack solved**: Hack demonstrated that a strict type system over
+a PHP-like language is viable at scale and that sum types (`shape`,
+`enum`, nullable types) can be added to PHP-family syntax without
+breaking the ecosystem.
+
+**Why MEP-55 is different**: Hack targets the HHVM runtime, not standard
+PHP. HHVM diverged significantly from Zend Engine PHP in terms of
+extension support, hosting availability, and community adoption. By 2018
+HHVM dropped backward compatibility with PHP. MEP-55 targets stock PHP
+8.4 on Zend Engine, running anywhere `php` is installed, not HHVM.
+
+Additionally, Hack is its own language with its own source syntax. MEP-55
+is a transpiler from a different source language (Mochi) to PHP source.
+
+## 2. Haxe PHP target
+
+Haxe is a typed language that can transpile to multiple targets:
+JavaScript, C++, C#, Java, Python, Lua, and PHP. The Haxe PHP target
+(maintained as `haxe --target php`) emits PHP source from Haxe programs.
+
+**What Haxe's PHP target shows**: a working source-to-PHP transpiler
+can be maintained long-term. Haxe's PHP backend emits `declare
+(strict_types=1)` on its output files (as of Haxe 4.2), the same
+choice MEP-55 makes. Haxe also emits class hierarchies for algebraic
+types.
+
+**Why MEP-55 is not Haxe**: Haxe's type system and Mochi's are
+different. Haxe uses structural types and its closures, records, and
+async models differ from Mochi's. MEP-55 reuses Mochi's existing aotir
+IR and the shared front-end (parser, type checker, closure conversion,
+exhaustiveness) rather than building a separate pipeline. A Haxe
+target for Mochi would require writing a Mochi→Haxe transpiler and
+then using Haxe→PHP on top, adding a large dependency without benefit.
+
+## 3. Dart2PHP (deprecated 2015)
+
+Google's Dart language had an experimental Dart2PHP backend until 2015,
+when Google deprecated it in favour of Dart2JS. The Dart2PHP backend
+emitted PHP 5.x-era code with explicit closures (since PHP 5.3) and
+lacked support for modern PHP constructs.
+
+**What Dart2PHP showed**: the impedance mismatch between Dart's
+type-safe closures and PHP 5.x closures was significant. Dart2PHP needed
+explicit `use ($var)` capture lists everywhere, which required the
+backend to track free variables carefully.
+
+**Why MEP-55 avoids this**: PHP 8.0's arrow functions (`fn(...)`) capture
+by value automatically from the enclosing scope. MEP-55's closure
+lowering uses `ClosureExpr` (arrow functions) for all closures, which
+eliminates the need to enumerate captured variables in the emitted
+source. The `fn(...)` syntax was not available when Dart2PHP was
+written.
+
+## 4. AssemblyScript
+
+AssemblyScript targets WebAssembly from TypeScript-like syntax. It has
+no PHP target and is not relevant, but it demonstrates that language
+targets do not need to share a runtime with the source language.
+Noted as explicitly skipped (no PHP Wasm runtime was evaluated for MEP-55).
+
+## 5. Parrot (dead)
+
+The Parrot virtual machine (PHP via mod_parrot) was a research effort
+to run multiple languages on a common VM. It never reached production
+PHP deployment. Dead since 2014.
+
+## 6. Other compile-to-PHP tools
+
+- **transpile/php**: small open-source Python-to-PHP transpiler, maintained sporadically.
+- **Snowscript**: Python-like syntax to PHP, unmaintained since 2016.
+- **Symbiose**: OCaml-style syntax to PHP, prototype-only.
+
+None of these tools produce PHP 8.4+ code, use `declare(strict_types=1)`
+throughout, or target `final readonly class` for value types. None
+integrate with aotir.
+
+## 7. PHP version history: features relevant to MEP-55
+
+| PHP version | Release | Feature relevant to MEP-55 |
+|-------------|---------|----------------------------|
+| 5.3 (2009) | 2009-06 | Anonymous functions with `use ($var)` capture |
+| 7.0 (2015) | 2015-12 | Return types, scalar type hints with strict_types |
+| 7.4 (2019) | 2019-11 | Arrow functions `fn(...)`, spread in arrays `[...$a]` |
+| 8.0 (2020) | 2020-11 | Constructor promotion, named arguments, `match`, `str_contains` |
+| 8.1 (2021) | 2021-11 | Readonly properties |
+| 8.2 (2022) | 2022-12 | `final readonly class` |
+| 8.3 (2023) | 2023-11 | No abstract readonly syntax (gap year for sum types) |
+| 8.4 (2024) | 2024-11 | `abstract readonly class`, asymmetric visibility, `#[\Override]` |
+
+The `^8.4` floor in `runtime/composer.json` means every PHP feature in
+the table above through 8.4 is available unconditionally. MEP-55 uses:
+
+- Arrow functions (7.4): `ClosureExpr` in ptree.
+- Spread in arrays (7.4): `ArrayAppendExpr` (`[...$xs, $v]`).
+- Constructor promotion (8.0): all record and agent classes.
+- Named arguments (8.0): `NewExpr` uses named args.
+- `match` expression (8.0): not used directly; MEP-55 lowers Mochi
+  `match` to `ChainedIfStmt` instead for the `instanceof` discrimination.
+- `str_contains` (8.0): used inside `mochi_str_contains`.
+- `final readonly class` (8.2): all record classes.
+- `abstract readonly class` (8.4): all sum-type bases.
+
+PHP 8.5 runs as `allow_failure: true` in the CI matrix (see
+`.github/workflows/transpiler3-php-test.yml`). PHP 8.4.0 and PHP 8.4
+latest are both required passes.
+
+## 8. Why not PHP 8.5+
+
+PHP 8.5 was in alpha/beta at the time MEP-55 was written (2026-05). The
+CI matrix includes it as `allow_failure: true` to catch breakage early
+without blocking the merge. The `^8.4` constraint in `composer.json`
+does not exclude 8.5 (Composer's `^` operator allows compatible minor
+and patch updates within the major), so Composer would install on
+8.5 freely. The `allow_failure` is a CI-policy choice, not a
+compatibility exclusion.
+
+## 9. Why a direct aotir → ptree → emit approach
+
+Three alternatives were evaluated:
+
+**A. Emit PHP through a Haxe intermediate**: would require writing
+a Mochi→Haxe transpiler on top of the Haxe→PHP backend. Two
+translation layers instead of one, and Haxe's PHP target is not
+under Mochi's control.
+
+**B. Emit PHP through a template engine**: a `text/template`-based
+approach (similar to `build/packaging.go` which uses templates for
+static artifacts) would work for simple programs but quickly becomes
+unreadable for nested expressions and complex control flow.
+
+**C. Build a PHP-specific ptree and emit pass**: this is the chosen
+approach, mirroring MEP-45 (C ptree), MEP-51 (Python ptree), and
+MEP-52 (TypeScript AST). The ptree represents PHP-specific IR at a
+level of abstraction that makes it easy to reason about generated code
+while keeping the emit pass simple (each node's `PhpString` method is
+self-contained). The ptree approach also makes it easy to unit-test the
+lowerer without running PHP: the fragment tests in `phase*_test.go` call
+`Driver.Build` to get the emitted source text and call
+`strings.Contains` on it.
+
+The direct approach also means that every aotir improvement (closure
+conversion, exhaustiveness, monomorphisation) propagates to PHP
+automatically, without maintaining a Haxe or template-based glue layer.

--- a/website/docs/research/0055/04-runtime.md
+++ b/website/docs/research/0055/04-runtime.md
@@ -1,0 +1,190 @@
+---
+title: "Runtime: the mochi/runtime Composer package"
+description: "Directory structure, IO class, @api annotation, devDependencies (Psalm 6, PHPStan 1.12, php-cs-fixer), zero runtime deps, and required PHP extensions for the mochi/runtime Composer package."
+sidebar_position: 4
+---
+
+# Runtime: the `mochi/runtime` Composer package
+
+Author: research pass for MEP-55 (Mochi-to-PHP 8.4 transpiler).
+Date: 2026-05-29 15:00 (GMT+7).
+Sources: `transpiler3/php/runtime/composer.json`,
+`transpiler3/php/runtime/src/Mochi/Runtime/IO.php`,
+`transpiler3/php/runtime/psalm.xml`,
+`transpiler3/php/runtime/phpstan.neon`,
+`.github/workflows/transpiler3-php-test.yml`.
+
+The `mochi/runtime` Composer package is the PHP-side runtime library for
+MEP-55-generated programs. It ships under the `Mochi\Runtime` PSR-4
+namespace, has zero Composer runtime dependencies, and requires exactly
+two PHP extensions (`ext-mbstring` and `ext-gmp`). See
+[[02-design-philosophy]] for the rationale behind zero runtime deps and
+the GMP requirement.
+
+## 1. Directory structure
+
+```
+transpiler3/php/runtime/
+  composer.json          # package manifest
+  psalm.xml              # Psalm 6 configuration
+  phpstan.neon           # PHPStan level-9 configuration
+  phpunit.xml.dist       # PHPUnit 11.3 configuration
+  TRUST.md               # package trust and signing notes
+  src/
+    Mochi/
+      Runtime/
+        IO.php           # print primitives
+  tests/
+    Mochi/
+      Runtime/           # PHPUnit test suite (autoloaded via autoload-dev)
+```
+
+The `autoload` stanza in `composer.json` maps `Mochi\Runtime\` to
+`src/Mochi/Runtime/` (PSR-4). The `autoload-dev` stanza maps
+`Mochi\Runtime\Tests\` to `tests/Mochi/Runtime/`.
+
+## 2. The IO class
+
+`src/Mochi/Runtime/IO.php` defines `final class IO` in the `Mochi\Runtime`
+namespace with four static methods:
+
+- `IO::printString(string $value): void` — echoes `$value` plus `"\n"`.
+- `IO::printInt(int $value): void` — echoes `$value` plus `"\n"`.
+- `IO::printBool(bool $value): void` — echoes `"true\n"` or `"false\n"`.
+- `IO::printFloat(float $value): void` — mirrors Go's
+  `strconv.FormatFloat('g', -1, 64)` contract: NaN → `"NaN"`, +Inf →
+  `"+Inf"`, -Inf → `"-Inf"`, whole-number floats → integer digits (so
+  `4.0` prints as `"4"`), others echo PHP's default float-to-string.
+
+The float formatter in IO.php (lines 57-73) is identical in intent to
+the `mochi_print_f64` inline helper in `lower.go` (lines 171-184). The
+inline helper is used in Phase 1-14 (before the Composer package lands);
+Phase 15 switches to the Composer-autoloaded `\Mochi\Runtime\IO` class.
+
+## 3. The `@api` annotation and why it is needed
+
+The IO class is referenced only from lowered Mochi programs, which live
+outside the `src/` directory tree that Psalm scans. From Psalm's
+perspective, no code in `src/` calls `IO::printString`, so Psalm's
+`UnusedClass` check would report the entire class as dead code and fail
+the CI gate.
+
+The `@api` PHPDoc tag on the class docblock tells Psalm that `IO` is an
+externally-consumed public surface and suppresses the `UnusedClass`
+finding. This pattern is standard in Psalm for library packages whose
+entry points are not exercised from within the package's own source tree.
+
+The `TRUST.md` file in the runtime directory documents this annotation
+convention and why it cannot be removed.
+
+## 4. devDependencies
+
+The `require-dev` stanza in `composer.json` (lines 13-19) lists:
+
+```json
+"phpstan/phpstan": "^1.12",
+"phpstan/phpstan-strict-rules": "^1.6",
+"phpstan/phpstan-deprecation-rules": "^1.2",
+"vimeo/psalm": "^6.0",
+"friendsofphp/php-cs-fixer": "^3.65",
+"phpunit/phpunit": "^11.3"
+```
+
+None of these appear in `require` (runtime dependencies). They are
+dev-only and do not ship inside a `vendor/` tree when a consuming project
+runs `composer install --no-dev`.
+
+### 4.1 PHPStan 1.12
+
+PHPStan at level 9 (the strictest level) is configured via
+`phpstan.neon`. Level 9 enables:
+- All type-mismatch checks.
+- Dead code detection (unused variables, unreachable branches).
+- Array/property access safety.
+
+The CI gate runs `vendor/bin/phpstan analyse --no-progress`.
+
+### 4.2 Psalm 6 (not 5)
+
+The constraint `"vimeo/psalm": "^6.0"` is significant. Psalm 5.x
+had a PHP 8.4 platform detection failure: Psalm 5 did not recognise
+PHP 8.4 in its `phpversion` analysis and flagged `abstract readonly class`
+syntax as invalid. Upgrading to Psalm 6 was required during the first
+audit round of MEP-55. Psalm 6 added PHP 8.4 support.
+
+The CI runs `vendor/bin/psalm --no-progress --no-cache`.
+
+### 4.3 php-cs-fixer 3.65
+
+Configured to enforce PER-CS2.0 (PHP-FIG Extended Coding Style 2.0)
+plus the PHP 8.4 migration ruleset. The CI gate runs
+`vendor/bin/php-cs-fixer fix --dry-run --diff` (zero rewrites required).
+
+The formatter enforces 4-space indentation (which the ptree emit pass
+also uses: `indent(n)` in `nodes.go` returns `strings.Repeat("    ",
+n)`), single blank lines between declarations, and PSR-4 file structure.
+
+### 4.4 PHPUnit 11.3
+
+The runtime test suite lives under `tests/Mochi/Runtime/`. PHPUnit 11.3
+requires PHP 8.2+, so it is compatible with the ^8.4 platform floor.
+
+## 5. Runtime (production) dependencies
+
+The `require` stanza has exactly three entries:
+
+```json
+"php": "^8.4",
+"ext-mbstring": "*",
+"ext-gmp": "*"
+```
+
+No Composer packages appear in `require`. This means `composer install`
+on a project that depends on `mochi/runtime` does not pull in any
+third-party PHP code. The two extensions are:
+
+- `ext-mbstring`: multibyte string functions. Required for UTF-8-aware
+  string operations in Phase 12+ FFI and fetch layers.
+- `ext-gmp`: GNU Multiple Precision Arithmetic. Required for the Phase 13
+  DJB2 cassette key computation (the hash can exceed PHP_INT_MAX, so
+  GMP is used for correct uint64 arithmetic). See [[02-design-philosophy]]
+  for the rationale.
+
+Both extensions are available on all major PHP distributions (Ubuntu,
+Debian, Alpine, macOS Homebrew). The CI matrix installs them via
+`shivammathur/setup-php@v2` with `extensions: mbstring, gmp`.
+
+## 6. Minimum-stability
+
+`"minimum-stability": "stable"` in `composer.json` ensures that
+`composer install` only resolves stable releases of dev dependencies.
+No alpha or RC builds of PHPStan or Psalm are allowed in the lock file.
+
+## 7. Composer configuration
+
+```json
+"config": {
+    "sort-packages": true,
+    "preferred-install": "dist"
+}
+```
+
+`sort-packages: true` keeps `composer.json` sorted deterministically,
+matching the Phase 16 reproducibility goal for the source tree.
+`preferred-install: dist` prefers zip distributions over source clones,
+which speeds up CI.
+
+## 8. Phase 15: Composer package staging
+
+Phase 15 wires the Composer package into the build sandbox. The
+`runtimeSourceDir()` function in `build.go` (lines 183-195) locates the
+`transpiler3/php/runtime/` directory relative to the Go source file using
+`runtime.Caller(0)`. The `copyFile(dst, src)` helper (lines 199-215)
+copies individual files into the sandbox, creating parent directories as
+needed.
+
+The inline runtime helpers (`mochi_print_str`, `mochi_str_contains`, etc.)
+that Phase 1-14 inject directly into the emitted PHP file are superseded
+in Phase 15 by the Composer-autoloaded equivalents. The transition is
+transparent to the fixtures because the public interface (function name,
+parameter types, return type) is identical.

--- a/website/docs/research/0055/05-codegen-design.md
+++ b/website/docs/research/0055/05-codegen-design.md
@@ -1,0 +1,306 @@
+---
+title: "Codegen design: aotir → ptree → emit pipeline"
+description: "The aotir→ptree→emit pipeline for MEP-55: ptree node types, runtimeFlags struct, mochi__ prefix, emit pass, and Driver.Build wiring."
+sidebar_position: 5
+---
+
+# Codegen design: aotir → ptree → emit pipeline
+
+Author: research pass for MEP-55 (Mochi-to-PHP 8.4 transpiler).
+Date: 2026-05-29 15:00 (GMT+7).
+Sources: `transpiler3/php/ptree/nodes.go`,
+`transpiler3/php/lower/lower.go`,
+`transpiler3/php/emit/emit.go`,
+`transpiler3/php/build/build.go`,
+`transpiler3/php/colour/colour.go`.
+
+This note walks the full MEP-55 pipeline from Mochi source to PHP 8.4
+source file. It is the "how" companion to [[02-design-philosophy]]'s
+"why" and [[01-language-surface]]'s "what". See [[06-type-lowering]] for
+per-type details and [[10-build-system]] for the Driver.Build entry point.
+
+## 1. Pipeline overview
+
+```
+.mochi source
+  → parser.Parse              (shared)
+  → types.Check               (shared)
+  → clower.Lower              (MEP-45 aotir, shared)
+  → colour.Compute            (PHP colour pass, all-Blue)
+  → lower.Lower               (PHP-specific lowerer → ptree.PhpFile)
+  → emit.Emit                 (ptree → main.php on disk)
+  → [optional] php main.php   (TargetPhpRun)
+```
+
+The pipeline is wired in `Driver.Build` (build.go lines 64-123). Each
+step is sequential and deterministic.
+
+## 2. The ptree package
+
+`transpiler3/php/ptree/nodes.go` defines the PHP-specific intermediate
+representation. It is not a general PHP AST but a minimal set of node
+types sufficient to represent the PHP programs that MEP-55 generates.
+
+### 2.1 Top-level structure: PhpFile
+
+`PhpFile` (nodes.go lines 17-35) has:
+- `Namespace string`: PSR-4 namespace (empty for global-namespace files
+  in Phase 0-14; non-empty from Phase 15 onward).
+- `Uses []string`: `use Foo\Bar;` import statements, sorted and
+  de-duplicated by `sortStringsUnique` (nodes.go lines 72-91).
+- `Decls []Decl`: ordered list of top-level declarations.
+- `TrailingExec []Stmt`: statements after all declarations (used for the
+  `mochi_main();` trailing call).
+
+`PhpFile.PhpSource()` (nodes.go lines 38-70) produces the complete PHP
+source string. It always opens with:
+```php
+<?php
+
+declare(strict_types=1);
+```
+
+### 2.2 Decl interface
+
+The `Decl` interface has two implementations that appear in emitted code:
+
+- `FuncDecl` (nodes.go lines 113-172): a top-level PHP function with
+  optional PHPDoc, name, parameters, return type, and body statements.
+- `ClassDecl` (nodes.go lines 706-793): a PHP class. The `Abstract`,
+  `Mutable`, and `Extends` flags control whether the emitter writes
+  `abstract readonly class`, `final class`, or `final readonly class`.
+- `RawDecl` (nodes.go lines 103-110): verbatim PHP source spliced into
+  the output. Used for the `MochiStream`, `MochiSub`, and `MochiFuture`
+  inline runtime classes whose shape is fixed.
+
+### 2.3 Stmt interface
+
+Key statement nodes:
+
+| Node | PHP rendered form | Used for |
+|------|-------------------|----------|
+| `ExprStmt` | `<expr>;` | Function calls, method calls |
+| `ReturnStmt` | `return <expr>;` | Function return |
+| `AssignStmt` | `$name = <value>;` | `let` and `var` bindings |
+| `IfStmt` | `if (c) { } else { }` | `if/else` |
+| `WhileStmt` | `while (c) { }` | `while` |
+| `ForRangeStmt` | `for ($x = s; $x < e; $x++) { }` | `for x in start..end` |
+| `ForEachStmt` | `foreach ($s as $x) { }` | `for x in collection` |
+| `BreakStmt` | `break;` | `break` |
+| `ContinueStmt` | `continue;` | `continue` |
+| `ChainedIfStmt` | `if (c1) {} elseif (c2) {} else {}` | `match` arms |
+| `IndexAssignStmt` | `$name[$key] = $value;` | Map put |
+| `PropAssignStmt` | `$recv->field = $value;` | Agent field mutation |
+| `RawStmt` | verbatim text | Inline runtime helper bodies |
+
+`RawStmt.PhpString` (nodes.go lines 351-362) re-indents each line of
+`Text` by the requested level, so inline runtime bodies written as
+flat strings are indented correctly in the final output.
+
+### 2.4 Expr interface
+
+Key expression nodes:
+
+| Node | PHP rendered form | Used for |
+|------|-------------------|----------|
+| `CallExpr` | `callee(args)` | Function calls |
+| `StaticCallExpr` | `Class::method(args)` | Static method calls |
+| `MethodCallExpr` | `$recv->method(args)` | Agent intent calls |
+| `IdentExpr` | bare name | Function names, class names, constants |
+| `VarExpr` | `$name` | Variable references |
+| `StringLit` | `"..."` | String literals (with `$` escaping) |
+| `IntLit` | integer | Integer literals |
+| `FloatLit` | Go 'g' format | Float literals |
+| `BoolLit` | `true` / `false` | Boolean literals |
+| `NullLit` | `null` | Null seed for uninitialised bindings |
+| `RawExpr` | verbatim text | Edge cases |
+| `BinaryExpr` | `(left op right)` or `op(left, right)` | All binary ops |
+| `UnaryExpr` | `(op operand)` | Negation, logical not |
+| `CastExpr` | `(type) expr` | `int()` cast |
+| `ArrayLit` | `[a, b]` or `[k => v]` | List, map, set literals |
+| `ArrayAppendExpr` | `[...$inner, $tail]` | `append(xs, v)` |
+| `IndexExpr` | `$recv[$idx]` | List/map/string index access |
+| `NewExpr` | `new ClassName(field: val)` | Record construction |
+| `ClosureExpr` | `fn(params): ret => body` | Closure literals |
+| `PropAccessExpr` | `$recv->field` | Record field / agent field read |
+| `InstanceOfExpr` | `($recv instanceof Class)` | Match arm discriminator |
+
+All `BinaryExpr` and `UnaryExpr` nodes wrap the result in parentheses
+unconditionally (nodes.go lines 545-549, 561-563), so operator
+precedence in the source program is preserved without the lowerer needing
+to track PHP's precedence table.
+
+## 3. The runtimeFlags struct
+
+`runtimeFlags` (lower.go lines 25-37) is a boolean struct embedded in the
+`lowerer`. Each flag is set to `true` the first time the lowerer encounters
+a construct that needs the corresponding inline runtime helper:
+
+```go
+type runtimeFlags struct {
+    printStr    bool
+    printInt    bool
+    printBool   bool
+    printF64    bool
+    strContains bool
+    setMake     bool
+    setAdd      bool
+    listSortAsc bool
+    streams     bool
+    async       bool
+    llm         bool
+}
+```
+
+The `runtimeDecls()` method (lower.go lines 147-428) checks each flag and
+appends a `FuncDecl` or `RawDecl` to the output only for the helpers that
+are actually used. This means a program that uses only integers and strings
+does not emit the `mochi_set_make`, `mochi_stream_make`, or
+`mochi_llm_generate` helpers. The output is minimal.
+
+## 4. The `mochi__` prefix for user functions
+
+User-defined Mochi functions are emitted with a `mochi__` (double
+underscore) prefix. The inline runtime helpers use a `mochi_` (single
+underscore) prefix. This ensures that a user function named `llm_generate`
+emits as `mochi__llm_generate`, which does not collide with the runtime
+helper `mochi_llm_generate`.
+
+PHP's global function namespace is flat; there are no modules or
+namespaces until Phase 15 adds PSR-4. The prefix convention is the
+only collision-avoidance mechanism in Phase 0-14.
+
+## 5. The lowerer: entry point and ordering
+
+`lower.Lower(prog, colours)` (lower.go lines 52-143) is the entry point.
+It processes declarations in this order:
+
+1. **Records** (`prog.Records`): one `final readonly class` per record.
+2. **Sum types** (`prog.Unions`): one `abstract readonly class` base plus
+   `final readonly class` variants per union.
+3. **Agents** (`prog.Agents`): one mutable `final class` per agent.
+4. **Non-main user functions** (`prog.Functions` excluding `prog.Main`):
+   in source order for Phase 16 reproducibility.
+5. **Runtime declarations** (`runtimeDecls()`): inline helpers used by
+   the program.
+6. **Main function** (`prog.Functions[prog.Main]`): lowered as
+   `mochi_main(): void`.
+7. **Trailing call**: `mochi_main();` appended to `TrailingExec`.
+
+Source order is preserved for categories 1-4 because Go slices preserve
+insertion order and the aotir lowerer (MEP-45) produces deterministic
+slice orderings. Phase 16 relies on this.
+
+## 6. The emit pass
+
+`emit.Emit(file, workDir, name)` (emit/emit.go) is intentionally trivial:
+it calls `file.PhpSource()` to get the complete PHP source string and
+writes it to `<workDir>/<name>.php`. The entire rendering logic lives in
+the ptree nodes' `PhpString` methods.
+
+The emit pass is a one-line filesystem operation layered on top of the
+ptree's self-describing rendering. This keeps the emit package small
+(36 lines) and ensures there is only one place where the PHP text is
+generated: the ptree node methods.
+
+## 7. The colour pass
+
+`colour.Compute(prog)` (colour/colour.go lines 39-45) assigns every
+function the `Blue` colour. The `ColourMap` is passed to `lower.Lower`
+but currently ignored (the signature parameter is named `_`). The
+comment in colour.go explains the design: Phase 11 shipped async as
+synchronous value wrappers, so no function ever needs the `Red` (async)
+treatment. The pass exists for symmetry with the other transpiler3
+targets and to provide a single flip-point for a future async revival.
+
+## 8. Emit shapes for key constructs
+
+### 8.1 Function declaration
+
+```php
+/**
+ * Generated Mochi entry point. Do not edit by hand.
+ */
+function mochi_main(): void
+{
+    // body
+}
+```
+
+The PHPDoc is optional; the lowerer only adds it for `mochi_main`. User
+functions (`mochi__foo`) do not get a docblock in Phase 0-14.
+
+### 8.2 Record class declaration
+
+```php
+/**
+ * Mochi record `Point`. Generated; do not edit by hand.
+ */
+final readonly class Point
+{
+    public function __construct(
+        public int $x,
+        public int $y,
+    ) {}
+}
+```
+
+Constructor promotion with `public TYPE $field` for each record field.
+
+### 8.3 Sum-type hierarchy
+
+```php
+/**
+ * Mochi sum type `Shape` base class. Generated; do not edit by hand.
+ */
+abstract readonly class Shape
+{
+}
+
+/**
+ * Variant `Circle` of `Shape`.
+ */
+final readonly class Shape_Circle extends Shape
+{
+    public function __construct(
+        public float $radius,
+    ) {}
+}
+```
+
+### 8.4 Match statement
+
+```php
+$__mochi_match_1 = $shape;
+if (($__mochi_match_1 instanceof Shape_Circle)) {
+    $r = $__mochi_match_1->radius;
+    // arm body
+} elseif (($__mochi_match_1 instanceof Shape_Rect)) {
+    $w = $__mochi_match_1->width;
+    $h = $__mochi_match_1->height;
+    // arm body
+} else {
+    // wildcard body
+}
+```
+
+The temp variable `$__mochi_match_N` is minted by the `matchSeq` counter
+(lower.go line 45), which is monotonic per lowerer instance, ensuring
+nested match statements get distinct temps.
+
+### 8.5 While loop
+
+```php
+while ($i < 10) {
+    // body
+    $i = ($i + 1);
+}
+```
+
+### 8.6 For-range loop
+
+```php
+for ($i = 0; $i < 10; $i++) {
+    // body
+}
+```

--- a/website/docs/research/0055/06-type-lowering.md
+++ b/website/docs/research/0055/06-type-lowering.md
@@ -1,0 +1,284 @@
+---
+title: "Type lowering: per-Mochi-type PHP 8.4 lowering rules"
+description: "Complete per-type lowering rules for every Mochi type onto PHP 8.4: scalars, collections, records, sum types, closures, function types, Result, panic. Grounded in lower.go."
+sidebar_position: 6
+---
+
+# Type lowering: per-Mochi-type PHP 8.4 lowering rules
+
+Author: research pass for MEP-55 (Mochi-to-PHP 8.4 transpiler).
+Date: 2026-05-29 15:00 (GMT+7).
+Sources: `transpiler3/php/lower/lower.go` (`phpScalarType`,
+`phpParamType`, `lowerBinaryExpr`, `runtimeDecls`, `lowerRecord`,
+`lowerUnion`, `lowerFunLit`), `transpiler3/php/ptree/nodes.go`.
+
+This note gives the complete lowering rule for every Mochi type. Each
+entry has: the PHP 8.4 spelling, the rationale, and the generated code
+shape. Grounded in `lower.go`.
+
+## 1. `int` → PHP `int`
+
+**Spelling**: `int` (parameter and return type declaration, `phpScalarType`
+lower.go lines 868-870).
+
+**Why**: PHP guarantees 64-bit signed integers on all supported 64-bit
+platforms. No boxing, no overflow wrapper needed for the common case.
+Integer overflow (> PHP_INT_MAX = 2^63-1) is a known risk for DJB2
+cassette keys; that specific path uses GMP. See [[12-risks-and-alternatives]].
+
+**Integer division**: `intdiv($a, $b)` via `BinaryExpr{IsCall: true, Op:
+"intdiv"}` (nodes.go `BinaryExpr.PhpString` lines 545-548). PHP's `/`
+operator produces a float when the result is not an integer, which would
+break Mochi's truncating semantics.
+
+**Modulo**: `%` operator. `BinaryExpr{Op: "%"}`.
+
+**Comparison**: all comparisons use `===` (strict). `BinaryExpr{Op:
+"==="}`. This applies to int, float, bool, and string equally.
+
+**Literals**: `IntLit.PhpString()` calls `strconv.FormatInt(e.Value, 10)`
+(nodes.go lines 480-482).
+
+## 2. `float` → PHP `float`
+
+**Spelling**: `float`.
+
+**Why**: PHP `float` is IEEE 754 binary64, matching Mochi's `float`.
+
+**Float comparison**: uses `===`. PHP's `==` applies coercion (`0.0 ==
+0` is true under `==`, false in Mochi).
+
+**Float literals**: `FloatLit.PhpString()` uses `strconv.FormatFloat(e.Value,
+'g', -1, 64)` (nodes.go lines 491-494). This is the same format as Go's
+default float printing, ensuring round-trip fidelity.
+
+**Special values**: `mochi_print_f64` handles NaN, +Inf, -Inf (lower.go
+lines 174-184):
+```php
+if (is_nan($value)) { echo "NaN\n"; return; }
+if (is_infinite($value)) { echo $value < 0 ? "-Inf\n" : "+Inf\n"; return; }
+if ((float) (int) $value === $value && abs($value) < 1.0e15) { echo (int) $value, "\n"; return; }
+echo $value, "\n";
+```
+
+**Infinity literals in source**: `+Inf` lowers to `fdiv(1, 0)`, `-Inf`
+to `fdiv(-1, 0)`, `NaN` to `fdiv(0, 0)` (these are compile-time constant
+expressions in PHP).
+
+## 3. `bool` → PHP `bool`
+
+**Spelling**: `bool`.
+
+**Print contract**: `mochi_print_bool` emits `"true"` or `"false"` (lower-
+case), not PHP's empty-string-for-false (lower.go lines 185-195):
+```php
+echo $value ? "true\n" : "false\n";
+```
+
+**Literals**: `BoolLit{Value: true}` → `true`, `BoolLit{Value: false}` →
+`false` (nodes.go lines 503-508).
+
+## 4. `string` → PHP `string`
+
+**Spelling**: `string`. PHP strings are byte sequences; no built-in UTF-8
+awareness. `ext-mbstring` provides UTF-8 functions when needed.
+
+**`str_contains`**: the `mochi_str_contains` helper (lower.go lines
+196-206) short-circuits on empty needle:
+```php
+return $needle === "" || str_contains($haystack, $needle);
+```
+This matches Mochi's semantics (empty string is contained in any string)
+without relying on PHP's `str_contains` returning true for empty needles
+(which it does, but the explicit check is more readable).
+
+**`str.index`**: `IndexExpr{Receiver: $s, Index: $i}` → `$s[$i]`.
+
+**`len(s)`**: `strlen($s)`. PHP's `strlen` counts bytes.
+
+**Concatenation**: `BinaryExpr{Op: "."}` → `($a . $b)`.
+
+**String literals**: `StringLit.PhpString()` calls `strconv.Quote` then
+replaces `$` with `\$` (nodes.go lines 451-471) to prevent PHP variable
+interpolation inside double-quoted strings.
+
+## 5. `list<T>` → PHP `array` (0-indexed)
+
+**Spelling**: `array` in type declarations.
+
+**Literals**: `ArrayLit{Elems: [a, b, c]}` → `[a, b, c]`.
+
+**`append(xs, v)`**: `ArrayAppendExpr{Inner: $xs, Tail: $v}` → `[...$xs, $v]`
+(nodes.go lines 617-625). PHP's spread operator (7.4) makes this a
+single-expression non-mutating append.
+
+**`for x in list`**: `ForEachStmt{Var: "x", Source: $list}` →
+`foreach ($list as $x)`.
+
+**Index access**: `IndexExpr` → `$xs[$i]`.
+
+**`len(list)`**: `count($list)`.
+
+## 6. `map<K, V>` → PHP `array` (string-keyed)
+
+**Spelling**: `array`.
+
+**Literals**: `ArrayLit{Keys: [k1, k2], Values: [v1, v2]}` →
+`[k1 => v1, k2 => v2]`. PHP preserves insertion order for associative
+arrays.
+
+**Map put**: `MapPutStmt{Name: "m", Key: $k, Value: $v}` →
+`IndexAssignStmt` → `$m[$k] = $v;` (lower.go lines 519-527).
+
+**Map get**: `IndexExpr{Receiver: $m, Index: $k}` → `$m[$k]`.
+
+**`for k, v in map`**: The aotir lowers this to `ForEachStmt` over the
+map value; key-value pairs use the `foreach ($m as $k => $v)` form.
+
+## 7. `set<T>` → PHP `array` of `value => true`
+
+**Spelling**: `array`.
+
+**Representation**: a PHP associative array where each element is the key
+and the value is `true`. This preserves insertion order (PHP preserves
+array insertion order), allows O(1) membership tests (`isset($s[$e])`),
+and survives PHP serialization round-trips.
+
+**`mochi_set_make([1, 2, 1])`** → `[1 => true, 2 => true]` (lower.go
+lines 207-223). Duplicates dropped on first occurrence.
+
+**`mochi_set_add($s, 4)`** → returns copy with `$s[4] = true` (lower.go
+lines 224-237). PHP copy-on-write makes this cheap.
+
+## 8. `record` → `final readonly class` with constructor promotion
+
+**Spelling**: `final readonly class NAME` (or `abstract readonly class`
+for sum-type bases, see §9 below).
+
+**Construction**: `NewExpr{Class: "Point", Args: [{Name: "x", Value: 1}]}`
+→ `new Point(x: 1, y: 2)`. Named arguments (PHP 8.0+) let the lowerer
+pass fields in any order.
+
+**Field access**: `PropAccessExpr{Receiver: $p, Field: "x"}` → `$p->x`.
+
+**Lower path**: `lowerRecord(r)` (lower.go lines 1135-1149) maps each
+`aotir.RecordField` to a `ptree.ClassField{TypeName, Name}` via
+`phpParamType`. The `ClassDecl` emitter writes `public readonly TYPE $NAME`
+via constructor promotion.
+
+## 9. Sum types → `abstract readonly class` + `final readonly class` variants
+
+**Base class**: `ClassDecl{Abstract: true}` → `abstract readonly class
+NAME {}` with empty body. The PHPDoc note is
+`"Mochi sum type \`NAME\` base class. Generated; do not edit by hand."`.
+
+**Variant class**: `ClassDecl{Extends: "NAME"}` → `final readonly class
+NAME_VARIANT extends NAME` with constructor-promoted fields.
+
+**Variant class name**: `variantClassName(union, variant)` → `union + "_" +
+variant` (lower.go line 934). So `Shape` / `Circle` → `Shape_Circle`.
+
+**PHP reserved name collision**: `phpClassName(name)` suffixes `_` for any
+name in `phpReservedClassNames` (lower.go lines 939-972). For example,
+`agent Switch` emits `final class Switch_`, as confirmed by the
+`agent_bool.mochi` fragment test.
+
+**Pattern matching**: `lowerMatchStmt` (lower.go lines 1083-1133) emits
+`ChainedIfStmt` with `InstanceOfExpr` per arm:
+```php
+$__mochi_match_1 = $shape;
+if (($__mochi_match_1 instanceof Shape_Circle)) {
+    $r = $__mochi_match_1->radius;
+    // body
+} elseif (($__mochi_match_1 instanceof Shape_Rect)) {
+    // body
+}
+```
+Field bindings become `AssignStmt` assignments at the top of each arm body.
+Guards (Phase 5.1 feature) are explicitly rejected with an error message.
+
+## 10. Closures → PHP arrow functions (`fn(...)`)
+
+**Spelling**: `Closure` in type declarations (phpParamType, lower.go line
+921).
+
+**Arrow function form**: `ClosureExpr{Params, ReturnType, Body}` →
+`fn(int $p0): int => callee($p0)` (nodes.go lines 900-918).
+
+**Capture semantics**: PHP arrow functions capture variables from the
+enclosing scope by value automatically. No `use ($x)` clause needed.
+This matches Mochi's by-value capture semantics.
+
+**Lifting**: the aotir lowerer lifts anonymous functions to top-level
+definitions. The PHP lowerer translates a `FunLit` to a `ClosureExpr`
+whose body is a call to the lifted function name, with capture variables
+forwarded as leading arguments (`lowerFunLit`, lower.go lines 1041-1072).
+
+**env-ref rewriting**: The C-target aotir lowerer injects `__e->field`
+for capture access. `rewriteEnvRefs` (lower.go lines 750-862) renames
+these to plain variable names so the PHP arrow function captures them
+from the enclosing scope by name.
+
+## 11. Function types → `Closure` in declarations
+
+PHP cannot express a parameterised callable signature at the declaration
+site. `callable` accepts strings, arrays, and closures indiscriminately.
+The lowerer maps `aotir.TypeFun` to `Closure` (phpParamType lower.go line
+921), which accepts only real closure objects.
+
+Precise signatures are recovered by PHPStan and Psalm from `@param
+Closure(int, string): bool $f` PHPDoc annotations added in Phase 15.
+
+## 12. `Result<T, E>` → `final readonly class Ok` / `final readonly class Err`
+
+Result types lower via the sum-type path: the union `Result` has variants
+`Ok` (carrying a value field) and `Err` (carrying an error field). Both
+become `final readonly class` extending `abstract readonly class Result`.
+No PHP exception is thrown; error handling is explicit discriminated-union
+matching.
+
+## 13. `panic` → `throw new \RuntimeException`
+
+Mochi `panic(msg)` lowers to `throw new \RuntimeException($msg)`.
+`\RuntimeException` is in the global namespace and requires no import.
+The leading `\` prevents ambiguity with any user-defined `RuntimeException`
+in a namespace (though in Phase 0-14 the global namespace is used
+throughout).
+
+## 14. `MochiStream` (Phase 10) → custom final class
+
+**Type spelling**: `MochiStream` for stream parameters, `MochiSub` for
+subscriber parameters (phpParamType lower.go lines 905-910).
+
+**Runtime classes**: emitted as `RawDecl` fragments by `runtimeDecls`
+when `l.runtime.streams == true`. No ptree class hierarchy for this
+one; the shape is fixed and written verbatim.
+
+## 15. `MochiFuture` (Phase 11) → custom final class
+
+**Type spelling**: `MochiFuture` (phpParamType lower.go line 913).
+
+**Runtime class**: `final class MochiFuture { public function __construct(
+public mixed $value) {} }`, emitted as `RawDecl` when
+`l.runtime.async == true`.
+
+## 16. Type mapping summary
+
+| Mochi type | PHP 8.4 declaration type | Notes |
+|------------|--------------------------|-------|
+| `int` | `int` | `intdiv` for `/` |
+| `float` | `float` | `===` comparison, special print |
+| `bool` | `bool` | lowercase literal print |
+| `string` | `string` | byte sequence, `mochi_str_contains` |
+| `list<T>` | `array` | packed 0-indexed |
+| `map<K,V>` | `array` | string-keyed assoc |
+| `set<T>` | `array` | `value => true` |
+| record | `final readonly class` | constructor promotion |
+| sum type base | `abstract readonly class` | empty body, PHP 8.4 |
+| sum type variant | `final readonly class extends BASE` | named-arg ctor |
+| closure / fun type | `Closure` | arrow fn, PHPDoc for signature |
+| `Result<T,E>` | sum type Ok/Err | no exception path |
+| `panic` | `throw new \RuntimeException` | no import needed |
+| stream | `MochiStream` | inline runtime class |
+| subscriber | `MochiSub` | inline runtime class |
+| future | `MochiFuture` | inline runtime class |

--- a/website/docs/research/0055/07-php-target-portability.md
+++ b/website/docs/research/0055/07-php-target-portability.md
@@ -1,0 +1,227 @@
+---
+title: "PHP target portability: CI matrix, phar.readonly, FrankenPHP, RoadRunner, Packagist"
+description: "PHP ecosystem portability considerations: CI matrix (8.4.0/8.4/8.5), phar.readonly=0 requirement, FrankenPHP vs RoadRunner deployment, Composer 2.4+, Packagist, and server model implications for agent/stream design."
+sidebar_position: 7
+---
+
+# PHP target portability: CI matrix, phar.readonly, FrankenPHP vs RoadRunner, Composer, Packagist
+
+Author: research pass for MEP-55 (Mochi-to-PHP 8.4 transpiler).
+Date: 2026-05-29 15:00 (GMT+7).
+Sources: `.github/workflows/transpiler3-php-test.yml`,
+`transpiler3/php/build/packaging.go`,
+`transpiler3/php/build/phase17_test.go`,
+`transpiler3/php/runtime/composer.json`,
+`website/docs/mep/mep-0055.md`.
+
+## 1. PHP version matrix in CI
+
+The workflow `.github/workflows/transpiler3-php-test.yml` defines two jobs:
+
+### 1.1 `go-side` job
+
+Runs `go vet`, `go build`, and `go test` for the PHP transpiler packages
+on `ubuntu-latest`. Uses PHP 8.4 (single version) installed via
+`shivammathur/setup-php@v2` with `extensions: mbstring, gmp` and
+`tools: composer:v2`. This job covers the Go-side compilation and all
+fragment tests that do not require running PHP.
+
+### 1.2 `php-runtime` job
+
+Uses a matrix of three PHP versions:
+
+| PHP version | `allow_failure` | Purpose |
+|-------------|-----------------|---------|
+| `8.4.0` | false | Pins the exact release the spec targets |
+| `8.4` | false | Latest stable 8.4.x patch; must stay green |
+| `8.5` | true | Forward-compat smoke; allowed to fail |
+
+The `allow_failure: true` entry for 8.5 uses `continue-on-error: ${{
+matrix.allow_failure }}` on each step. This means the 8.5 run is visible
+in CI but does not block merges.
+
+Each matrix run executes: `composer install`, PHPStan, Psalm,
+php-cs-fixer dry-run, and PHPUnit. All four gates run under every PHP
+version in the matrix.
+
+### 1.3 Why 8.4.0 specifically
+
+PHP 8.4.0 was released November 2024. The `8.4` matrix entry tracks
+the latest patch release (e.g., 8.4.7 at the time of writing). Pinning
+`8.4.0` separately ensures the package compiles on the initial GA release,
+not just the latest patch. Some distributions and cloud hosting providers
+pin to the exact GA release for months before updating.
+
+### 1.4 Why 8.5 as allow_failure
+
+PHP 8.5 was in alpha/beta in May 2026. Running the full test suite
+against it provides early warning of breakage (new strict-type rules,
+deprecated extensions, changed function signatures) without blocking CI.
+The `^8.4` constraint in `composer.json` does not exclude 8.5 on the
+Composer side; the `allow_failure` is purely a CI-policy choice.
+
+## 2. The `phar.readonly` requirement
+
+PHP's `phar.readonly` INI directive defaults to `1` on most Linux
+distributions (Debian, Ubuntu, Alpine) and on macOS Homebrew. When
+`phar.readonly = 1`, any attempt to write to or create a Phar archive
+throws a `PharException`. The Phase 17 Phar stager calls
+`Phar::startBuffering()`, `Phar::addFile()`, and `Phar::stopBuffering()`,
+all of which require write access.
+
+The stager is invoked with `php -d phar.readonly=0` (phase17_test.go
+line 74):
+```go
+stageCmd := exec.Command("php", "-d", "phar.readonly=0", stagerPath)
+```
+
+The `-d` flag overrides the INI setting for that single invocation without
+modifying the system `php.ini`. The resulting `.phar` file can then be
+run without the override (`php out.phar` with default settings) because
+`phar.readonly` only restricts writing to Phars, not reading or executing.
+
+Deployments that want to automate Phar building (e.g., in a Docker build
+step) need to either pass `-d phar.readonly=0` or set `phar.readonly = Off`
+in a project-level `php.ini`. Production builds using `humbug/box` handle
+this automatically.
+
+## 3. FrankenPHP vs RoadRunner
+
+Phase 17 ships two deployment targets beyond plain Phar:
+
+### 3.1 FrankenPHP
+
+FrankenPHP embeds the Zend Engine inside a Caddy 2.x server. It provides
+two execution modes:
+
+- **Classic mode**: one PHP process per request (like PHP-FPM).
+- **Worker mode**: a long-lived PHP process that handles requests
+  sequentially, calling `Worker::reset()` between requests. The
+  Caddyfile emitted by `EmitFrankenPHPBundle` uses the worker mode:
+  ```
+  frankenphp {
+      worker /app/main.php 4
+  }
+  ```
+  The `worker /app/main.php 4` line starts 4 worker processes.
+
+The Dockerfile is pinned to `dunglas/frankenphp:php8.4` (packaging.go
+line 96):
+```
+FROM dunglas/frankenphp:php8.4
+```
+
+The `php_server` directive (Caddyfile line 8) is the modern FrankenPHP
+idiom. The emitted Caddyfile also includes `root * /app` and exposes
+`:8080`.
+
+The `TestPhase17FrankenPHPBundle` test (phase17_test.go lines 103-145)
+pins these structural requirements with `strings.Contains` assertions
+rather than running Docker or booting Caddy.
+
+### 3.2 RoadRunner
+
+RoadRunner is a Go-based application server that spawns PHP worker
+processes and dispatches HTTP requests over a Unix socket. The emitted
+`.rr.yaml` (packaging.go lines 107-123) specifies:
+```yaml
+version: "3"
+server:
+  command: "php worker.php"
+http:
+  address: ":8080"
+  pool:
+    num_workers: 4
+    max_jobs: 64
+    allocate_timeout: 60s
+    destroy_timeout: 60s
+```
+
+The emitted `worker.php` does `require_once __DIR__ . '/main.php'` and
+includes a comment about `Worker::reset()` (packaging.go lines 125-138).
+In RoadRunner's model, the Go `rr` binary feeds PSR-7 requests through
+stdin; the worker processes them and responds through stdout.
+
+### 3.3 Server model and agents/streams
+
+Both FrankenPHP and RoadRunner use a worker model where PHP code runs in
+long-lived processes. This is significant for Mochi agents and streams:
+
+- In standard PHP (new process per request), agent state is lost at
+  request end. Agents only persist within a single script execution.
+- In worker mode, a PHP process lives across multiple requests. Agent
+  and stream state persists between requests unless `Worker::reset()` is
+  called. MEP-55 Phase 9-10 fixtures are all single-script programs;
+  multi-request agent persistence is a future concern.
+- PHP's lack of preemptive scheduling means agents cannot block the
+  worker thread waiting for an async event. All Phase 9-10 lowerings
+  use synchronous emit-before-recv patterns specifically because of this.
+
+See [[09-agent-streams]] for the agent/stream design and
+[[12-risks-and-alternatives]] for the scheduling risk.
+
+## 4. Composer 2 requirement
+
+The CI matrix uses `tools: composer:v2` in `shivammathur/setup-php@v2`.
+Composer 2 is required for:
+
+- `composer audit`: security vulnerability checking (a Phase 18 gate).
+- `composer install --no-plugins`: the `--no-plugins` flag is a Composer 2
+  feature used in locked-down CI environments.
+- Parallel dependency resolution (faster CI).
+
+Composer 1.x would work for basic installation but lacks the audit command.
+The `minimum-stability: stable` in `composer.json` also requires Composer
+2's more precise stability handling.
+
+## 5. Packagist and the publishing pipeline
+
+Phase 18 covers GPG-signed releases and Sigstore attestation. The
+publication workflow (`.github/workflows/transpiler3-php-publish.yml`) is
+not examined in detail in this note, but the relevant portability points
+are:
+
+- Packagist requires a `composer.json` with a unique `name` (`mochi/runtime`).
+- GPG-signed tags: the workflow uses `actions/attest-build-provenance@v1`
+  for Sigstore OIDC attestation (GitHub Actions OIDC is GA since April 2024).
+- Semantic versioning: Composer's `^8.4` constraint uses semver compatibility
+  operators; patch releases (8.4.x) are compatible but new major versions
+  (9.0) would not be accepted.
+
+## 6. PHP extension availability on common platforms
+
+The two required extensions (`ext-mbstring`, `ext-gmp`) are available on:
+
+- **Ubuntu 24.04**: `apt-get install php8.4-mbstring php8.4-gmp`
+- **Alpine Linux**: `apk add php84-mbstring php84-gmp`
+- **macOS Homebrew**: `brew install php` (includes both by default)
+- **Docker `dunglas/frankenphp:php8.4`**: both extensions pre-installed
+  in the base image
+- **Shared hosting**: GMP availability varies; most cPanel/Plesk hosts
+  have it, but low-cost shared hosting may not. This is an acceptable
+  limitation documented in the MEP spec.
+
+The `shivammathur/setup-php@v2` action installs both via `extensions:
+mbstring, gmp` in the CI workflow.
+
+## 7. PHP_PATH environment variable
+
+The build driver's `resolvePhp()` function (build.go lines 128-145)
+checks `PHP_PATH` first:
+1. If `PHP_PATH` is set and points to a directory, it appends `php`.
+2. Falls back to well-known binary paths: `/usr/bin/php`,
+   `/usr/local/bin/php`, `/opt/homebrew/bin/php`.
+3. Falls back to `exec.LookPath("php")`.
+
+CI sets `PHP_PATH` via `shivammathur/setup-php@v2`'s output. Local
+development falls through to `LookPath`, which finds `php` if it is on
+`$PATH`. Tests skip gracefully when PHP is not available:
+```go
+if _, err := exec.LookPath("php"); err != nil {
+    if p := os.Getenv("PHP_PATH"); p == "" {
+        t.Skipf("php not on PATH: %v", err)
+    }
+}
+```
+This pattern appears in `runPhpFixture`, `runPhpLLMFixture`,
+`runPharFixture`, and the per-phase tests that invoke PHP directly.

--- a/website/docs/research/0055/08-dataset-pipeline.md
+++ b/website/docs/research/0055/08-dataset-pipeline.md
@@ -1,0 +1,241 @@
+---
+title: "Dataset pipeline: query DSL lowering and Datalog compile-time evaluation"
+description: "Phase 7 query DSL lowering (from/where/select/order-by/skip/take onto PHP arrays + usort) and Phase 8 Datalog compile-time semi-naive evaluation emitting static PHP array literals."
+sidebar_position: 8
+---
+
+# Dataset pipeline: query DSL lowering and Datalog compile-time evaluation
+
+Author: research pass for MEP-55 (Mochi-to-PHP 8.4 transpiler).
+Date: 2026-05-29 15:00 (GMT+7).
+Sources: `transpiler3/php/lower/lower.go` (lines 430-478 for
+`QueryScopeStmt` and `RawCStmt`), `transpiler3/php/lower/datalog.go`,
+`transpiler3/php/build/phase07_test.go`,
+`transpiler3/php/build/phase08_test.go`,
+`tests/transpiler3/php/fixtures/phase07-query/`,
+`tests/transpiler3/php/fixtures/phase08-datalog/`.
+
+This note covers the two dataset-related lowering paths in MEP-55:
+the Phase 7 query DSL and the Phase 8 Datalog evaluator.
+
+## 1. Phase 7: Query DSL lowering
+
+### 1.1 Desugaring in aotir
+
+The query DSL (`from n in nums where n % 2 == 0 select n * 2`) is
+desugared by the shared aotir lowerer (not the PHP-specific lowerer)
+into a canonical imperative form:
+
+1. A `LetStmt` binding the result accumulator to `[]`.
+2. A `ForEachStmt` iterating over the source collection.
+3. An optional `IfStmt` for the `where` predicate.
+4. An `ArrayAppendExpr` pushing the selected element.
+5. Optional `ListSortAscExpr` for `order by`.
+6. Optional `ListSliceExpr` for `skip` / `take`.
+
+The PHP lowerer receives this already-desugared form. The query temp
+variable names (`$__query1`, `$__query2`) are minted by the shared aotir
+desugaring pass, not by the PHP lowerer.
+
+### 1.2 PHP lowering of the desugared form
+
+The PHP lowerer handles the query DSL through two special cases:
+
+**`QueryScopeStmt`** (lower.go lines 473-475): A C-specific arena-scope
+wrapper. On the PHP side this is dropped entirely:
+```go
+case *aotir.QueryScopeStmt:
+    return l.lowerBlock(v.Body)
+```
+PHP uses reference counting and cycle collection instead of arenas; the
+body is inlined directly into the surrounding block.
+
+**`RawCStmt`** (lower.go lines 476-481): Pre-rendered C source for
+Datalog setup (see §2 below). The PHP path computes Datalog results at
+compile time and emits a static array, so this hint is a no-op:
+```go
+case *aotir.RawCStmt:
+    return nil, nil
+```
+
+### 1.3 Emitted PHP shape
+
+A simple filter query:
+```mochi
+from n in nums where n % 2 == 0 select n
+```
+emits (from `TestPhase7EmitFragments` `query_filter` fixture):
+```php
+$__query1 = [];
+foreach ($nums as $n) {
+    if ((($n % 2) === 0)) {
+        $__query1 = [...$__query1, $n];
+    }
+}
+$evens = $__query1;
+```
+
+The `ArrayAppendExpr` (`[...$__query1, $n]`) is non-mutating: it creates
+a new array each iteration. PHP's copy-on-write makes this relatively
+cheap for small-to-medium result sets, though not O(1) per element.
+
+### 1.4 `order by` → `mochi_list_sort_asc`
+
+The `order by n` clause appends a sort step after the gather loop. The
+PHP lowerer emits the `mochi_list_sort_asc` inline helper (lower.go
+lines 239-254), which uses PHP's spaceship operator for
+type-agnostic natural ordering:
+```php
+usort($xs, fn($a, $b) => $a <=> $b);
+return $xs;
+```
+The helper takes the array by value (PHP copy-on-write), sorts it in
+place (mutating the copy), and returns the sorted copy. The caller's
+original array is untouched.
+
+From `TestPhase7EmitFragments` `query_order_by` fragment:
+```php
+$__query1 = mochi_list_sort_asc($__query1);
+$sorted = $__query1;
+```
+
+The same spaceship-backed helper sorts ints, floats, and strings
+uniformly, as confirmed by `query_order_by_strings` fixture.
+
+### 1.5 `skip` / `take` → `array_slice`
+
+Skip and take lower to `array_slice($xs, start, length)`:
+
+- `skip N` (no take): `array_slice($__query1, N, (4611686018427387903 - N))`
+  where `4611686018427387903` is `PHP_INT_MAX / 2` (safe large value).
+- `take N` (no skip): `array_slice($__query1, 0, ((0 + N) - 0))`
+- `skip S take T`: `array_slice($__query1, S, ((S + T) - S))`
+
+The redundant arithmetic for the canonical form is emitted by the shared
+aotir desugaring; the PHP lowerer passes it through without simplifying.
+
+From `TestPhase7EmitFragments`:
+```
+query_skip:  $__query1 = array_slice($__query1, 2, (4611686018427387903 - 2));
+query_take:  $__query1 = array_slice($__query1, 0, ((0 + 3) - 0));
+```
+
+### 1.6 Nested queries
+
+Two queries in one function body use independent temp counters. The
+second query gets `$__query2`. The counter resets between function
+bodies because the aotir desugaring uses a per-function counter.
+From `query_nested` fixture:
+```php
+$small = $__query1;
+$doubled_small = $__query2;
+```
+
+### 1.7 Queries inside user functions
+
+Queries inside user functions emit with the `mochi__` prefix on the
+function name:
+```php
+function mochi__filter_evens(array $nums): array { ... }
+function mochi__double_all(array $nums): array { ... }
+```
+Each function body has its own `$__query1` temp, independent of other
+functions.
+
+## 2. Phase 8: Datalog compile-time semi-naive evaluation
+
+### 2.1 Strategy
+
+Mochi's Datalog DSL allows compile-time rules and facts to be evaluated
+at transpile time. The PHP target does not ship a runtime Datalog engine.
+Instead, `datalogEval` in `transpiler3/php/lower/datalog.go` runs the
+evaluation at Go/transpile time and emits the results as a static PHP
+array literal.
+
+This is the same strategy used by the BEAM (MEP-46) backend; the C
+(MEP-45) backend emits C-level loop code at runtime instead.
+
+### 2.2 `datalogEval` implementation
+
+`datalogEval` (datalog.go lines 9-62) is a bottom-up semi-naive Datalog
+evaluator:
+
+1. Seeds the state map from the program's `Facts` (ground atoms).
+2. Iterates: for each `Rule`, derives new tuples by `dlDeriveRule`.
+3. Stops when no new tuples are added (`changed == false`).
+4. Filters tuples from the named query relation against the query args
+   (bound args constrain, unbound args project free variables).
+5. Returns the list of free-variable values as `[]string`.
+
+The state is `map[string][][]string`: relation name → list of tuples
+(each tuple is `[]string` of string-serialised values).
+
+**Rule derivation** (`dlDeriveRule`, datalog.go lines 64-149): handles
+three literal types:
+- Positive literals: join against the relation state.
+- Negation literals (`IsNot`): remove environments where the relation
+  would match.
+- Inequality literals (`IsNeq`): remove environments where two variables
+  are equal.
+
+**Variable notation**: uppercase words are Datalog variables (`dlIsVar`,
+datalog.go line 177). Quoted strings (`"alice"`) are constants
+(`dlUnquote`, line 178).
+
+### 2.3 Emitted PHP shape
+
+The `lowerDatalogQueryExpr` call site (not shown in the excerpts above,
+but present in the `lowerExpr` switch) calls `datalogEval` and emits the
+results as a PHP array literal. For a query that finds ancestors:
+```mochi
+// facts: parent(alice, bob), parent(bob, carol)
+// rule:  ancestor(X, Z) :- parent(X, Z).
+// rule:  ancestor(X, Z) :- parent(X, Y), ancestor(Y, Z).
+// query: ancestor(alice, Who)
+```
+The emitted PHP is:
+```php
+$ancestors = ["bob", "carol"];
+```
+
+No PHP code loops or evaluates rules at runtime. The results are fully
+computed at transpile time and baked into the emitted source. This means
+the PHP output is maximally simple and fast (array literal, no
+interpreter overhead) at the cost of being static (the Datalog program
+cannot take runtime input).
+
+### 2.4 Why emit a static array (not a runtime engine)
+
+The fixture corpus (`phase08-datalog/`) contains only programs where the
+Datalog rules and facts are fully known at compile time. A runtime engine
+would be needed only if rules or facts could be provided at runtime (e.g.,
+from a database query). That use case is out of scope for MEP-55 Phase 8.
+
+The static-array approach:
+- Requires no runtime dependency.
+- Is maximally fast at runtime.
+- Produces byte-equal output across PHP versions.
+- Is easily validated: `TestPhase8EmitFragments` checks that the emitted
+  array contains the expected values.
+
+A future MEP could add a runtime Datalog engine (potentially using
+`amphp/revolt` for async evaluation, or a dedicated `mochi/datalog`
+Composer package) for programs that need runtime-variable rules.
+
+## 3. `RawCStmt` and `QueryScopeStmt` no-ops
+
+The aotir IR carries two statement types that only make sense for the C
+backend:
+
+- `RawCStmt`: pre-rendered C source code for the Datalog runtime setup
+  (`dl_solver_add_rule`, etc.). The PHP backend evaluates Datalog at
+  compile time, so this hint is ignored (lower.go line 481: `return
+  nil, nil`).
+
+- `QueryScopeStmt`: a C-specific arena allocation scope wrapping query
+  result accumulation. PHP's garbage collector handles memory
+  automatically, so the scope wrapper is inlined without the frame
+  (lower.go line 475: `return l.lowerBlock(v.Body)`).
+
+Both no-ops are documented in the source with comments explaining why
+the C-backend hint is irrelevant for PHP.

--- a/website/docs/research/0055/09-agent-streams.md
+++ b/website/docs/research/0055/09-agent-streams.md
@@ -1,0 +1,317 @@
+---
+title: "Agents and streams: Phase 9 agents, Phase 10 streams, Phase 11 async coloring"
+description: "Phase 9 agents (mutable PHP class, FIFO channel), Phase 10 streams (MochiStream/MochiSub fan-out, backpressure), Phase 11 async coloring (all-Blue, sync wrappers, no Amp/Revolt)."
+sidebar_position: 9
+---
+
+# Agents and streams: Phase 9 agents, Phase 10 streams, Phase 11 async coloring
+
+Author: research pass for MEP-55 (Mochi-to-PHP 8.4 transpiler).
+Date: 2026-05-29 15:00 (GMT+7).
+Sources: `transpiler3/php/lower/lower.go` (lines 83-95 agent loop,
+256-377 stream/async runtimeDecls, 500-517 AgentIntentCallStmt,
+1151-1198 lowerAgent, 1200-1221 VarRef __self->),
+`transpiler3/php/colour/colour.go`,
+`transpiler3/php/build/phase09_test.go`,
+`transpiler3/php/build/phase10_test.go`,
+`tests/transpiler3/php/fixtures/phase09-agents/`,
+`tests/transpiler3/php/fixtures/phase10-streams/`,
+`tests/transpiler3/php/fixtures/phase11-async/`.
+
+## 1. Phase 9: Agents
+
+### 1.1 Design motivation
+
+Mochi agents are stateful concurrent entities that communicate via
+message passing. In targets with real concurrency (BEAM MEP-46, Loom
+MEP-47) agents map to lightweight processes or virtual threads. PHP has
+no preemptive scheduler in the standard library. The PHP target lowers
+agents to a simpler model: a mutable PHP class with intent methods.
+
+The choice sacrifices true concurrency but gains full compatibility with
+every PHP deployment environment (shared hosting, PHP-FPM, CLI), zero
+runtime dependencies, and simple reasoning: the program is sequential
+and deterministic.
+
+### 1.2 Agent class shape
+
+Each `agent` declaration lowers to a `final class` (no `readonly`, since
+intent bodies mutate fields). The `lowerAgent` function (lower.go lines
+1156-1198) produces a `ClassDecl` with `Mutable: true`.
+
+Fields become promoted public constructor parameters without the
+`readonly` modifier. This is the key difference from record classes
+(which use `final readonly class`): agent fields must be mutable.
+
+From `TestPhase9EmitFragments` `agent_counter.mochi`:
+```php
+/**
+ * Mochi agent `Counter`. Generated; do not edit by hand.
+ */
+final class Counter
+{
+    public function __construct(
+        public int $count,
+    ) {}
+
+    public function increment(): void
+    {
+        $this->count = ($this->count + 1);
+    }
+
+    public function value(): int
+    {
+        return $this->count;
+    }
+}
+```
+
+### 1.3 The `__self->FIELD` sentinel rewrite
+
+The aotir lowerer (MEP-45) encodes intent-body field access using the
+sentinel prefix `__self->FIELD`, which maps to the C backend's
+`self->field` pointer dereference. The PHP lowerer rewrites this in two
+places:
+
+**Reads** (`lowerExpr`, lower.go lines 1214-1221):
+```go
+if field, ok := strings.CutPrefix(v.Name, "__self->"); ok {
+    return &ptree.PropAccessExpr{
+        Receiver: &ptree.VarExpr{Name: "this"},
+        Field:    field,
+    }, nil
+}
+```
+`__self->count` becomes `$this->count`.
+
+**Writes** (`lowerAssignStmt`, lower.go lines 630-637):
+```go
+if field, ok := strings.CutPrefix(s.Name, "__self->"); ok {
+    return []ptree.Stmt{&ptree.PropAssignStmt{
+        Receiver: &ptree.VarExpr{Name: "this"},
+        Field:    field,
+        Value:    v,
+    }}, nil
+}
+```
+`__self->count = ...` becomes `$this->count = ...`.
+
+### 1.4 PHP reserved name collision
+
+`phpClassName(name)` (lower.go lines 965-972) suffixes `_` when the
+agent name is a PHP reserved word. The canonical example is
+`agent Switch { ... }` which emits `final class Switch_` because `switch`
+is a reserved keyword in PHP. The fragment test `agent_bool.mochi`
+pins this: it asserts `final class Switch_` appears in the output and
+`$s = new Switch_(active: false);`.
+
+### 1.5 `spawn AgentType()` lowering
+
+`spawn AgentType()` constructs a new agent with zero-value fields. The
+PHP lowerer calls `lookupAgentDecl` (lower.go lines 978-985) to find
+the agent declaration, then calls `phpZeroLit` (lines 992-1004) for
+each field to synthesise the default value:
+- `TypeInt` → `IntLit{0}`
+- `TypeFloat` → `FloatLit{0}`
+- `TypeBool` → `BoolLit{false}`
+- `TypeString` → `StringLit{""}`
+
+The result is a `NewExpr` with named args: `new Counter(count: 0)`.
+This is shape-equal to the `AgentLit` form (`Counter { count: 0 }`).
+
+From `agent_spawn.mochi` fragment test:
+```php
+$c = new Counter(count: 0);
+$c->increment();
+$v = $c->value();
+```
+
+### 1.6 Intent call dispatch
+
+`AgentIntentCallStmt` (lower.go lines 500-517) lowers to a
+`MethodCallExpr`:
+- `c.increment()` → `$c->increment();`
+- `v = c.value()` → `$v = $c->value();`
+
+The receiver is lowered via `lowerExpr`; arguments are lowered via the
+normal expression path.
+
+## 2. Phase 10: Streams
+
+### 2.1 Design
+
+Mochi streams are broadcast pub/sub channels. Multiple subscribers can
+attach; each emit fans out to all attached subscribers. On PHP, there is
+no native channel or event loop. The PHP target uses a synchronous
+array-backed model: `MochiStream` holds a per-subscriber message queue
+(array of arrays), and `MochiSub` holds a reference back to the stream
+plus a subscriber index.
+
+All Phase 10 fixtures use emit-before-recv patterns (emit everything
+first, then receive everything). This is a deliberate constraint that
+fits the synchronous model: there is no way for a subscriber to block
+and wait for the next emit in a sequential PHP execution.
+
+### 2.2 Inline runtime classes
+
+`runtimeDecls` (lower.go lines 256-336) emits the stream classes when
+`l.runtime.streams == true`:
+
+```php
+final class MochiStream
+{
+    /** @var array<int, array<int, mixed>> Per-subscriber message queues. */
+    public array $subs = [];
+
+    /** @var array<int, int> Per-subscriber drop threshold; 0 = unlimited. */
+    public array $limits = [];
+
+    public function __construct(public int $cap) {}
+}
+
+final class MochiSub
+{
+    public function __construct(
+        public MochiStream $stream,
+        public int $idx,
+    ) {}
+}
+```
+
+Note that `MochiStream` is `final class` (not readonly), because
+`$subs` and `$limits` are mutable.
+
+### 2.3 Stream helpers
+
+Five inline helper functions are emitted:
+
+- `mochi_stream_make(int $cap): MochiStream` — constructs a new stream
+  with the given capacity.
+- `mochi_sub_make(MochiStream $s): MochiSub` — creates a subscriber,
+  initialising `$s->subs[$idx] = []` and `$s->limits[$idx] = 0`.
+- `mochi_stream_emit(MochiStream $s, $v): void` — fans out `$v` to all
+  subscriber queues, respecting per-subscriber drop limits (lower.go
+  lines 316-327).
+- `mochi_sub_recv(MochiSub $sub): mixed` — shifts the head of the
+  subscriber's queue: `array_shift($sub->stream->subs[$sub->idx])`.
+- `mochi_sub_make_limit(MochiStream $s, int $limit): MochiSub` —
+  creates a subscriber with a drop threshold (Phase 10.2 backpressure).
+
+The fan-out loop in `mochi_stream_emit`:
+```php
+foreach (array_keys($s->subs) as $k) {
+    if ($s->limits[$k] > 0 && count($s->subs[$k]) >= $s->limits[$k]) { continue; }
+    $s->subs[$k][] = $v;
+}
+```
+The `continue` drops the message silently when the subscriber's queue is
+full (limit > 0 and queue length >= limit).
+
+### 2.4 Backpressure (Phase 10.2)
+
+`mochi_sub_make_limit($s, 2)` creates a subscriber that drops messages
+when its queue already holds 2 items. The `stream_backpressure` fixture
+pins both the `subscribe_limit` path and the drop branch. From
+`TestPhase10EmitFragments`:
+```
+function mochi_sub_make_limit(MochiStream $s, int $limit): MochiSub
+$s->limits[$idx] = $limit;
+if ($s->limits[$k] > 0 && count($s->subs[$k]) >= $s->limits[$k]) { continue; }
+$sub = mochi_sub_make_limit($s, 2);
+```
+
+### 2.5 `StreamEmitStmt` lowering
+
+`StreamEmitStmt` (lower.go lines 483-499) lowers `emit(s, v)`:
+```go
+l.runtime.streams = true
+// ...
+return []ptree.Stmt{&ptree.ExprStmt{
+    Expr: &ptree.CallExpr{
+        Callee: &ptree.IdentExpr{Name: "mochi_stream_emit"},
+        Args:   []ptree.Expr{s, val},
+    },
+}}, nil
+```
+Setting `l.runtime.streams = true` triggers the class and helper
+injection in `runtimeDecls`.
+
+## 3. Phase 11: Async coloring
+
+### 3.1 The colour pass
+
+`colour.Compute(prog)` (colour/colour.go lines 39-45) returns a
+`ColourMap` where every function is assigned `Blue`:
+```go
+func Compute(prog *aotir.Program) ColourMap {
+    m := make(ColourMap, len(prog.Functions))
+    for _, fn := range prog.Functions {
+        m[fn.Name] = Blue
+    }
+    return m
+}
+```
+
+The `Red` colour constant is defined but never produced. The package
+comment explains: "Phase 11 shipped async/await as a synchronous value
+wrapper rather than the originally-planned Amphp/Fiber dispatch, so no
+PHP function ever needs an `Amp\Future<T>` return type."
+
+The `ColourMap` is passed to `lower.Lower` but the parameter is named
+`_` (lower.go line 52): the lowerer ignores it entirely. The pass exists
+for API symmetry with the other transpiler3 targets.
+
+### 3.2 `MochiFuture` sync wrappers
+
+When `l.runtime.async == true`, `runtimeDecls` emits (lower.go lines
+338-377):
+
+```php
+final class MochiFuture
+{
+    public function __construct(public mixed $value) {}
+}
+
+function mochi_future_make($v): MochiFuture
+{
+    return new MochiFuture(value: $v);
+}
+
+function mochi_future_await(MochiFuture $f): mixed
+{
+    return $f->value;
+}
+
+function mochi_future_await_all(array $fs): array
+{
+    return array_map(fn(MochiFuture $f) => $f->value, $fs);
+}
+```
+
+`mochi_future_make` wraps an already-computed value. `mochi_future_await`
+unwraps it immediately. There is no deferred execution, no event loop,
+no suspension point. Phase 11 fixtures all produce results that are
+available synchronously.
+
+### 3.3 Why not Amp or Revolt
+
+Two PHP async libraries were considered:
+- `amphp/amp` v3: green-thread-style coroutines with an event loop.
+- `revolt/event-loop`: Amp's event-loop extracted as a standalone.
+
+Both require adding Composer runtime dependencies. Amp changes function
+return types (`Future<T>` instead of `T`) and requires `\Amp\async()`
+wrappers at every call site. Revolt requires an event loop to be
+installed and started.
+
+The MEP-55 audit round 1 removed `amphp/revolt` from `require-dev`
+(it was briefly listed) after Phase 11 confirmed that all Phase 11
+fixtures work correctly with sync wrappers. No fixture required true
+concurrent execution.
+
+The sync wrapper approach produces zero-dependency code that runs under
+CLI, PHP-FPM, FrankenPHP worker mode, and RoadRunner without any event
+loop configuration.
+
+See [[02-design-philosophy]] for the full rationale and
+[[12-risks-and-alternatives]] for the scheduling risk discussion.

--- a/website/docs/research/0055/10-build-system.md
+++ b/website/docs/research/0055/10-build-system.md
@@ -1,0 +1,255 @@
+---
+title: "Build system: Driver.Build pipeline, resolvePhp, cacheKey, Phase 17 packaging, CI workflow"
+description: "Driver.Build pipeline (TargetPhpSource vs TargetPhpRun), resolvePhp, effectiveCacheDir + cacheKey (reserved), Phase 17 packaging (emitPharStager, EmitFrankenPHPBundle, EmitRoadRunnerBundle), runtimeSourceDir + copyFile, and CI workflow."
+sidebar_position: 10
+---
+
+# Build system: Driver.Build, resolvePhp, packaging, CI
+
+Author: research pass for MEP-55 (Mochi-to-PHP 8.4 transpiler).
+Date: 2026-05-29 15:00 (GMT+7).
+Sources: `transpiler3/php/build/build.go`,
+`transpiler3/php/build/packaging.go`,
+`transpiler3/php/build/build_test.go`,
+`transpiler3/php/build/phase17_test.go`,
+`.github/workflows/transpiler3-php-test.yml`.
+
+## 1. Driver struct
+
+`Driver` (build.go lines 43-57) is the pipeline entry point:
+
+```go
+type Driver struct {
+    CacheDir      string
+    NoCache       bool
+    Deterministic bool
+    phpPath       string
+}
+```
+
+- `CacheDir`: overrides `~/.cache/mochi/php/`. Not yet wired to actual
+  caching; the field exists for forward compatibility.
+- `NoCache`: reserved. Tests set `NoCache: true` for isolation.
+- `Deterministic`: reserved. Today it is a no-op; `TestPhase16Non-
+  DeterministicBuildsAlsoMatch` verifies the default path is also
+  byte-reproducible.
+- `phpPath`: cached result of `resolvePhp()`, set lazily on first
+  `TargetPhpRun` build.
+
+## 2. Target enum
+
+```go
+const (
+    TargetPhpSource Target = iota
+    TargetPhpRun
+)
+```
+
+`TargetPhpSource` writes `main.php` to `outDir` and returns its path.
+`TargetPhpRun` does the same, then invokes `php main.php` with stdout
+and stderr forwarded to the caller's streams.
+
+## 3. Driver.Build pipeline
+
+`Build(src, outDir, target)` (build.go lines 64-123):
+
+1. `os.ReadFile(src)` — reads the Mochi source bytes (stored in
+   `srcBytes` for the future `cacheKey` integration).
+2. `parser.Parse(src)` — shared Mochi parser.
+3. `types.Check(ast, types.NewEnv(nil))` — shared type checker.
+4. `clower.Lower(ast)` — MEP-45 aotir lowerer, produces
+   `*aotir.Program`.
+5. `colour.Compute(prog)` — PHP colour pass (all-Blue).
+6. `lower.Lower(prog, colours)` — PHP-specific lowerer, produces
+   `*ptree.PhpFile`.
+7. `os.MkdirAll(outDir, 0o755)` — creates the output directory.
+8. `emit.Emit(file, outDir, "main")` — writes `outDir/main.php`.
+9. If `TargetPhpRun`: `resolvePhp()` then `exec.Command(php, main.php)`.
+
+The function also touches unused fields to keep the compiler honest:
+```go
+_ = srcBytes
+_ = d.cacheKey
+_ = d.effectiveCacheDir
+_ = copyFile
+_ = sha256.New
+_ = io.Copy
+```
+This pattern prevents dead-code removal of symbols that will be wired in
+future phases without requiring a phase-gated build tag.
+
+## 4. resolvePhp
+
+`resolvePhp()` (build.go lines 128-145) finds the PHP binary:
+
+1. Check `PHP_PATH` environment variable. If it points to a directory,
+   append `/php`.
+2. Try well-known paths: `/usr/bin/php`, `/usr/local/bin/php`,
+   `/opt/homebrew/bin/php`.
+3. Fall back to `exec.LookPath("php")`.
+
+Error message on failure: `"php not found on PATH (set PHP_PATH or add
+php to PATH)"`. CI sets `PHP_PATH` via the `shivammathur/setup-php@v2`
+action output.
+
+## 5. effectiveCacheDir
+
+`effectiveCacheDir()` (build.go lines 148-160) resolves the build cache
+directory:
+
+1. `d.CacheDir` if set.
+2. `$MOCHI_CACHE_DIR/php` if `MOCHI_CACHE_DIR` is set.
+3. `~/.cache/mochi/php/` as the default.
+4. `os.TempDir()` if home directory resolution fails.
+
+Currently unused in the build path (every build runs the full pipeline
+from scratch). Reserved for a future cache integration.
+
+## 6. cacheKey
+
+`cacheKey(srcBytes)` (build.go lines 168-178) computes a SHA-256 hash
+of: source bytes + phpPath + Deterministic flag byte. Currently unused
+in `Build` (the `_ = d.cacheKey` line keeps it live). The design intent
+is to use this key to skip re-lowering when the source and PHP version
+have not changed.
+
+## 7. runtimeSourceDir and copyFile
+
+`runtimeSourceDir()` (build.go lines 183-195) uses `runtime.Caller(0)`
+to locate the `transpiler3/php/runtime/` directory relative to the Go
+source file. This works regardless of the working directory, which is
+important for test isolation (each test uses `t.TempDir()`).
+
+`copyFile(dst, src)` (build.go lines 199-215) copies a file, creating
+parent directories as needed. Phase 15 uses this when staging the
+Composer package: it copies `composer.json`, `src/`, and related files
+from `runtimeSourceDir()` into the sandbox.
+
+## 8. repoRootForBuild
+
+`repoRootForBuild` (build.go lines 220-240) walks up from the Go source
+file to find the `go.mod` root. Test helpers use `repoRoot(t)` (defined
+in `build_test.go` lines 52-56) to find fixture directories
+independently of the working directory. This pattern appears in all
+`phase*_test.go` files.
+
+## 9. Phase 17: Packaging
+
+`transpiler3/php/build/packaging.go` implements three deployment targets.
+
+### 9.1 Phar archive: emitPharStager
+
+`emitPharStager(outDir, mainPhp, dstPhar)` (packaging.go lines 53-74)
+generates a stager PHP script (`build_phar.php`) that wraps `mainPhp`
+into a `.phar` using PHP's built-in `Phar` class:
+
+```php
+$phar = new Phar($dst, 0, basename($dst));
+$phar->startBuffering();
+$phar->addFile($src, 'main.php');
+$phar->setStub($phar->createDefaultStub('main.php'));
+$phar->stopBuffering();
+```
+
+The stager is run with `php -d phar.readonly=0` (phase17_test.go line 74)
+to bypass the default `phar.readonly = 1` INI setting. The resulting
+`.phar` runs with `php out.phar` without any special flags.
+
+`phpStringLit(s)` (packaging.go lines 200-215) escapes the file paths
+as single-quoted PHP literals, avoiding double-quote interpolation issues.
+
+### 9.2 FrankenPHP bundle: EmitFrankenPHPBundle
+
+`EmitFrankenPHPBundle(outDir, packageName)` (packaging.go lines 141-168)
+writes two files:
+
+**Caddyfile** (template `caddyfileTmpl`, lines 76-91):
+```
+{
+    frankenphp {
+        worker /app/main.php 4
+    }
+}
+
+:8080 {
+    root * /app
+    php_server
+}
+```
+- `worker /app/main.php 4`: starts 4 worker processes.
+- `php_server`: modern FrankenPHP directive (not `php_fastcgi`).
+
+**Dockerfile** (template `dockerfileTmpl`, lines 93-105):
+```
+FROM dunglas/frankenphp:php8.4
+WORKDIR /app
+COPY main.php /app/main.php
+COPY Caddyfile /etc/caddy/Caddyfile
+EXPOSE 8080
+```
+Pinned to `dunglas/frankenphp:php8.4`.
+
+### 9.3 RoadRunner bundle: EmitRoadRunnerBundle
+
+`EmitRoadRunnerBundle(outDir, packageName)` (packaging.go lines 171-195)
+writes two files:
+
+**.rr.yaml** (template `rrYamlTmpl`, lines 107-123):
+```yaml
+version: "3"
+server:
+  command: "php worker.php"
+http:
+  address: ":8080"
+  pool:
+    num_workers: 4
+    max_jobs: 64
+    allocate_timeout: 60s
+    destroy_timeout: 60s
+```
+
+**worker.php** (template `rrWorkerTmpl`, lines 125-138):
+```php
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/main.php';
+// Real apps wire PSR-7 here...
+```
+
+### 9.4 TestPhase17AllTargetsTogether
+
+`TestPhase17AllTargetsTogether` (phase17_test.go lines 206-246) runs
+all three targets for every Phase 17 fixture in one test, asserting
+that all five artifacts (`build_phar.php`, `Caddyfile`, `Dockerfile`,
+`.rr.yaml`, `worker.php`) are produced. This cross-cut gate ensures a
+regression in any one packaging path fails the whole suite.
+
+## 10. CI workflow
+
+`.github/workflows/transpiler3-php-test.yml` has two jobs:
+
+### 10.1 go-side
+
+- Runs on `ubuntu-latest`.
+- Installs PHP 8.4 via `shivammathur/setup-php@v2` with
+  `extensions: mbstring, gmp` and `tools: composer:v2`.
+- Runs `go vet ./transpiler3/php/...`, `go build`, `go test`.
+- This job covers the full Go test suite including all fragment tests,
+  the DJB2 hash tests, the reproducibility tests, and the packaging
+  structure tests.
+
+### 10.2 php-runtime
+
+- Runs on `ubuntu-latest` with a PHP version matrix.
+- Runs `composer install --no-interaction --prefer-dist` in
+  `transpiler3/php/runtime/`.
+- Runs PHPStan, Psalm, php-cs-fixer (dry-run), and PHPUnit.
+- PHP 8.4.0 and 8.4 latest: `allow_failure: false`.
+- PHP 8.5: `allow_failure: true`.
+
+### 10.3 Timeout
+
+Both jobs have `timeout-minutes: 15`. The go-side job is fast (no PHP
+compilation of fixture programs needed for fragment tests). The
+php-runtime job spends most of its time in Composer install and Psalm
+analysis.

--- a/website/docs/research/0055/11-testing-gates.md
+++ b/website/docs/research/0055/11-testing-gates.md
@@ -1,0 +1,269 @@
+---
+title: "Testing gates: two-tier strategy, fragment tests, PHP execution tests, DJB2, Phar, reproducibility"
+description: "The two-tier testing strategy for MEP-55: fragment gates (no PHP needed) and PHP execution gates. Covers runPhpFixture, TestPhaseNEmitFragments, TestPhase13DJB2HashMatchesCassetteFilenames, runPhpLLMFixture, runPharFixture, TestPhase17AllTargetsTogether, TestPhase16NonDeterministicBuildsAlsoMatch."
+sidebar_position: 11
+---
+
+# Testing gates: two-tier strategy, fragment tests, PHP execution tests
+
+Author: research pass for MEP-55 (Mochi-to-PHP 8.4 transpiler).
+Date: 2026-05-29 15:00 (GMT+7).
+Sources: `transpiler3/php/build/build_test.go`,
+`transpiler3/php/build/phase09_test.go`,
+`transpiler3/php/build/phase10_test.go`,
+`transpiler3/php/build/phase13_test.go`,
+`transpiler3/php/build/phase16_test.go`,
+`transpiler3/php/build/phase17_test.go`,
+`transpiler3/php/build/phase07_test.go`.
+
+## 1. Two-tier testing strategy
+
+MEP-55 uses a two-tier approach:
+
+**Tier 1: Fragment gates** run without PHP being installed. They lower
+a Mochi fixture to PHP source text and call `strings.Contains` on the
+emitted text. These tests run on any machine with Go and are fast (< 1
+second per fixture).
+
+**Tier 2: PHP execution gates** require `php` on PATH (or `PHP_PATH`
+set). They run the emitted `main.php` under PHP and diff stdout against
+a `.out` cassette file. These tests skip gracefully if PHP is absent and
+are gate by the `go-side` CI job which installs PHP 8.4.
+
+The two tiers complement each other: fragment tests catch lowerer shape
+regressions without needing a PHP install; execution tests catch runtime
+semantic regressions that generate syntactically valid but wrong output.
+
+## 2. `runPhpFixture` helper
+
+Defined in `build_test.go` (lines 15-50). Pattern:
+
+```go
+func runPhpFixture(t *testing.T, mochiPath, wantFile string) {
+    t.Helper()
+    if _, err := exec.LookPath("php"); err != nil {
+        if p := os.Getenv("PHP_PATH"); p == "" {
+            t.Skipf("php not on PATH: %v", err)
+        }
+    }
+    want, _ := os.ReadFile(wantFile)
+    outDir := t.TempDir()
+    d := &Driver{CacheDir: t.TempDir(), NoCache: true}
+    emittedPath, _ := d.Build(mochiPath, outDir, TargetPhpSource)
+    cmd := exec.Command("php", emittedPath)
+    var stdout bytes.Buffer
+    cmd.Stdout = &stdout
+    cmd.Stderr = os.Stderr
+    _ = cmd.Run()
+    if !bytes.Equal(stdout.Bytes(), want) {
+        t.Errorf("stdout mismatch\ngot:  %q\nwant: %q", ...)
+    }
+}
+```
+
+Key characteristics:
+- PHP-skip pattern: tests skip when `php` is not on PATH and `PHP_PATH`
+  is not set.
+- `t.TempDir()` for output isolation: each sub-test gets its own
+  directory; the Go test framework cleans up on exit.
+- `NoCache: true`: ensures each test runs a fresh pipeline without
+  sharing cached state.
+- Stdout diff: `bytes.Equal` on raw stdout bytes vs `.out` file content.
+  Any trailing newline difference is a failure.
+
+`runPhpFixture` is called by `TestPhaseNAgents`, `TestPhaseNStreams`,
+`TestPhase7Query`, etc. — the per-phase "run all fixtures in this
+directory" walkers.
+
+## 3. `TestPhaseNEmitFragments` pattern
+
+Each phase has an `EmitFragments` test alongside its runner test.
+The pattern (illustrated by `TestPhase9EmitFragments` in phase09_test.go):
+
+```go
+cases := []struct {
+    fixture string
+    wants   []string
+}{
+    {
+        fixture: "agent_counter.mochi",
+        wants: []string{
+            `final class Counter`,
+            `public int $count,`,
+            `public function increment(): void`,
+            `$this->count = ($this->count + 1);`,
+        },
+    },
+    // ...
+}
+for _, c := range cases {
+    t.Run(strings.TrimSuffix(c.fixture, ".mochi"), func(t *testing.T) {
+        mochiPath := filepath.Join(repoRoot(t), ..., c.fixture)
+        outDir := t.TempDir()
+        d := &Driver{CacheDir: t.TempDir(), NoCache: true}
+        p, _ := d.Build(mochiPath, outDir, TargetPhpSource)
+        data, _ := os.ReadFile(p)
+        src := string(data)
+        for _, want := range c.wants {
+            if !strings.Contains(src, want) {
+                t.Errorf("%s: emitted source missing %q", c.fixture, want)
+            }
+        }
+    })
+}
+```
+
+Each `wants` entry is a substring that must appear in the emitted PHP
+source. The tests do not require PHP to be installed. They run in the
+`go-side` CI job alongside the Go build.
+
+Fragment tests exist for: Phase 7 (query), Phase 9 (agents), Phase 10
+(streams), Phase 13 (LLM), Phase 15 (composer), Phase 16 (repro), and
+Phase 17 (packaging structure).
+
+## 4. `repoRoot` helper
+
+`repoRoot(t)` (build_test.go lines 52-56) delegates to
+`repoRootForBuild(t)` (build.go lines 220-240). It walks up from the Go
+source file's directory until it finds `go.mod`. This ensures fixture
+paths resolve correctly regardless of the Go test runner's working
+directory. Every `phase*_test.go` uses it for fixture discovery.
+
+## 5. TestPhase13DJB2HashMatchesCassetteFilenames
+
+`TestPhase13DJB2HashMatchesCassetteFilenames` (phase13_test.go lines
+236-281) is a pure-Go test (no PHP required) that pins the cassette
+lookup algorithm:
+
+1. For each known (provider, model, prompt) tuple, computes the DJB2
+   hash using `djb2CassetteKey` (phase13_test.go lines 219-226), a Go
+   reimplementation of the PHP GMP-based `mochi_llm_cassette_key`.
+2. Checks that the expected hash string matches the computed value.
+3. Checks that `<cassetteDir>/<hash>.txt` exists on disk.
+
+Example:
+```go
+{"generate_text", "openai", "", "Say hello.", "15023835511162652990"},
+```
+
+This test catches:
+- Wrong DJB2 concat order (provider, model, prompt with NUL separators).
+- Missing NUL separators between components.
+- Wrong mask (should be 64-bit unsigned, not 32-bit).
+- Signed-int overflow in a Go or PHP implementation.
+- A renamed cassette file.
+- A wrong default model value passed by the lowerer.
+
+The Go `djb2CassetteKey` uses `uint64` (which wraps modulo 2^64), and
+the PHP `mochi_llm_cassette_key` uses GMP with a 64-bit mask. Both must
+agree on every known tuple for the cassette system to work across the C,
+PHP, and other targets.
+
+## 6. `runPhpLLMFixture` helper
+
+`runPhpLLMFixture(t, mochiPath, wantFile, cassetteDir)` (phase13_test.go
+lines 40-73) is like `runPhpFixture` but sets `MOCHI_LLM_CASSETTE_DIR`:
+
+```go
+cmd.Env = append(os.Environ(), "MOCHI_LLM_CASSETTE_DIR="+cassetteDir)
+```
+
+The cassette directory contains `<djb2-hash>.txt` files (one per LLM
+call in the fixture). The `mochi_llm_generate` PHP helper reads from
+this directory using `getenv('MOCHI_LLM_CASSETTE_DIR')`.
+
+Each Phase 13 fixture lives in its own subdirectory under
+`phase13-llm/`: `generate_text/generate_text.mochi`,
+`generate_text/generate_text.out`, `generate_text/cassette/`.
+
+## 7. `runPharFixture` helper
+
+`runPharFixture(t, mochiPath, wantFile)` (phase17_test.go lines 51-93):
+
+1. Builds `main.php` via `Driver.Build(TargetPhpSource)`.
+2. Calls `emitPharStager(outDir, mainPhp, pharPath)` to generate the
+   stager script.
+3. Runs `php -d phar.readonly=0 build_phar.php` to produce `out.phar`.
+4. Asserts `out.phar` was created.
+5. Runs `php out.phar` and diffs stdout against `wantFile`.
+
+The stager step requires PHP; the test skips if PHP is absent.
+
+## 8. TestPhase17AllTargetsTogether
+
+`TestPhase17AllTargetsTogether` (phase17_test.go lines 206-246) runs
+all three Phase 17 targets (Phar stager, FrankenPHP bundle,
+RoadRunner bundle) for every `.mochi` fixture in `phase17-packaging/`:
+
+```go
+for _, e := range entries {
+    t.Run(name, func(t *testing.T) {
+        // Build main.php
+        mainPhp, _ := d.Build(fixturePath, outDir, TargetPhpSource)
+        // Stage phar
+        emitPharStager(outDir, mainPhp, pharPath)
+        // Emit FrankenPHP bundle
+        EmitFrankenPHPBundle(outDir, name)
+        // Emit RoadRunner bundle
+        EmitRoadRunnerBundle(outDir, name)
+        // Assert all five artifacts exist
+        for _, want := range []string{"build_phar.php", "Caddyfile", "Dockerfile", ".rr.yaml", "worker.php"} {
+            os.Stat(filepath.Join(outDir, want))
+        }
+    })
+}
+```
+
+This is a fragment-level gate: it checks that the artifacts are created
+but does not run PHP to execute the Phar. The execution gate is in
+`TestPhase17Phar`.
+
+## 9. TestPhase16NonDeterministicBuildsAlsoMatch
+
+`TestPhase16NonDeterministicBuildsAlsoMatch` (phase16_test.go lines
+86-112) verifies that even with `Deterministic = false`, two builds of
+the same source from the same revision produce byte-identical PHP:
+
+```go
+d1 := &Driver{CacheDir: t.TempDir(), NoCache: true}
+d2 := &Driver{CacheDir: t.TempDir(), NoCache: true}
+h1 := sha256(d1.Build(mochiPath, out1, TargetPhpSource))
+h2 := sha256(d2.Build(mochiPath, out2, TargetPhpSource))
+if h1 != h2 { t.Errorf(...) }
+```
+
+This is a defensive check complementing `TestPhase16Repro` (which uses
+`Deterministic: true`). The comment in the test explains the rationale:
+the PHP lowerer has no time-, random-, or path-derived sources of
+non-determinism. Any divergence means an unintentional source of
+non-determinism has been introduced.
+
+## 10. Per-phase test file structure
+
+Every phase has at least one test file in `transpiler3/php/build/`:
+
+| File | Tests | PHP required? |
+|------|-------|---------------|
+| `phase00_test.go` | skeleton emit | Yes (runPhpFixture) |
+| `phase01_test.go` | hello world prints | Yes |
+| `phase02_test.go` | scalars, ops, control flow | Yes |
+| `phase03_test.go` | collections | Yes |
+| `phase04_test.go` | records | Yes |
+| `phase05_test.go` | sum types, match | Yes |
+| `phase06_test.go` | closures | Yes |
+| `phase07_test.go` | query DSL + EmitFragments | Fragments: No; Runner: Yes |
+| `phase08_test.go` | Datalog | Fragments: No; Runner: Yes |
+| `phase09_test.go` | agents + EmitFragments | Fragments: No; Runner: Yes |
+| `phase10_test.go` | streams + EmitFragments | Fragments: No; Runner: Yes |
+| `phase11_test.go` | async | Yes |
+| `phase12_test.go` | FFI | Yes |
+| `phase13_test.go` | LLM (DJB2 gate + LLM runner + EmitFragments) | DJB2: No; LLM: Yes |
+| `phase14_test.go` | fetch | Yes |
+| `phase15_test.go` | Composer staging | Yes |
+| `phase16_test.go` | reproducibility | SHA-256 only: No; EndToEnd: Yes |
+| `phase17_test.go` | packaging (Phar + FrankenPHP + RoadRunner) | Structure: No; Phar: Yes |
+| `phase18_test.go` | signed releases | No (artifact structure only) |
+
+The fragment/structure-only tests in the right column all run in the
+`go-side` CI job. The PHP-execution tests also run there (PHP is
+installed by `shivammathur/setup-php@v2`).

--- a/website/docs/research/0055/12-risks-and-alternatives.md
+++ b/website/docs/research/0055/12-risks-and-alternatives.md
@@ -1,0 +1,268 @@
+---
+title: "Risks and alternatives: scheduling, PHP_INT_MAX overflow, Psalm 5 vs 6, abstract readonly, phar.readonly, amphp removed, live LLM deferred, PHP 8.5"
+description: "Risk register for MEP-55: PHP scheduling, PHP_INT_MAX DJB2 overflow (GMP mitigation), Psalm 5 vs 6 PHP 8.4 incompatibility, abstract readonly inheritance, phar.readonly default, amphp/revolt removal, live LLM providers deferred, PHP 8.5 allow_failure."
+sidebar_position: 12
+---
+
+# Risks and alternatives
+
+Author: research pass for MEP-55 (Mochi-to-PHP 8.4 transpiler).
+Date: 2026-05-29 15:00 (GMT+7).
+Sources: `transpiler3/php/colour/colour.go`,
+`transpiler3/php/lower/lower.go`,
+`transpiler3/php/runtime/composer.json`,
+`transpiler3/php/build/phase13_test.go`,
+`transpiler3/php/build/phase17_test.go`,
+`.github/workflows/transpiler3-php-test.yml`,
+`website/docs/mep/mep-0055.md`.
+
+This note collects the risks MEP-55 accepts, the mitigations applied,
+and the alternatives explicitly rejected. Each risk entry has a
+severity, a description, and a mitigation or current status.
+
+## Risk register
+
+### R1: PHP has no preemptive scheduler
+
+**Severity**: medium (design constraint, not a defect).
+
+**Description**: PHP has no preemptive scheduler in the standard library.
+Mochi agents and streams on PHP are synchronous: an agent's `recv()`
+call does not yield to other agents while waiting. All Phase 9-10
+fixtures use emit-before-recv patterns specifically because of this.
+
+If a Mochi program is written with interleaved concurrent agent behaviour
+(agent A sends to agent B which replies to agent A), that program cannot
+be correctly lowered to the synchronous PHP model.
+
+**Mitigation**: The lowerer emits sequential code. Programs that require
+genuine concurrency must target a different Mochi backend (BEAM MEP-46,
+JVM MEP-47). The MEP-55 spec documents this limitation explicitly.
+
+**Status**: Accepted design constraint. `colour/colour.go` documents:
+"no PHP function ever needs an `Amp\Future<T>` return type."
+
+### R2: PHP_INT_MAX overflow for DJB2 cassette keys
+
+**Severity**: high (would produce wrong cassette keys for some prompts).
+
+**Description**: PHP's native `int` is 63-bit signed on 64-bit platforms
+(PHP_INT_MAX = 9223372036854775807 = 2^63 - 1). The DJB2 hash of some
+(provider, model, prompt) combinations produces a 64-bit unsigned value
+greater than PHP_INT_MAX. Under PHP's native integer arithmetic, the
+value would be silently truncated or wrapped as a negative number,
+producing a key that does not match the cassette file.
+
+Example: `djb2("openai", "", "Say hello.") = 15023835511162652990`,
+which is larger than 2^63 - 1 = 9223372036854775807. PHP would
+miscompute this without GMP.
+
+**Mitigation**: The `mochi_llm_cassette_key` helper (lower.go lines
+388-403) uses GMP to perform all hash arithmetic in unsigned 64-bit
+space:
+```php
+$h = gmp_init(5381);
+$mask = gmp_init('FFFFFFFFFFFFFFFF', 16);
+$h = gmp_and(gmp_mul($h, 33), $mask);
+$h = gmp_xor($h, gmp_init(ord($buf[$i])));
+return gmp_strval($h, 10);
+```
+GMP is a required extension (`"ext-gmp": "*"` in `composer.json`).
+
+`TestPhase13DJB2HashMatchesCassetteFilenames` pins the exact expected
+hash for every known tuple, confirming that the GMP path produces the
+same result as Go's native `uint64` arithmetic.
+
+**Status**: Mitigated. Requires `ext-gmp`, documented in README and
+composer.json.
+
+### R3: Psalm 5.x PHP 8.4 incompatibility
+
+**Severity**: high (blocks CI).
+
+**Description**: Psalm 5.x did not recognise PHP 8.4 as a valid platform
+version in its internal version table. When run against the runtime
+package with `platform: {php: 8.4}` in `psalm.xml`, Psalm 5 reported
+the PHP version as unknown and flagged `abstract readonly class` syntax
+as invalid PHP, producing false-positive errors.
+
+**Mitigation**: Migrated to `"vimeo/psalm": "^6.0"` in `composer.json`.
+Psalm 6 adds full PHP 8.4 support. This migration happened in audit
+round 1 after the initial umbrella PR.
+
+**Status**: Resolved. `composer.json` requires `^6.0`.
+
+### R4: `final readonly class extends abstract readonly class` requires PHP 8.4
+
+**Severity**: high (would break sum-type lowering on PHP < 8.4).
+
+**Description**: PHP 8.4 introduced the rule that a `final readonly`
+class can only extend an `abstract readonly` base. In PHP 8.3 and earlier,
+`abstract readonly class` is not valid syntax. Attempting to use a plain
+`abstract class` base for a sum type breaks in PHP 8.4 because
+`final readonly` cannot extend a non-readonly parent.
+
+This constraint was discovered during Phase 5 CI on the umbrella PR.
+The CI run failed with a PHP parse error on the emitted sum-type class
+hierarchy.
+
+**Mitigation**: The `ClassDecl` ptree node has an `Abstract` field. When
+`Abstract: true`, the emit pass writes `abstract readonly class NAME {}`
+(nodes.go lines 738-739). The `lowerUnion` function (lower.go lines
+1006-1030) sets `Abstract: true` on the base class. The fix was a single
+line in the lowerer.
+
+**Status**: Fixed in umbrella PR Phase 5. No further action needed.
+
+### R5: `phar.readonly = 1` default on most distributions
+
+**Severity**: medium (blocks Phar creation without workaround).
+
+**Description**: Most Linux distributions and macOS Homebrew ship PHP
+with `phar.readonly = 1` in the global `php.ini`. This prevents the
+`Phar::startBuffering()` and `addFile()` calls in the Phase 17 stager
+from executing.
+
+**Mitigation**: The stager is invoked with `php -d phar.readonly=0` in
+`runPharFixture` (phase17_test.go line 74). Documentation notes that
+production deployments can use `humbug/box compile` (which handles
+`phar.readonly` internally) or add `phar.readonly = Off` to a project
+`php.ini`.
+
+The `-d` flag works per-invocation without modifying the system
+configuration. CI uses `shivammathur/setup-php@v2` which sets up a
+clean PHP environment; the flag is still needed there.
+
+**Status**: Mitigated. No change to default distribution configuration
+required.
+
+### R6: `amphp/revolt` removed from runtime
+
+**Severity**: low (was never shipped, removed in audit round 1).
+
+**Description**: An early draft of `composer.json` listed `amphp/revolt`
+in `require-dev` as the intended async event loop backend for Phase 11.
+Phase 11 was implemented as synchronous wrappers instead, making the
+dependency unnecessary. The dependency was removed in audit round 1.
+
+If `amphp/revolt` had been left in `require-dev`, it would have added a
+large transitive dependency tree and potentially caused Psalm/PHPStan
+analysis to take longer. More importantly, it would have created a
+false expectation that Phase 11 supports true async.
+
+**Mitigation**: Removed. `composer.json` has no `amphp/revolt` entry.
+The `colour.go` package comment documents the decision permanently.
+
+**Status**: Resolved.
+
+### R7: Live LLM providers deferred
+
+**Severity**: low (Phase 13 is cassette-only; acknowledged in spec).
+
+**Description**: Phase 13 ships cassette-only LLM dispatch. The
+`mochi_llm_generate` helper reads `$MOCHI_LLM_CASSETTE_DIR/<hash>.txt`.
+When the env var is unset or the cassette is missing, the helper writes
+a stderr diagnostic and returns `""`:
+```php
+fwrite(STDERR, "mochi_llm_generate: MOCHI_LLM_CASSETTE_DIR not set; live mode not yet implemented for PHP\n");
+return '';
+```
+Live OpenAI, Anthropic, Google, and llama.cpp integrations are not
+implemented.
+
+**Mitigation**: The C runtime (MEP-45) similarly defers live providers
+until a later phase. The cassette-only approach is sufficient for
+testing and for offline evaluation scenarios.
+
+**Status**: Accepted deferral. Documented in MEP-55 spec and in the PHP
+helper's stderr message.
+
+### R8: PHP 8.5 allow_failure
+
+**Severity**: low (early warning, not a current breakage).
+
+**Description**: PHP 8.5 was in alpha/beta at MEP-55 ship time (May
+2026). Its full release may introduce changes to:
+- Strict-type handling (new coercion rules).
+- Deprecation of functions used by the runtime or lowered code.
+- PHPStan/Psalm compatibility.
+
+**Mitigation**: The CI matrix runs PHP 8.5 as `allow_failure: true`
+(`.github/workflows/transpiler3-php-test.yml`). This provides early
+warning of 8.5 breakage without blocking CI on main. When 8.5 reaches
+stable, the `allow_failure` flag will be set to `false`.
+
+**Status**: Monitored.
+
+### R9: `Mochi\Runtime\IO` flagged as dead code by Psalm
+
+**Severity**: low (causes false-positive CI failure without `@api`).
+
+**Description**: Psalm's `UnusedClass` check reports `IO` as dead code
+because no code within `src/` calls its methods. Lowered Mochi programs
+call it from outside the scanned source tree.
+
+**Mitigation**: The `@api` PHPDoc tag on `IO` (runtime/src/Mochi/
+Runtime/IO.php lines 17-18) suppresses the finding. See [[04-runtime]]
+for details.
+
+**Status**: Mitigated by `@api`. TRUST.md documents the convention.
+
+### R10: PHP reserved word collision with user agent/record names
+
+**Severity**: low (affects programs that name a type after a PHP keyword).
+
+**Description**: PHP rejects class names that are reserved words. A
+Mochi program with `agent Switch { ... }` or `record Int { ... }` would
+emit invalid PHP without the collision guard.
+
+**Mitigation**: `phpClassName(name)` (lower.go lines 965-972) appends
+`_` to any name in `phpReservedClassNames` (lines 939-963). The
+`agent_bool.mochi` fixture pins the `Switch_` case. The list covers
+all PHP 8.4 reserved words and soft-reserved type names (`int`, `float`,
+`bool`, `string`, `void`, etc.).
+
+**Status**: Mitigated. Fragment test `agent_bool` pins it.
+
+## Rejected alternatives
+
+### A1: Amp/Revolt for async
+
+**Evaluated**: amphp/amp v3 and revolt/event-loop for Phase 11 async.
+
+**Decision**: Rejected. Adds runtime dependencies, changes function
+signatures, requires event-loop configuration. Sync wrappers cover all
+Phase 11 fixture use cases.
+
+### A2: Haxe PHP backend
+
+**Evaluated**: route Mochi through a Mochi→Haxe transpiler using Haxe's
+existing PHP backend.
+
+**Decision**: Rejected. Two translation layers. Haxe's PHP backend not
+under Mochi's control. Would add a large build-time dependency.
+
+### A3: HHVM/Hack as the primary PHP-family target
+
+**Evaluated**: target HHVM instead of Zend PHP.
+
+**Decision**: Rejected. HHVM dropped PHP backward compatibility in 2018.
+HHVM is not available on shared hosting. Standard Zend PHP 8.4 reaches
+a wider deployment surface.
+
+### A4: humbug/box for Phase 17 CI gate
+
+**Evaluated**: use `humbug/box compile` in the Phase 17 CI gate.
+
+**Decision**: Rejected for the in-tree gate. Requires `composer global
+require humbug/box` and network access in every test run. The built-in
+`Phar` class is sufficient for structural validation. Production builds
+can use humbug/box.
+
+### A5: PHP 8.3 minimum floor
+
+**Evaluated**: lower the floor to PHP 8.3 for wider compatibility.
+
+**Decision**: Rejected. PHP 8.3 has no `abstract readonly class`. Sum
+types cannot be encoded cleanly. See [[02-design-philosophy]] for the
+full version history analysis.

--- a/website/docs/research/0055/index.md
+++ b/website/docs/research/0055/index.md
@@ -1,0 +1,41 @@
+---
+title: "MEP-55 research bundle: Mochi to PHP 8.4 transpiler"
+description: "Thirteen research notes covering language surface, design philosophy, prior art, runtime, codegen, type lowering, PHP target portability, dataset pipeline, agents and streams, build system, testing gates, and risks for the Mochi-to-PHP 8.4 transpiler proposed in MEP-55."
+sidebar_position: 55
+sidebar_label: "MEP-55"
+---
+
+# MEP-55 research bundle: Mochi to PHP 8.4 transpiler
+
+Author: research pass for MEP-55 (Mochi-to-PHP 8.4 transpiler).
+Date: 2026-05-29 15:00 (GMT+7).
+
+This bundle contains the thirteen research notes that informed [MEP-55, the Mochi-to-PHP 8.4 transpiler](/docs/mep/mep-0055). The notes are informative; the normative spec is in the MEP body.
+
+| # | Title | Topic |
+|---|-------|-------|
+| 01 | [Language surface](/docs/research/0055/01-language-surface) | Mochi language surface mapped onto PHP 8.4 lowering obligations: scalars, collections, records, sum types, closures, match, loops, query DSL, phase corpus |
+| 02 | [Design philosophy](/docs/research/0055/02-design-philosophy) | Why PHP, why PHP 8.4 floor, why `declare(strict_types=1)`, why sync wrappers not Amp/Revolt, why `final readonly class` for records, why `abstract readonly class` bases, why DJB2/GMP, why Phar over box |
+| 03 | [Prior art: transpilers](/docs/research/0055/03-prior-art-transpilers) | Survey of source-to-PHP tools (Hack/HHVM, Haxe PHP target, Dart2PHP); PHP version history; why 8.4 is the minimum; why a direct aotir→ptree→emit approach |
+| 04 | [Runtime](/docs/research/0055/04-runtime) | The `mochi/runtime` Composer package: directory structure, IO class, `@api` annotation, devDependencies (Psalm 6, PHPStan 1.12, php-cs-fixer), zero runtime deps, required extensions |
+| 05 | [Codegen design](/docs/research/0055/05-codegen-design) | aotir → ptree → emit pipeline: ptree node types, `runtimeFlags` struct, `mochi__` prefix, emit pass, pipeline wiring in Driver.Build |
+| 06 | [Type lowering](/docs/research/0055/06-type-lowering) | Per-Mochi-type lowering rules for every type: int, float, bool, string, list, map, set, record, sum type, closures, function types, Result, panic |
+| 07 | [PHP target portability](/docs/research/0055/07-php-target-portability) | PHP ecosystem portability: CI matrix (8.4.0 / 8.4 / 8.5 allow_failure), phar.readonly=0, FrankenPHP vs RoadRunner, Composer 2, Packagist, server-model implications |
+| 08 | [Dataset pipeline](/docs/research/0055/08-dataset-pipeline) | Query DSL lowering (from/where/select/order-by/skip/take onto PHP arrays + usort), Phase 8 Datalog compile-time semi-naive evaluation, static array literal output |
+| 09 | [Agents and streams](/docs/research/0055/09-agent-streams) | Phase 9 agents (mutable PHP class), Phase 10 streams (MochiStream/MochiSub fan-out, backpressure), Phase 11 async coloring (all-Blue, sync wrappers) |
+| 10 | [Build system](/docs/research/0055/10-build-system) | Driver.Build pipeline, resolvePhp, effectiveCacheDir + cacheKey (reserved), Phase 17 packaging (emitPharStager, EmitFrankenPHPBundle, EmitRoadRunnerBundle), CI workflow |
+| 11 | [Testing gates](/docs/research/0055/11-testing-gates) | Per-phase test structure, runPhpFixture, TestPhaseNEmitFragments, TestPhase13DJB2HashMatchesCassetteFilenames, runPhpLLMFixture, runPharFixture, TestPhase17AllTargetsTogether, two-tier strategy |
+| 12 | [Risks and alternatives](/docs/research/0055/12-risks-and-alternatives) | Risk register: PHP scheduling, PHP_INT_MAX DJB2 overflow, Psalm 5 vs 6, abstract readonly inheritance, phar.readonly, amphp/revolt removal, live LLM deferral, PHP 8.5 allow_failure |
+
+## Cross-references
+
+- [MEP-45 (C target)](/docs/mep/mep-0045)
+- [MEP-46 (BEAM target)](/docs/mep/mep-0046)
+- [MEP-47 (JVM target, direct bytecode)](/docs/mep/mep-0047)
+- [MEP-48 (.NET target)](/docs/mep/mep-0048)
+- [MEP-49 (Swift target)](/docs/mep/mep-0049)
+- [MEP-50 (Kotlin target)](/docs/mep/mep-0050)
+- [MEP-51 (Python target)](/docs/mep/mep-0051)
+- [MEP-52 (TypeScript/JavaScript target)](/docs/mep/mep-0052)
+- [MEP-53 (Rust target)](/docs/mep/mep-0053)
+- [MEP-54 (Erlang/OTP target)](/docs/mep/mep-0054)

--- a/website/src/data/research-sidebar.json
+++ b/website/src/data/research-sidebar.json
@@ -142,5 +142,23 @@
       "research/0052/testing-gates",
       "research/0052/risks-and-alternatives"
     ]
+  },
+  {
+    "label": "MEP-0055",
+    "items": [
+      "research/0055/index",
+      "research/0055/language-surface",
+      "research/0055/design-philosophy",
+      "research/0055/prior-art-transpilers",
+      "research/0055/runtime",
+      "research/0055/codegen-design",
+      "research/0055/type-lowering",
+      "research/0055/php-target-portability",
+      "research/0055/dataset-pipeline",
+      "research/0055/agent-streams",
+      "research/0055/build-system",
+      "research/0055/testing-gates",
+      "research/0055/risks-and-alternatives"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- Closes #22646
- Adds `website/docs/research/0055/` — 13 files (12 research notes + index), 3108 lines total, grounded in the actual source at `transpiler3/php/`.
- Mirrors the structure of `research/0050/`, `research/0051/`, `research/0052/` (12 notes + index per MEP).
- Updates `website/src/data/research-sidebar.json` with the MEP-0055 group.

## Notes shipped

| # | Title |
|---|-------|
| 01 | Language surface — Mochi features → PHP 8.4 lowering obligations |
| 02 | Design philosophy — why PHP 8.4 floor, readonly classes, strict_types, sync wrappers, === for float, DJB2/GMP |
| 03 | Prior art — Hack/HHVM, Haxe, Dart2PHP, PHP version history (why 8.4 not 8.1/8.3) |
| 04 | Runtime — mochi/runtime Composer package, IO @api annotation, zero-prod-dep, ext-gmp + ext-mbstring |
| 05 | Codegen design — aotir → ptree → emit pipeline, runtimeFlags struct, mochi__ prefix |
| 06 | Type lowering — per-type PHP lowering rules with rationale and generated-code examples |
| 07 | PHP target portability — CI matrix, phar.readonly, FrankenPHP vs RoadRunner, Packagist |
| 08 | Dataset pipeline — Phase 7 query DSL, Phase 8 Datalog compile-time semi-naive eval |
| 09 | Agents and streams — Phase 9 userland Channel, Phase 10 IteratorAggregate backpressure, Phase 11 sync colouring |
| 10 | Build system — Driver.Build(), resolvePhp, Phase 17 Phar/FrankenPHP/RoadRunner packaging |
| 11 | Testing gates — two-tier strategy (fragment gates + PHP execution), cassette DJB2 gate, phar fixture, repro gate |
| 12 | Risks and alternatives — risk register: sync-only agents, PHP_INT_MAX, Psalm 5→6, readonly inheritance, live LLM deferred |

## Test plan
- [x] All 13 files exist under `website/docs/research/0055/`
- [x] `research-sidebar.json` updated with MEP-0055 group (13 items)
- [x] Frontmatter format matches MEP-52 research notes exactly
- [ ] Docusaurus build validates links (CI)