### PR TITLE
docs(mep-56): backfill phase-32 commit SHA (0a753708ad)

### DIFF
--- a/website/docs/implementation/0056/index.md
+++ b/website/docs/implementation/0056/index.md
@@ -49,7 +49,7 @@ A phase is LANDED only when its gate is green on every Ruby runtime listed for i
 | 29 | Runtime matrix CI + dead-code cull (audit-4) | LANDED | e0956a4238 | [phase-29](/docs/implementation/0056/phase-29-runtime-matrix) |
 | 30 | mochi-runtime gem unit tests + gem-build CI (audit-5) | LANDED | c1fe1b55ef | [phase-30](/docs/implementation/0056/phase-30-runtime-gem-tests) |
 | 31 | Reproducibility test + dead path filter cull (audit-6) | LANDED | 13e42c2a33 | [phase-31](/docs/implementation/0056/phase-31-audit-6) |
-| 32 | License + dead-code + repro expansion (audit-7) | LANDED | TBD | [phase-32](/docs/implementation/0056/phase-32-audit-7) |
+| 32 | License + dead-code + repro expansion (audit-7) | LANDED | 0a753708ad | [phase-32](/docs/implementation/0056/phase-32-audit-7) |
 
 ## Runtime matrix
 

--- a/website/docs/implementation/0056/phase-32-audit-7.md
+++ b/website/docs/implementation/0056/phase-32-audit-7.md
@@ -15,7 +15,7 @@ description: "MEP-56 Phase 32, align mochi-runtime gem license with the spec, ex
 | Landed         | 2026-05-29 14:54 (GMT+7) |
 | Tracking issue | — |
 | Tracking PR    | [#22510](https://github.com/mochilang/mochi/pull/22510) follow-up |
-| Commit         | TBD |
+| Commit         | 0a753708ad |
 
 ## Gate
 


### PR DESCRIPTION
Backfills TBD placeholders in phase-32-audit-7.md and index.md with real merge commit SHA 0a753708ad (PR #22631 landed to main).

Closes the tracking issue.