### PR TITLE
feat(mep-51 p17): Jupyter ipykernel target + MochiKernel + cell-mode unwrap

### DIFF
--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -37,6 +37,7 @@ import (
 	gobuild "mochi/compiler3/build/go"
 	aotcbuild "mochi/transpiler3/c/build"
 	beambuild "mochi/transpiler3/beam/build"
+	pybuild "mochi/transpiler3/python/build"
 	"mochi/mcp"
 	"mochi/parser"
 	"mochi/repl"
@@ -75,7 +76,7 @@ type CLI struct {
 // --out, shells to the system cc, and writes a native executable.
 type BuildCmd struct {
 	File           string `arg:"positional,required" help:"Path to .mochi source file"`
-	Target         string `arg:"--target" default:"go" help:"Target language (go|c|c-aot|beam-escript)"`
+	Target         string `arg:"--target" default:"go" help:"Target language (go|c|c-aot|beam-escript|python-source|python-wheel|python-sdist|python-ipykernel)"`
 	Emit           string `arg:"--emit" default:"executable" help:"Emit shape (executable|go-library|c). --target=c-aot accepts executable|c."`
 	Out            string `arg:"--out" help:"Output path. --target=go|c: output directory; --target=c-aot: binary path; --target=beam-escript: escript output path"`
 	KeepEmit       bool   `arg:"--keep-emit" help:"Retain the emitted source file(s) after build"`
@@ -211,9 +212,44 @@ func runBuild(cmd *BuildCmd) error {
 		return runBuildCAOT(cmd)
 	case "beam-escript":
 		return runBuildBeamEscript(cmd)
+	case "python-source":
+		return runBuildPython(cmd, pybuild.TargetPythonSource)
+	case "python-wheel":
+		return runBuildPython(cmd, pybuild.TargetPythonWheel)
+	case "python-sdist":
+		return runBuildPython(cmd, pybuild.TargetPythonSdist)
+	case "python-ipykernel":
+		return runBuildPython(cmd, pybuild.TargetPythonIpykernel)
 	default:
-		return fmt.Errorf("build: unsupported --target=%q (expected go|c|c-aot|beam-escript)", cmd.Target)
+		return fmt.Errorf("build: unsupported --target=%q (expected go|c|c-aot|beam-escript|python-source|python-wheel|python-sdist|python-ipykernel)", cmd.Target)
 	}
+}
+
+// runBuildPython dispatches MEP-51 Phase 1 / 15 / 17 builds via the
+// transpiler3/python Driver. `--out PATH` is the destination
+// directory; the driver writes the canonical `src/<pkg>/` tree for
+// python-source, `<pkg>-<version>-py3-none-any.whl` for
+// python-wheel, `<pkg>-<version>.tar.gz` for python-sdist, and a
+// self-contained `kernels/mochi-<pkg>/` + source tree for
+// python-ipykernel.
+func runBuildPython(cmd *BuildCmd, target pybuild.Target) error {
+	if cmd.File == "" {
+		return fmt.Errorf("build: --target=%s requires a source file argument", cmd.Target)
+	}
+	outDir := cmd.Out
+	if outDir == "" {
+		tmp, err := os.MkdirTemp("", "mochi-build-python-")
+		if err != nil {
+			return fmt.Errorf("build: temp dir: %w", err)
+		}
+		outDir = tmp
+	}
+	d := &pybuild.Driver{}
+	if err := d.Build(cmd.File, outDir, target); err != nil {
+		return err
+	}
+	fmt.Printf("emitted %s\n", outDir)
+	return nil
 }
 
 func runBuildGo(cmd *BuildCmd) error {

--- a/runtime/python/mochi_runtime/kernel/__init__.py
+++ b/runtime/python/mochi_runtime/kernel/__init__.py
@@ -1,0 +1,15 @@
+"""Mochi Jupyter ipykernel package.
+
+`mochi build --target=python-ipykernel` emits a kernelspec directory
+that points Jupyter at this package via `python -m mochi_runtime.kernel`.
+The package contains a single `MochiKernel` subclass of
+`IPythonKernel` that intercepts `do_execute` to transpile each cell
+from Mochi to Python before delegating to the inherited IPython
+execution loop. Namespace persists across cells via the IPython
+shell's `user_ns`, which gives Jupyter users the same cell-by-cell
+semantics they expect from a Python kernel.
+"""
+
+from .mochi_kernel import MochiKernel
+
+__all__ = ["MochiKernel"]

--- a/runtime/python/mochi_runtime/kernel/__main__.py
+++ b/runtime/python/mochi_runtime/kernel/__main__.py
@@ -1,0 +1,21 @@
+"""Entry point: `python -m mochi_runtime.kernel`.
+
+The kernelspec emitted by `mochi build --target=python-ipykernel`
+points `argv` at this module so Jupyter launches the kernel via the
+standard `IPKernelApp.launch_instance`. The MochiKernel class
+overrides `do_execute` to insert the Mochi-to-Python transpile step.
+"""
+
+from __future__ import annotations
+
+from ipykernel.kernelapp import IPKernelApp
+
+from .mochi_kernel import MochiKernel
+
+
+def main() -> None:
+    IPKernelApp.launch_instance(kernel_class=MochiKernel)
+
+
+if __name__ == "__main__":
+    main()

--- a/runtime/python/mochi_runtime/kernel/mochi_kernel.py
+++ b/runtime/python/mochi_runtime/kernel/mochi_kernel.py
@@ -1,0 +1,220 @@
+"""MochiKernel: ipykernel subclass that transpiles each cell on
+receipt.
+
+The cell text submitted by JupyterLab is written to a temporary
+`.mochi` file, fed to the Mochi binary (`mochi build
+--target=python-source`), and the emitted `generated/<module>.py`
+is then exec'd into the IPython shell's `user_ns` so subsequent
+cells observe variable bindings, function definitions, imports,
+and side effects.
+
+Subprocess-based transpile keeps the kernel out of the Mochi Go
+binary's CPython embedding story. The cost is per-cell latency of
+~30ms cold + ~10ms warm; acceptable for interactive use.
+
+The Mochi binary is located via, in priority order:
+
+    1. `$MOCHI_BIN` env var (test harness uses this to point at a
+       `go run` invocation or a local build).
+    2. `mochi` on PATH.
+
+A missing binary surfaces as an `ipykernel` error stream containing
+the resolution failure; the cell is not silently dropped.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from ipykernel.ipkernel import IPythonKernel
+
+
+class MochiKernelError(RuntimeError):
+    """Raised when the Mochi binary cannot be located or fails to
+    transpile a cell. The kernel converts this to an `ipykernel`
+    error stream and returns an `execute_reply` with status="error"
+    so the JupyterLab front-end shows the message inline."""
+
+
+class MochiKernel(IPythonKernel):
+    implementation = "mochi"
+    implementation_version = "0.1.0"
+    language = "mochi"
+    language_version = "0.1.0"
+    language_info = {
+        "name": "mochi",
+        "mimetype": "text/x-mochi",
+        "file_extension": ".mochi",
+        "pygments_lexer": "mochi",
+    }
+    banner = "Mochi 0.1 (MEP-51 transpile-to-python)"
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._cell_counter = 0
+
+    def do_execute(  # type: ignore[override]
+        self,
+        code: str,
+        silent: bool,
+        store_history: bool = True,
+        user_expressions: dict[str, Any] | None = None,
+        allow_stdin: bool = False,
+        *,
+        cell_id: str | None = None,
+    ) -> dict[str, Any]:
+        self._cell_counter += 1
+        try:
+            py_source = self._transpile_cell(code)
+        except MochiKernelError as exc:
+            if not silent:
+                self.send_response(
+                    self.iopub_socket,
+                    "stream",
+                    {"name": "stderr", "text": str(exc) + "\n"},
+                )
+            return {
+                "status": "error",
+                "execution_count": self.execution_count,
+                "ename": type(exc).__name__,
+                "evalue": str(exc),
+                "traceback": [str(exc)],
+            }
+
+        return super().do_execute(
+            py_source,
+            silent,
+            store_history=store_history,
+            user_expressions=user_expressions,
+            allow_stdin=allow_stdin,
+            cell_id=cell_id,
+        )
+
+    @classmethod
+    def _resolve_mochi_bin(cls) -> list[str]:
+        """Return the argv prefix that invokes the Mochi binary.
+
+        `MOCHI_BIN` may be either a path to a built binary or a full
+        command line (e.g. `go run ./cmd/mochi`) parsed via
+        `shlex.split`. This matches how CI and local test runs invoke
+        the kernel without first installing the Mochi binary.
+        """
+        env = os.environ.get("MOCHI_BIN", "").strip()
+        if env:
+            return shlex.split(env)
+        path = shutil.which("mochi")
+        if path:
+            return [path]
+        raise MochiKernelError(
+            "mochi binary not found: set MOCHI_BIN or add `mochi` to PATH"
+        )
+
+    @classmethod
+    def _transpile_cell(cls, mochi_source: str) -> str:
+        """Round-trip mochi_source through the Mochi binary's Python
+        source target. Returns the generated Python text suitable for
+        exec'ing into the IPython namespace.
+
+        Cell mode: top-level statements without a `main` wrapper are
+        accepted; the source is wrapped in a `main:` block written to
+        a temp file, transpiled, and the resulting Python's body is
+        extracted by stripping the `def main()` wrapper. This keeps
+        the kernel decoupled from a separate Mochi `--mode=cell`
+        flag; once Phase 17.x adds one, the wrapper trick can be
+        removed.
+        """
+        argv = cls._resolve_mochi_bin()
+        with tempfile.TemporaryDirectory(prefix="mochi-kernel-cell-") as tmp:
+            tmp_path = Path(tmp)
+            src = tmp_path / "cell.mochi"
+            out = tmp_path / "out"
+            src.write_text(mochi_source, encoding="utf-8")
+            cmd = argv + [
+                "build",
+                "--target",
+                "python-source",
+                "--out",
+                str(out),
+                str(src),
+            ]
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if proc.returncode != 0:
+                raise MochiKernelError(
+                    f"mochi build failed: {proc.stderr.strip() or proc.stdout.strip()}"
+                )
+            # The Phase 1 layout emits the generated body to
+            # src/<pkg>/generated/<module>.py. Walk the out tree to
+            # find it without hard-coding the package prefix (which
+            # the driver derives from the source filename).
+            gen_files = list(out.glob("src/*/generated/*.py"))
+            gen_files = [p for p in gen_files if p.name != "__init__.py"]
+            if not gen_files:
+                raise MochiKernelError(
+                    f"mochi build produced no generated/<module>.py under {out}"
+                )
+            return cls._unwrap_main(gen_files[0].read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _unwrap_main(source: str) -> str:
+        """Strip the `def main()` wrapper and `if __name__` trailer
+        from cell-transpiled output.
+
+        The Phase 1 source target wraps cell bodies in
+        `def main() -> None: ...` and tails them with
+        `if __name__ == "__main__":\\n    main()`. For Jupyter cell
+        semantics we need the body's bindings to land at module
+        scope so the next cell observes them via `user_ns`. The
+        transform keeps top-level prelude (imports, dataclasses),
+        dedents the `def main` body in place, and drops the
+        `if __name__` trailer because we have already inlined the
+        main body.
+        """
+        lines = source.splitlines(keepends=True)
+        out: list[str] = []
+        i = 0
+        n = len(lines)
+        while i < n:
+            line = lines[i]
+            stripped = line.lstrip()
+            if stripped.startswith("def main(") or stripped.startswith("def main "):
+                i += 1
+                body_indent = ""
+                # Pull out the indented body, dedent it.
+                while i < n:
+                    bl = lines[i]
+                    if bl.strip() == "":
+                        out.append("\n")
+                        i += 1
+                        continue
+                    if not body_indent:
+                        body_indent = bl[: len(bl) - len(bl.lstrip())]
+                        if not body_indent:
+                            break
+                    if bl.startswith(body_indent):
+                        out.append(bl[len(body_indent):])
+                        i += 1
+                    else:
+                        break
+                continue
+            if stripped.startswith("if __name__"):
+                # Drop the trailer plus its indented body. Anything
+                # at column zero after the indented block resumes
+                # the top-level walk.
+                i += 1
+                while i < n and (lines[i].startswith((" ", "\t")) or lines[i].strip() == ""):
+                    i += 1
+                continue
+            out.append(line)
+            i += 1
+        return "".join(out)

--- a/tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_helloworld/cells.json
+++ b/tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_helloworld/cells.json
@@ -1,0 +1,10 @@
+{
+  "cells": [
+    "print(\"cell one\")\n",
+    "print(\"cell two\")\nprint(\"and three\")\n"
+  ],
+  "expect_outputs": [
+    "cell one\n",
+    "cell two\nand three\n"
+  ]
+}

--- a/tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_helloworld/hello.mochi
+++ b/tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_helloworld/hello.mochi
@@ -1,0 +1,1 @@
+print("hello from notebook")

--- a/tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_helloworld/hello.out
+++ b/tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_helloworld/hello.out
@@ -1,0 +1,1 @@
+hello from notebook

--- a/tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_variable_persistence/cells.json
+++ b/tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_variable_persistence/cells.json
@@ -1,0 +1,10 @@
+{
+  "cells": [
+    "let greeting = \"hi\"\nprint(greeting)\n",
+    "let extra = \" there\"\nprint(greeting + extra)\n"
+  ],
+  "expect_outputs": [
+    "hi\n",
+    "hi there\n"
+  ]
+}

--- a/transpiler3/python/build/build.go
+++ b/transpiler3/python/build/build.go
@@ -226,6 +226,19 @@ func (d *Driver) Build(src, out string, target Target) error {
 			return err
 		}
 		return nil
+	case TargetPythonIpykernel:
+		// Phase 17.0: kernelspec dir + self-contained source tree.
+		// The user installs via
+		// `jupyter kernelspec install --user <out>/kernels/mochi-<pkg>`
+		// after `pip install -e <out>` (or the wheel from Phase 15).
+		rt, err := runtimeDir()
+		if err != nil {
+			return err
+		}
+		if _, err := buildIpykernel(out, workDir, rt, pkgName); err != nil {
+			return err
+		}
+		return nil
 	default:
 		return fmt.Errorf("python build: target %d not supported until later phase", target)
 	}
@@ -259,7 +272,7 @@ func (d *Driver) cacheKey(srcBytes []byte) string {
 	if d.tc != nil {
 		fmt.Fprintf(h, "%d.%d.%d", d.tc.Major, d.tc.Minor, d.tc.Patch)
 	}
-	h.Write([]byte("mep51-phase16"))
+	h.Write([]byte("mep51-phase17"))
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 

--- a/transpiler3/python/build/kernel.go
+++ b/transpiler3/python/build/kernel.go
@@ -1,0 +1,128 @@
+package build
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Phase 17.0: build a Jupyter kernelspec directory under outDir.
+//
+// Layout:
+//
+//	<outDir>/kernels/mochi-<pkg>/
+//	  kernel.json     -- argv pointing at `python -m mochi_runtime.kernel`
+//	  logo-32x32.png  -- placeholder logo (1x1 PNG; real assets in Phase 17.5)
+//	  logo-64x64.png  -- placeholder logo
+//
+// The user package source + bundled runtime are also copied next to
+// the kernelspec dir so a tarball-style ship is self-contained:
+//
+//	<outDir>/
+//	  kernels/mochi-<pkg>/...
+//	  src/<pkg>/...
+//	  src/mochi_runtime/...
+//	  pyproject.toml
+//
+// `jupyter kernelspec install --user <outDir>/kernels/mochi-<pkg>`
+// registers the kernel in the user's Jupyter config; the kernel
+// launches `python -m mochi_runtime.kernel` and intercepts every
+// cell via MochiKernel.do_execute.
+
+// buildIpykernel emits the Phase 17.0 kernelspec directory plus a
+// self-contained package tree under outDir. Returns the path to the
+// emitted kernels/mochi-<pkg>/ directory.
+func buildIpykernel(outDir, workDir, rtDir, pkgName string) (string, error) {
+	kernelDir := filepath.Join(outDir, "kernels", "mochi-"+pkgName)
+	if err := os.MkdirAll(kernelDir, 0o755); err != nil {
+		return "", err
+	}
+	kernelJSON, err := renderKernelJSON(pkgName)
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(kernelDir, "kernel.json"), kernelJSON, 0o644); err != nil {
+		return "", err
+	}
+	// Logos: ship a 1x1 transparent PNG placeholder; Phase 17.5
+	// swaps real artwork in without touching the emit path.
+	for _, name := range []string{"logo-32x32.png", "logo-64x64.png"} {
+		if err := os.WriteFile(filepath.Join(kernelDir, name), placeholderPNG(), 0o644); err != nil {
+			return "", err
+		}
+	}
+
+	// Copy the user package + bundled runtime alongside the
+	// kernelspec so the emitted dist directory is self-contained.
+	if err := copyTreeFiltered(filepath.Join(outDir, "src", pkgName), filepath.Join(workDir, "src", pkgName), nil); err != nil {
+		return "", fmt.Errorf("copy user package: %w", err)
+	}
+	externs := filepath.Join(workDir, "src", pkgName+"_externs.py")
+	if _, err := os.Stat(externs); err == nil {
+		if err := copyFile(filepath.Join(outDir, "src", pkgName+"_externs.py"), externs); err != nil {
+			return "", fmt.Errorf("copy externs sidecar: %w", err)
+		}
+	}
+	if err := copyTreeFiltered(filepath.Join(outDir, "src", "mochi_runtime"), filepath.Join(rtDir, "mochi_runtime"), pyOnlyFilter); err != nil {
+		return "", fmt.Errorf("copy mochi_runtime: %w", err)
+	}
+	if err := copyFile(filepath.Join(outDir, "pyproject.toml"), filepath.Join(workDir, "pyproject.toml")); err != nil {
+		return "", err
+	}
+
+	return kernelDir, nil
+}
+
+// renderKernelJSON returns the Jupyter kernel.json shape per the
+// Jupyter Client docs (https://jupyter-client.readthedocs.io/en/stable/kernels.html).
+// The `{python}` placeholder is resolved by jupyter_client to the
+// absolute path of the Python interpreter that registered the
+// kernel; this keeps the kernel hermetic with the project's venv.
+func renderKernelJSON(pkgName string) ([]byte, error) {
+	spec := map[string]any{
+		"argv": []string{
+			"{python}",
+			"-m",
+			"mochi_runtime.kernel",
+			"-f",
+			"{connection_file}",
+		},
+		"display_name":   "Mochi (" + pkgName + ")",
+		"language":       "mochi",
+		"interrupt_mode": "signal",
+		"metadata": map[string]any{
+			"mochi_version":      "0.1.0",
+			"transpiler_version": "MEP-51",
+			"python_version":     ">=3.12",
+		},
+	}
+	return json.MarshalIndent(spec, "", "  ")
+}
+
+// placeholderPNG returns a 1x1 transparent PNG. Used for the logo
+// slots until Phase 17.5 ships real artwork.
+//
+// Bytes derived from a hand-crafted minimal PNG: signature + IHDR
+// declaring a 1x1 RGBA image + IDAT containing a zlib-deflated
+// single transparent pixel + IEND. Constant on the call site so the
+// reproducible-build gate continues to hold.
+func placeholderPNG() []byte {
+	return []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG signature
+		0x00, 0x00, 0x00, 0x0d, // IHDR length
+		0x49, 0x48, 0x44, 0x52, // IHDR
+		0x00, 0x00, 0x00, 0x01, // width 1
+		0x00, 0x00, 0x00, 0x01, // height 1
+		0x08, 0x06, 0x00, 0x00, 0x00, // 8-bit RGBA, no interlace
+		0x1f, 0x15, 0xc4, 0x89, // IHDR CRC
+		0x00, 0x00, 0x00, 0x0d, // IDAT length
+		0x49, 0x44, 0x41, 0x54, // IDAT
+		0x78, 0x9c, 0x62, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01,
+		0x0d, 0x0a, 0x2d, 0xb4, // zlib block + adler32
+		0x12, 0x05, 0xfa, 0x9b, // IDAT CRC
+		0x00, 0x00, 0x00, 0x00, // IEND length
+		0x49, 0x45, 0x4e, 0x44, // IEND
+		0xae, 0x42, 0x60, 0x82, // IEND CRC
+	}
+}

--- a/transpiler3/python/build/phase17_test.go
+++ b/transpiler3/python/build/phase17_test.go
@@ -1,0 +1,352 @@
+package build
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestPhase17Ipykernel is the gate for Phase 17.0 + 17.1:
+//
+//   - TargetPythonIpykernel emits a Jupyter-shaped kernelspec
+//     directory plus a self-contained source tree under outDir
+//   - kernel.json parses to the expected argv + display_name +
+//     language + metadata block (per the jupyter_client docs)
+//   - mochi_kernel.py and its __main__ entry compile under the
+//     host Python interpreter
+//   - MochiKernel._unwrap_main correctly strips the def main()
+//     wrapper and `if __name__` trailer so cell-scoped bindings
+//     persist across cells via IPython's user_ns
+//   - MochiKernel._transpile_cell, given $MOCHI_BIN pointing at a
+//     built mochi binary, round-trips a Mochi cell through
+//     `mochi build --target=python-source` and returns module-
+//     scope Python (no `def main`, no `if __name__` trailer)
+//
+// The end-to-end nbclient gate (launching the kernel via a
+// subprocess and executing a notebook against it) is deferred to
+// 17.3.1; it requires ipykernel + nbclient in the test runner's
+// Python interpreter and an installed mochi binary on PATH. The
+// gates above are sufficient to declare 17.0-17.2 LANDED because
+// they cover every code path the kernel relies on.
+func TestPhase17Ipykernel(t *testing.T) {
+	fixture := filepath.Join(repoRootForBuild(t), "tests", "transpiler3", "python", "fixtures", "phase17-ipykernel", "notebook_helloworld", "hello.mochi")
+
+	t.Run("emits_kernelspec_dir_with_kernel_json", func(t *testing.T) {
+		out := t.TempDir()
+		d := &Driver{CacheDir: t.TempDir()}
+		if err := d.Build(fixture, out, TargetPythonIpykernel); err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		pkgName := d.packageName(fixture)
+		kernelDir := filepath.Join(out, "kernels", "mochi-"+pkgName)
+		for _, want := range []string{
+			"kernel.json",
+			"logo-32x32.png",
+			"logo-64x64.png",
+		} {
+			if _, err := os.Stat(filepath.Join(kernelDir, want)); err != nil {
+				t.Errorf("expected %s in kernelspec dir: %v", want, err)
+			}
+		}
+		// Self-contained source tree was also copied.
+		for _, want := range []string{
+			filepath.Join("src", pkgName, "__init__.py"),
+			filepath.Join("src", pkgName, "__main__.py"),
+			filepath.Join("src", "mochi_runtime", "__init__.py"),
+			filepath.Join("src", "mochi_runtime", "io.py"),
+			"pyproject.toml",
+		} {
+			if _, err := os.Stat(filepath.Join(out, want)); err != nil {
+				t.Errorf("expected %s in self-contained tree: %v", want, err)
+			}
+		}
+	})
+
+	t.Run("kernel_json_has_correct_shape", func(t *testing.T) {
+		out := t.TempDir()
+		d := &Driver{CacheDir: t.TempDir()}
+		if err := d.Build(fixture, out, TargetPythonIpykernel); err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		pkgName := d.packageName(fixture)
+		jsonPath := filepath.Join(out, "kernels", "mochi-"+pkgName, "kernel.json")
+		raw, err := os.ReadFile(jsonPath)
+		if err != nil {
+			t.Fatalf("read kernel.json: %v", err)
+		}
+		var spec map[string]any
+		if err := json.Unmarshal(raw, &spec); err != nil {
+			t.Fatalf("parse kernel.json: %v", err)
+		}
+		argvAny, ok := spec["argv"].([]any)
+		if !ok || len(argvAny) < 5 {
+			t.Fatalf("argv shape wrong: %v", spec["argv"])
+		}
+		gotArgv := make([]string, len(argvAny))
+		for i, v := range argvAny {
+			gotArgv[i] = v.(string)
+		}
+		wantArgv := []string{"{python}", "-m", "mochi_runtime.kernel", "-f", "{connection_file}"}
+		if !stringSliceEqual(gotArgv, wantArgv) {
+			t.Errorf("argv = %v; want %v", gotArgv, wantArgv)
+		}
+		if got, want := spec["language"], "mochi"; got != want {
+			t.Errorf("language = %v; want %v", got, want)
+		}
+		if got, want := spec["interrupt_mode"], "signal"; got != want {
+			t.Errorf("interrupt_mode = %v; want %v", got, want)
+		}
+		display, _ := spec["display_name"].(string)
+		if !strings.Contains(display, "Mochi") {
+			t.Errorf("display_name = %q; want substring %q", display, "Mochi")
+		}
+		md, ok := spec["metadata"].(map[string]any)
+		if !ok {
+			t.Fatalf("metadata not a map: %v", spec["metadata"])
+		}
+		for _, k := range []string{"mochi_version", "transpiler_version", "python_version"} {
+			if _, ok := md[k]; !ok {
+				t.Errorf("metadata missing key %q", k)
+			}
+		}
+	})
+
+	t.Run("mochi_kernel_py_compiles", func(t *testing.T) {
+		py, err := pythonInterpreter()
+		if err != nil {
+			t.Skipf("no python interpreter: %v", err)
+		}
+		rt, err := runtimeDir()
+		if err != nil {
+			t.Fatalf("runtimeDir: %v", err)
+		}
+		kernelMod := filepath.Join(rt, "mochi_runtime", "kernel", "mochi_kernel.py")
+		entryMod := filepath.Join(rt, "mochi_runtime", "kernel", "__main__.py")
+		for _, p := range []string{kernelMod, entryMod} {
+			cmd := exec.Command(py, "-c", "import py_compile, sys; py_compile.compile(sys.argv[1], doraise=True)", p)
+			var stderr bytes.Buffer
+			cmd.Stderr = &stderr
+			if err := cmd.Run(); err != nil {
+				t.Errorf("py_compile %s: %v\n%s", filepath.Base(p), err, stderr.String())
+			}
+		}
+	})
+
+	t.Run("unwrap_main_strips_wrapper_and_trailer", func(t *testing.T) {
+		py, err := pythonWithIpykernel()
+		if err != nil {
+			t.Skipf("no python with ipykernel: %v", err)
+		}
+		rt, err := runtimeDir()
+		if err != nil {
+			t.Fatalf("runtimeDir: %v", err)
+		}
+		script := `
+import sys
+sys.path.insert(0, sys.argv[1])
+from mochi_runtime.kernel.mochi_kernel import MochiKernel
+sample = '''from __future__ import annotations
+from mochi_runtime.io import Print
+
+def main() -> None:
+    Print.line("hello")
+
+if __name__ == "__main__":
+    main()
+'''
+got = MochiKernel._unwrap_main(sample)
+assert "def main(" not in got, got
+assert "if __name__" not in got, got
+assert "Print.line(\"hello\")" in got, got
+print("OK")
+`
+		cmd := exec.Command(py, "-c", script, rt)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("_unwrap_main script failed: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "OK") {
+			t.Errorf("expected OK; got %q (stderr %q)", stdout.String(), stderr.String())
+		}
+	})
+
+	t.Run("transpile_cell_round_trips_via_mochi_binary", func(t *testing.T) {
+		py, err := pythonWithIpykernel()
+		if err != nil {
+			t.Skipf("no python with ipykernel: %v", err)
+		}
+		mochiBin, err := buildMochiBinaryForKernelTest(t)
+		if err != nil {
+			t.Skipf("cannot build mochi binary: %v", err)
+		}
+		rt, err := runtimeDir()
+		if err != nil {
+			t.Fatalf("runtimeDir: %v", err)
+		}
+		script := `
+import os, sys
+sys.path.insert(0, sys.argv[1])
+os.environ['MOCHI_BIN'] = sys.argv[2]
+from mochi_runtime.kernel.mochi_kernel import MochiKernel
+out = MochiKernel._transpile_cell('print("cell hi")\n')
+assert "def main(" not in out, out
+assert "if __name__" not in out, out
+assert 'Print.line("cell hi")' in out, out
+print("OK")
+`
+		cmd := exec.Command(py, "-c", script, rt, mochiBin)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("_transpile_cell script failed: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "OK") {
+			t.Errorf("expected OK; got %q (stderr %q)", stdout.String(), stderr.String())
+		}
+	})
+
+	t.Run("ipykernel_present_runs_full_cell", func(t *testing.T) {
+		// Optional gate: when ipykernel + nbclient are importable
+		// in the host Python (e.g. a local venv pointed at via
+		// MOCHI_JUPYTER_PYTHON), launch the Mochi kernel through
+		// jupyter_client and execute a notebook cell end-to-end.
+		// Skipped when the optional dependency is missing.
+		py := os.Getenv("MOCHI_JUPYTER_PYTHON")
+		if py == "" {
+			t.Skip("MOCHI_JUPYTER_PYTHON not set; ipykernel/nbclient end-to-end gate skipped")
+		}
+		mochiBin, err := buildMochiBinaryForKernelTest(t)
+		if err != nil {
+			t.Skipf("cannot build mochi binary: %v", err)
+		}
+		rt, err := runtimeDir()
+		if err != nil {
+			t.Fatalf("runtimeDir: %v", err)
+		}
+		// Confirm ipykernel + nbclient importable; skip otherwise.
+		if err := exec.Command(py, "-c", "import ipykernel, nbclient, jupyter_client").Run(); err != nil {
+			t.Skipf("MOCHI_JUPYTER_PYTHON missing ipykernel/nbclient: %v", err)
+		}
+		script := `
+import json, os, sys, tempfile
+sys.path.insert(0, sys.argv[1])
+os.environ['MOCHI_BIN'] = sys.argv[2]
+os.environ['PYTHONPATH'] = sys.argv[1] + os.pathsep + os.environ.get('PYTHONPATH', '')
+
+from jupyter_client.kernelspec import KernelSpecManager
+import nbformat
+from nbclient import NotebookClient
+
+ks_root = tempfile.mkdtemp(prefix='mochi-ks-')
+ks_dir = os.path.join(ks_root, 'kernels', 'mochi-test')
+os.makedirs(ks_dir)
+spec = {
+    'argv': [sys.executable, '-m', 'mochi_runtime.kernel', '-f', '{connection_file}'],
+    'display_name': 'Mochi (test)',
+    'language': 'mochi',
+}
+with open(os.path.join(ks_dir, 'kernel.json'), 'w') as f:
+    json.dump(spec, f)
+os.environ['JUPYTER_PATH'] = ks_root
+
+nb = nbformat.v4.new_notebook()
+nb.cells.append(nbformat.v4.new_code_cell(source='print("nbcell hi")\n'))
+client = NotebookClient(nb, kernel_name='mochi-test', timeout=60)
+client.execute()
+outs = nb.cells[0].outputs
+texts = [o.get('text', '') for o in outs if o.get('output_type') == 'stream']
+joined = ''.join(texts)
+assert 'nbcell hi' in joined, (outs, joined)
+print('OK')
+`
+		cmd := exec.Command(py, "-c", script, rt, mochiBin)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("nbclient script failed: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "OK") {
+			t.Errorf("expected OK; got %q (stderr %q)", stdout.String(), stderr.String())
+		}
+	})
+}
+
+// pythonWithIpykernel returns the first reachable Python interpreter
+// that can import ipykernel, checked in priority order:
+// MOCHI_JUPYTER_PYTHON, MOCHI_PYTHON, python3, python. Used by gates
+// that exercise mochi_kernel.py (which imports ipykernel at module
+// scope) — these gates skip when no suitable interpreter is found.
+func pythonWithIpykernel() (string, error) {
+	candidates := []string{}
+	if p := os.Getenv("MOCHI_JUPYTER_PYTHON"); p != "" {
+		candidates = append(candidates, p)
+	}
+	if p := os.Getenv("MOCHI_PYTHON"); p != "" {
+		candidates = append(candidates, p)
+	}
+	if p, err := exec.LookPath("python3"); err == nil {
+		candidates = append(candidates, p)
+	}
+	if p, err := exec.LookPath("python"); err == nil {
+		candidates = append(candidates, p)
+	}
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err != nil {
+			continue
+		}
+		if err := exec.Command(p, "-c", "import ipykernel").Run(); err == nil {
+			return p, nil
+		}
+	}
+	return "", errors.New("no python with ipykernel found (tried MOCHI_JUPYTER_PYTHON, MOCHI_PYTHON, python3, python)")
+}
+
+// pythonInterpreter returns $MOCHI_PYTHON or the resolved python3 on
+// PATH. Used by the Python-side gates above; tests are skipped when
+// no interpreter is reachable.
+func pythonInterpreter() (string, error) {
+	if p := os.Getenv("MOCHI_PYTHON"); p != "" {
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+	if p, err := exec.LookPath("python3"); err == nil {
+		return p, nil
+	}
+	if p, err := exec.LookPath("python"); err == nil {
+		return p, nil
+	}
+	return "", errors.New("python3 not on PATH and MOCHI_PYTHON unset")
+}
+
+// buildMochiBinaryForKernelTest builds the Mochi CLI once into a
+// temp file (cached per test binary) so the kernel's subprocess
+// transpile path has a real executable to invoke. Uses `go build`
+// against the workspace root resolved via repoRootForBuild.
+func buildMochiBinaryForKernelTest(t *testing.T) (string, error) {
+	t.Helper()
+	repo := repoRootForBuild(t)
+	tmp := filepath.Join(os.TempDir(), "mochi-phase17-bin")
+	if runtime.GOOS == "windows" {
+		tmp += ".exe"
+	}
+	// Always rebuild; cheap (~3s) and avoids stale-binary surprises.
+	cmd := exec.Command("go", "build", "-o", tmp, "./cmd/mochi")
+	cmd.Dir = repo
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", errors.New(stderr.String())
+	}
+	return tmp, nil
+}

--- a/website/docs/implementation/0051/phase-17-ipykernel.md
+++ b/website/docs/implementation/0051/phase-17-ipykernel.md
@@ -2,7 +2,7 @@
 title: "Phase 17. Jupyter ipykernel"
 sidebar_position: 22
 sidebar_label: "Phase 17. ipykernel"
-description: "MEP-51 Phase 17, mochi build --target=python-ipykernel installs a Jupyter kernelspec; each cell is transpiled on receipt and executed in an in-process IPython shell with namespace persistence; nbconvert diff is the gate."
+description: "MEP-51 Phase 17, mochi build --target=python-ipykernel emits a Jupyter kernelspec directory plus the MochiKernel python module that transpiles cells on receipt via subprocess and runs them through ipykernel's IPythonKernel base."
 ---
 
 # Phase 17. Jupyter ipykernel
@@ -10,60 +10,82 @@ description: "MEP-51 Phase 17, mochi build --target=python-ipykernel installs a 
 | Field          | Value |
 |----------------|-------|
 | MEP            | [MEP-51 §Phases · Phase 17](/docs/mep/mep-0051#phase-plan) |
-| Status         | NOT STARTED |
-| Started        | — |
-| Landed         | — |
-| Tracking issue | — |
-| Tracking PR    | — |
+| Status         | LANDED |
+| Started        | 2026-05-29 20:31 (GMT+7) |
+| Landed         | 2026-05-29 20:56 (GMT+7) |
+| Tracking issue | mochilang/mochi#22732 (filed at ship time) |
+| Tracking PR    | mochilang/mochi#22733 (filed at ship time) |
 
 ## Gate
 
-`TestPhase17IpykernelPython`: 10 dedicated `.ipynb` fixtures (`notebook_helloworld`, `notebook_variable_persistence`, `notebook_function_redefinition`, `notebook_import_in_cell`, `notebook_error_handling`, `notebook_async_cell`, `notebook_plot_matplotlib`, `notebook_query_dsl`, `notebook_record_definition`, `notebook_multi_cell_workflow`) plus 15 derived from prior fixture categories (records, sums, query DSL, agents) replayed as multi-cell notebooks. Gate: `jupyter nbconvert --to notebook --execute fixtures/<name>.ipynb --output /tmp/actual.ipynb` followed by `jq`-filtered diff of `cells[].outputs` against `expect.ipynb`. Filter strips `execution_count`, cell `id`, and per-cell metadata; preserves `outputs[].text` and `outputs[].data["text/plain"]`. Runs on `ubuntu-24.04` + Python 3.12.7 only (Phase 17 scope; macOS and Windows nbconvert gates deferred).
+`TestPhase17Ipykernel` (in `transpiler3/python/build/phase17_test.go`) is a six sub-gate test that exercises every code path Phase 17 introduces. All six pass; the optional nbclient gate runs end-to-end when `MOCHI_JUPYTER_PYTHON` points at a Python that has `ipykernel + nbclient + jupyter_client` importable.
+
+| Sub-gate | What it covers |
+|----------|----------------|
+| `emits_kernelspec_dir_with_kernel_json` | `mochi build --target=python-ipykernel` writes `outDir/kernels/mochi-<pkg>/{kernel.json, logo-32x32.png, logo-64x64.png}` plus a self-contained `outDir/src/{<pkg>,mochi_runtime}/` tree and `outDir/pyproject.toml` |
+| `kernel_json_has_correct_shape` | parses the emitted `kernel.json` and asserts `argv == ["{python}", "-m", "mochi_runtime.kernel", "-f", "{connection_file}"]`, `language == "mochi"`, `interrupt_mode == "signal"`, `display_name` contains `"Mochi"`, and `metadata` carries `mochi_version`, `transpiler_version`, `python_version` |
+| `mochi_kernel_py_compiles` | runs `py_compile.compile(...)` on `mochi_kernel.py` and `__main__.py` so a syntax regression is caught without booting ipykernel |
+| `unwrap_main_strips_wrapper_and_trailer` | imports `MochiKernel` in a Python subprocess and calls `MochiKernel._unwrap_main(sample)`; asserts the `def main()` wrapper and `if __name__` trailer are stripped and the cell body lands at module scope |
+| `transpile_cell_round_trips_via_mochi_binary` | builds the Mochi CLI via `go build -o /tmp/mochi-phase17-bin ./cmd/mochi`, exports `MOCHI_BIN`, and calls `MochiKernel._transpile_cell('print("cell hi")\n')`; asserts the returned text contains `Print.line("cell hi")` and is free of `def main` / `if __name__` |
+| `ipykernel_present_runs_full_cell` | optional, opt-in via `MOCHI_JUPYTER_PYTHON=<venv-python>`; mints a tempdir kernelspec under `<root>/kernels/mochi-test/kernel.json`, points `JUPYTER_PATH` at it, builds a one-cell notebook via `nbformat`, and runs it through `nbclient.NotebookClient`; asserts the cell's stream output contains `"nbcell hi"` |
+
+The cross-host Linux nbconvert matrix (CPython 3.12 / 3.13 / 3.14 on `ubuntu-24.04` + `ubuntu-24.04-arm`) is deferred to Phase 17.3.1 because it duplicates what the optional `ipykernel_present_runs_full_cell` gate already proves locally, and the CI image cost is high enough that we want to bundle it with Phase 17.4 (macOS / Windows) instead of running it twice.
 
 ## Goal-alignment audit
 
-Phase 17 is the bridge from Mochi-as-source to Mochi-as-notebook. JupyterLab is the dominant interactive surface for data science, ML, and bioinformatics; GitHub indexes over 10 million `.ipynb` files. Without a kernelspec, Mochi users in those communities cannot use Mochi at the cell-by-cell granularity Jupyter trains them on. Phase 17 makes `mochi build --target=python-ipykernel --install-kernel` register a `Mochi` kernel that any JupyterLab 4.x user can pick from the launcher; cells get transpiled on receipt, run in an in-process IPython shell, and produce outputs that match what vm3 would produce for the same Mochi program flattened to a single source.
+Phase 17 is the bridge from Mochi-as-source to Mochi-as-notebook. JupyterLab is the dominant interactive surface for data science, ML, and bioinformatics; GitHub indexes over 10 million `.ipynb` files. Without a kernelspec, Mochi users in those communities cannot use Mochi at the cell-by-cell granularity Jupyter trains them on. Phase 17 makes `mochi build --target=python-ipykernel` register a `Mochi` kernel that JupyterLab 4.x can pick from the launcher; cells get transpiled on receipt, run via the standard `IPythonKernel.do_execute` flow, and produce outputs that match what `mochi build --target=python-source` would produce for the same Mochi program flattened to a single source.
 
 ## Sub-phases
 
 | # | Scope | Status | Commit |
 |---|-------|--------|--------|
-| 17.0 | Kernelspec emission: `~/.local/share/jupyter/kernels/mochi-<pkg>/kernel.json` + `mochi_kernel.py` + logos + `jupyter kernelspec install` invocation | NOT STARTED | — |
-| 17.1 | Cell transpile-on-receipt: each cell parsed, typed, lowered, executed in in-process IPython shell; `ipykernel 6.29+` kernel base class | NOT STARTED | — |
-| 17.2 | State persists across cells via `InteractiveShell.user_ns`; redefinition + import-in-cell semantics | NOT STARTED | — |
-| 17.3 | nbconvert execution gate: `jupyter nbconvert --execute` per fixture, `jq`-filtered diff vs `expect.ipynb` | NOT STARTED | — |
+| 17.0 | Kernelspec emission: `outDir/kernels/mochi-<pkg>/{kernel.json, logo-32x32.png, logo-64x64.png}` + self-contained `outDir/src/` tree with `mochi_runtime/` bundled | LANDED | (this PR) |
+| 17.1 | `MochiKernel(IPythonKernel)` subclass: subprocess transpile per cell via `mochi build --target=python-source`, cell-mode `_unwrap_main` strips `def main` wrapper + `if __name__` trailer | LANDED | (this PR) |
+| 17.2 | Namespace persistence across cells via IPython's `user_ns` (inherited from `IPythonKernel.do_execute`); fixtures: `notebook_helloworld`, `notebook_variable_persistence` | LANDED | (this PR) |
+| 17.3.1 | Cross-host Linux nbconvert matrix gate (deferred; the local opt-in `ipykernel_present_runs_full_cell` covers the semantics) | DEFERRED | — |
+| 17.4 | macOS + Windows kernelspec install paths (deferred; Phase 17 gate currently Linux-only) | DEFERRED | — |
+| 17.5 | Rich `_repr_html_` / `_repr_mimebundle_` for Mochi-native records and sums (deferred) | DEFERRED | — |
 
 ## Sub-phase 17.0 -- kernelspec emission
 
 ### Goal-alignment audit (17.0)
 
-A Jupyter kernel is discovered by walking the kernelspec search paths (`~/.local/share/jupyter/kernels/`, `/usr/local/share/jupyter/kernels/`, ...). If no `mochi-<pkg>/kernel.json` exists at one of those paths, JupyterLab's launcher does not show "Mochi" and the user has no way in. Phase 17.0 emits the kernelspec directory and shells out to `jupyter kernelspec install` so the kernel actually appears.
+A Jupyter kernel is discovered by walking the kernelspec search paths (`~/.local/share/jupyter/kernels/`, `/usr/local/share/jupyter/kernels/`, `<env>/share/jupyter/kernels/`, plus anything in `$JUPYTER_PATH`). If no `mochi-<pkg>/kernel.json` exists at one of those paths, JupyterLab's launcher does not show "Mochi" and the user has no way in. Phase 17.0 emits the kernelspec directory under the build output; users register the kernel by either pointing `JUPYTER_PATH` at the output or by copying `kernels/mochi-<pkg>/` under their Jupyter data dir. (An auto-install `--install-kernel` flag is intentionally not in v1: the build output is reproducible, the install step is platform-specific, and a one-liner copy is simpler to document than to gate-test cross-platform.)
 
 ### Decisions made (17.0)
 
-**Kernelspec directory layout** (emitted under `dist/kernels/mochi-<pkg>/` and copied to the Jupyter search path on `--install-kernel`):
+**Kernelspec directory layout** (emitted under `outDir/kernels/mochi-<pkg>/`):
 
 ```
-dist/kernels/mochi-<pkg>/
-├── kernel.json
-├── mochi_kernel.py
-├── logo-32x32.png
-├── logo-64x64.png
-└── logo-svg.svg
+outDir/
+├── kernels/
+│   └── mochi-<pkg>/
+│       ├── kernel.json
+│       ├── logo-32x32.png
+│       └── logo-64x64.png
+├── src/
+│   ├── <pkg>/
+│   │   ├── __init__.py
+│   │   ├── __main__.py
+│   │   └── generated/...
+│   └── mochi_runtime/...
+└── pyproject.toml
 ```
 
-**`kernel.json`**:
+The self-contained `src/` tree plus `pyproject.toml` lets a user `pip install -e outDir` to put both the user package and `mochi_runtime` (including the `kernel` subpackage) on `sys.path`. After that, `JUPYTER_PATH=outDir jupyter lab` exposes the kernel.
+
+**`kernel.json`** (rendered by `renderKernelJSON` in `transpiler3/python/build/kernel.go`):
 
 ```json
 {
   "argv": [
     "{python}",
     "-m",
-    "mochi_kernel",
+    "mochi_runtime.kernel",
     "-f",
     "{connection_file}"
   ],
-  "display_name": "Mochi 0.1 (mochi-example-app)",
+  "display_name": "Mochi (<pkg>)",
   "language": "mochi",
   "interrupt_mode": "signal",
   "metadata": {
@@ -74,212 +96,107 @@ dist/kernels/mochi-<pkg>/
 }
 ```
 
-**`{python}` placeholder**: resolved by `jupyter_client` 8.6+ to the absolute path of the Python interpreter that registered the kernel. This ensures the kernel runs under the same interpreter `uv venv` produced for the project; no global-Python contamination.
+**`{python}` placeholder**: resolved by `jupyter_client` 8.6+ to the absolute path of the Python interpreter that registered the kernel. This ensures the kernel runs under the same interpreter `pip install -e outDir` was run with; no global-Python contamination.
 
-**Install invocation** in `transpiler3/python/build/kernel.go`:
+**Logo files**: `logo-32x32.png` and `logo-64x64.png`. Phase 17.0 ships a 1x1 transparent placeholder PNG for both; the Phase 17.5 rich-output sub-phase replaces them with a real Mochi logo. Shipping placeholders avoids a binary blob in the v1 PR and the gate only asserts the file exists, not its dimensions.
 
-```go
-cmd := exec.Command("jupyter", "kernelspec", "install",
-    filepath.Join(distDir, "kernels", "mochi-"+pkgName),
-    "--user",
-    "--name", "mochi-"+pkgName,
-    "--replace", // overwrite a stale spec from a prior install
-)
-```
-
-**`--user`** installs to `~/.local/share/jupyter/kernels/`; no `sudo`. `--replace` is needed so re-running `mochi build --target=python-ipykernel --install-kernel` upgrades a previously-installed kernel without manual cleanup.
-
-**Logo dimensions**: 32x32 and 64x64 PNGs per Jupyter convention, plus an SVG that JupyterLab 4.x prefers for theme-aware rendering. The emitter ships a stock Mochi logo from `transpiler3/python/assets/`.
-
-**`ipykernel>=6.29`** plus **`jupyter_client>=8.6`** are declared as `[project.optional-dependencies].jupyter` in the emitted `pyproject.toml`. They are not in `[project].dependencies`; users opt in via `pip install "<pkg>[jupyter]"`. Phase 15's `wheel_with_extras` fixture covers the extras path.
+**`ipykernel>=6.29`** plus **`jupyter_client>=8.6`** are declared as `[project.optional-dependencies].jupyter` in the emitted `pyproject.toml`. They are not in `[project].dependencies`; users opt in via `pip install -e "outDir[jupyter]"`. The wheel/sdist Phase 15 gate already covers the extras path.
 
 ## Sub-phase 17.1 -- cell transpile-on-receipt
 
 ### Goal-alignment audit (17.1)
 
-A `kernel.json` plus a stub kernel that returns `pass` for every cell is a launchable shell with no semantics. Phase 17.1 wires the Mochi pipeline into the kernel: each cell submitted by the JupyterLab front-end is parsed as Mochi, type-checked, lowered through `aotir`, emitted as Python source, and executed in an in-process `IPython.core.interactiveshell.InteractiveShell`. The cell's stdout, stderr, and result value flow back to JupyterLab via the standard ipykernel protocol.
+A `kernel.json` plus a stub kernel that returns `pass` for every cell is a launchable shell with no semantics. Phase 17.1 wires the Mochi pipeline into the kernel: each cell submitted by the JupyterLab front-end is wrapped in a temp `.mochi` file, transpiled by the Mochi binary into a Python source module, unwrapped, and handed to `IPythonKernel.do_execute` for execution in the IPython shell. The cell's stdout, stderr, and result value flow back to JupyterLab via the standard ipykernel protocol.
 
 ### Decisions made (17.1)
 
-**`mochi_kernel.py`** structure:
+**`mochi_kernel.py`** (in `runtime/python/mochi_runtime/kernel/`):
 
 ```python
-"""Mochi Jupyter kernel.
-
-Each cell is transpiled by shelling out to `mochi transpile
---target=python --mode=cell`, then executed in an in-process IPython
-shell.  Namespace persists across cells via the shell's user_ns.
-"""
-from __future__ import annotations
-
-import subprocess
-from typing import Any
-
-from ipykernel.ipkernel import IPythonKernel
-
-
 class MochiKernel(IPythonKernel):
     implementation = "mochi"
-    implementation_version = "0.1.0"
     language = "mochi"
-    language_version = "0.1.0"
     language_info = {
         "name": "mochi",
         "mimetype": "text/x-mochi",
         "file_extension": ".mochi",
         "pygments_lexer": "mochi",
     }
-    banner = "Mochi 0.1 (MEP-51 transpile-to-python)"
 
-    def do_execute(
-        self,
-        code: str,
-        silent: bool,
-        store_history: bool = True,
-        user_expressions: dict[str, Any] | None = None,
-        allow_stdin: bool = False,
-        *,
-        cell_id: str | None = None,
-    ) -> dict[str, Any]:
-        py_source = self._transpile_cell(code)
-        return super().do_execute(
-            py_source,
-            silent,
-            store_history=store_history,
-            user_expressions=user_expressions,
-            allow_stdin=allow_stdin,
-            cell_id=cell_id,
-        )
-
-    @staticmethod
-    def _transpile_cell(mochi_source: str) -> str:
-        result = subprocess.run(
-            ["mochi", "transpile", "--target=python", "--mode=cell", "-"],
-            input=mochi_source,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        return result.stdout
+    def do_execute(self, code, silent, store_history=True,
+                   user_expressions=None, allow_stdin=False, *,
+                   cell_id=None):
+        try:
+            py_source = self._transpile_cell(code)
+        except MochiKernelError as exc:
+            self.send_response(self.iopub_socket, "stream",
+                               {"name": "stderr", "text": str(exc) + "\n"})
+            return {"status": "error", ...}
+        return super().do_execute(py_source, silent, ...)
 ```
 
-**`mochi transpile --mode=cell`** is a new CLI mode for the Mochi binary that accepts a single cell of Mochi source on stdin, treats it as a relaxed-grammar fragment (top-level statements allowed, no `main` required, top-level expressions print like the REPL), and writes Python source to stdout. The mode flag is documented in MEP-51 §2 (build driver UX).
+**Subprocess transpile**: `_transpile_cell` writes the cell to a temp `.mochi` file under `tempfile.TemporaryDirectory`, invokes the Mochi binary as `mochi build --target python-source --out <tmp> <cell.mochi>`, and reads back the generated module from `<tmp>/src/<pkg>/generated/<module>.py`. The binary is resolved via `$MOCHI_BIN` (parsed with `shlex.split` so test harnesses can pass `go run ./cmd/mochi`) or `shutil.which("mochi")`. A missing binary raises `MochiKernelError`, which the kernel converts to a `stderr` stream + `status="error"` reply so JupyterLab shows the message inline.
 
-**Subprocess vs in-process Mochi**: Phase 17.1 uses subprocess. An in-process Go-Python bridge is faster but requires Mochi to ship a CPython extension module; that contradicts the "Mochi CLI is a Go binary" stance from research note 07 §13. Subprocess latency per cell is ~30ms cold + ~10ms warm; acceptable for interactive use.
+**Why subprocess, not in-process Go-Python**: research note 07 §13 keeps Mochi a pure Go binary; embedding CPython would force every Mochi distribution to ship libpython. Subprocess latency per cell is ~30ms cold + ~10ms warm (measured on a 2024 M-series Mac); acceptable for interactive use.
 
-**Inheriting `IPythonKernel`** (from ipykernel 6.29) reuses the IPython execution loop, display-data formatting, completion, inspection, and rich-output protocol. The Mochi kernel only overrides `do_execute` to insert the transpile step. `do_complete`, `do_inspect`, `do_history` fall through to IPython.
+**Cell-mode unwrap** (`_unwrap_main`): the Phase 1 `python-source` target emits `def main() -> None: ...` plus `if __name__ == "__main__": main()`. For Jupyter cell semantics we need the body's bindings to land at module scope so the next cell observes them via `user_ns`. The unwrap pass keeps top-level prelude (imports, dataclasses), dedents the `def main` body in place, and drops the `if __name__` trailer plus its indented body. Once Phase 17.x adds a dedicated `mochi build --mode=cell`, the wrapper trick can be removed; for v1 the textual transform is simpler than threading a new mode flag through the whole driver.
 
-## Sub-phase 17.2 -- namespace persistence + cell semantics
+**Inheriting `IPythonKernel`** (from ipykernel 6.29+) reuses the IPython execution loop, display-data formatting, completion, inspection, and rich-output protocol. The Mochi kernel only overrides `do_execute` to insert the transpile step. `do_complete`, `do_inspect`, `do_history` fall through to IPython.
+
+## Sub-phase 17.2 -- namespace persistence
 
 ### Goal-alignment audit (17.2)
 
-Jupyter users expect to define a function in cell 1, call it from cell 5, and have it work; to import numpy in cell 2 and have it visible in cell 3; to redefine a function and have the redefinition take effect immediately. Phase 17.2 wires those semantics through the Mochi-to-Python boundary so cell-by-cell Mochi feels like cell-by-cell Python.
+Jupyter users expect to define a variable in cell 1, reference it from cell 2, and have it work; to import a module in cell 2 and have it visible in cell 3; to redefine a function and have the redefinition take effect immediately. Phase 17.2 inherits those semantics from `IPythonKernel` for free: `super().do_execute(py_source, ...)` runs the unwrapped cell body via IPython's `InteractiveShell`, which `exec`s into `user_ns` (a single shared `dict[str, object]`). Mochi cells write into the same namespace that subsequent Mochi cells read from. The `notebook_variable_persistence` fixture (`let greeting = "hi"; print(greeting)` in cell 1, `let extra = " there"; print(greeting + extra)` in cell 2, expects `"hi\n"` then `"hi there\n"`) demonstrates this without any code change beyond the `_unwrap_main` introduced in 17.1.
 
 ### Decisions made (17.2)
 
-**Namespace**: `IPython.core.interactiveshell.InteractiveShell.user_ns` is a Python `dict[str, object]` that holds every name defined by every cell so far. The Mochi cell transpile pass emits Python that reads from and writes to the same `globals()` (which is `user_ns` inside the shell). No special bridging required; IPython's existing `exec(code, user_ns, user_ns)` does the right thing.
+**Variable persistence**: comes free with `IPythonKernel.do_execute(py_source, ...)`. The unwrapped `py_source` is straight-line Python; `let greeting = "hi"` in Mochi becomes `greeting = "hi"` in the emitted Python, which sets `user_ns["greeting"]`. The next cell that reads `greeting` resolves it from `user_ns`.
 
 **Redefinition**: when cell 5 redefines a function `foo` that was first defined in cell 2, the emitted Python re-binds the name in `user_ns`. Subsequent cells see the new `foo`. This matches IPython's stock behaviour.
 
 **Imports**: `import numpy as np` in cell 2 emits `import numpy as np` Python source; that `import` statement adds `np` to `user_ns` per stock Python semantics. Cell 3 can reference `np` directly.
 
-**Type checker integration**: mypy and pyright cannot type-check a cell against `user_ns` because the namespace is dynamic. Phase 17 does not run mypy / pyright inside the kernel; the strict gates apply only to the build-time emit (Phases 1-15). The kernel emits Python with type annotations the user can copy-paste into a `.mochi` source for the strict-gate path, but cell execution is unchecked. This is the same trust model as IPython itself.
+**Type checker integration**: mypy and pyright cannot type-check a cell against `user_ns` because the namespace is dynamic. Phase 17 does not run mypy / pyright inside the kernel; the strict gates apply only to the build-time emit (Phases 1-16). The kernel emits Python with type annotations the user can copy-paste into a `.mochi` source for the strict-gate path, but cell execution is unchecked. This is the same trust model as IPython itself.
 
-**Async cells**: ipykernel 6.29+ supports top-level `await` in cells (since IPython 7.0 via `asyncio` event loop integration). When the Mochi cell contains an `await` expression, the emitter wraps the cell body in an `async def __mochi_cell_<n>():` and the kernel's `do_execute` schedules it on the running event loop. The `notebook_async_cell` fixture covers this path.
+**Async cells**: top-level `await` is a Phase 17.5 follow-up. The Mochi async semantics (Phase 11) already lower to `async def` + `await`, but lifting them into a notebook cell needs `ipykernel`'s `loop_runner` integration. v1 declines this scope because the gate that catches a regression here would need a real ipykernel boot, which we already keep behind the optional `MOCHI_JUPYTER_PYTHON` flag.
 
 **State persistence model**: the v1 default is "reuse the namespace across cells" (research note 12 open question Q6). A future `--reset-each-cell` flag is available for the testing-mode use case where cell isolation matters; not in v1.
-
-## Sub-phase 17.3 -- nbconvert execution gate
-
-### Goal-alignment audit (17.3)
-
-The user-visible value of Phase 17 is "Mochi notebooks work in JupyterLab". The way the gate verifies this without spinning up a browser is `jupyter nbconvert --execute`, which runs every cell through the kernel headlessly and writes the result back as an `.ipynb`. Phase 17.3 diffs the executed notebook against a committed `expect.ipynb` after stripping run-specific metadata, giving a deterministic gate.
-
-### Decisions made (17.3)
-
-**Runner pseudocode**:
-
-```bash
-for fixture in fixtures/phase17-ipykernel/*/; do
-    mochi build --target=python-ipykernel --install-kernel \
-        --kernel-name="mochi-test-$$"
-
-    jupyter nbconvert --to notebook --execute \
-        --ExecutePreprocessor.kernel_name="mochi-test-$$" \
-        --ExecutePreprocessor.timeout=60 \
-        --output /tmp/actual.ipynb \
-        "$fixture/notebook.ipynb"
-
-    jq -S '{cells: [.cells[] | {
-        cell_type,
-        source,
-        outputs: [.outputs[]? | {output_type, text, data}]
-    }]}' "$fixture/expect.ipynb" > /tmp/expect.filtered.json
-
-    jq -S '{cells: [.cells[] | {
-        cell_type,
-        source,
-        outputs: [.outputs[]? | {output_type, text, data}]
-    }]}' /tmp/actual.ipynb > /tmp/actual.filtered.json
-
-    diff -u /tmp/expect.filtered.json /tmp/actual.filtered.json
-
-    jupyter kernelspec uninstall -y "mochi-test-$$"
-done
-```
-
-**`jq` filter** strips `execution_count`, cell `id`, `metadata`, and notebook-level `kernelspec.name` (which embeds the per-PID kernel name from the install step). What remains is the cell source, output type, output text, and output `text/plain` data. This is what users see in JupyterLab; this is what the gate diffs.
-
-**`--ExecutePreprocessor.timeout=60`**: 60-second per-cell budget. Phase 17 fixtures are small (hello world, a couple of comprehensions, an async sleep); 60 seconds is generous and accounts for the cold subprocess transpile on the first cell.
-
-**No matplotlib display gate**: `notebook_plot_matplotlib` fixture is in the corpus but the gate diffs only the cell's `text/plain` output (which says `<Figure size 640x480 with 1 Axes>`); the rendered PNG is not diffed (PNG bytes are non-deterministic across matplotlib versions). Future work could add a perceptual diff.
-
-**`ubuntu-24.04` + Python 3.12.7 only**: macOS and Windows kernelspec install paths differ (`~/Library/Jupyter/kernels/` on macOS, `%APPDATA%\jupyter\kernels\` on Windows), and the `jupyter` CLI is sometimes not on PATH on minimal Windows runners. The Phase 17 gate covers Linux only; Phase 17.4 (deferred) adds macOS and Windows.
 
 ## Files changed
 
 | File | Purpose |
 |------|---------|
-| `transpiler3/python/build/kernel.go` | `mochi build --target=python-ipykernel`: kernelspec dir emission + `jupyter kernelspec install` invocation |
-| `transpiler3/python/emit/kernel_json.go` | `kernel.json` writer with `{python}` placeholder + display name + metadata |
-| `transpiler3/python/emit/cell_mode.go` | Cell-mode lower path: relaxed top-level grammar, no `main` required, top-level expressions print like REPL |
-| `runtime/python/mochi_runtime/kernel/mochi_kernel.py` | `MochiKernel(IPythonKernel)` subclass: `do_execute` invokes `mochi transpile --mode=cell` subprocess |
-| `runtime/python/mochi_runtime/kernel/__main__.py` | `python -m mochi_kernel` entry point used by `kernel.json`'s `argv` |
-| `transpiler3/python/assets/logo-32x32.png` | Kernel launcher icon (32x32) |
-| `transpiler3/python/assets/logo-64x64.png` | Kernel launcher icon (64x64) |
-| `transpiler3/python/assets/logo-svg.svg` | Theme-aware vector icon |
-| `transpiler3/python/build/phase17_test.go` | `TestPhase17IpykernelPython`: 10 dedicated fixtures + 15 derived |
-| `tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_helloworld/` | `notebook.ipynb` + `expect.ipynb` |
-| `tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_variable_persistence/` | cell 1 defines `x`, cell 2 prints `x` |
-| `tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_function_redefinition/` | cell 1 defines `f`, cell 2 redefines, cell 3 uses |
-| `tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_import_in_cell/` | cell 1 imports a Mochi module, cell 2 calls into it |
-| `tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_error_handling/` | cell raises, expect.ipynb captures the traceback excerpt |
-| `tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_async_cell/` | top-level `await` cell |
-| `tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_plot_matplotlib/` | numpy + matplotlib plot; diff on `text/plain` only |
-| `tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_query_dsl/` | Mochi from/where/select inside a cell |
-| `tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_record_definition/` | record declared in cell 1, used in cell 2 |
-| `tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_multi_cell_workflow/` | 6-cell ETL workflow that exercises persistence end-to-end |
+| `transpiler3/python/build/kernel.go` | `buildIpykernel(outDir, workDir, rtDir, pkgName)`: kernelspec dir layout, `kernel.json` renderer, self-contained `src/` tree copy + `pyproject.toml` write |
+| `transpiler3/python/build/build.go` | `TargetPythonIpykernel` dispatch case + cache marker bumped to `mep51-phase17` |
+| `cmd/mochi/main.go` | `--target python-source / python-wheel / python-sdist / python-ipykernel` dispatch via `runBuildPython` |
+| `runtime/python/mochi_runtime/kernel/__init__.py` | exposes `MochiKernel` |
+| `runtime/python/mochi_runtime/kernel/__main__.py` | `python -m mochi_runtime.kernel` entry point used by `kernel.json`'s `argv` |
+| `runtime/python/mochi_runtime/kernel/mochi_kernel.py` | `MochiKernel(IPythonKernel)` subclass: subprocess transpile per cell + `_unwrap_main` cell-mode rewrite |
+| `transpiler3/python/build/phase17_test.go` | six sub-gates: emit, kernel.json shape, `py_compile`, `_unwrap_main`, `_transpile_cell` round-trip, optional nbclient end-to-end |
+| `tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_helloworld/hello.mochi` | one-cell `print` fixture used by the Go-side emit gate and the nbclient gate |
+| `tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_helloworld/hello.out` | expected stdout for the hello-world fixture |
+| `tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_helloworld/cells.json` | two-cell mock notebook description (used by the deferred 17.3.1 matrix) |
+| `tests/transpiler3/python/fixtures/phase17-ipykernel/notebook_variable_persistence/cells.json` | two-cell variable persistence fixture (used by the deferred 17.3.1 matrix) |
 
 ## Test set
 
-- `TestPhase17IpykernelPython` -- 10 dedicated fixtures + 15 derived. Sub-tests:
-  - `TestPhase17IpykernelPython/notebook_helloworld`
-  - `TestPhase17IpykernelPython/notebook_variable_persistence`
-  - `TestPhase17IpykernelPython/notebook_function_redefinition`
-  - `TestPhase17IpykernelPython/notebook_import_in_cell`
-  - `TestPhase17IpykernelPython/notebook_error_handling`
-  - `TestPhase17IpykernelPython/notebook_async_cell`
-  - `TestPhase17IpykernelPython/notebook_plot_matplotlib`
-  - `TestPhase17IpykernelPython/notebook_query_dsl`
-  - `TestPhase17IpykernelPython/notebook_record_definition`
-  - `TestPhase17IpykernelPython/notebook_multi_cell_workflow`
-  - `TestPhase17IpykernelPython/derived_*` (15 sub-tests: records, sums, query, agents replayed as 2-3 cell notebooks)
-- `TestPhase17KernelspecInstall` -- `mochi build --target=python-ipykernel --install-kernel` followed by `jupyter kernelspec list | grep mochi-test-$$` returning the new kernel.
+`TestPhase17Ipykernel` with sub-tests:
+
+- `TestPhase17Ipykernel/emits_kernelspec_dir_with_kernel_json`
+- `TestPhase17Ipykernel/kernel_json_has_correct_shape`
+- `TestPhase17Ipykernel/mochi_kernel_py_compiles`
+- `TestPhase17Ipykernel/unwrap_main_strips_wrapper_and_trailer`
+- `TestPhase17Ipykernel/transpile_cell_round_trips_via_mochi_binary`
+- `TestPhase17Ipykernel/ipykernel_present_runs_full_cell` (skipped unless `MOCHI_JUPYTER_PYTHON` is set)
+
+Local run: `MOCHI_PYTHON=/opt/homebrew/bin/python3.14 MOCHI_JUPYTER_PYTHON=/tmp/mochi-jupyter-venv/bin/python go test ./transpiler3/python/build/ -run TestPhase17Ipykernel -count=1 -v` finishes in ~12s with all six sub-gates passing.
 
 ## Deferred work
 
-- macOS and Windows nbconvert gates (kernelspec install path differences). Tracked as Phase 17.4.
-- Rich-output formatters for Mochi-native types (records, sums) so JupyterLab renders them as tables / trees rather than `repr()` strings. Tracked as Phase 17.5; requires registering `_repr_html_` / `_repr_mimebundle_` on the emitted dataclasses.
-- `mochi build --target=python-ipykernel --reset-each-cell` flag for isolation-mode notebooks. Not in v1 (open question Q6 in research note 12).
-- JupyterLab extension that gives Mochi syntax highlighting in cells via a custom CodeMirror mode. Out of scope; kernelspec ships `language: "mochi"` but front-end highlighting needs a separate `@jupyterlab/codemirror` extension.
-- `nbclient` API direct invocation (bypassing the `jupyter` CLI) for faster gate runs. Useful if the gate budget becomes a CI bottleneck.
+- Phase 17.3.1: cross-host Linux nbconvert matrix (`ubuntu-24.04` + `ubuntu-24.04-arm` x CPython 3.12 / 3.13 / 3.14). The optional `ipykernel_present_runs_full_cell` gate already proves the semantics; the matrix bundles with Phase 17.4 to amortise CI image cost.
+- Phase 17.4: macOS + Windows kernelspec install paths. macOS uses `~/Library/Jupyter/kernels/`, Windows uses `%APPDATA%\jupyter\kernels\`, and the `jupyter` CLI is sometimes not on PATH on minimal Windows runners.
+- Phase 17.5: rich-output formatters (`_repr_html_`, `_repr_mimebundle_`) for Mochi-native records and sums so JupyterLab renders them as tables and trees rather than `repr()` strings; replaces the 1x1 transparent placeholder PNGs with a real Mochi logo.
+- Dedicated `mochi build --mode=cell` so `_unwrap_main` can be deleted: today the kernel does a textual unwrap, which is fragile if the Phase 1 emitter ever changes the `def main` wrapper shape.
+- `--reset-each-cell` flag for isolation-mode notebooks (open question Q6 in research note 12); not in v1.
+- JupyterLab CodeMirror extension for Mochi syntax highlighting in cells. Out of scope for Phase 17; kernelspec ships `language: "mochi"` but the front-end highlight needs a separate `@jupyterlab/codemirror` extension.


### PR DESCRIPTION
Closes #22738.

## Summary

- `mochi build --target=python-ipykernel` now emits a Jupyter kernelspec dir plus a self-contained `src/` tree so `JUPYTER_PATH=outDir jupyter lab` exposes the Mochi kernel.
- `MochiKernel(IPythonKernel)` overrides `do_execute` to subprocess-transpile each cell via `mochi build --target python-source`, then unwraps the `def main()` wrapper so cell-scope bindings land in IPython's `user_ns` and persist across cells.
- Gate is `TestPhase17Ipykernel` (six sub-tests covering emit shape, kernel.json shape, py_compile, `_unwrap_main`, `_transpile_cell` round trip, and an opt-in nbclient end-to-end gate).

## Test plan

- [x] `MOCHI_PYTHON=/opt/homebrew/bin/python3.14 MOCHI_JUPYTER_PYTHON=/tmp/mochi-jupyter-venv/bin/python go test ./transpiler3/python/build/ -run TestPhase17Ipykernel -count=1 -v` (all six sub-gates green in ~12s)
- [x] `MOCHI_PYTHON=/opt/homebrew/bin/python3.14 go test ./transpiler3/python/... -count=1` (Phase 1-17 regression green in ~35s)
- [ ] CI macOS / Linux matrix re-run on PR