### PR TITLE
docs(mep-74): bidirectional Go module bridge spec + research bundle + impl tracking

### DIFF
--- a/package3/go/README.md
+++ b/package3/go/README.md
@@ -1,0 +1,52 @@
+# package3/go
+
+Bidirectional Go module bridge for Mochi. Implementation lives under this directory once phases land per [MEP-74 implementation tracking](../../website/docs/implementation/0074/index.md).
+
+## Status
+
+Stub. No code yet. The phase-00 skeleton (`go.mod` for the bridge, helper-binary plumbing, package layout) is the first implementation deliverable.
+
+## What this is
+
+The MEP-74 bridge sits between MEP-54 (Mochi-to-Go transpiler) and MEP-57 (Mochi source-level package system). Two directions:
+
+- **Consume**: `import go "<module>@<semver>" as <alias>` in Mochi source. The bridge ingests `go/packages.Load` via the `package3/go/cmd/go-ingest` helper, lowers via a closed type table, synthesises a cgo wrapper package with `//export` directives, builds it as a `c-archive`, and exposes Go items as Mochi `extern fn` declarations.
+- **Publish**: `mochi pkg publish --to=git-tag`. The bridge lowers the Mochi package via a new `TargetGoLibrary` emit (canonical-import-path-respecting Go package with `go.mod`), commits the generated tree to the user's git remote, tags with `v<semver>` so `proxy.golang.org` picks it up asynchronously, and optionally signs the sibling `v<semver>.sig` tag with Sigstore keyless cosign.
+
+## Planned layout
+
+```
+package3/go/
+  cmd/
+    go-ingest/    # go/packages ApiSurface emitter (phase 3)
+  moduleproxy/    # proxy.golang.org client (phase 1)
+  sumdb/          # sum.golang.org transparency client (phase 2)
+  apisurface/     # ApiSurface JSON parser (phase 4)
+  typemap/        # closed type-mapping table + SkipReport (phase 5)
+  wrapper/        # cgo wrapper synthesiser (phase 6)
+  emit/           # Mochi extern-fn emitter (phase 7)
+  build/          # workspace + go build orchestration (phase 9)
+  publish/        # git-tag publish + cosign (phases 12-13)
+  goroutine/      # cgo handle pool + bridge runtime (phase 14)
+  tinygo/         # TinyGo embedded subset (phase 16)
+  vanity/         # vanity-import redirect resolver (phase 17)
+```
+
+## How MEP-74 differs from MEP-73
+
+Three architectural simplifications versus the Rust bridge:
+
+- **Stable ingest, no nightly toolchain.** `go/packages` + `go/types` are in-stdlib and stable since 2018. The Rust bridge depends on nightly-only rustdoc-JSON.
+- **No async runtime singleton.** Go's runtime ships the goroutine scheduler inside every c-archive. No equivalent of MEP-73's tokio `OnceLock<Runtime>`.
+- **Built-in transparency log.** `sum.golang.org` provides a Merkle-tree checksum DB out of the box, mandatorily cross-checked at lock time. The Rust bridge layers Sigstore on top because crates.io has no equivalent.
+
+Two architectural complications versus the Rust bridge:
+
+- **Publish is git-tag, not registry-upload.** No central registry to publish to. `proxy.golang.org` discovers modules by polling git remotes for `v<semver>` tags. Publishing is a `git push` + `git tag` + (optional) cosign-sign sequence rather than an upload-token API call.
+- **Cgo cost per call.** ~200ns per crossing on darwin-arm64. The bridge offers a batched-variant wrapper for hot-loop call sites; the Rust bridge has no equivalent because `extern "C"` calls cost ~5ns.
+
+## References
+
+- [MEP-74 spec](../../website/docs/mep/mep-0074.md) for the normative design.
+- [MEP-74 research bundle](../../website/docs/research/0074/index.md) for the 12-note deep-research collection.
+- [MEP-74 implementation tracking](../../website/docs/implementation/0074/index.md) for the 18-phase rollout.

--- a/website/docs/implementation/0074/index.md
+++ b/website/docs/implementation/0074/index.md
@@ -1,0 +1,116 @@
+---
+title: MEP-74 implementation tracking
+sidebar_position: 1
+sidebar_label: "MEP 74. Mochi+Go package manager"
+description: "Per-phase implementation tracking for MEP-74 (Mochi+Go package manager). Status + commit columns capture how each phase landed on main, plus the per-target coverage matrix for host stable Go, linux-amd64+arm64, windows-amd64, wasm-wasip1, wasm-js, and tinygo embedded."
+---
+
+# MEP-74 implementation tracking
+
+Per-phase tracking for [MEP-74 Mochi+Go package manager](/docs/mep/mep-0074). Status values: `NOT STARTED`, `IN PROGRESS`, `BLOCKED`, `LANDED`, `DEFERRED`. Commit is the merge commit short SHA on `main` (or, for the umbrella PR, the in-branch commit on `mep/0074-go-package`).
+
+A phase is LANDED only when its gate is green for every applicable target (consume direction + publish direction). Missing surfaces become N.1, N.2, ... sub-phases per the umbrella-phase coverage rule.
+
+## Phase status
+
+| Phase | Title | Status | Commit | Tracking page |
+|-------|-------|--------|--------|---------------|
+| 0 | Skeleton: package3/go/ layout + helper-binary plumbing | NOT STARTED | — | [phase-00](/docs/implementation/0074/phase-00-skeleton) |
+| 1 | Module-proxy client (`proxy.golang.org` info/mod/zip reader, h1:-hash verify) | NOT STARTED | — | [phase-01](/docs/implementation/0074/phase-01-module-proxy) |
+| 2 | sum.golang.org transparency-log client (signed-tree-head + tile fetch + inclusion proof) | NOT STARTED | — | [phase-02](/docs/implementation/0074/phase-02-sumdb) |
+| 3 | go/packages ingest helper (`package3/go/cmd/go-ingest`) | NOT STARTED | — | [phase-03](/docs/implementation/0074/phase-03-gopackages-ingest) |
+| 4 | ApiSurface JSON schema + bridge-side parser | NOT STARTED | — | [phase-04](/docs/implementation/0074/phase-04-apisurface) |
+| 5 | Closed type-mapping table (scalars / strings / `[]byte` / `[]T` / `map[K]V` / structs / interfaces / `chan T` / `func` / `error` / generics) | NOT STARTED | — | [phase-05](/docs/implementation/0074/phase-05-type-mapping) |
+| 6 | Cgo wrapper synthesiser (`//export` directives + `c-archive` + handle pool) | NOT STARTED | — | [phase-06](/docs/implementation/0074/phase-06-wrapper) |
+| 7 | Mochi-side extern fn emitter + alias shim file generation | NOT STARTED | — | [phase-07](/docs/implementation/0074/phase-07-extern-emit) |
+| 8 | `import go "<module>@<semver>" as <alias>` grammar + parser | NOT STARTED | — | [phase-08](/docs/implementation/0074/phase-08-import-grammar) |
+| 9 | Build orchestration: workspace synth + `go build -buildmode=c-archive` + artifact link | NOT STARTED | — | [phase-09](/docs/implementation/0074/phase-09-build) |
+| 10 | mochi.lock `[[go-package]]` integration + `--check` mode | NOT STARTED | — | [phase-10](/docs/implementation/0074/phase-10-lockfile) |
+| 11 | `TargetGoLibrary` emit (`go.mod` + exported package + `_cgo_export.h`) | NOT STARTED | — | [phase-11](/docs/implementation/0074/phase-11-go-library-emit) |
+| 12 | Git-tag publish flow (`mochi pkg publish --to=git-tag`) + canonical-import-path gate | NOT STARTED | — | [phase-12](/docs/implementation/0074/phase-12-git-tag-publish) |
+| 13 | Cosign-on-sibling-tag opt-in (`mochi pkg publish --cosign-sign`) | NOT STARTED | — | [phase-13](/docs/implementation/0074/phase-13-cosign) |
+| 14 | Goroutine bridge (cgo handle pool + channel-as-handle + callback-as-handle) | NOT STARTED | — | [phase-14](/docs/implementation/0074/phase-14-goroutine-bridge) |
+| 15 | Monomorphisation (`[go.monomorphise]` manifest + per-instantiation wrapper) | NOT STARTED | — | [phase-15](/docs/implementation/0074/phase-15-monomorphise) |
+| 16 | TinyGo embedded subset (`profile = "embedded"` + `//go:linkname` wrapper) | NOT STARTED | — | [phase-16](/docs/implementation/0074/phase-16-tinygo-embedded) |
+| 17 | Vanity-import resolver + wasm-wasip1 / wasm-js publish gate (wazero host integration) | NOT STARTED | — | [phase-17](/docs/implementation/0074/phase-17-vanity-and-wasm) |
+
+## Target coverage matrix
+
+Each phase's LANDED gate must be green for every applicable target. `n/a` cells mark targets where the phase does not apply (for example, publish-only phases on consume-only targets, or cgo-dependent phases on wasm targets).
+
+| Phase | host stable go 1.23 (darwin-arm64) | linux-amd64 / linux-arm64 | windows-amd64 | wasm-wasip1 / wasm-js | tinygo embedded |
+|-------|--------|--------|--------|--------|--------|
+| 0. skeleton | NOT STARTED | n/a | n/a | n/a | n/a |
+| 1. module-proxy client | NOT STARTED | n/a | n/a | n/a | n/a |
+| 2. sum.golang.org client | NOT STARTED | n/a | n/a | n/a | n/a |
+| 3. go/packages ingest | NOT STARTED | n/a | n/a | n/a | n/a |
+| 4. ApiSurface JSON | NOT STARTED | n/a | n/a | n/a | n/a |
+| 5. type-mapping table | NOT STARTED | required | required | required | required |
+| 6. cgo wrapper synthesiser | NOT STARTED | required | required | n/a (cgo off on wasm) | required (no_cgo subset) |
+| 7. extern emitter | NOT STARTED | required | required | required | required |
+| 8. import-go grammar (semver) | NOT STARTED | required | required | required | required |
+| 9. build orchestration | NOT STARTED | required | required | required (no cgo) | required |
+| 10. mochi.lock integration | NOT STARTED | required | required | required | required |
+| 11. TargetGoLibrary emit | NOT STARTED | required | required | required | required |
+| 12. git-tag publish | NOT STARTED | n/a (publish is host-only) | n/a | n/a | n/a |
+| 13. cosign on tag.sig | NOT STARTED | n/a | n/a | n/a | n/a |
+| 14. goroutine bridge | NOT STARTED | required | required | n/a (no goroutines on wasm-js without scheduler shim) | required |
+| 15. monomorphisation | NOT STARTED | required | required | required | required |
+| 16. TinyGo embedded subset | NOT STARTED | n/a | n/a | required (wasm-js via tinygo) | required |
+| 17. vanity-import + WASI publish | NOT STARTED | required | required | required | n/a |
+
+Cell legend: `required` means the phase's gate runs against this target; `n/a` means the phase's behaviour is intentionally not exercised on this target (architectural reason in parentheses).
+
+## Per-phase fields
+
+Each phase tracking page documents (or will document, once the phase begins):
+
+- **Gate**: the test or check that must pass for the phase to be LANDED on every applicable target column.
+- **Files to touch**: the bridge-side files (Go) and emit-side files (Go template) the phase introduces or modifies.
+- **Fixtures**: which of the 24-module fixture corpus the phase validates against.
+- **Skip count**: the expected SkipReport count per fixture module (golden numbers).
+- **Sub-phase decomposition** (if needed): N.1, N.2, ... entries when an upstream constraint forces splitting.
+
+## Fixture corpus
+
+The 24-module fixture corpus (April 2026 top-25-most-imported-on-pkg.go.dev minus the deprecated `github.com/pkg/errors` standalone usage):
+
+testify (stretchr/testify), cobra (spf13/cobra), viper (spf13/viper), logrus (sirupsen/logrus), uuid (google/uuid), mux (gorilla/mux), pkg/errors, go-cmp (google/go-cmp), protobuf (google.golang.org/protobuf), json-iterator (json-iterator/go), go-spew (davecgh/go-spew), golang/mock, xxhash/v2 (cespare/xxhash), go-isatty (mattn/go-isatty), klauspost/compress, prometheus/client_golang, zap (uber-go/zap), yaml.v3 (gopkg.in/yaml.v3), pflag (spf13/pflag), gin (gin-gonic/gin), echo/v4 (labstack/echo), fasthttp (valyala/fasthttp), sqlx (jmoiron/sqlx), color (fatih/color).
+
+Each phase that touches the type-mapping, wrapper, or runtime layer asserts golden counts against this corpus. The corpus is regenerated quarterly to track module API drift.
+
+## Implementation location
+
+The bridge lives at `package3/go/` in the repo root:
+
+```
+package3/go/
+  README.md               # pointer to MEP-74 spec
+  cmd/
+    go-ingest/            # go/packages ApiSurface emitter (phase 3)
+  moduleproxy/            # proxy.golang.org client (phase 1)
+  sumdb/                  # sum.golang.org transparency client (phase 2)
+  apisurface/             # ApiSurface JSON parser (phase 4)
+  typemap/                # closed type table (phase 5)
+  wrapper/                # cgo wrapper synthesiser (phase 6)
+  emit/                   # Mochi extern fn emitter (phase 7)
+  build/                  # workspace + go build orchestration (phase 9)
+  publish/                # git-tag publish + cosign (phases 12-13)
+  goroutine/              # cgo handle pool + bridge runtime (phase 14)
+  tinygo/                 # TinyGo embedded subset (phase 16)
+  vanity/                 # vanity-import redirect resolver (phase 17)
+```
+
+The `package3/go/` location is shared with the broader MEP-57 polyglot package work (where `package3/` is the v3 package-system tree). It sits next to `package3/rust/` (MEP-73) and follows the same internal structure.
+
+## Status snapshot
+
+As of 2026-05-29: all 18 phases NOT STARTED. The MEP spec and research bundle are landed; implementation is the next major undertaking.
+
+## Cross-references
+
+- [MEP-74 spec](/docs/mep/mep-0074) for the normative design.
+- [MEP-74 research bundle](/docs/research/0074/) for the 12-note deep-research collection.
+- [MEP-54 implementation tracking](/docs/implementation/0054) for the underlying Go transpiler that MEP-74 extends.
+- [MEP-57 implementation tracking](/docs/implementation/0057) for the polyglot package system MEP-74 builds on.
+- [MEP-73 implementation tracking](/docs/implementation/0073) for the sister Rust-bridge phase plan.

--- a/website/docs/mep/mep-0074.md
+++ b/website/docs/mep/mep-0074.md
@@ -1,0 +1,466 @@
+---
+mep: 74
+title: "Mochi and Go package bridge: bidirectional Go-module interop with go/packages + go/types ingest, auto-generated cgo wrapper package, no-boilerplate import go syntax, proxy.golang.org consume + git-tag publish flow, sum.golang.org checksum-DB pinning, optional Sigstore cosign signing, and a content-addressed Go dependency cache under package3/go/"
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-29
+sidebar_position: 74
+sidebar_label: MEP 74. Mochi and Go package bridge
+description: "Bidirectional package interop between Mochi and the Go module ecosystem. Direction 1 (Mochi as Go-module consumer): an `import go \"<module>@<semver>\" as <alias>` surface form auto-resolves through the mochi.lock pin, fetches the source via the Go module proxy protocol (GOPROXY=https://proxy.golang.org by default) into the content-addressed blob store under `~/.cache/mochi/go-deps/`, verifies against sum.golang.org's checksum database, runs `go/packages.Load` to extract a full `*types.Package` with every exported identifier and its `types.Type`, walks that surface through a closed Go-to-Mochi type translation table (int64/int32/float64/string/[]T/map[K]V/struct/interface/chan/func/pointer/error plus a refusal set for unexported fields, generic type parameters beyond the monomorphised concretisations declared in mochi.toml, `unsafe.Pointer`, `cgo.Handle`, runtime/internal types, type-erased `interface{}` return positions whose erasure would lose statically-checkable types, and reflective `reflect.Value` / `reflect.Type` plumbing), and emits a synthesized cgo-compatible wrapper Go package (`go_wrap/`) with `//export` directives that the MEP-54 build path links into the final binary via `go build -buildmode=c-archive` plus the existing cc-rs link surface, plus matching `extern type` and `extern fn` Mochi declarations the parser accepts as if hand-written. Direction 2 (Mochi as Go-module producer): a new MEP-54 build target `TargetGoLibrary` (separate from the existing `TargetGoModule`) lowers a Mochi package to a publishable Go module with a real `package <name>` directory layout, exports the user's public API as `func` and `type` declarations with proper godoc comments, populates `go.mod` with `module <vanity-path>`, generates a matching cgo `_cgo_export.h` for non-Go consumers, sets the publish-side metadata (the README at the repo root, the LICENSE file, the doc.go package comment, the `// Package foo provides ...` summary), and ships via `mochi pkg publish --to=go+git+<repo-url>@<tag>` by tagging a git commit, pushing the tag, and waiting for the module proxy to pick it up (with an optional Sigstore-cosign signature attached as a sibling tag `<tag>.sig` per the experimental gosum-cosign workflow draft of 2026-Q1). The bridge is implemented in `package3/go/` and consumes MEP-57's `mochi.toml` plus `mochi.lock` infrastructure. The reference build adds a `[[go-package]]` table to `mochi.lock` recording the resolved module path, the resolved version (a semver tag, a pseudo-version, or a git rev), BLAKE3-256 + h1: of the .zip module artefact (the h1: hash is what sum.golang.org publishes, so the lockfile cross-verifies against the public checksum DB), the go/packages JSON-form revision hash, the user-declared capability surface (`net`, `fs`, `proc`, `cgo`, `unsafe`), and the generated wrapper SHA-256 (so a `mochi pkg lock --check` fails if a transitive go/packages drift would silently regenerate the wrapper with a different signature). The 18-phase delivery plan walks from package3/go/ skeleton through GOPROXY client, sum.golang.org cross-check, content-addressed module cache, go/packages ingest, type-mapping table, cgo wrapper synthesizer, Mochi extern emitter, `import go` grammar wiring (the keyword already exists for MEP-54 phase 10 FFI; MEP-74 extends it to take semver), MEP-54 build orchestration, mochi.lock integration, TargetGoLibrary emit, git-tag publish flow, optional cosign signing, goroutine bridge (channels↔streams + spawn↔go statement), monomorphisation of generic functions, an embedded subset that admits TinyGo-compatible packages only, a vanity-import-path resolver, and a WASI / wasm-js publish gate. Each phase is gated against a per-module ingest fixture corpus drawn from a curated 24-module set (stretchr/testify, spf13/cobra, spf13/viper, sirupsen/logrus, google/uuid, gorilla/mux, pkg/errors, google/go-cmp, golang/protobuf, json-iterator/go, davecgh/go-spew, golang/mock, cespare/xxhash/v2, mattn/go-isatty, klauspost/compress, prometheus/client_golang, uber-go/zap, gopkg.in/yaml.v3, spf13/pflag, gin-gonic/gin, labstack/echo/v4, valyala/fasthttp, jmoiron/sqlx, fatih/color) covering the top-25-most-imported-on-pkg.go.dev April 2026 snapshot. The bridge does NOT attempt to translate `internal/` packages, does NOT support build-tag-conditional compilation paths whose tags are not declared in mochi.toml, does NOT support `cgo` source files inside imported modules without an explicit `[capabilities] cgo = true` opt-in, and does NOT cover `unsafe.Pointer` arithmetic at the FFI boundary."
+---
+
+# MEP 74. Mochi and Go package bridge
+
+| Field    | Value |
+|----------|-------|
+| MEP      | 74 |
+| Title    | Mochi and Go package bridge |
+| Author   | Mochi core |
+| Status   | Draft |
+| Type     | Standards Track |
+| Created  | 2026-05-29 20:25 (GMT+7) |
+| Depends  | MEP-1 (Grammar, for the `import go` extension), MEP-2 (AST, for the import node), MEP-4 (Type System), MEP-13 (ADTs and Match, for `error` → Result desugar), MEP-45 (C transpiler, for the FFI sidecar pattern), MEP-54 (Go transpiler, for the lowering pipeline, the runtime module, the existing `TargetGoModule` target, and the existing `import go "..."` FFI surface), MEP-57 (Mochi module and package system, for `mochi.toml`, `mochi.lock`, content-addressed object store, capability declaration model, and Sigstore-keyless trusted publishing) |
+| Research | [/docs/research/0074/](/docs/research/0074/) |
+| Tracking | [/docs/implementation/0074/](/docs/implementation/0074/) |
+
+## Abstract
+
+Mochi today (May 2026, immediately after MEP-54's Go target landed at 18 phases and MEP-57's source-level package system reached Draft) has nine code-emitting targets and the beginnings of a source-level package management story. MEP-54 phase 10 wired a minimal `import go "<package>"` FFI surface that the Go target understands (the import becomes a Go import statement with FFI mangling stripped, then linked through the host Go toolchain), but it does not version-pin the imported module, does not record a checksum, does not gate on a capability declaration, and does not run on any target other than Go. The Mochi-to-Go path emits a `package main` executable that ships the runtime module `dev.mochilang/runtime/go` as its only Go dependency at module pin time; user-written Mochi programs cannot pull in arbitrary modules from pkg.go.dev with a version constraint, and a Mochi package author cannot publish their work as a Go module that downstream Go users `go get`. The 1.5-million-plus modules indexed at pkg.go.dev (April 2026 snapshot from the pkg.go.dev public stats endpoint) remain semi-off-limits to Mochi authors, and the Go ecosystem cannot consume Mochi packages directly.
+
+MEP-74 specifies the **bidirectional Go module bridge**: Mochi packages can consume any well-formed Go module via `import go "<module>@<semver>" as <alias>` with no user-written FFI boilerplate beyond what MEP-54 phase 10 already requires, with sum.golang.org checksum-DB verification on the consume path, and with a per-module capability declaration. Mochi packages can publish to the Go module ecosystem via `mochi pkg publish --to=go+git+<repo-url>@<tag>` (the Go ecosystem has no central registry; publication is a git-tag operation that the module proxy at `proxy.golang.org` picks up on next fetch, optionally accompanied by a Sigstore cosign signature on a sibling `<tag>.sig` tag per the experimental gosum-cosign workflow draft of 2026-Q1). The bridge is the fifth source-language interop story Mochi ships (after the Go FFI of `import go "..."` at MEP-54 phase 10, the Python FFI of `import python "..."`, the TypeScript / Deno FFI of `import typescript "..."`, and the MEP-73 Rust bridge), the second one that targets a typed semver-versioned package ecosystem as both a consumer and a producer (after MEP-73 Rust), and the first one where the source-language toolchain itself ships a stable, machine-readable, in-stdlib API surface (`go/packages` plus `go/types`) so the ingest pipeline does not require a nightly toolchain.
+
+The proposal builds on MEP-57's manifest / lockfile / capability infrastructure, MEP-54's emit pipeline, and MEP-73's bridge philosophy, and adds a new self-contained component under `package3/go/`. The Mochi grammar gains semver-pinned forms for the existing `go` `<lang>` token in the FFI-import production (no new keywords). The Mochi build pipeline gains one new target (`TargetGoLibrary` in MEP-54's build driver, parallel to the existing `TargetGoModule` which only writes the source tree). The lockfile gains one new repeated table (`[[go-package]]`). No existing transpiler MEP needs structural change; MEP-54 phase 10's existing FFI mangling pass is extended (not replaced) to honour the new lockfile pin.
+
+The system is anchored on eight load-bearing decisions, each justified in §Rationale and surveyed in the companion research notes:
+
+1. **`go/packages` + `go/types` from the Go standard library as the canonical machine-readable Go module surface.** The Go toolchain ships `go/packages.Load` (under `golang.org/x/tools/go/packages`) which returns a full `[]*packages.Package` tree where each `*packages.Package` carries a `*types.Package` exposing every exported identifier with its full `types.Type` (named types, struct fields with `types.Var`, methods with `types.Func`, interfaces with full method sets, signatures with parameter and result tuples, type parameters since Go 1.18). This is the same surface that `gopls`, `staticcheck`, and `golangci-lint` consume; it has been stable since Go 1.11 (August 2018) with a documented compatibility promise. The bridge ingests this surface via a small Go-side helper binary (`package3/go/cmd/govet/go-ingest`) that emits a JSON document describing every public item, which the main Mochi binary (written in Go itself) parses. Parsing Go source directly is rejected (would duplicate `go/parser` + `go/types` for no gain). Reading `pkg.go.dev`'s HTML documentation is rejected (it is rendered, not normative). Using `gomobile bind`'s `.aar` / `.framework` output is rejected (it only supports a tiny subset of Go and targets mobile-only). See [[01-language-surface]] §2, [[04-go-doc-ast-ingest]] §1, [[02-design-philosophy]] §1.
+
+2. **Auto-synthesised cgo wrapper Go package (`go_wrap/`) per imported Go dep, not direct cgo invocation or direct `dlopen` of pre-built shared libraries.** For each Go module the user imports, the bridge generates a sibling Go package (`<workdir>/go_wrap/<module-flat-name>/`) that imports the source module and exposes a flat `//export` surface wrapping each translatable public item: scalar return types pass through directly, `string` becomes `*C.char` plus an explicit `mochi_go_<module>_string_free` symbol (the matching `C.free` on the Go-allocated string requires `C.GoString` then `C.CString` round-trip to escape Go's GC), `[]T` becomes a `(ptr, len, cap)` triple plus a `_free` symbol on the C side, `map[K]V` becomes an opaque `*C.MochiMap` handle with explicit `_get` / `_set` / `_iter` / `_free` symbols (Go maps cannot be passed across the cgo boundary safely), `error` becomes a pair of out-pointers plus a `mochi_status` return code (matching the MEP-73 `Result<T, E>` shape), `chan T` becomes a `*C.MochiChannel` handle with `_send` / `_recv` / `_close` symbols, and `func` types become `*C.MochiFunc` handles with a `_call` symbol that takes a packed argument slice. The wrapper package is built as a `c-archive` via `go build -buildmode=c-archive -o libwrap.a` (which has been a first-class Go build mode since Go 1.5 in 2015 and which the MEP-54 Phase 15 work already exercised for the `go-module` target) and linked into the final binary by the MEP-54 driver's existing link-step path. This indirection accepts the wrapper-codegen cost in exchange for a clean Mochi-side ABI (no need to teach Mochi's lowering pass about Go's GC, its method-set rules, or its interface satisfaction), a single static link surface for the whole dependency graph (no per-module `plugin.Open` path; Go's `plugin` build mode is linux-only and brittle), and a per-wrapper SHA-256 lockfile pin that catches silent go/packages drift. The alternative of having Mochi emit Go code directly that calls the source module without an intermediate wrapper is rejected because Mochi's `aotir` IR is target-agnostic by design; teaching it about Go's interface satisfaction would break the multi-backend invariant. See [[02-design-philosophy]] §2, [[03-prior-art-bridges]] §3, [[09-abi-stability]] §1.
+
+3. **Closed Go-to-Mochi type translation table, with explicit refusal on out-of-table cases.** The translation covers `int↔int`, `int32↔int` (with overflow guard at the FFI boundary), `int64↔int`, `uint↔int` (with positive-range guard), `float32↔float`, `float64↔float`, `bool↔bool`, `string↔string`, `[]byte↔bytes`, `[]T↔list<T>` (when T is in-table), `map[K]V↔map<K, V>` (when K is `string` or integer and V is in-table; map iteration order is non-deterministic on the Go side and the wrapper documents this), `*T↔T?` (a nullable handle for pointer types where T is a named struct or named primitive), named struct types `type S struct { A int; B string }↔record S { A: int, B: string }` (only fully-exported fields; mixed-export structs project the exported subset and skip the rest with a SkipReport entry), named interface types `type I interface { M() }↔ extern type I` (opaque handle with method-call thunks), `error↔ try-catch desugar` (matches MEP-73 `Result<T, E>` shape), `chan T↔stream<T>` (with explicit `_close` semantics on the wrapper side), `func(A, B) (C, error)↔ fun(A, B) -> Result<C>` (signature-mapped), and the `...T` variadic suffix as `varargs<T>`. Items outside the table (generic type parameters beyond the monomorphised concretisations declared in `mochi.toml`'s `[go.monomorphise]` section, `unsafe.Pointer`, `reflect.Value`, `reflect.Type`, `cgo.Handle`, channel directions on type-aliases (`chan<- T` vs `<-chan T`), unexported types in exported positions, `interface{}` / `any` in non-constrained positions, struct fields with `tags` whose semantics depend on a tag-consuming downstream library, and any item whose visibility crosses an `internal/` directory boundary) are skipped with a `SkipReport` entry that names the item and the reason. The user can override with a hand-written `extern fn` declaration that takes responsibility for the type at the FFI boundary. Aggressive translation (e.g., synthesising a Mochi wrapper for every `interface{}` return) is rejected: the bridge promises zero boilerplate, not full generality. See [[05-type-mapping]] §1, [[02-design-philosophy]] §3.
+
+4. **`import go "<module-path>@<semver>" as <alias>` as the surface, with `<semver>` resolved through `mochi.lock`, extending MEP-54 phase 10's existing keyword.** The grammar's `go` `<lang>` token already exists from MEP-54 phase 10. MEP-74 extends the existing `<spec>` production to admit:
+
+    - `<module-path>`: bare module path (e.g., `github.com/spf13/cobra`), resolves through the manifest constraint plus `mochi.lock`.
+    - `<module-path>@<semver-req>`: explicit version constraint (`v1.8.0`, `^v1.8`, `~v1.8.0`, `>=v1.0.0 <v2.0.0`, `latest`).
+    - `<module-path>@<pseudo-version>`: Go pseudo-version like `v0.0.0-20240101120000-abcdef123456` (UTC YYYYMMDDhhmmss + git-rev short hash; the Go module proxy mints these for any git commit without a semver tag).
+    - `<module-path>@git+<url>#<rev>`: git source override (escape hatch for forks).
+    - `<module-path>@path+<relative-path>`: path source for replace-directive-like local development.
+
+    Bare names resolve to the highest version on the module proxy that satisfies the manifest's `[go-dependencies]` constraint (the bridge auto-rewrites the import to match the resolved version on next `mochi pkg lock`). The `mochi.lock` lockfile records the resolved version, BLAKE3-256 + the Go `h1:` hash (base64-of-sha256-of-zip-content; identical to what sum.golang.org publishes), the `go/packages` revision hash, the SHA-256 of the generated wrapper package's source, and the capability surface declared for the module. No other Mochi syntax changes are introduced; `import go` participates in the same module-resolution flow as `import rust` / `import python` / `import typescript`. See [[01-language-surface]] §1, [[06-go-module-publish-flow]] §2.
+
+5. **Mochi → Go library module emission via a new `TargetGoLibrary` MEP-54 target, parallel to the existing `TargetGoModule`.** MEP-54 today exposes `TargetGoBinaryLinuxAmd64`, `TargetGoBinaryLinuxArm64`, `TargetGoBinaryDarwinAmd64`, `TargetGoBinaryDarwinArm64`, `TargetGoBinaryWindowsAmd64`, `TargetGoBinaryFreeBSDAmd64`, `TargetGoModule` (emit-the-source-tree only, no build), `TargetGoWasmJS`, and `TargetGoWasiP1`. MEP-74 adds `TargetGoLibrary`. Where `TargetGoModule` writes a `package main` with a `func main()`, the library path emits a `package <name>` with `func`, `type`, `const`, and `var` declarations mirroring the Mochi package's public surface; sets `module <vanity-import-path>` in `go.mod`; runs the bridge's cbindgen-equivalent (a built-in `_cgo_export.h` emitter; cgo's standard tooling already does this when `-buildmode=c-archive` is used, but the library target also emits a plain Go header for non-Go non-cgo consumers); populates the publish-side metadata (the `doc.go` with the package summary, the `README.md` at the repo root, the `LICENSE` file, the `// Package foo provides ...` first-sentence rule godoc enforces) from the Mochi package's `mochi.toml`; and emits a `go.sum` pinning every transitive dependency. The driver's `Build` function gates the library path on `Driver.LibraryMode=true` plus `target == TargetGoLibrary`. See [[01-language-surface]] §3, [[06-go-module-publish-flow]] §1.
+
+6. **Git-tag-based publish to a user-owned git repo, with the module proxy and sum.golang.org picking it up automatically, plus an optional Sigstore cosign signature on a sibling `<tag>.sig` tag.** Go has no central package registry analogous to crates.io, npm, or PyPI. Module publication is a git operation: tag a commit with a semver-compatible tag (e.g., `v1.2.3`) and push the tag to the canonical-import-path repo. The next time a Go user `go get`s the module, the module proxy at `proxy.golang.org` fetches the new tag, computes the `h1:` hash, submits it to the Go checksum database (sum.golang.org, a Merkle-tree transparency log operated by the Go team), and serves the result. There is no upload endpoint. MEP-74's publish flow:
+
+    1. Builds the library module via `TargetGoLibrary`.
+    2. Validates `go vet ./...` and `gofmt -l ./...` produce zero diagnostics.
+    3. Runs `go build ./...` against the emitted module to confirm it compiles.
+    4. Tags the canonical-import-path repo at HEAD with the requested semver tag.
+    5. Optionally constructs a Sigstore cosign signature over the git tag's commit SHA via the OIDC token from the CI environment, attaches the signature blob as a sibling git tag `<tag>.sig` (the gosum-cosign workflow draft of 2026-Q1; the Go team has not committed to a canonical signing format yet, but cosign-over-git-tag is the front-runner).
+    6. Pushes the tag (and optionally `<tag>.sig`) to the canonical-import-path remote.
+    7. Optionally pings `proxy.golang.org/<module-path>/@v/<tag>.info` to warm the module proxy's cache.
+
+    The `mochi pkg publish --to=go+git+<repo-url>@<tag>` CLI orchestrates this. The legacy upload-to-a-private-registry path (e.g., Athens, JFrog Go) is supported via `--to=go+goproxy+<url>` which uploads a `.zip` to a private GOPROXY-compatible server. There is no `GO_PROXY_TOKEN` analogue; authentication to the publish endpoint (git over SSH, or HTTPS-with-PAT) is the user's existing git authentication. See [[06-go-module-publish-flow]] §1, [[07-sigstore-go-checksumdb]] §1.
+
+7. **Goroutine bridge that exposes Go's first-class concurrency (`go` statement, `chan`, `select`) to Mochi without a runtime singleton.** Unlike the Rust bridge's tokio singleton problem, Go's runtime ships with the goroutine scheduler built in: a Go function called from Mochi via cgo runs on a Go runtime thread (cgo callbacks acquire a per-call goroutine), and the function can spawn its own goroutines with the `go` statement freely. The bridge has no global runtime to construct. The bridge does need to map Mochi's `spawn <expr>` to the wrapper's `go <expr-shim>()` and Mochi's `stream<T>` to the wrapper's `chan T`; these mappings happen at wrapper-synthesis time, with the wrapper holding a `sync.Map` of active channels keyed by opaque handle ID. The wrapper exposes per-channel `_send`, `_recv`, and `_close` cgo-exported functions. The runtime cost of cgo-calling into Go is ~200ns per call (measured on darwin-arm64, Go 1.23, May 2026) plus the goroutine context-switch cost if the called function blocks. This is materially higher than Mochi-native function calls; programs that hot-loop across the cgo boundary pay this cost per iteration. See [[08-goroutine-bridge]] §1, [[02-design-philosophy]] §4.
+
+8. **sum.golang.org checksum-DB integration as a hard prerequisite of every lock operation; private-module `GONOSUMCHECK` is opt-in per-module only.** The Go ecosystem ships an unusually strong supply-chain story by 2026 standards: the module proxy at `proxy.golang.org` and the checksum database at `sum.golang.org` are jointly operated by the Go team, and every `go get` of a public module since Go 1.13 (September 2019) is verified against the checksum DB by default. The checksum DB is a Merkle-tree transparency log: every published module version is appended, and the log's signed tree head is anchored in the public timeline. MEP-74 requires that every `[[go-package]]` lock entry record both the BLAKE3-256 of the .zip module artefact (the bridge's authoritative hash) AND the `h1:` hash sum.golang.org publishes (cross-checked against the public DB at lock time). The cross-check is a hard error on mismatch (the `h1:` differs from the artefact the bridge downloaded → the proxy is lying or the upstream module was rewritten → the lock fails until the user explicitly accepts the new hash). The Go-private-module workflow (where the module path is not publicly resolvable; e.g., a corporate `corp.example.com/internal/foo`) opts out via `[go.private] modules = ["corp.example.com/**"]` in `mochi.toml`, mirroring the `GOPRIVATE` / `GONOSUMCHECK` Go-side environment variables. See [[07-sigstore-go-checksumdb]] §1, [[02-design-philosophy]] §5.
+
+The gate for each delivery phase is empirical: the bridge must successfully ingest a curated 24-module fixture corpus (drawn from the April 2026 top-25-most-imported-on-pkg.go.dev snapshot: github.com/stretchr/testify, github.com/spf13/cobra, github.com/spf13/viper, github.com/sirupsen/logrus, github.com/google/uuid, github.com/gorilla/mux, github.com/pkg/errors, github.com/google/go-cmp, github.com/golang/protobuf, github.com/json-iterator/go, github.com/davecgh/go-spew, github.com/golang/mock, github.com/cespare/xxhash/v2, github.com/mattn/go-isatty, github.com/klauspost/compress, github.com/prometheus/client_golang, go.uber.org/zap, gopkg.in/yaml.v3, github.com/spf13/pflag, github.com/gin-gonic/gin, github.com/labstack/echo/v4, github.com/valyala/fasthttp, github.com/jmoiron/sqlx, github.com/fatih/color); generate a translatable surface for every public item the closed type-table covers; emit a `SkipReport` for every item out of table; produce a Mochi `extern fn` corpus that parses cleanly; and build the resulting wrapper-plus-Mochi binary via MEP-54's existing `go build` path with zero additional flags. A separate publish gate exercises the `TargetGoLibrary` path against an in-tree mock git remote and a mock GOPROXY (the same `goproxy-mock` harness that MEP-57 phase 11 introduced), asserts that the published module `go get`s cleanly into a synthetic downstream consumer, and asserts that the optional cosign signature verifies against the Sigstore root of trust.
+
+## Motivation
+
+Mochi today (May 2026) integrates with foreign ecosystems through four FFI surfaces: Go (via MEP-54 phase 10's `import go "<package>"` flow, name-mangled and linked through the host Go toolchain, but with no version pinning), Python (via `import python "<module>"`), TypeScript / Deno (via `import typescript "<spec>"`), and Rust (via MEP-73's `import rust "<crate>@<semver>"`, with full version-pinning + capability + sumdb-equivalent). The Go surface is the oldest and the least developed of the four despite Go being Mochi's primary host-language target: MEP-54 phase 10 admits any `import go "<package>"` and trusts whatever is in the user's `GOPATH` or `GOROOT`. There is no manifest entry, no lockfile entry, no version constraint, no checksum verification, no capability declaration, no publish path. The MEP-74 motivation is to close that gap and bring the Go bridge to parity with MEP-73 Rust:
+
+1. **The Go module ecosystem is the canonical 2024-2026 destination for backend services, cloud infrastructure tooling, CLI applications, CI tooling, observability stacks, and the broad Kubernetes / container-orchestration / cloud-native world.** pkg.go.dev indexes 1.5M+ modules (April 2026 snapshot); the top-1000 most-imported modules account for 90%+ of the Go imports observed across the public pkg.go.dev backend (Q1 2026 internal stats). A Mochi program needing JSON Schema validation (`xeipuuv/gojsonschema`), modern HTTP routing (`gin-gonic/gin`, `labstack/echo`, `valyala/fasthttp`), zero-allocation logging (`uber-go/zap`), cobra-based CLI scaffolding (`spf13/cobra`), or proto3 serialisation (`golang/protobuf`, `protocolbuffers/protobuf-go`) has only a name-resolution-best-effort path today.
+
+2. **The Go ecosystem expects publishable Go modules as the unit of distribution; Mochi must learn to emit one.** When a Mochi package author writes a useful library, the natural distribution channel for a Go-using audience is a tagged commit on a public git repo with a proper `go.mod`. MEP-54 phase 15 (the `go-module` target) writes a source tree but does not produce a publish-ready library module: there is no `doc.go` package comment, no godoc-formatted public-API surface, no `go.sum`, no transitive-dep pinning, no LICENSE harvest from `mochi.toml`. MEP-74 extends MEP-54 to emit user packages as publish-ready library modules with the right metadata.
+
+3. **Go's checksum-DB-as-transparency-log is the closest thing the Go ecosystem has to crates.io's RFC #3724 trusted publishing, and Mochi's lockfile must integrate with it.** sum.golang.org has operated since September 2019 (Go 1.13) as a Merkle-tree transparency log of every public Go module version. Every Go user's `go get` validates against the DB by default. A 2026 Mochi-to-Go bridge that does not cross-check `[[go-package]]` lockfile hashes against sum.golang.org is shipping a weaker supply-chain story than `go get` itself. The cross-check is a one-RTT HTTP GET per dep at lock time; the cost is negligible; the safety gain is substantial.
+
+4. **The "import go" surface has zero learning curve for Mochi users.** `import go "github.com/spf13/cobra@^v1.8" as cobra` is the same shape as `import rust "tokio@^1.42"` and `import python "numpy"`. Mochi users do not need to know what a `go.mod` is, what a `go.sum` is, what `replace` directives are, what `go vet`'s pure-Go subset rules are, what a build tag is, what a goroutine is, what `cgo` is, what `//export` is, what `unsafe.Pointer` is, what a vanity import path is, what a pseudo-version is, what sum.golang.org's `h1:` hash format is. They write `import go "..." as ...` and the bridge does the rest.
+
+5. **`go/packages` + `go/types` give Mochi a turn-key stable, machine-readable, in-stdlib API surface for every Go module.** Unlike rustdoc-JSON (which is nightly-only and behind `-Z unstable-options` as of MEP-73 spec authoring), the Go ingest path is stable, ships in the standard library extension `golang.org/x/tools`, and has been API-stable since 2018. The bridge ingest binary is a ~300-LOC Go program that loads the module with `packages.Load(packages.NeedTypes | packages.NeedDeps | packages.NeedTypesInfo)`, walks every `*types.Package`, and emits a JSON document the bridge consumes. No nightly toolchain. No experimental flag. No schema-version pinning needed. This is materially less risky than MEP-73's rustdoc-JSON ingest.
+
+6. **MEP-57 + MEP-73 already shipped the prerequisite manifest / lockfile / capability / publish infrastructure.** The `mochi.toml` table layout, the `mochi.lock` serialisation, the BLAKE3-256 + secondary-hash dual-hashing, the trusted-publishing OIDC token exchange model, the content-addressed object store, and the capability declaration scheme all transfer to the Go bridge with no architectural duplication. MEP-74 is additive on top of MEP-57 + MEP-73: one new manifest section (`[go-dependencies]`), one new lockfile repeated table (`[[go-package]]`), one new CLI surface (`mochi pkg publish --to=go+git+...`).
+
+7. **The bridge stays small and audit-friendly.** The reference implementation under `package3/go/` is targeted at ~5,500 LOC of Go across the module-proxy client, the sum.golang.org cross-check, the `go/packages` ingest binary, the type-mapping pass, the cgo wrapper synthesiser, the Mochi extern emitter, the lockfile integrator, the git-tag publish flow, and the goroutine-bridge runtime hook. There is no Go-side dynamic codegen at user-machine time (the wrapper is fully synthesised by the Go-side bridge binary; the user's `go build` only compiles, never generates code from `go/packages`). There is no `unsafe.Pointer` in the synthesised wrapper unless the user opts in via `[capabilities] unsafe = true`.
+
+8. **The bridge closes a competitive gap with the Rust bridge.** MEP-73 shipped a full bidirectional Rust bridge with semver pinning, capability declaration, lockfile cross-check, and publish-to-crates.io. The Go bridge under MEP-54 phase 10 lags on every one of those axes. Closing the gap is a one-MEP investment; deferring it would push the Mochi-Go interop story behind the Mochi-Rust interop story, which is the wrong relative ordering given that Go is Mochi's host language and Go is the more widely deployed of the two ecosystems by deployed-instance count.
+
+## Specification
+
+This section is normative. Sub-notes under [/docs/research/0074/](/docs/research/0074/) are informative.
+
+### 1. Pipeline overview
+
+MEP-74 introduces a per-import Go dependency resolution layer that sits between the Mochi parser (after MEP-57 has resolved `mochi.toml`) and the MEP-54 build driver:
+
+```
+mochi.toml [go-dependencies]
+   |  pkgmanifest.Parse + pkgsolver.Solve (MEP-57)
+   v
+resolved Go dep tree (module path + version + source URL)
+   |  package3/go/goproxy.Fetch (proxy.golang.org sparse-index protocol)
+   v
+.zip module artefacts in ~/.cache/mochi/go-deps/<blake3-hex>/
+   |  package3/go/sumdb.Verify (sum.golang.org h1: cross-check)
+   v
+hash-verified module sources
+   |  package3/go/cmd/go-ingest (go/packages.Load + types walk, JSON emit)
+   v
+ApiSurface JSON document per module
+   |  package3/go/typemap.Translate (closed Go-to-Mochi table)
+   v
+TranslatedSurface + SkipReport per module
+   |  package3/go/wrapsyn.Emit (synthesised cgo wrapper package)
+   v
+go_wrap/<module>/ Go package source tree
+   |  package3/go/externemit.Emit (Mochi extern fn / extern type)
+   v
+synthesised .mochi shim file per module, imported by the user's source
+   |  MEP-54 Driver.Build (TargetGoBinary* / TargetGoLibrary)
+   v
+binary or library module
+```
+
+The bridge does not invoke `go build` at ingest time. The only Go toolchain invocation is the `go-ingest` helper binary, which calls `go/packages.Load` on the cached module sources to produce the ApiSurface JSON. The wrapper package is emitted as source by the Go-side bridge binary and built by the user's normal `go build` (orchestrated by the MEP-54 driver) alongside the user's program.
+
+### 2. Manifest extension: `[go-dependencies]` and `[go]`
+
+The MEP-57 `mochi.toml` gains two new optional top-level tables:
+
+```toml
+[go-dependencies]
+"github.com/spf13/cobra" = "^v1.8.0"
+"github.com/sirupsen/logrus" = { version = "^v1.9", build-tags = ["json_logging"] }
+"go.uber.org/zap" = "^v1.27"
+"gopkg.in/yaml.v3" = "^v3.0.1"
+"my-local-module" = { path = "../my-module" }
+"my-git-fork" = { git = "https://github.com/example/my-fork", rev = "abc123def4" }
+
+[go]
+go-version = "1.23"
+goroutine-bridge = { default-buffer = 1, max-handles = 4096 }
+monomorphise = [
+    { item = "encoding/json.Unmarshal", T = "MyStruct" },
+    { item = "sync.Pool", T = "MyStruct" },
+]
+build-tags = ["json_logging", "go_purego"]
+
+[go.publish]
+canonical-import-path = "github.com/example/my-mochi-lib"
+go-version-floor = "1.21"
+license = "Apache-2.0 OR MIT"
+cgo-export = true
+
+[go.capabilities]
+net = true
+fs = false
+proc = false
+cgo = false
+unsafe = false
+
+[go.private]
+modules = ["corp.example.com/**"]
+sumdb-skip = ["corp.example.com/**"]
+```
+
+`[go-dependencies]` follows Go's `go.mod` `require` grammar verbatim: simple string for version, table for inline version + build-tags + path / git / branch / rev / tag. This is intentional: Mochi users with Go background can copy from existing `go.mod` files without translation; the bridge passes the table through to the synthesised wrapper module's `go.mod` with no edits.
+
+The `[go]` table holds Mochi-specific knobs:
+
+- `go-version`: the Go toolchain minimum the wrapper module declares (matches MEP-54's floor). Default `"1.21"`.
+- `goroutine-bridge.default-buffer`: default channel buffer size when a Go `chan T` is exposed as a Mochi `stream<T>`. Default `1` (unbuffered Go channels have `cap == 0` but the wrapper allocates a 1-buffered channel to avoid lock-step semantics).
+- `goroutine-bridge.max-handles`: maximum live cgo handles before the wrapper rejects new ones (a defensive bound; the underlying `cgo.Handle` is uint64 so the hard limit is 2^64, but a soft limit prevents leak amplification).
+- `monomorphise`: a list of explicit generic instantiations. For each entry, the bridge emits the wrapper for `<item><T>` rather than refusing the import (the default behaviour for generic items). Required for Go 1.18+ generic items.
+- `build-tags`: build tags the wrapper compilation respects. Mirrors the Go `-tags` flag.
+
+The `[go.publish]` table holds Mochi-as-library knobs:
+
+- `canonical-import-path`: the module path the published `go.mod` declares (e.g., `github.com/example/my-mochi-lib`). REQUIRED when `mochi pkg publish --to=go+git+...` is invoked.
+- `go-version-floor`: the minimum Go toolchain the published module supports. Written into `go.mod`'s `go <version>` directive.
+- `license`: the SPDX licence expression. Written into the package-root LICENSE file plus the `doc.go` first line.
+- `cgo-export`: whether to emit `_cgo_export.h` for non-Go consumers. Default `false`.
+
+The `[go.capabilities]` table holds Go-bridge-specific capability flags (a strict refinement of MEP-57's `[capabilities]` table):
+
+- `net`: the Go dep graph contains modules that open network sockets (`net.Dial`, `net/http`, gRPC).
+- `fs`: the dep graph reads or writes files (`os.Open`, `io/fs`).
+- `proc`: the dep graph spawns processes (`os/exec.Command`).
+- `cgo`: the dep graph contains files with `import "C"`.
+- `unsafe`: the dep graph contains files importing `unsafe`.
+
+The `[go.private]` table opts modules out of the sum.golang.org cross-check:
+
+- `modules`: glob patterns of canonical-import-paths the proxy should not be queried for (the bridge bypasses `proxy.golang.org` and reaches the upstream git repo directly).
+- `sumdb-skip`: glob patterns for which the bridge skips the `sum.golang.org` cross-check. Defaults to the `modules` value.
+
+### 3. Lockfile extension: `[[go-package]]`
+
+The MEP-57 `mochi.lock` gains one new repeated table:
+
+```toml
+[[go-package]]
+module = "github.com/spf13/cobra"
+version = "v1.8.0"
+source = { kind = "module-proxy", proxy = "https://proxy.golang.org" }
+zip-blake3 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+zip-h1 = "h1:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+sumdb-verified = true
+sumdb-tree-size = 12345678
+sumdb-record-hash = "abc...def"
+api-surface-sha256 = "..."
+wrapper-sha256 = "..."
+capabilities-declared = ["fs"]
+dependencies = ["github.com/spf13/pflag@v1.0.6", "github.com/inconshreveable/mousetrap@v1.1.0"]
+build-tags = []
+```
+
+`zip-blake3` is the BLAKE3-256 of the module .zip artefact (the bridge's primary verification hash, matches MEP-57's broader BLAKE3 + secondary-hash rule).
+
+`zip-h1` is the Go ecosystem's `h1:` hash: `"h1:" + base64.StdEncoding.EncodeToString(sha256(zip-content))`. This is what sum.golang.org publishes. The bridge cross-checks `zip-h1` against the public DB at lock time.
+
+`sumdb-verified` records whether the cross-check succeeded. `true` is the only acceptable value for public modules; `[go.private]` modules record `false` plus a comment naming the override.
+
+`sumdb-tree-size` records the global checksum-DB tree size at lock time (the Merkle tree's leaf count when this module was looked up). The tree size is monotonic; a future `--check` can request a consistency proof from sum.golang.org showing that the lock-time leaf is still in the current tree.
+
+`sumdb-record-hash` records the SHA-256 of the specific log record for this module version (the canonical record body is `<module> <version> <h1:hash>` plus a `\n`-separator).
+
+`api-surface-sha256` records the SHA-256 of the JSON ApiSurface the bridge ingested. A drift here at `--check` time is a hard error (the upstream module silently changed its public surface).
+
+`wrapper-sha256` records the SHA-256 of the synthesised wrapper package's source tree (concatenated file-by-file). A drift here at `--check` time is a hard error.
+
+`capabilities-declared` is the capability set the manifest declared at lock time.
+
+`dependencies` is the resolved transitive dep graph.
+
+`build-tags` is the build-tag set the lock was taken under (different tag sets produce different ApiSurface trees; the lockfile pins the tag set).
+
+### 4. Surface syntax: `import go "..." as <alias>` (extended)
+
+The Mochi grammar's existing FFI-import production (already shipping for MEP-54 phase 10):
+
+```
+ImportStmt := "import" Lang? StringLit "as" Ident ("auto")?
+Lang := "go" | "python" | "typescript" | "rust"
+```
+
+The `go` `<lang>` token was wired by MEP-54 phase 10 for bare-name imports (`import go "fmt"`). MEP-74 extends the `<spec>` form to admit:
+
+- `<module-path>`: bare module path. Resolves through `[go-dependencies]` plus `mochi.lock`.
+- `<module-path>@<semver-req>`: explicit version constraint.
+- `<module-path>@<pseudo-version>`: pseudo-version `v0.0.0-YYYYMMDDhhmmss-shortrev`.
+- `<module-path>@git+<url>` or `<module-path>@git+<url>#<rev>`: git source.
+- `<module-path>@path+<relative>`: path source.
+
+Example surface:
+
+```mochi
+import go "github.com/spf13/cobra@^v1.8" as cobra
+import go "github.com/sirupsen/logrus" as log
+import go "go.uber.org/zap@v1.27.0" as zap
+
+fn main() {
+    let cmd = cobra.new_command()
+    cmd.set_use("hello")
+    cmd.set_short("say hello")
+    cmd.set_run(fun(args: list<string>) {
+        log.info("hello, world")
+    })
+    cmd.execute()
+}
+```
+
+The `<alias>` introduces a Mochi namespace. Symbol resolution looks up `<alias>.<item>` and binds against the synthesised `extern fn` declaration the bridge generated for `<module-path>.<Item>`. Item names: Go's exported items are PascalCase; the bridge auto-lowercases the first letter to match Mochi's snake_case / camelCase convention (`cobra.Command` → `cobra.command`, `cobra.NewCommand` → `cobra.new_command`). This rename pass is reversible (each emitted `extern fn` carries a `from go "<module>.<OrigName>"` clause).
+
+The `auto` modifier (already accepted by MEP-54 phase 10 for `import go ... auto`) carries forward unchanged.
+
+### 5. CLI surface
+
+The Mochi CLI gains the following additions, all under the existing `mochi pkg` subcommand:
+
+- `mochi pkg add go <module>[@<semver>]`: adds an entry to `[go-dependencies]` and runs `mochi pkg lock`.
+- `mochi pkg lock`: as today (MEP-57), now extended to walk `[go-dependencies]`, query the Go module proxy for resolution, fetch each module .zip into the content-addressed cache, cross-check against sum.golang.org, run `go-ingest` to produce ApiSurface JSON, synthesise the wrapper, and write `[[go-package]]` entries.
+- `mochi pkg lock --check`: as today, now extended to verify `zip-blake3`, `zip-h1`, `sumdb-record-hash`, `api-surface-sha256`, `wrapper-sha256`, and `capabilities-declared` for every `[[go-package]]` entry.
+- `mochi pkg lock --sumdb-consistency`: optionally fetches a Merkle consistency proof from sum.golang.org showing the lock-time tree leaf is still in the current tree (cost: ~2 RTTs per dep; the bridge runs this in parallel).
+- `mochi pkg publish --to=go+git+<repo-url>@<tag> [--dry-run] [--cosign-sign]`: builds the package as a Go library module via `TargetGoLibrary`, validates with `go vet` + `gofmt`, runs `go build`, tags the canonical-import-path repo, optionally cosign-signs the tag, pushes. `--dry-run` skips the push.
+- `mochi pkg publish --to=go+goproxy+<url>` (alternative): uploads the module .zip to a private GOPROXY-compatible endpoint instead of git-tagging.
+- `mochi pkg sync go`: regenerates the wrapper package from scratch (without changing the lockfile). Used after manual edits to the synthesised shim file.
+
+### 6. Build orchestration
+
+When a Mochi program contains one or more semver-pinned `import go "..."` declarations, the MEP-54 build driver gains the following extensions:
+
+1. Before invoking `go build`, the driver invokes `package3/go/Bridge.PrepareWorkspace(workdir, mochiLock)` which:
+   - For each `[[go-package]]` in `mochi.lock`, materialises the module source from the content-addressed cache into `<workdir>/go_deps/<module>-<version>/`.
+   - Materialises the synthesised wrapper package into `<workdir>/go_wrap/<module>/`.
+   - Writes a `<workdir>/go.mod` module manifest with `replace` directives for every materialised module (matches the existing `go-module` target's pattern) plus every wrapper package as a `replace` to its workspace path.
+
+2. The MEP-54 emit pass treats each `import go "<module>" as <alias>` (now semver-pinned) as a Mochi `import "./go_wrap/<module>/shim.mochi" as <alias>` shim, where the shim file is the `extern fn` corpus the bridge emitted.
+
+3. The wrapper package's `go.mod` declares the source module as a `require` entry with the exact version pinned from `mochi.lock`.
+
+4. The user's `go build` (invoked by `Driver.Build`) compiles the wrapper, the main package, and the source modules together. Wrapper packages compiled for a binary target are linked statically; wrapper packages compiled for `TargetGoLibrary` are exported via `//export` and built with `-buildmode=c-archive`.
+
+5. The driver invalidates the cache when any `[[go-package]]` `wrapper-sha256` changes (per MEP-54 phase 0's cache-key construction).
+
+### 7. Goroutine bridge runtime hook
+
+The wrapper package for any source module that exposes `chan T` or `func(...)` callback parameters includes a generated `mochi_rt.go` file:
+
+```go
+//go:build mochi_wrap
+
+package gowrap_<module>
+
+import (
+    "runtime/cgo"
+    "sync"
+)
+
+var (
+    handlesMu sync.Mutex
+    handles   = map[uint64]cgo.Handle{}
+    nextID    uint64
+)
+
+func acquireHandle(v any) uint64 {
+    handlesMu.Lock()
+    defer handlesMu.Unlock()
+    nextID++
+    h := cgo.NewHandle(v)
+    handles[nextID] = h
+    return nextID
+}
+
+func releaseHandle(id uint64) {
+    handlesMu.Lock()
+    h, ok := handles[id]
+    if ok {
+        delete(handles, id)
+    }
+    handlesMu.Unlock()
+    if ok {
+        h.Delete()
+    }
+}
+
+func resolveHandle(id uint64) any {
+    handlesMu.Lock()
+    defer handlesMu.Unlock()
+    return handles[id].Value()
+}
+```
+
+Channel and callback bindings use `acquireHandle` / `releaseHandle` to bridge the cgo boundary safely. Pure-sync modules (no `chan`, no callback params, no exported method that returns one) skip the runtime file entirely and pay zero cgo-handle cost.
+
+### 8. sum.golang.org cross-check
+
+At lock time, for each public (non-`[go.private]`) module, the bridge issues two HTTP GETs to `https://sum.golang.org`:
+
+1. `GET /lookup/<module>@<version>` returns the canonical record body (`<module> <version> h1:<base64-sha256>\n`) plus the signed tree head at the time of the lookup.
+2. `GET /tile/8/0/<...>` fetches the Merkle tile path proving the record is in the tree.
+
+The bridge verifies:
+
+- The record's `h1:` field equals the `h1:` the bridge computed from the downloaded .zip.
+- The record is included in the tree via the tile path.
+- The tree head signature is valid against the Go team's sum.golang.org public key (hard-coded in the bridge).
+
+A mismatch on any of these three is a hard error at `mochi pkg lock` time. The user can override by adding the module to `[go.private] sumdb-skip = [...]`, which records `sumdb-verified = false` in the lockfile.
+
+## Phases
+
+See [/docs/implementation/0074/](/docs/implementation/0074/) for the per-phase tracking matrix. Eighteen phases cover skeleton (0), module-proxy client (1), sum.golang.org client (2), `go/packages` ingest helper (3), ApiSurface JSON schema (4), type-mapping table (5), cgo wrapper synthesiser (6), Mochi extern emitter (7), import-go grammar extension (8), build orchestration (9), mochi.lock integration (10), TargetGoLibrary emit (11), git-tag publish flow (12), cosign signing on `<tag>.sig` (13), goroutine bridge (14), monomorphisation of generics (15), TinyGo / embedded subset (16), and vanity-import-path resolver + WASI publish gate (17).
+
+A phase is LANDED only when its gate is green for every target in the matrix below.
+
+### Target matrix
+
+| Phase | host stable go 1.23 (darwin-arm64) | linux-amd64 / linux-arm64 | windows-amd64 | wasm-wasip1 / wasm-js | tinygo embedded |
+|-------|------------------------------------|-----------------------------|----------------|------------------------|------------------|
+| 0. skeleton | NOT STARTED | n/a | n/a | n/a | n/a |
+| 1. module-proxy client | NOT STARTED | n/a | n/a | n/a | n/a |
+| 2. sum.golang.org client | NOT STARTED | n/a | n/a | n/a | n/a |
+| 3. go/packages ingest | NOT STARTED | n/a | n/a | n/a | n/a |
+| 4. ApiSurface JSON | NOT STARTED | n/a | n/a | n/a | n/a |
+| 5. type-mapping table | NOT STARTED | required | required | required | required |
+| 6. cgo wrapper synthesiser | NOT STARTED | required | required | n/a (cgo off on wasm) | required (no_cgo subset) |
+| 7. extern emitter | NOT STARTED | required | required | required | required |
+| 8. import-go grammar (semver) | NOT STARTED | required | required | required | required |
+| 9. build orchestration | NOT STARTED | required | required | required (no cgo) | required |
+| 10. mochi.lock integration | NOT STARTED | required | required | required | required |
+| 11. TargetGoLibrary emit | NOT STARTED | required | required | required | required |
+| 12. git-tag publish | NOT STARTED | n/a (publish is host-only) | n/a | n/a | n/a |
+| 13. cosign on tag.sig | NOT STARTED | n/a | n/a | n/a | n/a |
+| 14. goroutine bridge | NOT STARTED | required | required | n/a (no goroutines on wasm-js without scheduler shim) | required |
+| 15. monomorphisation | NOT STARTED | required | required | required | required |
+| 16. TinyGo embedded subset | NOT STARTED | n/a | n/a | required (wasm-js via tinygo) | required |
+| 17. vanity-import + WASI publish | NOT STARTED | required | required | required | n/a |
+
+A phase marked `n/a` for a target is intentional: the bridge does not promise the behaviour on that target.
+
+## Alternatives considered
+
+1. **Parse Go source directly with `go/parser` instead of via `go/packages`.** Rejected: `go/parser` returns an untyped AST; the bridge needs `types.Type` to translate accurately. `go/packages` is exactly the right level (it runs `go/parser` plus `go/types` plus dep resolution). There is no win from going one level lower in the Go stdlib.
+
+2. **Use `pkg.go.dev`'s HTML rendering as the API source.** Rejected: HTML is rendered for human reading, not normative. The same data lives in `go/packages` in machine form.
+
+3. **Use `gomobile bind`'s `.aar` / `.framework` output as the bridge surface.** Rejected: `gomobile bind` supports a tiny subset of Go (no generics, no channels in exported positions, no interfaces with non-builtin types in method signatures). MEP-74 needs the full surface.
+
+4. **Generate cgo source code with hand-written `//export` directives (a la `gobind`).** Rejected: this IS what MEP-74 does, just with a closed type table and the type-mapping decisions made by the bridge rather than by the user. `gobind`'s approach (the user writes the bridge interface) is the boilerplate violation MEP-74 was designed to avoid.
+
+5. **Use Go's `plugin` build mode instead of `c-archive`.** Rejected: `plugin` is linux-only, has hard limitations on cross-package symbol visibility, and has known dlopen-time crashes on Go version drift. `c-archive` is portable across darwin, linux, windows, freebsd.
+
+6. **Use protobuf or flatbuffers as the cross-boundary serialisation instead of cgo.** Rejected: introduces a runtime dependency the user did not opt into, adds 100ns+ per call for the marshal step, and would still need cgo for the actual call dispatch. The cgo path is the shortest.
+
+7. **Translate Go's goroutine scheduler into Mochi's host runtime.** Rejected: Go's goroutine scheduler is deeply tied to the Go runtime (GC interaction, preemption via segmented stacks, channel multiplexing in `runtime/chan.go`). Reimplementing it in Mochi would be a 10,000+ LOC project and would lag the Go team's optimisations. The bridge sidesteps the impedance by letting the Go runtime's scheduler run inside the cgo c-archive; Mochi just calls cgo functions and waits for them to return.
+
+8. **Treat the Go module proxy's `info`, `mod`, `zip` triple as the bridge surface (skip `go/packages`).** Rejected: the triple is enough for fetch + verify but does not parse the Go source. The bridge still needs `go/packages` for type-aware translation.
+
+9. **Allow long-lived `GOPROXY` API tokens for private-module fetch.** Acknowledged but not rejected: private modules legitimately need authentication. The bridge supports `GOPROXY` env-var passthrough and `.netrc`-style git-credential helpers for private remotes. There is no long-lived token to "publish" because publishing is a git push to a user-controlled remote.
+
+10. **Sigstore-keyless mandatory for publish (mirror MEP-73's stance).** Rejected for v1: the Go ecosystem has not converged on a canonical signing format. The gosum-cosign workflow draft of 2026-Q1 is the front-runner but has not landed in any production Go tooling. MEP-74 ships `--cosign-sign` as opt-in and re-evaluates the default when the Go team publishes a canonical signing spec.
+
+11. **Use `golang.org/x/mod` as a dep instead of re-implementing the module-proxy client in `package3/go/goproxy`.** Accepted partially: the bridge uses `golang.org/x/mod/module` and `golang.org/x/mod/semver` for module path validation and semver comparison (these are pure functions with no I/O). The bridge re-implements the HTTP client for the proxy because the bridge needs to interleave the BLAKE3-256 hash computation with the .zip download, which is awkward with the upstream client.
+
+12. **Use `cgo`-less wrappers via `purego` (a Go library that calls into shared libraries via dlopen without cgo).** Rejected for v1: `purego` is a recent project (first commit 2022, GA 2024) that requires the source module ship a `.so`/`.dylib`. Most pkg.go.dev modules are pure Go; they do not ship binaries. The cgo path covers more modules.
+
+13. **Hand-author the type-mapping table per-module rather than have one shared closed table.** Rejected: this is the MEP-73 cxx-style violation. The closed table is a one-time investment that covers every module.
+
+14. **Use the wazero runtime for wasm-target Go interop rather than the cgo path.** Acknowledged: wazero is the right tool when the source module compiles to wasm. The bridge's wasm-wasip1 target uses wazero internally for the wasm execution; the wrapper synthesis is the same.
+
+## Risks
+
+1. **The cgo cost per call is real.** A Mochi loop calling into a Go function 1M times pays ~200ms cumulative cgo overhead on darwin-arm64 (200ns × 1M). Hot loops should batch. Mitigation: the wrapper synthesiser detects hot-path candidates (functions whose Mochi caller is in a `for` body) and offers a `batched` variant that takes a slice on the input side, dispatches once, and returns a slice on the output side. Documented in [[09-abi-stability]] §3.
+
+2. **Go's GC and cgo interact non-trivially.** A pointer the Go side passes to the C side via `//export` is NOT GC-managed on the C side; the C side must release it explicitly via the matching `_free` symbol or the underlying Go object becomes unreachable from Go GC's perspective and may be moved. Mitigation: the wrapper synthesiser inserts `runtime.KeepAlive` calls at the end of every `//export` function, and the wrapper documents the ownership contract per item. See [[09-abi-stability]] §2.
+
+3. **Generic monomorphisation explosion.** A Go module that exposes a generic function over N types and the user lists M monomorphisations produces a wrapper with M cgo exports. The combinatorial explosion is real. Mitigation: the `[go.monomorphise]` table is required to enumerate; the bridge does not auto-monomorphise.
+
+4. **The Go module proxy can serve a different .zip than the upstream git repo if proxy.golang.org is compromised.** The sum.golang.org cross-check is the mitigation; the bridge always cross-checks unless `[go.private] sumdb-skip` opts out.
+
+5. **sum.golang.org operates a single signing key.** The transparency log's tree-head signature is signed by one Go-team-controlled key. If that key is compromised, the cross-check provides no protection. Mitigation: this is the same trust assumption every `go get` makes by default. Mochi adopts the same trust model. A future sub-phase could integrate with a second log (e.g., Sigstore Rekor) for defence-in-depth.
+
+6. **TinyGo embedded subset is small.** TinyGo (the alternative Go compiler for microcontrollers, gaining traction since 2018) supports a subset of the Go stdlib and a subset of pkg.go.dev modules (estimated 8-15% of the top 1,000 are TinyGo-compatible). Modules requiring reflect, cgo, or runtime features (channels under contention, goroutine spawn-and-wait at scale) fail to compile under TinyGo. Mitigation: the embedded gate (phase 16) checks TinyGo compatibility at lock time; non-compatible modules are rejected with a clear diagnostic.
+
+7. **Build-tag-conditional code paths.** A module that conditions important code on a build tag (`//go:build json_logging`) produces a different ApiSurface under different tag sets. The lockfile pins the tag set at lock time. Mitigation: changing `[go.build-tags]` requires re-running `mochi pkg lock`; the `--check` mode catches drift.
+
+8. **Vanity import paths require an HTTP redirect.** Modules at vanity paths (`go.uber.org/zap` → `github.com/uber-go/zap`) require the bridge to honour the `<meta name="go-import">` redirect in the canonical URL's HTML response. Mitigation: the phase 17 vanity-import resolver implements the redirect logic per the Go modules spec.
+
+9. **Cross-platform `_cgo_export.h` generation.** The cgo-generated header depends on the host C compiler's pointer width and integer sizes. A wrapper built on darwin-arm64 may produce a slightly different header than the same wrapper on linux-amd64. Mitigation: the bridge writes the header to `<workdir>/go_wrap/<module>/<goarch>-<goos>.h` and the build driver picks the right one.
+
+10. **Go's `internal/` package visibility rule.** Imports of `<module>/internal/*` from outside the module tree are compile errors. The bridge respects this rule: an item whose qualified name traverses an `internal/` boundary is silently skipped (no SkipReport entry; the item is invisible to the bridge by Go's own rules).
+
+11. **Mochi-as-library `cgo` symbol collision when published as a c-archive consumed by non-Go.** Multiple Mochi libraries compiled to c-archives loaded into the same process collide on the `mochi_<module>_<fn>` symbol prefix. Mitigation: the bridge prefixes every exported symbol with the publishing module's path-hash plus its version major; collisions only arise across compatible majors of the same library.
+
+12. **Go's `go.mod` `replace` directive does not survive publish.** When a published Go module is consumed by another, the consumer's `go.mod` does NOT inherit the producer's `replace` directives. Mitigation: `mochi pkg publish` rejects publishing a module that has unresolved `replace` directives in its `[go-dependencies]`; all replaces must point to a real upstream version before publish.
+
+13. **CI image dependency on the Go toolchain plus optionally TinyGo.** The MEP-54 gates already require the Go toolchain; MEP-74 adds optional TinyGo for phase 16 and `cosign` for phase 13. The CI image is bigger. Mitigation: the standard `mochilang/ci-go` image bundles the full toolset; standalone users install via `go install` plus `brew install cosign tinygo`.
+
+## Acknowledgements
+
+This MEP builds on MEP-54 (Go transpiler) for the gotree IR, the build driver, the runtime module, the cgo build flow, the `go-module` target's source-tree emit, and the existing `import go "..."` FFI surface; on MEP-57 (Mochi module and package system) for the `mochi.toml` manifest, the `mochi.lock` lockfile, the BLAKE3 + secondary-hash dual-hashing, the content-addressed object store, and the capability declaration scheme; on MEP-45 (C transpiler) for the FFI sidecar pattern; on MEP-73 (Mochi+Rust package bridge) for the bidirectional-bridge spec template, the closed-type-table philosophy, the synthesised-wrapper-crate analogue, and the capability-monotonicity rule; on the `golang.org/x/tools/go/packages` package maintained by the Go team for the canonical ApiSurface; on the `golang.org/x/mod` module for the module-path and semver utilities; on the Go team's `sum.golang.org` and `proxy.golang.org` infrastructure for the supply-chain backbone; on the gosum-cosign workflow draft of 2026-Q1 for the publish-side signing direction; on the TinyGo project for the embedded-Go subset; on cgo, `runtime/cgo`, and the `//export` directive for the C-ABI bridge; on `gomobile bind` and `gopy` for prior art on Go-to-other-language bridging; on the wazero project for the wasm-side Go interop story; on the Athens project and JFrog Go for the alternative-GOPROXY publish surface; and on Russ Cox's modules design (the canonical golang.org/x/mod and golang.org/x/tools/go/packages design) for the entire structure the bridge plugs into.

--- a/website/docs/research/0074/01-language-surface.md
+++ b/website/docs/research/0074/01-language-surface.md
@@ -1,0 +1,250 @@
+---
+title: "01. Language surface"
+sidebar_position: 2
+sidebar_label: "01. Language surface"
+description: "The `import go \"<module>@<semver>\" as <alias>` import form, the `[go-dependencies]` / `[go]` / `[go.publish]` / `[go.capabilities]` / `[go.private]` manifest tables, the CLI subcommands (`mochi pkg add go`, `mochi pkg lock`, `mochi pkg publish --to=go+git+...`, `mochi pkg sync go`), and the per-import alias resolution rule."
+---
+
+# 01. Language surface
+
+This note covers the user-visible surface MEP-74 introduces: the import syntax (extending MEP-54 phase 10's existing `go` keyword), the manifest tables, and the CLI subcommands. Everything below is observable through `mochi --help` and `mochi.toml` schema validation; the user does not need to read the rest of the bundle to use the bridge.
+
+## Import syntax
+
+The Mochi grammar's `ImportStmt` production (MEP-1) already accepts a `Lang` token between `import` and the string literal; MEP-54 phase 10 wired the `go` alternative for bare-name imports. MEP-74 extends the `<spec>` form without introducing a new keyword:
+
+```
+ImportStmt := "import" Lang? StringLit "as" Ident ("auto")?
+Lang := "go" | "python" | "typescript" | "rust"
+```
+
+The string literal for `Lang == "go"` is one of:
+
+| Form | Resolution |
+|------|------------|
+| `<module-path>` | Bare module path (e.g., `github.com/spf13/cobra`). Resolves through `[go-dependencies]` plus `mochi.lock`. |
+| `<module-path>@<semver-req>` | Explicit constraint (`v1.8.0`, `^v1.8`, `~v1.8.0`, `>=v1.0 <v2.0`, `latest`). |
+| `<module-path>@<pseudo-version>` | Pseudo-version `v0.0.0-YYYYMMDDhhmmss-shortrev` (Go's canonical untagged-commit form). |
+| `<module-path>@git+<url>` | Git source override (used for forks). |
+| `<module-path>@git+<url>#<rev>` | Git source pinned to revision or tag. |
+| `<module-path>@path+<rel-path>` | Path source, relative to the manifest. |
+
+The first form, the bare module path, is the same shape MEP-54 phase 10 accepts today; MEP-74 keeps that compatibility and adds the `@<...>` suffix forms as opt-in. A Mochi program written against MEP-54 phase 10 continues to parse unchanged.
+
+Example surface:
+
+```mochi
+import go "github.com/spf13/cobra@^v1.8" as cobra
+import go "github.com/sirupsen/logrus" as log
+import go "go.uber.org/zap@v1.27.0" as zap
+import go "encoding/json" as json
+
+fn main() {
+    let cmd = cobra.new_command()
+    cmd.set_use("hello")
+    cmd.set_short("say hello")
+    cmd.set_run(fun(args: list<string>) {
+        log.info("hello, world")
+        let bytes = json.marshal({"k": "v"})
+        log.info(bytes.to_string())
+    })
+    cmd.execute()
+}
+```
+
+The `<alias>` introduces a Mochi namespace bound at the import site. Symbol lookup `<alias>.<item>` resolves to the synthesised `extern fn` declaration the bridge generated for the Go module's exported item.
+
+### Stdlib paths
+
+Bare stdlib paths (`encoding/json`, `net/http`, `strings`, `bytes`, `time`) are admitted without an `@<version>` suffix. The Go stdlib version is implicit: it ships with the Go toolchain, so the resolved version is the Go toolchain version (recorded in the lockfile as `version = "stdlib@<go-version>"`). Stdlib imports skip the sum.golang.org cross-check.
+
+### Name renaming
+
+Go's exported items are PascalCase by Go style; Mochi's idiom is snake_case for functions and PascalCase for types. The bridge auto-applies the following rename pass:
+
+- `cobra.NewCommand` (Go func) → `cobra.new_command` (Mochi)
+- `cobra.Command` (Go type) → `cobra.Command` (preserved; type names match)
+- `cobra.Command.SetUse` (Go method) → `cobra.Command.set_use` (snake_case method)
+- `json.MarshalIndent` (Go func) → `json.marshal_indent`
+
+The emitted `extern fn` carries a `from go "<module>.<OrigName>"` clause that records the round-trip:
+
+```mochi
+extern fn cobra.new_command(): cobra.Command from go "github.com/spf13/cobra.NewCommand"
+```
+
+This lets `mochi pkg sync go` regenerate the shim file without reading the user's source.
+
+The `auto` modifier (already accepted for `import go ... auto` since MEP-54 phase 10) is admitted unchanged. With `auto`, every public top-level item of the module is bound at file scope rather than under the alias namespace.
+
+## Manifest: `[go-dependencies]`
+
+This table is the user-facing dependency declaration. It uses Go's `require` grammar verbatim:
+
+```toml
+[go-dependencies]
+"github.com/spf13/cobra" = "^v1.8.0"
+"github.com/sirupsen/logrus" = { version = "^v1.9", build-tags = ["json_logging"] }
+"go.uber.org/zap" = "^v1.27"
+"gopkg.in/yaml.v3" = "^v3.0.1"
+"my-local-module" = { path = "../my-module" }
+"my-git-fork" = { git = "https://github.com/example/my-fork", rev = "abc123def4" }
+```
+
+The grammar:
+
+- A bare string is shorthand for `{ version = "..." }`.
+- The table form admits `version`, `build-tags`, `path`, `git`, `branch`, `rev`, `tag`, `replace` (for `replace` directives), and `indirect = true` (rare; bridges to Go's indirect requirements).
+- Module paths must validate against `golang.org/x/mod/module.CheckPath`.
+- Semver constraints follow the standard Mochi MEP-57 grammar (^, ~, >=, &lt;, =).
+- Cyclic dependencies are rejected at lock time.
+
+The user does not write a separate `go.mod`. The bridge synthesises the workspace `go.mod` at build time, populating `require` from `[go-dependencies]` and pinning the exact resolved version from `mochi.lock`.
+
+## Manifest: `[go]`
+
+```toml
+[go]
+go-version = "1.23"
+goroutine-bridge = { default-buffer = 1, max-handles = 4096 }
+monomorphise = [
+    { item = "encoding/json.Unmarshal", T = "MyStruct" },
+    { item = "sync.Pool", T = "MyStruct" },
+]
+build-tags = ["json_logging", "go_purego"]
+```
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `go-version` | `"1.21"` | Go toolchain floor declared in the wrapper module's `go.mod`. |
+| `goroutine-bridge.default-buffer` | `1` | Default channel buffer for Go `chan T` exposed as Mochi `stream<T>`. |
+| `goroutine-bridge.max-handles` | `4096` | Soft upper bound on live cgo handles before the wrapper rejects new ones. |
+| `monomorphise` | `[]` | Explicit generic instantiations. Each entry binds one `<item>` at one `<T>`. |
+| `build-tags` | `[]` | Build tags the wrapper compilation respects. |
+
+The `monomorphise` table is the only path to import a generic-parameter Go item (Go gained generics in 1.18, March 2022). The bridge does not auto-monomorphise.
+
+## Manifest: `[go.publish]`
+
+```toml
+[go.publish]
+canonical-import-path = "github.com/example/my-mochi-lib"
+go-version-floor = "1.21"
+license = "Apache-2.0 OR MIT"
+cgo-export = true
+```
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `canonical-import-path` | unset | The module path declared in the published `go.mod`. REQUIRED for `mochi pkg publish --to=go+git+...`. |
+| `go-version-floor` | `"1.21"` | The `go <version>` directive value written into the published `go.mod`. |
+| `license` | `""` | SPDX licence expression. Drives the LICENSE file and the `doc.go` first line. |
+| `cgo-export` | `false` | Whether to emit `_cgo_export.h` for non-Go consumers. |
+
+## Manifest: `[go.capabilities]`
+
+```toml
+[go.capabilities]
+net = true
+fs = false
+proc = false
+cgo = false
+unsafe = false
+```
+
+These capability flags are a strict refinement of MEP-57's `[capabilities]` table. The bridge walks the Go dep graph at lock time, computes the union of capability marks across every reachable module (via a curated capability database; the same db that MEP-73 uses, extended with the Go-stdlib-induced cap classification), and asserts that the union is a subset of the user's `[go.capabilities]` declaration.
+
+## Manifest: `[go.private]`
+
+```toml
+[go.private]
+modules = ["corp.example.com/**"]
+sumdb-skip = ["corp.example.com/**"]
+```
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `modules` | `[]` | Glob patterns for which the bridge bypasses `proxy.golang.org` and reaches the upstream git repo directly. |
+| `sumdb-skip` | `modules` value | Glob patterns for which the bridge skips the `sum.golang.org` cross-check. |
+
+These mirror the `GOPRIVATE` / `GONOSUMCHECK` env vars Go uses for the same purpose.
+
+## CLI surface
+
+The `mochi pkg` subcommand gains four new operations and extends two existing ones:
+
+### `mochi pkg add go <module>[@<semver>]`
+
+```
+$ mochi pkg add go github.com/spf13/cobra@^v1.8 --build-tags=json_logging
+Added "github.com/spf13/cobra" = { version = "^v1.8", build-tags = ["json_logging"] } to [go-dependencies]
+Running mochi pkg lock ...
+Resolved 12 Go modules (cobra + 11 transitive)
+Cross-verified against sum.golang.org (12/12 records present in tree)
+Wrote mochi.lock (+12 [[go-package]] entries)
+```
+
+Equivalent to manually editing `mochi.toml` plus running `mochi pkg lock`. Idempotent.
+
+### `mochi pkg lock`
+
+Walks `[go-dependencies]`, runs the resolver against the Go module proxy, downloads each module .zip to the content-addressed cache, cross-checks against sum.golang.org, runs `go-ingest` on each, synthesises the wrapper for each, and writes a `[[go-package]]` entry per dep into `mochi.lock`.
+
+### `mochi pkg lock --check`
+
+Reads `mochi.lock`, recomputes every `zip-blake3`, `zip-h1`, `api-surface-sha256`, `wrapper-sha256`, cross-checks `sumdb-record-hash` against sum.golang.org's current tree, and exits non-zero on any mismatch. CI-enforced reproducibility gate.
+
+### `mochi pkg lock --sumdb-consistency`
+
+Additionally fetches a Merkle consistency proof from sum.golang.org for every public module, asserting that the lock-time tree leaf is still present in the current tree. Optional because of the per-dep RTT cost.
+
+### `mochi pkg publish --to=go+git+<repo-url>@<tag> [--dry-run] [--cosign-sign]`
+
+- Builds the package via `Driver.Build` with `target = TargetGoLibrary`.
+- Runs `go vet ./...` + `gofmt -l ./...` and rejects on diagnostics.
+- Runs `go build ./...` against the emitted module.
+- Tags the canonical-import-path repo at HEAD with the requested semver tag.
+- With `--cosign-sign`: constructs a cosign signature over the tag's commit SHA via the CI OIDC token, attaches it as a sibling git tag `<tag>.sig`.
+- Pushes the tag (and optionally `<tag>.sig`) to the canonical-import-path remote.
+- With `--dry-run`: stops before the push.
+- Optionally pings `proxy.golang.org/<module>/@v/<tag>.info` to warm the module proxy.
+
+### `mochi pkg publish --to=go+goproxy+<url>`
+
+Alternative: uploads the module .zip to a private GOPROXY-compatible endpoint instead of git-tagging.
+
+### `mochi pkg sync go`
+
+Re-runs the wrapper synthesiser from the existing `mochi.lock`, without re-resolving versions. Used after manual edits to the synthesised shim file, or after a bridge upgrade that changes the wrapper format.
+
+## Per-import alias resolution
+
+The alias `<alias>` introduced by `import go "<spec>" as <alias>` participates in normal Mochi name resolution. The bridge generates a shim file at `<workdir>/go_wrap/<module>/shim.mochi` containing a corpus of `extern fn` and `extern type` declarations like:
+
+```mochi
+extern type Command
+extern fn new_command(): Command from go "github.com/spf13/cobra.NewCommand"
+extern fn (cmd: Command) set_use(use: string) from go "github.com/spf13/cobra.Command.SetUse"
+extern fn (cmd: Command) execute(): Result<unit> from go "github.com/spf13/cobra.Command.Execute"
+```
+
+The import `import go "github.com/spf13/cobra@^v1.8" as cobra` becomes (post-resolution) `import "./go_wrap/github_com_spf13_cobra/shim.mochi" as cobra`. The synthesised shim is read by the parser exactly as a hand-written `.mochi` file would be. The shim file is regenerated on every `mochi pkg lock` and is gitignored by default.
+
+Users who need to edit the synthesised bindings should override individual items in their own source via:
+
+```mochi
+import go "github.com/spf13/cobra@^v1.8" as cobra_auto
+extern fn cobra_new_command(): cobra_auto.Command from go "github.com/spf13/cobra.NewCommand" custom
+```
+
+The `custom` modifier keeps the override stable across `mochi pkg sync go` runs.
+
+## Cross-references
+
+- [[02-design-philosophy]] for the rationale.
+- [[04-go-doc-ast-ingest]] for how the public surface is discovered.
+- [[05-type-mapping]] for the closed translation table the shim file uses.
+- [[06-go-module-publish-flow]] for the `mochi pkg publish` path.
+- [[10-interface-and-method-set]] for how Go interfaces become Mochi extern types.
+- [MEP-74 §4](/docs/mep/mep-0074#4-surface-syntax-import-go--as-alias-extended) for the normative syntax.
+- [MEP-57](/docs/mep/mep-0057) for the broader `mochi.toml` + `mochi.lock` model this extends.

--- a/website/docs/research/0074/02-design-philosophy.md
+++ b/website/docs/research/0074/02-design-philosophy.md
@@ -1,0 +1,125 @@
+---
+title: "02. Design philosophy"
+sidebar_position: 3
+sidebar_label: "02. Design philosophy"
+description: "Why a bidirectional bridge, why go/packages over alternatives, why a synthesised cgo wrapper package over direct cgo emission or gomobile-style codegen, why no async runtime singleton is needed for Go (the runtime ships in the c-archive), why sum.golang.org cross-check is mandatory by default, why the type-mapping table is closed not open."
+---
+
+# 02. Design philosophy
+
+This note frames the six load-bearing design decisions in MEP-74 alongside the alternatives that were considered and rejected. Each section follows the same structure: the decision, the alternatives, the trade-offs. The note parallels the MEP-73 §02 design philosophy note; readers familiar with MEP-73 will find the structure unchanged and only the Go-specific reasoning different.
+
+## 1. Why bidirectional
+
+MEP-54 phase 10 already shipped a one-way Go consume path (a Mochi program can name a Go package and link against it via the host Go toolchain). MEP-74 could have stopped at "fix the consume path: add semver pinning, capability declaration, and lockfile pinning" and deferred Mochi-as-Go-publisher to a future MEP. Or could have shipped the publish direction without touching the consume path.
+
+Shipping both directions in one MEP is the right scope because:
+
+- **Symmetric distribution.** A library author writes Mochi, depends on Go modules, publishes to a publicly-resolvable git repo that the module proxy picks up. A library consumer either writes Mochi (uses MEP-74's `import go`) or writes Go (uses `go get` against the published canonical-import-path). A unidirectional bridge would leave one side of the symmetry broken.
+
+- **Shared sum.golang.org integration.** The consume path verifies imported modules against sum.golang.org's checksum DB. The publish path optionally adds a cosign signature over the published git tag. Both interact with the Go supply-chain surface; implementing one without the other would leave a notch in the design.
+
+- **Shared capability surface.** The `[go.capabilities]` table that audits which capabilities the imported dep graph requires has its mirror in MEP-57's `[capabilities]` table that audits which capabilities the Mochi-published library requires. The same monotonicity rule applies; the audit pass is shared.
+
+- **Parity with MEP-73.** The Rust bridge ships bidirectional. Shipping a unidirectional Go bridge would leave the Go interop story behind the Rust interop story for no defensible reason.
+
+The trade-off is that MEP-74 is a larger spec than a strict single-direction extension would be. The compensating gain (parity with MEP-73, single capability surface, single lockfile section, single ingest pipeline) is large.
+
+## 2. Why `go/packages` + `go/types`
+
+The bridge needs a machine-readable description of every Go module's public surface. Four candidate sources existed:
+
+- **`go/packages.Load`** (under `golang.org/x/tools/go/packages`, which the Go team officially maintains as the canonical "load a Go program into a typed form" entry point). Returns `[]*packages.Package` where each `*packages.Package` carries a `*types.Package` exposing every exported identifier with its full `types.Type`. Stable since 2018, used by gopls, staticcheck, golangci-lint, and effectively every Go static-analysis tool. Ships in the official Go module `golang.org/x/tools`.
+
+- **`go/parser` + manual type inference.** One level lower in the Go stdlib: returns untyped ASTs. The bridge would have to re-implement `go/types` to recover the type information. Wasteful (go/types is the right tool already).
+
+- **`pkg.go.dev` HTML scraping.** The website renders the public API as HTML; the bridge could parse the HTML. Rejected: HTML is rendered for human reading, not normative. Items behind feature flags, build tags, or platform-conditional code paths are conditional in `go/packages` but flat in HTML.
+
+- **`gomobile bind`'s `.aar` / `.framework` schema.** gomobile generates Java / Objective-C bindings for a tiny subset of Go. The schema is conservative (no channels, no generics, no interfaces with complex method signatures, no goroutine-spawning callbacks). Insufficient for full bridging.
+
+`go/packages` wins on every axis: stable, machine-readable, in-stdlib, with full type information. The only cost is that the bridge needs a Go-toolchain-resident helper binary (`package3/go/cmd/go-ingest`) to call `packages.Load`; the binary emits a JSON document that the main Mochi binary parses. The helper is ~300 LOC.
+
+This is materially less risky than MEP-73's rustdoc-JSON ingest, which is nightly-only and behind `-Z unstable-options` as of May 2026. The Go bridge can run on stable Go from day one.
+
+## 3. Why synthesised cgo wrapper package
+
+Given an ingested ApiSurface, the bridge has three routes to making Go items callable from Mochi:
+
+- **Direct cgo in the user's main**: the MEP-54 emit pass generates Go source that imports the source module directly. This is what MEP-54 phase 10 does today for unversioned imports. The cost: every additional Go feature the bridge wants to expose (generics, channels, callbacks, interfaces with non-trivial method sets) has to be taught to the `aotir` IR, which violates the target-agnostic invariant.
+
+- **Synthesised cgo wrapper Go package**: the bridge generates a sibling Go package that imports the source module and exposes a flat `//export` surface wrapping each translatable public item. The Mochi side calls into the wrapper via a known, stable, generics-free, interface-free C ABI. The wrapper is built via `go build -buildmode=c-archive`.
+
+- **gomobile-bind-style codegen**: the user authors an interface description file (`.gobind`); gomobile generates the bindings on both sides. Same boilerplate violation MEP-73 §02-3 rejects.
+
+The synthesised wrapper path is the only one that delivers the "no boilerplate" promise without breaking the `aotir` IR's target-agnosticism. The wrapper-package build is added to the user's `go build`; warm-cache wrapper compile is ~1-3 seconds per module, cold-cache ~5-15 seconds (Go's compile speed is materially better than Rust's). The wrappers are cached in `~/.cache/mochi/go-deps/wrappers/<wrapper-sha256>/` and shared across workspaces.
+
+The wrapper-vs-direct trade-off mirrors how gopy works (gopy generates Python bindings for Go by synthesising a wrapper) and how PyO3 / napi-rs work in Rust. The bridge does the synthesis from the Go side at lock time, not by Go generate directives at compile time, so the user does not edit Go source at all.
+
+## 4. Why no async runtime singleton is needed
+
+This is the load-bearing difference from MEP-73. MEP-73's bridge synthesises a tokio runtime singleton because Rust's `async fn` requires a host executor and Mochi does not provide one. Go does not have this problem:
+
+- Go's `goroutine` is preemptible green-threading inside the Go runtime. The runtime scheduler ships in every Go binary including c-archives.
+- A cgo call from Mochi into a Go function `f` runs `f` on a Go runtime thread (cgo callbacks acquire a per-call goroutine).
+- If `f` spawns its own goroutines (`go some_func()`), the Go runtime schedules them; the cgo call returns when `f` returns; the spawned goroutines continue running in the background until the c-archive's Go runtime is shut down (which only happens at process exit).
+- If `f` blocks on a channel receive (`<-ch`), the Go runtime parks the goroutine and the cgo call blocks until the receive completes.
+
+The bridge has zero runtime-singleton code. The cost: every cgo call carries the goroutine scheduler's overhead (a per-call goroutine acquire), which is ~200ns on darwin-arm64 (May 2026 benchmark). Programs that hot-loop across the cgo boundary pay this per iteration. The mitigation is the batched-variant wrapper (§[[09-abi-stability]] §3).
+
+The bridge does need a small piece of cgo-handle plumbing to bridge Mochi's `stream<T>` to Go's `chan T` and Mochi callback values to Go func parameters. This plumbing is a `sync.Map` of active handles plus per-channel `_send` / `_recv` / `_close` exported functions. ~150 LOC total. No runtime executor singleton.
+
+## 5. Why sum.golang.org cross-check is mandatory by default
+
+The Go ecosystem ships an unusually strong supply-chain story by 2026 standards:
+
+- The module proxy at `proxy.golang.org` caches every public module .zip and serves them on `go get`.
+- The checksum database at `sum.golang.org` is a Merkle-tree transparency log: every public module version is appended, the log's signed tree head is anchored in the public timeline, and clients can fetch a consistency proof on demand.
+- Every `go get` since Go 1.13 (September 2019) cross-checks the module .zip against sum.golang.org by default.
+
+A 2026 Mochi-to-Go bridge that does not cross-check `[[go-package]]` lockfile hashes against sum.golang.org is shipping a weaker supply-chain story than `go get` itself. The cross-check is one HTTP GET per dep at lock time; the cost is negligible; the safety gain is substantial.
+
+The alternative would be to make the cross-check opt-in, e.g., via a `sumdb-verify = true` flag. Rejected: the Go-ecosystem default is opt-out for private modules only (`GONOSUMCHECK`), and Mochi should match. The bridge ships with `[go.private] sumdb-skip = [...]` as the opt-out path, mirroring `GONOSUMCHECK` semantics.
+
+This is the second-strongest supply-chain stance in any Mochi MEP (after MEP-73's Sigstore-keyless-only stance). It is strictly stronger than what the Rust bridge can offer because the Rust ecosystem does not have a comparable transparency log (Sigstore Rekor is the closest analogue, and it is opt-in per-publisher; sum.golang.org is mandatory for every public module).
+
+## 6. Why a closed type-mapping table
+
+Same argument as MEP-73 §02-6, transferred to Go:
+
+- **Predictable user surface.** The Mochi user can read the table and predict whether a given Go item translates.
+- **Refusal is information.** The `SkipReport` tells the user precisely why an item was skipped.
+- **Generic explosion containment.** Go 1.18+ generics are bounded by the explicit `[go.monomorphise]` declaration.
+- **Auditability.** The table fits in a single source file (~250 LOC of Go).
+
+Go's type system is slightly richer than Rust's at the closed-table level because Go has first-class channels (`chan T`), first-class function types (`func(...) (..., error)`), and structural interfaces (`type I interface { M() }`). The bridge handles all three via the cgo-handle pattern: channels become opaque handles with `_send` / `_recv` / `_close` cgo exports, function values become opaque handles with a `_call` cgo export, and interfaces become opaque handles with per-method cgo exports.
+
+The cost: the closed table refuses many items the user might want. The mitigation is the `extern fn ... from go "..." custom` override path: the user can always escape the table by taking responsibility for the FFI boundary.
+
+## 7. Why git-tag publish over a central registry
+
+The Go ecosystem famously has no central package registry. Module publication is a git operation: tag a commit with a semver-compatible tag and push the tag to the canonical-import-path repo. The module proxy picks up the new tag on the next `go get`.
+
+This is materially different from Rust's crates.io / Python's PyPI / Node's npm / Maven Central. The bridge embraces the difference rather than trying to abstract it away:
+
+- **`mochi pkg publish --to=go+git+<repo-url>@<tag>`** is a thin wrapper around `git tag <tag> && git push origin <tag>`. The Mochi side adds: build via `TargetGoLibrary`, validate `go vet` / `gofmt` / `go build`, optionally cosign-sign the tag.
+
+- **No upload endpoint.** The bridge does not POST a tarball to a registry. The git remote (GitHub, GitLab, Gitea, self-hosted) is the upload target.
+
+- **Module proxy is implicit.** Once the tag exists on the public remote, `proxy.golang.org` fetches it on the next request and submits it to sum.golang.org. The bridge does not coordinate with the proxy directly (though it can ping the proxy to warm the cache).
+
+- **Authentication is git authentication.** SSH key or HTTPS Personal Access Token (PAT). No `GO_PROXY_TOKEN`. No long-lived API token.
+
+The cost: the publish target has to support publicly-resolvable git URLs. A private corporate repo at `corp.example.com/internal/foo` is publishable, but only consumers with credentials to that repo can `go get` it. This matches Go's normal behaviour.
+
+The benefit: no central-registry single-point-of-failure for Mochi-to-Go publish. The git remote landscape is more diverse and more resilient than any single registry.
+
+## Cross-references
+
+- [[01-language-surface]] for the user-visible surface.
+- [[03-prior-art-bridges]] for the gopy / gomobile / gobind comparison the wrapper-vs-direct decision draws on.
+- [[04-go-doc-ast-ingest]] for the `go/packages` schema choice.
+- [[05-type-mapping]] for the closed-table contents.
+- [[07-sigstore-go-checksumdb]] for the sum.golang.org cross-check and the optional cosign signing.
+- [[08-goroutine-bridge]] for the no-runtime-singleton story.
+- [MEP-74](/docs/mep/mep-0074) for the normative spec.
+- [MEP-73](/docs/mep/mep-0073) for the sister Rust bridge whose design philosophy this note mirrors.

--- a/website/docs/research/0074/03-prior-art-bridges.md
+++ b/website/docs/research/0074/03-prior-art-bridges.md
@@ -1,0 +1,204 @@
+---
+title: "03. Prior-art Go bridges"
+sidebar_position: 4
+sidebar_label: "03. Prior-art bridges"
+description: "Survey of existing Go-to-other-language bridges (gopy, gomobile bind, gobind, swig, c-shared / c-archive build modes, purego, wazero, cgo-style FFI consumers like the JNA / JNI Go variants, and the proposed dotnet-go integration). What each gets right, what each requires the user to write, and what MEP-74 borrows."
+---
+
+# 03. Prior-art Go bridges
+
+This note surveys the existing landscape of Go-to-other-language and other-language-to-Go bridges as of 2026-05. The bridge MEP-74 specifies draws design decisions from the strongest of these and explicitly rejects boilerplate patterns from the weakest. The survey covers ten bridges across two directions:
+
+| Bridge | Direction | Boilerplate | ABI | Status |
+|--------|-----------|-------------|------|--------|
+| gopy | Go → Python | Low (annotation-free) | cgo + Python C-API | Active (last release 2024-Q4) |
+| gomobile bind | Go → Java/Objective-C | None for the subset it supports; subset is restrictive | gomobile-native ABI | Active (Go team-maintained) |
+| gobind | Go → mobile (gomobile's internal codegen) | None | Internal | Internal-only |
+| swig (Go target) | C/C++ → Go | High (`.i` interface file per binding) | swig-managed C glue | Active but Go target is in maintenance |
+| c-archive / c-shared | Go → C / any | Medium (the user writes `//export` directives) | C ABI | Stable since Go 1.5 (2015) |
+| purego | Other → Go via dlopen without cgo | Medium (the user writes Go-side signatures) | dlopen | Active (first GA 2024) |
+| wazero | Wasm host → wasm-compiled Go | None (the wasm module is self-describing) | wasm component model | Active, GA 2023 |
+| JNI-Go | JNI ↔ Go | High (JNI requires per-method registration) | JVM ABI | Niche |
+| dotnet-go | Go ↔ .NET | Medium (the user writes a `[GoExport]` annotation per method) | CLR P/Invoke | Experimental, Microsoft Research |
+| cppgo | C++ → Go | High (a `.cppgo` interface file per binding) | cgo via swig | Niche |
+
+The rest of this note walks each in turn, calls out what MEP-74 borrows, and what MEP-74 rejects.
+
+## gopy (Go → Python)
+
+[gopy](https://github.com/go-python/gopy), maintained since 2014, generates Python bindings for a Go package by parsing the package via `go/types` and emitting a cgo wrapper plus a CPython extension module. The user invokes `gopy pkg <module-path>` and gets a `.so` they can `import` from Python.
+
+What gopy gets right:
+
+- **`go/types` as the ingest source.** gopy was the bridge that established `go/types` as the right level of abstraction for Go-bridge ingest. MEP-74 borrows this entire decision.
+- **Closed type-mapping table.** gopy has a fixed translation from Go scalars / strings / slices / maps to Python equivalents and refuses on out-of-table cases. MEP-74's table is structurally similar.
+- **Wrapper package, not direct cgo emission.** gopy emits a sibling Go package (`pkg_go.go`) that calls into the source. MEP-74's `go_wrap/<module>/` directory is the same pattern.
+- **No annotation requirement.** The user does not add `// gopy:export` markers; gopy reads the package's exported items as-is.
+
+What gopy gets wrong (from MEP-74's perspective):
+
+- **Python-specific.** The output is CPython-extension-only; the wrapper is not reusable from other consumers.
+- **No version pinning.** gopy operates on whatever is in `GOPATH`. No semver constraint, no checksum, no capability declaration.
+- **No async story.** Goroutine-spawning items are reflected to Python but the Python side has no idiomatic way to await them.
+
+MEP-74 takes gopy's structural decisions (go/types ingest, closed table, sibling wrapper package, no annotations) and adds the missing pieces (version pin, checksum verification, capability declaration, publish path).
+
+## gomobile bind (Go → Java/Objective-C)
+
+[gomobile bind](https://pkg.go.dev/golang.org/x/mobile/cmd/gomobile), Go-team-maintained since 2015, generates `.aar` (Android) and `.framework` (iOS) bindings from a Go package. The user runs `gomobile bind -target=android <pkg>` and gets an Android library.
+
+What gomobile bind gets right:
+
+- **Self-describing output artifact.** The `.aar` / `.framework` carries the Go runtime inside, so consumers do not need a Go toolchain. MEP-74's `TargetGoLibrary` with `cgo-export = true` produces a similar self-contained artifact.
+- **Closed subset of Go that the bridge supports.** gomobile bind explicitly documents what it can translate (a narrow subset of Go types) and refuses everything else. The refusal-is-information principle MEP-74 also adopts.
+
+What gomobile bind gets wrong (from MEP-74's perspective):
+
+- **The subset is too narrow.** No channels in exported positions. No goroutine callbacks. No interfaces with non-builtin types in method signatures. No generics. MEP-74's subset is materially wider because the Mochi-side ABI does not have to play nicely with Java's GC / iOS's ARC.
+- **Build artefact is heavy.** The .aar / .framework bundles the Go runtime; the artifact is megabytes. The c-archive path is lighter for native-host consumers.
+
+MEP-74 takes gomobile bind's "documented subset + refusal" decision and skips the heavyweight build-output side.
+
+## gobind (gomobile's internal codegen)
+
+[gobind](https://pkg.go.dev/golang.org/x/mobile/cmd/gobind) is the underlying codegen tool gomobile invokes. It reads a Go package and emits Java / Objective-C source plus Go cgo glue. The output of gobind is the input to gomobile's downstream native-toolchain invocation.
+
+What gobind gets right:
+
+- **`go/packages` ingest.** Same as gopy. Solid choice.
+- **JSON intermediate format.** gobind serialises the resolved API surface as JSON before downstream codegen. MEP-74's `ApiSurface` JSON document is a similar pattern, except MEP-74's JSON is consumed by the Mochi-side bridge binary rather than by a downstream codegen step.
+
+What gobind gets wrong:
+
+- **Tightly coupled to gomobile.** gobind is not designed as a standalone tool; using it outside of gomobile requires hacky scripting.
+
+MEP-74's `package3/go/cmd/go-ingest` is structurally what gobind is, but standalone and tailored to Mochi.
+
+## swig (Go target)
+
+[SWIG](https://www.swig.org), the venerable C/C++-to-many-languages bridge, has a Go target. The user authors a `.i` interface file describing which C/C++ items to expose and how, and swig emits Go cgo bindings.
+
+What swig gets right (for its problem space):
+
+- **Languages-agnostic.** swig targets ~20 languages from a single `.i` file.
+- **Mature.** Two decades of production use.
+
+What swig gets wrong (from MEP-74's perspective):
+
+- **Required interface file.** swig requires the user to author `.i`. Boilerplate violation.
+- **Direction is wrong.** swig goes C/C++ → Go, not Go → other. The MEP-74 problem is the other direction.
+- **Go target is in maintenance.** As of 2026, swig's Go target hasn't seen a feature commit in 18 months.
+
+MEP-74 does not borrow from swig.
+
+## `c-archive` / `c-shared` (Go's native FFI build modes)
+
+Since Go 1.5 (August 2015), the `go build` command has accepted `-buildmode=c-archive` (emit a `.a` static library plus a `.h` header) and `-buildmode=c-shared` (emit a `.so` / `.dylib` shared library plus a `.h`). The user adds `//export <Symbol>` directives above each Go function they want exposed; cgo handles the codegen.
+
+What c-archive gets right:
+
+- **First-class Go feature.** No external tool. `go build -buildmode=c-archive` is in the official Go toolchain.
+- **Universal C ABI.** Any C-compatible consumer (Mochi, Rust via FFI, Python via ctypes, JNI, you name it) can link against the .a.
+- **The Go runtime ships inside.** The c-archive includes the Go scheduler, GC, channel multiplexer. The consumer does not need a Go toolchain at consume time.
+- **Stable for a decade.** Since 2015. Production-grade.
+
+What c-archive requires the user to write:
+
+- The `//export <Symbol>` directive per Go function. This is per-symbol boilerplate.
+- The C-side header is generated, but the consumer still has to know the symbol naming convention.
+
+MEP-74's wrapper package IS a c-archive with auto-generated `//export` directives. The bridge writes the directives so the user does not have to. The bridge picks the symbol naming convention (`mochi_go_<module>_<fn>`) so collisions are predictable. The bridge handles the consume-side linking via the MEP-54 build driver.
+
+This is the single largest piece of prior art MEP-74 builds on. The entire bridge is a layer of auto-generated `//export`-laden Go source that sits on top of the c-archive primitive.
+
+## purego (call into Go without cgo)
+
+[purego](https://github.com/ebitengine/purego), a project from the Ebiten game engine team, lets non-Go code call into Go-written shared libraries (.so / .dylib) via dlopen, bypassing cgo entirely. The Go side must be compiled to `-buildmode=c-shared`; the non-Go side declares the Go-side function signatures in its own language and resolves them via dlsym.
+
+What purego gets right:
+
+- **Avoids cgo overhead.** Direct dlopen is ~50ns per call versus ~200ns for cgo.
+- **Works on platforms where cgo is awkward.** iOS, certain WASM hosts.
+
+What purego requires the user to write:
+
+- The Go-side function signatures in the consumer's own language. Boilerplate.
+- The consumer must dlopen the .so / .dylib at runtime. More than c-archive's static-link path.
+
+MEP-74 evaluated purego as the consumer-side ABI and rejected it because:
+
+- The consumer-side boilerplate violates the no-boilerplate promise.
+- purego's GA is too recent (2024) to bet on for the v1 bridge.
+- Most pkg.go.dev modules are pure Go (no `.so` / `.dylib` published); the consumer would have to compile them locally anyway, which is exactly what the c-archive path does.
+
+A future MEP-74 v2 could add purego as an alternative consume path on platforms where cgo is unavailable (wasm-js). See [[12-risks-and-alternatives]] §A12.
+
+## wazero (wasm host → Go wasm module)
+
+[wazero](https://wazero.io), a pure-Go wasm runtime by the Tetrate team, lets a Go program load a wasm module and call its exports. Since Go 1.21 supports `GOOS=wasip1 GOARCH=wasm`, a Go module can be compiled to wasm and consumed via wazero.
+
+What wazero gets right (for its problem space):
+
+- **No cgo on the consume side.** Wazero is pure Go.
+- **Sandboxed execution.** The wasm module cannot reach beyond the wasm-imports the host provides.
+- **Cross-platform.** Works wherever Go runs.
+
+What wazero gets wrong (from MEP-74's perspective):
+
+- **WASI-only Go modules.** Not every Go module compiles to wasm-wasip1; modules using cgo or platform-specific syscalls don't.
+- **Two-level translation.** Go → wasm → wasm-host → consumer. The Mochi-side ABI is wasm, not native, which adds cost.
+
+MEP-74's wasm-wasip1 publish gate (phase 17) leans on wazero for the wasm-consume-side. The native-host consume path uses the c-archive route.
+
+## JNI-Go variants
+
+Several projects bridge Go to JVM via JNI: [jnigi](https://github.com/timob/jnigi), [Go-Java-Bridge](https://github.com/yourbasic/go-java-bridge), and others. These typically require the user to write JNI-style `RegisterNatives` boilerplate on the Java side and `import "C"` cgo on the Go side.
+
+What JNI-Go bridges get right: JVM compatibility, mature platform.
+
+What they get wrong: per-method registration boilerplate, JVM lifecycle management. Not relevant to MEP-74 except as a counterexample of what not to do.
+
+## dotnet-go (Microsoft Research, experimental)
+
+A 2025 Microsoft Research project that bridges Go to .NET via the CLR's P/Invoke surface. The user writes `[GoExport]` C# attributes on placeholder methods; the bridge resolves them at load time against a Go c-shared library.
+
+What dotnet-go gets right: explicit annotations make the binding surface auditable on the C# side.
+
+What MEP-74 takes: nothing directly. The bridge serves as a counterexample for the "explicit annotation" path that MEP-74 rejects.
+
+## cppgo (C++ → Go via swig)
+
+A swig-on-Go-target variant that adds a `.cppgo` interface file for C++ specifics. Niche.
+
+What MEP-74 takes: nothing.
+
+## What MEP-74 borrows by component
+
+| Component | Borrows from | Decision |
+|-----------|--------------|----------|
+| Ingest source | gopy, gobind | `go/packages.Load` + `go/types` |
+| Wrapper-vs-direct | gopy, c-archive | Synthesised sibling wrapper package |
+| ABI primitive | c-archive (Go-stdlib) | `go build -buildmode=c-archive` |
+| Symbol naming | none (MEP-74 invents) | `mochi_go_<module-path-hash>_<fn>` |
+| Refusal-is-info | gomobile bind | Closed table + SkipReport |
+| JSON intermediate | gobind | `ApiSurface` JSON document |
+| Cross-platform wasm | wazero | Wasm-wasip1 consume path (phase 17) |
+
+## What MEP-74 explicitly rejects
+
+| Pattern | Source | Reason |
+|---------|--------|--------|
+| Required interface file | swig, cxx, uniffi | Boilerplate violation |
+| Per-method registration | JNI | Boilerplate violation |
+| `[GoExport]` attribute | dotnet-go | Boilerplate violation |
+| Heavyweight artifact | gomobile bind | Cost too high for native-host consumers |
+| dlopen-only consume | purego | Pre-GA; consumer boilerplate |
+| Subset narrower than the closed type table | gomobile bind | Bridge promises wider coverage |
+
+## Cross-references
+
+- [[02-design-philosophy]] §3 for why wrapper-package wins over direct.
+- [[04-go-doc-ast-ingest]] for the `go/packages` schema deep-dive.
+- [[09-abi-stability]] for the c-archive ABI contract.
+- [[11-tinygo-embedded-wasm]] for the wazero / wasm-wasip1 consume path.
+- [MEP-74 §1](/docs/mep/mep-0074#1-pipeline-overview) for the pipeline this prior art informs.

--- a/website/docs/research/0074/04-go-doc-ast-ingest.md
+++ b/website/docs/research/0074/04-go-doc-ast-ingest.md
@@ -1,0 +1,192 @@
+---
+title: "04. go/packages + go/types ingest"
+sidebar_position: 5
+sidebar_label: "04. go/packages ingest"
+description: "The `go/packages.Load` flow, the `types.Type` discriminator tree, why no nightly toolchain is needed (unlike MEP-73's rustdoc-JSON), the Go-side helper binary shape, the ApiSurface JSON schema."
+---
+
+# 04. `go/packages` + `go/types` ingest
+
+This note details the ingest pipeline: how the bridge turns a Go module .zip in the content-addressed cache into a structured ApiSurface JSON document the typemap can consume.
+
+## The two-layer Go stdlib API
+
+The Go stdlib (and its supplement `golang.org/x/tools`) ships two complementary packages the bridge uses:
+
+- **`go/types`** (in-stdlib since Go 1.5, 2015): the type representation. Every Go type has a `types.Type` value. The discriminator tree:
+  - `*types.Basic` (int, int32, int64, float64, string, bool, ...)
+  - `*types.Pointer` (*T)
+  - `*types.Slice` ([]T)
+  - `*types.Array` ([N]T)
+  - `*types.Map` (map[K]V)
+  - `*types.Chan` (chan T, <-chan T, chan<- T)
+  - `*types.Struct` (struct { ... }; query fields via `NumFields()` and `Field(i)`)
+  - `*types.Interface` (interface { ... }; query method set via `NumMethods()` and `Method(i)`)
+  - `*types.Signature` (func types; query params and results via `Params()` and `Results()`)
+  - `*types.Named` (named types via `type` declarations; the wrapper around any of the above)
+  - `*types.TypeParam` (Go 1.18+ generics)
+  - `*types.Union` (interface constraint unions in generics)
+  - `*types.Tuple` (multi-return signatures)
+
+- **`golang.org/x/tools/go/packages`** (separate Go module, stable since 2018): loads a Go program into a typed form. `packages.Load(cfg, patterns...)` returns `[]*packages.Package` where each entry carries:
+  - `Name` (package name, e.g., `cobra`)
+  - `PkgPath` (canonical-import-path, e.g., `github.com/spf13/cobra`)
+  - `GoFiles` (list of source files)
+  - `Imports` (transitive dep map)
+  - `Types` (a `*types.Package` with the full export scope)
+  - `TypesInfo` (a `*types.Info` with token-to-type mappings)
+
+The combination is exactly what the bridge needs: `packages.Load` gives the dep graph, `types.Package` gives the surface, and `TypesInfo` gives the source-token to type mapping for diagnostics.
+
+## Why no nightly toolchain
+
+Unlike MEP-73's rustdoc-JSON ingest (which requires `cargo +nightly rustdoc --output-format=json -Z unstable-options`), the Go ingest path runs on stable Go from day one:
+
+- `go/types` has been stable in the Go stdlib since Go 1.5 (August 2015).
+- `golang.org/x/tools/go/packages` has documented backwards-compatibility since 2018.
+- The Go team's stability commitment for these APIs is as strong as for `net/http` or `encoding/json`.
+
+The bridge's helper binary builds against stable Go and can be cross-compiled to every host the Mochi toolchain runs on.
+
+This is the single largest risk-reduction relative to MEP-73. The Rust bridge has to ship a nightly rustup-toolchain-install command in its onboarding; the Go bridge does not.
+
+## Helper binary shape
+
+The bridge ships a Go-toolchain-resident helper at `package3/go/cmd/go-ingest` (~300 LOC):
+
+```go
+package main
+
+import (
+    "encoding/json"
+    "go/types"
+    "os"
+
+    "golang.org/x/tools/go/packages"
+)
+
+type ApiSurface struct {
+    Module       string       `json:"module"`
+    Version      string       `json:"version"`
+    GoVersion    string       `json:"go_version"`
+    Items        []ApiItem    `json:"items"`
+    Skipped      []SkipReport `json:"skipped"`
+}
+
+type ApiItem struct {
+    Kind   string         `json:"kind"` // "func" | "type" | "const" | "var" | "method"
+    Name   string         `json:"name"`
+    Type   ApiTypeRef     `json:"type"`
+    Doc    string         `json:"doc,omitempty"`
+    Methods []ApiItem     `json:"methods,omitempty"` // for type items
+    TypeParams []ApiTypeParam `json:"type_params,omitempty"` // for generic items
+}
+
+type ApiTypeRef struct {
+    Kind     string       `json:"kind"` // "basic" | "pointer" | "slice" | "map" | "chan" | "struct" | "interface" | "func" | "named" | "type_param" | "error"
+    Basic    string       `json:"basic,omitempty"`     // "int64", "float64", "string", ...
+    Elem     *ApiTypeRef  `json:"elem,omitempty"`      // slice / pointer / chan element
+    Key      *ApiTypeRef  `json:"key,omitempty"`       // map key
+    Value    *ApiTypeRef  `json:"value,omitempty"`     // map value
+    Fields   []ApiField   `json:"fields,omitempty"`    // struct fields
+    Methods  []ApiItem    `json:"methods,omitempty"`   // interface methods
+    Params   []ApiTypeRef `json:"params,omitempty"`    // func params
+    Results  []ApiTypeRef `json:"results,omitempty"`   // func results
+    Variadic bool         `json:"variadic,omitempty"`  // func variadic
+    Named    string       `json:"named,omitempty"`     // canonical-path "."-joined name
+    Dir      string       `json:"dir,omitempty"`       // chan direction "send", "recv", "both"
+    TypeParam string      `json:"type_param,omitempty"` // type-param name
+}
+
+type ApiField struct {
+    Name string     `json:"name"`
+    Type ApiTypeRef `json:"type"`
+    Tag  string     `json:"tag,omitempty"`
+    Anonymous bool  `json:"anonymous,omitempty"`
+}
+
+type ApiTypeParam struct {
+    Name       string     `json:"name"`
+    Constraint ApiTypeRef `json:"constraint"`
+}
+
+type SkipReport struct {
+    Item   string `json:"item"`
+    Reason string `json:"reason"`
+}
+
+func main() {
+    cfg := &packages.Config{
+        Mode: packages.NeedName | packages.NeedTypes | packages.NeedDeps |
+              packages.NeedTypesInfo | packages.NeedSyntax | packages.NeedFiles,
+        Dir:  os.Args[1],
+    }
+    pkgs, err := packages.Load(cfg, "./...")
+    if err != nil { panic(err) }
+    surface := walk(pkgs)
+    json.NewEncoder(os.Stdout).Encode(surface)
+}
+```
+
+(Full implementation lives in `package3/go/cmd/go-ingest/main.go`; the snippet above shows the data shape.)
+
+## ApiSurface JSON schema
+
+The emitted JSON document is the contract between the helper binary and the bridge's main Go binary. The schema is the closed shape above. A schema version (`api_surface_schema_version`) field at the top level records the schema epoch; bridge upgrades that change the schema bump the version.
+
+The `Type.Kind` discriminator is the closed set the typemap pass consumes. Items with `Kind` outside the set are not emitted; they appear in the `Skipped` array with a reason string.
+
+## Walk order and visibility rules
+
+The helper walks every `*packages.Package` and emits an `ApiItem` for every exported identifier in the package's `Scope()` (computed via `pkg.Types.Scope()` and iterated with `Names()`). Visibility rules:
+
+- An identifier is exported iff its first rune is uppercase (Go's universal rule).
+- An identifier inside an `internal/` directory subtree is invisible to consumers outside the module tree. The helper checks the import path against `golang.org/x/mod/module.MatchPath(<...>, "internal")` and silently skips.
+- Identifiers with a `// Deprecated:` comment in the godoc are still emitted, but the bridge marks them with a `deprecated = true` field that the typemap honours (it emits a warning in the `extern fn` declaration).
+- Identifiers behind build tags are emitted if the build-tag set the manifest declares includes the tag. The helper is invoked with the user's tag set via `cfg.BuildFlags`.
+
+## Generic items
+
+Go 1.18+ generic items (functions and types with `[T constraint]` type parameters) are emitted with the `type_params` array populated. The typemap pass refuses generic items by default; the user opts in via `[go.monomorphise]`. When an entry like `{ item = "encoding/json.Unmarshal", T = "MyStruct" }` is declared, the bridge synthesises a non-generic wrapper that instantiates the source at the declared `T`.
+
+## Method sets and receiver kinds
+
+A Go type can have value-receiver methods and pointer-receiver methods. The combined method set:
+
+- For value type `T`: methods with receiver `T` (not methods with receiver `*T`; this matters for interface satisfaction).
+- For pointer type `*T`: methods with receiver `T` AND methods with receiver `*T`.
+
+The helper emits both receiver kinds with a `receiver_kind: "value"` or `receiver_kind: "pointer"` field on each method item. The wrapper synthesiser uses this to pick the right call shape on the cgo side (passing by value vs. by pointer).
+
+## Embedded fields and promoted methods
+
+A Go struct can embed another struct or interface (`type Foo struct { Bar; ... }`), which promotes the embedded type's methods and exported fields to the embedding type's surface. The helper resolves promotions and emits the promoted items in the embedding type's `methods` array, with a `promoted_from = "<embedded-type-path>"` field for traceability.
+
+## Test files
+
+`*_test.go` files are NOT included in the ApiSurface. Test files are conditionally compiled and would inflate the surface with helper utilities. The helper invokes `packages.Load` with the default `Tests = false` to exclude them.
+
+## Cgo files
+
+A source file declaring `import "C"` is a cgo file. The helper emits cgo-file items but marks them with a `requires_cgo = true` field. The bridge's `[go.capabilities] cgo` check refuses the import unless the user opts in.
+
+## Performance
+
+The helper takes ~50-500ms per module on warm filesystem cache (measured against the 24-module fixture corpus on darwin-arm64 with Go 1.23, May 2026). For a Mochi program with 30 imported modules, the total ingest time is ~5-15 seconds at `mochi pkg lock`. The result is cached in `~/.cache/mochi/go-deps/api-surface/<api-surface-sha256>/`; subsequent locks against the same module versions skip the ingest step.
+
+## Why not consume the `go doc -json` output
+
+Go 1.22 added a `go doc -json` flag that emits a JSON-formatted godoc summary. The bridge does not use it because:
+
+- `go doc` operates on the rendered documentation, not the full type information.
+- `go doc -json` does not expose `types.Type` discriminators; the bridge would have to parse natural-language type strings.
+- `go doc -json`'s schema is not as stable as `go/packages` (added 2024 vs. 2018).
+
+The `go/packages` path is the right level of abstraction.
+
+## Cross-references
+
+- [[02-design-philosophy]] §2 for why `go/packages` over alternatives.
+- [[05-type-mapping]] for what the typemap pass does with the ApiSurface.
+- [[10-interface-and-method-set]] for the interface and method-set encoding details.
+- [MEP-74 §1](/docs/mep/mep-0074#1-pipeline-overview) for where ingest sits in the pipeline.

--- a/website/docs/research/0074/05-type-mapping.md
+++ b/website/docs/research/0074/05-type-mapping.md
@@ -1,0 +1,238 @@
+---
+title: "05. Type mapping"
+sidebar_position: 6
+sidebar_label: "05. Type mapping"
+description: "The complete closed translation table from Go types to Mochi types, the refusal cases, the generic monomorphisation rule, the string vs []byte parameter handling, the error desugar, the chan-as-stream and func-as-callback handle patterns."
+---
+
+# 05. Type mapping table
+
+This note documents the closed translation from Go types to Mochi types. The table is the same shape MEP-73's §05 documents for Rust, adapted for Go's type system.
+
+## Scalar types
+
+| Go type | Mochi type | Notes |
+|---------|-----------|-------|
+| `bool` | `bool` | Direct passthrough. |
+| `int` | `int` | Mochi `int` is 64-bit on all targets; Go `int` is platform-width. The wrapper inserts a runtime check when Go `int` is 32-bit (rare: only on 32-bit linux / wasm-js). |
+| `int8`, `int16`, `int32` | `int` | Sign-extend on the C side. |
+| `int64` | `int` | Direct passthrough (both are 64-bit). |
+| `uint`, `uint8`, `uint16`, `uint32` | `int` | The wrapper guards positive-range at the boundary; out-of-range values raise a runtime error. |
+| `uint64` | `int` | The wrapper rejects values `> int64.MaxValue` at the boundary. |
+| `uintptr` | `int` | Same as `uint64`. |
+| `float32` | `float` | Widening cast. |
+| `float64` | `float` | Direct passthrough. |
+| `byte` (= `uint8`) | `int` | (with positive-range guard) |
+| `rune` (= `int32`) | `int` | |
+| `complex64`, `complex128` | refused | Mochi has no complex type. The user can hand-write an `extern fn` that takes (real, imag) pairs. |
+
+## Strings and byte slices
+
+| Go type | Mochi type | Notes |
+|---------|-----------|-------|
+| `string` | `string` | At the cgo boundary, Go's `string` is copied to a C `char*` via `C.CString`. The wrapper inserts the matching `C.free` call inside a `defer` block. Free symbol: `mochi_go_<module>_string_free(*const c_char)`. |
+| `[]byte` | `bytes` | Owned `(ptr, len, cap)` triple. The wrapper inserts a `_free` symbol that calls `runtime.KeepAlive` and lets Go GC handle reclamation after the Mochi side calls free. |
+
+The `string` round-trip cost is a `C.CString` allocation per call (the Go side cannot pass its internal `string` directly because the underlying buffer is GC-tracked and can move). For hot loops, the user can opt into a `string` builder pattern via the `batched` wrapper variant.
+
+## Collection types
+
+| Go type | Mochi type | Notes |
+|---------|-----------|-------|
+| `[]T` (slice of in-table T) | `list<T>` | `(ptr, len, cap)` triple. The wrapper provides element-wise getter/setter symbols. |
+| `[N]T` (array of in-table T) | `list<T>` | Fixed-size on the Go side; the wrapper allocates a slice and copies. |
+| `map[K]V` (K is `string` or integer; V is in-table) | `map<K, V>` | Opaque `*C.MochiMap` handle. Symbols: `_get`, `_set`, `_delete`, `_iter_begin`, `_iter_next`, `_iter_end`, `_free`. |
+| `map[K]V` (K is a struct or interface) | refused | Mochi's map keys are `string` or integer; mapping struct keys would require hashing on the C side which the wrapper does not implement. |
+
+Go's `map` is the trickiest case. Go maps cannot be passed across the cgo boundary because the underlying hash table is GC-tracked and the bucket layout is internal. The wrapper exposes a per-handle iterator with `_iter_*` symbols; the Mochi side bridges this to Mochi's `for k, v in m { ... }` loop via the iterator protocol. Iteration order is non-deterministic on the Go side (Go intentionally randomises map iteration); the wrapper documents this.
+
+## Pointer types
+
+| Go type | Mochi type | Notes |
+|---------|-----------|-------|
+| `*T` (T is a named struct) | `T?` (nullable handle) | Opaque cgo handle. The wrapper exposes constructor / accessor symbols per exported field. |
+| `*T` (T is a named primitive like `*int`) | `int?` | Auto-dereferenced on the boundary; nil maps to Mochi `nil`. |
+| `*T` (T is unexported) | refused | The Mochi side cannot construct or inspect an unexported type. |
+| `**T` (pointer-to-pointer) | refused | Mochi has no pointer arithmetic; double-pointer semantics don't translate. |
+
+## Struct types
+
+A Go struct with all-exported fields, all of which are in-table, becomes a Mochi `record`:
+
+```go
+type User struct {
+    ID    int64
+    Name  string
+    Email string
+}
+```
+
+```mochi
+record User {
+    ID: int,
+    Name: string,
+    Email: string,
+}
+```
+
+A struct with mixed-export fields (some uppercase, some lowercase) projects the exported subset:
+
+```go
+type Internal struct {
+    Public  string
+    private int
+}
+```
+
+```mochi
+record Internal {
+    Public: string,
+}
+```
+
+A `SkipReport` entry records the dropped `private` field. The wrapper exposes only the public accessor.
+
+A struct embedding another struct or interface promotes the embedded type's exported fields and methods. The bridge resolves promotions at ingest time.
+
+## Interface types
+
+A Go interface becomes a Mochi `extern type` with per-method `extern fn` declarations:
+
+```go
+type Reader interface {
+    Read(p []byte) (n int, err error)
+}
+```
+
+```mochi
+extern type Reader
+extern fn (r: Reader) read(p: bytes): Result<int> from go "io.Reader.Read"
+```
+
+The Mochi side gets an opaque handle; method calls go through cgo. Mochi cannot itself implement a Go interface (the implementation would have to live on the Go side); a future MEP could add this via callback handles, but MEP-74 v1 does not.
+
+## Channel types
+
+A Go `chan T` (bidirectional) becomes a Mochi `stream<T>`:
+
+```go
+func Tick(d time.Duration) <-chan time.Time
+```
+
+```mochi
+extern fn tick(d: int): stream<int> from go "time.Tick"
+```
+
+The wrapper allocates a Go channel of buffer size `[go.goroutine-bridge.default-buffer]`, registers it as a cgo handle, and exposes `_send`, `_recv`, `_close` symbols. The Mochi side consumes the stream via the normal stream-iterator protocol.
+
+Direction-restricted channels (`<-chan T`, `chan<- T`) project the appropriate subset of operations. A receive-only channel maps to a Mochi `stream<T>` with the `send` operation disabled.
+
+## Function types
+
+A Go `func` value (taken as a parameter, returned from a function, or stored in a field) becomes a Mochi callback handle:
+
+```go
+func Walk(root string, fn func(path string) error) error
+```
+
+```mochi
+extern fn walk(root: string, fn: fun(path: string) -> Result<unit>): Result<unit> from go "path/filepath.Walk"
+```
+
+The wrapper registers the Mochi callback as a cgo handle, calls into Go, and dispatches each invocation back to Mochi via the `_call` cgo export. The cost is two cgo crossings per callback invocation (Mochi → Go → callback → Mochi → Go → return).
+
+## The `error` interface
+
+Go's `error` is an interface with one method (`Error() string`). MEP-74 treats it as a built-in sum type rather than as a generic interface:
+
+```go
+func Open(name string) (*File, error)
+```
+
+```mochi
+extern fn open(name: string): Result<File> from go "os.Open"
+```
+
+The Mochi `Result<T>` desugar uses the same `try` / `catch` lowering MEP-73 introduced for `Result<T, E>` in Rust. The error value's `Error() string` call result is the carried message.
+
+## Tuple returns
+
+A Go function returning multiple values returns a tuple to Mochi:
+
+```go
+func Split(s string, sep string) []string
+func Cut(s string, sep string) (before, after string, found bool)
+```
+
+```mochi
+extern fn split(s: string, sep: string): list<string> from go "strings.Split"
+extern fn cut(s: string, sep: string): tuple<string, string, bool> from go "strings.Cut"
+```
+
+The last-position `error` is special-cased: `(T, error)` becomes `Result<T>` rather than `tuple<T, Result<unit>>`. The `(T1, T2, error)` becomes `Result<tuple<T1, T2>>`. The desugar is documented per-fn in the emitted shim.
+
+## Variadic parameters
+
+A Go `...T` variadic parameter becomes Mochi `varargs<T>`:
+
+```go
+func Printf(format string, args ...any)
+```
+
+The `any` case is refused by default; with `[go.monomorphise]` declarations, the user can bind `Printf` at concrete types.
+
+## Generic items
+
+Go 1.18+ generics are refused by default; opt-in via `[go.monomorphise]`. The bridge synthesises one wrapper per declared instantiation:
+
+```toml
+[go.monomorphise]
+items = [
+    { item = "encoding/json.Unmarshal", T = "MyStruct" },
+    { item = "slices.Sort", T = "int64" },
+    { item = "slices.Sort", T = "string" },
+]
+```
+
+The wrapper emits `mochi_go_<module>_<fn>_<T>` symbols per instantiation. The Mochi shim file declares each as a separate `extern fn`.
+
+## Refusal cases
+
+Items are skipped with a `SkipReport` for the following reasons:
+
+| Reason | Example |
+|--------|---------|
+| `unexported_in_position` | A function returning an unexported type. |
+| `internal_path` | Item lives under `<module>/internal/`. |
+| `generic_without_monomorphise` | Generic item not listed in `[go.monomorphise]`. |
+| `unsafe_pointer` | Item involves `unsafe.Pointer`. |
+| `reflect_value` | Item involves `reflect.Value` or `reflect.Type`. |
+| `cgo_handle` | Item involves `cgo.Handle` directly (without going through the bridge's own handle pool). |
+| `interface_with_complex_method` | Interface method returns a type outside the table. |
+| `chan_of_struct_with_unexported` | Channel element type fails the struct projection. |
+| `map_key_not_basic` | Map key is a struct or interface. |
+| `requires_cgo_capability` | Module declares `import "C"` and the user has not opted in. |
+| `build_tag_excluded` | Item is behind a build tag not in `[go.build-tags]`. |
+
+Each `SkipReport` carries the qualified item name and the reason; the user sees them as warnings during `mochi pkg lock`.
+
+## Type round-trip table
+
+| Boundary direction | Cost | Notes |
+|--------------------|------|-------|
+| Mochi `int` → Go `int64` | 0 (passthrough) | Both are 64-bit on 64-bit hosts. |
+| Mochi `string` → Go `string` | ~50ns + alloc | `C.CString` then `C.GoString`. |
+| Mochi `list<int>` → Go `[]int64` | O(n) copy | Slice header passed; backing memory copied. |
+| Mochi `bytes` → Go `[]byte` | O(n) copy | Same as list. |
+| Mochi callback → Go `func` | ~150ns/invocation | Handle registration + dispatch. |
+| Go `chan T` → Mochi `stream<T>` | ~200ns/element | cgo crossing per element. |
+| Go `error` → Mochi `Result<T>` | ~100ns on error path | Calls `.Error() string`. |
+
+## Cross-references
+
+- [[02-design-philosophy]] §6 for why the table is closed.
+- [[04-go-doc-ast-ingest]] for the ApiSurface JSON shape the typemap consumes.
+- [[09-abi-stability]] for the cgo boundary contract.
+- [[10-interface-and-method-set]] for the interface encoding deep-dive.
+- [[08-goroutine-bridge]] for the channel and callback handle protocols.
+- [MEP-74 §1.3](/docs/mep/mep-0074#1-pipeline-overview) for where the typemap sits in the pipeline.

--- a/website/docs/research/0074/06-go-module-publish-flow.md
+++ b/website/docs/research/0074/06-go-module-publish-flow.md
@@ -1,0 +1,163 @@
+---
+title: "06. Go module publish flow"
+sidebar_position: 7
+sidebar_label: "06. Module publish flow"
+description: "The git-tag upload protocol, the canonical-import-path requirement, the module proxy's caching behaviour, the per-module metadata requirements, the publish-side gate against a synthetic downstream consumer."
+---
+
+# 06. Go module publish flow
+
+This note documents the publish direction (Mochi → Go module) end-to-end. The Go ecosystem's publish model is fundamentally different from Rust's crates.io / npm's registry / PyPI's upload endpoint: there is no central registry. Module publication is a git operation that the module proxy at `proxy.golang.org` picks up asynchronously.
+
+## The git-tag-as-publish model
+
+To publish a Go module at version `v1.2.3`:
+
+1. Have a public git repository (GitHub, GitLab, Gitea, self-hosted) at a canonical-import-path URL like `github.com/example/my-mochi-lib`.
+2. The repo contains a `go.mod` with `module github.com/example/my-mochi-lib` at the root (or under a `vN/` subdirectory for v2+).
+3. Tag a commit with the semver tag: `git tag v1.2.3 && git push origin v1.2.3`.
+4. The first time anyone `go get github.com/example/my-mochi-lib@v1.2.3` runs, the Go module proxy fetches the tag, packages the source tree as a `.zip`, computes the `h1:` checksum, and serves it.
+5. The proxy submits the `(module, version, h1:hash)` triple to sum.golang.org's checksum DB. The DB appends the triple to its Merkle tree and signs the new tree head.
+6. From this point forward, every `go get` of `v1.2.3` is served from the proxy and verified against the checksum DB.
+
+There is no upload step. There is no central registry POST. There is no API token. The entire publish protocol is git push.
+
+## What MEP-74's `mochi pkg publish --to=go+git+<repo>@<tag>` does
+
+The CLI orchestrates:
+
+1. **Build the library module.** `Driver.Build` with `target = TargetGoLibrary` writes a publish-ready Go module to `<workdir>/publish/`:
+   - `go.mod` with `module <canonical-import-path>` and `go <go-version-floor>`.
+   - `doc.go` with the `// Package foo provides ...` first-sentence godoc rule plus the SPDX licence comment.
+   - `LICENSE` file copied from the SPDX template for the declared licence.
+   - `README.md` carried over from the Mochi package's `README.md` (if present).
+   - `<pkg-name>.go` source files mirroring the Mochi package's public surface.
+   - `go.sum` pinning every transitive dependency from `[go-dependencies]`.
+
+2. **Validate.** Run inside `<workdir>/publish/`:
+   - `gofmt -l .` must return zero files (the emit pass is already gofmt-clean, but the validation is the safety net).
+   - `go vet ./...` must return zero diagnostics.
+   - `go build ./...` must succeed.
+   - `go test ./...` is NOT run (test files don't ship in the published module by Go convention).
+   - `golint`-style godoc rule checks (every exported identifier has a doc comment).
+
+3. **Stage the publish commit.** Either:
+   - `<repo-url>` points to an existing local clone: stage the publish-tree files in the clone, commit with a message like `Release v1.2.3 (mochi pkg publish)`.
+   - `<repo-url>` is a remote URL: clone the repo to `<workdir>/publish-repo/`, copy the publish-tree files in, commit, push the branch.
+
+4. **Tag.** Run `git tag <tag>` at the publish commit.
+
+5. **Optionally sign.** With `--cosign-sign`, the bridge:
+   - Acquires an OIDC token from the CI environment (GitHub Actions `id-token: write` claim, GitLab CI ID token, etc.).
+   - Calls `cosign sign-blob --identity-token <oidc> --bundle <tag>.sig` against the commit SHA.
+   - Creates a sibling git tag `<tag>.sig` whose annotated message is the cosign bundle (base64-encoded JSON).
+   - The signing flow is opt-in v1; the Go team has not committed to a canonical signing format yet.
+
+6. **Push.** `git push origin <tag>` (and optionally `<tag>.sig`).
+
+7. **Warm the proxy cache** (optional). HTTP GET `https://proxy.golang.org/<canonical-import-path>/@v/<tag>.info`. This triggers the proxy to fetch the new tag and submit it to sum.golang.org. Without this, the first consumer to `go get` the new version pays the cold-fetch latency.
+
+## Layout of the emitted publish-tree
+
+For a Mochi package `my-mochi-lib` at canonical-import-path `github.com/example/my-mochi-lib`:
+
+```
+publish/
+  go.mod                  # module github.com/example/my-mochi-lib + go 1.21 + require ...
+  go.sum                  # transitive hashes
+  doc.go                  # // Package mymochilib provides ...
+  LICENSE                 # Apache-2.0 OR MIT
+  README.md               # carried over from Mochi
+  user.go                 # func User(...) ...
+  user_test.go            # NOT emitted; test files do not ship
+  internal/               # NOT emitted; internal helpers stay in the Mochi package
+```
+
+The package name comes from the canonical-import-path's last segment (with hyphens stripped per Go convention: `my-mochi-lib` → package `mymochilib`).
+
+## The canonical-import-path requirement
+
+`[go.publish] canonical-import-path` is REQUIRED. The bridge writes this value into `go.mod`'s `module` directive. A mismatch between the declared path and the git remote URL is a fatal publish error: the module proxy would refuse to serve a module whose `go.mod` declares a different canonical path than the proxy's URL.
+
+For vanity import paths (`go.uber.org/zap` → `github.com/uber-go/zap`), the bridge supports the vanity-redirect protocol per phase 17. The canonical-import-path is the vanity URL; the git remote is the actual host. The Mochi side configures the vanity redirect via a `[go.publish.vanity]` table.
+
+## Pre-existing repo state
+
+The bridge does not erase the repo's prior state. If the repo already has commits, the publish-tree files are layered on top of HEAD. This means:
+
+- A user can run `mochi pkg publish` multiple times against the same repo with different tags; each run adds a new commit.
+- A user can intermix Mochi-published commits with hand-authored Go commits in the same repo (e.g., editing the README between Mochi releases).
+- Tag immutability is enforced by git; the bridge refuses to re-tag an existing tag.
+
+## Semver discipline
+
+The bridge does not pick the next semver tag automatically. The user provides the tag explicitly via the `@<tag>` suffix:
+
+```
+mochi pkg publish --to=go+git+github.com/example/my-mochi-lib@v1.2.3
+```
+
+The bridge validates:
+
+- The tag is a valid semver (per `golang.org/x/mod/semver.IsValid`).
+- The tag is not already present in the remote.
+- For v2+ modules, the canonical-import-path includes the `vN/` suffix (Go's "semver major in path" rule: `github.com/foo/bar/v2`).
+
+## The major-version rule
+
+Go's module system embeds the major version in the import path for v2+:
+
+```
+v0.x.y, v1.x.y  →  github.com/foo/bar
+v2.x.y          →  github.com/foo/bar/v2
+v3.x.y          →  github.com/foo/bar/v3
+```
+
+The bridge enforces this rule: when publishing v2.0.0 or higher, `[go.publish] canonical-import-path` must include the `/vN` suffix. The published `go.mod` accordingly declares `module github.com/foo/bar/v2`.
+
+## The publish-side gate
+
+`mochi pkg publish --dry-run` exercises the full flow except the push step. This is the CI-gated reproducibility check:
+
+- Build, validate, stage, tag locally, optionally sign.
+- Diff the staged publish-tree against the prior `v.<N-1>` tag's tree (if a prior tag exists). Report changed files for the publisher's review.
+- Run a synthetic downstream consumer: in a sibling temp directory, write a tiny Go program that imports the staged module and calls a representative exported function. Run `go build` to confirm the API contract.
+
+The synthetic downstream consumer is the bridge's catch-net for API regressions: if the publish would break downstream `go get`s of the new tag, the dry-run catches it.
+
+## Private GOPROXY alternative
+
+For private modules hosted on Athens / JFrog Go / a self-hosted Go module proxy, the bridge supports:
+
+```
+mochi pkg publish --to=go+goproxy+https://goproxy.corp.example.com@v1.2.3
+```
+
+This path:
+
+- Builds and validates the same publish-tree.
+- Packages it as a `.zip` per the Go module proxy spec: zip-of-`<canonical-path>@<version>/` directory.
+- Computes the `h1:` hash.
+- POSTs the .zip to `<proxy-url>/<canonical-path>/@v/<version>.zip` plus the `.mod` and `.info` files per the GOPROXY-compatible upload spec.
+
+This bypasses the git-tag flow entirely and is useful for corporate proxies. Authentication is `.netrc` or HTTP basic; there is no Mochi-managed token.
+
+## Verification of the published module
+
+After publish, the user can verify the result by running `go get` against the canonical-import-path from a clean GOPATH:
+
+```
+$ GOPATH=$(mktemp -d) go get github.com/example/my-mochi-lib@v1.2.3
+$ ls $GOPATH/pkg/mod/github.com/example/my-mochi-lib@v1.2.3/
+go.mod  LICENSE  README.md  doc.go  user.go
+```
+
+If the module proxy has cached the new tag (within ~30s of the push under normal conditions), this works immediately. If not, `GOPROXY=direct go get` bypasses the proxy and fetches from the git remote directly.
+
+## Cross-references
+
+- [[01-language-surface]] for the `[go.publish]` manifest table.
+- [[07-sigstore-go-checksumdb]] for the optional cosign signing and the sum.golang.org integration.
+- [[09-abi-stability]] for the cgo export contract when `cgo-export = true`.
+- [MEP-74 §6](/docs/mep/mep-0074#6-build-orchestration) for the build orchestration this publish flow extends.
+- [The Go module reference](https://go.dev/ref/mod) for the canonical Go-side documentation.

--- a/website/docs/research/0074/07-sigstore-go-checksumdb.md
+++ b/website/docs/research/0074/07-sigstore-go-checksumdb.md
@@ -1,0 +1,138 @@
+---
+title: "07. Sigstore and Go checksum DB"
+sidebar_position: 8
+sidebar_label: "07. Sigstore + sum.golang.org"
+description: "The sum.golang.org transparency log structure, the Merkle-tree consistency proof protocol, the gosum-cosign workflow draft of 2026-Q1, the optional <tag>.sig sibling tag, the verification path at consume time, and the design trade-off vs MEP-73's Sigstore-keyless-mandatory stance."
+---
+
+# 07. Sigstore and Go checksum DB
+
+This note details the supply-chain story: how the bridge verifies imported Go modules against the public checksum DB at consume time, and how the bridge optionally signs published modules with cosign for downstream verification.
+
+## sum.golang.org as a transparency log
+
+The Go team operates two complementary services at the heart of the Go module supply chain:
+
+- **`proxy.golang.org`**: a caching mirror of every public Go module. Fetches modules from their canonical-import-path's git remote on first request, caches the .zip, serves all subsequent requests from cache.
+
+- **`sum.golang.org`**: a Merkle-tree transparency log of every public module version. The log records `(module, version, h1:hash)` triples; the tree head is signed by a Go-team-controlled key; the log is append-only and consistency-proven.
+
+Every `go get` of a public module since Go 1.13 (September 2019) verifies the downloaded module against sum.golang.org by default. The verification:
+
+1. Download the module .zip from the proxy.
+2. Compute `h1:<base64(sha256(zip-bytes))>`.
+3. Fetch `https://sum.golang.org/lookup/<module>@<version>`. This returns the canonical record body plus the tree's signed head at lookup time.
+4. Assert the bridge's computed `h1:` equals the record's `h1:`.
+5. Fetch the Merkle tile path proving the record is included in the signed tree.
+6. Verify the tree head signature against the Go team's hard-coded public key.
+
+If any step fails, `go get` aborts. This is a hard supply-chain gate, on by default.
+
+## How MEP-74 integrates with sum.golang.org
+
+MEP-74 makes this verification a hard requirement of every `mochi pkg lock` for public modules. The implementation:
+
+```go
+// package3/go/sumdb/verify.go (sketch)
+
+type SumdbClient struct {
+    BaseURL   string // default "https://sum.golang.org"
+    PubKey    ed25519.PublicKey
+}
+
+func (c *SumdbClient) Verify(module, version string, computedH1 string) (record SumdbRecord, err error) {
+    // 1. Lookup
+    resp, err := http.Get(c.BaseURL + "/lookup/" + module + "@" + version)
+    // ...
+    // 2. Parse record body: "<module> <version> h1:<base64>\n"
+    rec := parseRecord(body)
+    if rec.H1 != computedH1 {
+        return rec, fmt.Errorf("h1 mismatch: expected %s, got %s", rec.H1, computedH1)
+    }
+    // 3. Verify signed tree head
+    if !ed25519.Verify(c.PubKey, rec.TreeHead.Bytes(), rec.TreeHead.Signature) {
+        return rec, errors.New("sumdb signature invalid")
+    }
+    // 4. Fetch Merkle tile path and verify inclusion
+    tiles, err := c.FetchTiles(rec.RecordIndex, rec.TreeHead.Size)
+    if !inclusionProof(rec, tiles, rec.TreeHead.Hash) {
+        return rec, errors.New("sumdb inclusion proof invalid")
+    }
+    return rec, nil
+}
+```
+
+The hard-coded public key is the one the Go team publishes at https://sum.golang.org/latest. Mochi pins the key at bridge compile time; key rotation requires a new bridge release.
+
+The verification result (`sumdb-record-hash`, `sumdb-tree-size`) is recorded in `mochi.lock`'s `[[go-package]]` entry. A later `--check` can request a Merkle consistency proof from sum.golang.org showing that the lock-time leaf is still in the current tree.
+
+## Private-module opt-out
+
+Not every module is public-resolvable. Corporate modules at `corp.example.com/internal/foo` legitimately do not appear in sum.golang.org. The bridge supports per-glob opt-out:
+
+```toml
+[go.private]
+modules = ["corp.example.com/**"]
+sumdb-skip = ["corp.example.com/**"]
+```
+
+This mirrors the `GOPRIVATE` / `GONOSUMCHECK` Go-side env vars. Modules matching `sumdb-skip` patterns:
+
+- Skip the sum.golang.org cross-check.
+- Record `sumdb-verified = false` in `mochi.lock` (audit trail).
+- Still verify the BLAKE3-256 of the downloaded .zip against the recorded hash (the bridge's primary integrity check).
+
+The opt-out is per-glob, not global: a project mixing public and private modules verifies the public ones strictly and skips the private ones.
+
+## The gosum-cosign workflow draft
+
+The Go team has not committed to a canonical publish-side signing format as of 2026-05. The closest community draft is the **gosum-cosign workflow** (originated in a discussions post on golang-tools-dev in 2026-Q1):
+
+- After tagging a release `v1.2.3`, the publisher signs the tag's commit SHA with cosign:
+  ```
+  cosign sign-blob --identity-token <oidc-jwt> --bundle v1.2.3.sig <commit-sha-as-file>
+  ```
+- The signature bundle is attached as a sibling annotated git tag `v1.2.3.sig`.
+- Downstream consumers can fetch the sibling tag and verify against Sigstore's transparency log (Rekor).
+
+MEP-74 supports this workflow under the `--cosign-sign` flag on `mochi pkg publish`. The flag is opt-in for v1 because:
+
+1. The workflow is a draft, not a standard. The Go team may pick a different format.
+2. Consumers must know to look for the `<tag>.sig` sibling tag; no Go-stdlib tooling does this yet.
+3. Sigstore's trust model is parallel to sum.golang.org's, not a substitute. Both can coexist.
+
+The bridge re-evaluates the default when the Go team publishes a canonical signing spec.
+
+## Comparison with MEP-73's Sigstore-mandatory stance
+
+MEP-73 §02-5 makes Sigstore-keyless OIDC mandatory for crates.io publish. MEP-74 does not. The asymmetry is justified:
+
+- crates.io has a registry POST endpoint that accepts an OIDC token. MEP-73 can require it.
+- Go has no central upload endpoint. The publish operation is `git push`. The bridge cannot require the user's git remote to verify a signature it does not understand.
+- sum.golang.org provides a separate, well-established transparency log that catches the same class of attacks (post-publish module rewriting). MEP-74 cross-checks against it on every lock.
+
+The net supply-chain guarantee:
+
+| Threat | MEP-73 (Rust) defence | MEP-74 (Go) defence |
+|--------|------------------------|----------------------|
+| Compromised long-lived publish token | Sigstore-keyless OIDC, no long-lived token | git push auth (user's existing) |
+| Post-publish module rewriting | Sigstore Rekor log + Mochi lockfile pin | sum.golang.org Merkle log + Mochi lockfile pin |
+| Compromised registry mirror | Sigstore Fulcio cert + Rekor inclusion | sum.golang.org `h1:` cross-check |
+| Compromised consumer's local clock | Sigstore RFC3161 timestamp | sum.golang.org tree-head timestamp |
+| Source repo rewritten history | Sigstore commit-attestation | git pseudo-version + go.sum |
+
+The defences are different but the coverage is comparable. MEP-74's coverage is arguably stronger on the post-publish-rewriting axis (the Go log has been operational since 2019 with universal adoption; Sigstore Rekor is younger and not universal).
+
+## Operational considerations
+
+- **Latency.** The sum.golang.org lookup adds one HTTP RTT per dep at lock time. With 30 deps, the cumulative cost is ~3-6 seconds on a normal connection. The bridge runs the lookups in parallel via a worker pool of 8.
+- **Availability.** sum.golang.org has a public uptime SLA from the Go team. The bridge does not provide a fallback log; if sum.golang.org is unreachable, `mochi pkg lock` fails (with a clear diagnostic suggesting `[go.private] sumdb-skip` as the workaround for the affected module). A `--sumdb-offline` flag exists but is recommended only for air-gapped builds.
+- **Geographic latency.** sum.golang.org is CDN-fronted; latency from any continent is &lt; 300ms.
+
+## Cross-references
+
+- [[02-design-philosophy]] §5 for why the cross-check is mandatory by default.
+- [[06-go-module-publish-flow]] §5 for the publish-side cosign integration.
+- [[12-risks-and-alternatives]] §R5 for the single-signing-key risk.
+- [The Go sumdb spec](https://go.dev/ref/mod#authenticating) for the canonical protocol documentation.
+- [MEP-73 §07](/docs/research/0073/07-sigstore-cargo-rfc3724) for the sister Rust-bridge approach.

--- a/website/docs/research/0074/08-goroutine-bridge.md
+++ b/website/docs/research/0074/08-goroutine-bridge.md
@@ -1,0 +1,205 @@
+---
+title: "08. Goroutine bridge"
+sidebar_position: 9
+sidebar_label: "08. Goroutine bridge"
+description: "The cgo boundary cost, the Go runtime scheduler inside the c-archive, the channel-as-handle pattern, the callback-as-handle pattern, the cgo.Handle lifetime story, why no runtime singleton is needed unlike MEP-73's tokio singleton."
+---
+
+# 08. Goroutine bridge
+
+This note details how the bridge exposes Go's first-class concurrency (goroutines, channels, `select`) to Mochi. The story is materially simpler than MEP-73's Rust async bridge because Go's runtime ships with the goroutine scheduler built in.
+
+## No runtime singleton
+
+MEP-73 §08 documents an entire singleton pattern: a process-wide `tokio::runtime::Runtime` constructed lazily on first async-rust call, with the runtime's `block_on` dispatching every async call. The Rust async story requires a host executor.
+
+The Go story does not. Every Go binary, including c-archives, ships the goroutine scheduler. When Mochi cgo-calls into a wrapper-exported function:
+
+- The cgo call acquires a per-call goroutine on the Go side.
+- The function runs inside the Go runtime's scheduler.
+- If the function spawns goroutines (`go some_func()`), the scheduler picks them up automatically.
+- If the function blocks on a channel receive (`<-ch`), the scheduler parks the goroutine.
+- When the function returns, the cgo call returns.
+
+The bridge has no runtime to construct. No `OnceLock<Runtime>`. No lazy init.
+
+## The cgo boundary cost
+
+Each cgo call from Mochi into Go costs ~200ns on darwin-arm64 (Go 1.23, May 2026, measured on Apple M3). Breakdown:
+
+- ~50ns: cgo state machine transition (push the C call frame, switch to the Go execution context).
+- ~100ns: per-call goroutine acquire from the goroutine pool (Go reuses goroutines from a per-thread pool; the first call on a thread is slightly slower).
+- ~50ns: argument marshalling for the call (varies with argument count and size).
+
+Going the other direction (Go callback into Mochi via a registered handle) adds another ~150ns. So a Mochi callback invoked from inside a Go function costs ~350ns per round-trip.
+
+The cost is materially higher than Mochi-native calls (~5ns). Programs that hot-loop across the cgo boundary pay this per iteration. The mitigation is the batched-variant wrapper.
+
+## The batched-variant wrapper
+
+For functions identified as hot-path candidates (the synthesiser inspects the user's Mochi source for `for x in xs { go_fn(x) }`-shaped patterns), the bridge offers a batched variant:
+
+```go
+// Original signature
+func ProcessOne(x int64) int64
+
+// Synthesised batched variant
+//export mochi_go_<module>_ProcessOne_batched
+func ProcessOne_batched(xs []int64) []int64 {
+    out := make([]int64, len(xs))
+    for i, x := range xs {
+        out[i] = ProcessOne(x)
+    }
+    return out
+}
+```
+
+The Mochi side calls the batched variant with a slice; the per-call cgo cost is amortised across the batch. A 1M-element batch pays one cgo crossing instead of 1M.
+
+The batched variant is opt-in via a `[go.batched]` table in `mochi.toml`:
+
+```toml
+[go.batched]
+items = [
+    "github.com/example/processor.ProcessOne",
+    "github.com/example/hasher.Hash",
+]
+```
+
+## Channel handle pattern
+
+Go's `chan T` cannot be passed directly across the cgo boundary (cgo only handles primitive C types and pointers). The bridge exposes channels as opaque cgo handles via the `runtime/cgo` package (in-stdlib since Go 1.17, August 2021).
+
+```go
+// Wrapper for a Go function returning a chan.
+//export mochi_go_<module>_Tick
+func mochi_go_time_Tick(duration int64) uint64 {
+    ch := time.Tick(time.Duration(duration))
+    return acquireHandle(ch)
+}
+
+//export mochi_go_<module>_chan_recv_time
+func mochi_go_chan_recv_time(handle uint64) (int64, bool) {
+    ch := resolveHandle(handle).(<-chan time.Time)
+    t, ok := <-ch
+    if !ok { return 0, false }
+    return t.UnixNano(), true
+}
+
+//export mochi_go_<module>_chan_close
+func mochi_go_chan_close(handle uint64) {
+    releaseHandle(handle)
+}
+```
+
+The Mochi side gets a `stream<int>` whose iterator calls `mochi_go_<module>_chan_recv_<elem-type>` per element and stops on `ok = false`. The closing of the stream calls `mochi_go_<module>_chan_close`.
+
+### Handle lifetime
+
+The handle pool is a `sync.Map[uint64]any` keyed by a monotonically incrementing uint64. The wrapper module's `mochi_rt.go` file holds:
+
+```go
+var (
+    handlesMu sync.Mutex
+    handles   = map[uint64]cgo.Handle{}
+    nextID    uint64
+)
+
+func acquireHandle(v any) uint64 {
+    handlesMu.Lock()
+    defer handlesMu.Unlock()
+    nextID++
+    h := cgo.NewHandle(v)
+    handles[nextID] = h
+    return nextID
+}
+
+func releaseHandle(id uint64) {
+    handlesMu.Lock()
+    h, ok := handles[id]
+    if ok { delete(handles, id) }
+    handlesMu.Unlock()
+    if ok { h.Delete() }
+}
+```
+
+The `cgo.NewHandle` is the canonical Go-stdlib way to pin a Go value across the cgo boundary (the standard alternative, `runtime.SetFinalizer`, is less safe). The handle keeps the value alive (preventing GC) until `Delete()` is called.
+
+A handle leaked (the Mochi side forgets to call `_close`) is recovered at process exit when the c-archive is torn down. During process lifetime, a leak accumulates one slot in the `handles` map per leak. The `[go.goroutine-bridge.max-handles]` soft limit (default 4096) is the back-pressure: when the pool size exceeds the limit, new acquires fail.
+
+## Callback handle pattern
+
+Go functions taking `func` parameters (`func(...) ...`) receive Mochi callbacks via the symmetric handle pattern:
+
+```go
+//export mochi_go_<module>_Walk
+func mochi_go_filepath_Walk(root *C.char, fnHandle uint64) C.int {
+    fn := resolveHandle(fnHandle).(func(string) error)
+    err := filepath.Walk(C.GoString(root), func(path string, info fs.FileInfo, err error) error {
+        return fn(path)
+    })
+    if err != nil { return cgoErrorCode(err) }
+    return 0
+}
+```
+
+The Mochi side does:
+
+1. Construct a callback closure as a Mochi `fun` value.
+2. Register it via `mochi_go_<module>_callback_register_<sig>(closurePtr)` which returns a handle.
+3. Call `mochi_go_filepath_Walk(root, callbackHandle)`.
+4. Inside Go, every `filepath.Walk` callback invocation dispatches back through `_call_<sig>(handle, args...)` which the Mochi side handles by calling the registered closure.
+5. After the outer call returns, the Mochi side calls `mochi_go_<module>_callback_release(handle)` to clean up.
+
+The bridge inserts the `register` and `release` calls into the synthesised shim file automatically; the user does not write any of this plumbing.
+
+## `select` and multi-channel coordination
+
+Go's `select` statement multiplexes over multiple channels. The bridge does not expose `select` directly to Mochi (it would require the Mochi side to express the multiplexing intent). Instead, the wrapper for any function internally using `select` is opaque: the function returns when its `select` completes, and the Mochi side sees only the function's result.
+
+The Mochi side can do its own multiplexing via `stream<T>` selection (Mochi's streams have a `select(...)` combinator), but only over Mochi-side streams. Cross-language multiplexing (one Mochi stream and one Go channel) is not supported.
+
+## Goroutine spawning
+
+Mochi's `spawn <expr>` lowers to `go <expr-shim>()` in the wrapper when `<expr>` calls a Go-exported function. The Go runtime schedules the spawned goroutine; the Mochi side gets back a `Future<T>` that resolves when the goroutine completes.
+
+The implementation: the wrapper exposes a `spawn_<fn>` variant for each exported `fn`:
+
+```go
+//export mochi_go_<module>_<fn>_spawn
+func mochi_go_<module>_<fn>_spawn(args ...) uint64 {
+    resultCh := make(chan resultType, 1)
+    go func() {
+        resultCh <- <fn>(args...)
+    }()
+    return acquireHandle(resultCh)
+}
+
+//export mochi_go_<module>_<fn>_await
+func mochi_go_<module>_<fn>_await(handle uint64) resultType {
+    ch := resolveHandle(handle).(chan resultType)
+    r := <-ch
+    releaseHandle(handle)
+    return r
+}
+```
+
+The Mochi side's `Future<T>` wraps the handle and exposes `.await()` which calls `_await`.
+
+## Concurrent execution semantics
+
+Multiple Mochi-side cgo calls into the same wrapper run concurrently inside the Go runtime's scheduler. Go's scheduler picks the right number of OS threads (controlled by `GOMAXPROCS`, default = `runtime.NumCPU()`). The bridge does not need to coordinate; the Go runtime handles it.
+
+Two caveats:
+
+- **GC stop-the-world events.** A Go GC pause (~ms scale on a typical wrapper module) blocks all cgo calls into the wrapper. The pause frequency depends on the wrapper's allocation pressure.
+- **Goroutine leaks.** A goroutine spawned by a wrapper function that never returns leaks. The bridge documents the lifetime contract per spawned-goroutine variant.
+
+## Cross-references
+
+- [[02-design-philosophy]] §4 for why no runtime singleton.
+- [[05-type-mapping]] for the `chan` and `func` mappings.
+- [[09-abi-stability]] for the cgo boundary contract.
+- [[12-risks-and-alternatives]] §R1 for the cgo cost risk.
+- [The runtime/cgo package documentation](https://pkg.go.dev/runtime/cgo) for the handle pattern.
+- [MEP-73 §08](/docs/research/0073/08-async-bridge) for the sister Rust-bridge tokio singleton.

--- a/website/docs/research/0074/09-abi-stability.md
+++ b/website/docs/research/0074/09-abi-stability.md
@@ -1,0 +1,168 @@
+---
+title: "09. ABI stability"
+sidebar_position: 10
+sidebar_label: "09. ABI stability"
+description: "The cgo `//export` ABI guarantees, the C-side ownership contract, the runtime.KeepAlive invariant, the string and slice round-trip mechanics, the c-archive vs c-shared decision, the cross-platform header story, and the batched-variant optimisation for hot loops."
+---
+
+# 09. ABI stability
+
+This note covers the ABI contract between Mochi and the synthesised wrapper package. The contract is layered: cgo's `//export` ABI underneath, the bridge's symbol-naming and ownership conventions on top.
+
+## The cgo `//export` ABI
+
+A Go function annotated with `//export Foo` is exposed as a C-callable symbol with the C-side declaration:
+
+```c
+extern <C-return-type> Foo(<C-argument-types>);
+```
+
+The cgo translation:
+
+| Go type | C type |
+|---------|--------|
+| `int8`, `int16`, `int32`, `int64` | `int8_t`, `int16_t`, `int32_t`, `int64_t` |
+| `uint8`, `uint16`, `uint32`, `uint64` | `uint8_t`, `uint16_t`, `uint32_t`, `uint64_t` |
+| `float32`, `float64` | `float`, `double` |
+| `bool` | `_Bool` (C99) |
+| `*C.char` | `char*` |
+| `[]byte` via `unsafe.Slice` | not supported as `//export` arg; use `*C.char` + `int` |
+| `unsafe.Pointer` | `void*` |
+| Multi-return `(T, error)` | struct return: `typedef struct { T r0; char* r1; } Foo_return;` |
+
+The bridge restricts itself to the safe subset: scalar arguments, `*C.char` for strings, `*C.void` (cast to specific struct pointers) for opaque handles, multi-return structs for `Result<T>`-shaped functions. The full `unsafe.Pointer` surface is not used in the synthesised wrapper.
+
+## C-side ownership contract
+
+The bridge documents the ownership of every value crossing the boundary:
+
+| Value direction | Allocator | Releaser | Lifetime |
+|------------------|-----------|----------|----------|
+| Mochi → Go scalar | n/a | n/a | per-call |
+| Mochi → Go `*C.char` (string) | Mochi side via `mochi_make_cstr` | the Go side after `C.GoString` copies | per-call |
+| Go → Mochi `*C.char` (string) | Go side via `C.CString` | the Mochi side via `mochi_go_<module>_string_free` | until free |
+| Go → Mochi struct handle | Go side via `C.malloc`-equivalent backing the cgo handle | the Mochi side via `mochi_go_<module>_<type>_free` | until free |
+| Go → Mochi slice triple | Go side; backing array pinned by `cgo.Handle` | Mochi side via `mochi_go_<module>_<type>_free` | until free |
+| Mochi → Go callback | Mochi-side closure registered as handle | Mochi side via `mochi_go_<module>_callback_release` | scope of the outer call |
+
+Every `//export` function the wrapper emits has a matching `_free` symbol (when it returns an owned value). The Mochi side calls the appropriate `_free` from a `defer`-equivalent block when the value goes out of Mochi scope.
+
+## The `runtime.KeepAlive` invariant
+
+A subtle Go-side concern: when the wrapper passes a Go object's internal pointer to the C side, Go's GC can move or reclaim the object if it cannot prove the object is still reachable from Go code. The fix: insert `runtime.KeepAlive(obj)` at the end of every `//export` function, before the return:
+
+```go
+//export mochi_go_module_GetData
+func mochi_go_module_GetData(handle uint64) *C.char {
+    obj := resolveHandle(handle).(*Data)
+    cstr := C.CString(obj.Text)
+    runtime.KeepAlive(obj) // ensure obj is not GC'd while cstr is in C-side scope
+    return cstr
+}
+```
+
+The bridge's wrapper synthesiser inserts `runtime.KeepAlive` on every variable that participates in a C-side pointer at function return. This is mechanical and correct by construction.
+
+## String round-trip mechanics
+
+Strings are the most expensive scalar to cross the boundary. The round-trip:
+
+- **Mochi → Go**: Mochi side allocates a C string via its own allocator (`mochi_make_cstr` in the Mochi runtime). The C string is passed to the wrapper. The wrapper calls `C.GoString(cstr)` which copies the bytes into a Go-allocated string. The C string can be freed immediately after the call returns.
+
+- **Go → Mochi**: Wrapper side calls `C.CString(goStr)` which mallocs a C buffer and copies the bytes. The C buffer is returned to Mochi. Mochi side eventually calls `mochi_go_<module>_string_free(cstr)` which (on the wrapper side) calls `C.free(unsafe.Pointer(cstr))`.
+
+The cost: two allocations and two copies per round-trip. For a hot loop processing string arguments, this dominates the cgo overhead. The batched variant amortises by passing a `[]string`-as-`(ptr, len, cap)`-triples slice.
+
+## Slice round-trip mechanics
+
+Slices follow a similar pattern. The `[]T` (for in-table T) round-trip:
+
+- **Mochi → Go**: Mochi side passes a `(ptr, len, cap)` triple. The wrapper reconstructs a Go slice header via `unsafe.Slice(ptr, len)`. The slice elements are read by the Go function; modifications are visible to Mochi because the backing array is shared.
+
+- **Go → Mochi**: Wrapper allocates a backing C array via `C.malloc(sizeof(T) * len)`, copies the slice elements into it, returns the `(ptr, len, cap)` triple. The Mochi side eventually calls `mochi_go_<module>_<type>_free(ptr)` which the wrapper resolves via `C.free`.
+
+For `[]byte`, the bridge can sometimes avoid the copy: if the Go function does not retain the slice past return, the wrapper can pass the Mochi-side pointer directly. The bridge does this when the source function's signature is `func(p []byte) ...` with no goroutine-spawn or channel-send that would extend the slice's lifetime.
+
+## c-archive vs c-shared
+
+Go offers two C-ABI build modes:
+
+- **`-buildmode=c-archive`**: emit a static library (`.a`) plus header. Linked into the consumer's binary statically. Whole-program optimisation possible. Single-binary deployment.
+
+- **`-buildmode=c-shared`**: emit a shared library (`.so` / `.dylib` / `.dll`) plus header. Dynamically loaded by the consumer. Symbol resolution at runtime. Multiple consumers can share the same .so.
+
+MEP-74 uses `c-archive` for the consume direction (wrapper packages linked into the Mochi binary) and offers both `c-archive` and `c-shared` for the publish direction (Mochi-as-library consumed by non-Go via `[go.publish.crate-type-equivalent]`).
+
+The c-archive trade-off:
+
+- Each wrapper module is its own `.a`, linked statically into the final binary. A program importing 10 Go modules has 10 c-archives linked in.
+- The Go runtime is embedded once per c-archive but the linker deduplicates the runtime symbols across c-archives (the Go team's c-archive design accommodates this).
+- The final binary size grows linearly with the number of imported Go modules (~1-3 MB per typical module, dominated by transitive deps).
+
+The c-shared trade-off:
+
+- The consumer dlopens the .so / .dylib at runtime; if not on the user's library path, the load fails.
+- Multiple consumers can share the .so; memory savings on multi-process deployments.
+- Cross-platform packaging is harder (the .so / .dylib name and path conventions vary).
+
+MEP-74 defaults to c-archive because single-binary deployment matches the rest of MEP-54's Go-target story.
+
+## Cross-platform header
+
+The `_cgo_export.h` header cgo generates contains the C-side declarations for every `//export`. The header is host-arch-specific:
+
+- `int` width differs (`int` is 32-bit on most platforms; the bridge uses `int64_t` / `int32_t` exclusively to avoid the variation).
+- Struct alignment differs (the bridge uses `#pragma pack(8)` to force 8-byte alignment).
+- Pointer width differs on 32-bit platforms (the bridge guards on `sizeof(void*) == 8`; 32-bit hosts are not supported on the consume side).
+
+The bridge writes the header to `<workdir>/go_wrap/<module>/<goarch>-<goos>.h` and the build driver picks the right one based on the build target.
+
+## Symbol-naming convention
+
+Every `//export` symbol the wrapper emits is named:
+
+```
+mochi_go_<module-path-hash>_<item-name-snake-case>
+```
+
+Where:
+
+- `<module-path-hash>` is the first 8 hex characters of `SHA-256(canonical-import-path)`. This avoids long module-path names in symbols and makes collisions across different versions of the same module deterministic (different versions produce different hashes only if their canonical-import-path differs, which it does for v2+).
+- `<item-name-snake-case>` is the Go-export item name with PascalCase converted to snake_case.
+
+Examples:
+
+- `github.com/spf13/cobra.NewCommand` → `mochi_go_a1b2c3d4_new_command`
+- `github.com/spf13/cobra.Command.SetUse` → `mochi_go_a1b2c3d4_command_set_use`
+
+The hash prefix isolates wrapper packages from one another and prevents global-namespace collisions when multiple wrappers are linked into the same binary.
+
+## The batched-variant optimisation
+
+For functions called in hot loops, the bridge synthesises a batched variant that processes a slice in one cgo crossing. The synthesiser identifies hot-path candidates by inspecting the user's Mochi source for `for x in xs { wrapped_call(x) }`-shaped patterns; when one is found and the source function is opted into `[go.batched]`, the bridge offers both the per-element variant and the batched variant. The user selects per-call via `<alias>.<fn>_batched(xs)`.
+
+The cost amortisation:
+
+- Per-element: 200ns × N cgo crossings = 200N ns
+- Batched: 200ns + (50ns × N marshalling) = 200ns + 50N ns
+
+For N = 1,000, the per-element cost is 200μs; the batched cost is 50.2μs. ~4x speedup. For N = 1M, the speedup is ~4x. The crossover is around N = 1.
+
+## ABI stability across Go versions
+
+Go's c-archive ABI has been stable since Go 1.5 (August 2015). Specific guarantees:
+
+- `//export` symbol calling convention is platform's standard C calling convention (cdecl on x86, AAPCS64 on arm64, etc.).
+- Multi-return structs are passed by value following the platform's struct-return convention.
+- `*C.char` is `char*`, pointer-width.
+- The Go runtime initialisation runs lazily on first cgo entry; consumers do not need to call an init function explicitly (older versions of Go required this; since Go 1.10 it is automatic).
+
+The bridge pins the wrapper's `go-version-floor = "1.21"` (the same floor MEP-54 uses). Older Go versions are not supported on the consume side; users wanting older-Go support can override via the manifest.
+
+## Cross-references
+
+- [[02-design-philosophy]] §3 for why c-archive over alternatives.
+- [[05-type-mapping]] for the type translation that determines the ABI per item.
+- [[08-goroutine-bridge]] for the channel and callback ABI extensions.
+- [[12-risks-and-alternatives]] §R1 for the cgo cost discussion.
+- [The cgo documentation](https://pkg.go.dev/cmd/cgo) for the upstream ABI documentation.

--- a/website/docs/research/0074/10-interface-and-method-set.md
+++ b/website/docs/research/0074/10-interface-and-method-set.md
@@ -1,0 +1,206 @@
+---
+title: "10. Interfaces and method sets"
+sidebar_position: 11
+sidebar_label: "10. Interfaces and method sets"
+description: "Go's structural interface satisfaction, the value-receiver vs pointer-receiver method-set rules, how the bridge translates `type I interface { M() }` into Mochi extern types, the embedded-interface promotion story, the empty-interface `any` / `interface{}` refusal, the trait-object analogue to Rust's `dyn Trait`."
+---
+
+# 10. Interfaces and method sets
+
+This note covers the trickiest part of the type-mapping: Go interfaces and their interaction with method sets. Go's interface semantics are structural (any type with the right method set satisfies the interface) and the satisfaction rules are subtle (value vs pointer receivers). The bridge has to encode all of this through the cgo boundary.
+
+## Go interfaces are structural
+
+A Go interface is a method set. A type satisfies the interface iff its method set includes every method the interface lists. There is no explicit `implements` declaration; satisfaction is checked structurally by the compiler:
+
+```go
+type Reader interface {
+    Read(p []byte) (n int, err error)
+}
+
+type FileReader struct { f *os.File }
+
+func (r *FileReader) Read(p []byte) (n int, err error) {
+    return r.f.Read(p)
+}
+
+// FileReader satisfies Reader implicitly; no `type FileReader implements Reader` declaration.
+```
+
+The bridge's strategy: an interface type becomes a Mochi `extern type` with per-method `extern fn` declarations. The Mochi side holds an opaque handle; method calls dispatch through cgo to the underlying Go value:
+
+```mochi
+extern type Reader
+extern fn (r: Reader) read(p: bytes): Result<int> from go "io.Reader.Read"
+```
+
+The Mochi user cannot construct a `Reader` value directly; they obtain it from a Go function that returns `Reader` (e.g., `os.Open` returns `*os.File` which the wrapper auto-promotes to a `Reader` handle when assigned to a `Reader`-typed variable).
+
+## Method sets: value vs pointer receivers
+
+A Go method can have a value receiver (`func (r T) M()`) or a pointer receiver (`func (r *T) M()`). The method-set rules:
+
+- Method set of type `T`: methods with receiver `T` (only value receivers).
+- Method set of type `*T`: methods with receiver `T` OR receiver `*T` (both).
+
+This matters for interface satisfaction: a value of type `T` satisfies an interface only if every interface method has a value-receiver implementation on `T`. A value of type `*T` always satisfies.
+
+The bridge encodes the receiver kind in the emitted `extern fn`:
+
+```mochi
+extern type Buffer  // wraps Go *bytes.Buffer
+extern fn (b: Buffer) write_string(s: string): Result<int> from go "bytes.Buffer.WriteString" receiver "pointer"
+extern fn (b: Buffer) string(): string from go "bytes.Buffer.String" receiver "value"
+```
+
+The `receiver "pointer"` / `receiver "value"` clause is honoured by the wrapper synthesiser when it picks the call shape:
+
+- For value-receiver methods, the wrapper takes the handle by value (copy the Go value out of the handle, call the method, copy back if mutated... actually Go's value semantics means the wrapper just dereferences the handle, copies the value, calls the method, ignores the copy because value receivers can't mutate).
+- For pointer-receiver methods, the wrapper takes the handle, dereferences to get the pointer, calls the method.
+
+The bridge always exposes the more-complete `*T` method set; Mochi values are always opaque handles to `*T` (pointer to the underlying Go value). This sidesteps the receiver-kind subtlety on the consumer side: every Mochi call through the bridge sees the pointer's method set, which is the superset.
+
+## Empty interface (`any` / `interface{}`)
+
+Go's empty interface, written `interface{}` pre-1.18 or `any` from 1.18 onwards, accepts any value. The bridge refuses items whose signature has an `any` in a position the bridge cannot resolve at ingest time:
+
+- A function `func(args ...any)` is refused unless the user lists explicit `[go.monomorphise]` entries binding each arg type.
+- A function returning `any` is refused; the bridge cannot type the return on the Mochi side.
+- A struct field of type `any` is refused.
+- A `map[string]any` value is refused.
+
+The user can hand-author a `custom` `extern fn` that takes responsibility for the `any` at the FFI boundary (e.g., using runtime type assertions on the Go side via a hand-written wrapper item).
+
+## Embedded interfaces
+
+A Go interface can embed another interface:
+
+```go
+type ReadWriter interface {
+    Reader
+    Writer
+}
+```
+
+The method set of `ReadWriter` is the union of `Reader`'s and `Writer`'s. The bridge resolves the embedding at ingest time and emits the flattened method set:
+
+```mochi
+extern type ReadWriter
+extern fn (rw: ReadWriter) read(p: bytes): Result<int> from go "io.ReadWriter.Read"
+extern fn (rw: ReadWriter) write(p: bytes): Result<int> from go "io.ReadWriter.Write"
+```
+
+A `promoted_from = "<source-interface>"` annotation on each emitted item tracks the embedding (purely informational).
+
+## Type assertions and interface conversion
+
+Go has two-form type assertions:
+
+```go
+var r Reader = someExpr()
+fr, ok := r.(*FileReader)  // succeed only if r dynamically is *FileReader
+```
+
+Mochi does not have this surface directly. The bridge offers a `try_as_<concrete-type>` method on every interface type:
+
+```mochi
+let r: Reader = open_file("path")
+let maybe_fr: FileReader? = r.try_as_file_reader()
+if maybe_fr is some {
+    // use the FileReader-specific methods
+}
+```
+
+The wrapper implements the `try_as_*` method via a Go-side type switch:
+
+```go
+//export mochi_go_<module>_Reader_try_as_FileReader
+func mochi_go_<module>_Reader_try_as_FileReader(handle uint64) uint64 {
+    r := resolveHandle(handle).(Reader)
+    if fr, ok := r.(*FileReader); ok {
+        return acquireHandle(fr)
+    }
+    return 0 // 0 sentinel = nil
+}
+```
+
+The Mochi side sees the result as `FileReader?` (`null` when the assertion fails).
+
+## Common-stdlib interfaces
+
+Several Go interfaces are universally implemented and worth special-casing:
+
+| Interface | Mochi treatment |
+|-----------|-----------------|
+| `error` | Special: desugared into Mochi `Result<T>` for return positions. |
+| `fmt.Stringer` (`String() string`) | Mapped to Mochi's `to_string()` convention. |
+| `io.Reader` / `io.Writer` | Mapped to opaque handles with `read` / `write` methods. |
+| `sort.Interface` | Refused: Mochi has its own sort surface; cross-language `sort.Sort` is not supported. |
+| `context.Context` | Mapped to an opaque `Context` extern type; the bridge provides `context.background()`, `context.with_timeout()`, etc. shims. |
+
+The `fmt.Stringer` special-case is implicit: any wrapped type whose underlying Go type satisfies `fmt.Stringer` automatically gets a Mochi `.to_string()` method.
+
+## Type parameter constraints (generics)
+
+Go 1.18+ generics introduce type parameter constraints, which are interfaces:
+
+```go
+type Ordered interface {
+    ~int | ~int64 | ~float64 | ~string
+}
+
+func Min[T Ordered](a, b T) T
+```
+
+The constraint `Ordered` is a special interface (a "type union") that does not have method-set satisfaction; it has type-membership satisfaction. The bridge refuses generic items whose constraint is a type union (the bridge's monomorphisation has to pick specific types from the union).
+
+When `[go.monomorphise]` declares an instantiation, the bridge synthesises one wrapper per instantiation:
+
+```toml
+[go.monomorphise]
+items = [
+    { item = "golang.org/x/exp/constraints.Min", T = "int64" },
+    { item = "golang.org/x/exp/constraints.Min", T = "float64" },
+]
+```
+
+Generates:
+
+```go
+//export mochi_go_<module>_Min_int64
+func mochi_go_<module>_Min_int64(a, b int64) int64 {
+    return constraints.Min[int64](a, b)
+}
+
+//export mochi_go_<module>_Min_float64
+func mochi_go_<module>_Min_float64(a, b float64) float64 {
+    return constraints.Min[float64](a, b)
+}
+```
+
+The Mochi shim file declares each as a separate `extern fn`; the user calls `constraints.min_int64(...)` or `constraints.min_float64(...)`.
+
+## Interface method dispatch cost
+
+Each Mochi-side method call on an interface handle costs:
+
+- Cgo call into the wrapper: ~200ns.
+- Wrapper does `resolveHandle(id).(InterfaceType)`: ~30ns (sync.Map lookup + type-assert).
+- Wrapper dispatches to the concrete type's method: Go's interface dispatch via the itab cache: ~5ns.
+- Total: ~235ns per call.
+
+This is materially more expensive than a Mochi-native method call (~5ns) but comparable to a typical Go interface dispatch in a benchmark loop.
+
+## Trait-object analogue
+
+Go interfaces play the role Rust's `dyn Trait` plays. MEP-73 §10 documents the lifetime-and-ownership story for `dyn Trait`. The Go story is simpler because Go interfaces are not lifetime-parameterised: every interface value owns its underlying data (via the interface's internal `(type-pointer, data-pointer)` representation). The bridge's opaque handle simply pins the interface value via `cgo.Handle`.
+
+There is no equivalent of Rust's `Box<dyn Trait>` distinction; every Go interface value is already "boxed" in the interface representation.
+
+## Cross-references
+
+- [[05-type-mapping]] for the broader translation table.
+- [[09-abi-stability]] for the cgo dispatch cost.
+- [[04-go-doc-ast-ingest]] for how method sets are extracted from `*types.Interface`.
+- [[12-risks-and-alternatives]] §R9 for the cgo-export symbol collision risk.
+- [The Go spec on method sets](https://go.dev/ref/spec#Method_sets) for the canonical rules.

--- a/website/docs/research/0074/11-tinygo-embedded-wasm.md
+++ b/website/docs/research/0074/11-tinygo-embedded-wasm.md
@@ -1,0 +1,129 @@
+---
+title: "11. TinyGo, embedded, and wasm"
+sidebar_position: 12
+sidebar_label: "11. TinyGo and embedded"
+description: "The TinyGo subset of pkg.go.dev, the no-cgo embedded path, the wasm-js and wasm-wasip1 surface, what kind of Go modules Mochi can consume on bare metal, the firmware story, and how the wasm targets interact with wazero."
+---
+
+# 11. TinyGo, embedded, and wasm
+
+This note covers the constrained targets: TinyGo (alternative Go compiler for microcontrollers), wasm-wasip1, and wasm-js. The bridge's behaviour on these targets is a strict subset of the host-binary behaviour documented in [[09-abi-stability]].
+
+## TinyGo: alternative compiler for constrained targets
+
+[TinyGo](https://tinygo.org), first released in 2018 and stable since 2020, is an alternative Go compiler targeting microcontrollers (Cortex-M, RISC-V, AVR), wasm, and bare-metal x86. TinyGo implements a subset of the Go language and stdlib:
+
+- **Supported**: most language features (functions, structs, interfaces, goroutines, channels via a cooperative scheduler).
+- **Not supported**: full reflect (TinyGo has a partial implementation), cgo (TinyGo replaces cgo with `wasm_import`-style calls in wasm targets and direct linker symbols in MCU targets), `runtime/debug` package, large parts of `net/http` (no TLS by default; can be added via tinyusb), goroutines under heavy contention (the scheduler is cooperative, not preemptive).
+- **Modified**: the GC is conservative-mark-sweep (smaller than Go's tri-colour concurrent GC); `runtime.NumCPU()` is always 1.
+
+The bridge's TinyGo subset (phase 16) consumes Go modules that compile under TinyGo. Modules that depend on reflect-heavy or cgo-using packages are rejected at lock time with a clear diagnostic.
+
+## The TinyGo-compatible module subset
+
+Of pkg.go.dev's top 1,000 modules (April 2026), an estimated 8-15% compile under TinyGo. The subset is biased toward:
+
+- Pure-algorithm modules: hashing (xxhash, sha2, blake3), encoding (base64, hex, gob), parsing (json without reflect-based codegen).
+- Embedded-system modules: tinygo.org/x/drivers (sensors, displays), tinygo.org/x/tinyfs (filesystem), tinygo.org/x/bluetooth.
+- Pure-data-structure modules: container/list, slices, sort, math, golang.org/x/exp/constraints.
+
+The subset excludes:
+
+- `net/http` (modulo TinyGo's partial implementation).
+- gRPC and protobuf (reflect-heavy).
+- Any module pulling in `reflect.Value.Call`-based dispatch.
+- Most observability stacks (zap, logrus, prometheus).
+
+The bridge's lock-time TinyGo gate runs the synthesised wrapper through `tinygo build -target=wasm-wasi -o /dev/null .` (or the target architecture); a non-zero exit indicates the module is not TinyGo-compatible. The lock fails with a diagnostic naming the incompatible item.
+
+## The no-cgo embedded path
+
+For MCU and bare-metal targets, cgo is not available (no C compiler in the target's toolchain; no shared library loader). The bridge's embedded path emits the wrapper without `//export` directives and instead uses TinyGo's `//go:linkname` directives to expose the wrapper functions as linker symbols:
+
+```go
+//go:build tinygo && embedded
+
+package gowrap_<module>
+
+//go:linkname mochi_go_<module>_Foo Foo
+func mochi_go_<module>_Foo(arg int64) int64 {
+    return Foo(arg)
+}
+```
+
+The Mochi side links against these symbols directly (no cgo runtime). The cost: the Mochi side has to know the symbol naming convention statically (the bridge writes a small `.mochi-embed-symbols.json` file alongside the wrapper that records the symbol-to-name mapping).
+
+## wasm-wasip1 target
+
+wasm-wasip1 (the WebAssembly System Interface, preview 1) is a wasm target with a POSIX-like syscall surface. Go 1.21 added official support via `GOOS=wasip1 GOARCH=wasm`. TinyGo has supported wasi for longer.
+
+The bridge's wasm-wasip1 behaviour:
+
+- The wrapper is compiled to `.wasm` via `GOOS=wasip1 GOARCH=wasm go build -o wrap.wasm`.
+- The Mochi side embeds [wazero](https://wazero.io) (a pure-Go wasm runtime) to host the wrapper.
+- Cross-boundary calls go through wazero's host-function call surface rather than cgo.
+- Goroutines work via Go's cooperative scheduler embedded in the wasm module.
+- Channels work (with bounded buffers).
+- cgo is not available; the bridge refuses Go modules with `import "C"`.
+- The Go GC runs inside the wasm module; the embedding host has no GC interaction.
+
+The cost-per-call on wasm-wasip1 is higher than on native (the wasm runtime adds ~500ns per host-function call). The bridge's batched-variant optimisation is more impactful here.
+
+## wasm-js target
+
+The wasm-js target (`GOOS=js GOARCH=wasm`) is for browser execution. The bridge supports it via the `syscall/js` package, with two notable constraints:
+
+- **No goroutine preemption.** The wasm-js scheduler is cooperative; a goroutine spinning in a tight loop never yields. The bridge documents this in the per-function notes; functions known to spin-loop are not exposed.
+- **Async dispatch.** wasm-js callbacks from JS into Go are inherently async; the wasm-js `js.FuncOf` callback registers a JS function that calls the Go side. The bridge's callback handle pattern adapts to this: instead of cgo `_call`, the wrapper exposes a `js.FuncOf`-registered JS function per callback.
+
+The Mochi side, when targeting wasm-js, links the wrapper as a JS module loaded by the Mochi-wasm-js runtime. The cost-per-call is dominated by the JS-to-wasm transition (~300ns on V8, May 2026).
+
+## What kind of Go modules Mochi can consume on each target
+
+| Target | cgo | reflect | net | goroutines | TLS |
+|--------|------|---------|------|--------------|------|
+| native host (darwin/linux/windows) | yes | yes | yes | yes | yes |
+| wasm-wasip1 | no | yes | partial (no TLS by default) | yes (cooperative) | no (without tinyusb) |
+| wasm-js | no | yes | partial (via fetch) | yes (cooperative) | yes (via fetch's underlying browser) |
+| tinygo embedded MCU | no | partial | no | yes (cooperative) | no |
+
+The bridge's gate (phase 16 for tinygo, phase 17 for wasm) validates per-target compatibility at lock time.
+
+## The firmware story
+
+For embedded users targeting actual hardware (ARM Cortex-M, ESP32, RISC-V boards), the bridge's flow is:
+
+1. Mochi program written normally, with `import go "tinygo.org/x/drivers/bme280" as bme280`.
+2. `mochi pkg lock` validates that `bme280` compiles under TinyGo.
+3. `mochi build --target=tinygo-cortex-m4 --runtime=tinygo` invokes the bridge's TinyGo-aware build path:
+   - Synthesises the wrapper using `//go:linkname` instead of `//export`.
+   - Invokes `tinygo build -target=stm32f4 -o firmware.elf .`.
+   - The output is a flashable ELF.
+
+The bridge does not own the flashing step (the user invokes `tinygo flash` or `st-link` themselves).
+
+## The wazero embedding strategy
+
+For wasm-wasip1 consumers, the Mochi wasm-wasip1 binary embeds wazero and hosts every imported Go module's wrapper as a wasm module inside the wazero runtime. The plumbing:
+
+- The Mochi-wasm-wasip1 main binary contains the wazero runtime initialised at startup.
+- Each `import go "<module>" as <alias>` becomes a wazero `runtime.InstantiateModule(...)` call that loads the wrapper's `.wasm`.
+- Cross-boundary calls go through wazero's host-function call surface.
+- Each wasm module's Go runtime is independent (each module has its own scheduler, GC).
+
+The cost: each wrapper module carries ~200 KB of Go runtime + stdlib in its `.wasm`. A Mochi program importing 5 Go modules adds ~1 MB to the wasm binary size.
+
+The benefit: full Go module compatibility on wasm targets (modulo the TinyGo subset for the wrapper itself).
+
+## Future direction: wasm component model
+
+The WebAssembly Component Model, stabilising through 2026-2027, will let wasm modules expose typed interfaces (WIT) that consumers call without per-module host-function plumbing. The bridge's wasm-wasip1 path is ready to migrate to the component model once it stabilises; the migration path is documented in [[12-risks-and-alternatives]] §A12.
+
+## Cross-references
+
+- [[02-design-philosophy]] §3 for why cgo (and its absence on wasm) drives the wrapper-vs-direct decision.
+- [[09-abi-stability]] for the cgo ABI the host targets use.
+- [[12-risks-and-alternatives]] §R6 for the TinyGo-subset-size risk.
+- [The TinyGo documentation](https://tinygo.org/docs/) for the upstream compatibility table.
+- [The wazero documentation](https://wazero.io/docs/) for the wasm-host story.
+- [The Go wasm-wasip1 documentation](https://go.dev/wiki/WebAssembly) for the official wasm target.

--- a/website/docs/research/0074/12-risks-and-alternatives.md
+++ b/website/docs/research/0074/12-risks-and-alternatives.md
@@ -1,0 +1,217 @@
+---
+title: "12. Risks and alternatives"
+sidebar_position: 13
+sidebar_label: "12. Risks and alternatives"
+description: "The risk register (cgo cost, Go GC interaction, generic explosion, module proxy compromise, sum.golang.org single-key trust, TinyGo subset size) and the rejected alternatives (parse Go source directly, pkg.go.dev HTML scraping, gomobile bind subset, plugin build mode, protobuf bridge, scheduler reimplementation, purego-only path, dotnet-go annotation surface)."
+---
+
+# 12. Risks and alternatives
+
+This note is the consolidated risk register plus the rejected-alternatives ledger. It parallels MEP-73's §12, with the entries adapted to Go's reality. Risks (R) and alternatives (A) are numbered for cross-reference from other notes and the MEP-74 spec.
+
+## Risks
+
+### R1. The cgo cost per call is real and visible in benchmarks
+
+Each cgo crossing costs ~200ns on darwin-arm64 (Go 1.23, May 2026). For workloads that hot-loop across the boundary (per-element transformations, per-message dispatch in a server), this is the dominant cost.
+
+**Mitigation**: the batched-variant wrapper amortises across N elements; the bridge documents the cost per `extern fn` in the emitted shim file's comments. For functions whose Mochi caller is in a `for` body, the bridge automatically offers a `<fn>_batched` variant.
+
+**Residual risk**: the user has to know to call the batched variant. The bridge could add a static-analysis warning when an `extern fn` is called inside a `for` body without the batched variant, but the warning is best-effort.
+
+### R2. Go's GC and cgo interact non-trivially
+
+A pointer the Go side passes to the C side via `//export` is NOT GC-managed on the C side. If the Mochi side holds the pointer past the cgo call return without an explicit pin, Go's GC may move or reclaim the underlying object. The classic failure mode: a cgo call returns a `*C.char`; the Mochi side stores it; the underlying Go string is GC'd; the Mochi side later reads garbage.
+
+**Mitigation**: the wrapper synthesiser inserts `runtime.KeepAlive(obj)` at the end of every `//export` function for every parameter that escapes via pointer. For values where the Mochi side needs to hold the pointer past the call, the wrapper uses `cgo.NewHandle` to pin the Go object until the Mochi side calls `_free`.
+
+**Residual risk**: a user hand-writing a `custom` `extern fn` could violate the contract. The bridge's documentation warns about this; the `unsafe` capability declaration is the audit trail.
+
+### R3. Generic monomorphisation explosion
+
+A Go module exposing a generic function over many possible types, paired with a user who lists many monomorphisations, produces a wrapper with O(N×M) `//export` symbols. The combinatorial explosion is real.
+
+**Mitigation**: the `[go.monomorphise]` table is REQUIRED to enumerate; the bridge does not auto-monomorphise. The lockfile records the instantiation list; a manifest change is the user's explicit opt-in to the explosion.
+
+### R4. The Go module proxy can serve a different .zip than the upstream git repo
+
+If proxy.golang.org is compromised (or if a corporate proxy is compromised), the proxy can serve a malicious .zip while the upstream git repo holds the legitimate source. The sum.golang.org cross-check is the primary mitigation; if the proxy's .zip differs from the checksum-DB-recorded `h1:`, the lock fails.
+
+**Mitigation**: every public module lock cross-checks against sum.golang.org. The `[go.private] sumdb-skip` opt-out is the only way to bypass; the lockfile records `sumdb-verified = false` for audit.
+
+**Residual risk**: a successful attack on both the proxy AND sum.golang.org is conceivable but requires compromising two separately-keyed services. The trust model is the same as `go get`'s default.
+
+### R5. sum.golang.org operates a single signing key
+
+The Go checksum DB's tree head is signed by one Go-team-controlled Ed25519 key. If that key is compromised, the cross-check provides no protection. The bridge's hard-coded pubkey is the same one the Go toolchain ships.
+
+**Mitigation**: the trust assumption is identical to `go get`'s default. Mochi inherits the Go-ecosystem's trust model; if that model is broken, the Go ecosystem at large has bigger problems than the bridge.
+
+**Future direction**: a sub-phase could integrate with a second log (e.g., Sigstore Rekor recording Go module hashes; an industry working group is exploring this in 2026-Q1) for defence-in-depth.
+
+### R6. TinyGo embedded subset is small
+
+Only ~8-15% of pkg.go.dev's top 1,000 modules compile under TinyGo. Most modules pulling in reflect, cgo, or net/http with TLS fail.
+
+**Mitigation**: the embedded gate (phase 16) checks TinyGo compatibility at lock time; non-compatible modules are rejected with a clear diagnostic.
+
+**Residual risk**: users targeting embedded face a constrained module choice. The mitigation is to document the TinyGo-compatible subset prominently in the user-facing docs.
+
+### R7. Build-tag-conditional code paths produce different surfaces
+
+A module that conditions important code on `//go:build` tags produces a different ApiSurface under different tag sets. The lockfile pins the tag set at lock time.
+
+**Mitigation**: changing `[go.build-tags]` requires re-running `mochi pkg lock`; the `--check` mode catches drift. The lockfile's `build-tags` field is the audit trail.
+
+### R8. Vanity import paths require an HTTP redirect
+
+Modules at vanity paths (`go.uber.org/zap` redirecting to `github.com/uber-go/zap`) require the bridge to honour the `<meta name="go-import">` redirect in the canonical URL's HTML response.
+
+**Mitigation**: the phase 17 vanity-import resolver implements the redirect logic per the Go modules spec.
+
+**Residual risk**: a vanity-host that goes down breaks lock until the redirect is resolved. The bridge caches the redirect resolution in `~/.cache/mochi/go-deps/vanity-redirects/` for resilience.
+
+### R9. Cross-platform `_cgo_export.h` generation
+
+The cgo-generated header depends on the host C compiler's pointer width and integer sizes. A wrapper built on darwin-arm64 may produce a slightly different header than the same wrapper on linux-amd64.
+
+**Mitigation**: the bridge writes the header to `<workdir>/go_wrap/<module>/<goarch>-<goos>.h` and the build driver picks the right one. The build matrix in the implementation tracking page validates each (target, host) pair.
+
+### R10. Go's `internal/` package visibility rule
+
+Imports of `<module>/internal/*` from outside the module tree are compile errors. The bridge respects this rule: an item whose qualified name traverses an `internal/` boundary is silently skipped.
+
+**Mitigation**: the typemap pass treats `internal` items as invisible. No SkipReport is emitted (the item is invisible by Go's own rules; surfacing it in the report would be noise).
+
+**Residual risk**: a user who depends on an `internal` item must fork the module or hand-write a custom `extern fn` (which then violates the source module's encapsulation, but at the user's explicit choice).
+
+### R11. Mochi-as-library cgo symbol collision
+
+Multiple Mochi libraries compiled to c-archives loaded into the same process collide on the `mochi_go_<module>_<fn>` symbol prefix.
+
+**Mitigation**: the bridge prefixes every exported symbol with the publishing module's path-hash (first 8 hex chars of SHA-256 of canonical-import-path). Collisions only arise across compatible majors of the same library.
+
+### R12. Go's `replace` directive does not survive publish
+
+When a published Go module is consumed by another, the consumer's `go.mod` does NOT inherit the producer's `replace` directives. A Mochi package using `[go-dependencies] = { path = "../local-fork" }` produces a published module that downstream consumers cannot resolve.
+
+**Mitigation**: `mochi pkg publish` rejects publishing a module that has unresolved `replace` directives in `[go-dependencies]`; all replaces must point to a real upstream version before publish.
+
+### R13. CI image dependency
+
+The MEP-54 gates already require the Go toolchain. MEP-74 adds:
+
+- Optional TinyGo for phase 16.
+- Optional `cosign` for phase 13.
+- The `go-ingest` helper binary, which is built from Go source and is part of the bridge.
+
+The CI image is bigger.
+
+**Mitigation**: the standard `mochilang/ci-go` image bundles the full toolset. Standalone users install via `go install` plus `brew install cosign tinygo` / `apt-get install cosign tinygo`.
+
+### R14. Go runtime version drift between wrapper and source module
+
+The wrapper's `go.mod` pins `go <version>`. The source module's `go.mod` may pin a different version. The Go toolchain picks the higher of the two for the build. If the wrapper's required version is older than the source's, the build fails.
+
+**Mitigation**: the bridge synthesises the wrapper's `go.mod` with `go <max(wrapper-floor, source-floors)>`. The lockfile records the resolved floor.
+
+### R15. Wasm-target absence of cgo
+
+wasm-wasip1 and wasm-js targets do not support cgo. The bridge's wasm path uses wazero (host-side wasm runtime) instead of cgo for cross-boundary calls.
+
+**Mitigation**: the wasm path is gated separately (phase 17); modules with `import "C"` are rejected for wasm targets.
+
+## Rejected alternatives
+
+### A1. Parse Go source directly with `go/parser`
+
+Rejected: `go/parser` returns an untyped AST. The bridge needs `types.Type` to translate accurately. `go/packages` is exactly the right level (it runs `go/parser` plus `go/types` plus dep resolution). There is no win from going one level lower.
+
+### A2. Use pkg.go.dev's HTML rendering as the API source
+
+Rejected: HTML is rendered for human reading, not normative. Items behind feature flags or platform-conditional code are flat in HTML but conditional in `go/packages`.
+
+### A3. Use `gomobile bind`'s subset as the bridge surface
+
+Rejected: gomobile bind supports a tiny subset of Go (no channels, no callbacks with non-builtin types, no generics). The MEP-74 bridge needs the full surface.
+
+### A4. Generate cgo source with hand-written `//export` directives (gobind-style)
+
+Rejected: that IS what MEP-74 does, just with the type-mapping decisions made by the bridge rather than by the user. gobind's user-written interface file is the boilerplate violation MEP-74 avoids.
+
+### A5. Use Go's `plugin` build mode
+
+Rejected: `plugin` is linux-only, has hard limitations on cross-package symbol visibility, and has known dlopen-time crashes on Go version drift. `c-archive` is portable across darwin, linux, windows, freebsd.
+
+### A6. Protobuf or flatbuffers as cross-boundary serialisation instead of cgo
+
+Rejected: introduces a runtime dependency the user did not opt into, adds 100ns+ per call for the marshal step, and would still need cgo for the actual call dispatch. The cgo path is the shortest.
+
+### A7. Translate Go's goroutine scheduler into Mochi's host runtime
+
+Rejected: Go's goroutine scheduler is deeply tied to the Go runtime (GC interaction, preemption via segmented stacks, channel multiplexing in `runtime/chan.go`). Reimplementing in Mochi would be a 10,000+ LOC project lagging the Go team's optimisations. The bridge sidesteps the impedance by letting the Go runtime's scheduler run inside the c-archive.
+
+### A8. Treat the Go module proxy's `info`, `mod`, `zip` triple as the bridge surface (skip `go/packages`)
+
+Rejected: the triple is enough for fetch + verify but does not parse the Go source. The bridge still needs `go/packages` for type-aware translation.
+
+### A9. Long-lived `GOPROXY` API tokens for private-module fetch
+
+Acknowledged but not rejected: private modules legitimately need authentication. The bridge supports `GOPROXY` env-var passthrough and `.netrc`-style git-credential helpers. There is no long-lived token to "publish" because publishing is a git push to a user-controlled remote.
+
+### A10. Sigstore-keyless mandatory for publish (mirror MEP-73's stance)
+
+Rejected for v1: the Go ecosystem has not converged on a canonical signing format. The gosum-cosign workflow draft of 2026-Q1 is the front-runner but has not landed in any production Go tooling. MEP-74 ships `--cosign-sign` as opt-in and re-evaluates the default when the Go team publishes a canonical signing spec.
+
+### A11. `golang.org/x/mod`-driven re-implementation vs in-bridge HTTP client
+
+Accepted partially: the bridge uses `golang.org/x/mod/module` and `golang.org/x/mod/semver` for module-path validation and semver comparison (pure functions with no I/O). The bridge re-implements the HTTP client for the proxy because the bridge needs to interleave BLAKE3-256 hashing with the .zip download, which is awkward with the upstream client.
+
+### A12. `purego`-only consume path (no cgo)
+
+Rejected for v1: `purego` is a recent project (first commit 2022, GA 2024) that requires the source module ship a `.so`/`.dylib`. Most pkg.go.dev modules are pure Go and do not ship binaries. The cgo path covers more modules.
+
+A future MEP-74 v2 could add purego as an alternative consume path on platforms where cgo is unavailable (wasm-js without wazero). See R15 for the platform-specific reasoning.
+
+### A13. Hand-author the type-mapping table per-module
+
+Rejected: this is the cxx-style violation MEP-73 already rejected. The closed table is a one-time investment that covers every module.
+
+### A14. wazero-only wasm-target instead of cgo+wazero hybrid
+
+Rejected: the host-binary targets (darwin / linux / windows native) materially outperform wazero for cross-boundary calls. wazero is the right tool for wasm hosts; cgo is the right tool for native hosts. The bridge picks per-target.
+
+### A15. dotnet-go-style `[GoExport]` annotation surface
+
+Rejected: explicit annotations are the boilerplate violation MEP-74 was designed to avoid. The bridge derives the export set from `go/packages`.
+
+### A16. Reuse MEP-54 phase 10's `import go "..."` exactly without semver extension
+
+Rejected: phase 10 admits any package name and trusts the host toolchain. MEP-74 adds the semver pin, lockfile, capability declaration, and sumdb verification. Removing these would leave the same gap MEP-74 was authored to close.
+
+### A17. Split into MEP-74 consume + MEP-75 publish
+
+Rejected: the consume and publish directions share the manifest tables, the lockfile sections, the capability surface, and the sum.golang.org integration. Splitting would force two redundant lockfile-section migrations and would push the Mochi-as-Go-publisher story behind both the MEP-73 Rust publish and the MEP-74 consume by an arbitrary amount of time.
+
+### A18. Use `go.work` workspace files instead of synthesised `go.mod` per build
+
+Rejected: `go.work` is the user's workspace, not the bridge's. The bridge owns the build's workspace; mixing manifest authorities is the same anti-pattern MEP-73 §11 rejected for Cargo. The bridge does respect a user-provided `go.work` for path-source modules during development (mirroring how `replace` works in `go.mod`), but the canonical workspace is the bridge's.
+
+### A19. Make TinyGo the default compiler (drop standard Go)
+
+Rejected: TinyGo's subset is too restrictive for the majority of pkg.go.dev modules. The standard Go toolchain remains the default; TinyGo is opt-in via the embedded profile.
+
+### A20. Skip cosign signing entirely (don't even offer the opt-in)
+
+Rejected: even though the Go ecosystem has no canonical signing format, the bridge ships the opt-in so users who want defence-in-depth can have it. The opt-in is non-default; users who don't enable it pay no cost.
+
+## Cross-references
+
+- [[02-design-philosophy]] for the design decisions these alternatives evaluate.
+- [[06-go-module-publish-flow]] for the publish-side details.
+- [[07-sigstore-go-checksumdb]] for the supply-chain story.
+- [[08-goroutine-bridge]] for the cgo-cost discussion.
+- [[09-abi-stability]] for the c-archive vs alternatives.
+- [[11-tinygo-embedded-wasm]] for the TinyGo subset.
+- [MEP-74](/docs/mep/mep-0074) for the normative spec.
+- [MEP-73 §12](/docs/research/0073/12-risks-and-alternatives) for the sister Rust-bridge risk register.

--- a/website/docs/research/0074/index.md
+++ b/website/docs/research/0074/index.md
@@ -1,0 +1,35 @@
+---
+title: "MEP-74 research bundle"
+sidebar_position: 1
+sidebar_label: "Overview"
+description: "Twelve research notes covering the design space behind MEP-74: language surface, design philosophy, prior-art Go bridges, go/packages + go/types ingest, the closed type-mapping table, the git-tag publish flow, the sum.golang.org checksum-DB integration, the goroutine bridge, ABI stability under cgo, Go interfaces and method sets, the TinyGo embedded subset, plus the risks and rejected alternatives register."
+---
+
+# MEP-74 research bundle
+
+This bundle is the informative companion to [MEP-74](/docs/mep/mep-0074). It documents the design space the Go bridge sits in: prior art, the choices considered and rejected, the trade-offs accepted, and the open risks. The bundle is meant to be read alongside the spec, not in place of it.
+
+## Notes
+
+| Note | Subject |
+|------|---------|
+| [01. Language surface](01-language-surface.md) | The `import go "<module>@<semver>" as <alias>` import shape, the `mochi.toml` `[go-dependencies]` + `[go]` tables, the CLI surface (`mochi pkg add go`, `mochi pkg publish --to=go+git+...`), and the per-import alias semantics. |
+| [02. Design philosophy](02-design-philosophy.md) | Why a bidirectional bridge, why `go/packages` over alternatives, why a synthesised cgo wrapper package over direct cgo invocation, why no async runtime singleton is needed for Go, why sum.golang.org cross-check is mandatory by default. |
+| [03. Prior-art bridges](03-prior-art-bridges.md) | gopy, gomobile bind, gobind, swig, c-shared / c-archive build modes, purego, wazero, JNA / JNI Go variants, dotnet-go. What each gets right, what each requires the user to write, and what MEP-74 borrows. |
+| [04. go/packages + go/types ingest](04-go-doc-ast-ingest.md) | The `go/packages.Load` flow, the `types.Type` discriminator tree, the stability story, why no nightly toolchain is needed, the Go-side helper binary shape. |
+| [05. Type mapping table](05-type-mapping.md) | The complete closed translation table, the refusal cases, the generic monomorphisation rule, the `string` vs `[]byte` parameter handling, the `error` desugar, the `chan` and `func` mappings. |
+| [06. Go module publish flow](06-go-module-publish-flow.md) | The git-tag upload protocol, the canonical-import-path requirement, the module proxy's caching behaviour, the per-module metadata requirements, the publish-side gate. |
+| [07. Sigstore and Go checksum DB](07-sigstore-go-checksumdb.md) | The sum.golang.org transparency log, the Merkle-tree consistency proof, the gosum-cosign workflow draft, the optional `<tag>.sig` sibling tag, the verification path at consume time. |
+| [08. Goroutine bridge](08-goroutine-bridge.md) | The cgo boundary cost, the goroutine scheduler inside the c-archive, the channel-as-handle pattern, the callback-as-handle pattern, the cgo.Handle lifetime story. |
+| [09. ABI stability](09-abi-stability.md) | The cgo `//export` ABI, the C-side ownership contract, the `runtime.KeepAlive` invariant, the `string` and slice round-trip, the c-archive vs c-shared decision, the cross-platform header story. |
+| [10. Interfaces and method sets](10-interface-and-method-set.md) | Go's structural interface satisfaction, the method-set rules (value vs pointer receiver), how the bridge translates `type I interface { M() }` into Mochi extern types, the trait-object analogue. |
+| [11. TinyGo and embedded](11-tinygo-embedded-wasm.md) | The TinyGo subset of pkg.go.dev, the no-cgo embedded path, the wasm-js and wasm-wasip1 surface, what kind of Go modules Mochi can consume on bare metal. |
+| [12. Risks and alternatives](12-risks-and-alternatives.md) | The risk register (cgo cost, GC interaction, generic explosion, proxy compromise, sumdb single-key trust) and the rejected alternatives (parse source directly, pkg.go.dev HTML, gomobile bind, plugin build mode, protobuf bridge, scheduler reimplementation). |
+
+## Cross-references
+
+- [MEP-74 spec](/docs/mep/mep-0074) — the normative document.
+- [MEP-54](/docs/mep/mep-0054) — the Go transpiler this bridge builds on.
+- [MEP-57](/docs/mep/mep-0057) — the source-level package system whose manifest and lockfile the bridge extends.
+- [MEP-73](/docs/mep/mep-0073) — the sister Rust bridge whose spec template MEP-74 mirrors.
+- [Implementation tracking](/docs/implementation/0074/) — the per-phase delivery status.


### PR DESCRIPTION
Tracks #22734.

## Summary

- New MEP-74 (Mochi+Go bidirectional package bridge) mirroring MEP-73's Rust-bridge structure adapted to Go's ecosystem.
- Two directions: consume Go modules via `import go "<module>@<semver>"` through a cgo c-archive wrapper, and publish Mochi packages as Go modules via a git-tag flow that proxy.golang.org picks up asynchronously.
- 18-phase delivery plan, per-target coverage matrix (host stable Go 1.23 / linux-amd64+arm64 / windows-amd64 / wasm-wasip1+wasm-js / tinygo embedded).
- No implementation code yet; phase 0 is the first code deliverable in a follow-up PR.

## What landed

- `website/docs/mep/mep-0074.md` (normative spec)
- `website/docs/research/0074/` (index + 12 deep-research chapters: language surface, design philosophy, prior-art bridges, go/packages ingest, type mapping, publish flow, sumdb integration, goroutine bridge, ABI stability, interfaces, TinyGo+wasm, risks)
- `website/docs/implementation/0074/index.md` (per-phase tracking + target matrix + fixture corpus)
- `package3/go/README.md` (stub mirroring `package3/rust/README.md`)

## Architectural deltas from MEP-73

Three simplifications:
- Stable in-stdlib ingest (`go/packages` since 2018) versus nightly-only rustdoc-JSON.
- No async runtime singleton; Go's goroutine scheduler ships in every c-archive.
- Mandatory `sum.golang.org` transparency-log cross-check (Go ecosystem ships its own Merkle log).

Two complications:
- Publish is git-tag, not registry-upload; no central registry.
- Cgo costs ~200ns per crossing; batched-variant wrapper amortises on hot loops.

## Test plan

- [ ] Docusaurus build succeeds locally (`cd website && npm run build`)
- [ ] Sidebar auto-generation picks up `website/docs/research/0074/` and `website/docs/implementation/0074/`
- [ ] Cross-links between MEP-74 and MEP-73 resolve
- [ ] CI green