### PR TITLE
docs(mep-0057): round 8 struct consistency fixes

### DIFF
--- a/website/docs/implementation/0057/phase-00-skeleton.md
+++ b/website/docs/implementation/0057/phase-00-skeleton.md
@@ -94,11 +94,12 @@ type Dep struct {
     Rev      string   `toml:"rev,omitempty"`            // git commit-ish
     Tag      string   `toml:"tag,omitempty"`            // git tag
     Branch   string   `toml:"branch,omitempty"`         // git branch
-    Optional bool     `toml:"optional,omitempty"`
-    Features []string `toml:"features,omitempty"`       // pkg feature set
-    Default  *bool    `toml:"default-features,omitempty"`
-    Registry string   `toml:"registry,omitempty"`       // mirror override
-    Targets  []string `toml:"targets,omitempty"`        // limit to listed transpiler targets
+    Optional  bool     `toml:"optional,omitempty"`
+    Features  []string `toml:"features,omitempty"`       // pkg feature set
+    Default   *bool    `toml:"default-features,omitempty"`
+    Registry  string   `toml:"registry,omitempty"`       // mirror override
+    Targets   []string `toml:"targets,omitempty"`        // limit to listed transpiler targets
+    Workspace bool     `toml:"workspace,omitempty"`      // inherit from [workspace.dependencies]
 }
 
 type Capabilities struct {
@@ -129,10 +130,16 @@ type Provenance struct {
     SourceDate  *time.Time `toml:"source-date,omitempty"`
 }
 
+// Workspace stub; Phase 1 promotes it to pkg/pkgmanifest/workspace.go
+// and Phase 3 adds DefaultTarget, Dependencies, Targets, AllowMultiVer.
 type Workspace struct {
-    Members  []string `toml:"members,omitempty"`
-    Exclude  []string `toml:"exclude,omitempty"`
-    Resolver string   `toml:"resolver,omitempty"`       // "pubgrub" (default) or "mvs"
+    Members        []string            `toml:"members,omitempty"`
+    Exclude        []string            `toml:"exclude,omitempty"`
+    Resolver       string              `toml:"resolver,omitempty"`         // "pubgrub" (default) or "mvs"
+    DefaultTarget  []string            `toml:"default-target,omitempty"`   // added Phase 3
+    Dependencies   map[string]Dep      `toml:"dependencies,omitempty"`     // added Phase 3
+    Targets        map[string][]string `toml:"targets,omitempty"`          // added Phase 3
+    AllowMultiVer  []string            `toml:"allow-multi-version,omitempty"` // added Phase 3
 }
 ```
 


### PR DESCRIPTION
## Summary

- Add `Workspace bool` field to `Dep` struct (Phase 0 skeleton); Phase 3 `ResolveMemberDeps` reads `dep.Workspace` and would fail to compile without it.
- Expand `Workspace` stub from 3 fields to 6 fields to match Phase 3's full definition (`DefaultTarget`, `Dependencies`, `Targets`, `AllowMultiVer`); annotated with "added Phase 3" so the incremental ownership is clear.

## Test plan

- [ ] All other round 8 consistency checks (mirror verbs, bench/cache verbs, CycloneDX 1.6, TUF codes, SBOM) came back clean.
- [ ] Phase 0 skeleton compiles with the new fields.
- [ ] Phase 3's `ResolveMemberDeps` and workspace parsing code references `dep.Workspace` and workspace fields that now exist in phase-00's declared struct.

Closes #22682