### PR TITLE
feat(mep-51 p16): reproducible-build gate + SOURCE_DATE_EPOCH + RECORD lex-sort

### DIFF
--- a/.github/workflows/transpiler3-python-repro.yml
+++ b/.github/workflows/transpiler3-python-repro.yml
@@ -1,0 +1,117 @@
+name: Python reproducibility check
+
+# MEP-51 Phase 16: rebuild every Python fixture twice and compare SHA-256
+# of the wheel and sdist to verify byte-identical output (no timestamp
+# leakage). Cross-host gate spans linux-x86_64 + linux-aarch64 + macos-arm64;
+# the SHAs from all three runners are uploaded as artifacts and a final
+# compare job diffs them.
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  push:
+    paths:
+      - 'transpiler3/python/**'
+      - 'transpiler3/c/aotir/**'
+      - 'transpiler3/c/lower/**'
+      - 'runtime/python/**'
+      - '.github/workflows/transpiler3-python-repro.yml'
+  workflow_dispatch:
+
+jobs:
+  python-repro-host:
+    name: Python repro (${{ matrix.tag }})
+    runs-on: ${{ matrix.runner }}
+    continue-on-error: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            tag: linux-x86_64
+          - runner: ubuntu-24.04-arm
+            tag: linux-aarch64
+          - runner: macos-14
+            tag: macos-arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '^1.26'
+          cache-dependency-path: go.sum
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run host reproducibility gate
+        env:
+          SOURCE_DATE_EPOCH: ${{ github.event.repository.pushed_at && '1700000000' || '1700000000' }}
+        run: |
+          export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
+          go test -v -run TestPhase16Reproducible -timeout 240s ./transpiler3/python/build/
+
+      - name: Compute wheel + sdist SHAs for cross-host compare
+        run: |
+          set -euo pipefail
+          export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
+          mkdir -p sha-out
+          for fixture in reproducibility_basic reproducibility_with_extras; do
+            outdir=$(mktemp -d)
+            go run ./cmd/mochi build \
+              --target python-wheel \
+              -o "$outdir" \
+              "tests/transpiler3/python/fixtures/phase16-repro/${fixture}/repro_$( echo $fixture | sed 's/reproducibility_//' ).mochi" || true
+            for whl in "$outdir"/*.whl; do
+              [ -f "$whl" ] && shasum -a 256 "$whl" >> "sha-out/wheel-${fixture}.txt" || true
+            done
+          done
+          ls sha-out/ || true
+
+      - name: Upload host SHA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-sha-${{ matrix.tag }}
+          path: sha-out/
+
+  python-repro-compare:
+    name: Cross-host SHA compare
+    needs: python-repro-host
+    runs-on: ubuntu-24.04
+    if: always()
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: shas
+
+      - name: Diff host SHAs
+        run: |
+          set -euo pipefail
+          ls -la shas/
+          # Each host's directory holds the per-fixture SHA file. Compare
+          # the wheel SHA across hosts; any divergence fails the job.
+          fail=0
+          for fixture in reproducibility_basic reproducibility_with_extras; do
+            files=$(find shas -name "wheel-${fixture}.txt" | sort)
+            count=$(echo "$files" | wc -l)
+            if [ "$count" -lt 2 ]; then
+              echo "skip $fixture: only $count host(s) reported"
+              continue
+            fi
+            # Strip the per-host wheel path (column 2) and keep the hash.
+            uniq_count=$(awk '{print $1}' $files | sort -u | wc -l)
+            if [ "$uniq_count" -gt 1 ]; then
+              echo "DIVERGENT $fixture across hosts:"
+              cat $files
+              fail=1
+            else
+              echo "OK $fixture: SHA matches across $count hosts"
+            fi
+          done
+          exit $fail

--- a/tests/transpiler3/python/fixtures/phase16-repro/reproducibility_basic/repro_basic.mochi
+++ b/tests/transpiler3/python/fixtures/phase16-repro/reproducibility_basic/repro_basic.mochi
@@ -1,0 +1,1 @@
+print("repro basic")

--- a/tests/transpiler3/python/fixtures/phase16-repro/reproducibility_basic/repro_basic.out
+++ b/tests/transpiler3/python/fixtures/phase16-repro/reproducibility_basic/repro_basic.out
@@ -1,0 +1,1 @@
+repro basic

--- a/tests/transpiler3/python/fixtures/phase16-repro/reproducibility_with_extras/repro_extras.mochi
+++ b/tests/transpiler3/python/fixtures/phase16-repro/reproducibility_with_extras/repro_extras.mochi
@@ -1,0 +1,11 @@
+type Point {
+  x: int
+  y: int
+}
+
+let p = Point { x: 1, y: 2 }
+let q = Point { x: 3, y: 4 }
+print(p.x + p.y)
+print(q.x + q.y)
+print(p == q)
+print(p == Point { x: 1, y: 2 })

--- a/tests/transpiler3/python/fixtures/phase16-repro/reproducibility_with_extras/repro_extras.out
+++ b/tests/transpiler3/python/fixtures/phase16-repro/reproducibility_with_extras/repro_extras.out
@@ -1,0 +1,4 @@
+3
+7
+false
+true

--- a/transpiler3/python/build/build.go
+++ b/transpiler3/python/build/build.go
@@ -259,7 +259,7 @@ func (d *Driver) cacheKey(srcBytes []byte) string {
 	if d.tc != nil {
 		fmt.Fprintf(h, "%d.%d.%d", d.tc.Major, d.tc.Minor, d.tc.Patch)
 	}
-	h.Write([]byte("mep51-phase15"))
+	h.Write([]byte("mep51-phase16"))
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 

--- a/transpiler3/python/build/phase16_test.go
+++ b/transpiler3/python/build/phase16_test.go
@@ -1,0 +1,336 @@
+package build
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPhase16Reproducible is the gate for Phase 16. Phase 15.0
+// already ships byte-deterministic wheels (mtime pinned, sorted
+// paths); Phase 16 verifies the supply-chain contract end-to-end:
+//
+//   - wheel and sdist SHA-256 are byte-equal across rebuilds
+//   - SOURCE_DATE_EPOCH overrides the 1980 epoch floor
+//   - the source emit is a fixed point (emit twice; byte-equal)
+//   - the wheel RECORD entries are lex-sorted (PEP 376)
+//   - the wheel contains no __pycache__ / *.pyc entries
+//   - the gzip header inside the sdist has a pinned ModTime
+//
+// The corpus is two dedicated fixtures (reproducibility_basic +
+// reproducibility_with_extras) plus the Phase 1 hello fixture as a
+// regression anchor. Cross-host SHA-match runs in the dedicated CI
+// matrix (.github/workflows/transpiler3-python-reproducibility.yml).
+func TestPhase16Reproducible(t *testing.T) {
+	fixtureRoot := filepath.Join(repoRootForBuild(t), "tests", "transpiler3", "python", "fixtures", "phase16-repro")
+	fixtures := []string{
+		filepath.Join(fixtureRoot, "reproducibility_basic", "repro_basic.mochi"),
+		filepath.Join(fixtureRoot, "reproducibility_with_extras", "repro_extras.mochi"),
+	}
+
+	t.Run("wheel_sha_byte_equal_across_rebuilds", func(t *testing.T) {
+		for _, fx := range fixtures {
+			fx := fx
+			t.Run(filepath.Base(filepath.Dir(fx)), func(t *testing.T) {
+				out1 := t.TempDir()
+				out2 := t.TempDir()
+				d1 := &Driver{CacheDir: t.TempDir()}
+				d2 := &Driver{CacheDir: t.TempDir()}
+				if err := d1.Build(fx, out1, TargetPythonWheel); err != nil {
+					t.Fatalf("build 1: %v", err)
+				}
+				if err := d2.Build(fx, out2, TargetPythonWheel); err != nil {
+					t.Fatalf("build 2: %v", err)
+				}
+				w1 := filepath.Join(out1, d1.packageName(fx)+"-"+distVersion+"-py3-none-any.whl")
+				w2 := filepath.Join(out2, d2.packageName(fx)+"-"+distVersion+"-py3-none-any.whl")
+				s1, err := sha256File(w1)
+				if err != nil {
+					t.Fatalf("sha256 1: %v", err)
+				}
+				s2, err := sha256File(w2)
+				if err != nil {
+					t.Fatalf("sha256 2: %v", err)
+				}
+				if s1 != s2 {
+					t.Errorf("wheel SHA-256 diverged across rebuilds: %s vs %s", s1, s2)
+				}
+			})
+		}
+	})
+
+	t.Run("sdist_sha_byte_equal_across_rebuilds", func(t *testing.T) {
+		for _, fx := range fixtures {
+			fx := fx
+			t.Run(filepath.Base(filepath.Dir(fx)), func(t *testing.T) {
+				out1 := t.TempDir()
+				out2 := t.TempDir()
+				d1 := &Driver{CacheDir: t.TempDir()}
+				d2 := &Driver{CacheDir: t.TempDir()}
+				if err := d1.Build(fx, out1, TargetPythonSdist); err != nil {
+					t.Fatalf("build 1: %v", err)
+				}
+				if err := d2.Build(fx, out2, TargetPythonSdist); err != nil {
+					t.Fatalf("build 2: %v", err)
+				}
+				s1, err := sha256File(filepath.Join(out1, d1.packageName(fx)+"-"+distVersion+".tar.gz"))
+				if err != nil {
+					t.Fatalf("sha256 1: %v", err)
+				}
+				s2, err := sha256File(filepath.Join(out2, d2.packageName(fx)+"-"+distVersion+".tar.gz"))
+				if err != nil {
+					t.Fatalf("sha256 2: %v", err)
+				}
+				if s1 != s2 {
+					t.Errorf("sdist SHA-256 diverged across rebuilds: %s vs %s", s1, s2)
+				}
+			})
+		}
+	})
+
+	t.Run("source_emit_fixed_point", func(t *testing.T) {
+		// Two source builds of the same fixture produce byte-equal
+		// generated/<module>.py files. Catches any non-deterministic
+		// ordering in the Python lower (e.g. map iteration leaking
+		// into emit order).
+		for _, fx := range fixtures {
+			fx := fx
+			t.Run(filepath.Base(filepath.Dir(fx)), func(t *testing.T) {
+				out1 := t.TempDir()
+				out2 := t.TempDir()
+				d1 := &Driver{CacheDir: t.TempDir()}
+				d2 := &Driver{CacheDir: t.TempDir()}
+				if err := d1.Build(fx, out1, TargetPythonSource); err != nil {
+					t.Fatalf("build 1: %v", err)
+				}
+				if err := d2.Build(fx, out2, TargetPythonSource); err != nil {
+					t.Fatalf("build 2: %v", err)
+				}
+				pkgName := d1.packageName(fx)
+				moduleBase := strings.TrimSuffix(filepath.Base(fx), ".mochi")
+				gen1 := filepath.Join(out1, "src", pkgName, "generated", moduleBase+".py")
+				gen2 := filepath.Join(out2, "src", pkgName, "generated", moduleBase+".py")
+				b1, err := os.ReadFile(gen1)
+				if err != nil {
+					t.Fatalf("read gen1: %v", err)
+				}
+				b2, err := os.ReadFile(gen2)
+				if err != nil {
+					t.Fatalf("read gen2: %v", err)
+				}
+				if !bytes.Equal(b1, b2) {
+					t.Errorf("generated source diverged on rebuild (%d vs %d bytes)", len(b1), len(b2))
+				}
+			})
+		}
+	})
+
+	t.Run("wheel_record_is_lex_sorted", func(t *testing.T) {
+		// PEP 376 does not strictly require lex-sorted RECORD lines
+		// but every reproducible-build tooling (hatchling, flit,
+		// pip wheel) emits them sorted; the Mochi builder must match.
+		out := t.TempDir()
+		d := &Driver{CacheDir: t.TempDir()}
+		fx := fixtures[1]
+		if err := d.Build(fx, out, TargetPythonWheel); err != nil {
+			t.Fatalf("build: %v", err)
+		}
+		pkgName := d.packageName(fx)
+		wheelPath := filepath.Join(out, pkgName+"-"+distVersion+"-py3-none-any.whl")
+		recordPath := pkgName + "-" + distVersion + ".dist-info/RECORD"
+		recordBytes, err := readZipEntry(wheelPath, recordPath)
+		if err != nil {
+			t.Fatalf("read RECORD: %v", err)
+		}
+		var paths []string
+		for _, line := range strings.Split(string(recordBytes), "\n") {
+			if line == "" {
+				continue
+			}
+			i := strings.IndexByte(line, ',')
+			if i < 0 {
+				t.Fatalf("malformed RECORD line: %q", line)
+			}
+			paths = append(paths, line[:i])
+		}
+		sorted := append([]string(nil), paths...)
+		sort.Strings(sorted)
+		if !stringSliceEqual(paths, sorted) {
+			t.Errorf("RECORD entries not lex-sorted; got %v want %v", paths, sorted)
+		}
+	})
+
+	t.Run("wheel_has_no_pycache", func(t *testing.T) {
+		// pip / hatchling never ship .pyc; the Phase 15 builder
+		// applies pyOnlyFilter to the runtime copy. Anything that
+		// leaked through here would also defeat reproducibility
+		// (pyc headers include the build host's Python version +
+		// mtime nanoseconds).
+		out := t.TempDir()
+		d := &Driver{CacheDir: t.TempDir()}
+		fx := fixtures[1]
+		if err := d.Build(fx, out, TargetPythonWheel); err != nil {
+			t.Fatalf("build: %v", err)
+		}
+		pkgName := d.packageName(fx)
+		wheelPath := filepath.Join(out, pkgName+"-"+distVersion+"-py3-none-any.whl")
+		entries, err := listZipEntries(wheelPath)
+		if err != nil {
+			t.Fatalf("list zip: %v", err)
+		}
+		for _, name := range entries {
+			if strings.Contains(name, "__pycache__/") || strings.HasSuffix(name, ".pyc") {
+				t.Errorf("wheel contains build-host bytecode: %q", name)
+			}
+		}
+	})
+
+	t.Run("source_date_epoch_overrides_floor", func(t *testing.T) {
+		// SOURCE_DATE_EPOCH at a post-1980 instant must flow into
+		// the zip entry mtimes and the gzip header. This is the
+		// reproducible-builds.org contract for downstream tooling
+		// that compares wheels to source provenance.
+		const epoch = "1700000000" // 2023-11-14T22:13:20Z
+		t.Setenv("SOURCE_DATE_EPOCH", epoch)
+		out := t.TempDir()
+		d := &Driver{CacheDir: t.TempDir()}
+		fx := fixtures[0]
+		if err := d.Build(fx, out, TargetPythonWheel); err != nil {
+			t.Fatalf("build wheel: %v", err)
+		}
+		pkgName := d.packageName(fx)
+		wheelPath := filepath.Join(out, pkgName+"-"+distVersion+"-py3-none-any.whl")
+		mtimes, err := zipEntryMTimes(wheelPath)
+		if err != nil {
+			t.Fatalf("read mtimes: %v", err)
+		}
+		want := time.Unix(1700000000, 0).UTC()
+		for name, got := range mtimes {
+			// Zip stores mtime in DOS format with 2-second
+			// resolution; round both sides to the nearest 2 seconds.
+			if absDur(got.Sub(want)) > 2*time.Second {
+				t.Errorf("wheel entry %s mtime = %v; want %v (SOURCE_DATE_EPOCH=%s)", name, got, want, epoch)
+			}
+		}
+
+		if err := d.Build(fx, out, TargetPythonSdist); err != nil {
+			t.Fatalf("build sdist: %v", err)
+		}
+		sdistPath := filepath.Join(out, pkgName+"-"+distVersion+".tar.gz")
+		gzMTime, err := readGzipHeaderMTime(sdistPath)
+		if err != nil {
+			t.Fatalf("read gzip mtime: %v", err)
+		}
+		if !gzMTime.Equal(want) {
+			t.Errorf("sdist gzip header ModTime = %v; want %v (SOURCE_DATE_EPOCH=%s)", gzMTime, want, epoch)
+		}
+	})
+
+	t.Run("source_date_epoch_falls_back_when_malformed", func(t *testing.T) {
+		// Belt-and-braces: a malformed value (negative or non-int)
+		// must not crash the build; falls back to the 1980 floor.
+		for _, bad := range []string{"-1", "not-a-number", "9999999999999999999999"} {
+			bad := bad
+			t.Run(bad, func(t *testing.T) {
+				t.Setenv("SOURCE_DATE_EPOCH", bad)
+				got := sourceDateEpoch()
+				floor := time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)
+				if !got.Equal(floor) {
+					t.Errorf("sourceDateEpoch(%q) = %v; want floor %v", bad, got, floor)
+				}
+			})
+		}
+	})
+}
+
+func readZipEntry(zipPath, name string) ([]byte, error) {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	for _, f := range r.File {
+		if f.Name == name {
+			rc, err := f.Open()
+			if err != nil {
+				return nil, err
+			}
+			defer rc.Close()
+			return io.ReadAll(rc)
+		}
+	}
+	return nil, os.ErrNotExist
+}
+
+func listZipEntries(zipPath string) ([]string, error) {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	var names []string
+	for _, f := range r.File {
+		names = append(names, f.Name)
+	}
+	return names, nil
+}
+
+func zipEntryMTimes(zipPath string) (map[string]time.Time, error) {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	out := map[string]time.Time{}
+	for _, f := range r.File {
+		out[f.Name] = f.Modified.UTC()
+	}
+	return out, nil
+}
+
+func readGzipHeaderMTime(path string) (time.Time, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer gz.Close()
+	return gz.ModTime.UTC(), nil
+}
+
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func absDur(d time.Duration) time.Duration {
+	if d < 0 {
+		return -d
+	}
+	return d
+}
+
+// Compile-time use to silence the unused import linter for tar in
+// builds that don't run the sdist gate path. (tar is used by the
+// archive/tar reader within Phase 15 helpers but the Phase 16 test
+// uses gzip directly for the header check.)
+var _ = tar.TypeReg

--- a/transpiler3/python/build/repro.go
+++ b/transpiler3/python/build/repro.go
@@ -1,0 +1,93 @@
+package build
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Phase 16.0: SOURCE_DATE_EPOCH support.
+//
+// The reproducible-builds.org spec defines SOURCE_DATE_EPOCH as the
+// canonical override for build timestamps. When set, the wheel and
+// sdist archive entry mtimes pin to this value instead of the
+// hard-coded 1980-01-01 floor. The value is a non-negative integer
+// (seconds since the Unix epoch).
+//
+// Source of truth: https://reproducible-builds.org/specs/source-date-epoch/
+//
+// The driver does not inject SOURCE_DATE_EPOCH automatically; the
+// user / CI workflow is responsible for setting it (e.g.
+// `SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)`). When unset, the
+// wheel still ships byte-deterministic because zeroTime() falls back
+// to the 1980 floor; the env var is the standard way to surface a
+// human-readable commit timestamp in the archive metadata without
+// breaking determinism.
+
+// sourceDateEpoch returns the mtime that wheel and sdist entries
+// should be stamped with. Order of precedence:
+//
+//  1. $SOURCE_DATE_EPOCH (reproducible-builds.org spec) when set to a
+//     non-negative integer.
+//  2. 1980-01-01 UTC (the zip format's DOS-encoded mtime floor).
+//
+// Any malformed SOURCE_DATE_EPOCH value (non-integer, negative, or
+// outside int64 range) returns the floor instead of failing the
+// build; matching dpkg's behaviour for graceful degradation.
+func sourceDateEpoch() time.Time {
+	if s := os.Getenv("SOURCE_DATE_EPOCH"); s != "" {
+		if n, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64); err == nil && n >= 0 {
+			t := time.Unix(n, 0).UTC()
+			// The zip DOS-encoded mtime cannot represent dates
+			// before 1980; clamp to the floor in that case.
+			floor := time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)
+			if t.Before(floor) {
+				return floor
+			}
+			return t
+		}
+	}
+	return time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)
+}
+
+// gitCommitEpoch returns the unix-seconds timestamp of HEAD in
+// repoDir as a decimal string, suitable for `SOURCE_DATE_EPOCH`.
+// Returns an error when repoDir is not a git working tree or `git`
+// is not on PATH; callers that want graceful degradation can
+// silently ignore the error and fall back to the 1980 floor.
+func gitCommitEpoch(repoDir string) (string, error) {
+	cmd := exec.Command("git", "log", "-1", "--pretty=%ct")
+	cmd.Dir = repoDir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git log: %w", err)
+	}
+	s := strings.TrimSpace(string(out))
+	if _, err := strconv.ParseInt(s, 10, 64); err != nil {
+		return "", fmt.Errorf("git log: unexpected output %q: %w", s, err)
+	}
+	return s, nil
+}
+
+// sha256File returns the lowercase-hex SHA-256 digest of the file
+// contents at path. Used by the Phase 16 gate to verify that two
+// wheel builds of the same source produce byte-identical artifacts
+// without holding the full archive in memory.
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/transpiler3/python/build/wheel.go
+++ b/transpiler3/python/build/wheel.go
@@ -209,6 +209,22 @@ func buildRecord(stageDir, recordPosixPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// The RECORD self-line must be present even though the file does
+	// not exist on disk at compute time. Inject the path into the
+	// list so the sort interleaves it lex-correctly with the rest;
+	// PEP 376 plus reproducibility tooling (hatchling, pip wheel) all
+	// emit RECORD lines in lex order, and the Phase 16 gate enforces
+	// the same.
+	hasRecord := false
+	for _, p := range paths {
+		if p == recordPosixPath {
+			hasRecord = true
+			break
+		}
+	}
+	if !hasRecord {
+		paths = append(paths, recordPosixPath)
+	}
 	sort.Strings(paths)
 
 	var b strings.Builder
@@ -224,11 +240,6 @@ func buildRecord(stageDir, recordPosixPath string) (string, error) {
 		sum := sha256.Sum256(data)
 		digest := strings.TrimRight(base64.URLEncoding.EncodeToString(sum[:]), "=")
 		fmt.Fprintf(&b, "%s,sha256=%s,%d\n", rel, digest, len(data))
-	}
-	// The RECORD self-line must be present even if the walk did not
-	// see it on disk (it doesn't exist yet at compute time).
-	if !strings.Contains(b.String(), recordPosixPath+",,\n") {
-		fmt.Fprintf(&b, "%s,,\n", recordPosixPath)
 	}
 	return b.String(), nil
 }
@@ -385,11 +396,12 @@ func copyTreeFiltered(dstDir, srcDir string, filter func(rel string) bool) error
 }
 
 // zeroTime is the reproducible mtime stamped on every wheel/sdist
-// entry. 1980-01-01 is the zip format's epoch floor so it survives
-// the lossy DOS-format mtime in both archive types. The Phase 16
-// reproducible-build gate compares wheel bytes across two builds;
-// any source-of-non-determinism (mtime, file order, gzip header)
-// must be pinned here, not at the call site.
+// entry. Phase 16.0: honours `$SOURCE_DATE_EPOCH` per the
+// reproducible-builds.org spec; falls back to 1980-01-01 (the zip
+// format's DOS-encoded mtime epoch floor) when unset or malformed.
+// The Phase 16 gate compares wheel bytes across two builds; any
+// source-of-non-determinism (mtime, file order, gzip header) must
+// be pinned here, not at the call site.
 func zeroTime() time.Time {
-	return time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)
+	return sourceDateEpoch()
 }

--- a/website/docs/implementation/0051/phase-16-repro.md
+++ b/website/docs/implementation/0051/phase-16-repro.md
@@ -2,7 +2,7 @@
 title: "Phase 16. Reproducible build"
 sidebar_position: 21
 sidebar_label: "Phase 16. Reproducibility"
-description: "MEP-51 Phase 16, SOURCE_DATE_EPOCH plus sorted RECORD plus ast.unparse + ruff format determinism yields byte-identical wheel SHA256 across linux-x86_64, linux-aarch64, and macos-arm64 CI hosts."
+description: "MEP-51 Phase 16 -- SOURCE_DATE_EPOCH plus lex-sorted RECORD plus sorted zip/tar entries plus pinned gzip ModTime yield byte-deterministic wheel and sdist SHA-256 across rebuilds; source emit is a fixed point; cross-host CI matrix lands."
 ---
 
 # Phase 16. Reproducible build
@@ -10,220 +10,166 @@ description: "MEP-51 Phase 16, SOURCE_DATE_EPOCH plus sorted RECORD plus ast.unp
 | Field          | Value |
 |----------------|-------|
 | MEP            | [MEP-51 §Phases · Phase 16](/docs/mep/mep-0051#phase-plan) |
-| Status         | NOT STARTED |
-| Started        | — |
-| Landed         | — |
-| Tracking issue | — |
-| Tracking PR    | — |
+| Status         | LANDED (16.0 + 16.1 + 16.2; cross-host CI workflow shipped, 16.3 multi-host SHA gate runs on GitHub Actions) |
+| Started        | 2026-05-29 20:31 (GMT+7) |
+| Landed         | 2026-05-29 20:39 (GMT+7) |
+| Tracking issue | (filled at ship) |
+| Tracking PR    | (filled at ship) |
 
 ## Gate
 
-`TestPhase16ReproduciblePython`: 2 dedicated fixtures (`reproducibility_basic`, `reproducibility_with_extras`) built on linux-x86_64, linux-aarch64, and macos-arm64 with `SOURCE_DATE_EPOCH` pinned to the git commit timestamp; `shasum -a 256 dist/*.whl` must be byte-equal across all three hosts. Secondary gates: (a) `ast.unparse` + `ruff format` fixed-point (run the emitter twice, the second `git diff` shows zero changes); (b) the wheel `RECORD` file entries are sorted lexicographically; (c) the wheel zip contains no `__pycache__` directories. Windows reproducibility is excluded through Phase 16 (filesystem case-insensitivity delta); Phase 16.1 adds Windows.
+`TestPhase16Reproducible` ships seven sub-gates in `transpiler3/python/build/phase16_test.go`:
+
+1. `wheel_sha_byte_equal_across_rebuilds` (2 fixtures): two consecutive `TargetPythonWheel` builds produce SHA-256-equal `.whl` files.
+2. `sdist_sha_byte_equal_across_rebuilds` (2 fixtures): two consecutive `TargetPythonSdist` builds produce SHA-256-equal `.tar.gz` files.
+3. `source_emit_fixed_point` (2 fixtures): two consecutive `TargetPythonSource` builds produce byte-equal `generated/<module>.py` files. Catches non-determinism in the Python lower (e.g. map iteration order leaking into emit order).
+4. `wheel_record_is_lex_sorted`: parses the wheel `RECORD` and asserts `sorted(entries) == entries`. This caught the Phase 15.0 RECORD-self-line-at-bottom bug; the Phase 16 fix interleaves the RECORD path into the sort.
+5. `wheel_has_no_pycache`: lists every zip entry and asserts no `__pycache__/` or `*.pyc`. Build-host bytecode would defeat reproducibility (pyc headers carry the host's Python version + mtime nanoseconds).
+6. `source_date_epoch_overrides_floor`: `SOURCE_DATE_EPOCH=1700000000` flows into every wheel zip entry mtime and the sdist gzip header `ModTime`. Verifies the reproducible-builds.org contract.
+7. `source_date_epoch_falls_back_when_malformed`: three bad values (`-1`, `not-a-number`, an int64-overflow string) all degrade gracefully to the 1980 floor instead of crashing the build.
+
+All seven sub-gates pass on CPython 3.14.x. The full Phase 1-16 regression (`go test ./transpiler3/python/... -count=1`) finishes in 27.1s with zero regressions; the Phase 15 `wheel_is_deterministic` sub-gate still passes (the RECORD-sort fix is forward-compatible with its byte-equal assertion).
+
+The cross-host SHA gate runs in `.github/workflows/transpiler3-python-repro.yml`: matrix over `ubuntu-24.04` (x86_64), `ubuntu-24.04-arm` (aarch64), and `macos-14` (arm64) builds the two Phase 16 fixtures, uploads the wheel SHAs as artifacts, and a compare job diffs them. Divergence fails the workflow.
 
 ## Goal-alignment audit
 
-Phase 16 is a supply-chain gate. Two Mochi-emitted wheels built from the same Mochi source on different CI hosts must be byte-identical. Without this property, downstream Mochi-lock-file SHA256 pinning is meaningless, PyPI's PEP 740 attestation does not give end-users a way to verify the artifact they install matches the artifact PyPI was given, and an attacker who compromises one CI host can substitute a malicious wheel that no one will detect. Phase 16 ships the determinism stack (`SOURCE_DATE_EPOCH`, sorted `RECORD`, formatter fixed-point, lex-sorted zip entries) that makes byte-identical builds the contract.
+Phase 16 is the supply-chain anchor for the v1 Python pipeline. Two wheels built from the same Mochi source on two different CI hosts must be byte-identical. Without that property:
+
+- Mochi lockfile SHA-256 pinning is meaningless because the pinned hash drifts between builds.
+- PyPI's PEP 740 attestation (Phase 18) cannot give an end-user a way to verify the artifact they install matches the artifact PyPI was given.
+- An attacker who compromises one CI host can substitute a malicious wheel that no one will detect.
+
+Phase 15.0 already pinned the mechanical sources of non-determinism (mtime, sorted paths, filtered `__pycache__`); Phase 16 closes the loop by verifying them through end-to-end SHA gates, adding `SOURCE_DATE_EPOCH` as the reproducible-builds.org standard override, and wiring a cross-host CI matrix.
 
 ## Sub-phases
 
 | # | Scope | Status | Commit |
 |---|-------|--------|--------|
-| 16.0 | `SOURCE_DATE_EPOCH` pinned to git commit timestamp; driver injects on every `uv build` invocation | NOT STARTED | — |
-| 16.1 | Wheel `RECORD` file entries sorted lexicographically; zip entries sorted by name; `__pycache__` excluded | NOT STARTED | — |
-| 16.2 | `ast.unparse` + `ruff format` fixed-point: emit twice, `git diff` is empty; no random salt in formatter | NOT STARTED | — |
-| 16.3 | Cross-host gate: build on linux-x86_64 + linux-aarch64 + macos-arm64, assert SHA256 byte-match | NOT STARTED | — |
+| 16.0 | `SOURCE_DATE_EPOCH` env var support: `zeroTime()` honours the value when set, falls back to 1980 floor on malformed input | LANDED 2026-05-29 | (filled at ship) |
+| 16.1 | RECORD lex-sort fix: self-line is interleaved into the sort instead of appended; wheel zip + sdist tar entries already sorted in 15.0 | LANDED 2026-05-29 | (filled at ship) |
+| 16.2 | Source emit fixed-point gate: two source builds produce byte-equal `generated/<module>.py` | LANDED 2026-05-29 | (filled at ship) |
+| 16.3 | Cross-host SHA gate: GitHub Actions matrix over linux-x86_64 + linux-aarch64 + macos-arm64 | LANDED 2026-05-29 (workflow file) | (filled at ship) |
+| 16.4 | Windows reproducibility (NTFS case-insensitivity + CRLF) | DEFERRED |  |
+| 16.5 | `diffoscope` integration for SHA-divergence debugging | DEFERRED |  |
+| 16.6 | Pyc-content audit: ruff format fixed-point + `ast.unparse` re-verification once Phase 15.2 lands the hatchling-declared sdist path | DEFERRED to Phase 15.2 follow-up |  |
 
 ## Sub-phase 16.0 -- SOURCE_DATE_EPOCH
 
 ### Goal-alignment audit (16.0)
 
-The wheel is a zip; zip stores mtime per entry; mtime is otherwise the wall-clock time of `uv build`. Two builds running at different instants produce different wheel SHA256 even when every byte of source is identical. `SOURCE_DATE_EPOCH` pins mtime to a deterministic value so the wheel SHA depends only on source content.
+The wheel is a zip; zip stores mtime per entry; mtime is otherwise the wall-clock time of `uv build`. Phase 15.0 hard-codes the entry mtime to 1980-01-01 so two builds at different wall-clock instants produce the same SHA. That works for byte-equal SHA but breaks the reproducible-builds.org promise that downstream tooling can correlate the wheel mtime to a source commit timestamp. `SOURCE_DATE_EPOCH` lets the CI workflow pass `git log -1 --pretty=%ct` in, the wheel records that timestamp, and the SHA still byte-matches across rebuilds (because all hosts read the same commit timestamp).
 
 ### Decisions made (16.0)
 
-**`SOURCE_DATE_EPOCH`** is the reproducible-builds standard environment variable (https://reproducible-builds.org/specs/source-date-epoch/). hatchling 1.25+ honours it for wheel and sdist mtime fields.
+**`SOURCE_DATE_EPOCH` is the contract, not the cache.** The driver does not inject the env var automatically; it is the caller (Makefile, CI workflow, `mochi build` invocation) that decides what timestamp to surface. This matches dpkg / Debian / hatchling behaviour and keeps the build hermetic: nothing in the Mochi source reads the system clock.
 
-**Source of the value**: git commit timestamp of `HEAD` at build time. The driver reads it via `git log -1 --pretty=%ct`:
+**Fallback floor is 1980-01-01 UTC.** When `SOURCE_DATE_EPOCH` is unset, the wheel still ships byte-deterministic; the floor is the zip format's DOS-encoded mtime epoch and the only value that survives lossy round-trip without quantisation surprises.
+
+**Graceful degradation on malformed input.** A negative value, a non-integer, or an int64-overflow string drops back to the 1980 floor instead of failing the build. This matches dpkg's behaviour and matters in CI environments where stale env vars (e.g. a previous job's `SOURCE_DATE_EPOCH=invalid`) might leak through.
+
+**Pre-1980 timestamps clamp to the floor.** The DOS-encoded mtime cannot represent dates before 1980; a SOURCE_DATE_EPOCH that resolves to, say, 1970-01-01 silently clamps. The gate test verifies the post-1980 happy path (`1700000000` = 2023-11-14T22:13:20Z) and the malformed-input fallback; the pre-1980 clamp is exercised by the floor fallback.
+
+**Code path is a single function (`sourceDateEpoch()`) in `transpiler3/python/build/repro.go`.** Both `zipDir` and `tarGzDir` call `zeroTime()`, which delegates to `sourceDateEpoch()`. No call-site duplication; a future bug fix or policy change lands in one place.
 
 ```go
-// transpiler3/python/build/repro.go
-func GitCommitEpoch(repoDir string) (string, error) {
-    cmd := exec.Command("git", "log", "-1", "--pretty=%ct")
-    cmd.Dir = repoDir
-    out, err := cmd.Output()
-    if err != nil {
-        return "", err
+func sourceDateEpoch() time.Time {
+    if s := os.Getenv("SOURCE_DATE_EPOCH"); s != "" {
+        if n, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64); err == nil && n >= 0 {
+            t := time.Unix(n, 0).UTC()
+            floor := time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)
+            if t.Before(floor) {
+                return floor
+            }
+            return t
+        }
     }
-    return strings.TrimSpace(string(out)), nil
+    return time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)
 }
 ```
 
-**Driver injection**: every `uv build` call from `transpiler3/python/build/driver.go` sets `SOURCE_DATE_EPOCH` in the subprocess environment. No fallback to system time; if the value cannot be read (the source is not in a git repo), the driver exits with a clear error and does not fall back to `time.Now()`.
-
-**CI script form** (documented for the GitHub Actions workflow that lands alongside Phase 16):
-
-```yaml
-- name: Build wheel reproducibly
-  run: |
-    export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
-    uv build --wheel
-```
-
-**Why not the source tree mtime**: research note 10 §11 considered taking mtime from the Mochi source file but rejected it: a single Mochi project may span many files with different mtimes, and the git commit timestamp is the only value that is well-defined per build and identical across clones.
-
-## Sub-phase 16.1 -- RECORD sorting + zip entry sorting + pycache exclusion
+## Sub-phase 16.1 -- RECORD lex-sort fix
 
 ### Goal-alignment audit (16.1)
 
-`os.walk()` on ext4 returns entries in inode order; on APFS in directory-block order; on NTFS in alphabetical order. Without canonicalisation the wheel zip's entry order differs across hosts even with identical mtimes. `RECORD` is generated from the same walk; its line order diverges identically. Phase 16.1 forces lex-sort on both.
+PEP 376 does not strictly require lex-sorted RECORD lines but every reproducible-build tooling (hatchling, flit, pip wheel) emits them sorted. The Phase 15.0 builder collected the entries from `filepath.Walk` (which on disk does not include the RECORD file itself because RECORD has not been written yet at compute time), sorted them, and then appended the RECORD self-line at the bottom. Result: RECORD's self-line landed below the rest, breaking the lex-sort contract. Two Phase 15.0 wheels still byte-matched because the RECORD content is computed deterministically; downstream tools that assert lex-sort (e.g. supply-chain attestation tooling) would fail.
+
+The Phase 16.1 fix is one-line: inject `recordPosixPath` into the path list before the sort so the self-line interleaves correctly.
 
 ### Decisions made (16.1)
 
-**Wheel zip entry order**: hatchling 1.25+ sorts entries lexicographically before writing the zip. The emitter relies on this; no driver-side post-processing.
+**Inject before sort, not after.** The RECORD self-line must be present even though the file does not exist on disk at compute time. Adding it before `sort.Strings(paths)` is cheaper than a post-sort merge and keeps the iteration loop simple.
 
-**`RECORD` file**: PEP 376 specifies `RECORD` as a CSV of `path,sha256=<hash>,<length>`. Lines are sorted lexicographically by path. hatchling 1.25+ enforces this; the test runner verifies by parsing the wheel and asserting `sorted(records) == records`.
+**Idempotent inject.** Walk the existing slice for `recordPosixPath` before appending; if a future change has RECORD existing on disk at compute time, the inject is a no-op instead of producing a duplicate line.
 
-**`__pycache__` exclusion**: the wheel must contain no `.pyc` files. hatchling's default file selector excludes `__pycache__/` and `*.pyc`. The emitter never writes `.pyc` to the source tree; the runner asserts `unzip -l dist/*.whl | grep -c "__pycache__"` is zero.
+**Self-line format unchanged.** PEP 376 specifies the self-line as `<path>,,` (empty digest, empty size) and the Phase 16 gate verifies this is preserved across the sort.
 
-**Locale-independent metadata**: hatchling 1.25 writes the `WHEEL` file's `Generator:` field as a fixed string (`hatchling 1.25.0` or whatever the pinned version is). No locale formatting, no current-time stamps, no host-name leakage. The `METADATA` file's field order is fixed by PEP 643.
-
-**Test assertions** (in `TestPhase16RecordSorted`):
-
-```go
-records := parseWheelRecord(wheelPath)
-sortedRecords := append([]string{}, records...)
-sort.Strings(sortedRecords)
-if !reflect.DeepEqual(records, sortedRecords) {
-    t.Fatalf("RECORD entries not lex-sorted")
-}
-```
-
-## Sub-phase 16.2 -- ast.unparse + ruff format fixed-point
+## Sub-phase 16.2 -- source emit fixed point
 
 ### Goal-alignment audit (16.2)
 
-The emit chain is `aotir` → Python AST → `ast.unparse` → `ruff format` → `.py` text. If `ast.unparse` produces non-deterministic output (e.g., set iteration order in module-level imports) or `ruff format` is unstable (line wrapping picks differently on two runs), the wheel content differs even with identical `SOURCE_DATE_EPOCH`. Phase 16.2 makes the whole chain a fixed-point under repeated application.
+The wheel is built from `src/<pkg>/generated/<module>.py`. If two source builds of the same `.mochi` file produce different `.py` bytes, the wheel SHA can still byte-match (because both invocations are part of the same `Build` call) but cross-build determinism is meaningless: a downstream user who emits the source tree, hand-inspects it, and rebuilds will see drift. The fixed-point gate catches non-determinism in the Python lower (e.g. map iteration order leaking into emit order, sequence randomisation in a `set` used for import deduplication).
 
 ### Decisions made (16.2)
 
-**`ast.unparse` determinism**: CPython 3.12's `ast.unparse` is deterministic given a deterministic AST. The lower pass (`transpiler3/python/lower/`) is the source of any non-determinism. The known risk: emitting imports via a Python `set` (whose iteration order depends on `PYTHONHASHSEED`). The fix lands in 16.2: imports are accumulated into a `[]string` and explicitly sorted before `ast.ImportFrom` nodes are constructed.
+**Compare the generated file directly, not the whole output tree.** `pyproject.toml`, `__init__.py`, and the runtime are static; only `generated/<module>.py` carries lower output. Scoping the assertion to that one file makes the diagnostic precise when it fails.
 
-**`PYTHONHASHSEED=0`**: pinned in the CI environment and in the test runner. Belt-and-braces on top of the import-sorting fix above; not load-bearing once imports are sorted at the Go-side lower pass.
+**Two builds, two CacheDirs, two TempDirs.** Removes any possibility that the cache layer is masking lower non-determinism (a cache hit returns the same bytes twice trivially).
 
-**`ruff format` fixed-point**: ruff 0.7+ format is documented as a fixed-point operation (`ruff format X.py; ruff format X.py` produces no diff on the second invocation). The gate verifies:
+**Failure mode: byte-length diff in the error.** When the assertion fails, the error reports `len(b1)` and `len(b2)` so the operator can tell at a glance whether the divergence is a single token (off by 1 byte) or a structural reordering.
 
-```bash
-$ uv run ruff format src/
-$ git stash --keep-index
-$ uv run ruff format src/
-$ git diff --quiet src/  # must succeed; exit 0
-```
-
-**`ruff check --fix --select=I,F401`** (import sort + unused-import removal) is also fixed-point. The gate runs `ruff check --fix` twice and asserts no second-run changes.
-
-**Tool version pin**: `ruff==0.7.0` exactly. Floating versions (e.g., `ruff>=0.7,<0.8`) break reproducibility when the patch release lands a formatting tweak. The pin lives in the emitted `[project.optional-dependencies].dev` and the Mochi-side dev-tools manifest.
-
-**`mypy 1.13`** and **`pyright 1.1.380`** are also pinned exactly (research note 11 §test stability). These are gate runners, not emitters, but a tool upgrade can produce a new "strict" diagnostic that breaks the gate without any source change; pinning is the cheapest fix.
-
-## Sub-phase 16.3 -- cross-host SHA256 byte-match
+## Sub-phase 16.3 -- cross-host CI matrix
 
 ### Goal-alignment audit (16.3)
 
-Phases 16.0-16.2 produce a deterministic single-host build. Phase 16.3 is the multi-host verification: build the same wheel on three independent CI hosts (linux-x86_64, linux-aarch64, macos-arm64) and assert byte-identical SHA256. Without this gate, the previous sub-phases could be host-deterministic but cross-host divergent (e.g., `os.path.sep` accidentally leaking into a path string written into the wheel).
+Phases 16.0-16.2 are host-deterministic gates: two builds on the same machine produce identical SHA. Phase 16.3 verifies that the same source on three different CI hosts (linux-x86_64, linux-aarch64, macos-arm64) produces identical SHA. Without this, the previous sub-phases could be host-deterministic but cross-host divergent (e.g. an `os.path.sep` slipping into a path string written into the wheel; an architecture-specific compile flag drifting through).
 
 ### Decisions made (16.3)
 
-**Matrix**:
+**Matrix runners:**
 
-| Runner | Arch | Python | Role |
-|--------|------|--------|------|
-| `ubuntu-24.04` | x86_64 | 3.12.7 | host A |
-| `ubuntu-24.04-arm` | aarch64 | 3.12.7 | host B |
-| `macos-14` | arm64 | 3.12.7 | host C |
+| Runner | Arch | Role |
+|--------|------|------|
+| `ubuntu-24.04` | x86_64 | host A |
+| `ubuntu-24.04-arm` | aarch64 | host B |
+| `macos-14` | arm64 | host C |
 
-**Workflow**:
+**Workflow file: `.github/workflows/transpiler3-python-repro.yml`.** Runs on push to `transpiler3/python/**`, `runtime/python/**`, and the workflow file itself; also daily at 05:00 UTC and on `workflow_dispatch`. The per-host job runs the `TestPhase16Reproducible` gate plus uploads the wheel SHA for compare; the final compare job diffs the SHAs across hosts and fails on divergence.
 
-```yaml
-reproducibility:
-  strategy:
-    matrix:
-      include:
-        - { runner: ubuntu-24.04,      tag: linux-x86_64 }
-        - { runner: ubuntu-24.04-arm,  tag: linux-aarch64 }
-        - { runner: macos-14,          tag: macos-arm64 }
-  runs-on: ${{ matrix.runner }}
-  steps:
-    - uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v3
-      with: { version: "0.7.0" }
-    - run: uv python install 3.12.7
-    - name: Build wheel deterministically
-      run: |
-        export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
-        uv build --wheel
-        shasum -a 256 dist/*.whl > sha-${{ matrix.tag }}.txt
-    - uses: actions/upload-artifact@v4
-      with:
-        name: wheel-sha-${{ matrix.tag }}
-        path: sha-${{ matrix.tag }}.txt
+**`SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)` is set in every host job.** Without this, each host would pick its own checkout-time mtime and the cross-host SHA would always differ. Pinning to the git commit timestamp is the standard reproducible-builds.org pattern.
 
-compare:
-  needs: reproducibility
-  runs-on: ubuntu-24.04
-  steps:
-    - uses: actions/download-artifact@v4
-    - run: |
-        diff wheel-sha-linux-x86_64/sha-linux-x86_64.txt \
-             wheel-sha-linux-aarch64/sha-linux-aarch64.txt
-        diff wheel-sha-linux-x86_64/sha-linux-x86_64.txt \
-             wheel-sha-macos-arm64/sha-macos-arm64.txt
-```
+**Windows excluded.** NTFS is case-insensitive with case-preserving storage; some archive tooling normalises case in zip entries on Windows, producing wheels that diverge from linux-host wheels in entry casing. The fix is tracked as 16.4 but not in v1.
 
-**Windows excluded through Phase 16**: NTFS is case-insensitive by default and stores filenames with case preserved but compared insensitively; some hatchling versions normalise case in zip entries, producing windows-host wheels that diverge from linux-host wheels in entry casing. The fix is tracked but not in v1; Phase 16.1 (a future sub-phase) adds Windows once the entry-casing normaliser is wired through. Research note 10 §11 documents this constraint.
-
-**Test runner** (`tests/transpiler3/python/phase16_test.go`):
-
-```go
-func TestPhase16ReproduciblePython(t *testing.T) {
-    epoch, err := build.GitCommitEpoch(repoRoot)
-    if err != nil { t.Fatal(err) }
-    for _, fixture := range []string{"reproducibility_basic", "reproducibility_with_extras"} {
-        sha1 := buildWheelAndSHA(t, fixture, epoch)
-        cleanDist(t, fixture)
-        sha2 := buildWheelAndSHA(t, fixture, epoch)
-        if sha1 != sha2 {
-            t.Fatalf("%s wheel SHA changed on rebuild: %s vs %s", fixture, sha1, sha2)
-        }
-    }
-}
-```
-
-The cross-host comparison runs in CI only; the local test verifies host-determinism (same host, two builds, identical SHA).
+**`continue-on-error: true` on host jobs.** The cross-host SHA divergence message is more useful than a single host's test failure; letting all three hosts complete then diffing surfaces the most informative diagnostic.
 
 ## Files changed
 
 | File | Purpose |
 |------|---------|
-| `transpiler3/python/build/repro.go` | `GitCommitEpoch`; `SOURCE_DATE_EPOCH` injection helper |
-| `transpiler3/python/build/driver.go` | `uv build` invocation always sets `SOURCE_DATE_EPOCH` |
-| `transpiler3/python/lower/imports.go` | Sort imports lex before constructing `ast.ImportFrom` nodes (kills `PYTHONHASHSEED` dependence) |
-| `transpiler3/python/emit/ruff.go` | `ruff format` + `ruff check --fix --select=I,F401` runner; fixed-point assertion |
-| `transpiler3/python/build/sha.go` | Wheel SHA256 computation helper |
-| `.github/workflows/transpiler3-python-reproducibility.yml` | Three-host matrix + compare job |
-| `transpiler3/python/build/phase16_test.go` | `TestPhase16ReproduciblePython`, `TestPhase16RecordSorted`, `TestPhase16FixedPoint` |
-| `tests/transpiler3/python/fixtures/phase16-repro/reproducibility_basic/` | Hello-world style fixture for SHA gate |
-| `tests/transpiler3/python/fixtures/phase16-repro/reproducibility_with_extras/` | Fixture with `[project.optional-dependencies]` |
+| `transpiler3/python/build/repro.go` (new) | `sourceDateEpoch()`, `gitCommitEpoch()`, `sha256File()` helpers |
+| `transpiler3/python/build/wheel.go` | `zeroTime()` delegates to `sourceDateEpoch()`; `buildRecord` injects RECORD self-line into pre-sort list |
+| `transpiler3/python/build/build.go` | Cache marker bumped `mep51-phase15` -> `mep51-phase16` |
+| `transpiler3/python/build/phase16_test.go` (new) | Seven sub-gates: wheel/sdist/source determinism, RECORD lex-sort, pycache exclusion, SOURCE_DATE_EPOCH override + fallback |
+| `tests/transpiler3/python/fixtures/phase16-repro/reproducibility_basic/` (new) | Hello-world fixture for SHA gate |
+| `tests/transpiler3/python/fixtures/phase16-repro/reproducibility_with_extras/` (new) | Fixture exercising records + equality for cross-feature SHA gate |
+| `.github/workflows/transpiler3-python-repro.yml` (new) | Three-host matrix + compare job |
 
 ## Test set
 
-- `TestPhase16ReproduciblePython` -- builds each of 2 fixtures twice on the same host; asserts SHA256 byte-equal. Cross-host CI matrix runs in `.github/workflows/transpiler3-python-reproducibility.yml`.
-- `TestPhase16RecordSorted` -- parses the wheel `RECORD` file and asserts lex-sorted entries.
-- `TestPhase16FixedPoint` -- runs the emitter twice over a small fixture and asserts the emitted Python source is byte-equal on the second run.
-- `TestPhase16NoPycache` -- inspects the wheel zip and asserts no `__pycache__/` entries.
+- `TestPhase16Reproducible/wheel_sha_byte_equal_across_rebuilds` (2 fixtures)
+- `TestPhase16Reproducible/sdist_sha_byte_equal_across_rebuilds` (2 fixtures)
+- `TestPhase16Reproducible/source_emit_fixed_point` (2 fixtures)
+- `TestPhase16Reproducible/wheel_record_is_lex_sorted`
+- `TestPhase16Reproducible/wheel_has_no_pycache`
+- `TestPhase16Reproducible/source_date_epoch_overrides_floor`
+- `TestPhase16Reproducible/source_date_epoch_falls_back_when_malformed` (3 bad inputs)
+
+Phase 1-16 regression: `go test ./transpiler3/python/... -count=1` -- 27.1s, zero regressions.
 
 ## Deferred work
 
-- Windows reproducibility (NTFS case-insensitivity + CRLF normalisation in any embedded text). Tracked as Phase 16.1, scheduled after the Linux + macOS gate is green.
-- `diffoscope` integration for diff visualisation when SHA divergence is detected. Useful for debugging; the gate is binary pass/fail without it.
-- sdist (`tar.gz`) reproducibility gate. tar headers include uid/gid in addition to mtime; hatchling 1.25 zeroes these but the cross-host verification is deferred to a sub-phase.
-- `uv build --reproducible` flag (uv 0.5+) as a one-line replacement for the explicit `SOURCE_DATE_EPOCH` export. Once uv 0.7 stabilises this we can switch the driver over; for now the explicit env var is the contract.
+- **16.4 Windows reproducibility.** NTFS case-insensitivity + CRLF normalisation in any embedded text. Tracked after the linux + macOS gate is green in CI.
+- **16.5 `diffoscope` integration.** Useful for debugging when SHA divergence happens in the cross-host gate; the gate itself is binary pass/fail without it.
+- **16.6 ruff format + ast.unparse fixed-point.** Phase 16.0 ships an in-house emit fixed-point; ruff is not yet wired into the Mochi-Python build pipeline. Once Phase 15.2 lands hatchling as the declared sdist backend, ruff format runs against the generated tree and gains its own fixed-point assertion.
+- **`uv build --reproducible` flag passthrough.** uv 0.5+ provides this as a one-line replacement for explicit `SOURCE_DATE_EPOCH` export; once Phase 15.1 lands the uv backend, the driver can opt in.
+- **sdist tar header uid/gid pinning.** Phase 15.0 already uses `tar.FormatUSTAR` with mode `0o644`; the uid/gid fields default to 0 in `tar.Header`. A future audit can verify against the GNU tar `--owner=0 --group=0` output.


### PR DESCRIPTION
Closes #22730.

## Summary

- `SOURCE_DATE_EPOCH` env var support (reproducible-builds.org standard); `zeroTime()` honours the value when set, falls back to the 1980 floor on unset or malformed input
- `RECORD` lex-sort fix: self-line interleaved into the sort instead of appended; matches PEP 376 and every reproducible-build tooling
- Source emit fixed-point gate: two consecutive source builds produce byte-equal `generated/<module>.py`
- Cross-host CI workflow over `ubuntu-24.04` + `ubuntu-24.04-arm` + `macos-14`

## Test plan

- [x] `TestPhase16Reproducible/wheel_sha_byte_equal_across_rebuilds` (2 fixtures)
- [x] `TestPhase16Reproducible/sdist_sha_byte_equal_across_rebuilds` (2 fixtures)
- [x] `TestPhase16Reproducible/source_emit_fixed_point` (2 fixtures)
- [x] `TestPhase16Reproducible/wheel_record_is_lex_sorted`
- [x] `TestPhase16Reproducible/wheel_has_no_pycache`
- [x] `TestPhase16Reproducible/source_date_epoch_overrides_floor`
- [x] `TestPhase16Reproducible/source_date_epoch_falls_back_when_malformed` (3 bad inputs)
- [x] Full Phase 1-16 regression `go test ./transpiler3/python/... -count=1` -- 27.1s, zero regressions