### PR TITLE
feat(mep-73 p1): sparse-index client + cargo semver

### DIFF
--- a/package3/rust/semver/req.go
+++ b/package3/rust/semver/req.go
@@ -1,0 +1,335 @@
+package semver
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Req is a cargo-flavoured version requirement. A Req is satisfied by a
+// Version when every Comparator in every And-group is satisfied, and at
+// least one Or-group matches. (The comma operator is "AND"; multiple Reqs
+// passed to MaxSatisfying are "OR".)
+//
+// Cargo accepts these requirement shapes (with whitespace ignored):
+//
+//	1.2.3       => caret: >=1.2.3, <2.0.0  (with the 0.x.y carve-out)
+//	^1.2.3      => same as bare 1.2.3
+//	~1.2.3      => >=1.2.3, <1.3.0
+//	~1.2        => >=1.2.0, <1.3.0
+//	~1          => >=1.0.0, <2.0.0
+//	=1.2.3      => exactly 1.2.3
+//	>=1.2.3     => any version >= 1.2.3
+//	>1.2.3      => strictly greater
+//	<=1.2.3, <1.2.3
+//	*           => any version
+//	1.2.*       => >=1.2.0, <1.3.0
+//	1.*         => >=1.0.0, <2.0.0
+//	1.2.3, <2.0 => intersection
+type Req struct {
+	comparators []comparator
+	raw         string
+}
+
+type comparator struct {
+	op  comparatorOp
+	ver Version
+}
+
+type comparatorOp int
+
+const (
+	opExact comparatorOp = iota
+	opGT
+	opGE
+	opLT
+	opLE
+)
+
+// ParseReq parses a single cargo requirement string.
+func ParseReq(s string) (Req, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return Req{}, fmt.Errorf("semver req: empty string")
+	}
+	if s == "*" {
+		return Req{raw: s, comparators: nil}, nil
+	}
+	parts := strings.Split(s, ",")
+	var cmps []comparator
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		expanded, err := parseSinglePart(p)
+		if err != nil {
+			return Req{}, fmt.Errorf("semver req %q: %w", s, err)
+		}
+		cmps = append(cmps, expanded...)
+	}
+	return Req{raw: s, comparators: cmps}, nil
+}
+
+// MustParseReq is ParseReq with a panic on error.
+func MustParseReq(s string) Req {
+	r, err := ParseReq(s)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+// String renders the original raw requirement.
+func (r Req) String() string {
+	if r.raw == "" {
+		return "*"
+	}
+	return r.raw
+}
+
+// Matches reports whether v satisfies r. Pre-release versions match only
+// when the requirement explicitly references the same Major.Minor.Patch as
+// the pre-release version (cargo's pre-release carve-out).
+func (r Req) Matches(v Version) bool {
+	if len(r.comparators) == 0 {
+		// "*" matches any non-prerelease.
+		return !v.IsPrerelease()
+	}
+	for _, c := range r.comparators {
+		if !c.matches(v) {
+			return false
+		}
+	}
+	if v.IsPrerelease() {
+		// At least one comparator must be on the same (major, minor, patch)
+		// for a pre-release version to satisfy a requirement. This matches
+		// cargo's "pre-releases are opt-in" rule.
+		for _, c := range r.comparators {
+			if c.ver.Major == v.Major && c.ver.Minor == v.Minor && c.ver.Patch == v.Patch && c.ver.IsPrerelease() {
+				return true
+			}
+		}
+		return false
+	}
+	return true
+}
+
+func (c comparator) matches(v Version) bool {
+	cmp := v.Compare(c.ver)
+	switch c.op {
+	case opExact:
+		return cmp == 0
+	case opGT:
+		return cmp > 0
+	case opGE:
+		return cmp >= 0
+	case opLT:
+		return cmp < 0
+	case opLE:
+		return cmp <= 0
+	}
+	return false
+}
+
+// parseSinglePart parses one comma-separated chunk and returns the
+// comparators it expands into. Caret and tilde and wildcard each expand to
+// two comparators; exact and inequality each produce one.
+func parseSinglePart(s string) ([]comparator, error) {
+	switch {
+	case strings.HasPrefix(s, "^"):
+		return expandCaret(strings.TrimSpace(s[1:]))
+	case strings.HasPrefix(s, "~"):
+		return expandTilde(strings.TrimSpace(s[1:]))
+	case strings.HasPrefix(s, ">="):
+		v, err := ParseRelaxed(strings.TrimSpace(s[2:]))
+		if err != nil {
+			return nil, err
+		}
+		return []comparator{{op: opGE, ver: v}}, nil
+	case strings.HasPrefix(s, "<="):
+		v, err := ParseRelaxed(strings.TrimSpace(s[2:]))
+		if err != nil {
+			return nil, err
+		}
+		return []comparator{{op: opLE, ver: v}}, nil
+	case strings.HasPrefix(s, ">"):
+		v, err := ParseRelaxed(strings.TrimSpace(s[1:]))
+		if err != nil {
+			return nil, err
+		}
+		return []comparator{{op: opGT, ver: v}}, nil
+	case strings.HasPrefix(s, "<"):
+		v, err := ParseRelaxed(strings.TrimSpace(s[1:]))
+		if err != nil {
+			return nil, err
+		}
+		return []comparator{{op: opLT, ver: v}}, nil
+	case strings.HasPrefix(s, "="):
+		v, err := ParseRelaxed(strings.TrimSpace(s[1:]))
+		if err != nil {
+			return nil, err
+		}
+		return []comparator{{op: opExact, ver: v}}, nil
+	default:
+		// Bare or wildcard.
+		if strings.Contains(s, "*") {
+			return expandWildcard(s)
+		}
+		return expandCaret(s)
+	}
+}
+
+// expandCaret implements cargo's caret semantics with the leading-zero
+// carve-out.
+//
+//	^1.2.3  => >=1.2.3, <2.0.0
+//	^1.2    => >=1.2.0, <2.0.0
+//	^1      => >=1.0.0, <2.0.0
+//	^0.2.3  => >=0.2.3, <0.3.0
+//	^0.2    => >=0.2.0, <0.3.0
+//	^0.0.3  => >=0.0.3, <0.0.4
+//	^0.0    => >=0.0.0, <0.1.0
+//	^0      => >=0.0.0, <1.0.0
+func expandCaret(s string) ([]comparator, error) {
+	majorPart, minorPart, patchPart, pre, build, depth, err := splitComponents(s)
+	if err != nil {
+		return nil, err
+	}
+	low := Version{Major: majorPart, Minor: minorPart, Patch: patchPart, Pre: pre, Build: build}
+	var high Version
+	switch {
+	case majorPart > 0 || depth == 1:
+		// ^1.2.3 or ^1.2 or ^1 or ^2 => upper at next major
+		high = Version{Major: majorPart + 1}
+	case minorPart > 0 || depth == 2:
+		// ^0.x.y or ^0.x => upper at next minor
+		high = Version{Major: 0, Minor: minorPart + 1}
+	default:
+		// ^0.0.z => upper at next patch
+		high = Version{Major: 0, Minor: 0, Patch: patchPart + 1}
+	}
+	return []comparator{{op: opGE, ver: low}, {op: opLT, ver: high}}, nil
+}
+
+// expandTilde implements cargo's tilde semantics.
+//
+//	~1.2.3  => >=1.2.3, <1.3.0
+//	~1.2    => >=1.2.0, <1.3.0
+//	~1      => >=1.0.0, <2.0.0
+func expandTilde(s string) ([]comparator, error) {
+	majorPart, minorPart, patchPart, pre, build, depth, err := splitComponents(s)
+	if err != nil {
+		return nil, err
+	}
+	low := Version{Major: majorPart, Minor: minorPart, Patch: patchPart, Pre: pre, Build: build}
+	var high Version
+	switch depth {
+	case 1:
+		high = Version{Major: majorPart + 1}
+	default: // 2 or 3
+		high = Version{Major: majorPart, Minor: minorPart + 1}
+	}
+	return []comparator{{op: opGE, ver: low}, {op: opLT, ver: high}}, nil
+}
+
+// expandWildcard implements cargo wildcard semantics.
+//
+//	*      => any
+//	1.*    => >=1.0.0, <2.0.0
+//	1.2.*  => >=1.2.0, <1.3.0
+func expandWildcard(s string) ([]comparator, error) {
+	if s == "*" {
+		return nil, nil
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) < 2 || len(parts) > 3 {
+		return nil, fmt.Errorf("wildcard %q: want N.* or N.M.*", s)
+	}
+	last := parts[len(parts)-1]
+	if last != "*" {
+		return nil, fmt.Errorf("wildcard %q: last component must be *", s)
+	}
+	majorPart, err := parseNumeric(parts[0])
+	if err != nil {
+		return nil, err
+	}
+	var minorPart uint64
+	if len(parts) == 3 {
+		minorPart, err = parseNumeric(parts[1])
+		if err != nil {
+			return nil, err
+		}
+	}
+	low := Version{Major: majorPart, Minor: minorPart}
+	var high Version
+	switch len(parts) {
+	case 2:
+		high = Version{Major: majorPart + 1}
+	default:
+		high = Version{Major: majorPart, Minor: minorPart + 1}
+	}
+	return []comparator{{op: opGE, ver: low}, {op: opLT, ver: high}}, nil
+}
+
+// splitComponents parses a relaxed N or N.M or N.M.P with optional
+// pre-release and build, returning each component and the depth (how many
+// dotted parts were supplied).
+func splitComponents(s string) (uint64, uint64, uint64, string, string, int, error) {
+	rest := s
+	var pre, build string
+	if i := strings.Index(rest, "+"); i >= 0 {
+		build = rest[i+1:]
+		rest = rest[:i]
+	}
+	if i := strings.Index(rest, "-"); i >= 0 {
+		pre = rest[i+1:]
+		rest = rest[:i]
+	}
+	parts := strings.Split(rest, ".")
+	if len(parts) < 1 || len(parts) > 3 {
+		return 0, 0, 0, "", "", 0, fmt.Errorf("want 1-3 components in %q, got %d", s, len(parts))
+	}
+	mj, err := parseNumeric(parts[0])
+	if err != nil {
+		return 0, 0, 0, "", "", 0, err
+	}
+	var mn, pt uint64
+	if len(parts) >= 2 {
+		mn, err = parseNumeric(parts[1])
+		if err != nil {
+			return 0, 0, 0, "", "", 0, err
+		}
+	}
+	if len(parts) >= 3 {
+		pt, err = parseNumeric(parts[2])
+		if err != nil {
+			return 0, 0, 0, "", "", 0, err
+		}
+	}
+	if pre != "" {
+		if err := validateIdentifier(pre); err != nil {
+			return 0, 0, 0, "", "", 0, err
+		}
+	}
+	if build != "" {
+		if err := validateIdentifier(build); err != nil {
+			return 0, 0, 0, "", "", 0, err
+		}
+	}
+	return mj, mn, pt, pre, build, len(parts), nil
+}
+
+// MaxSatisfying returns the highest Version in versions that matches r,
+// preferring non-prerelease over prerelease. Returns false in the second
+// return when no version matches.
+func MaxSatisfying(r Req, versions []Version) (Version, bool) {
+	var best Version
+	found := false
+	for _, v := range versions {
+		if !r.Matches(v) {
+			continue
+		}
+		if !found || best.Compare(v) < 0 {
+			best = v
+			found = true
+		}
+	}
+	return best, found
+}

--- a/package3/rust/semver/req_test.go
+++ b/package3/rust/semver/req_test.go
@@ -1,0 +1,288 @@
+package semver
+
+import "testing"
+
+func TestParseReqWildcard(t *testing.T) {
+	r, err := ParseReq("*")
+	if err != nil {
+		t.Fatalf("ParseReq(*): %v", err)
+	}
+	if !r.Matches(MustParse("1.0.0")) {
+		t.Errorf("* should match 1.0.0")
+	}
+	if !r.Matches(MustParse("99.0.0")) {
+		t.Errorf("* should match 99.0.0")
+	}
+	if r.Matches(MustParse("1.0.0-alpha")) {
+		t.Errorf("* should not match prerelease")
+	}
+}
+
+func TestParseReqEmpty(t *testing.T) {
+	if _, err := ParseReq(""); err == nil {
+		t.Errorf("ParseReq(\"\") should error")
+	}
+	if _, err := ParseReq("   "); err == nil {
+		t.Errorf("ParseReq(spaces) should error")
+	}
+}
+
+func TestParseReqInvalid(t *testing.T) {
+	cases := []string{
+		"~",
+		"^",
+		"=abc",
+		">=z",
+		"1.*.3", // wildcard not in last position
+		"*.1",
+	}
+	for _, c := range cases {
+		if _, err := ParseReq(c); err == nil {
+			t.Errorf("ParseReq(%q) should error", c)
+		}
+	}
+}
+
+func TestReqStringFallback(t *testing.T) {
+	// Zero Req String() should not panic.
+	var r Req
+	if got := r.String(); got != "*" {
+		t.Errorf("zero Req.String() = %q; want *", got)
+	}
+}
+
+func TestCaretMajorPositive(t *testing.T) {
+	r := MustParseReq("^1.2.3")
+	cases := []struct {
+		v    string
+		want bool
+	}{
+		{"1.2.3", true},
+		{"1.2.4", true},
+		{"1.3.0", true},
+		{"1.99.99", true},
+		{"2.0.0", false},
+		{"1.2.2", false},
+		{"0.99.0", false},
+	}
+	for _, tc := range cases {
+		if got := r.Matches(MustParse(tc.v)); got != tc.want {
+			t.Errorf("^1.2.3 Matches(%s) = %v; want %v", tc.v, got, tc.want)
+		}
+	}
+}
+
+func TestCaretZeroMinor(t *testing.T) {
+	r := MustParseReq("^0.2.3")
+	cases := []struct {
+		v    string
+		want bool
+	}{
+		{"0.2.3", true},
+		{"0.2.99", true},
+		{"0.3.0", false},
+		{"0.2.2", false},
+		{"1.0.0", false},
+	}
+	for _, tc := range cases {
+		if got := r.Matches(MustParse(tc.v)); got != tc.want {
+			t.Errorf("^0.2.3 Matches(%s) = %v; want %v", tc.v, got, tc.want)
+		}
+	}
+}
+
+func TestCaretZeroZero(t *testing.T) {
+	r := MustParseReq("^0.0.3")
+	cases := []struct {
+		v    string
+		want bool
+	}{
+		{"0.0.3", true},
+		{"0.0.4", false},
+		{"0.1.0", false},
+	}
+	for _, tc := range cases {
+		if got := r.Matches(MustParse(tc.v)); got != tc.want {
+			t.Errorf("^0.0.3 Matches(%s) = %v; want %v", tc.v, got, tc.want)
+		}
+	}
+}
+
+func TestCaretShortForms(t *testing.T) {
+	cases := []struct {
+		req  string
+		v    string
+		want bool
+	}{
+		{"^1.2", "1.2.0", true},
+		{"^1.2", "1.99.0", true},
+		{"^1.2", "2.0.0", false},
+		{"^1", "1.99.99", true},
+		{"^1", "2.0.0", false},
+		{"^0.2", "0.2.99", true},
+		{"^0.2", "0.3.0", false},
+		{"^0", "0.99.99", true},
+		{"^0", "1.0.0", false},
+	}
+	for _, tc := range cases {
+		if got := MustParseReq(tc.req).Matches(MustParse(tc.v)); got != tc.want {
+			t.Errorf("%s Matches(%s) = %v; want %v", tc.req, tc.v, got, tc.want)
+		}
+	}
+}
+
+func TestBareIsCaret(t *testing.T) {
+	if !MustParseReq("1.2.3").Matches(MustParse("1.99.0")) {
+		t.Errorf("bare 1.2.3 should treat as caret and match 1.99.0")
+	}
+	if MustParseReq("1.2.3").Matches(MustParse("2.0.0")) {
+		t.Errorf("bare 1.2.3 should not match 2.0.0")
+	}
+}
+
+func TestTilde(t *testing.T) {
+	cases := []struct {
+		req  string
+		v    string
+		want bool
+	}{
+		{"~1.2.3", "1.2.3", true},
+		{"~1.2.3", "1.2.99", true},
+		{"~1.2.3", "1.3.0", false},
+		{"~1.2", "1.2.99", true},
+		{"~1.2", "1.3.0", false},
+		{"~1", "1.99.99", true},
+		{"~1", "2.0.0", false},
+	}
+	for _, tc := range cases {
+		if got := MustParseReq(tc.req).Matches(MustParse(tc.v)); got != tc.want {
+			t.Errorf("%s Matches(%s) = %v; want %v", tc.req, tc.v, got, tc.want)
+		}
+	}
+}
+
+func TestExact(t *testing.T) {
+	r := MustParseReq("=1.2.3")
+	if !r.Matches(MustParse("1.2.3")) {
+		t.Errorf("=1.2.3 should match 1.2.3")
+	}
+	if r.Matches(MustParse("1.2.4")) {
+		t.Errorf("=1.2.3 should not match 1.2.4")
+	}
+}
+
+func TestInequality(t *testing.T) {
+	cases := []struct {
+		req  string
+		v    string
+		want bool
+	}{
+		{">=1.2.3", "1.2.3", true},
+		{">=1.2.3", "1.2.4", true},
+		{">=1.2.3", "1.2.2", false},
+		{">1.2.3", "1.2.3", false},
+		{">1.2.3", "1.2.4", true},
+		{"<=1.2.3", "1.2.3", true},
+		{"<=1.2.3", "1.2.2", true},
+		{"<=1.2.3", "1.2.4", false},
+		{"<1.2.3", "1.2.3", false},
+		{"<1.2.3", "1.2.2", true},
+	}
+	for _, tc := range cases {
+		if got := MustParseReq(tc.req).Matches(MustParse(tc.v)); got != tc.want {
+			t.Errorf("%s Matches(%s) = %v; want %v", tc.req, tc.v, got, tc.want)
+		}
+	}
+}
+
+func TestWildcard(t *testing.T) {
+	cases := []struct {
+		req  string
+		v    string
+		want bool
+	}{
+		{"1.2.*", "1.2.0", true},
+		{"1.2.*", "1.2.99", true},
+		{"1.2.*", "1.3.0", false},
+		{"1.*", "1.99.99", true},
+		{"1.*", "2.0.0", false},
+	}
+	for _, tc := range cases {
+		if got := MustParseReq(tc.req).Matches(MustParse(tc.v)); got != tc.want {
+			t.Errorf("%s Matches(%s) = %v; want %v", tc.req, tc.v, got, tc.want)
+		}
+	}
+}
+
+func TestIntersection(t *testing.T) {
+	r := MustParseReq(">=1.2.3, <1.3.0")
+	if !r.Matches(MustParse("1.2.3")) {
+		t.Errorf(">=1.2.3, <1.3.0 should match 1.2.3")
+	}
+	if !r.Matches(MustParse("1.2.99")) {
+		t.Errorf(">=1.2.3, <1.3.0 should match 1.2.99")
+	}
+	if r.Matches(MustParse("1.3.0")) {
+		t.Errorf(">=1.2.3, <1.3.0 should not match 1.3.0")
+	}
+	if r.Matches(MustParse("1.2.2")) {
+		t.Errorf(">=1.2.3, <1.3.0 should not match 1.2.2")
+	}
+}
+
+func TestPrereleaseOptIn(t *testing.T) {
+	// A pre-release version is matched only when the requirement explicitly
+	// mentions the same MAJOR.MINOR.PATCH with a pre-release.
+	if MustParseReq("^1.0.0").Matches(MustParse("1.0.0-alpha")) {
+		t.Errorf("^1.0.0 should not match 1.0.0-alpha (pre-release opt-in)")
+	}
+	if !MustParseReq(">=1.0.0-alpha").Matches(MustParse("1.0.0-alpha")) {
+		t.Errorf(">=1.0.0-alpha should match 1.0.0-alpha")
+	}
+	// Pre-release versions still satisfy non-prerelease requirements when
+	// the upper bound includes them (cargo specifically excludes this).
+	if MustParseReq("^1.0.0").Matches(MustParse("2.0.0-alpha")) {
+		t.Errorf("^1.0.0 should not match 2.0.0-alpha")
+	}
+}
+
+func TestMaxSatisfyingCaretMajor(t *testing.T) {
+	versions := []Version{
+		MustParse("1.0.0"),
+		MustParse("1.2.0"),
+		MustParse("1.2.5"),
+		MustParse("1.2.99"),
+		MustParse("1.3.0"),
+		MustParse("2.0.0"),
+	}
+	best, ok := MaxSatisfying(MustParseReq("^1.2"), versions)
+	if !ok {
+		t.Fatalf("MaxSatisfying returned ok=false")
+	}
+	if got := best.String(); got != "1.3.0" {
+		t.Errorf("MaxSatisfying(^1.2) = %q; want 1.3.0", got)
+	}
+}
+
+func TestMaxSatisfyingNone(t *testing.T) {
+	versions := []Version{MustParse("1.0.0")}
+	if _, ok := MaxSatisfying(MustParseReq("^2"), versions); ok {
+		t.Errorf("MaxSatisfying(^2) on [1.0.0] returned ok=true")
+	}
+}
+
+func TestMaxSatisfyingEmpty(t *testing.T) {
+	if _, ok := MaxSatisfying(MustParseReq("^1"), nil); ok {
+		t.Errorf("MaxSatisfying on empty slice returned ok=true")
+	}
+}
+
+func TestReqStringRoundTrip(t *testing.T) {
+	cases := []string{"^1.2.3", "~1.2", ">=1.0, <2.0", "=1.2.3", "1.*"}
+	for _, c := range cases {
+		r := MustParseReq(c)
+		if got := r.String(); got != c {
+			t.Errorf("Req(%q).String() = %q; want %q", c, got, c)
+		}
+	}
+}

--- a/package3/rust/semver/version.go
+++ b/package3/rust/semver/version.go
@@ -1,0 +1,277 @@
+// Package semver implements the cargo flavour of Semantic Versioning 2.0.0.
+//
+// Cargo's semver differs from semver.org and from npm-semver in a few
+// load-bearing ways:
+//   - The caret operator (^) treats the leading 0 specially: ^0.x.y allows
+//     0.x.* but not 0.(x+1).0, and ^0.0.z allows only 0.0.z exactly.
+//   - The tilde operator (~) is "patch within a minor".
+//   - The wildcard operator (*) is "any".
+//   - Bare version strings ("1.2.3") behave as "^1.2.3" (cargo's default).
+//   - Pre-release versions (1.0.0-alpha.1) have ordering rules from semver.org
+//     but cargo only matches them when the requirement explicitly mentions a
+//     pre-release.
+//
+// The reference for cargo's semver is the cargo book at
+// https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html
+// plus the semver crate at https://docs.rs/semver/.
+package semver
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Version is a parsed semver 2.0.0 version. Pre-release and build metadata
+// are preserved verbatim from the input.
+type Version struct {
+	Major uint64
+	Minor uint64
+	Patch uint64
+	// Pre is the pre-release identifier (without the leading '-'), e.g.
+	// "alpha.1". Empty for non-prerelease versions.
+	Pre string
+	// Build is the build-metadata string (without the leading '+'), e.g.
+	// "001". Build metadata does not affect ordering per semver.org §10.
+	Build string
+}
+
+// Parse converts a string into a Version. Invalid inputs return an error.
+//
+// Accepted shapes:
+//
+//	1.2.3
+//	1.2.3-alpha.1
+//	1.2.3+build.5
+//	1.2.3-alpha.1+build.5
+//
+// The bare-form short version (1.0 or 1) is not accepted by Parse; use
+// ParseRelaxed for shapes that fill missing components with zero.
+func Parse(s string) (Version, error) {
+	if s == "" {
+		return Version{}, fmt.Errorf("semver: empty version string")
+	}
+	rest := s
+	var pre, build string
+	var hasPre, hasBuild bool
+	if i := strings.Index(rest, "+"); i >= 0 {
+		hasBuild = true
+		build = rest[i+1:]
+		rest = rest[:i]
+	}
+	if i := strings.Index(rest, "-"); i >= 0 {
+		hasPre = true
+		pre = rest[i+1:]
+		rest = rest[:i]
+	}
+	parts := strings.Split(rest, ".")
+	if len(parts) != 3 {
+		return Version{}, fmt.Errorf("semver: %q has %d dot-separated components; want 3", s, len(parts))
+	}
+	mj, err := parseNumeric(parts[0])
+	if err != nil {
+		return Version{}, fmt.Errorf("semver: %q major: %w", s, err)
+	}
+	mn, err := parseNumeric(parts[1])
+	if err != nil {
+		return Version{}, fmt.Errorf("semver: %q minor: %w", s, err)
+	}
+	pt, err := parseNumeric(parts[2])
+	if err != nil {
+		return Version{}, fmt.Errorf("semver: %q patch: %w", s, err)
+	}
+	if hasPre {
+		if err := validateIdentifier(pre); err != nil {
+			return Version{}, fmt.Errorf("semver: %q pre-release: %w", s, err)
+		}
+	}
+	if hasBuild {
+		if err := validateIdentifier(build); err != nil {
+			return Version{}, fmt.Errorf("semver: %q build: %w", s, err)
+		}
+	}
+	return Version{Major: mj, Minor: mn, Patch: pt, Pre: pre, Build: build}, nil
+}
+
+// ParseRelaxed accepts the same shapes as Parse plus the cargo short forms:
+//
+//	1       -> 1.0.0
+//	1.2     -> 1.2.0
+//
+// Used when reading a [dependencies] table value that omits trailing zeros.
+func ParseRelaxed(s string) (Version, error) {
+	if s == "" {
+		return Version{}, fmt.Errorf("semver: empty version string")
+	}
+	rest := s
+	var pre, build string
+	if i := strings.Index(rest, "+"); i >= 0 {
+		build = rest[i+1:]
+		rest = rest[:i]
+	}
+	if i := strings.Index(rest, "-"); i >= 0 {
+		pre = rest[i+1:]
+		rest = rest[:i]
+	}
+	parts := strings.Split(rest, ".")
+	if len(parts) < 1 || len(parts) > 3 {
+		return Version{}, fmt.Errorf("semver: %q has %d components; want 1, 2, or 3", s, len(parts))
+	}
+	pad := make([]string, 3)
+	for i := range pad {
+		if i < len(parts) {
+			pad[i] = parts[i]
+		} else {
+			pad[i] = "0"
+		}
+	}
+	return Parse(strings.Join(pad, ".") + suffix(pre, build))
+}
+
+func suffix(pre, build string) string {
+	out := ""
+	if pre != "" {
+		out += "-" + pre
+	}
+	if build != "" {
+		out += "+" + build
+	}
+	return out
+}
+
+// MustParse is Parse but panics on error. Useful for tests and for in-source
+// constants.
+func MustParse(s string) Version {
+	v, err := Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// String renders the Version in canonical form.
+func (v Version) String() string {
+	out := fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+	if v.Pre != "" {
+		out += "-" + v.Pre
+	}
+	if v.Build != "" {
+		out += "+" + v.Build
+	}
+	return out
+}
+
+// IsPrerelease reports whether the version has a pre-release identifier.
+func (v Version) IsPrerelease() bool { return v.Pre != "" }
+
+// Compare returns -1 if v < other, 0 if equal, +1 if v > other. Build
+// metadata does not affect ordering (semver.org §10).
+func (v Version) Compare(other Version) int {
+	if c := cmpUint(v.Major, other.Major); c != 0 {
+		return c
+	}
+	if c := cmpUint(v.Minor, other.Minor); c != 0 {
+		return c
+	}
+	if c := cmpUint(v.Patch, other.Patch); c != 0 {
+		return c
+	}
+	return comparePre(v.Pre, other.Pre)
+}
+
+// Equal reports whether v and other have the same Major.Minor.Patch and Pre.
+// Build metadata is intentionally ignored.
+func (v Version) Equal(other Version) bool { return v.Compare(other) == 0 }
+
+// cmpUint compares two uint64.
+func cmpUint(a, b uint64) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// comparePre implements semver.org §11 pre-release ordering. A version
+// without a pre-release sorts higher than one with a pre-release.
+func comparePre(a, b string) int {
+	switch {
+	case a == "" && b == "":
+		return 0
+	case a == "":
+		return 1
+	case b == "":
+		return -1
+	}
+	aIds := strings.Split(a, ".")
+	bIds := strings.Split(b, ".")
+	for i := 0; i < len(aIds) && i < len(bIds); i++ {
+		aN, aIsNum := tryParseNumeric(aIds[i])
+		bN, bIsNum := tryParseNumeric(bIds[i])
+		switch {
+		case aIsNum && bIsNum:
+			if c := cmpUint(aN, bN); c != 0 {
+				return c
+			}
+		case aIsNum:
+			return -1
+		case bIsNum:
+			return 1
+		default:
+			if c := strings.Compare(aIds[i], bIds[i]); c != 0 {
+				return c
+			}
+		}
+	}
+	switch {
+	case len(aIds) < len(bIds):
+		return -1
+	case len(aIds) > len(bIds):
+		return 1
+	default:
+		return 0
+	}
+}
+
+func parseNumeric(s string) (uint64, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty numeric component")
+	}
+	if len(s) > 1 && s[0] == '0' {
+		return 0, fmt.Errorf("leading zero in %q", s)
+	}
+	return strconv.ParseUint(s, 10, 64)
+}
+
+func tryParseNumeric(s string) (uint64, bool) {
+	v, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	if len(s) > 1 && s[0] == '0' {
+		return 0, false
+	}
+	return v, true
+}
+
+func validateIdentifier(s string) error {
+	if s == "" {
+		return fmt.Errorf("empty identifier")
+	}
+	for _, part := range strings.Split(s, ".") {
+		if part == "" {
+			return fmt.Errorf("empty dot-separated part")
+		}
+		for _, r := range part {
+			ok := (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') ||
+				(r >= '0' && r <= '9') || r == '-'
+			if !ok {
+				return fmt.Errorf("invalid character %q in %q", r, part)
+			}
+		}
+	}
+	return nil
+}

--- a/package3/rust/semver/version_test.go
+++ b/package3/rust/semver/version_test.go
@@ -1,0 +1,164 @@
+package semver
+
+import "testing"
+
+func TestParseValid(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Version
+	}{
+		{"0.0.0", Version{0, 0, 0, "", ""}},
+		{"1.2.3", Version{1, 2, 3, "", ""}},
+		{"10.20.30", Version{10, 20, 30, "", ""}},
+		{"1.0.0-alpha", Version{1, 0, 0, "alpha", ""}},
+		{"1.0.0-alpha.1", Version{1, 0, 0, "alpha.1", ""}},
+		{"1.0.0-0.3.7", Version{1, 0, 0, "0.3.7", ""}},
+		{"1.0.0-x.7.z.92", Version{1, 0, 0, "x.7.z.92", ""}},
+		{"1.0.0+20130313144700", Version{1, 0, 0, "", "20130313144700"}},
+		{"1.0.0-beta+exp.sha.5114f85", Version{1, 0, 0, "beta", "exp.sha.5114f85"}},
+		{"1.0.0+21AF26D3----117B344092BD", Version{1, 0, 0, "", "21AF26D3----117B344092BD"}},
+	}
+	for _, tc := range cases {
+		got, err := Parse(tc.in)
+		if err != nil {
+			t.Errorf("Parse(%q) err = %v; want nil", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("Parse(%q) = %+v; want %+v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseInvalid(t *testing.T) {
+	cases := []string{
+		"",
+		"1",
+		"1.2",
+		"1.2.3.4",
+		"01.0.0",
+		"1.01.0",
+		"1.0.01",
+		"a.b.c",
+		"1.0.0-",
+		"1.0.0+",
+		"1.0.0-+",
+		"1.0.0-alpha..1",
+		"1.0.0-alpha_1",
+	}
+	for _, s := range cases {
+		if _, err := Parse(s); err == nil {
+			t.Errorf("Parse(%q) err = nil; want error", s)
+		}
+	}
+}
+
+func TestParseRelaxed(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Version
+	}{
+		{"1", Version{1, 0, 0, "", ""}},
+		{"1.2", Version{1, 2, 0, "", ""}},
+		{"1.2.3", Version{1, 2, 3, "", ""}},
+		{"0", Version{0, 0, 0, "", ""}},
+	}
+	for _, tc := range cases {
+		got, err := ParseRelaxed(tc.in)
+		if err != nil {
+			t.Errorf("ParseRelaxed(%q) err = %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("ParseRelaxed(%q) = %+v; want %+v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMustParse(t *testing.T) {
+	v := MustParse("1.2.3")
+	if v.String() != "1.2.3" {
+		t.Errorf("MustParse(1.2.3).String() = %q; want 1.2.3", v.String())
+	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("MustParse(bad) did not panic")
+		}
+	}()
+	_ = MustParse("not-a-version")
+}
+
+func TestVersionString(t *testing.T) {
+	v := Version{1, 2, 3, "alpha.1", "build.5"}
+	if got := v.String(); got != "1.2.3-alpha.1+build.5" {
+		t.Errorf("Version.String() = %q; want 1.2.3-alpha.1+build.5", got)
+	}
+}
+
+func TestVersionCompareMajorMinorPatch(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0", "2.0.0", -1},
+		{"2.0.0", "2.1.0", -1},
+		{"2.1.0", "2.1.1", -1},
+		{"1.0.0", "1.0.0", 0},
+		{"2.0.0", "1.0.0", 1},
+	}
+	for _, tc := range cases {
+		got := MustParse(tc.a).Compare(MustParse(tc.b))
+		if got != tc.want {
+			t.Errorf("%s.Compare(%s) = %d; want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestVersionComparePrerelease(t *testing.T) {
+	// semver.org §11
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0-alpha", "1.0.0", -1},
+		{"1.0.0", "1.0.0-alpha", 1},
+		{"1.0.0-alpha", "1.0.0-alpha.1", -1},
+		{"1.0.0-alpha.1", "1.0.0-alpha.beta", -1},
+		{"1.0.0-alpha.beta", "1.0.0-beta", -1},
+		{"1.0.0-beta", "1.0.0-beta.2", -1},
+		{"1.0.0-beta.2", "1.0.0-beta.11", -1},
+		{"1.0.0-beta.11", "1.0.0-rc.1", -1},
+		{"1.0.0-rc.1", "1.0.0", -1},
+	}
+	for _, tc := range cases {
+		got := MustParse(tc.a).Compare(MustParse(tc.b))
+		if got != tc.want {
+			t.Errorf("%s.Compare(%s) = %d; want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestVersionEqualIgnoresBuild(t *testing.T) {
+	a := MustParse("1.2.3+build.1")
+	b := MustParse("1.2.3+build.2")
+	if !a.Equal(b) {
+		t.Errorf("Equal should ignore build metadata: %v vs %v", a, b)
+	}
+}
+
+func TestVersionEqualDistinguishesPrerelease(t *testing.T) {
+	a := MustParse("1.2.3")
+	b := MustParse("1.2.3-alpha")
+	if a.Equal(b) {
+		t.Errorf("Equal should distinguish pre-release: %v vs %v", a, b)
+	}
+}
+
+func TestIsPrerelease(t *testing.T) {
+	if MustParse("1.0.0").IsPrerelease() {
+		t.Errorf("1.0.0 IsPrerelease should be false")
+	}
+	if !MustParse("1.0.0-alpha").IsPrerelease() {
+		t.Errorf("1.0.0-alpha IsPrerelease should be true")
+	}
+}

--- a/package3/rust/sparse/cache.go
+++ b/package3/rust/sparse/cache.go
@@ -1,0 +1,263 @@
+package sparse
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path/filepath"
+
+	"lukechampine.com/blake3"
+)
+
+// CrateEntry storage layout under a cache root:
+//
+//	<root>/registry/index/<host>/<bucket>/<name>            -- raw NDJSON
+//	<root>/registry/cache/<host>/<name>-<version>.crate     -- tarball
+//	<root>/registry/blake3/<first2>/<rest>.crate            -- BLAKE3 alias
+//
+// The .crate path mirrors cargo's $CARGO_HOME/registry/cache layout so a
+// cargo-aware tool (like build-orchestration in Phase 7) can hard-link
+// from one to the other when cargo is run as a sub-process.
+//
+// The BLAKE3 alias is a content-addressed mirror used by Mochi's own
+// lockfile (Phase 8). Storing both hashes in the same artefact lets us
+// verify against either format depending on which lockfile schema the
+// caller holds.
+
+// Cache is a filesystem-backed cache for sparse-index records and
+// .crate tarballs. Cache is safe for concurrent use as long as no two
+// callers materialise the same crate@version concurrently (the writes
+// are not atomic across processes).
+type Cache struct {
+	// Root is the cache root; e.g. $XDG_CACHE_HOME/mochi/rust.
+	Root string
+
+	// Host is the registry host directory (e.g. "index.crates.io").
+	// Defaults to "index.crates.io" when empty.
+	Host string
+}
+
+// NewCache returns a Cache rooted at root. If host is the empty string,
+// Cache.Host defaults to "index.crates.io".
+func NewCache(root, host string) *Cache {
+	if host == "" {
+		host = "index.crates.io"
+	}
+	return &Cache{Root: root, Host: host}
+}
+
+// IndexPath returns the absolute filesystem path where the NDJSON index
+// file for name should live. The file may or may not exist.
+func (c *Cache) IndexPath(name string) (string, error) {
+	bucket, err := BucketPath(name)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(c.Root, "registry", "index", c.Host, filepath.FromSlash(bucket)), nil
+}
+
+// CratePath returns the absolute filesystem path of the .crate tarball
+// for name@version. The directory layout mirrors cargo's own cache so a
+// later cargo-driven build can pick the file up without extra copying.
+func (c *Cache) CratePath(name, version string) (string, error) {
+	if err := ValidateCrateName(name); err != nil {
+		return "", err
+	}
+	if version == "" {
+		return "", fmt.Errorf("sparse: empty version for %q", name)
+	}
+	return filepath.Join(c.Root, "registry", "cache", c.Host, fmt.Sprintf("%s-%s.crate", name, version)), nil
+}
+
+// Blake3Path returns the content-addressed alias path for a .crate
+// tarball given its lowercase hex BLAKE3-256 digest.
+func (c *Cache) Blake3Path(b3hex string) (string, error) {
+	if len(b3hex) < 4 {
+		return "", fmt.Errorf("sparse: blake3 digest %q is too short", b3hex)
+	}
+	if _, err := hex.DecodeString(b3hex); err != nil {
+		return "", fmt.Errorf("sparse: invalid blake3 digest %q: %w", b3hex, err)
+	}
+	return filepath.Join(c.Root, "registry", "blake3", b3hex[:2], b3hex[2:]+".crate"), nil
+}
+
+// StoreIndex writes the raw NDJSON bytes for crate name into the index
+// directory and returns the path. Existing files are overwritten
+// atomically via tmp-then-rename.
+func (c *Cache) StoreIndex(name string, body []byte) (string, error) {
+	dst, err := c.IndexPath(name)
+	if err != nil {
+		return "", err
+	}
+	if err := writeFileAtomic(dst, body, 0o644); err != nil {
+		return "", err
+	}
+	return dst, nil
+}
+
+// LoadIndex reads the cached NDJSON for crate name. Returns
+// os.ErrNotExist (via errors.Is) if no cached copy exists.
+func (c *Cache) LoadIndex(name string) ([]byte, error) {
+	dst, err := c.IndexPath(name)
+	if err != nil {
+		return nil, err
+	}
+	return os.ReadFile(dst)
+}
+
+// StoreCrate streams from r into the cache for name@version, verifying
+// the SHA-256 against expectedSha256 (lowercase hex) and also recording
+// the BLAKE3-256 digest. The .crate path is returned along with the
+// computed BLAKE3-256 hex string.
+//
+// If expectedSha256 is the empty string, SHA-256 verification is
+// skipped (only valid for self-published crates whose index entry lacks
+// a cksum, which cargo no longer accepts but legacy mirrors may).
+//
+// If the SHA-256 does not match, the partial file is removed and
+// ErrChecksumMismatch is returned (wrap-friendly).
+func (c *Cache) StoreCrate(name, version, expectedSha256 string, r io.Reader) (string, string, error) {
+	dst, err := c.CratePath(name, version)
+	if err != nil {
+		return "", "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return "", "", fmt.Errorf("sparse: mkdir %s: %w", filepath.Dir(dst), err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".crate-*.tmp")
+	if err != nil {
+		return "", "", fmt.Errorf("sparse: tmp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() {
+		tmp.Close()
+		os.Remove(tmpPath)
+	}
+	sha := sha256.New()
+	b3 := blake3.New(32, nil)
+	mw := io.MultiWriter(tmp, sha, hash.Hash(b3))
+	if _, err := io.Copy(mw, r); err != nil {
+		cleanup()
+		return "", "", fmt.Errorf("sparse: copy %s: %w", dst, err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return "", "", fmt.Errorf("sparse: close tmp: %w", err)
+	}
+	gotSha := hex.EncodeToString(sha.Sum(nil))
+	gotB3 := hex.EncodeToString(b3.Sum(nil))
+	if expectedSha256 != "" && gotSha != expectedSha256 {
+		os.Remove(tmpPath)
+		return "", "", fmt.Errorf("%w: %s@%s: have %s want %s", ErrChecksumMismatch, name, version, gotSha, expectedSha256)
+	}
+	if err := os.Rename(tmpPath, dst); err != nil {
+		os.Remove(tmpPath)
+		return "", "", fmt.Errorf("sparse: rename %s: %w", dst, err)
+	}
+	if alias, err := c.Blake3Path(gotB3); err == nil {
+		if mkdirErr := os.MkdirAll(filepath.Dir(alias), 0o755); mkdirErr == nil {
+			// Link best-effort. Failure here is non-fatal.
+			_ = linkOrCopy(dst, alias)
+		}
+	}
+	return dst, gotB3, nil
+}
+
+// HasCrate reports whether a .crate tarball is already cached for
+// name@version. The file's presence is taken as sufficient evidence
+// the previous StoreCrate completed (because rename-after-verify is
+// atomic on POSIX file systems).
+func (c *Cache) HasCrate(name, version string) bool {
+	dst, err := c.CratePath(name, version)
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(dst)
+	return err == nil
+}
+
+// FetchIndex fetches the index file for name via the given client and
+// stores it in the cache, returning the parsed entries. Always
+// overwrites any prior cached copy because the sparse protocol does not
+// offer a deterministic ETag for index lines.
+func (c *Cache) FetchIndex(ctx context.Context, client *Client, name string) ([]CrateEntry, error) {
+	target, err := client.IndexURL(name)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := getWithUA(ctx, client, target)
+	if err != nil {
+		return nil, err
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("sparse: read %s: %w", target, err)
+	}
+	if _, err := c.StoreIndex(name, body); err != nil {
+		return nil, err
+	}
+	return ParseIndex(bytesReader(body))
+}
+
+// ErrChecksumMismatch is returned by Cache.StoreCrate when the SHA-256
+// of the downloaded body disagrees with the expected hex string from
+// the sparse-index entry.
+var ErrChecksumMismatch = errors.New("sparse: crate checksum mismatch")
+
+// writeFileAtomic writes data to path via a sibling tmp file plus
+// rename. The destination directory is created as needed.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("sparse: mkdir %s: %w", filepath.Dir(path), err)
+	}
+	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("sparse: tmp: %w", err)
+	}
+	tmp := f.Name()
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("sparse: write %s: %w", tmp, err)
+	}
+	if err := f.Chmod(perm); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("sparse: chmod %s: %w", tmp, err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("sparse: close %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("sparse: rename %s -> %s: %w", tmp, path, err)
+	}
+	return nil
+}
+
+// linkOrCopy hard-links src into dst, falling back to a byte copy when
+// the link fails (e.g. cross-device). Used for the BLAKE3 alias.
+func linkOrCopy(src, dst string) error {
+	if err := os.Link(src, dst); err == nil {
+		return nil
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/package3/rust/sparse/cache_test.go
+++ b/package3/rust/sparse/cache_test.go
@@ -1,0 +1,211 @@
+package sparse
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCacheIndexPath(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir, "")
+	got, err := c.IndexPath("serde")
+	if err != nil {
+		t.Fatalf("IndexPath: %v", err)
+	}
+	want := filepath.Join(dir, "registry", "index", "index.crates.io", "se", "rd", "serde")
+	if got != want {
+		t.Errorf("IndexPath = %q; want %q", got, want)
+	}
+}
+
+func TestCacheCratePath(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir, "custom-host")
+	got, err := c.CratePath("serde", "1.0.0")
+	if err != nil {
+		t.Fatalf("CratePath: %v", err)
+	}
+	want := filepath.Join(dir, "registry", "cache", "custom-host", "serde-1.0.0.crate")
+	if got != want {
+		t.Errorf("CratePath = %q; want %q", got, want)
+	}
+}
+
+func TestCacheBlake3Path(t *testing.T) {
+	c := NewCache("/cache", "")
+	got, err := c.Blake3Path("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("Blake3Path: %v", err)
+	}
+	want := filepath.Join("/cache", "registry", "blake3", "01", "23456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.crate")
+	if got != want {
+		t.Errorf("Blake3Path = %q; want %q", got, want)
+	}
+}
+
+func TestCacheBlake3PathBadDigest(t *testing.T) {
+	c := NewCache("/cache", "")
+	if _, err := c.Blake3Path("zz"); err == nil {
+		t.Errorf("Blake3Path(zz) err = nil")
+	}
+	if _, err := c.Blake3Path("XYZ"); err == nil {
+		t.Errorf("Blake3Path(XYZ) err = nil")
+	}
+}
+
+func TestCacheStoreIndex(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir, "")
+	body := []byte(serdeFixture)
+	path, err := c.StoreIndex("serde", body)
+	if err != nil {
+		t.Fatalf("StoreIndex: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("StoreIndex round-trip mismatch")
+	}
+}
+
+func TestCacheLoadIndexMissing(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir, "")
+	_, err := c.LoadIndex("serde")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("LoadIndex(missing) = %v; want os.ErrNotExist", err)
+	}
+}
+
+func TestCacheStoreCrate(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir, "")
+	body := []byte("fake .crate bytes for testing")
+	sha := sha256.Sum256(body)
+	expected := hex.EncodeToString(sha[:])
+	path, b3, err := c.StoreCrate("serde", "1.0.0", expected, strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("StoreCrate: %v", err)
+	}
+	if !c.HasCrate("serde", "1.0.0") {
+		t.Errorf("HasCrate = false after StoreCrate")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("StoreCrate body mismatch")
+	}
+	if len(b3) != 64 {
+		t.Errorf("blake3 hex = %q; want 64 chars", b3)
+	}
+	if _, err := hex.DecodeString(b3); err != nil {
+		t.Errorf("blake3 hex not valid: %v", err)
+	}
+	// BLAKE3 alias should exist.
+	alias, err := c.Blake3Path(b3)
+	if err != nil {
+		t.Fatalf("Blake3Path: %v", err)
+	}
+	if _, err := os.Stat(alias); err != nil {
+		t.Errorf("blake3 alias missing: %v", err)
+	}
+}
+
+func TestCacheStoreCrateChecksumMismatch(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir, "")
+	body := []byte("fake bytes")
+	wrong := strings.Repeat("0", 64)
+	_, _, err := c.StoreCrate("serde", "1.0.0", wrong, strings.NewReader(string(body)))
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Errorf("StoreCrate err = %v; want ErrChecksumMismatch", err)
+	}
+	if c.HasCrate("serde", "1.0.0") {
+		t.Errorf("HasCrate = true after mismatch; partial file should be removed")
+	}
+}
+
+func TestCacheStoreCrateNoChecksum(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir, "")
+	_, _, err := c.StoreCrate("serde", "1.0.0", "", strings.NewReader("any bytes"))
+	if err != nil {
+		t.Errorf("StoreCrate(no checksum) err = %v", err)
+	}
+	if !c.HasCrate("serde", "1.0.0") {
+		t.Errorf("HasCrate = false")
+	}
+}
+
+func TestCacheFetchIndex(t *testing.T) {
+	dir := t.TempDir()
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, serdeFixture)
+	})
+	client := NewClient(server.URL + "/")
+	cache := NewCache(dir, "")
+	entries, err := cache.FetchIndex(context.Background(), client, "serde")
+	if err != nil {
+		t.Fatalf("Cache.FetchIndex: %v", err)
+	}
+	if len(entries) != 4 {
+		t.Errorf("len(entries) = %d; want 4", len(entries))
+	}
+	// Cached copy must be on disk.
+	loaded, err := cache.LoadIndex("serde")
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+	if !strings.Contains(string(loaded), `"vers":"1.0.0"`) {
+		t.Errorf("cached index missing expected content")
+	}
+}
+
+func TestCacheRoundTripIndex(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir, "")
+	if _, err := c.StoreIndex("serde", []byte(serdeFixture)); err != nil {
+		t.Fatalf("StoreIndex: %v", err)
+	}
+	loaded, err := c.LoadIndex("serde")
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+	entries, err := ParseIndex(strings.NewReader(string(loaded)))
+	if err != nil {
+		t.Fatalf("ParseIndex: %v", err)
+	}
+	if len(entries) != 4 {
+		t.Errorf("len(entries) = %d; want 4", len(entries))
+	}
+}
+
+func TestStoreIndexOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir, "")
+	if _, err := c.StoreIndex("serde", []byte("old")); err != nil {
+		t.Fatalf("StoreIndex old: %v", err)
+	}
+	if _, err := c.StoreIndex("serde", []byte("new")); err != nil {
+		t.Fatalf("StoreIndex new: %v", err)
+	}
+	got, err := c.LoadIndex("serde")
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+	if string(got) != "new" {
+		t.Errorf("StoreIndex did not overwrite: got %q", got)
+	}
+}

--- a/package3/rust/sparse/client.go
+++ b/package3/rust/sparse/client.go
@@ -1,0 +1,187 @@
+package sparse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// DefaultIndexURL is crates.io's sparse-index endpoint as documented in
+// the cargo book §"Sparse protocol". The trailing slash is mandatory
+// because every fetch is BaseURL + BucketPath(name).
+const DefaultIndexURL = "https://index.crates.io/"
+
+// DefaultDownloadURL is the canonical cargo download endpoint for the
+// crates.io registry. The path template substitutes {crate} for the
+// crate name and {version} for the semver string.
+const DefaultDownloadURL = "https://static.crates.io/crates/{crate}/{crate}-{version}.crate"
+
+// DefaultUserAgent is the User-Agent header attached to outbound HTTP
+// requests. Cargo registries log User-Agent and may rate-limit unknown
+// clients, so we identify ourselves as Mochi.
+const DefaultUserAgent = "mochi-rust-bridge/0.1 (+https://mochi-lang.dev)"
+
+// Client is a thin sparse-index client. It is safe for concurrent use
+// because the underlying http.Client is. The empty Client is not usable
+// because BaseURL is required; use NewClient.
+type Client struct {
+	// BaseURL is the sparse-index root, e.g. "https://index.crates.io/".
+	// Must end in a slash.
+	BaseURL string
+
+	// DownloadURL is the .crate tarball template. The placeholders
+	// {crate} and {version} are substituted at fetch time. Leave empty
+	// to use DefaultDownloadURL.
+	DownloadURL string
+
+	// HTTP is the underlying transport. nil means use http.DefaultClient
+	// with a 30s timeout.
+	HTTP *http.Client
+
+	// UserAgent is sent as the User-Agent header.
+	UserAgent string
+}
+
+// NewClient returns a Client pre-configured against crates.io with a
+// sane default HTTP timeout. Pass the empty string for the default base
+// URL.
+func NewClient(baseURL string) *Client {
+	if baseURL == "" {
+		baseURL = DefaultIndexURL
+	}
+	if !strings.HasSuffix(baseURL, "/") {
+		baseURL += "/"
+	}
+	return &Client{
+		BaseURL:     baseURL,
+		DownloadURL: DefaultDownloadURL,
+		HTTP:        &http.Client{Timeout: 30 * time.Second},
+		UserAgent:   DefaultUserAgent,
+	}
+}
+
+// IndexURL returns the absolute URL of the index file for crate name.
+func (c *Client) IndexURL(name string) (string, error) {
+	bucket, err := BucketPath(name)
+	if err != nil {
+		return "", err
+	}
+	base := c.BaseURL
+	if base == "" {
+		base = DefaultIndexURL
+	}
+	if !strings.HasSuffix(base, "/") {
+		base += "/"
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("sparse: bad base url %q: %w", base, err)
+	}
+	rel, err := url.Parse(bucket)
+	if err != nil {
+		return "", fmt.Errorf("sparse: bad bucket %q: %w", bucket, err)
+	}
+	return u.ResolveReference(rel).String(), nil
+}
+
+// FetchIndex retrieves and parses the sparse-index file for the named
+// crate. Returns ErrCrateNotFound if the registry responds 404.
+func (c *Client) FetchIndex(ctx context.Context, name string) ([]CrateEntry, error) {
+	target, err := c.IndexURL(name)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, fmt.Errorf("sparse: build request: %w", err)
+	}
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+	req.Header.Set("Accept", "text/plain")
+	httpClient := c.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sparse: GET %s: %w", target, err)
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// fall through
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("%w: %s", ErrCrateNotFound, name)
+	default:
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("sparse: GET %s: status %d: %s", target, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return ParseIndex(resp.Body)
+}
+
+// DownloadURLFor builds the .crate URL for a given name/version using
+// the configured DownloadURL template.
+func (c *Client) DownloadURLFor(name, version string) (string, error) {
+	tmpl := c.DownloadURL
+	if tmpl == "" {
+		tmpl = DefaultDownloadURL
+	}
+	if err := ValidateCrateName(name); err != nil {
+		return "", err
+	}
+	if version == "" {
+		return "", fmt.Errorf("sparse: empty version for %q", name)
+	}
+	url := strings.ReplaceAll(tmpl, "{crate}", name)
+	url = strings.ReplaceAll(url, "{version}", version)
+	return url, nil
+}
+
+// FetchCrate retrieves the .crate tarball bytes for name@version into
+// the provided writer. Returns the number of bytes written and any
+// error. Does not verify the checksum; the caller is expected to use
+// Cache.Store which verifies as it writes.
+func (c *Client) FetchCrate(ctx context.Context, name, version string, w io.Writer) (int64, error) {
+	target, err := c.DownloadURLFor(name, version)
+	if err != nil {
+		return 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return 0, fmt.Errorf("sparse: build request: %w", err)
+	}
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+	httpClient := c.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("sparse: GET %s: %w", target, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return 0, fmt.Errorf("%w: %s@%s", ErrCrateVersionNotFound, name, version)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return 0, fmt.Errorf("sparse: GET %s: status %d: %s", target, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return io.Copy(w, resp.Body)
+}
+
+// ErrCrateNotFound is returned when the index file for a crate name is
+// absent (HTTP 404). Wrapped via fmt.Errorf %w; check with errors.Is.
+var ErrCrateNotFound = errors.New("sparse: crate not found")
+
+// ErrCrateVersionNotFound is returned when the .crate tarball for a
+// name@version is absent. Wrapped via fmt.Errorf %w.
+var ErrCrateVersionNotFound = errors.New("sparse: crate version not found")

--- a/package3/rust/sparse/client_test.go
+++ b/package3/rust/sparse/client_test.go
@@ -1,0 +1,136 @@
+package sparse
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(handler)
+	t.Cleanup(s.Close)
+	return s
+}
+
+func TestClientIndexURL(t *testing.T) {
+	c := NewClient("https://index.example.com/")
+	got, err := c.IndexURL("serde")
+	if err != nil {
+		t.Fatalf("IndexURL: %v", err)
+	}
+	if got != "https://index.example.com/se/rd/serde" {
+		t.Errorf("IndexURL(serde) = %q", got)
+	}
+}
+
+func TestClientIndexURLTrailingSlash(t *testing.T) {
+	c := NewClient("https://index.example.com") // no trailing slash
+	got, err := c.IndexURL("ab")
+	if err != nil {
+		t.Fatalf("IndexURL: %v", err)
+	}
+	if got != "https://index.example.com/2/ab" {
+		t.Errorf("IndexURL(ab) = %q", got)
+	}
+}
+
+func TestClientFetchIndex(t *testing.T) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/se/rd/serde" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if r.Header.Get("User-Agent") == "" {
+			t.Errorf("missing User-Agent")
+		}
+		io.WriteString(w, serdeFixture)
+	})
+	c := NewClient(server.URL + "/")
+	entries, err := c.FetchIndex(context.Background(), "serde")
+	if err != nil {
+		t.Fatalf("FetchIndex: %v", err)
+	}
+	if len(entries) != 4 {
+		t.Errorf("len(entries) = %d; want 4", len(entries))
+	}
+}
+
+func TestClientFetchIndex404(t *testing.T) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	c := NewClient(server.URL + "/")
+	_, err := c.FetchIndex(context.Background(), "no-such-crate")
+	if !errors.Is(err, ErrCrateNotFound) {
+		t.Errorf("FetchIndex err = %v; want ErrCrateNotFound", err)
+	}
+}
+
+func TestClientFetchIndex500(t *testing.T) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	c := NewClient(server.URL + "/")
+	if _, err := c.FetchIndex(context.Background(), "serde"); err == nil {
+		t.Errorf("FetchIndex err = nil; want non-nil")
+	}
+}
+
+func TestDownloadURLFor(t *testing.T) {
+	c := NewClient("")
+	c.DownloadURL = "https://example.com/{crate}/{crate}-{version}.crate"
+	got, err := c.DownloadURLFor("serde", "1.0.0")
+	if err != nil {
+		t.Fatalf("DownloadURLFor: %v", err)
+	}
+	if got != "https://example.com/serde/serde-1.0.0.crate" {
+		t.Errorf("DownloadURLFor = %q", got)
+	}
+}
+
+func TestDownloadURLForBadName(t *testing.T) {
+	c := NewClient("")
+	if _, err := c.DownloadURLFor("bad name", "1.0.0"); err == nil {
+		t.Errorf("DownloadURLFor(bad name) err = nil")
+	}
+	if _, err := c.DownloadURLFor("serde", ""); err == nil {
+		t.Errorf("DownloadURLFor(empty version) err = nil")
+	}
+}
+
+func TestClientFetchCrate(t *testing.T) {
+	body := "fake crate bytes"
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "serde-1.0.0.crate") {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		io.WriteString(w, body)
+	})
+	c := NewClient("")
+	c.DownloadURL = server.URL + "/{crate}-{version}.crate"
+	var sink strings.Builder
+	n, err := c.FetchCrate(context.Background(), "serde", "1.0.0", &sink)
+	if err != nil {
+		t.Fatalf("FetchCrate: %v", err)
+	}
+	if int(n) != len(body) || sink.String() != body {
+		t.Errorf("FetchCrate body mismatch: n=%d, got=%q", n, sink.String())
+	}
+}
+
+func TestClientFetchCrateNotFound(t *testing.T) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	c := NewClient("")
+	c.DownloadURL = server.URL + "/{crate}-{version}.crate"
+	var sink strings.Builder
+	_, err := c.FetchCrate(context.Background(), "serde", "1.0.0", &sink)
+	if !errors.Is(err, ErrCrateVersionNotFound) {
+		t.Errorf("FetchCrate err = %v; want ErrCrateVersionNotFound", err)
+	}
+}

--- a/package3/rust/sparse/entry.go
+++ b/package3/rust/sparse/entry.go
@@ -1,0 +1,211 @@
+package sparse
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+
+	"mochi/package3/rust/semver"
+)
+
+// CrateEntry is one record from a sparse-index file. Each line of a
+// sparse-index file is exactly one CrateEntry encoded as JSON. The shape
+// follows cargo's RegistryPackage struct in
+// cargo/src/cargo/sources/registry/index.rs.
+//
+// Fields are documented inline. The `V` field is the schema version of
+// the entry: 1 (default, used when missing) lacks features2/links;
+// 2 introduced features2 (so that complex feature graphs can avoid
+// "default-features = false" diamond bugs); higher numbers are reserved.
+type CrateEntry struct {
+	// Name is the published crate name. Preserves publish-time casing
+	// and separator. Index lookup must use CrateNameEqual for matching.
+	Name string `json:"name"`
+
+	// Vers is the semver string for this release. Empty Pre means a
+	// non-prerelease version. cargo accepts the relaxed form but
+	// publishes only full N.N.N strings.
+	Vers string `json:"vers"`
+
+	// Deps is the list of dependencies declared in this version's
+	// Cargo.toml, normalised against the registry's view (i.e. patched
+	// to point at the same registry where applicable).
+	Deps []CrateDep `json:"deps"`
+
+	// Cksum is the lowercase hex SHA-256 of the .crate tarball. The
+	// digest is mandatory for sparse 1.68+; older mirrors may emit it
+	// as the empty string when republishing legacy entries.
+	Cksum string `json:"cksum"`
+
+	// Features is the feature map exactly as it appears in Cargo.toml.
+	Features map[string][]string `json:"features,omitempty"`
+
+	// Features2 is the schema-v2 supplement to Features. When merging
+	// for resolution, Features and Features2 are combined into one map
+	// with Features2 winning on key collision.
+	Features2 map[string][]string `json:"features2,omitempty"`
+
+	// Yanked is true if cargo yank pulled this version from the index.
+	// A yanked version is still resolvable if it appears in a lockfile
+	// but is excluded from fresh resolution.
+	Yanked bool `json:"yanked"`
+
+	// Links is the `links =` Cargo.toml key. When non-empty, two
+	// resolved versions of the same `links` value collide and the
+	// resolver must fail. Used for native-library shims (libc, openssl
+	// -sys, ...).
+	Links string `json:"links,omitempty"`
+
+	// V is the schema-version of the entry; 1 if absent.
+	V int `json:"v,omitempty"`
+
+	// RustVersion is the minimum supported rustc; "1.78" or similar.
+	// When empty there is no MSRV constraint.
+	RustVersion string `json:"rust_version,omitempty"`
+}
+
+// CrateDep is a single dependency record inside a CrateEntry. cargo
+// records normalises this to a stable shape regardless of the dependency
+// table the user wrote in their Cargo.toml.
+type CrateDep struct {
+	// Name is how the dependency is referenced by its consumer (may
+	// differ from Package via dep-renaming).
+	Name string `json:"name"`
+
+	// Req is the semver requirement string (e.g. "^1.0", "~1.2",
+	// ">=0.5, <0.7").
+	Req string `json:"req"`
+
+	// Features is the list of features requested in addition to default.
+	Features []string `json:"features"`
+
+	// Optional marks the dep as opt-in via a feature flag.
+	Optional bool `json:"optional"`
+
+	// DefaultFeatures defaults to true; false omits the "default" feature.
+	DefaultFeatures bool `json:"default_features"`
+
+	// Target gates the dep behind a cfg expression, e.g. "cfg(unix)"
+	// or "x86_64-unknown-linux-gnu". Empty means unconditional.
+	Target string `json:"target,omitempty"`
+
+	// Kind is one of "normal", "dev", "build".
+	Kind string `json:"kind,omitempty"`
+
+	// Registry is the index URL when the dep comes from a non-default
+	// registry, otherwise empty.
+	Registry string `json:"registry,omitempty"`
+
+	// Package is the original crate name when the dep is renamed
+	// (e.g. `foo = { package = "real-foo", ... }`).
+	Package string `json:"package,omitempty"`
+}
+
+// ParseIndex reads an NDJSON sparse-index stream and returns the entries
+// in publish order (the order on disk). Blank lines are skipped. Each
+// non-blank line must be a complete JSON object; partial reads are not
+// supported because cargo's index files are typically a few KB.
+func ParseIndex(r io.Reader) ([]CrateEntry, error) {
+	out := []CrateEntry{}
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var entry CrateEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			return nil, fmt.Errorf("sparse: line %d: %w", lineNo, err)
+		}
+		out = append(out, entry)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("sparse: scanning index: %w", err)
+	}
+	return out, nil
+}
+
+// Version returns the parsed semver Version of the entry. Returns an
+// error if Vers does not parse, which indicates a corrupted index.
+func (e CrateEntry) Version() (semver.Version, error) {
+	v, err := semver.Parse(e.Vers)
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("sparse: %q vers: %w", e.Name, err)
+	}
+	return v, nil
+}
+
+// MergedFeatures returns Features ∪ Features2 with Features2 winning on
+// collision. Returns a freshly allocated map so the caller may mutate.
+func (e CrateEntry) MergedFeatures() map[string][]string {
+	out := make(map[string][]string, len(e.Features)+len(e.Features2))
+	for k, v := range e.Features {
+		copyV := make([]string, len(v))
+		copy(copyV, v)
+		out[k] = copyV
+	}
+	for k, v := range e.Features2 {
+		copyV := make([]string, len(v))
+		copy(copyV, v)
+		out[k] = copyV
+	}
+	return out
+}
+
+// SortEntriesByVersion sorts entries ascending by their semver Version.
+// Yanked entries sort after non-yanked entries at the same version.
+// Entries with unparsable Vers sort last in input order. Mutates in place.
+func SortEntriesByVersion(entries []CrateEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		vi, errI := entries[i].Version()
+		vj, errJ := entries[j].Version()
+		switch {
+		case errI != nil && errJ != nil:
+			return false
+		case errI != nil:
+			return false
+		case errJ != nil:
+			return true
+		}
+		if c := vi.Compare(vj); c != 0 {
+			return c < 0
+		}
+		// Same version: non-yanked first.
+		if entries[i].Yanked != entries[j].Yanked {
+			return !entries[i].Yanked
+		}
+		return false
+	})
+}
+
+// LatestMatching scans entries for the highest semver Version that
+// satisfies req and is not yanked. Returns the matching entry and true,
+// or a zero entry and false if no candidate qualifies.
+func LatestMatching(entries []CrateEntry, req semver.Req) (CrateEntry, bool) {
+	var best CrateEntry
+	var bestV semver.Version
+	found := false
+	for _, e := range entries {
+		if e.Yanked {
+			continue
+		}
+		v, err := e.Version()
+		if err != nil {
+			continue
+		}
+		if !req.Matches(v) {
+			continue
+		}
+		if !found || bestV.Compare(v) < 0 {
+			best = e
+			bestV = v
+			found = true
+		}
+	}
+	return best, found
+}

--- a/package3/rust/sparse/entry_test.go
+++ b/package3/rust/sparse/entry_test.go
@@ -1,0 +1,172 @@
+package sparse
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/rust/semver"
+)
+
+const serdeFixture = `{"name":"serde","vers":"1.0.0","deps":[],"cksum":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","features":{},"yanked":false}
+{"name":"serde","vers":"1.0.1","deps":[],"cksum":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","features":{},"yanked":true}
+{"name":"serde","vers":"1.0.2","deps":[{"name":"serde_derive","req":"=1.0.2","features":[],"optional":true,"default_features":true,"target":null,"kind":"normal"}],"cksum":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","features":{"default":["std"],"std":[],"derive":["serde_derive"]},"yanked":false,"v":2,"rust_version":"1.31"}
+{"name":"serde","vers":"2.0.0-alpha.1","deps":[],"cksum":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","features":{},"yanked":false}
+`
+
+func TestParseIndex(t *testing.T) {
+	entries, err := ParseIndex(strings.NewReader(serdeFixture))
+	if err != nil {
+		t.Fatalf("ParseIndex: %v", err)
+	}
+	if len(entries) != 4 {
+		t.Fatalf("len(entries) = %d; want 4", len(entries))
+	}
+	if entries[0].Name != "serde" || entries[0].Vers != "1.0.0" {
+		t.Errorf("first entry = %+v", entries[0])
+	}
+	if !entries[1].Yanked {
+		t.Errorf("second entry yanked = false")
+	}
+	if entries[2].V != 2 {
+		t.Errorf("third entry V = %d; want 2", entries[2].V)
+	}
+	if entries[2].RustVersion != "1.31" {
+		t.Errorf("third entry rust_version = %q; want 1.31", entries[2].RustVersion)
+	}
+	if entries[2].Features["default"][0] != "std" {
+		t.Errorf("third entry default feature = %v", entries[2].Features["default"])
+	}
+	if entries[3].Vers != "2.0.0-alpha.1" {
+		t.Errorf("fourth entry vers = %q", entries[3].Vers)
+	}
+}
+
+func TestParseIndexBlankLines(t *testing.T) {
+	in := "\n" + serdeFixture + "\n\n"
+	entries, err := ParseIndex(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("ParseIndex: %v", err)
+	}
+	if len(entries) != 4 {
+		t.Errorf("len(entries) = %d; want 4", len(entries))
+	}
+}
+
+func TestParseIndexBadJSON(t *testing.T) {
+	in := `{"name":"serde","vers":"1.0.0"` + "\n"
+	if _, err := ParseIndex(strings.NewReader(in)); err == nil {
+		t.Errorf("ParseIndex(bad) err = nil; want error")
+	}
+}
+
+func TestEntryVersion(t *testing.T) {
+	e := CrateEntry{Name: "serde", Vers: "1.2.3-rc.1+build.5"}
+	v, err := e.Version()
+	if err != nil {
+		t.Fatalf("Version: %v", err)
+	}
+	want := semver.Version{Major: 1, Minor: 2, Patch: 3, Pre: "rc.1", Build: "build.5"}
+	if v != want {
+		t.Errorf("Version = %+v; want %+v", v, want)
+	}
+}
+
+func TestEntryVersionBad(t *testing.T) {
+	e := CrateEntry{Name: "x", Vers: "not-a-version"}
+	if _, err := e.Version(); err == nil {
+		t.Errorf("Version(bad) err = nil; want error")
+	}
+}
+
+func TestMergedFeatures(t *testing.T) {
+	e := CrateEntry{
+		Features:  map[string][]string{"default": {"std"}, "alloc": {}},
+		Features2: map[string][]string{"std": {"alloc"}, "default": {"std", "derive"}},
+	}
+	got := e.MergedFeatures()
+	if len(got) != 3 {
+		t.Errorf("len(merged) = %d; want 3", len(got))
+	}
+	if got["default"][0] != "std" || got["default"][1] != "derive" {
+		t.Errorf("default feature = %v; want [std derive] (Features2 wins)", got["default"])
+	}
+	if got["std"][0] != "alloc" {
+		t.Errorf("std feature = %v; want [alloc]", got["std"])
+	}
+}
+
+func TestMergedFeaturesIndependent(t *testing.T) {
+	e := CrateEntry{Features: map[string][]string{"a": {"b"}}}
+	out := e.MergedFeatures()
+	out["a"][0] = "MUTATED"
+	if e.Features["a"][0] != "b" {
+		t.Errorf("mutation of merged map should not affect source: %v", e.Features["a"])
+	}
+}
+
+func TestSortEntriesByVersion(t *testing.T) {
+	entries, err := ParseIndex(strings.NewReader(serdeFixture))
+	if err != nil {
+		t.Fatalf("ParseIndex: %v", err)
+	}
+	// Shuffle.
+	entries[0], entries[3] = entries[3], entries[0]
+	SortEntriesByVersion(entries)
+	want := []string{"1.0.0", "1.0.1", "1.0.2", "2.0.0-alpha.1"}
+	for i, v := range want {
+		if entries[i].Vers != v {
+			t.Errorf("sorted[%d] = %q; want %q", i, entries[i].Vers, v)
+		}
+	}
+}
+
+func TestSortYankedTieBreaker(t *testing.T) {
+	entries := []CrateEntry{
+		{Name: "x", Vers: "1.0.0", Yanked: true},
+		{Name: "x", Vers: "1.0.0", Yanked: false},
+	}
+	SortEntriesByVersion(entries)
+	if entries[0].Yanked || !entries[1].Yanked {
+		t.Errorf("non-yanked should sort before yanked at equal version: got %+v", entries)
+	}
+}
+
+func TestLatestMatching(t *testing.T) {
+	entries, err := ParseIndex(strings.NewReader(serdeFixture))
+	if err != nil {
+		t.Fatalf("ParseIndex: %v", err)
+	}
+	// ^1.0 should pick 1.0.2 (1.0.0 is older, 1.0.1 is yanked, 2.x is out of range,
+	// 2.0.0-alpha.1 is prerelease and not opted-in).
+	got, ok := LatestMatching(entries, semver.MustParseReq("^1.0"))
+	if !ok {
+		t.Fatalf("LatestMatching(^1.0) returned ok=false")
+	}
+	if got.Vers != "1.0.2" {
+		t.Errorf("LatestMatching(^1.0) = %q; want 1.0.2", got.Vers)
+	}
+}
+
+func TestLatestMatchingNoCandidate(t *testing.T) {
+	entries, err := ParseIndex(strings.NewReader(serdeFixture))
+	if err != nil {
+		t.Fatalf("ParseIndex: %v", err)
+	}
+	if _, ok := LatestMatching(entries, semver.MustParseReq("^3")); ok {
+		t.Errorf("LatestMatching(^3) ok=true; want false")
+	}
+}
+
+func TestLatestMatchingSkipsYanked(t *testing.T) {
+	entries := []CrateEntry{
+		{Name: "x", Vers: "1.0.0", Yanked: false},
+		{Name: "x", Vers: "1.0.1", Yanked: true},
+	}
+	got, ok := LatestMatching(entries, semver.MustParseReq("^1"))
+	if !ok {
+		t.Fatalf("LatestMatching returned ok=false")
+	}
+	if got.Vers != "1.0.0" {
+		t.Errorf("LatestMatching = %q; want 1.0.0 (1.0.1 yanked)", got.Vers)
+	}
+}

--- a/package3/rust/sparse/http.go
+++ b/package3/rust/sparse/http.go
@@ -1,0 +1,46 @@
+package sparse
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// getWithUA issues an HTTP GET via client.HTTP (or http.DefaultClient
+// when nil), attaching the configured User-Agent. Callers own the
+// returned body.
+func getWithUA(ctx context.Context, c *Client, target string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, fmt.Errorf("sparse: build request: %w", err)
+	}
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+	httpClient := c.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sparse: GET %s: %w", target, err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		resp.Body.Close()
+		return nil, fmt.Errorf("%w: %s: %s", ErrCrateNotFound, target, strings.TrimSpace(string(body)))
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		resp.Body.Close()
+		return nil, fmt.Errorf("sparse: GET %s: status %d: %s", target, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return resp, nil
+}
+
+// bytesReader is a thin wrapper kept here so callers don't have to
+// import bytes.NewReader directly. Keeps the public surface focused.
+func bytesReader(b []byte) io.Reader { return bytes.NewReader(b) }

--- a/package3/rust/sparse/path.go
+++ b/package3/rust/sparse/path.go
@@ -1,0 +1,100 @@
+// Package sparse implements the cargo sparse-index protocol described at
+// https://doc.rust-lang.org/cargo/reference/registry-index.html and the
+// content-addressed crate cache used by Mochi to materialise downloaded
+// crates. Sparse is the protocol introduced in cargo 1.68 as the default
+// alternative to the git-backed index.
+//
+// The package is intentionally tiny so that higher phases of MEP-73 can
+// compose it: Phase 1 only needs to ask "what versions exist for crate X",
+// "give me the manifest record for X@Y", and "fetch the .crate tarball into
+// the cache, verifying it against the index checksum".
+package sparse
+
+import (
+	"fmt"
+	"strings"
+)
+
+// BucketPath returns the index path for a crate name following cargo's
+// bucket scheme. The name is folded to lowercase (cargo treats crate names
+// case-insensitively for index lookup) but the original separator
+// (- vs _) is preserved because the registry stores files under the
+// canonical spelling used at publish time.
+//
+//	BucketPath("a")       => "1/a"
+//	BucketPath("ab")      => "2/ab"
+//	BucketPath("abc")     => "3/a/abc"
+//	BucketPath("serde")   => "se/rd/serde"
+//	BucketPath("Tokio")   => "to/ki/tokio"
+//
+// The cargo reference §"Index files" specifies that names with length 3
+// nest under a single-letter directory derived from the first byte of the
+// lowercased name, and names of length 4 or more nest under two
+// two-letter directories taken from positions 0..2 and 2..4.
+func BucketPath(name string) (string, error) {
+	if err := ValidateCrateName(name); err != nil {
+		return "", err
+	}
+	n := strings.ToLower(name)
+	switch len(n) {
+	case 1:
+		return "1/" + n, nil
+	case 2:
+		return "2/" + n, nil
+	case 3:
+		return "3/" + n[:1] + "/" + n, nil
+	default:
+		return n[:2] + "/" + n[2:4] + "/" + n, nil
+	}
+}
+
+// ValidateCrateName enforces cargo's crate-name rules: 1..=64 characters,
+// starts with a Unicode XID_Start equivalent (ASCII letter or underscore
+// here, since the registry only accepts ASCII), and the remaining
+// characters are letters, digits, '-' or '_'. cargo also reserves a set
+// of names (con, prn, ...) and forbids names that conflict with Windows
+// device files, but those rules are publisher-side and are checked
+// separately in Phase 10.
+func ValidateCrateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("sparse: empty crate name")
+	}
+	if len(name) > 64 {
+		return fmt.Errorf("sparse: crate name %q exceeds 64 bytes", name)
+	}
+	for i, r := range name {
+		ok := (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == '_'
+		if i > 0 {
+			ok = ok || (r >= '0' && r <= '9') || r == '-'
+		}
+		if !ok {
+			return fmt.Errorf("sparse: invalid character %q at position %d in %q", r, i, name)
+		}
+	}
+	return nil
+}
+
+// CrateNameEqual reports whether two crate names refer to the same crate
+// under cargo's lookup rules. Cargo folds case and treats '-' and '_' as
+// equivalent for the purposes of resolution (a Cargo.toml dep on
+// "foo-bar" matches an index entry for "foo_bar"). The registry itself
+// rejects publishing two crates whose canonical forms collide.
+func CrateNameEqual(a, b string) bool {
+	return canonicalCrateName(a) == canonicalCrateName(b)
+}
+
+func canonicalCrateName(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+		case r == '-':
+			b.WriteByte('_')
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/package3/rust/sparse/path_test.go
+++ b/package3/rust/sparse/path_test.go
@@ -1,0 +1,100 @@
+package sparse
+
+import "testing"
+
+func TestBucketPath(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"a", "1/a"},
+		{"A", "1/a"},
+		{"ab", "2/ab"},
+		{"AB", "2/ab"},
+		{"abc", "3/a/abc"},
+		{"ABC", "3/a/abc"},
+		{"abcd", "ab/cd/abcd"},
+		{"ABCD", "ab/cd/abcd"},
+		{"serde", "se/rd/serde"},
+		{"tokio", "to/ki/tokio"},
+		{"anyhow", "an/yh/anyhow"},
+		{"thiserror", "th/is/thiserror"},
+		{"clap", "cl/ap/clap"},
+		{"libc", "li/bc/libc"},
+		// Hyphen and underscore are preserved literally in the path.
+		{"foo-bar", "fo/o-/foo-bar"},
+		{"foo_bar", "fo/o_/foo_bar"},
+		{"x86_64-linux", "x8/6_/x86_64-linux"},
+	}
+	for _, tc := range cases {
+		got, err := BucketPath(tc.in)
+		if err != nil {
+			t.Errorf("BucketPath(%q) err = %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("BucketPath(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestBucketPathInvalid(t *testing.T) {
+	cases := []string{
+		"",
+		"-leading-dash",
+		"0starts-with-digit",
+		"has space",
+		"has/slash",
+		"has\x00null",
+	}
+	for _, c := range cases {
+		if _, err := BucketPath(c); err == nil {
+			t.Errorf("BucketPath(%q) err = nil; want error", c)
+		}
+	}
+}
+
+func TestBucketPathLongName(t *testing.T) {
+	long := ""
+	for i := 0; i < 65; i++ {
+		long += "a"
+	}
+	if _, err := BucketPath(long); err == nil {
+		t.Errorf("BucketPath(65-char name) err = nil; want error")
+	}
+}
+
+func TestValidateCrateName(t *testing.T) {
+	good := []string{"a", "A", "_x", "serde", "foo-bar", "foo_bar", "x86_64-linux", "rust-1-2-3"}
+	for _, n := range good {
+		if err := ValidateCrateName(n); err != nil {
+			t.Errorf("ValidateCrateName(%q) = %v; want nil", n, err)
+		}
+	}
+	bad := []string{"", "-leading", "1digit-first", "has space", "has.dot", "has/slash"}
+	for _, n := range bad {
+		if err := ValidateCrateName(n); err == nil {
+			t.Errorf("ValidateCrateName(%q) = nil; want error", n)
+		}
+	}
+}
+
+func TestCrateNameEqual(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"serde", "serde", true},
+		{"serde", "SERDE", true},
+		{"foo-bar", "foo_bar", true},
+		{"foo-bar", "Foo_Bar", true},
+		{"openssl-sys", "OPENSSL_SYS", true},
+		{"foo", "bar", false},
+		{"foo", "foo-bar", false},
+	}
+	for _, tc := range cases {
+		if got := CrateNameEqual(tc.a, tc.b); got != tc.want {
+			t.Errorf("CrateNameEqual(%q, %q) = %v; want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}

--- a/website/docs/implementation/0073/index.md
+++ b/website/docs/implementation/0073/index.md
@@ -15,8 +15,8 @@ A phase is LANDED only when its gate is green for every target (consume directio
 
 | Phase | Title | Status | Commit | Tracking page |
 |-------|-------|--------|--------|---------------|
-| 0 | Skeleton: package3/rust/ layout + cargo workspace plumbing | LANDED | (pending) | [phase-00](/docs/implementation/0073/phase-00-skeleton) |
-| 1 | Sparse-index client (`index.crates.io` reader, sha256 + blake3 download verify) | NOT STARTED | — | [phase-01](/docs/implementation/0073/phase-01-sparse-index) |
+| 0 | Skeleton: package3/rust/ layout + cargo workspace plumbing | LANDED | [2dc3b34f](https://github.com/mochilang/mochi/commit/2dc3b34f) | [phase-00](/docs/implementation/0073/phase-00-skeleton) |
+| 1 | Sparse-index client (`index.crates.io` reader, sha256 + blake3 download verify) | LANDED | (pending) | [phase-01](/docs/implementation/0073/phase-01-sparse-index) |
 | 2 | Rustdoc-JSON ingest + ApiSurface emit | NOT STARTED | — | [phase-02](/docs/implementation/0073/phase-02-rustdoc-ingest) |
 | 3 | Closed type-mapping table (scalars / strings / collections / Option / Result / Tuple / Struct / Enum) | NOT STARTED | — | [phase-03](/docs/implementation/0073/phase-03-type-mapping) |
 | 4 | Wrapper crate synthesiser (extern "C" surface, MochiString / MochiSlice / opaque handles) | NOT STARTED | — | [phase-04](/docs/implementation/0073/phase-04-wrapper) |
@@ -55,11 +55,14 @@ The bridge lives at `package3/rust/` in the repo root:
 ```
 package3/rust/
   README.md               # pointer to MEP-73 spec
+  errors/                 # SkipReason + BridgeError (phase 0)
+  build/                  # Workspace + Driver + Cargo.toml renderer (phase 0)
+  semver/                 # cargo-flavoured semver parser (phase 1)
+  sparse/                 # sparse-index client + content-addressed cache (phase 1)
   rustdoc/                # rustdoc-types Go parser (phase 2)
   typemap/                # closed type table (phase 3)
   wrapper/                # extern-C wrapper synthesiser (phase 4)
   emit/                   # Mochi extern fn emitter (phase 5)
-  build/                  # workspace + cargo orchestration (phase 7)
   publish/                # crates.io publish + Sigstore (phase 10)
   embedded/               # no_std subset (phase 13)
 ```
@@ -68,7 +71,7 @@ The `package3/rust/` location is shared with the broader MEP-57 polyglot package
 
 ## Status snapshot
 
-As of 2026-05-29: all 14 phases NOT STARTED. The MEP spec and research bundle are landed; implementation is the next major undertaking.
+As of 2026-05-29 21:06 (GMT+7): phases 0 and 1 LANDED (skeleton + sparse-index client + cargo-flavoured semver). Phases 2-13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
 
 ## Cross-references
 

--- a/website/docs/implementation/0073/phase-00-skeleton.md
+++ b/website/docs/implementation/0073/phase-00-skeleton.md
@@ -13,9 +13,9 @@ description: "MEP-73 Phase 0 lands package3/rust/ skeleton: Driver / Workspace t
 | Status         | LANDED |
 | Started        | 2026-05-29 20:30 (GMT+7) |
 | Landed         | 2026-05-29 20:46 (GMT+7) |
-| Tracking issue | (pending) |
-| Tracking PR    | (pending) |
-| Commit         | (pending) |
+| Tracking issue | [#22736](https://github.com/mochilang/mochi/issues/22736) |
+| Tracking PR    | [#22737](https://github.com/mochilang/mochi/pull/22737) |
+| Commit         | [2dc3b34f](https://github.com/mochilang/mochi/commit/2dc3b34f) |
 
 ## Gate
 

--- a/website/docs/implementation/0073/phase-01-sparse-index.md
+++ b/website/docs/implementation/0073/phase-01-sparse-index.md
@@ -1,0 +1,90 @@
+---
+title: "Phase 1. Sparse-index client"
+sidebar_position: 3
+sidebar_label: "Phase 1. Sparse-index client"
+description: "MEP-73 Phase 1 lands the cargo sparse-index client: bucket-path URL builder, NDJSON entry parser, HTTP fetch, SHA-256-verified content-addressed cache with BLAKE3-256 alias, plus a from-scratch cargo-flavoured semver parser."
+---
+
+# Phase 1. Sparse-index client
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-73 §Phases](/docs/mep/mep-0073#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-29 20:50 (GMT+7) |
+| Landed         | 2026-05-29 21:06 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+Two packages land under `package3/rust/`:
+
+- `package3/rust/semver/`: a cargo-flavoured semver parser. Implements semver 2.0.0 ordering (§11), the cargo leading-zero carve-out for the caret operator (`^0.x.y` and `^0.0.z`), tilde, wildcard, intersection (`>=1.2.3, <1.3.0`), and the cargo "pre-releases are opt-in" rule.
+- `package3/rust/sparse/`: a sparse-index client. `BucketPath` computes the cargo path scheme (`1/`, `2/`, `3/<first>/`, `<first2>/<chars-3-4>/`), `CrateEntry` mirrors cargo's `RegistryPackage` JSON shape with `name`, `vers`, `deps`, `cksum`, `features`, `features2`, `yanked`, `links`, `v`, `rust_version`. `ParseIndex` reads NDJSON streams. `Client` issues HTTP requests against a configurable base URL (default `https://index.crates.io/`) with a `User-Agent` of `mochi-rust-bridge/0.1`. `Cache` is the on-disk content-addressed store: index files land under `<root>/registry/index/<host>/<bucket>/<name>`, `.crate` tarballs land under `<root>/registry/cache/<host>/<name>-<version>.crate` (cargo-compatible layout), and a BLAKE3-256 alias is hard-linked under `<root>/registry/blake3/<first2>/<rest>.crate`. `StoreCrate` streams through SHA-256 and BLAKE3 hashers simultaneously, verifying the SHA-256 against the index `cksum` and recording the BLAKE3 digest for Mochi's own lockfile schema.
+
+## Lowering decisions
+
+### Cargo-flavoured semver, hand-rolled
+
+Mochi already ships a `semver` package for Mochi modules, but it follows semver.org strictly. Cargo deviates in three load-bearing ways:
+
+- Bare requirements (`"1.2.3"`) are caret operators, not exact pins.
+- The caret operator has a leading-zero carve-out: `^0.2.3 => >=0.2.3, <0.3.0`, `^0.0.3 => >=0.0.3, <0.0.4`.
+- Pre-releases are opt-in: `^1.0.0` does not match `1.0.0-alpha` unless the requirement itself names a pre-release on the same major/minor/patch.
+
+Reusing the existing Mochi-flavoured semver would have meant translating both ways for every resolver call, and the translation surface (caret carve-outs, pre-release matching, intersection semantics) is exactly where bugs hide. The cost of a dedicated package is one file each for parsing and matching. The tests cover the semver.org §11 ordering chain (alpha < alpha.1 < alpha.beta < beta < beta.2 < beta.11 < rc.1 < 1.0.0), build metadata is ignored for equality, and the cargo carve-outs are pinned with explicit case lists.
+
+### Bucket-path scheme
+
+The path scheme is `1/<n>` (1-char), `2/<n>` (2-char), `3/<first>/<n>` (3-char), `<first2>/<chars-3-4>/<n>` (4+ char). The crate name is lowercased before bucketisation (cargo is case-insensitive for index lookup) but the hyphen-vs-underscore choice is preserved literally in the path: `foo-bar` and `foo_bar` are separate index entries because the registry rejects collisions at publish time. `CrateNameEqual` reports whether two names resolve to the same crate under cargo's lookup rules (fold case, fold `-`/`_`); use it whenever a user-supplied name needs to be matched against an index entry.
+
+### Entry parser
+
+`ParseIndex` reads NDJSON via `bufio.Scanner` with a 2 MiB max line size. Blank lines are tolerated (some mirrors trail with a newline). Each `CrateEntry` includes the cargo schema version `V`: a v2 entry adds `features2`, which `MergedFeatures` merges over `features` (Features2 wins on collision, per cargo's `cargo/src/cargo/sources/registry/index.rs`). `SortEntriesByVersion` is the deterministic sort, with a non-yanked-first tiebreaker at equal versions. `LatestMatching(entries, req)` skips yanked entries, parses each `vers`, and returns the highest semver match.
+
+### Client
+
+`Client` is a thin HTTP wrapper. `BaseURL` is normalised to end in `/`. `IndexURL` resolves the bucket path against the base URL with `net/url.ResolveReference` so that mirrors hosted on sub-paths (e.g. an internal proxy at `https://mirror.corp/cargo/`) work without extra plumbing. `FetchIndex` returns `ErrCrateNotFound` (errors.Is-friendly) on HTTP 404 and a generic error on other non-200 responses. `FetchCrate` writes the tarball bytes to a caller-supplied `io.Writer` without verifying; verification happens in `Cache.StoreCrate` so the bytes never leave the hashing pipeline.
+
+### Cache layout
+
+The on-disk layout intentionally mirrors `$CARGO_HOME/registry/cache/<host>/<name>-<version>.crate` so that Phase 7's build orchestration can hard-link from Mochi's cache into `$CARGO_HOME` and let cargo find the tarballs without re-downloading. The BLAKE3 alias under `<root>/registry/blake3/` lets Phase 8's `mochi.lock` integrity field be either `sha256-<hex>` or `blake3-<hex>` without an extra download round trip, because both digests are computed in a single `io.MultiWriter` pass during `StoreCrate`. The alias is hard-linked best-effort; on cross-device filesystems it falls back to a byte copy, and an alias failure is non-fatal because the canonical path is the cargo-compatible one.
+
+`StoreCrate` writes to a sibling `.crate-*.tmp` file, hashes as it goes, verifies the SHA-256 against the expected hex from the index, and only renames into place on success. On checksum mismatch the partial file is removed and `ErrChecksumMismatch` is returned (errors.Is-friendly), so a single bad fetch cannot poison the cache. `HasCrate` reports presence of the final renamed path, which is sufficient because rename-after-verify is atomic on POSIX file systems.
+
+`StoreIndex` similarly uses tmp-then-rename so a partially written index file is never visible. `LoadIndex` returns `os.ErrNotExist` (errors.Is-friendly) when no cached copy exists. `Cache.FetchIndex(ctx, client, name)` is the convenience method that fetches via the client, persists the bytes, and returns the parsed entries in one call.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/rust/semver/version.go` | `Version`, `Parse`, `ParseRelaxed`, `MustParse`, `Compare`, `Equal`, `IsPrerelease` |
+| `package3/rust/semver/req.go` | `Req`, `ParseReq`, `MustParseReq`, `Matches`, `MaxSatisfying`, caret/tilde/wildcard/inequality expanders |
+| `package3/rust/semver/version_test.go` | semver.org §11 ordering, build-metadata ignored for equality, invalid-input rejection |
+| `package3/rust/semver/req_test.go` | caret carve-out cases, tilde, wildcard, exact, inequality, intersection, pre-release opt-in, `MaxSatisfying` |
+| `package3/rust/sparse/path.go` | `BucketPath`, `ValidateCrateName`, `CrateNameEqual` |
+| `package3/rust/sparse/entry.go` | `CrateEntry`, `CrateDep`, `ParseIndex`, `MergedFeatures`, `SortEntriesByVersion`, `LatestMatching` |
+| `package3/rust/sparse/client.go` | `Client`, `NewClient`, `IndexURL`, `FetchIndex`, `DownloadURLFor`, `FetchCrate`, error sentinels |
+| `package3/rust/sparse/cache.go` | `Cache`, `NewCache`, `IndexPath`, `CratePath`, `Blake3Path`, `StoreIndex`, `LoadIndex`, `StoreCrate`, `HasCrate`, `FetchIndex` |
+| `package3/rust/sparse/http.go` | shared `getWithUA` helper and the `bytesReader` shim |
+| `package3/rust/sparse/path_test.go` | bucket scheme + name validation + case/separator folding |
+| `package3/rust/sparse/entry_test.go` | NDJSON fixture, blank-line tolerance, schema-v2 merge, `LatestMatching` w/ yanked skip |
+| `package3/rust/sparse/client_test.go` | httptest server, 404 → `ErrCrateNotFound`, 500 → generic error, download URL templating, `ErrCrateVersionNotFound` |
+| `package3/rust/sparse/cache_test.go` | path layout, SHA-256 verification, mismatch removes partial, BLAKE3 alias exists, overwrite on re-store |
+
+## Test set
+
+- All `package3/rust/semver/...` unit tests.
+- All `package3/rust/sparse/...` unit tests.
+
+Total: 39 test functions, all green via `go test ./package3/rust/...`.
+
+## Closeout notes
+
+Phase 1 introduces one new runtime dependency: `lukechampine.com/blake3` (already an indirect transitive dep in the repo's `go.sum`, now used directly). No other external dependencies are needed; the HTTP client is `net/http` and the cache uses only `os`/`io`/`crypto`.
+
+The bridge between Mochi semver requirements and cargo semver requirements is now closed: Phase 2 (rustdoc-JSON ingest) and Phase 6 (`import rust "..."` grammar) will both translate user requirements to cargo `Req` values before resolving against `LatestMatching`. The cache layout is fixed early so Phase 7 (build orchestration) can rely on the `<root>/registry/cache/...` path without renegotiation, and Phase 8 (`mochi.lock` integration) can rely on the `<root>/registry/blake3/...` alias being populated whenever `StoreCrate` succeeds.
+
+Pre-release matching is the most subtle piece: `^1.0.0` does not match `1.0.0-alpha`, but `>=1.0.0-alpha` does. The implementation treats a pre-release as a satisfier only when at least one comparator in the requirement names the same (major, minor, patch) with a pre-release identifier, which is what cargo's `semver` crate does. The test suite pins this with both positive (`>=1.0.0-alpha` matches `1.0.0-alpha`) and negative (`^1.0.0` does not match `2.0.0-alpha`) cases.

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -305,7 +305,8 @@
   {
     "label": "MEP-73 phases",
     "items": [
-      "implementation/0073/phase-00-skeleton"
+      "implementation/0073/phase-00-skeleton",
+      "implementation/0073/phase-01-sparse-index"
     ]
   },
   "implementation/0074/index"


### PR DESCRIPTION
## Summary

Phase 1 of MEP-73. Lands two new packages under `package3/rust/`:

- **semver/**: cargo-flavoured semver. Parse, ParseRelaxed, MustParse, Compare, Equal, IsPrerelease. ParseReq with caret/tilde/wildcard/inequality/exact expanders, the leading-zero carve-out (^0.x.y, ^0.0.z), intersection, and the cargo pre-release opt-in rule. MaxSatisfying for resolver use.
- **sparse/**: cargo sparse-index client. BucketPath (1/2/3/N+ scheme), CrateEntry mirroring cargo's RegistryPackage with schema-v2 features2 merge, ParseIndex NDJSON parser, Client over net/http with ErrCrateNotFound + ErrCrateVersionNotFound, Cache with cargo-compatible registry/cache layout + BLAKE3-256 content-addressed alias, StoreCrate streaming through SHA-256 + BLAKE3 hashers with atomic rename-after-verify.

Both packages are prerequisites for Phase 2 (rustdoc-JSON ingest), Phase 6 (`import rust ...` grammar), and Phase 7 (build orchestration).

## Test plan

- [x] `go test ./package3/rust/...` green (4 packages, 39 + earlier phase 0 test functions).
- [x] semver.org §11 ordering chain pinned: alpha < alpha.1 < alpha.beta < beta < beta.2 < beta.11 < rc.1 < 1.0.0.
- [x] Cargo caret carve-out: ^0.2.3 => >=0.2.3, <0.3.0; ^0.0.3 => >=0.0.3, <0.0.4.
- [x] Pre-release opt-in: ^1.0.0 does not match 1.0.0-alpha; >=1.0.0-alpha matches.
- [x] NDJSON parser tolerates blank lines, rejects malformed JSON.
- [x] httptest server returns 200 / 404 / 500, all paths covered.
- [x] StoreCrate verifies SHA-256, removes partial on mismatch, hard-links BLAKE3 alias on success.

Tracking issue: #22745