### PR TITLE
feat(transpiler3/go): MEP-54 Phase 15.0 (TargetGoModule packaging)

### DIFF
--- a/transpiler3/go/build/driver.go
+++ b/transpiler3/go/build/driver.go
@@ -75,8 +75,9 @@ type Driver struct {
 // gotree.File, renders it via emit, writes go.mod, invokes
 // `go build`, and writes the produced binary to out.
 //
-// target and profile are accepted for forward compatibility;
-// Phase 1 builds only for the host tuple.
+// When target == TargetGoModule, Build skips `go build` and
+// instead copies the work directory (go.mod + main.go) into
+// out as a publish-ready Go module. profile is informational.
 func (d *Driver) Build(src, out string, target, profile string) error {
 	if src == "" {
 		return errors.New("transpiler3/go/build: source path is required")
@@ -128,8 +129,48 @@ func (d *Driver) Build(src, out string, target, profile string) error {
 	if err != nil {
 		return fmt.Errorf("transpiler3/go/build: abs %s: %w", out, err)
 	}
+
+	if Target(target) == TargetGoModule {
+		if err := copyModule(workDir, absOut); err != nil {
+			return fmt.Errorf("transpiler3/go/build: copy module: %w", err)
+		}
+		return nil
+	}
+
 	if err := goBuild(d.GoBin, workDir, absOut, nil); err != nil {
 		return err
+	}
+	return nil
+}
+
+// copyModule copies the work directory's go.mod + *.go files
+// into outDir as a publish-ready Go module. No `go build` is
+// invoked; the caller can `cd outDir && go build .` themselves.
+//
+// The destination is created if missing. Existing files with
+// the same name are overwritten so re-runs are idempotent.
+func copyModule(workDir, outDir string) error {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir out: %w", err)
+	}
+	entries, err := os.ReadDir(workDir)
+	if err != nil {
+		return fmt.Errorf("read work dir: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		src := filepath.Join(workDir, name)
+		dst := filepath.Join(outDir, name)
+		b, err := os.ReadFile(src)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", src, err)
+		}
+		if err := os.WriteFile(dst, b, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", dst, err)
+		}
 	}
 	return nil
 }

--- a/transpiler3/go/build/phase15_test.go
+++ b/transpiler3/go/build/phase15_test.go
@@ -1,0 +1,127 @@
+package build
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestPhase15GoModule gates the MEP-54 Phase 15 target
+// `go-module`. When target == TargetGoModule, Driver.Build
+// must skip `go build` and emit a publish-ready Go module to
+// the out directory: at minimum go.mod + main.go.
+//
+// The test then runs `go build .` against the copied module
+// to prove the emitted artifact is buildable on its own; the
+// produced binary must execute and match expect.txt.
+func TestPhase15GoModule(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Phase 1 ships POSIX `go` invocation only; Windows lands in Phase 16")
+	}
+	root := repoRoot(t)
+	src := filepath.Join(root, "tests", "transpiler3", "go", "fixtures", "hello", "hello.mochi")
+	want, err := os.ReadFile(filepath.Join(root, "tests", "transpiler3", "go", "fixtures", "hello", "expect.txt"))
+	if err != nil {
+		t.Fatalf("read expect.txt: %v", err)
+	}
+
+	outDir := filepath.Join(t.TempDir(), "module-out")
+	d := &Driver{CacheDir: t.TempDir()}
+	if err := d.Build(src, outDir, string(TargetGoModule), ""); err != nil {
+		t.Fatalf("Driver.Build (go-module): %v", err)
+	}
+
+	for _, name := range []string{"main.go", "go.mod"} {
+		if _, err := os.Stat(filepath.Join(outDir, name)); err != nil {
+			t.Fatalf("module out missing %s: %v", name, err)
+		}
+	}
+
+	// Build the copied module from outDir and exec the binary.
+	binPath := filepath.Join(t.TempDir(), "hello-from-module")
+	cmd := exec.Command("go", "build", "-trimpath", "-buildvcs=false", "-o", binPath, ".")
+	cmd.Dir = outDir
+	var bstderr bytes.Buffer
+	cmd.Stderr = &bstderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("go build copied module: %v\n%s", err, bstderr.String())
+	}
+
+	run := exec.Command(binPath)
+	var stdout bytes.Buffer
+	run.Stdout = &stdout
+	run.Stderr = os.Stderr
+	if err := run.Run(); err != nil {
+		t.Fatalf("run copied-module binary: %v", err)
+	}
+	if got := stdout.String(); got != string(want) {
+		t.Fatalf("stdout mismatch:\n--- want ---\n%q\n--- got ---\n%q", string(want), got)
+	}
+}
+
+// TestPhase15GoModuleContent verifies the go.mod copied into
+// the module out directory matches the canonical template
+// (module mochi_userprog + go 1.26.0 + toolchain go1.26.3)
+// and that main.go declares package main with a main func.
+func TestPhase15GoModuleContent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Phase 1 ships POSIX `go` invocation only; Windows lands in Phase 16")
+	}
+	root := repoRoot(t)
+	src := filepath.Join(root, "tests", "transpiler3", "go", "fixtures", "hello", "hello.mochi")
+	outDir := filepath.Join(t.TempDir(), "module-out")
+	d := &Driver{CacheDir: t.TempDir()}
+	if err := d.Build(src, outDir, string(TargetGoModule), ""); err != nil {
+		t.Fatalf("Driver.Build: %v", err)
+	}
+
+	modBytes, err := os.ReadFile(filepath.Join(outDir, "go.mod"))
+	if err != nil {
+		t.Fatalf("read go.mod: %v", err)
+	}
+	for _, marker := range []string{"module mochi_userprog", "go 1.26.0", "toolchain go1.26.3"} {
+		if !strings.Contains(string(modBytes), marker) {
+			t.Fatalf("go.mod missing %q:\n%s", marker, string(modBytes))
+		}
+	}
+
+	mainBytes, err := os.ReadFile(filepath.Join(outDir, "main.go"))
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	for _, marker := range []string{"package main", "func main()"} {
+		if !strings.Contains(string(mainBytes), marker) {
+			t.Fatalf("main.go missing %q:\n%s", marker, string(mainBytes))
+		}
+	}
+}
+
+// TestPhase15GoModuleCustomModulePath verifies that
+// Driver.ModulePath is honored when emitting a go-module
+// artifact (publish flow needs to control the module name).
+func TestPhase15GoModuleCustomModulePath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Phase 1 ships POSIX `go` invocation only; Windows lands in Phase 16")
+	}
+	root := repoRoot(t)
+	src := filepath.Join(root, "tests", "transpiler3", "go", "fixtures", "hello", "hello.mochi")
+	outDir := filepath.Join(t.TempDir(), "module-out")
+	d := &Driver{
+		CacheDir:   t.TempDir(),
+		ModulePath: "example.com/userprog",
+	}
+	if err := d.Build(src, outDir, string(TargetGoModule), ""); err != nil {
+		t.Fatalf("Driver.Build: %v", err)
+	}
+	modBytes, err := os.ReadFile(filepath.Join(outDir, "go.mod"))
+	if err != nil {
+		t.Fatalf("read go.mod: %v", err)
+	}
+	if !strings.Contains(string(modBytes), "module example.com/userprog") {
+		t.Fatalf("custom ModulePath not honored:\n%s", string(modBytes))
+	}
+}


### PR DESCRIPTION
Closes #22695.

## Summary

- Wires the `go-module` target in `Driver.Build`: instead of invoking `go build`, the driver copies the work directory's `go.mod` + emitted `*.go` files into the output directory as a publish-ready Go module.
- Callers can `cd <out> && go build .` independently to inspect the staged module before pkg.go.dev publish (Phase 18).
- `Driver.ModulePath` is honored so the emitted module name is caller-controlled.

## Gates

- `TestPhase15GoModule`: end-to-end smoke (copy module + `go build .` from copy + exec + stdout match against `hello/expect.txt`).
- `TestPhase15GoModuleContent`: go.mod template fields (`module mochi_userprog`, `go 1.26.0`, `toolchain go1.26.3`) + main.go declares `package main` + `func main()`.
- `TestPhase15GoModuleCustomModulePath`: `Driver.ModulePath = "example.com/userprog"` lands in the copied `go.mod`.

## Test plan

- [x] `go test ./transpiler3/go/build/ -run TestPhase15` (3/3 pass)
- [x] `go test ./transpiler3/go/build/` full suite green (516s, exit 0)
- [ ] CI clears the full transpiler3/go matrix

## Out of scope

- Vendoring (no external Go deps yet)
- pkg.go.dev publish (Phase 18)