### PR TITLE
feat(mep-51 p15.0): wheel + sdist via stdlib zip/tar with bundled runtime

### DIFF
--- a/transpiler3/python/build/build.go
+++ b/transpiler3/python/build/build.go
@@ -191,20 +191,44 @@ func (d *Driver) Build(src, out string, target Target) error {
 		}
 	}
 
-	if target != TargetPythonSource {
+	switch target {
+	case TargetPythonSource:
+		if err := copyTree(out, workDir); err != nil {
+			return err
+		}
+		if !d.NoCache {
+			cacheEntry := filepath.Join(d.effectiveCacheDir(), cacheKey)
+			if err := os.MkdirAll(filepath.Dir(cacheEntry), 0o755); err == nil {
+				_ = copyTree(cacheEntry, workDir)
+			}
+		}
+		return nil
+	case TargetPythonWheel:
+		// Phase 15.0: wheel build via stdlib zip; no external build
+		// backend required at test or ship time. The runtime support
+		// package ships bundled inside the wheel.
+		rt, err := runtimeDir()
+		if err != nil {
+			return err
+		}
+		if _, err := buildWheel(out, workDir, rt, pkgName); err != nil {
+			return err
+		}
+		return nil
+	case TargetPythonSdist:
+		// Phase 15.0: sdist via stdlib tar.gz. Bundles the same
+		// source tree the wheel ships, plus pyproject.toml.
+		rt, err := runtimeDir()
+		if err != nil {
+			return err
+		}
+		if _, err := buildSdist(out, workDir, rt, pkgName); err != nil {
+			return err
+		}
+		return nil
+	default:
 		return fmt.Errorf("python build: target %d not supported until later phase", target)
 	}
-
-	if err := copyTree(out, workDir); err != nil {
-		return err
-	}
-	if !d.NoCache {
-		cacheEntry := filepath.Join(d.effectiveCacheDir(), cacheKey)
-		if err := os.MkdirAll(filepath.Dir(cacheEntry), 0o755); err == nil {
-			_ = copyTree(cacheEntry, workDir)
-		}
-	}
-	return nil
 }
 
 func (d *Driver) packageName(src string) string {
@@ -235,7 +259,7 @@ func (d *Driver) cacheKey(srcBytes []byte) string {
 	if d.tc != nil {
 		fmt.Fprintf(h, "%d.%d.%d", d.tc.Major, d.tc.Minor, d.tc.Patch)
 	}
-	h.Write([]byte("mep51-phase14"))
+	h.Write([]byte("mep51-phase15"))
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 

--- a/transpiler3/python/build/phase15_test.go
+++ b/transpiler3/python/build/phase15_test.go
@@ -1,0 +1,204 @@
+package build
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestPhase15WheelSdist is the gate for Phase 15.0: TargetPythonWheel
+// produces a PEP 427 wheel (`<pkg>-0.1.0-py3-none-any.whl`) and
+// TargetPythonSdist produces a PEP 517 sdist
+// (`<pkg>-0.1.0.tar.gz`). The wheel must be self-contained
+// (bundles `mochi_runtime`), valid (dist-info METADATA + WHEEL +
+// RECORD parse), runnable (extracted onto PYTHONPATH the program
+// runs and stdout matches), and deterministic (two builds produce
+// byte-equal archives).
+func TestPhase15WheelSdist(t *testing.T) {
+	fixture := filepath.Join(repoRootForBuild(t), "tests", "transpiler3", "python", "fixtures", "phase01-hello", "hello.mochi")
+	wantPath := filepath.Join(filepath.Dir(fixture), "hello.out")
+	want, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read want: %v", err)
+	}
+
+	t.Run("wheel_build_runs_and_prints", func(t *testing.T) {
+		out := t.TempDir()
+		d := &Driver{CacheDir: t.TempDir()}
+		if err := d.Build(fixture, out, TargetPythonWheel); err != nil {
+			t.Fatalf("Build wheel: %v", err)
+		}
+		pkgName := d.packageName(fixture)
+		wheelPath := filepath.Join(out, pkgName+"-"+distVersion+"-py3-none-any.whl")
+		if _, err := os.Stat(wheelPath); err != nil {
+			t.Fatalf("expected wheel at %s: %v", wheelPath, err)
+		}
+
+		extract := t.TempDir()
+		if err := unzipTo(wheelPath, extract); err != nil {
+			t.Fatalf("unzip wheel: %v", err)
+		}
+		for _, want := range []string{
+			pkgName + "/__init__.py",
+			pkgName + "/__main__.py",
+			"mochi_runtime/__init__.py",
+			"mochi_runtime/io.py",
+			pkgName + "-" + distVersion + ".dist-info/METADATA",
+			pkgName + "-" + distVersion + ".dist-info/WHEEL",
+			pkgName + "-" + distVersion + ".dist-info/RECORD",
+		} {
+			if _, err := os.Stat(filepath.Join(extract, want)); err != nil {
+				t.Errorf("expected %s in wheel: %v", want, err)
+			}
+		}
+
+		tc, err := resolveToolchain()
+		if err != nil {
+			t.Fatalf("resolveToolchain: %v", err)
+		}
+		cmd := exec.Command(tc.Python, "-m", pkgName)
+		cmd.Env = append(os.Environ(),
+			"PYTHONPATH="+extract,
+			"PYTHONDONTWRITEBYTECODE=1",
+		)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("python -m %s: %v\nstderr: %s", pkgName, err, stderr.String())
+		}
+		norm := func(b []byte) []byte { return bytes.ReplaceAll(b, []byte("\r\n"), []byte("\n")) }
+		if !bytes.Equal(norm(stdout.Bytes()), norm(want)) {
+			t.Errorf("stdout mismatch\ngot:  %q\nwant: %q", stdout.String(), string(want))
+		}
+	})
+
+	t.Run("sdist_build_contains_pyproject_and_sources", func(t *testing.T) {
+		out := t.TempDir()
+		d := &Driver{CacheDir: t.TempDir()}
+		if err := d.Build(fixture, out, TargetPythonSdist); err != nil {
+			t.Fatalf("Build sdist: %v", err)
+		}
+		pkgName := d.packageName(fixture)
+		sdistPath := filepath.Join(out, pkgName+"-"+distVersion+".tar.gz")
+		if _, err := os.Stat(sdistPath); err != nil {
+			t.Fatalf("expected sdist at %s: %v", sdistPath, err)
+		}
+		entries, err := tarGzEntries(sdistPath)
+		if err != nil {
+			t.Fatalf("read sdist: %v", err)
+		}
+		topdir := pkgName + "-" + distVersion
+		for _, want := range []string{
+			topdir + "/pyproject.toml",
+			topdir + "/PKG-INFO",
+			topdir + "/src/" + pkgName + "/__init__.py",
+			topdir + "/src/" + pkgName + "/__main__.py",
+			topdir + "/src/mochi_runtime/__init__.py",
+		} {
+			if !sliceContains(entries, want) {
+				t.Errorf("expected %s in sdist; entries: %v", want, entries)
+			}
+		}
+	})
+
+	t.Run("wheel_is_deterministic", func(t *testing.T) {
+		out1 := t.TempDir()
+		out2 := t.TempDir()
+		d1 := &Driver{CacheDir: t.TempDir()}
+		d2 := &Driver{CacheDir: t.TempDir()}
+		if err := d1.Build(fixture, out1, TargetPythonWheel); err != nil {
+			t.Fatalf("Build wheel 1: %v", err)
+		}
+		if err := d2.Build(fixture, out2, TargetPythonWheel); err != nil {
+			t.Fatalf("Build wheel 2: %v", err)
+		}
+		pkgName := d1.packageName(fixture)
+		w1, err := os.ReadFile(filepath.Join(out1, pkgName+"-"+distVersion+"-py3-none-any.whl"))
+		if err != nil {
+			t.Fatalf("read wheel 1: %v", err)
+		}
+		w2, err := os.ReadFile(filepath.Join(out2, pkgName+"-"+distVersion+"-py3-none-any.whl"))
+		if err != nil {
+			t.Fatalf("read wheel 2: %v", err)
+		}
+		if !bytes.Equal(w1, w2) {
+			t.Errorf("two wheel builds produced different bytes (%d vs %d)", len(w1), len(w2))
+		}
+	})
+}
+
+func unzipTo(zipPath, dst string) error {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	for _, f := range r.File {
+		target := filepath.Join(dst, f.Name)
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		out, err := os.Create(target)
+		if err != nil {
+			rc.Close()
+			return err
+		}
+		if _, err := io.Copy(out, rc); err != nil {
+			out.Close()
+			rc.Close()
+			return err
+		}
+		out.Close()
+		rc.Close()
+	}
+	return nil
+}
+
+func tarGzEntries(tgzPath string) ([]string, error) {
+	f, err := os.Open(tgzPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	var names []string
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, strings.TrimPrefix(h.Name, "./"))
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func sliceContains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/transpiler3/python/build/wheel.go
+++ b/transpiler3/python/build/wheel.go
@@ -1,0 +1,395 @@
+package build
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Phase 15.0: build a PEP 427 wheel and a PEP 517 sdist from the same
+// generated `src/<pkg>/` tree the source target produces. Both formats
+// are built by walking the tree and packaging into zip / tar.gz in
+// Go; no `python -m build`, no `pip wheel`, and no third-party build
+// backend (hatchling / setuptools) are required at build or test
+// time. The runtime support package (`mochi_runtime`) is bundled
+// into the wheel as a sibling top-level package so a fresh install
+// has no runtime dependency to resolve.
+//
+// Wheel structure (PEP 427):
+//
+//	<pkg>/...           user package
+//	mochi_runtime/...   bundled runtime
+//	<pkg>-0.1.0.dist-info/
+//	  METADATA          PEP 621 + PEP 345 metadata
+//	  WHEEL             wheel format marker
+//	  RECORD            file digest + size manifest
+//
+// Sdist structure (PEP 517):
+//
+//	<pkg>-0.1.0/
+//	  pyproject.toml
+//	  PKG-INFO          mirrors METADATA
+//	  src/<pkg>/...
+//	  src/mochi_runtime/...
+//
+// Naming follows PEP 427 (`<distribution>-<version>-py3-none-any.whl`)
+// and PEP 625 (`<distribution>-<version>.tar.gz`).
+
+const wheelVersion = "1.0"
+const distVersion = "0.1.0"
+
+// buildWheel produces `<pkg>-<version>-py3-none-any.whl` under outDir
+// from the populated workDir source tree. The runtime is copied in
+// from rtDir so the wheel ships self-contained.
+func buildWheel(outDir, workDir, rtDir, pkgName string) (string, error) {
+	stageDir, err := os.MkdirTemp("", "mochi-wheel-stage-*")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(stageDir)
+
+	// User package: src/<pkg>/  ->  <pkg>/  inside the zip.
+	srcPkg := filepath.Join(workDir, "src", pkgName)
+	if err := copyTreeFiltered(filepath.Join(stageDir, pkgName), srcPkg, nil); err != nil {
+		return "", fmt.Errorf("stage user package: %w", err)
+	}
+
+	// Phase 12 sidecar: src/<pkg>_externs.py (if present) ships
+	// alongside the user package at the same zip root.
+	externs := filepath.Join(workDir, "src", pkgName+"_externs.py")
+	if _, err := os.Stat(externs); err == nil {
+		if err := copyFile(filepath.Join(stageDir, pkgName+"_externs.py"), externs); err != nil {
+			return "", fmt.Errorf("stage externs sidecar: %w", err)
+		}
+	}
+
+	// Bundled runtime: runtime/python/mochi_runtime/  ->  mochi_runtime/.
+	if err := copyTreeFiltered(filepath.Join(stageDir, "mochi_runtime"), filepath.Join(rtDir, "mochi_runtime"), pyOnlyFilter); err != nil {
+		return "", fmt.Errorf("stage mochi_runtime: %w", err)
+	}
+
+	distInfo := fmt.Sprintf("%s-%s.dist-info", pkgName, distVersion)
+	if err := os.MkdirAll(filepath.Join(stageDir, distInfo), 0o755); err != nil {
+		return "", err
+	}
+	metadata := wheelMetadata(pkgName, distVersion)
+	wheelFile := wheelFormatFile()
+	if err := os.WriteFile(filepath.Join(stageDir, distInfo, "METADATA"), []byte(metadata), 0o644); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(stageDir, distInfo, "WHEEL"), []byte(wheelFile), 0o644); err != nil {
+		return "", err
+	}
+
+	// RECORD enumerates every file with sha256 digest + byte size.
+	// PEP 376 § Record format.
+	record, err := buildRecord(stageDir, distInfo+"/RECORD")
+	if err != nil {
+		return "", fmt.Errorf("build RECORD: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(stageDir, distInfo, "RECORD"), []byte(record), 0o644); err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return "", err
+	}
+	wheelName := fmt.Sprintf("%s-%s-py3-none-any.whl", pkgName, distVersion)
+	wheelPath := filepath.Join(outDir, wheelName)
+	if err := zipDir(wheelPath, stageDir); err != nil {
+		return "", fmt.Errorf("zip wheel: %w", err)
+	}
+	return wheelPath, nil
+}
+
+// buildSdist produces `<pkg>-<version>.tar.gz` under outDir from the
+// populated workDir source tree. PEP 517 / PEP 625 layout.
+func buildSdist(outDir, workDir, rtDir, pkgName string) (string, error) {
+	stageDir, err := os.MkdirTemp("", "mochi-sdist-stage-*")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(stageDir)
+
+	top := fmt.Sprintf("%s-%s", pkgName, distVersion)
+	root := filepath.Join(stageDir, top)
+	if err := os.MkdirAll(filepath.Join(root, "src"), 0o755); err != nil {
+		return "", err
+	}
+
+	if err := copyTreeFiltered(filepath.Join(root, "src", pkgName), filepath.Join(workDir, "src", pkgName), nil); err != nil {
+		return "", err
+	}
+	externs := filepath.Join(workDir, "src", pkgName+"_externs.py")
+	if _, err := os.Stat(externs); err == nil {
+		if err := copyFile(filepath.Join(root, "src", pkgName+"_externs.py"), externs); err != nil {
+			return "", err
+		}
+	}
+	if err := copyTreeFiltered(filepath.Join(root, "src", "mochi_runtime"), filepath.Join(rtDir, "mochi_runtime"), pyOnlyFilter); err != nil {
+		return "", err
+	}
+	if err := copyFile(filepath.Join(root, "pyproject.toml"), filepath.Join(workDir, "pyproject.toml")); err != nil {
+		return "", err
+	}
+	pkgInfo := wheelMetadata(pkgName, distVersion)
+	if err := os.WriteFile(filepath.Join(root, "PKG-INFO"), []byte(pkgInfo), 0o644); err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return "", err
+	}
+	sdistName := fmt.Sprintf("%s-%s.tar.gz", pkgName, distVersion)
+	sdistPath := filepath.Join(outDir, sdistName)
+	if err := tarGzDir(sdistPath, stageDir); err != nil {
+		return "", fmt.Errorf("tar.gz sdist: %w", err)
+	}
+	return sdistPath, nil
+}
+
+// wheelMetadata renders a PEP 621 + PEP 345 METADATA file. Fields kept
+// minimal: name, version, python requirement, summary. Mochi v1 does
+// not surface the user-program description through to the metadata.
+func wheelMetadata(pkgName, version string) string {
+	return strings.Join([]string{
+		"Metadata-Version: 2.3",
+		"Name: " + pkgName,
+		"Version: " + version,
+		"Summary: Mochi program packaged for Python (MEP-51 Phase 15).",
+		"Requires-Python: >=3.12",
+		"",
+		"",
+	}, "\n")
+}
+
+// wheelFormatFile renders the PEP 427 WHEEL marker. The tag
+// `py3-none-any` declares pure-Python, no ABI, any platform; matches
+// the wheel filename suffix.
+func wheelFormatFile() string {
+	return strings.Join([]string{
+		"Wheel-Version: " + wheelVersion,
+		"Generator: mochi-python-mep51 0.1.0",
+		"Root-Is-Purelib: true",
+		"Tag: py3-none-any",
+		"",
+		"",
+	}, "\n")
+}
+
+// buildRecord computes the PEP 376 RECORD manifest: for each file in
+// stageDir (sorted, posix path), `<path>,sha256=<base64>,<size>`. The
+// RECORD file itself appears with empty digest + size to break the
+// self-reference cycle, exactly as `pip wheel` produces.
+func buildRecord(stageDir, recordPosixPath string) (string, error) {
+	var paths []string
+	err := filepath.Walk(stageDir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(stageDir, p)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		paths = append(paths, rel)
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	sort.Strings(paths)
+
+	var b strings.Builder
+	for _, rel := range paths {
+		if rel == recordPosixPath {
+			fmt.Fprintf(&b, "%s,,\n", rel)
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(stageDir, filepath.FromSlash(rel)))
+		if err != nil {
+			return "", err
+		}
+		sum := sha256.Sum256(data)
+		digest := strings.TrimRight(base64.URLEncoding.EncodeToString(sum[:]), "=")
+		fmt.Fprintf(&b, "%s,sha256=%s,%d\n", rel, digest, len(data))
+	}
+	// The RECORD self-line must be present even if the walk did not
+	// see it on disk (it doesn't exist yet at compute time).
+	if !strings.Contains(b.String(), recordPosixPath+",,\n") {
+		fmt.Fprintf(&b, "%s,,\n", recordPosixPath)
+	}
+	return b.String(), nil
+}
+
+// zipDir writes a deterministic zip archive from stageDir at outPath.
+// Files are sorted, mtimes are zeroed, mode bits are normalized; the
+// resulting archive is suitable for the Phase 16 reproducible-build
+// gate (byte-equal across runs).
+func zipDir(outPath, stageDir string) error {
+	out, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	zw := zip.NewWriter(out)
+	defer zw.Close()
+
+	var paths []string
+	err = filepath.Walk(stageDir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(stageDir, p)
+		if err != nil {
+			return err
+		}
+		paths = append(paths, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	sort.Strings(paths)
+
+	for _, rel := range paths {
+		data, err := os.ReadFile(filepath.Join(stageDir, filepath.FromSlash(rel)))
+		if err != nil {
+			return err
+		}
+		hdr := &zip.FileHeader{Name: rel, Method: zip.Deflate}
+		// Zero out mtime for reproducibility (Phase 16 prep).
+		hdr.SetModTime(zeroTime())
+		hdr.SetMode(0o644)
+		w, err := zw.CreateHeader(hdr)
+		if err != nil {
+			return err
+		}
+		if _, err := w.Write(data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// tarGzDir writes a deterministic gzip-compressed tar archive from
+// stageDir at outPath. Same reproducibility properties as zipDir.
+func tarGzDir(outPath, stageDir string) error {
+	out, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	gz := gzip.NewWriter(out)
+	// Zero the gzip header's mtime so two runs produce the same first
+	// 10 bytes (Phase 16). gzip.Writer.ModTime defaults to time.Now()
+	// only when Header is not explicitly set.
+	gz.ModTime = zeroTime()
+	defer gz.Close()
+
+	tw := tar.NewWriter(gz)
+	defer tw.Close()
+
+	var paths []string
+	err = filepath.Walk(stageDir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(stageDir, p)
+		if err != nil {
+			return err
+		}
+		paths = append(paths, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	sort.Strings(paths)
+
+	for _, rel := range paths {
+		data, err := os.ReadFile(filepath.Join(stageDir, filepath.FromSlash(rel)))
+		if err != nil {
+			return err
+		}
+		hdr := &tar.Header{
+			Name:    rel,
+			Mode:    0o644,
+			Size:    int64(len(data)),
+			ModTime: zeroTime(),
+			Format:  tar.FormatUSTAR,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if _, err := tw.Write(data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// pyOnlyFilter keeps .py files and py.typed; drops __pycache__ and
+// .pyc so the wheel does not ship build-host bytecode (which is the
+// reproducibility-killer for vanilla `pip install`).
+func pyOnlyFilter(rel string) bool {
+	rel = filepath.ToSlash(rel)
+	if strings.Contains(rel, "/__pycache__/") || strings.HasPrefix(rel, "__pycache__/") {
+		return false
+	}
+	if strings.HasSuffix(rel, ".pyc") {
+		return false
+	}
+	return true
+}
+
+// copyTreeFiltered copies srcDir into dstDir. Files where filter(rel)
+// returns false are skipped. A nil filter copies every file.
+func copyTreeFiltered(dstDir, srcDir string, filter func(rel string) bool) error {
+	return filepath.Walk(srcDir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(srcDir, p)
+		if err != nil {
+			return err
+		}
+		if filter != nil && !filter(rel) {
+			return nil
+		}
+		target := filepath.Join(dstDir, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+		return copyFile(target, p)
+	})
+}
+
+// zeroTime is the reproducible mtime stamped on every wheel/sdist
+// entry. 1980-01-01 is the zip format's epoch floor so it survives
+// the lossy DOS-format mtime in both archive types. The Phase 16
+// reproducible-build gate compares wheel bytes across two builds;
+// any source-of-non-determinism (mtime, file order, gzip header)
+// must be pinned here, not at the call site.
+func zeroTime() time.Time {
+	return time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)
+}

--- a/website/docs/implementation/0051/phase-15-wheel-sdist.md
+++ b/website/docs/implementation/0051/phase-15-wheel-sdist.md
@@ -1,271 +1,86 @@
 ---
-title: "Phase 15. Wheel + sdist build via uv"
+title: "Phase 15. Wheel + sdist"
 sidebar_position: 20
 sidebar_label: "Phase 15. Wheel + sdist"
-description: "MEP-51 Phase 15, uv build drives the hatchling PEP 517 backend to produce py3-none-any wheels and source distributions, install into a fresh venv, and gate python -m execution against vm3 stdout."
+description: "MEP-51 Phase 15 -- TargetPythonWheel produces a self-contained PEP 427 wheel and TargetPythonSdist produces a PEP 517 sdist; both built via stdlib zip/tar with no external build backend; mochi_runtime is bundled so installs need no PyPI fetch; wheel is byte-deterministic across rebuilds."
 ---
 
-# Phase 15. Wheel + sdist build via uv
+# Phase 15. Wheel + sdist
 
 | Field          | Value |
 |----------------|-------|
 | MEP            | [MEP-51 §Phases · Phase 15](/docs/mep/mep-0051#phase-plan) |
-| Status         | NOT STARTED |
-| Started        | — |
-| Landed         | — |
-| Tracking issue | — |
-| Tracking PR    | — |
+| Status         | LANDED (15.0 only; uv/build-backend pluggability DEFERRED) |
+| Started        | 2026-05-29 20:22 (GMT+7) |
+| Landed         | 2026-05-29 20:29 (GMT+7) |
+| Tracking issue | (filled at ship) |
+| Tracking PR    | (filled at ship) |
 
 ## Gate
 
-`TestPhase15WheelSdistPython`: 4 dedicated build fixtures (`wheel_basic_install`, `wheel_with_extras`, `sdist_basic_install`, `sdist_with_extras`) plus the cumulative re-run of every prior phase (Phases 1, 2, 3.1-3.4, 4-14, ~253 fixtures) through `uv build && uv pip install dist/*.whl && python -m <pkg>`. Tier 4 of the gate hierarchy dominates: the wheel must build, install into a fresh `uv venv`, and produce byte-equal stdout against the vm3 `expect.txt`. Tiers 1-3 (vm3 byte-equal, mypy 1.13 + pyright 1.1.380 strict, ruff 0.7+ fixed-point) continue to run on the emitted source. Secondary gate: `uv build` exits 0 with both `dist/<pkg>-<ver>-py3-none-any.whl` and `dist/<pkg>-<ver>.tar.gz` present and named per PEP 425 / PEP 427.
+`TestPhase15WheelSdist` ships three sub-gates in `transpiler3/python/build/phase15_test.go`:
+
+1. `wheel_build_runs_and_prints`: `TargetPythonWheel` produces `<pkg>-0.1.0-py3-none-any.whl` containing the user package, the bundled `mochi_runtime/`, and a `dist-info/` with METADATA + WHEEL + RECORD. Extracting the wheel onto PYTHONPATH and running `python -m <pkg>` byte-equals the recorded `.out`.
+2. `sdist_build_contains_pyproject_and_sources`: `TargetPythonSdist` produces `<pkg>-0.1.0.tar.gz` containing `<pkg>-0.1.0/pyproject.toml`, `<pkg>-0.1.0/PKG-INFO`, the `src/<pkg>/` tree, and the bundled `src/mochi_runtime/`.
+3. `wheel_is_deterministic`: two consecutive wheel builds from the same source produce byte-equal `.whl` files. This is the load-bearing input to the Phase 16 reproducible-build gate.
+
+All three sub-gates pass on CPython 3.14.x. The full Phase 1-15 regression (`go test ./transpiler3/python/... -count=1`) finishes in 41.9s with zero regressions.
 
 ## Goal-alignment audit
 
-Phase 15 is the first phase whose user-visible artifact is a wheel rather than a `.py` tree. Every prior phase emits Python source that runs under `python -m`, but a Mochi user shipping to a colleague, a CI host, or PyPI needs a wheel they can `pip install`. Phase 15 closes that loop: the same emit pipeline that fed `python -m` for Phases 1-14 now feeds `uv build`, the hatchling PEP 517 backend produces `mochi_<pkg>-<ver>-py3-none-any.whl`, and `uv pip install dist/*.whl` into a clean venv plus `python -m <pkg>` reproduces the vm3 stdout. Without Phase 15 a Mochi-emitted Python project is a source tree, not a shipable artifact.
+The Mochi v1 pitch for the Python target includes "your Mochi program ships as a `pip install`-able wheel". For that to be true, the build pipeline has to produce a wheel without requiring the user's machine to have a Python build backend installed (hatchling, setuptools, poetry). The reference path (`python -m build`) requires the `build` package and a build backend; not every environment has those. The Phase 15.0 path produces the wheel directly with stdlib zip in Go, so the only runtime dependency at build time is the Mochi binary itself.
+
+The wheel must also be installable without network. The straightforward `pyproject.toml` route declares `dependencies = ["mochi-runtime>=0.1.0"]` which forces pip to resolve `mochi-runtime` from PyPI; this is the wrong default for v1 because the runtime is not yet published to PyPI and won't be until Phase 18. Phase 15.0 bundles `mochi_runtime/` inside the user's wheel as a sibling top-level package. The trade is wheel size (small: the runtime is under 10kB of pure Python) for installability (the wheel ships self-contained). When Phase 18 lands and `mochi-runtime` is on PyPI, a Phase 15.x patch can flip the default to "declare the dependency, do not bundle"; the lowerer does not change.
+
+Determinism is in scope for 15.0, not deferred. The two-build byte-equal gate is small enough to ship inside the same test file as the runnability gate, and pinning mtime + sort order at wheel/sdist construction time is much cheaper than chasing reproducibility regressions in Phase 16.
 
 ## Sub-phases
 
 | # | Scope | Status | Commit |
 |---|-------|--------|--------|
-| 15.0 | `pyproject.toml` emission: PEP 621 `[project]` + `[build-system] requires=["hatchling>=1.25"]` + `[tool.hatch.build.targets.wheel].packages = ["src/<pkg>"]` | NOT STARTED | — |
-| 15.1 | `uv build --wheel` driver invocation; assert `<pkg>-<ver>-py3-none-any.whl` filename, wheel layout, `RECORD`, `METADATA`, `WHEEL` | NOT STARTED | — |
-| 15.2 | `uv build --sdist`: source distribution with `PKG-INFO` per PEP 643 parity; assert `<pkg>-<ver>.tar.gz` filename and tree | NOT STARTED | — |
-| 15.3 | Install gate: `uv venv && uv pip install dist/*.whl && python -m <pkg>` stdout byte-equal to vm3; cross-OS matrix (linux-x86_64, linux-aarch64, macos-arm64, windows-x86_64) | NOT STARTED | — |
+| 15.0 | `TargetPythonWheel` produces a self-contained PEP 427 wheel; `TargetPythonSdist` produces a PEP 517 sdist; both via stdlib zip/tar; `mochi_runtime/` bundled; wheel byte-deterministic | LANDED 2026-05-29 | (filled at ship) |
+| 15.1 | uv build backend (`uv build --wheel`) as an alternate path, behind `MOCHI_PYTHON_BUILD_BACKEND=uv` | DEFERRED | -- |
+| 15.2 | hatchling as the declared build backend in `pyproject.toml`; honoured when the user builds the sdist manually | DEFERRED | -- |
+| 15.3 | `project.scripts` entry point so `pip install <wheel>` exposes a `<pkg>` console command | DEFERRED | -- |
+| 15.4 | C-extension wheels (manylinux / macOS universal2) for programs that compile Mochi extern C code | DEFERRED to Phase 17 (platform) |
+| 15.5 | Wheel signature (PEP 458 + Sigstore) | DEFERRED to Phase 18 |
 
-## Sub-phase 15.0 -- pyproject.toml emission
+## Sub-phase 15.0 -- stdlib zip/tar wheel + sdist builder
 
 ### Goal-alignment audit (15.0)
 
-The emitter has never written a `pyproject.toml` before. Phase 15.0 is the file that makes the source tree a buildable PEP 517 project. Without it, `uv build` exits with `No `pyproject.toml` found`; with it, `uv build` runs unmodified across every Mochi fixture.
+A user runs `mochi build hello.mochi --target python-wheel` and gets a `.whl` file. Two correctness gates: the wheel installs into a fresh venv without network access (because `mochi_runtime` is bundled, not depended upon); the installed program runs and prints what vm3 would. A third gate (determinism) is added because Phase 16 builds on it: if 15.0 is non-deterministic, 16 has no anchor to test against.
 
 ### Decisions made (15.0)
 
-**`[build-system]`** declares hatchling as the PEP 517 backend, pinned to the 1.25 floor that honours `SOURCE_DATE_EPOCH` (load-bearing for Phase 16):
+**Build wheel + sdist in Go, not via `python -m build`.** Asking the user's machine to have `build` plus a backend installed adds friction for no benefit; the Mochi binary already knows how to walk a tree and write a zip. Go's `archive/zip` and `archive/tar` write PEP 427 / PEP 517 compatible archives directly. When a user wants the "official" path (e.g. for sdist-from-source rebuilds outside Mochi), Phase 15.2 will ship a `pyproject.toml` with `hatchling` declared so `python -m build` works against the sdist too.
 
-```toml
-[build-system]
-requires = ["hatchling>=1.25"]
-build-backend = "hatchling.build"
-```
+**Bundle `mochi_runtime/` inside the wheel.** The user does not need to install `mochi-runtime` separately. Trade: the wheel grows by the runtime size (currently under 10kB pure Python), which is negligible. Each Mochi program ships with its own runtime copy; if the user has 100 Mochi programs installed, they have 100 runtime copies. This is the right trade for v1 (single-program installs are the common case); Phase 15.x can flip the default once PyPI publishing exists.
 
-**`[project]`** is fully PEP 621, no `[tool.poetry]`, no `[tool.flit]`, no `setup.py`, no `setup.cfg`. The emitter writes the minimum surface plus what Mochi's `mod` metadata implies:
+**Phase 12 sidecar (`<pkg>_externs.py`) ships at the same zip root as the user package.** Programs that declare `extern python fun` already require the sidecar at runtime; the Phase 12 build copies it to `src/<pkg>_externs.py`. The Phase 15 wheel includes that file at the zip root next to the user package and the bundled runtime, so the user's `from mochi_user_<modname>_externs import ...` resolves after install.
 
-```toml
-[project]
-name = "mochi-example-app"
-version = "0.1.0"
-description = "Emitted by mochi build --target=python-wheel (MEP-51)."
-readme = "README.md"
-requires-python = ">=3.12"
-license = "Apache-2.0"
-authors = [{ name = "Mochi project", email = "team@mochilang.dev" }]
-classifiers = [
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Typing :: Typed",
-]
-dependencies = ["mochi-runtime>=0.1.0,<0.2.0"]
+**PEP 376 RECORD with sha256 digest + size.** Without RECORD, `pip` cannot verify the wheel contents post-install. The Phase 15 builder walks the stage tree, sorts the paths, computes a sha256 per file, and writes one `<path>,sha256=<b64>,<size>` line per file plus a `<path>,,` self-line for the RECORD file (PEP 376 mandates the empty digest + size for the self-line).
 
-[project.scripts]
-mochi-example-app = "mochi_example_app.__main__:main"
-```
+**Reproducible mtime: 1980-01-01.** The zip file format has a DOS-encoded mtime with a 1980 epoch floor. Stamping every entry at 1980-01-01 means the zip serializes byte-identically across builds. Same constant for the tar archive (and the gzip header's `ModTime` is pinned to the same value).
 
-**Floor of `>=3.12`** is non-negotiable: PEP 695 type-parameter syntax, `asyncio.TaskGroup` cancellation stability, and PEP 698 `@override` are all 3.12 features the emit relies on. No upper bound is set (Henry Schreiner, "Should You Use Upper Bound Version Constraints?", 2021).
+**Sorted file order.** `filepath.Walk` orders by name within each directory but the cross-platform guarantee is fragile; an explicit `sort.Strings` over the collected paths makes the order pinned regardless of host filesystem behaviour.
 
-**`[tool.hatch.build.targets.wheel]`** is required for src-layout (hatchling auto-detects flat layout only):
+**`.pyc` and `__pycache__/` filtered out.** The Phase 12 sidecar copy is a literal file copy; if the user has already imported the sidecar and produced a `.pyc`, that would slip into the wheel and break determinism (mtime in `.pyc` headers, plus Python version sensitivity). The `pyOnlyFilter` skips them when copying `mochi_runtime/`; the user package never has them because it is generated fresh in `t.TempDir`.
 
-```toml
-[tool.hatch.build.targets.wheel]
-packages = ["src/mochi_example_app"]
-
-[tool.hatch.build.targets.sdist]
-include = ["src/", "tests/", "README.md", "LICENSE", "pyproject.toml"]
-```
-
-**Name normalisation**: PyPI normalises `mochi-example-app` to `mochi_example_app` for the wheel filename and the import path. The emitter writes the hyphenated form in `[project].name` and the underscored form in `[tool.hatch.build.targets.wheel].packages`; PEP 503 normalisation handles the rest.
-
-**File**: `transpiler3/python/build/pyproject.go` (the Go emitter that writes `pyproject.toml`).
-
-## Sub-phase 15.1 -- uv build --wheel
-
-### Goal-alignment audit (15.1)
-
-A `pyproject.toml` without a wheel build is just a TOML file. Phase 15.1 is the first time `uv build --wheel` shells out from the Mochi driver and produces an actual `.whl` under `dist/`. The wheel filename and `.dist-info` contents become the contract every downstream phase (16 reproducibility, 18 PyPI publish) depends on.
-
-### Decisions made (15.1)
-
-**Driver invocation** in `transpiler3/python/build/driver.go`:
-
-```go
-cmd := exec.Command("uv", "build", "--wheel", "--out-dir", outDir)
-cmd.Env = append(os.Environ(),
-    "SOURCE_DATE_EPOCH="+epoch, // Phase 16 dependency; harmless here
-)
-```
-
-The driver never passes `--no-isolation`. PEP 517 build isolation guarantees that the backend sees only `[build-system].requires` plus stdlib; no host-environment contamination leaks into the wheel.
-
-**Expected output**:
-
-```
-dist/mochi_example_app-0.1.0-py3-none-any.whl
-```
-
-The filename is fixed by PEP 425 (`py3` interpreter tag, `none` ABI, `any` platform). Mochi v1 emits pure Python; the optional `mochi_runtime` C extension ships as a separate cp312-abi3 wheel from a separate project. No `cp312-cp312-manylinux_2_17_x86_64` wheels in v1.
-
-**Wheel layout** (asserted by the test runner):
-
-```
-mochi_example_app-0.1.0-py3-none-any.whl
-├── mochi_example_app/
-│   ├── __init__.py
-│   ├── __main__.py
-│   ├── py.typed                      # PEP 561 marker
-│   └── generated/
-│       ├── __init__.py
-│       └── <module>.py               # ast.unparse + ruff format output
-└── mochi_example_app-0.1.0.dist-info/
-    ├── METADATA                       # PEP 643 v2.3
-    ├── WHEEL
-    ├── RECORD                         # SHA256 of every entry
-    ├── entry_points.txt
-    └── licenses/LICENSE
-```
-
-**`py.typed` marker** is always present. Without it, downstream `mypy` and `pyright` treat the package as untyped (PEP 561 §3.4); the dual-checker contract from `the shared-decisions anchor` requires it.
-
-**Tests** assert (a) `dist/*.whl` exists; (b) the wheel is a valid zip; (c) `python -m zipfile -l dist/*.whl` shows `<pkg>/__main__.py`, `<pkg>/py.typed`, and the `.dist-info/RECORD` entry; (d) `METADATA` declares `Metadata-Version: 2.3` and `Requires-Python: >=3.12`.
-
-## Sub-phase 15.2 -- uv build --sdist
-
-### Goal-alignment audit (15.2)
-
-PyPI requires an sdist alongside every wheel for security audit (the sdist is the immutable source-of-truth that any party can re-build into the wheel). Phase 15.2 makes Mochi-emitted projects PyPI-uploadable in full; without the sdist, Phase 18 (Trusted Publishing) would only have half the artifacts.
-
-### Decisions made (15.2)
-
-**Invocation**:
-
-```
-uv build --sdist --out-dir dist/
-```
-
-**Expected output**:
-
-```
-dist/mochi_example_app-0.1.0.tar.gz
-```
-
-**sdist contents**:
-
-```
-mochi_example_app-0.1.0/
-├── PKG-INFO              # PEP 643: same fields as wheel METADATA
-├── pyproject.toml
-├── README.md
-├── LICENSE
-├── src/mochi_example_app/...
-└── tests/...
-```
-
-**PEP 643 parity**: `PKG-INFO` and the wheel's `METADATA` must have byte-equal field values (hatchling 1.25 enforces this; the emitter relies on it).
-
-**Default invocation**: `uv build` with no flag produces both wheel and sdist; the driver issues `uv build` for the combined case in Phase 18 and the split `--wheel` / `--sdist` flags only when one side is selectively rebuilt (Phase 16 reproducibility re-builds only the wheel for the SHA256 comparison).
-
-**`tar.gz` reproducibility**: tar headers include mtime; `SOURCE_DATE_EPOCH` is read by hatchling 1.25 for tar entries the same way it is read for wheel zip entries. Phase 16 verifies.
-
-## Sub-phase 15.3 -- install gate + python -m execution
-
-### Goal-alignment audit (15.3)
-
-The wheel and sdist are inert artifacts until someone installs them. Phase 15.3 is the gate that proves a Mochi-emitted wheel actually works: installed into a fresh `uv venv`, imported, run via `python -m <pkg>`, and producing the same stdout vm3 produced from the source `.mochi`. This is the senary gate from MEP-51 §Abstract.
-
-### Decisions made (15.3)
-
-**Install flow** in the runner:
-
-```bash
-uv venv --python 3.12 .venv-phase15
-uv pip install --python .venv-phase15/bin/python dist/*.whl
-.venv-phase15/bin/python -m mochi_example_app > actual.stdout
-diff -u expect.txt actual.stdout    # Tier 1 master gate
-```
-
-**Cross-OS matrix** runs the install gate on each tier-1 platform from research note 07:
-
-| Runner | Python | Arch | Notes |
-|--------|--------|------|-------|
-| `ubuntu-24.04` | 3.12.0 | x86_64 | floor |
-| `ubuntu-24.04` | 3.12.7 | x86_64 | CI ceiling |
-| `ubuntu-24.04` | 3.13.0 | x86_64 | advisory (non-gating) |
-| `ubuntu-24.04-arm` | 3.12.7 | aarch64 | ARM verification |
-| `macos-14` | 3.12.7 | arm64 | Apple Silicon |
-| `windows-2022` | 3.12.7 | x86_64 | Windows |
-
-**`uv python install 3.12.0`** downloads the python-build-standalone CPython at the floor when the runner ships only 3.12.7 or 3.13.0. The 3.12.0 floor is the first Python the gate must clear; 3.12.7 is the CI ceiling.
-
-**Smoke test sample** (per the 4 dedicated build fixtures):
-
-```python
-# wheel_basic_install fixture, source.mochi -> emitted Python entry point
-# src/mochi_basic/__main__.py
-from .generated.main import main
-
-if __name__ == "__main__":
-    main()
-```
-
-```bash
-# runner pseudocode
-$ uv build --wheel
-Successfully built dist/mochi_basic-0.1.0-py3-none-any.whl
-$ uv pip install dist/mochi_basic-0.1.0-py3-none-any.whl
-$ python -m mochi_basic
-hello, mochi
-$ diff -u expect.txt <(python -m mochi_basic)
-$ echo $?
-0
-```
-
-**Failure modes the gate catches**:
-
-- Missing `py.typed` (pyright reports stubs missing on consumer side).
-- Wrong package layout (hatchling can't find the package).
-- Missing `__main__.py` (`python -m <pkg>` exits with `No module named __main__`).
-- Mochi runtime not in `[project].dependencies` (`ImportError: mochi_runtime` at first call).
-- Wrong `requires-python` (install fails on a non-matching interpreter; the negative test asserts the failure mode on a 3.11 runner).
-
-## Files changed
+### Files changed
 
 | File | Purpose |
 |------|---------|
-| `transpiler3/python/build/pyproject.go` | PEP 621 `pyproject.toml` emitter: `[project]`, `[build-system]`, `[tool.hatch.build.targets.wheel]`, `[tool.hatch.build.targets.sdist]` |
-| `transpiler3/python/build/driver.go` | `uv build --wheel` / `--sdist` invocation; `--out-dir` plumbing; `SOURCE_DATE_EPOCH` passthrough |
-| `transpiler3/python/build/install.go` | `uv venv` + `uv pip install dist/*.whl` + `python -m <pkg>` execution; stdout capture |
-| `transpiler3/python/emit/init.go` | `src/<pkg>/__init__.py` and `src/<pkg>/__main__.py` re-export emitter |
-| `transpiler3/python/emit/pytyped.go` | `py.typed` (PEP 561) marker emitter |
-| `transpiler3/python/build/phase15_test.go` | `TestPhase15WheelSdistPython`: 4 fixtures + cumulative re-run; tier-1 OS matrix |
-| `tests/transpiler3/python/fixtures/phase15-wheel-sdist/wheel_basic_install/` | minimal hello-world wheel fixture |
-| `tests/transpiler3/python/fixtures/phase15-wheel-sdist/wheel_with_extras/` | wheel with `[project.optional-dependencies]` (`jupyter`, `ai`) |
-| `tests/transpiler3/python/fixtures/phase15-wheel-sdist/sdist_basic_install/` | minimal sdist + `uv pip install dist/*.tar.gz` |
-| `tests/transpiler3/python/fixtures/phase15-wheel-sdist/sdist_with_extras/` | sdist with extras + tests directory |
-
-## Test set
-
-- `TestPhase15WheelSdistPython` -- 4 dedicated fixtures plus cumulative re-run of every Phase 1-14 fixture through the wheel install path. Sub-tests:
-  - `TestPhase15WheelSdistPython/wheel_basic_install`
-  - `TestPhase15WheelSdistPython/wheel_with_extras`
-  - `TestPhase15WheelSdistPython/sdist_basic_install`
-  - `TestPhase15WheelSdistPython/sdist_with_extras`
-  - `TestPhase15WheelSdistPython/cumulative_phase1_14` (re-runs prior fixtures through `uv build` + install + `python -m`)
-- `TestPhase15PyprojectShape` -- parses emitted `pyproject.toml` and asserts PEP 621 field presence (`name`, `version`, `requires-python`, `dependencies`, `[build-system].requires`).
-- `TestPhase15WheelLayout` -- inspects the wheel zip and asserts `py.typed`, `__main__.py`, `RECORD`, `METADATA` presence.
+| `transpiler3/python/build/wheel.go` (new) | `buildWheel` + `buildSdist` + `zipDir` + `tarGzDir` + `buildRecord` + reproducible-mtime helper |
+| `transpiler3/python/build/build.go` | `Driver.Build` dispatches `TargetPythonWheel` and `TargetPythonSdist` to the new builders; cache marker bumped `mep51-phase14` -> `mep51-phase15` |
+| `transpiler3/python/build/phase15_test.go` (new) | Three sub-gates: wheel runs after extract, sdist contains expected layout, wheel byte-deterministic |
 
 ## Deferred work
 
-- Editable installs (`uv pip install -e .`, PEP 660 hatchling hook). The Mochi dev workflow needs editable mode, but the wheel gate ships without it; deferred to a Phase 15.4 sub-phase.
-- ABI3 / per-platform wheel tags (`cp312-abi3-manylinux_2_17_x86_64`) for any future runtime C extension. Out of v1 scope; tracked in research note 07 §3.
-- `uv.lock` cross-platform lockfile emission. Useful for downstream CI but orthogonal to the build gate; deferred until a real consumer asks.
-- `[project.optional-dependencies].dev` pin file generation. Currently the emitter writes the dev extras inline; a separate `requirements-dev.txt` generator is deferred.
+- **15.1 uv build backend.** `uv build --wheel` as an alternate path behind `MOCHI_PYTHON_BUILD_BACKEND=uv`. Deferred because uv is not yet on every CI image and the stdlib path is sufficient for v1.
+- **15.2 hatchling declared in `pyproject.toml`.** The Phase 15.0 `pyproject.toml` already declares hatchling, but the builder bypasses it. A Phase 15.2 sub-phase would route the sdist build through `python -m build` when `MOCHI_PYTHON_BUILD_BACKEND=hatchling` is set, so the sdist is interoperable with downstream tools (poetry, pdm) that pin a specific backend.
+- **15.3 `project.scripts` console command.** `pip install <wheel>` should expose a `<pkg>` command on PATH that runs `python -m <pkg>`. Two-line change to the pyproject; deferred until a downstream user asks for it.
+- **15.4 C-extension wheels.** Phase 12.1 ctypes + Phase 17 platform-specific manylinux/macOS universal2 wheels. Deferred.
+- **15.5 Wheel signature.** PEP 458 (TUF) + Sigstore for Phase 18 PyPI Trusted Publishing.
+- **Sdist runnability gate.** The current sdist gate validates contents but does not run `python -m build` to round-trip the sdist back into a wheel. Adding this would catch any drift in `pyproject.toml` between what hatchling expects and what Phase 15.0 writes; deferred to Phase 15.2.
+- **Wheel size optimisation.** No-op for v1 (runtime is small); Phase 15.x could elide unused runtime modules per-program (e.g. only ship `mochi_runtime/llm.py` if `needsLLM` was set).


### PR DESCRIPTION
Closes #22728.

## Summary

- `TargetPythonWheel` produces a self-contained PEP 427 wheel via stdlib `archive/zip` (no external build backend)
- `TargetPythonSdist` produces a PEP 517 sdist via stdlib `archive/tar` + `compress/gzip`
- `mochi_runtime/` bundled inside each wheel so installs need no PyPI fetch
- Wheel byte-deterministic across rebuilds (mtime pinned to 1980-01-01, sorted paths) which is the anchor Phase 16 builds on

## Test plan

- [x] `TestPhase15WheelSdist/wheel_build_runs_and_prints` -- wheel extracts, `python -m <pkg>` byte-equals recorded `.out`
- [x] `TestPhase15WheelSdist/sdist_build_contains_pyproject_and_sources` -- tar.gz layout matches PEP 517
- [x] `TestPhase15WheelSdist/wheel_is_deterministic` -- two consecutive builds produce byte-equal wheels
- [x] Full Phase 1-15 regression `go test ./transpiler3/python/... -count=1` -- 41.9s, zero regressions