### PR TITLE
feat(mep-73 p2): rustdoc-JSON ingest + ApiSurface walker

### DIFF
--- a/package3/rust/rustdoc/document.go
+++ b/package3/rust/rustdoc/document.go
@@ -1,0 +1,187 @@
+// Package rustdoc parses the rustdoc-json output produced by
+// `cargo +nightly rustdoc --output-format=json` (or its alias
+// `cargo +nightly doc --output-format=json`) and emits a normalised
+// ApiSurface that downstream MEP-73 phases consume.
+//
+// The wire format is the rustdoc-types schema maintained at
+// https://github.com/rust-lang/rust/tree/master/src/rustdoc-types and
+// rendered as JSON-Schema at https://rust-lang.github.io/rustdoc-types/.
+// As of May 2026 nightly the canonical format_version is 39; the
+// parser refuses versions outside the supported range with a precise
+// diagnostic so that a nightly drift never produces silently wrong
+// output (MEP-73 §"Schema version compatibility").
+//
+// The package intentionally only models the variants the bridge can
+// turn into a Mochi extern declaration. Everything else is converted
+// into a SkipReport so the user can audit refusals and so the build
+// remains stable when rust-lang/rust adds new variants.
+package rustdoc
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Document is the top-level rustdoc-json shape. The crate is the root
+// module identified by Root; everything reachable from there appears in
+// Index.
+type Document struct {
+	// Root is the rustdoc Id of the crate's root module.
+	Root string `json:"root"`
+
+	// CrateVersion is the Cargo.toml [package] version. May be empty if
+	// the crate was rendered without one.
+	CrateVersion string `json:"crate_version,omitempty"`
+
+	// IncludesPrivate is true when rustdoc was invoked with
+	// --document-private-items. The bridge only walks public items, so
+	// the field is informational.
+	IncludesPrivate bool `json:"includes_private"`
+
+	// Index maps Id -> Item for every item in the document.
+	Index map[string]Item `json:"index"`
+
+	// Paths maps Id -> PathInfo for short path lookup. The walker
+	// consults it to render module-qualified names without
+	// reconstructing them from the Index.
+	Paths map[string]PathInfo `json:"paths"`
+
+	// ExternalCrates maps crate-id -> name for IDs that resolve to
+	// items outside this crate (e.g. std::vec::Vec).
+	ExternalCrates map[string]ExternalCrate `json:"external_crates,omitempty"`
+
+	// FormatVersion is the rustdoc-types schema version. The parser
+	// pins a supported range; see SupportedFormatVersions.
+	FormatVersion int `json:"format_version"`
+
+	// Target captures the host triple + target_features when present.
+	Target *TargetInfo `json:"target,omitempty"`
+}
+
+// ExternalCrate is a crate referenced but not described by this document.
+type ExternalCrate struct {
+	Name string `json:"name"`
+	HTMLRoot string `json:"html_root_url,omitempty"`
+}
+
+// PathInfo is the short Path record in Document.Paths. The Path slice
+// holds the dotted segments leading to the item.
+type PathInfo struct {
+	CrateID int      `json:"crate_id"`
+	Path    []string `json:"path"`
+	Kind    string   `json:"kind"`
+}
+
+// TargetInfo is the optional `target` member added in format_version 35+.
+// The bridge does not act on it yet, but parsing it keeps round-tripping
+// honest.
+type TargetInfo struct {
+	Triple         string   `json:"triple,omitempty"`
+	TargetFeatures []string `json:"target_features,omitempty"`
+}
+
+// Item is a single entry in Document.Index. Each Item carries common
+// metadata (visibility, span, attrs, docs) and one variant in Inner.
+type Item struct {
+	ID            string          `json:"id"`
+	CrateID       int             `json:"crate_id"`
+	Name          string          `json:"name,omitempty"`
+	Span          *Span           `json:"span,omitempty"`
+	Visibility    Visibility      `json:"visibility"`
+	Docs          string          `json:"docs,omitempty"`
+	Links         map[string]string `json:"links,omitempty"`
+	Attrs         []string        `json:"attrs,omitempty"`
+	Deprecation   *Deprecation    `json:"deprecation,omitempty"`
+	Inner         ItemEnum        `json:"inner"`
+}
+
+// Span is a source-position record. Used only for diagnostics.
+type Span struct {
+	Filename string `json:"filename"`
+	Begin    [2]int `json:"begin"`
+	End      [2]int `json:"end"`
+}
+
+// Deprecation captures the #[deprecated(...)] attribute payload.
+type Deprecation struct {
+	Since string `json:"since,omitempty"`
+	Note  string `json:"note,omitempty"`
+}
+
+// Visibility is a sum of public / default (crate-private) / restricted.
+// The wire format is either the literal string "public" or "default",
+// or a tagged object {"restricted": {...}} / {"crate": "..."}.
+type Visibility struct {
+	Kind  VisibilityKind
+	Path  string // for Restricted / Crate
+}
+
+// VisibilityKind enumerates the surface forms.
+type VisibilityKind int
+
+const (
+	VisibilityPublic VisibilityKind = iota
+	VisibilityDefault
+	VisibilityCrate
+	VisibilityRestricted
+)
+
+// String returns a stable token, useful for SkipReport rendering.
+func (v VisibilityKind) String() string {
+	switch v {
+	case VisibilityPublic:
+		return "public"
+	case VisibilityDefault:
+		return "default"
+	case VisibilityCrate:
+		return "crate"
+	case VisibilityRestricted:
+		return "restricted"
+	}
+	return "unknown"
+}
+
+// IsPublic reports whether the item is exported in the crate's public
+// API surface. The bridge only walks public items.
+func (v Visibility) IsPublic() bool { return v.Kind == VisibilityPublic }
+
+// UnmarshalJSON handles both the bare string and the tagged-object form.
+func (v *Visibility) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		switch s {
+		case "public":
+			v.Kind = VisibilityPublic
+			return nil
+		case "default":
+			v.Kind = VisibilityDefault
+			return nil
+		}
+		return fmt.Errorf("rustdoc: unknown visibility %q", s)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return fmt.Errorf("rustdoc: visibility: %w", err)
+	}
+	if raw, ok := obj["restricted"]; ok {
+		var r struct {
+			ParentID string `json:"parent"`
+			Path     string `json:"path"`
+		}
+		if err := json.Unmarshal(raw, &r); err != nil {
+			return fmt.Errorf("rustdoc: visibility.restricted: %w", err)
+		}
+		v.Kind = VisibilityRestricted
+		v.Path = r.Path
+		return nil
+	}
+	if raw, ok := obj["crate"]; ok {
+		var s string
+		if err := json.Unmarshal(raw, &s); err == nil {
+			v.Kind = VisibilityCrate
+			v.Path = s
+			return nil
+		}
+	}
+	return fmt.Errorf("rustdoc: unknown visibility shape %s", string(data))
+}

--- a/package3/rust/rustdoc/item.go
+++ b/package3/rust/rustdoc/item.go
@@ -1,0 +1,475 @@
+package rustdoc
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// ItemEnum is the rustdoc-types `ItemEnum` discriminated union. The
+// wire shape is `{"variant_tag": variant_payload}` and we keep
+// exactly one of the embedded pointer fields populated per Item. A
+// pointer field that remains nil means the item is not of that kind.
+//
+// The set of variants below covers the ones MEP-73 phase 2 needs to
+// recognise. Unknown variants land in Unknown and become a SkipReport
+// during the walk so that rust-lang/rust adding new variants does not
+// break the parse.
+type ItemEnum struct {
+	Module      *ModuleItem      `json:"module,omitempty"`
+	ExternCrate *ExternCrateItem `json:"extern_crate,omitempty"`
+	Use         *UseItem         `json:"use,omitempty"`
+	Struct      *StructItem      `json:"struct,omitempty"`
+	StructField *Type            `json:"struct_field,omitempty"`
+	Enum        *EnumItem        `json:"enum,omitempty"`
+	Variant     *VariantItem     `json:"variant,omitempty"`
+	Function    *FunctionItem    `json:"function,omitempty"`
+	Trait       *TraitItem       `json:"trait,omitempty"`
+	Impl        *ImplItem        `json:"impl,omitempty"`
+	TypeAlias   *TypeAliasItem   `json:"type_alias,omitempty"`
+	Constant    *ConstantItem    `json:"constant,omitempty"`
+	Static      *StaticItem      `json:"static,omitempty"`
+	Macro       *MacroItem       `json:"macro,omitempty"`
+	ProcMacro   *ProcMacroItem   `json:"proc_macro,omitempty"`
+	Primitive   *PrimitiveItem   `json:"primitive,omitempty"`
+	AssocConst  *AssocConstItem  `json:"assoc_const,omitempty"`
+	AssocType   *AssocTypeItem   `json:"assoc_type,omitempty"`
+
+	// Unknown captures the variant tag of any unrecognised entry so
+	// the walker can produce a precise SkipReport. The payload is
+	// discarded because the type-mapping phase does not look at it.
+	Unknown string `json:"-"`
+}
+
+// Kind returns a stable token describing which variant is populated.
+// Returns "unknown" with the offending tag included when Unknown is set.
+func (e ItemEnum) Kind() string {
+	switch {
+	case e.Module != nil:
+		return "module"
+	case e.ExternCrate != nil:
+		return "extern_crate"
+	case e.Use != nil:
+		return "use"
+	case e.Struct != nil:
+		return "struct"
+	case e.StructField != nil:
+		return "struct_field"
+	case e.Enum != nil:
+		return "enum"
+	case e.Variant != nil:
+		return "variant"
+	case e.Function != nil:
+		return "function"
+	case e.Trait != nil:
+		return "trait"
+	case e.Impl != nil:
+		return "impl"
+	case e.TypeAlias != nil:
+		return "type_alias"
+	case e.Constant != nil:
+		return "constant"
+	case e.Static != nil:
+		return "static"
+	case e.Macro != nil:
+		return "macro"
+	case e.ProcMacro != nil:
+		return "proc_macro"
+	case e.Primitive != nil:
+		return "primitive"
+	case e.AssocConst != nil:
+		return "assoc_const"
+	case e.AssocType != nil:
+		return "assoc_type"
+	}
+	if e.Unknown != "" {
+		return "unknown:" + e.Unknown
+	}
+	return "empty"
+}
+
+// UnmarshalJSON dispatches on the tagged-object key. Falls back to
+// Unknown when the tag is not in the recognised set.
+func (e *ItemEnum) UnmarshalJSON(data []byte) error {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return fmt.Errorf("rustdoc: item enum: %w", err)
+	}
+	if len(obj) == 0 {
+		return nil
+	}
+	// Pick the key deterministically so error messages are stable.
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	tag := keys[0]
+	raw := obj[tag]
+	switch tag {
+	case "module":
+		var x ModuleItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: module: %w", err)
+		}
+		e.Module = &x
+	case "extern_crate":
+		var x ExternCrateItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: extern_crate: %w", err)
+		}
+		e.ExternCrate = &x
+	case "use":
+		var x UseItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: use: %w", err)
+		}
+		e.Use = &x
+	case "struct":
+		var x StructItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: struct: %w", err)
+		}
+		e.Struct = &x
+	case "struct_field":
+		var x Type
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: struct_field: %w", err)
+		}
+		e.StructField = &x
+	case "enum":
+		var x EnumItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: enum: %w", err)
+		}
+		e.Enum = &x
+	case "variant":
+		var x VariantItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: variant: %w", err)
+		}
+		e.Variant = &x
+	case "function":
+		var x FunctionItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: function: %w", err)
+		}
+		e.Function = &x
+	case "trait":
+		var x TraitItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: trait: %w", err)
+		}
+		e.Trait = &x
+	case "impl":
+		var x ImplItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: impl: %w", err)
+		}
+		e.Impl = &x
+	case "type_alias":
+		var x TypeAliasItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: type_alias: %w", err)
+		}
+		e.TypeAlias = &x
+	case "constant":
+		var x ConstantItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: constant: %w", err)
+		}
+		e.Constant = &x
+	case "static":
+		var x StaticItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: static: %w", err)
+		}
+		e.Static = &x
+	case "macro":
+		var x MacroItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: macro: %w", err)
+		}
+		e.Macro = &x
+	case "proc_macro":
+		var x ProcMacroItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: proc_macro: %w", err)
+		}
+		e.ProcMacro = &x
+	case "primitive":
+		var x PrimitiveItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: primitive: %w", err)
+		}
+		e.Primitive = &x
+	case "assoc_const":
+		var x AssocConstItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: assoc_const: %w", err)
+		}
+		e.AssocConst = &x
+	case "assoc_type":
+		var x AssocTypeItem
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: assoc_type: %w", err)
+		}
+		e.AssocType = &x
+	default:
+		e.Unknown = tag
+	}
+	return nil
+}
+
+// ModuleItem holds a module's child Item IDs.
+type ModuleItem struct {
+	IsCrate    bool     `json:"is_crate"`
+	Items      []string `json:"items"`
+	IsStripped bool     `json:"is_stripped"`
+}
+
+// ExternCrateItem records an `extern crate` declaration.
+type ExternCrateItem struct {
+	Name   string `json:"name"`
+	Rename string `json:"rename,omitempty"`
+}
+
+// UseItem records a `use ...;` re-export.
+type UseItem struct {
+	Source string `json:"source"`
+	Name   string `json:"name"`
+	ID     string `json:"id,omitempty"`
+	IsGlob bool   `json:"is_glob"`
+}
+
+// StructItem is the payload of a `struct` declaration.
+type StructItem struct {
+	Kind         StructKind `json:"kind"`
+	Generics     Generics   `json:"generics"`
+	Impls        []string   `json:"impls,omitempty"`
+}
+
+// StructKind discriminates plain / tuple / unit structs.
+type StructKind struct {
+	Plain   *StructPlain `json:"plain,omitempty"`
+	Tuple   []*string    `json:"tuple,omitempty"` // nil = unit struct?
+	Unit    *struct{}    `json:"unit,omitempty"`
+}
+
+// StructPlain holds plain-struct field IDs.
+type StructPlain struct {
+	Fields            []string `json:"fields"`
+	HasStrippedFields bool     `json:"has_stripped_fields"`
+}
+
+// EnumItem is the payload of an `enum` declaration.
+type EnumItem struct {
+	Generics       Generics `json:"generics"`
+	Variants       []string `json:"variants"`
+	HasStrippedVariants bool `json:"has_stripped_variants"`
+	Impls          []string `json:"impls,omitempty"`
+}
+
+// VariantItem is the payload of an enum-variant Item.
+type VariantItem struct {
+	Kind          VariantKind     `json:"kind"`
+	Discriminant  *Discriminant   `json:"discriminant,omitempty"`
+}
+
+// VariantKind discriminates plain / tuple / struct variants.
+type VariantKind struct {
+	Plain  *struct{}     `json:"plain,omitempty"`
+	Tuple  []*string     `json:"tuple,omitempty"`
+	Struct *VariantStruct `json:"struct,omitempty"`
+}
+
+// VariantStruct holds field IDs for a struct-shaped variant.
+type VariantStruct struct {
+	Fields            []string `json:"fields"`
+	HasStrippedFields bool     `json:"has_stripped_fields"`
+}
+
+// Discriminant carries the user-declared discriminant for an enum variant.
+type Discriminant struct {
+	Expr  string `json:"expr"`
+	Value string `json:"value"`
+}
+
+// FunctionItem holds a fn signature plus declarative metadata.
+type FunctionItem struct {
+	Sig         FunctionSig   `json:"sig"`
+	Generics    Generics      `json:"generics"`
+	Header      FunctionHeader `json:"header"`
+	HasBody     bool          `json:"has_body"`
+}
+
+// FunctionSig is the input/output shape.
+type FunctionSig struct {
+	Inputs    []FunctionInput `json:"inputs"`
+	Output    *Type           `json:"output,omitempty"`
+	IsCVariadic bool          `json:"is_c_variadic"`
+}
+
+// FunctionInput is one positional parameter.
+type FunctionInput struct {
+	Name string `json:"-"`
+	Type Type   `json:"-"`
+}
+
+// UnmarshalJSON expects the wire shape ["name", Type] (rustdoc-json
+// represents fn inputs as a 2-tuple).
+func (fi *FunctionInput) UnmarshalJSON(data []byte) error {
+	var arr []json.RawMessage
+	if err := json.Unmarshal(data, &arr); err != nil {
+		return fmt.Errorf("rustdoc: function input: %w", err)
+	}
+	if len(arr) != 2 {
+		return fmt.Errorf("rustdoc: function input: want 2-tuple, got %d", len(arr))
+	}
+	if err := json.Unmarshal(arr[0], &fi.Name); err != nil {
+		return fmt.Errorf("rustdoc: function input name: %w", err)
+	}
+	if err := json.Unmarshal(arr[1], &fi.Type); err != nil {
+		return fmt.Errorf("rustdoc: function input type: %w", err)
+	}
+	return nil
+}
+
+// FunctionHeader is the per-fn modifier set (unsafe, const, async, abi).
+type FunctionHeader struct {
+	IsConst   bool   `json:"is_const"`
+	IsUnsafe  bool   `json:"is_unsafe"`
+	IsAsync   bool   `json:"is_async"`
+	ABI       ABI    `json:"abi"`
+}
+
+// ABI is the FFI calling convention. The wire form is either the
+// literal string "Rust" / "C" / "system" / ... or a tagged-object form
+// like {"C": {"unwind": true}}.
+type ABI struct {
+	Name   string
+	Unwind bool
+}
+
+// UnmarshalJSON handles both the bare-string and object forms.
+func (a *ABI) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		a.Name = s
+		return nil
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return fmt.Errorf("rustdoc: abi: %w", err)
+	}
+	for k, raw := range obj {
+		a.Name = k
+		var inner struct {
+			Unwind bool `json:"unwind"`
+		}
+		_ = json.Unmarshal(raw, &inner)
+		a.Unwind = inner.Unwind
+		return nil
+	}
+	return nil
+}
+
+// TraitItem is the payload of a `trait` declaration.
+type TraitItem struct {
+	IsAuto      bool     `json:"is_auto"`
+	IsUnsafe    bool     `json:"is_unsafe"`
+	Items       []string `json:"items"`
+	Generics    Generics `json:"generics"`
+	Bounds      []GenericBound `json:"bounds,omitempty"`
+	Implementations []string `json:"implementations,omitempty"`
+}
+
+// ImplItem is the payload of an `impl` block.
+type ImplItem struct {
+	IsUnsafe   bool       `json:"is_unsafe"`
+	Generics   Generics   `json:"generics"`
+	ProvidedTraitMethods []string `json:"provided_trait_methods,omitempty"`
+	Trait      *PathType  `json:"trait,omitempty"`
+	For        Type       `json:"for"`
+	Items      []string   `json:"items"`
+	Negative   bool       `json:"negative"`
+	Synthetic  bool       `json:"synthetic"`
+	BlanketImpl *Type     `json:"blanket_impl,omitempty"`
+}
+
+// TypeAliasItem is the payload of `type Foo = Bar;`.
+type TypeAliasItem struct {
+	Type     Type     `json:"type"`
+	Generics Generics `json:"generics"`
+}
+
+// ConstantItem is the payload of `const FOO: Ty = ...`.
+type ConstantItem struct {
+	Type  Type     `json:"type"`
+	Const ConstValue `json:"const"`
+}
+
+// StaticItem is the payload of `static FOO: Ty = ...`.
+type StaticItem struct {
+	Type     Type   `json:"type"`
+	Mutable  bool   `json:"mutable"`
+	Expr     string `json:"expr,omitempty"`
+	IsUnsafe bool   `json:"is_unsafe"`
+}
+
+// ConstValue captures `expr = ...` / `value = ...` / `is_literal`.
+type ConstValue struct {
+	Expr      string `json:"expr"`
+	Value     string `json:"value,omitempty"`
+	IsLiteral bool   `json:"is_literal"`
+}
+
+// MacroItem is the source text of a declarative macro.
+type MacroItem string
+
+// UnmarshalJSON accepts both a bare string and a wrapper object.
+func (m *MacroItem) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*m = MacroItem(s)
+		return nil
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return fmt.Errorf("rustdoc: macro: %w", err)
+	}
+	if raw, ok := obj["macro_definition"]; ok {
+		var s string
+		if err := json.Unmarshal(raw, &s); err == nil {
+			*m = MacroItem(s)
+			return nil
+		}
+	}
+	return nil
+}
+
+// ProcMacroItem describes a `#[proc_macro]` attribute / derive macro.
+type ProcMacroItem struct {
+	Kind    string   `json:"kind"`
+	Helpers []string `json:"helpers,omitempty"`
+}
+
+// PrimitiveItem is a primitive type entry (rare; usually from std).
+type PrimitiveItem struct {
+	Name  string   `json:"name"`
+	Impls []string `json:"impls,omitempty"`
+}
+
+// AssocConstItem is an associated const inside a trait or impl.
+type AssocConstItem struct {
+	Type  Type   `json:"type"`
+	Value string `json:"value,omitempty"`
+}
+
+// AssocTypeItem is an associated type inside a trait or impl.
+type AssocTypeItem struct {
+	Generics Generics `json:"generics"`
+	Bounds   []GenericBound `json:"bounds,omitempty"`
+	Default  *Type    `json:"default,omitempty"`
+	Type     *Type    `json:"type,omitempty"`
+}

--- a/package3/rust/rustdoc/parse.go
+++ b/package3/rust/rustdoc/parse.go
@@ -1,0 +1,71 @@
+package rustdoc
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// SupportedFormatVersions enumerates the rustdoc-types schema versions
+// the bridge handles. The May 2026 nightly emits version 39; the
+// parser also accepts 37 / 38 because they are forward-compatible at
+// the variant level for the items MEP-73 cares about. Versions older
+// than 37 used the now-renamed "fn"/"typedef" tags and are rejected.
+//
+// When rust-lang/rust bumps the schema, the bridge release notes will
+// add the new version here only after the on-disk fixture corpus has
+// been re-verified against it.
+var SupportedFormatVersions = []int{37, 38, 39}
+
+// MinSupportedFormatVersion is the lowest format_version the parser
+// will accept. Versions below this fail at Parse time.
+const MinSupportedFormatVersion = 37
+
+// MaxSupportedFormatVersion is the highest format_version the parser
+// will accept.
+const MaxSupportedFormatVersion = 39
+
+// ErrUnsupportedFormatVersion is returned by Parse when the document's
+// format_version is outside SupportedFormatVersions. errors.Is-friendly.
+type ErrUnsupportedFormatVersion struct {
+	Got int
+}
+
+func (e *ErrUnsupportedFormatVersion) Error() string {
+	return fmt.Sprintf("rustdoc: unsupported format_version=%d (supported: %d..%d)", e.Got, MinSupportedFormatVersion, MaxSupportedFormatVersion)
+}
+
+// Parse reads a rustdoc-json document from r and returns the parsed
+// Document. The format_version is checked against the supported range
+// and an *ErrUnsupportedFormatVersion is returned on mismatch.
+func Parse(r io.Reader) (*Document, error) {
+	dec := json.NewDecoder(r)
+	dec.UseNumber()
+	dec.DisallowUnknownFields() // surfaces drift in our struct shape
+	// Use a tolerant decoder for the main pass, then re-decode strict.
+	// In practice we don't enable DisallowUnknownFields because
+	// rustdoc-json adds new optional fields constantly; the structs
+	// we declared above must keep parsing without complaint when a
+	// new optional field shows up.
+	dec = json.NewDecoder(r)
+	var doc Document
+	if err := dec.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("rustdoc: decode document: %w", err)
+	}
+	if doc.FormatVersion < MinSupportedFormatVersion || doc.FormatVersion > MaxSupportedFormatVersion {
+		return &doc, &ErrUnsupportedFormatVersion{Got: doc.FormatVersion}
+	}
+	return &doc, nil
+}
+
+// ParseBytes is the []byte form of Parse.
+func ParseBytes(data []byte) (*Document, error) {
+	var doc Document
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("rustdoc: decode document: %w", err)
+	}
+	if doc.FormatVersion < MinSupportedFormatVersion || doc.FormatVersion > MaxSupportedFormatVersion {
+		return &doc, &ErrUnsupportedFormatVersion{Got: doc.FormatVersion}
+	}
+	return &doc, nil
+}

--- a/package3/rust/rustdoc/parse_test.go
+++ b/package3/rust/rustdoc/parse_test.go
@@ -1,0 +1,131 @@
+package rustdoc
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+const minimalDoc = `{
+  "root": "0:0:0",
+  "crate_version": "1.0.0",
+  "includes_private": false,
+  "index": {
+    "0:0:0": {
+      "id": "0:0:0",
+      "crate_id": 0,
+      "name": "demo",
+      "visibility": "public",
+      "inner": {"module": {"is_crate": true, "items": [], "is_stripped": false}}
+    }
+  },
+  "paths": {
+    "0:0:0": {"crate_id": 0, "path": ["demo"], "kind": "module"}
+  },
+  "external_crates": {},
+  "format_version": 39
+}`
+
+func TestParseMinimal(t *testing.T) {
+	doc, err := Parse(strings.NewReader(minimalDoc))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if doc.Root != "0:0:0" {
+		t.Errorf("Root = %q", doc.Root)
+	}
+	if doc.CrateVersion != "1.0.0" {
+		t.Errorf("CrateVersion = %q", doc.CrateVersion)
+	}
+	if doc.FormatVersion != 39 {
+		t.Errorf("FormatVersion = %d", doc.FormatVersion)
+	}
+	if len(doc.Index) != 1 {
+		t.Errorf("len(Index) = %d", len(doc.Index))
+	}
+	if root := doc.Index["0:0:0"]; root.Inner.Kind() != "module" {
+		t.Errorf("root.Inner.Kind = %q", root.Inner.Kind())
+	}
+}
+
+func TestParseUnsupportedVersion(t *testing.T) {
+	in := strings.Replace(minimalDoc, `"format_version": 39`, `"format_version": 1`, 1)
+	_, err := Parse(strings.NewReader(in))
+	var unsup *ErrUnsupportedFormatVersion
+	if !errors.As(err, &unsup) {
+		t.Fatalf("Parse(format_version=1) err = %v; want ErrUnsupportedFormatVersion", err)
+	}
+	if unsup.Got != 1 {
+		t.Errorf("ErrUnsupportedFormatVersion.Got = %d; want 1", unsup.Got)
+	}
+}
+
+func TestParseFutureVersion(t *testing.T) {
+	in := strings.Replace(minimalDoc, `"format_version": 39`, `"format_version": 99`, 1)
+	_, err := Parse(strings.NewReader(in))
+	var unsup *ErrUnsupportedFormatVersion
+	if !errors.As(err, &unsup) {
+		t.Fatalf("Parse(format_version=99) err = %v; want ErrUnsupportedFormatVersion", err)
+	}
+}
+
+func TestSupportedFormatVersionsContains(t *testing.T) {
+	want := map[int]bool{37: true, 38: true, 39: true}
+	if len(SupportedFormatVersions) != len(want) {
+		t.Errorf("SupportedFormatVersions = %v", SupportedFormatVersions)
+	}
+	for _, v := range SupportedFormatVersions {
+		if !want[v] {
+			t.Errorf("unexpected version %d", v)
+		}
+	}
+}
+
+func TestParseBytes(t *testing.T) {
+	doc, err := ParseBytes([]byte(minimalDoc))
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	if doc.CrateVersion != "1.0.0" {
+		t.Errorf("CrateVersion = %q", doc.CrateVersion)
+	}
+}
+
+func TestParseBadJSON(t *testing.T) {
+	if _, err := Parse(strings.NewReader("not json")); err == nil {
+		t.Errorf("Parse(garbage) err = nil; want error")
+	}
+}
+
+func TestVisibilityVariants(t *testing.T) {
+	cases := []struct {
+		raw  string
+		kind VisibilityKind
+		isPub bool
+	}{
+		{`"public"`, VisibilityPublic, true},
+		{`"default"`, VisibilityDefault, false},
+		{`{"crate": "demo"}`, VisibilityCrate, false},
+		{`{"restricted": {"parent": "0:0:0", "path": "demo::inner"}}`, VisibilityRestricted, false},
+	}
+	for _, tc := range cases {
+		var v Visibility
+		if err := v.UnmarshalJSON([]byte(tc.raw)); err != nil {
+			t.Errorf("UnmarshalJSON(%s) err = %v", tc.raw, err)
+			continue
+		}
+		if v.Kind != tc.kind {
+			t.Errorf("UnmarshalJSON(%s).Kind = %v; want %v", tc.raw, v.Kind, tc.kind)
+		}
+		if v.IsPublic() != tc.isPub {
+			t.Errorf("UnmarshalJSON(%s).IsPublic = %v; want %v", tc.raw, v.IsPublic(), tc.isPub)
+		}
+	}
+}
+
+func TestVisibilityUnknown(t *testing.T) {
+	var v Visibility
+	if err := v.UnmarshalJSON([]byte(`"weird"`)); err == nil {
+		t.Errorf("UnmarshalJSON(weird) err = nil")
+	}
+}

--- a/package3/rust/rustdoc/surface.go
+++ b/package3/rust/rustdoc/surface.go
@@ -1,0 +1,143 @@
+package rustdoc
+
+import (
+	"fmt"
+
+	"mochi/package3/rust/errors"
+)
+
+// ApiSurface is the bridge-level distilled view of a rustdoc Document.
+// It carries only what later phases need: a flat per-kind list of
+// public items, each with a module-qualified path, and a SkipReport
+// for every item that could not be lowered.
+type ApiSurface struct {
+	CrateName     string
+	CrateVersion  string
+	FormatVersion int
+
+	Functions   []FunctionEntry
+	Structs     []StructEntry
+	Enums       []EnumEntry
+	TypeAliases []TypeAliasEntry
+	Constants   []ConstantEntry
+	Traits      []TraitEntry
+
+	Skipped []errors.SkipReport
+}
+
+// FunctionEntry is a public function lifted out of the document.
+type FunctionEntry struct {
+	ID       string
+	Path     []string // module-qualified path, e.g. ["serde","de","from_str"]
+	Inputs   []ParamEntry
+	Output   *Type
+	Header   FunctionHeader
+	Generics Generics
+}
+
+// ParamEntry is one function parameter.
+type ParamEntry struct {
+	Name string
+	Type Type
+}
+
+// StructEntry is a public struct.
+type StructEntry struct {
+	ID       string
+	Path     []string
+	Kind     string // "plain", "tuple", "unit"
+	Fields   []FieldEntry
+	Generics Generics
+}
+
+// FieldEntry is a struct or struct-variant field.
+type FieldEntry struct {
+	ID   string
+	Name string
+	Type Type
+}
+
+// EnumEntry is a public enum.
+type EnumEntry struct {
+	ID       string
+	Path     []string
+	Variants []VariantEntry
+	Generics Generics
+}
+
+// VariantEntry is a public enum variant.
+type VariantEntry struct {
+	ID     string
+	Name   string
+	Kind   string // "plain", "tuple", "struct"
+	Fields []FieldEntry
+	Tuple  []Type
+}
+
+// TypeAliasEntry is a public `type X = Y;`.
+type TypeAliasEntry struct {
+	ID       string
+	Path     []string
+	Type     Type
+	Generics Generics
+}
+
+// ConstantEntry is a public `const NAME: T = ...`.
+type ConstantEntry struct {
+	ID   string
+	Path []string
+	Type Type
+}
+
+// TraitEntry is a public trait. The bridge does not yet generate
+// trait bindings (phase 4 covers concrete impls), but tracking traits
+// keeps SkipReport granularity high.
+type TraitEntry struct {
+	ID         string
+	Path       []string
+	IsUnsafe   bool
+	IsAuto     bool
+	Generics   Generics
+}
+
+// Skip appends a SkipReport for a single item, attributing it to the
+// item's ID + module-qualified path.
+func (s *ApiSurface) skip(itemID string, path []string, reason errors.SkipReason, detail string) {
+	name := joinPath(path)
+	if name == "" {
+		name = itemID
+	}
+	s.Skipped = append(s.Skipped, errors.SkipReport{
+		ItemPath: name,
+		Reason:   reason,
+		Detail:   detail,
+	})
+}
+
+// joinPath renders a path slice as a Rust-style `a::b::c` string.
+func joinPath(p []string) string {
+	if len(p) == 0 {
+		return ""
+	}
+	out := p[0]
+	for _, s := range p[1:] {
+		out += "::" + s
+	}
+	return out
+}
+
+// renderTypeKind formats a Type for SkipReport detail strings. Keeps
+// the rendering deterministic for golden diffs.
+func renderTypeKind(t Type) string {
+	switch t.Kind() {
+	case "resolved_path":
+		if t.ResolvedPath != nil {
+			return fmt.Sprintf("resolved_path(%s)", t.ResolvedPath.Path)
+		}
+	case "primitive":
+		return fmt.Sprintf("primitive(%s)", t.Primitive)
+	case "generic":
+		return fmt.Sprintf("generic(%s)", t.Generic)
+	}
+	return t.Kind()
+}

--- a/package3/rust/rustdoc/type.go
+++ b/package3/rust/rustdoc/type.go
@@ -1,0 +1,387 @@
+package rustdoc
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// Type is the rustdoc-types `Type` discriminated union. Like ItemEnum,
+// the wire shape is a tagged object with exactly one populated key. The
+// bridge models every variant that needs different SkipReport
+// classification; everything else lands in Unknown.
+type Type struct {
+	ResolvedPath    *PathType         `json:"resolved_path,omitempty"`
+	DynTrait        *DynTraitType     `json:"dyn_trait,omitempty"`
+	Generic         string            `json:"generic,omitempty"`
+	Primitive       string            `json:"primitive,omitempty"`
+	FunctionPointer *FunctionPointer  `json:"function_pointer,omitempty"`
+	Tuple           []Type            `json:"tuple,omitempty"`
+	Slice           *Type             `json:"slice,omitempty"`
+	Array           *ArrayType        `json:"array,omitempty"`
+	Pat             *PatType          `json:"pat,omitempty"`
+	ImplTrait       []GenericBound    `json:"impl_trait,omitempty"`
+	Infer           bool              `json:"infer,omitempty"`
+	RawPointer      *RawPointerType   `json:"raw_pointer,omitempty"`
+	BorrowedRef     *BorrowedRefType  `json:"borrowed_ref,omitempty"`
+	QualifiedPath   *QualifiedPathType `json:"qualified_path,omitempty"`
+
+	// Unknown captures any variant tag the bridge does not model.
+	Unknown string `json:"-"`
+}
+
+// Kind returns a stable tag describing the populated variant. Empty
+// when no variant is set.
+func (t Type) Kind() string {
+	switch {
+	case t.ResolvedPath != nil:
+		return "resolved_path"
+	case t.DynTrait != nil:
+		return "dyn_trait"
+	case t.Generic != "":
+		return "generic"
+	case t.Primitive != "":
+		return "primitive"
+	case t.FunctionPointer != nil:
+		return "function_pointer"
+	case len(t.Tuple) > 0:
+		return "tuple"
+	case t.Slice != nil:
+		return "slice"
+	case t.Array != nil:
+		return "array"
+	case t.Pat != nil:
+		return "pat"
+	case len(t.ImplTrait) > 0:
+		return "impl_trait"
+	case t.Infer:
+		return "infer"
+	case t.RawPointer != nil:
+		return "raw_pointer"
+	case t.BorrowedRef != nil:
+		return "borrowed_ref"
+	case t.QualifiedPath != nil:
+		return "qualified_path"
+	}
+	if t.Unknown != "" {
+		return "unknown:" + t.Unknown
+	}
+	return "empty"
+}
+
+// UnmarshalJSON dispatches on the single tag key.
+func (t *Type) UnmarshalJSON(data []byte) error {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		// rustdoc sometimes emits a bare string for variants that have
+		// no payload (e.g. "infer"); handle that here.
+		var s string
+		if err2 := json.Unmarshal(data, &s); err2 == nil {
+			switch s {
+			case "infer":
+				t.Infer = true
+				return nil
+			}
+			t.Unknown = s
+			return nil
+		}
+		return fmt.Errorf("rustdoc: type: %w", err)
+	}
+	if len(obj) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	tag := keys[0]
+	raw := obj[tag]
+	switch tag {
+	case "resolved_path":
+		var x PathType
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: type.resolved_path: %w", err)
+		}
+		t.ResolvedPath = &x
+	case "dyn_trait":
+		var x DynTraitType
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: type.dyn_trait: %w", err)
+		}
+		t.DynTrait = &x
+	case "generic":
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return fmt.Errorf("rustdoc: type.generic: %w", err)
+		}
+		t.Generic = s
+	case "primitive":
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return fmt.Errorf("rustdoc: type.primitive: %w", err)
+		}
+		t.Primitive = s
+	case "function_pointer":
+		var x FunctionPointer
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: type.function_pointer: %w", err)
+		}
+		t.FunctionPointer = &x
+	case "tuple":
+		var ts []Type
+		if err := json.Unmarshal(raw, &ts); err != nil {
+			return fmt.Errorf("rustdoc: type.tuple: %w", err)
+		}
+		t.Tuple = ts
+	case "slice":
+		var x Type
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: type.slice: %w", err)
+		}
+		t.Slice = &x
+	case "array":
+		var x ArrayType
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: type.array: %w", err)
+		}
+		t.Array = &x
+	case "pat":
+		var x PatType
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: type.pat: %w", err)
+		}
+		t.Pat = &x
+	case "impl_trait":
+		var bs []GenericBound
+		if err := json.Unmarshal(raw, &bs); err != nil {
+			return fmt.Errorf("rustdoc: type.impl_trait: %w", err)
+		}
+		t.ImplTrait = bs
+	case "raw_pointer":
+		var x RawPointerType
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: type.raw_pointer: %w", err)
+		}
+		t.RawPointer = &x
+	case "borrowed_ref":
+		var x BorrowedRefType
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: type.borrowed_ref: %w", err)
+		}
+		t.BorrowedRef = &x
+	case "qualified_path":
+		var x QualifiedPathType
+		if err := json.Unmarshal(raw, &x); err != nil {
+			return fmt.Errorf("rustdoc: type.qualified_path: %w", err)
+		}
+		t.QualifiedPath = &x
+	default:
+		t.Unknown = tag
+	}
+	return nil
+}
+
+// PathType is the payload of a `resolved_path` Type. It points at an
+// Item via ID and may carry generic arguments.
+type PathType struct {
+	ID   string      `json:"id"`
+	Path string      `json:"path"`
+	Args *GenericArgs `json:"args,omitempty"`
+}
+
+// DynTraitType captures `dyn Trait1 + Trait2 + 'a`.
+type DynTraitType struct {
+	Traits   []PolyTrait `json:"traits"`
+	Lifetime string      `json:"lifetime,omitempty"`
+}
+
+// PolyTrait is the higher-ranked-trait-bound form `for<'a> Trait<...>`.
+type PolyTrait struct {
+	Trait         PathType         `json:"trait"`
+	GenericParams []GenericParamDef `json:"generic_params,omitempty"`
+}
+
+// FunctionPointer captures `fn(...) -> ...` types.
+type FunctionPointer struct {
+	Sig           FunctionSig      `json:"sig"`
+	GenericParams []GenericParamDef `json:"generic_params,omitempty"`
+	Header        FunctionHeader   `json:"header"`
+}
+
+// ArrayType is `[T; N]`.
+type ArrayType struct {
+	Type Type   `json:"type"`
+	Len  string `json:"len"`
+}
+
+// PatType captures unstable pattern types.
+type PatType struct {
+	Base    Type   `json:"base"`
+	Pattern string `json:"pattern,omitempty"`
+}
+
+// RawPointerType is `*const T` / `*mut T`.
+type RawPointerType struct {
+	IsMutable bool `json:"is_mutable"`
+	Type      Type `json:"type"`
+}
+
+// BorrowedRefType is `&'a T` / `&'a mut T`.
+type BorrowedRefType struct {
+	Lifetime  string `json:"lifetime,omitempty"`
+	IsMutable bool   `json:"is_mutable"`
+	Type      Type   `json:"type"`
+}
+
+// QualifiedPathType is `<T as Trait>::Item`.
+type QualifiedPathType struct {
+	Name     string    `json:"name"`
+	Args     GenericArgs `json:"args"`
+	SelfType Type      `json:"self_type"`
+	Trait    *PathType `json:"trait,omitempty"`
+}
+
+// Generics is the full generics declaration on an item: params + where.
+type Generics struct {
+	Params       []GenericParamDef    `json:"params,omitempty"`
+	WherePredicates []WherePredicate `json:"where_predicates,omitempty"`
+}
+
+// GenericParamDef is one of `<T: Bound>`, `<'a>`, `<const N: usize>`.
+type GenericParamDef struct {
+	Name string             `json:"name"`
+	Kind GenericParamDefKind `json:"kind"`
+}
+
+// GenericParamDefKind is the discriminator over lifetime / type / const.
+type GenericParamDefKind struct {
+	Lifetime *struct {
+		Outlives []string `json:"outlives,omitempty"`
+	} `json:"lifetime,omitempty"`
+	Type *struct {
+		Bounds  []GenericBound `json:"bounds,omitempty"`
+		Default *Type          `json:"default,omitempty"`
+		Synthetic bool         `json:"synthetic"`
+	} `json:"type,omitempty"`
+	Const *struct {
+		Type    Type   `json:"type"`
+		Default string `json:"default,omitempty"`
+	} `json:"const,omitempty"`
+}
+
+// GenericArgs is the args portion of a path / trait reference. Two
+// shapes: AngleBracketed `<A, B = C>` and Parenthesized `(A, B) -> C`.
+type GenericArgs struct {
+	AngleBracketed *AngleBracketedArgs `json:"angle_bracketed,omitempty"`
+	Parenthesized  *ParenthesizedArgs  `json:"parenthesized,omitempty"`
+}
+
+// AngleBracketedArgs is `<A, B = C, 'x>`.
+type AngleBracketedArgs struct {
+	Args       []GenericArg     `json:"args,omitempty"`
+	Constraints []AssocItemConstraint `json:"constraints,omitempty"`
+}
+
+// ParenthesizedArgs is `(A, B) -> C` (used for Fn traits).
+type ParenthesizedArgs struct {
+	Inputs []Type `json:"inputs"`
+	Output *Type  `json:"output,omitempty"`
+}
+
+// GenericArg is one positional generic argument.
+type GenericArg struct {
+	Lifetime string `json:"lifetime,omitempty"`
+	Type     *Type  `json:"type,omitempty"`
+	Const    *ConstValue `json:"const,omitempty"`
+	Infer    bool `json:"infer,omitempty"`
+}
+
+// UnmarshalJSON handles the tagged-object form.
+func (a *GenericArg) UnmarshalJSON(data []byte) error {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return fmt.Errorf("rustdoc: generic arg: %w", err)
+	}
+	for k, raw := range obj {
+		switch k {
+		case "lifetime":
+			_ = json.Unmarshal(raw, &a.Lifetime)
+		case "type":
+			var t Type
+			if err := json.Unmarshal(raw, &t); err != nil {
+				return fmt.Errorf("rustdoc: generic arg.type: %w", err)
+			}
+			a.Type = &t
+		case "const":
+			var c ConstValue
+			if err := json.Unmarshal(raw, &c); err != nil {
+				return fmt.Errorf("rustdoc: generic arg.const: %w", err)
+			}
+			a.Const = &c
+		case "infer":
+			a.Infer = true
+		}
+	}
+	return nil
+}
+
+// AssocItemConstraint is `Item = Ty` or `Item: Bound`.
+type AssocItemConstraint struct {
+	Name    string `json:"name"`
+	Args    GenericArgs `json:"args"`
+	Binding AssocItemBinding `json:"binding"`
+}
+
+// AssocItemBinding is `= Ty` or `: Bound`.
+type AssocItemBinding struct {
+	Equality *Term         `json:"equality,omitempty"`
+	Constraint []GenericBound `json:"constraint,omitempty"`
+}
+
+// Term is `Ty` or a const-value.
+type Term struct {
+	Type  *Type      `json:"type,omitempty"`
+	Const *ConstValue `json:"const,omitempty"`
+}
+
+// GenericBound is `T: Bound` (TraitBound), `T: 'a` (Outlives), or
+// `use<...>` (the captured-generics opt-out).
+type GenericBound struct {
+	TraitBound *TraitBound `json:"trait_bound,omitempty"`
+	Outlives   string      `json:"outlives,omitempty"`
+	Use        []string    `json:"use,omitempty"`
+}
+
+// TraitBound is the `Trait<...>` body of a TraitBound generic bound.
+type TraitBound struct {
+	Trait         PathType         `json:"trait"`
+	GenericParams []GenericParamDef `json:"generic_params,omitempty"`
+	Modifier      string           `json:"modifier,omitempty"` // "none", "maybe", "maybe_const"
+}
+
+// WherePredicate models the entries in a `where` clause.
+type WherePredicate struct {
+	BoundPredicate    *BoundPredicate    `json:"bound_predicate,omitempty"`
+	LifetimePredicate *LifetimePredicate `json:"lifetime_predicate,omitempty"`
+	EqPredicate       *EqPredicate       `json:"eq_predicate,omitempty"`
+}
+
+// BoundPredicate is `T: Bound + 'a`.
+type BoundPredicate struct {
+	Type          Type             `json:"type"`
+	Bounds        []GenericBound   `json:"bounds"`
+	GenericParams []GenericParamDef `json:"generic_params,omitempty"`
+}
+
+// LifetimePredicate is `'a: 'b + 'c`.
+type LifetimePredicate struct {
+	Lifetime string   `json:"lifetime"`
+	Outlives []string `json:"outlives"`
+}
+
+// EqPredicate is `Item = Ty` inside a where clause.
+type EqPredicate struct {
+	LHS Type `json:"lhs"`
+	RHS Term `json:"rhs"`
+}

--- a/package3/rust/rustdoc/type_test.go
+++ b/package3/rust/rustdoc/type_test.go
@@ -1,0 +1,176 @@
+package rustdoc
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTypeResolvedPath(t *testing.T) {
+	var got Type
+	if err := json.Unmarshal([]byte(`{"resolved_path": {"id":"0:0:1","path":"std::vec::Vec"}}`), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Kind() != "resolved_path" {
+		t.Errorf("Kind = %q", got.Kind())
+	}
+	if got.ResolvedPath == nil || got.ResolvedPath.Path != "std::vec::Vec" {
+		t.Errorf("ResolvedPath = %+v", got.ResolvedPath)
+	}
+}
+
+func TestTypePrimitive(t *testing.T) {
+	var got Type
+	if err := json.Unmarshal([]byte(`{"primitive": "u8"}`), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Kind() != "primitive" {
+		t.Errorf("Kind = %q", got.Kind())
+	}
+	if got.Primitive != "u8" {
+		t.Errorf("Primitive = %q", got.Primitive)
+	}
+}
+
+func TestTypeGeneric(t *testing.T) {
+	var got Type
+	if err := json.Unmarshal([]byte(`{"generic": "T"}`), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Kind() != "generic" || got.Generic != "T" {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestTypeTuple(t *testing.T) {
+	var got Type
+	if err := json.Unmarshal([]byte(`{"tuple": [{"primitive":"i32"},{"primitive":"f64"}]}`), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Kind() != "tuple" || len(got.Tuple) != 2 {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestTypeSlice(t *testing.T) {
+	var got Type
+	if err := json.Unmarshal([]byte(`{"slice": {"primitive": "u8"}}`), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Kind() != "slice" || got.Slice == nil || got.Slice.Primitive != "u8" {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestTypeArray(t *testing.T) {
+	var got Type
+	if err := json.Unmarshal([]byte(`{"array": {"type": {"primitive":"u8"}, "len": "32"}}`), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Kind() != "array" || got.Array == nil || got.Array.Len != "32" {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestTypeBorrowedRef(t *testing.T) {
+	var got Type
+	if err := json.Unmarshal([]byte(`{"borrowed_ref": {"lifetime": "'a", "is_mutable": false, "type": {"primitive":"str"}}}`), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Kind() != "borrowed_ref" {
+		t.Errorf("Kind = %q", got.Kind())
+	}
+	if got.BorrowedRef.Lifetime != "'a" {
+		t.Errorf("Lifetime = %q", got.BorrowedRef.Lifetime)
+	}
+}
+
+func TestTypeRawPointer(t *testing.T) {
+	var got Type
+	if err := json.Unmarshal([]byte(`{"raw_pointer": {"is_mutable": true, "type": {"primitive":"u8"}}}`), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Kind() != "raw_pointer" || !got.RawPointer.IsMutable {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestTypeDynTrait(t *testing.T) {
+	var got Type
+	in := `{"dyn_trait": {"traits": [{"trait": {"id":"0:0:1","path":"core::fmt::Debug"}}], "lifetime": "'static"}}`
+	if err := json.Unmarshal([]byte(in), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Kind() != "dyn_trait" || got.DynTrait.Lifetime != "'static" {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestTypeImplTrait(t *testing.T) {
+	var got Type
+	in := `{"impl_trait": [{"trait_bound": {"trait": {"id":"0:0:1","path":"core::iter::Iterator"}}}]}`
+	if err := json.Unmarshal([]byte(in), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Kind() != "impl_trait" || len(got.ImplTrait) != 1 {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestTypeUnknownVariant(t *testing.T) {
+	var got Type
+	in := `{"hypothetical_future_variant_42": {"foo": "bar"}}`
+	if err := json.Unmarshal([]byte(in), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Kind() != "unknown:hypothetical_future_variant_42" {
+		t.Errorf("Kind = %q; want unknown:hypothetical_future_variant_42", got.Kind())
+	}
+}
+
+func TestItemEnumUnknown(t *testing.T) {
+	var got ItemEnum
+	in := `{"future_item_kind": {"foo": "bar"}}`
+	if err := json.Unmarshal([]byte(in), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Kind() != "unknown:future_item_kind" {
+		t.Errorf("Kind = %q; want unknown:future_item_kind", got.Kind())
+	}
+}
+
+func TestFunctionInputUnmarshal(t *testing.T) {
+	var got FunctionInput
+	if err := json.Unmarshal([]byte(`["bytes", {"primitive": "u8"}]`), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Name != "bytes" || got.Type.Primitive != "u8" {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestFunctionInputBadShape(t *testing.T) {
+	var got FunctionInput
+	if err := json.Unmarshal([]byte(`{"name":"x","type":{"primitive":"u8"}}`), &got); err == nil {
+		t.Errorf("Unmarshal(object) err = nil; want error (input must be 2-tuple)")
+	}
+}
+
+func TestABIBareString(t *testing.T) {
+	var got ABI
+	if err := json.Unmarshal([]byte(`"C"`), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Name != "C" || got.Unwind {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestABITaggedObject(t *testing.T) {
+	var got ABI
+	if err := json.Unmarshal([]byte(`{"C": {"unwind": true}}`), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Name != "C" || !got.Unwind {
+		t.Errorf("got = %+v", got)
+	}
+}

--- a/package3/rust/rustdoc/walk.go
+++ b/package3/rust/rustdoc/walk.go
@@ -1,0 +1,343 @@
+package rustdoc
+
+import (
+	"fmt"
+	"sort"
+
+	"mochi/package3/rust/errors"
+)
+
+// Walk traverses doc from its Root module, collecting every public
+// item reachable via Module.Items into an ApiSurface. Items that are
+// not lowerable (lifetime-parameterised, generic without
+// monomorphisation, raw-pointer typed, ...) become a SkipReport rather
+// than failing the whole walk.
+//
+// The walker honours the visibility filter: only items whose
+// Visibility.IsPublic() is true are emitted. Use-re-exports
+// (`pub use foo::Bar`) are followed if their target ID resolves to a
+// public item.
+//
+// The walker is deterministic: items within a module are emitted in
+// rustdoc's declared order (Module.Items is already deterministic),
+// and SkipReports come out in walk order.
+func Walk(doc *Document) (*ApiSurface, error) {
+	if doc == nil {
+		return nil, fmt.Errorf("rustdoc: walk: nil document")
+	}
+	root, ok := doc.Index[doc.Root]
+	if !ok {
+		return nil, fmt.Errorf("rustdoc: walk: root id %q not in index", doc.Root)
+	}
+	crateName := root.Name
+	w := &walker{
+		doc:       doc,
+		seen:      make(map[string]bool),
+		crateName: crateName,
+		surface: &ApiSurface{
+			CrateName:     crateName,
+			CrateVersion:  doc.CrateVersion,
+			FormatVersion: doc.FormatVersion,
+		},
+	}
+	w.walkItem(doc.Root, nil)
+	return w.surface, nil
+}
+
+type walker struct {
+	doc       *Document
+	seen      map[string]bool
+	crateName string
+	surface   *ApiSurface
+}
+
+func (w *walker) walkItem(id string, path []string) {
+	if w.seen[id] {
+		return
+	}
+	w.seen[id] = true
+	item, ok := w.doc.Index[id]
+	if !ok {
+		// External or stripped item; record nothing.
+		return
+	}
+	if !item.Visibility.IsPublic() && item.Inner.Kind() != "module" {
+		// Non-public items don't reach the surface.
+		return
+	}
+	itemPath := path
+	if item.Name != "" {
+		itemPath = append(append([]string(nil), path...), item.Name)
+	}
+	switch item.Inner.Kind() {
+	case "module":
+		w.walkModule(id, item, itemPath)
+	case "function":
+		w.emitFunction(id, item, itemPath)
+	case "struct":
+		w.emitStruct(id, item, itemPath)
+	case "enum":
+		w.emitEnum(id, item, itemPath)
+	case "type_alias":
+		w.emitTypeAlias(id, item, itemPath)
+	case "constant":
+		w.emitConstant(id, item, itemPath)
+	case "trait":
+		w.emitTrait(id, item, itemPath)
+	case "use":
+		w.followUse(item, path)
+	case "extern_crate", "primitive", "static", "macro", "proc_macro", "impl", "assoc_const", "assoc_type", "variant", "struct_field":
+		// Skipped at this layer; type-mapping (phase 3) handles where useful.
+		w.surface.skip(id, itemPath, mapKindToSkipReason(item.Inner.Kind()), item.Inner.Kind())
+	default:
+		w.surface.skip(id, itemPath, errors.SkipUnknown, item.Inner.Kind())
+	}
+}
+
+func (w *walker) walkModule(id string, item Item, path []string) {
+	mod := item.Inner.Module
+	if mod == nil {
+		return
+	}
+	for _, child := range mod.Items {
+		w.walkItem(child, path)
+	}
+}
+
+func (w *walker) followUse(item Item, parentPath []string) {
+	u := item.Inner.Use
+	if u == nil || u.IsGlob || u.ID == "" {
+		return
+	}
+	// Follow with the *target*'s own path; the use re-export is
+	// effectively transparent for the surface.
+	w.walkItem(u.ID, parentPath)
+}
+
+func (w *walker) emitFunction(id string, item Item, path []string) {
+	fn := item.Inner.Function
+	if fn == nil {
+		return
+	}
+	if len(fn.Generics.Params) > 0 {
+		w.surface.skip(id, path, errors.SkipGeneric, "generic params on function")
+		return
+	}
+	if fn.Header.IsUnsafe {
+		w.surface.skip(id, path, errors.SkipExternFnUnsafe, "unsafe fn")
+		return
+	}
+	if fn.Header.ABI.Name != "" && fn.Header.ABI.Name != "Rust" && fn.Header.ABI.Name != "C" {
+		w.surface.skip(id, path, errors.SkipCustomAbi, fn.Header.ABI.Name)
+		return
+	}
+	entry := FunctionEntry{
+		ID:       id,
+		Path:     append([]string(nil), path...),
+		Header:   fn.Header,
+		Generics: fn.Generics,
+	}
+	for _, in := range fn.Sig.Inputs {
+		entry.Inputs = append(entry.Inputs, ParamEntry{Name: in.Name, Type: in.Type})
+	}
+	if fn.Sig.Output != nil {
+		out := *fn.Sig.Output
+		entry.Output = &out
+	}
+	w.surface.Functions = append(w.surface.Functions, entry)
+}
+
+func (w *walker) emitStruct(id string, item Item, path []string) {
+	s := item.Inner.Struct
+	if s == nil {
+		return
+	}
+	if len(s.Generics.Params) > 0 {
+		w.surface.skip(id, path, errors.SkipGeneric, "generic struct")
+		return
+	}
+	entry := StructEntry{ID: id, Path: append([]string(nil), path...), Generics: s.Generics}
+	switch {
+	case s.Kind.Plain != nil:
+		entry.Kind = "plain"
+		entry.Fields = w.collectFields(s.Kind.Plain.Fields)
+	case s.Kind.Tuple != nil:
+		entry.Kind = "tuple"
+		entry.Fields = w.collectTupleFields(s.Kind.Tuple)
+	case s.Kind.Unit != nil:
+		entry.Kind = "unit"
+	}
+	w.surface.Structs = append(w.surface.Structs, entry)
+}
+
+func (w *walker) collectFields(ids []string) []FieldEntry {
+	out := make([]FieldEntry, 0, len(ids))
+	for _, id := range ids {
+		item, ok := w.doc.Index[id]
+		if !ok {
+			continue
+		}
+		if item.Inner.StructField == nil {
+			continue
+		}
+		out = append(out, FieldEntry{ID: id, Name: item.Name, Type: *item.Inner.StructField})
+	}
+	return out
+}
+
+func (w *walker) collectTupleFields(ids []*string) []FieldEntry {
+	out := make([]FieldEntry, 0, len(ids))
+	for i, idPtr := range ids {
+		if idPtr == nil {
+			out = append(out, FieldEntry{Name: fmt.Sprintf("%d", i)})
+			continue
+		}
+		item, ok := w.doc.Index[*idPtr]
+		if !ok {
+			continue
+		}
+		if item.Inner.StructField == nil {
+			continue
+		}
+		out = append(out, FieldEntry{ID: *idPtr, Name: fmt.Sprintf("%d", i), Type: *item.Inner.StructField})
+	}
+	return out
+}
+
+func (w *walker) emitEnum(id string, item Item, path []string) {
+	e := item.Inner.Enum
+	if e == nil {
+		return
+	}
+	if len(e.Generics.Params) > 0 {
+		w.surface.skip(id, path, errors.SkipGeneric, "generic enum")
+		return
+	}
+	entry := EnumEntry{ID: id, Path: append([]string(nil), path...), Generics: e.Generics}
+	for _, vid := range e.Variants {
+		vItem, ok := w.doc.Index[vid]
+		if !ok || vItem.Inner.Variant == nil {
+			continue
+		}
+		v := vItem.Inner.Variant
+		ve := VariantEntry{ID: vid, Name: vItem.Name}
+		switch {
+		case v.Kind.Plain != nil:
+			ve.Kind = "plain"
+		case v.Kind.Tuple != nil:
+			ve.Kind = "tuple"
+			for _, idPtr := range v.Kind.Tuple {
+				if idPtr == nil {
+					continue
+				}
+				fItem, ok := w.doc.Index[*idPtr]
+				if !ok || fItem.Inner.StructField == nil {
+					continue
+				}
+				ve.Tuple = append(ve.Tuple, *fItem.Inner.StructField)
+			}
+		case v.Kind.Struct != nil:
+			ve.Kind = "struct"
+			ve.Fields = w.collectFields(v.Kind.Struct.Fields)
+		}
+		entry.Variants = append(entry.Variants, ve)
+	}
+	w.surface.Enums = append(w.surface.Enums, entry)
+}
+
+func (w *walker) emitTypeAlias(id string, item Item, path []string) {
+	a := item.Inner.TypeAlias
+	if a == nil {
+		return
+	}
+	if len(a.Generics.Params) > 0 {
+		w.surface.skip(id, path, errors.SkipGeneric, "generic type alias")
+		return
+	}
+	w.surface.TypeAliases = append(w.surface.TypeAliases, TypeAliasEntry{
+		ID:       id,
+		Path:     append([]string(nil), path...),
+		Type:     a.Type,
+		Generics: a.Generics,
+	})
+}
+
+func (w *walker) emitConstant(id string, item Item, path []string) {
+	c := item.Inner.Constant
+	if c == nil {
+		return
+	}
+	w.surface.Constants = append(w.surface.Constants, ConstantEntry{
+		ID:   id,
+		Path: append([]string(nil), path...),
+		Type: c.Type,
+	})
+}
+
+func (w *walker) emitTrait(id string, item Item, path []string) {
+	t := item.Inner.Trait
+	if t == nil {
+		return
+	}
+	w.surface.Traits = append(w.surface.Traits, TraitEntry{
+		ID:       id,
+		Path:     append([]string(nil), path...),
+		IsUnsafe: t.IsUnsafe,
+		IsAuto:   t.IsAuto,
+		Generics: t.Generics,
+	})
+	// A trait declaration itself does not produce an extern binding;
+	// record a skip so the user can see why the binding is absent.
+	w.surface.skip(id, path, errors.SkipTrait, "trait declaration")
+}
+
+// mapKindToSkipReason maps an item-kind tag to the closest
+// SkipReason. Defaults to SkipUnknown when no specific match exists.
+func mapKindToSkipReason(kind string) errors.SkipReason {
+	switch kind {
+	case "macro", "proc_macro":
+		return errors.SkipMacro
+	case "static":
+		return errors.SkipConstant
+	case "extern_crate", "primitive", "impl", "assoc_const", "assoc_type", "variant", "struct_field":
+		return errors.SkipUnknown
+	}
+	return errors.SkipUnknown
+}
+
+// SortSkipped sorts the SkipReport slice by item path for stable
+// golden output. Mutates in place.
+func (s *ApiSurface) SortSkipped() {
+	sort.SliceStable(s.Skipped, func(i, j int) bool {
+		if s.Skipped[i].ItemPath == s.Skipped[j].ItemPath {
+			return s.Skipped[i].Reason.String() < s.Skipped[j].Reason.String()
+		}
+		return s.Skipped[i].ItemPath < s.Skipped[j].ItemPath
+	})
+}
+
+// Counts returns a snapshot of per-kind counts for a quick fixture
+// assertion. Useful in tests that pin a "this many functions, this
+// many structs" invariant against a known crate.
+type Counts struct {
+	Functions   int
+	Structs     int
+	Enums       int
+	TypeAliases int
+	Constants   int
+	Traits      int
+	Skipped     int
+}
+
+// Snapshot returns the Counts for s.
+func (s *ApiSurface) Snapshot() Counts {
+	return Counts{
+		Functions:   len(s.Functions),
+		Structs:     len(s.Structs),
+		Enums:       len(s.Enums),
+		TypeAliases: len(s.TypeAliases),
+		Constants:   len(s.Constants),
+		Traits:      len(s.Traits),
+		Skipped:     len(s.Skipped),
+	}
+}

--- a/package3/rust/rustdoc/walk_test.go
+++ b/package3/rust/rustdoc/walk_test.go
@@ -1,0 +1,313 @@
+package rustdoc
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/rust/errors"
+)
+
+// hexlikeDoc is a hand-written rustdoc fixture modelled after the
+// `hex` crate (one of the 24 fixture crates in the MEP-73 corpus).
+// It contains:
+//   - the crate root module
+//   - a public `encode` function: fn(&[u8]) -> String
+//   - a public `decode` function: fn(&str) -> Result<Vec<u8>, FromHexError>
+//   - a public unit struct `FromHexError`
+//   - a public enum `FromHexErrorKind` with three variants
+//   - a public type alias `Bytes = Vec<u8>`
+//   - a public const `MAX_LENGTH: usize = 1024`
+//   - a generic fn `decode_to_slice<T>` that should produce a SkipGeneric
+//   - an unsafe fn `as_str_unchecked` that should produce SkipExternFnUnsafe
+//   - a non-public helper struct that must NOT appear in the surface
+//   - a trait `FromHex` that should record a SkipTrait
+const hexlikeDoc = `{
+  "root": "0:0:0",
+  "crate_version": "0.4.3",
+  "includes_private": false,
+  "index": {
+    "0:0:0": {
+      "id": "0:0:0", "crate_id": 0, "name": "hex", "visibility": "public",
+      "inner": {"module": {"is_crate": true, "items": ["0:0:1","0:0:2","0:0:3","0:0:4","0:0:6","0:0:7","0:0:8","0:0:9","0:0:10","0:0:11"], "is_stripped": false}}
+    },
+    "0:0:1": {
+      "id": "0:0:1", "crate_id": 0, "name": "encode", "visibility": "public",
+      "inner": {"function": {
+        "sig": {"inputs": [["bytes", {"borrowed_ref": {"is_mutable": false, "type": {"slice": {"primitive": "u8"}}}}]], "output": {"resolved_path": {"id":"std:String","path":"alloc::string::String"}}, "is_c_variadic": false},
+        "generics": {"params": [], "where_predicates": []},
+        "header": {"is_const": false, "is_unsafe": false, "is_async": false, "abi": "Rust"},
+        "has_body": true
+      }}
+    },
+    "0:0:2": {
+      "id": "0:0:2", "crate_id": 0, "name": "decode", "visibility": "public",
+      "inner": {"function": {
+        "sig": {"inputs": [["s", {"borrowed_ref": {"is_mutable": false, "type": {"primitive": "str"}}}]], "output": {"resolved_path": {"id":"std:Result","path":"core::result::Result"}}, "is_c_variadic": false},
+        "generics": {"params": [], "where_predicates": []},
+        "header": {"is_const": false, "is_unsafe": false, "is_async": false, "abi": "Rust"},
+        "has_body": true
+      }}
+    },
+    "0:0:3": {
+      "id": "0:0:3", "crate_id": 0, "name": "FromHexError", "visibility": "public",
+      "inner": {"struct": {"kind": {"unit": {}}, "generics": {"params": [], "where_predicates": []}}}
+    },
+    "0:0:4": {
+      "id": "0:0:4", "crate_id": 0, "name": "FromHexErrorKind", "visibility": "public",
+      "inner": {"enum": {"generics": {"params": [], "where_predicates": []}, "variants": ["0:0:4a","0:0:4b","0:0:4c"], "has_stripped_variants": false}}
+    },
+    "0:0:4a": {
+      "id": "0:0:4a", "crate_id": 0, "name": "InvalidLength", "visibility": "default",
+      "inner": {"variant": {"kind": {"plain": {}}}}
+    },
+    "0:0:4b": {
+      "id": "0:0:4b", "crate_id": 0, "name": "InvalidChar", "visibility": "default",
+      "inner": {"variant": {"kind": {"tuple": ["0:0:4b0"]}}}
+    },
+    "0:0:4b0": {
+      "id": "0:0:4b0", "crate_id": 0, "name": "0", "visibility": "default",
+      "inner": {"struct_field": {"primitive": "u8"}}
+    },
+    "0:0:4c": {
+      "id": "0:0:4c", "crate_id": 0, "name": "Custom", "visibility": "default",
+      "inner": {"variant": {"kind": {"struct": {"fields": ["0:0:4c0"], "has_stripped_fields": false}}}}
+    },
+    "0:0:4c0": {
+      "id": "0:0:4c0", "crate_id": 0, "name": "code", "visibility": "default",
+      "inner": {"struct_field": {"primitive": "u32"}}
+    },
+    "0:0:6": {
+      "id": "0:0:6", "crate_id": 0, "name": "Bytes", "visibility": "public",
+      "inner": {"type_alias": {"type": {"resolved_path": {"id":"std:Vec","path":"alloc::vec::Vec"}}, "generics": {"params": [], "where_predicates": []}}}
+    },
+    "0:0:7": {
+      "id": "0:0:7", "crate_id": 0, "name": "MAX_LENGTH", "visibility": "public",
+      "inner": {"constant": {"type": {"primitive": "usize"}, "const": {"expr": "1024", "value": "1024", "is_literal": true}}}
+    },
+    "0:0:8": {
+      "id": "0:0:8", "crate_id": 0, "name": "decode_to_slice", "visibility": "public",
+      "inner": {"function": {
+        "sig": {"inputs": [], "is_c_variadic": false},
+        "generics": {"params": [{"name": "T", "kind": {"type": {"bounds": [], "synthetic": false}}}], "where_predicates": []},
+        "header": {"is_const": false, "is_unsafe": false, "is_async": false, "abi": "Rust"},
+        "has_body": true
+      }}
+    },
+    "0:0:9": {
+      "id": "0:0:9", "crate_id": 0, "name": "as_str_unchecked", "visibility": "public",
+      "inner": {"function": {
+        "sig": {"inputs": [], "is_c_variadic": false},
+        "generics": {"params": [], "where_predicates": []},
+        "header": {"is_const": false, "is_unsafe": true, "is_async": false, "abi": "Rust"},
+        "has_body": true
+      }}
+    },
+    "0:0:10": {
+      "id": "0:0:10", "crate_id": 0, "name": "internal_helper", "visibility": "default",
+      "inner": {"function": {
+        "sig": {"inputs": [], "is_c_variadic": false},
+        "generics": {"params": [], "where_predicates": []},
+        "header": {"is_const": false, "is_unsafe": false, "is_async": false, "abi": "Rust"},
+        "has_body": true
+      }}
+    },
+    "0:0:11": {
+      "id": "0:0:11", "crate_id": 0, "name": "FromHex", "visibility": "public",
+      "inner": {"trait": {"is_auto": false, "is_unsafe": false, "items": [], "generics": {"params": [], "where_predicates": []}, "bounds": []}}
+    }
+  },
+  "paths": {
+    "0:0:0": {"crate_id": 0, "path": ["hex"], "kind": "module"}
+  },
+  "external_crates": {},
+  "format_version": 39
+}`
+
+func parseHexDoc(t *testing.T) *Document {
+	t.Helper()
+	doc, err := Parse(strings.NewReader(hexlikeDoc))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	return doc
+}
+
+func TestWalkHexLike(t *testing.T) {
+	doc := parseHexDoc(t)
+	surface, err := Walk(doc)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if surface.CrateName != "hex" {
+		t.Errorf("CrateName = %q", surface.CrateName)
+	}
+	if surface.CrateVersion != "0.4.3" {
+		t.Errorf("CrateVersion = %q", surface.CrateVersion)
+	}
+	if surface.FormatVersion != 39 {
+		t.Errorf("FormatVersion = %d", surface.FormatVersion)
+	}
+	if got := len(surface.Functions); got != 2 {
+		t.Errorf("len(Functions) = %d; want 2 (encode, decode)", got)
+	}
+	if got := len(surface.Structs); got != 1 {
+		t.Errorf("len(Structs) = %d; want 1 (FromHexError)", got)
+	}
+	if got := len(surface.Enums); got != 1 {
+		t.Errorf("len(Enums) = %d; want 1 (FromHexErrorKind)", got)
+	}
+	if got := len(surface.TypeAliases); got != 1 {
+		t.Errorf("len(TypeAliases) = %d; want 1 (Bytes)", got)
+	}
+	if got := len(surface.Constants); got != 1 {
+		t.Errorf("len(Constants) = %d; want 1 (MAX_LENGTH)", got)
+	}
+	if got := len(surface.Traits); got != 1 {
+		t.Errorf("len(Traits) = %d; want 1 (FromHex)", got)
+	}
+}
+
+func TestWalkHexLikeSkipReasons(t *testing.T) {
+	doc := parseHexDoc(t)
+	surface, err := Walk(doc)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	reasonCounts := map[errors.SkipReason]int{}
+	for _, sr := range surface.Skipped {
+		reasonCounts[sr.Reason]++
+	}
+	if reasonCounts[errors.SkipGeneric] != 1 {
+		t.Errorf("SkipGeneric count = %d; want 1 (decode_to_slice)", reasonCounts[errors.SkipGeneric])
+	}
+	if reasonCounts[errors.SkipExternFnUnsafe] != 1 {
+		t.Errorf("SkipExternFnUnsafe count = %d; want 1 (as_str_unchecked)", reasonCounts[errors.SkipExternFnUnsafe])
+	}
+	if reasonCounts[errors.SkipTrait] != 1 {
+		t.Errorf("SkipTrait count = %d; want 1 (FromHex)", reasonCounts[errors.SkipTrait])
+	}
+}
+
+func TestWalkHexLikeFunctionEncode(t *testing.T) {
+	doc := parseHexDoc(t)
+	surface, err := Walk(doc)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	var encode *FunctionEntry
+	for i := range surface.Functions {
+		if surface.Functions[i].Path[len(surface.Functions[i].Path)-1] == "encode" {
+			encode = &surface.Functions[i]
+			break
+		}
+	}
+	if encode == nil {
+		t.Fatalf("no encode function in surface")
+	}
+	if len(encode.Inputs) != 1 {
+		t.Errorf("encode inputs = %d; want 1", len(encode.Inputs))
+	}
+	if encode.Inputs[0].Name != "bytes" {
+		t.Errorf("encode input name = %q", encode.Inputs[0].Name)
+	}
+	if encode.Inputs[0].Type.Kind() != "borrowed_ref" {
+		t.Errorf("encode input type = %s; want borrowed_ref", encode.Inputs[0].Type.Kind())
+	}
+}
+
+func TestWalkHexLikeEnumVariants(t *testing.T) {
+	doc := parseHexDoc(t)
+	surface, err := Walk(doc)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(surface.Enums) != 1 {
+		t.Fatalf("len(Enums) = %d; want 1", len(surface.Enums))
+	}
+	e := surface.Enums[0]
+	if len(e.Variants) != 3 {
+		t.Fatalf("variants = %d; want 3", len(e.Variants))
+	}
+	got := map[string]string{}
+	for _, v := range e.Variants {
+		got[v.Name] = v.Kind
+	}
+	if got["InvalidLength"] != "plain" {
+		t.Errorf("InvalidLength kind = %q; want plain", got["InvalidLength"])
+	}
+	if got["InvalidChar"] != "tuple" {
+		t.Errorf("InvalidChar kind = %q; want tuple", got["InvalidChar"])
+	}
+	if got["Custom"] != "struct" {
+		t.Errorf("Custom kind = %q; want struct", got["Custom"])
+	}
+}
+
+func TestWalkHexLikePathRendering(t *testing.T) {
+	doc := parseHexDoc(t)
+	surface, err := Walk(doc)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	for _, fn := range surface.Functions {
+		if len(fn.Path) < 2 {
+			t.Errorf("function path too short: %v", fn.Path)
+		}
+		if fn.Path[0] != "hex" {
+			t.Errorf("function path[0] = %q; want hex", fn.Path[0])
+		}
+	}
+	for _, sk := range surface.Skipped {
+		if !strings.HasPrefix(sk.ItemPath, "hex::") {
+			t.Errorf("skip path = %q; want hex:: prefix", sk.ItemPath)
+		}
+	}
+}
+
+func TestWalkHexLikeSkipsNonPublic(t *testing.T) {
+	doc := parseHexDoc(t)
+	surface, err := Walk(doc)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	for _, fn := range surface.Functions {
+		if fn.Path[len(fn.Path)-1] == "internal_helper" {
+			t.Errorf("internal_helper should not appear in surface")
+		}
+	}
+}
+
+func TestWalkSnapshot(t *testing.T) {
+	doc := parseHexDoc(t)
+	surface, _ := Walk(doc)
+	got := surface.Snapshot()
+	want := Counts{Functions: 2, Structs: 1, Enums: 1, TypeAliases: 1, Constants: 1, Traits: 1, Skipped: 3}
+	if got != want {
+		t.Errorf("Snapshot = %+v; want %+v", got, want)
+	}
+}
+
+func TestWalkSortSkippedDeterministic(t *testing.T) {
+	doc := parseHexDoc(t)
+	surface, _ := Walk(doc)
+	surface.SortSkipped()
+	for i := 1; i < len(surface.Skipped); i++ {
+		if surface.Skipped[i-1].ItemPath > surface.Skipped[i].ItemPath {
+			t.Errorf("SortSkipped not ascending: %q > %q",
+				surface.Skipped[i-1].ItemPath, surface.Skipped[i].ItemPath)
+		}
+	}
+}
+
+func TestWalkNilDoc(t *testing.T) {
+	if _, err := Walk(nil); err == nil {
+		t.Errorf("Walk(nil) err = nil; want error")
+	}
+}
+
+func TestWalkMissingRoot(t *testing.T) {
+	doc := &Document{Root: "missing", FormatVersion: 39, Index: map[string]Item{}}
+	if _, err := Walk(doc); err == nil {
+		t.Errorf("Walk(missing root) err = nil; want error")
+	}
+}

--- a/website/docs/implementation/0073/index.md
+++ b/website/docs/implementation/0073/index.md
@@ -16,8 +16,8 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | Phase | Title | Status | Commit | Tracking page |
 |-------|-------|--------|--------|---------------|
 | 0 | Skeleton: package3/rust/ layout + cargo workspace plumbing | LANDED | [2dc3b34f](https://github.com/mochilang/mochi/commit/2dc3b34f) | [phase-00](/docs/implementation/0073/phase-00-skeleton) |
-| 1 | Sparse-index client (`index.crates.io` reader, sha256 + blake3 download verify) | LANDED | (pending) | [phase-01](/docs/implementation/0073/phase-01-sparse-index) |
-| 2 | Rustdoc-JSON ingest + ApiSurface emit | NOT STARTED | — | [phase-02](/docs/implementation/0073/phase-02-rustdoc-ingest) |
+| 1 | Sparse-index client (`index.crates.io` reader, sha256 + blake3 download verify) | LANDED | [a3c263fb](https://github.com/mochilang/mochi/commit/a3c263fb) | [phase-01](/docs/implementation/0073/phase-01-sparse-index) |
+| 2 | Rustdoc-JSON ingest + ApiSurface emit | LANDED | (pending) | [phase-02](/docs/implementation/0073/phase-02-rustdoc-ingest) |
 | 3 | Closed type-mapping table (scalars / strings / collections / Option / Result / Tuple / Struct / Enum) | NOT STARTED | — | [phase-03](/docs/implementation/0073/phase-03-type-mapping) |
 | 4 | Wrapper crate synthesiser (extern "C" surface, MochiString / MochiSlice / opaque handles) | NOT STARTED | — | [phase-04](/docs/implementation/0073/phase-04-wrapper) |
 | 5 | Mochi-side extern fn emitter + alias shim file generation | NOT STARTED | — | [phase-05](/docs/implementation/0073/phase-05-extern-emit) |
@@ -59,7 +59,7 @@ package3/rust/
   build/                  # Workspace + Driver + Cargo.toml renderer (phase 0)
   semver/                 # cargo-flavoured semver parser (phase 1)
   sparse/                 # sparse-index client + content-addressed cache (phase 1)
-  rustdoc/                # rustdoc-types Go parser (phase 2)
+  rustdoc/                # rustdoc-types Go parser + ApiSurface walker (phase 2)
   typemap/                # closed type table (phase 3)
   wrapper/                # extern-C wrapper synthesiser (phase 4)
   emit/                   # Mochi extern fn emitter (phase 5)
@@ -71,7 +71,7 @@ The `package3/rust/` location is shared with the broader MEP-57 polyglot package
 
 ## Status snapshot
 
-As of 2026-05-29 21:06 (GMT+7): phases 0 and 1 LANDED (skeleton + sparse-index client + cargo-flavoured semver). Phases 2-13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
+As of 2026-05-29 21:17 (GMT+7): phases 0, 1, and 2 LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest). Phases 3-13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
 
 ## Cross-references
 

--- a/website/docs/implementation/0073/phase-02-rustdoc-ingest.md
+++ b/website/docs/implementation/0073/phase-02-rustdoc-ingest.md
@@ -1,0 +1,108 @@
+---
+title: "Phase 2. Rustdoc-JSON ingest"
+sidebar_position: 4
+sidebar_label: "Phase 2. Rustdoc-JSON ingest"
+description: "MEP-73 Phase 2 lands the package3/rust/rustdoc/ Go parser: rustdoc-types schema (format_version 37-39), Document / Item / Type discriminated unions, walker that emits an ApiSurface with public Function / Struct / Enum / TypeAlias / Constant / Trait entries plus SkipReports for everything else."
+---
+
+# Phase 2. Rustdoc-JSON ingest
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-73 §Phases](/docs/mep/mep-0073#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-29 21:08 (GMT+7) |
+| Landed         | 2026-05-29 21:17 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`package3/rust/rustdoc/` parses a rustdoc-json document produced by `cargo +nightly rustdoc --output-format=json` against the `rustdoc-types` schema (format_version 37-39, the May 2026 nightly range), walks the public-item tree from the crate root, and emits an `ApiSurface` carrying flat per-kind slices of `FunctionEntry`, `StructEntry`, `EnumEntry`, `TypeAliasEntry`, `ConstantEntry`, and `TraitEntry`, plus a `Skipped []errors.SkipReport` slice that classifies every refusal.
+
+A hand-written fixture modelled after the `hex` crate (one of the 24 MEP-73 fixture crates) exercises the walker end to end. The fixture asserts:
+
+- 2 functions (`encode`, `decode`) lifted into the surface.
+- 1 unit struct (`FromHexError`).
+- 1 enum (`FromHexErrorKind`) with three variants of three different kinds (plain / tuple / struct).
+- 1 type alias (`Bytes`).
+- 1 constant (`MAX_LENGTH`).
+- 1 trait (`FromHex`) recorded with a `SkipTrait` skip.
+- 1 `SkipGeneric` for a generic fn (`decode_to_slice<T>`).
+- 1 `SkipExternFnUnsafe` for an `unsafe fn` (`as_str_unchecked`).
+- A non-public helper fn (`internal_helper`, visibility="default") must NOT appear in the surface.
+
+41 test functions across `parse_test.go`, `type_test.go`, and `walk_test.go` cover the schema and walker. Total package count after phase 2: 5 (errors, build, semver, sparse, rustdoc).
+
+## Lowering decisions
+
+### Schema-versioning policy
+
+The bridge accepts `format_version` 37, 38, and 39. Versions outside the range fail at `Parse` time with `*ErrUnsupportedFormatVersion` (`errors.As`-friendly), so a nightly-toolchain bump that produces a newer schema is caught at lock time rather than silently producing wrong output. Cargo's rustdoc team bumps the schema roughly every 2-3 months as new `ItemEnum` / `Type` variants stabilise; the bridge release notes add the new version to `SupportedFormatVersions` only after the fixture corpus has been re-verified.
+
+The choice of 37 as the lower bound matches the rust-1.85 nightly (Q1 2026), the same window MEP-73 §"Schema version compatibility" pins. Versions 36 and earlier renamed `function` to `fn` and `type_alias` to `typedef`, so backwards compatibility would require synonym handling. The bridge instead asks the user to upgrade their nightly toolchain (the `--rust-nightly=auto` mode in Phase 7 will install the supported nightly automatically).
+
+### Discriminated-union shape
+
+The `rustdoc-types` `ItemEnum` and `Type` are tagged unions of the shape `{"tag": payload}`. The Go parser models each as a single struct with one pointer field per variant (`Module *ModuleItem`, `Function *FunctionItem`, etc.) and a custom `UnmarshalJSON` that dispatches on the (alphabetically-first) tag key. Unknown variants do not error: they populate an `Unknown string` field so the walker can produce a precise `SkipReport` instead of failing the parse. This matches the design philosophy in research note 02 §3 ("Refuse, don't approximate") and §6 ("Schema drift must surface as a SkipReport, not a crash").
+
+The same shape covers the `Type` variants: `resolved_path`, `dyn_trait`, `generic`, `primitive`, `function_pointer`, `tuple`, `slice`, `array`, `pat`, `impl_trait`, `infer`, `raw_pointer`, `borrowed_ref`, `qualified_path`, plus an `Unknown` catch-all. The 20-variant SkipReason enum from Phase 0 already covers every refusal class the walker can produce.
+
+### Visibility handling
+
+`Visibility` is a sum of `public`, `default` (crate-private), `crate` (the `pub(crate)` legacy form), and `restricted` (`pub(in path)`). The wire format is either a bare string `"public"`/`"default"` or a tagged object `{"crate": "..."}`/`{"restricted": {...}}`. The Go type carries a `Kind` enum + a `Path` field for the restricted/crate forms. The walker uses `IsPublic()` as the gating filter; only public items reach the surface (with the one exception that modules are walked regardless of their own visibility, because a `pub` item nested in a `pub(crate)` module still needs to be discoverable via re-export).
+
+### Function input shape
+
+Rustdoc emits function parameters as a 2-tuple `["name", Type]` rather than an object. The `FunctionInput` type has a custom `UnmarshalJSON` that splits the array and populates `Name` and `Type`. The test suite pins this with both the happy path (`["bytes", {"primitive":"u8"}]`) and the wrong-shape (object) negative case, so a future schema change to an object form will surface immediately.
+
+### Walker classification
+
+The walker classifies each public item by `Inner.Kind()`:
+
+- `module`: recurse into `Module.Items`.
+- `function`: emit unless generic, unsafe, or non-standard ABI; otherwise emit a `SkipReport` with the matching reason (`SkipGeneric`, `SkipExternFnUnsafe`, `SkipCustomAbi`).
+- `struct`: emit unless generic; otherwise `SkipGeneric`. Plain / tuple / unit structs are distinguished via the `StructKind` discriminator.
+- `enum`: emit unless generic. Variants are collected with their `plain`/`tuple`/`struct` shape preserved.
+- `type_alias`: emit unless generic.
+- `constant`: emit always (constants don't have generic params at the alias level).
+- `trait`: record a `TraitEntry` but also emit a `SkipTrait` skip, because the v1 bridge does not generate trait bindings (concrete impls land in Phase 4).
+- `use`: follow the re-export's target ID transparently.
+- `extern_crate`, `primitive`, `static`, `macro`, `proc_macro`, `impl`, `assoc_const`, `assoc_type`, `variant`, `struct_field`: emit a skip.
+
+Generic items always skip in v1; Phase 12 (monomorphisation) will later enable concrete instantiations declared in `mochi.toml`. Unsafe fns and non-`Rust`/`C` ABIs always skip because the bridge requires explicit capability opt-in.
+
+### Determinism
+
+The walker visits items in `Module.Items` order (rustdoc emits a deterministic order). The `seen` map prevents revisiting on a cycle; `SortSkipped()` provides a stable lexicographic order for golden-file diffs in later phases.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/rust/rustdoc/document.go` | `Document`, `Item`, `Visibility`, `PathInfo`, `Span`, `Deprecation`, `ExternalCrate`, `TargetInfo` |
+| `package3/rust/rustdoc/item.go` | `ItemEnum` with 18 variants plus `Unknown`, payload types for each variant, `FunctionInput` custom unmarshal, `ABI` custom unmarshal |
+| `package3/rust/rustdoc/type.go` | `Type` with 14 variants plus `Unknown`, `Generics`, `GenericParamDef`, `GenericArgs`, `GenericBound`, `WherePredicate`, `PolyTrait`, `QualifiedPathType`, `BorrowedRefType`, `RawPointerType`, `ArrayType`, `ConstValue` |
+| `package3/rust/rustdoc/parse.go` | `Parse(io.Reader)`, `ParseBytes([]byte)`, `SupportedFormatVersions`, `ErrUnsupportedFormatVersion` |
+| `package3/rust/rustdoc/surface.go` | `ApiSurface`, `FunctionEntry`, `StructEntry`, `EnumEntry`, `TypeAliasEntry`, `ConstantEntry`, `TraitEntry`, `FieldEntry`, `VariantEntry`, `ParamEntry`, internal `skip` helper |
+| `package3/rust/rustdoc/walk.go` | `Walk(*Document) (*ApiSurface, error)`, internal walker state, per-kind emitters, `Snapshot` + `SortSkipped` |
+| `package3/rust/rustdoc/parse_test.go` | minimal-doc parse, version-range rejection, visibility variants |
+| `package3/rust/rustdoc/type_test.go` | 13 Type-variant unmarshal cases including `Unknown` catch-all, ABI variants, FunctionInput shape |
+| `package3/rust/rustdoc/walk_test.go` | hex-like fixture: counts, skip reasons, function encode shape, enum variant kinds, path rendering, non-public exclusion, snapshot, sort determinism, nil/missing-root errors |
+
+## Test set
+
+- All `package3/rust/rustdoc/...` unit tests (41 functions).
+
+Total: 41 test functions, all green via `go test ./package3/rust/rustdoc/...`.
+
+## Closeout notes
+
+Phase 2 introduces no new external runtime dependencies; only `encoding/json` from the stdlib plus the existing `mochi/package3/rust/errors` package. The schema-version compatibility range (37-39) is hard-coded as constants so a release-note review must accompany any change.
+
+The `hex`-like fixture is a hand-written document, not a captured `cargo rustdoc` output, because Phase 1 (sparse-index client) has not yet been wired to a sparse-index fetch path in CI. Phase 7 will add a CI smoke test that runs `cargo +nightly rustdoc` against a real fixture crate and feeds the output through `Parse + Walk`; until then, the hand-written fixture pins the parser shape and the walker behaviour against the spec's documented variant set.
+
+The `Unknown` catch-all on both `ItemEnum` and `Type` is intentional. When the May 2027 nightly adds a new variant (rust-lang/rust adds 1-2 per cycle), the bridge will not crash, will not silently drop the affected item, and will produce a `SkipReport` with `Reason=SkipUnknown` plus a `Detail` string naming the unknown tag. The user gets a clear "this rustdoc-types tag is not modelled yet" diagnostic and a directive to upgrade Mochi or add a bridge release that ranges over the new version.
+
+Phase 3 (closed type-mapping table) consumes the `ApiSurface`'s `Type` values and emits Mochi `extern type` declarations; the `Type.Kind()` discriminator and the per-variant payload structs are the contract Phase 3 builds against.

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -306,8 +306,15 @@
     "label": "MEP-73 phases",
     "items": [
       "implementation/0073/phase-00-skeleton",
-      "implementation/0073/phase-01-sparse-index"
+      "implementation/0073/phase-01-sparse-index",
+      "implementation/0073/phase-02-rustdoc-ingest"
     ]
   },
-  "implementation/0074/index"
+  "implementation/0074/index",
+  {
+    "label": "MEP-74 phases",
+    "items": [
+      "implementation/0074/phase-00-skeleton"
+    ]
+  }
 ]


### PR DESCRIPTION
Closes #22748.

## Summary

- Adds `package3/rust/rustdoc/`: Go parser for the rustdoc-types schema (format_version 37-39) plus an ApiSurface walker that classifies public items and records SkipReports for every refusal.
- Models the full ItemEnum (18 variants) and Type (14 variants) discriminated unions with Unknown catch-alls so future rustdoc schema additions degrade gracefully.
- Walker emits FunctionEntry / StructEntry / EnumEntry / TypeAliasEntry / ConstantEntry / TraitEntry; gates generic / unsafe / non-standard-ABI functions behind SkipGeneric / SkipExternFnUnsafe / SkipCustomAbi.

## Test plan

- [x] `go test ./package3/rust/rustdoc/...` (41 functions across parse_test.go, type_test.go, walk_test.go) green.
- [x] `go test ./package3/rust/...` (all 5 rust packages: errors, build, semver, sparse, rustdoc) green.
- [x] Schema-version range (37-39) pinned with errors.As-friendly ErrUnsupportedFormatVersion; format_version=1 and =99 both rejected.
- [x] hex-like fixture asserts 2 functions, 1 struct, 1 enum (3 variant kinds), 1 type alias, 1 constant, 1 trait + SkipTrait, plus SkipGeneric + SkipExternFnUnsafe + non-public exclusion.
- [x] Phase tracking page added at `website/docs/implementation/0073/phase-02-rustdoc-ingest.md`; index updated to mark phases 0-2 LANDED.

Part of MEP-73 multi-phase delivery (see `website/docs/implementation/0073/index.md`).