### PR TITLE
MEP-74 phase 1: proxy.golang.org module-proxy client

### DIFF
--- a/package3/go/moduleproxy/cache.go
+++ b/package3/go/moduleproxy/cache.go
@@ -1,0 +1,268 @@
+package moduleproxy
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// CacheLayout describes the on-disk layout of the module proxy cache.
+//
+// The layout mirrors Go's own download cache under GOMODCACHE/cache/download,
+// keyed by escaped module path + escaped version + artifact kind:
+//
+//	<root>/<escaped-modpath>/@v/<escaped-version>.info
+//	<root>/<escaped-modpath>/@v/<escaped-version>.mod
+//	<root>/<escaped-modpath>/@v/<escaped-version>.zip
+//	<root>/<escaped-modpath>/@v/<escaped-version>.ziphash
+//
+// The ziphash file holds the h1: digest of the zip, which doubles as the
+// integrity record consumed by the sumdb phase. The mod file is kept
+// alongside but its own h1: digest is *not* stored here (it is derived
+// on demand via HashGoMod, so writes can be a single round-trip).
+//
+// Roots are deterministic across machines: the same module@version always
+// lands at the same relative path. The cache is safe for concurrent use
+// across processes because every artifact write is atomic (write to
+// temp file then rename), and concurrent readers see either the old
+// file or the new one but never a partial write.
+type CacheLayout struct {
+	// Root is the absolute directory under which cache files are written.
+	Root string
+}
+
+// NewCache returns a CacheLayout rooted under the given directory. If
+// root is empty the layout falls back to the user's default cache
+// directory (XDG_CACHE_HOME on Linux/BSD, ~/Library/Caches on macOS,
+// %LocalAppData% on Windows) under a "mochi-go-bridge/modules"
+// subdirectory.
+func NewCache(root string) (*CacheLayout, error) {
+	if root == "" {
+		def, err := defaultCacheRoot()
+		if err != nil {
+			return nil, err
+		}
+		root = def
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("moduleproxy: cache root abs: %w", err)
+	}
+	if err := os.MkdirAll(abs, 0o755); err != nil {
+		return nil, fmt.Errorf("moduleproxy: mkdir cache root: %w", err)
+	}
+	return &CacheLayout{Root: abs}, nil
+}
+
+// InfoPath returns the on-disk path for the .info JSON of module@version.
+func (c *CacheLayout) InfoPath(modulePath, version string) (string, error) {
+	return c.artifactPath(modulePath, version, "info")
+}
+
+// ModPath returns the on-disk path for the .mod of module@version.
+func (c *CacheLayout) ModPath(modulePath, version string) (string, error) {
+	return c.artifactPath(modulePath, version, "mod")
+}
+
+// ZipPath returns the on-disk path for the .zip of module@version.
+func (c *CacheLayout) ZipPath(modulePath, version string) (string, error) {
+	return c.artifactPath(modulePath, version, "zip")
+}
+
+// ZipHashPath returns the on-disk path for the .ziphash sidecar.
+func (c *CacheLayout) ZipHashPath(modulePath, version string) (string, error) {
+	return c.artifactPath(modulePath, version, "ziphash")
+}
+
+func (c *CacheLayout) artifactPath(modulePath, version, ext string) (string, error) {
+	escMod, err := EscapePath(modulePath)
+	if err != nil {
+		return "", err
+	}
+	escVer, err := EscapeVersion(version)
+	if err != nil {
+		return "", err
+	}
+	// Replace OS path separators inside the escaped module path with
+	// the platform separator. The escaped form is always "/"-delimited,
+	// so on windows we need to translate. filepath.FromSlash handles
+	// this.
+	return filepath.Join(c.Root, filepath.FromSlash(escMod), "@v", escVer+"."+ext), nil
+}
+
+// WriteFile writes data to dst atomically. Parents are created as needed.
+// The temporary file is in the same directory as dst so the rename is
+// guaranteed to be atomic on POSIX and same-volume on Windows.
+func WriteFile(dst string, data []byte, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("moduleproxy: mkdir for %s: %w", dst, err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), "."+filepath.Base(dst)+".tmp.")
+	if err != nil {
+		return fmt.Errorf("moduleproxy: create temp for %s: %w", dst, err)
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if any step below fails.
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
+		return fmt.Errorf("moduleproxy: write %s: %w", dst, err)
+	}
+	if err := tmp.Chmod(mode); err != nil && runtime.GOOS != "windows" {
+		cleanup()
+		return fmt.Errorf("moduleproxy: chmod %s: %w", dst, err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("moduleproxy: close %s: %w", dst, err)
+	}
+	if err := os.Rename(tmpName, dst); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("moduleproxy: rename %s: %w", dst, err)
+	}
+	return nil
+}
+
+// StoreZip writes the zip body for module@version into the cache and
+// records its h1: digest in the sidecar .ziphash file. The zip body is
+// streamed from src; src must produce the entire body for HashZip to
+// validate prefix entries.
+//
+// StoreZip is verify-on-store: if the entries inside the zip do not all
+// share the "<modulePath>@<version>/" prefix, the function returns an
+// error and the zip is *not* persisted.
+func (c *CacheLayout) StoreZip(modulePath, version string, src io.Reader) (string, error) {
+	zipPath, err := c.ZipPath(modulePath, version)
+	if err != nil {
+		return "", err
+	}
+	buf, err := io.ReadAll(src)
+	if err != nil {
+		return "", fmt.Errorf("moduleproxy: read zip body: %w", err)
+	}
+	digest, err := HashZip(bytes.NewReader(buf), modulePath, version)
+	if err != nil {
+		return "", err
+	}
+	if err := WriteFile(zipPath, buf, 0o644); err != nil {
+		return "", err
+	}
+	hashPath, err := c.ZipHashPath(modulePath, version)
+	if err != nil {
+		return "", err
+	}
+	if err := WriteFile(hashPath, []byte(digest+"\n"), 0o644); err != nil {
+		return "", err
+	}
+	return digest, nil
+}
+
+// StoreMod writes the go.mod body for module@version into the cache.
+// Returns the h1: digest of the mod file (which is the "<v>/go.mod"
+// line later written into go.sum).
+func (c *CacheLayout) StoreMod(modulePath, version string, modBytes []byte) (string, error) {
+	modPath, err := c.ModPath(modulePath, version)
+	if err != nil {
+		return "", err
+	}
+	if err := WriteFile(modPath, modBytes, 0o644); err != nil {
+		return "", err
+	}
+	return HashGoMod(modBytes), nil
+}
+
+// StoreInfo writes the raw .info JSON body into the cache.
+func (c *CacheLayout) StoreInfo(modulePath, version string, infoBytes []byte) error {
+	infoPath, err := c.InfoPath(modulePath, version)
+	if err != nil {
+		return err
+	}
+	return WriteFile(infoPath, infoBytes, 0o644)
+}
+
+// Has returns true if every artifact (info, mod, zip, ziphash) for
+// module@version exists in the cache.
+func (c *CacheLayout) Has(modulePath, version string) bool {
+	for _, ext := range []string{"info", "mod", "zip", "ziphash"} {
+		p, err := c.artifactPath(modulePath, version, ext)
+		if err != nil {
+			return false
+		}
+		if _, err := os.Stat(p); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// VerifyZip recomputes the h1: digest of the on-disk zip and compares
+// it against the stored .ziphash sidecar. Returns ErrCacheCorrupt if
+// the file is missing or the digest no longer matches.
+func (c *CacheLayout) VerifyZip(modulePath, version string) error {
+	zipPath, err := c.ZipPath(modulePath, version)
+	if err != nil {
+		return err
+	}
+	hashPath, err := c.ZipHashPath(modulePath, version)
+	if err != nil {
+		return err
+	}
+	zipBytes, err := os.ReadFile(zipPath)
+	if err != nil {
+		return fmt.Errorf("%w: read zip: %v", ErrCacheCorrupt, err)
+	}
+	want, err := os.ReadFile(hashPath)
+	if err != nil {
+		return fmt.Errorf("%w: read ziphash: %v", ErrCacheCorrupt, err)
+	}
+	wantStr := strings.TrimSpace(string(want))
+	got, err := HashZip(bytes.NewReader(zipBytes), modulePath, version)
+	if err != nil {
+		return fmt.Errorf("%w: rehash: %v", ErrCacheCorrupt, err)
+	}
+	if got != wantStr {
+		return fmt.Errorf("%w: %s@%s digest mismatch: got %s, want %s",
+			ErrCacheCorrupt, modulePath, version, got, wantStr)
+	}
+	return nil
+}
+
+// ErrCacheCorrupt is returned when a cached artifact fails its
+// integrity check. Callers should typically delete the corresponding
+// files and refetch.
+var ErrCacheCorrupt = errors.New("moduleproxy: cache corrupt")
+
+// FingerprintBytes returns a stable lowercase hex sha256 of data. It
+// is independent of the h1: dirhash; it is suitable for short
+// content-fingerprinting where the dirhash framing would be overkill
+// (e.g. logging, test assertions).
+func FingerprintBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// defaultCacheRoot picks a per-OS default directory for the bridge's
+// module cache. It does *not* reach into the Go toolchain's GOMODCACHE
+// because the bridge cache is conceptually separate (different
+// integrity policy, different layout guarantees).
+func defaultCacheRoot() (string, error) {
+	if env := os.Getenv("MOCHI_GO_BRIDGE_CACHE"); env != "" {
+		return env, nil
+	}
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("moduleproxy: locate user cache dir: %w", err)
+	}
+	return filepath.Join(dir, "mochi-go-bridge", "modules"), nil
+}
+

--- a/package3/go/moduleproxy/cache_test.go
+++ b/package3/go/moduleproxy/cache_test.go
@@ -1,0 +1,241 @@
+package moduleproxy
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCachePathsEscapeUppercase(t *testing.T) {
+	c := &CacheLayout{Root: t.TempDir()}
+	got, err := c.InfoPath("github.com/Spf13/Cobra", "v1.0.0")
+	if err != nil {
+		t.Fatalf("InfoPath: %v", err)
+	}
+	// Path should contain the escaped form "!spf13" / "!cobra".
+	if !strings.Contains(got, "!spf13") || !strings.Contains(got, "!cobra") {
+		t.Errorf("InfoPath did not escape upper-case path: %q", got)
+	}
+	if !strings.HasSuffix(got, "v1.0.0.info") {
+		t.Errorf("InfoPath suffix wrong: %q", got)
+	}
+}
+
+func TestCachePathsEscapeVersion(t *testing.T) {
+	c := &CacheLayout{Root: t.TempDir()}
+	got, err := c.ModPath("x", "v1.0.0-Pre")
+	if err != nil {
+		t.Fatalf("ModPath: %v", err)
+	}
+	if !strings.HasSuffix(got, "v1.0.0-!pre.mod") {
+		t.Errorf("ModPath version not escaped: %q", got)
+	}
+}
+
+func TestStoreZipRoundTrip(t *testing.T) {
+	c := &CacheLayout{Root: t.TempDir()}
+	zipBytes := mustBuildZip(t, map[string]string{
+		"example.com/foo@v1.2.3/main.go": "package main\n",
+		"example.com/foo@v1.2.3/go.mod":  "module example.com/foo\n\ngo 1.21\n",
+	})
+	digest, err := c.StoreZip("example.com/foo", "v1.2.3", bytes.NewReader(zipBytes))
+	if err != nil {
+		t.Fatalf("StoreZip: %v", err)
+	}
+	if !strings.HasPrefix(digest, "h1:") {
+		t.Errorf("digest missing h1: prefix: %q", digest)
+	}
+	if _, err := c.StoreMod("example.com/foo", "v1.2.3", []byte("module example.com/foo\n\ngo 1.21\n")); err != nil {
+		t.Fatalf("StoreMod: %v", err)
+	}
+	if err := c.StoreInfo("example.com/foo", "v1.2.3", []byte(`{"Version":"v1.2.3"}`)); err != nil {
+		t.Fatalf("StoreInfo: %v", err)
+	}
+	if !c.Has("example.com/foo", "v1.2.3") {
+		t.Errorf("cache.Has returned false after StoreZip + StoreMod + StoreInfo")
+	}
+	if err := c.VerifyZip("example.com/foo", "v1.2.3"); err != nil {
+		t.Errorf("VerifyZip after StoreZip: %v", err)
+	}
+}
+
+func TestHasReturnsFalseWhenAnyArtifactMissing(t *testing.T) {
+	c := &CacheLayout{Root: t.TempDir()}
+	if c.Has("x", "v1") {
+		t.Errorf("Has on empty cache returned true")
+	}
+	// Stash only the .info and confirm Has still returns false.
+	if err := c.StoreInfo("x", "v1", []byte(`{"Version":"v1"}`)); err != nil {
+		t.Fatalf("StoreInfo: %v", err)
+	}
+	if c.Has("x", "v1") {
+		t.Errorf("Has returned true with only info present")
+	}
+}
+
+func TestStoreZipRejectsMismatchedPrefix(t *testing.T) {
+	c := &CacheLayout{Root: t.TempDir()}
+	zipBytes := mustBuildZip(t, map[string]string{
+		"WRONGPATH/main.go": "package main\n",
+	})
+	_, err := c.StoreZip("example.com/foo", "v1.0.0", bytes.NewReader(zipBytes))
+	if err == nil {
+		t.Errorf("StoreZip accepted mismatched-prefix zip; want error")
+	}
+	// And the artifact must not exist on disk after the rejection.
+	zp, _ := c.ZipPath("example.com/foo", "v1.0.0")
+	if _, statErr := os.Stat(zp); statErr == nil {
+		t.Errorf("StoreZip created %s despite hash failure", zp)
+	}
+}
+
+func TestVerifyZipDetectsTampering(t *testing.T) {
+	c := &CacheLayout{Root: t.TempDir()}
+	zipBytes := mustBuildZip(t, map[string]string{
+		"example.com/foo@v1/main.go": "package main\n",
+	})
+	if _, err := c.StoreZip("example.com/foo", "v1", bytes.NewReader(zipBytes)); err != nil {
+		t.Fatalf("StoreZip: %v", err)
+	}
+	// Overwrite the zip with different bytes; integrity must fail.
+	tampered := mustBuildZip(t, map[string]string{
+		"example.com/foo@v1/main.go": "package main\nvar x = 1\n",
+	})
+	zp, _ := c.ZipPath("example.com/foo", "v1")
+	if err := os.WriteFile(zp, tampered, 0o644); err != nil {
+		t.Fatalf("tamper write: %v", err)
+	}
+	err := c.VerifyZip("example.com/foo", "v1")
+	if err == nil {
+		t.Errorf("VerifyZip returned nil after tampering; want ErrCacheCorrupt")
+	}
+	if !errors.Is(err, ErrCacheCorrupt) {
+		t.Errorf("VerifyZip err = %v; want ErrCacheCorrupt", err)
+	}
+}
+
+func TestVerifyZipMissingFiles(t *testing.T) {
+	c := &CacheLayout{Root: t.TempDir()}
+	err := c.VerifyZip("x", "v1")
+	if !errors.Is(err, ErrCacheCorrupt) {
+		t.Errorf("VerifyZip on missing files = %v; want ErrCacheCorrupt", err)
+	}
+}
+
+func TestStoreModReturnsHashGoModDigest(t *testing.T) {
+	c := &CacheLayout{Root: t.TempDir()}
+	modBytes := []byte("module example.com/foo\n\ngo 1.21\n")
+	digest, err := c.StoreMod("example.com/foo", "v1.0.0", modBytes)
+	if err != nil {
+		t.Fatalf("StoreMod: %v", err)
+	}
+	if digest != HashGoMod(modBytes) {
+		t.Errorf("StoreMod digest %q != HashGoMod %q", digest, HashGoMod(modBytes))
+	}
+	// And the file must exist.
+	mp, _ := c.ModPath("example.com/foo", "v1.0.0")
+	got, err := os.ReadFile(mp)
+	if err != nil {
+		t.Fatalf("read stored mod: %v", err)
+	}
+	if !bytes.Equal(got, modBytes) {
+		t.Errorf("stored .mod body mismatch")
+	}
+}
+
+func TestWriteFileAtomic(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "sub", "out.txt")
+	if err := WriteFile(dst, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("WriteFile contents = %q; want hello", got)
+	}
+	// Confirm no leftover temp files in the directory.
+	entries, err := os.ReadDir(filepath.Dir(dst))
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".out.txt.tmp") {
+			t.Errorf("leftover temp file %q", e.Name())
+		}
+	}
+}
+
+func TestNewCacheCreatesRoot(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "cache")
+	c, err := NewCache(dir)
+	if err != nil {
+		t.Fatalf("NewCache: %v", err)
+	}
+	if c.Root != dir {
+		// On macOS t.TempDir can resolve through /var symlink; allow that.
+		abs, _ := filepath.Abs(dir)
+		if c.Root != abs {
+			t.Errorf("NewCache.Root = %q; want %q (or its abs form)", c.Root, dir)
+		}
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Errorf("Stat created cache root: %v", err)
+	} else if !info.IsDir() {
+		t.Errorf("cache root is not a directory")
+	}
+}
+
+func TestNewCacheRespectsEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("MOCHI_GO_BRIDGE_CACHE", dir)
+	c, err := NewCache("")
+	if err != nil {
+		t.Fatalf("NewCache: %v", err)
+	}
+	abs, _ := filepath.Abs(dir)
+	if c.Root != abs {
+		t.Errorf("NewCache(env) root = %q; want %q", c.Root, abs)
+	}
+}
+
+func TestFingerprintBytes(t *testing.T) {
+	got := FingerprintBytes([]byte("hello\n"))
+	// sha256("hello\n") = 5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
+	want := "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"
+	if got != want {
+		t.Errorf("FingerprintBytes = %q; want %q", got, want)
+	}
+}
+
+// Round-trip a real-looking zip through the cache and re-read it via
+// the standard library zip parser to make sure StoreZip did not
+// corrupt the body during atomic-write.
+func TestStoreZipPreservesBytes(t *testing.T) {
+	c := &CacheLayout{Root: t.TempDir()}
+	zipBytes := mustBuildZip(t, map[string]string{
+		"example.com/foo@v1/main.go": "package main\n",
+	})
+	if _, err := c.StoreZip("example.com/foo", "v1", bytes.NewReader(zipBytes)); err != nil {
+		t.Fatalf("StoreZip: %v", err)
+	}
+	zp, _ := c.ZipPath("example.com/foo", "v1")
+	got, err := os.ReadFile(zp)
+	if err != nil {
+		t.Fatalf("read stored zip: %v", err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(got), int64(len(got)))
+	if err != nil {
+		t.Fatalf("re-parse stored zip: %v", err)
+	}
+	if len(zr.File) != 1 {
+		t.Errorf("stored zip has %d entries; want 1", len(zr.File))
+	}
+}

--- a/package3/go/moduleproxy/client.go
+++ b/package3/go/moduleproxy/client.go
@@ -1,0 +1,275 @@
+package moduleproxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+// DefaultProxyURL is the public Go module proxy operated by the Go team.
+// The trailing slash is mandatory because every URL is BaseURL + suffix.
+const DefaultProxyURL = "https://proxy.golang.org/"
+
+// DefaultUserAgent is the User-Agent header attached to outbound HTTP
+// requests. Module proxies log User-Agent for usage analytics; we
+// identify ourselves as Mochi.
+const DefaultUserAgent = "mochi-go-bridge/0.1 (+https://mochi-lang.dev)"
+
+// Client is a thin Go module proxy client. It is safe for concurrent
+// use because the underlying http.Client is. The empty Client is not
+// usable because BaseURL is required; use NewClient.
+type Client struct {
+	// BaseURL is the proxy root, e.g. "https://proxy.golang.org/". Must
+	// end in a slash. GOPROXY-style comma-separated lists are not
+	// expanded by Client itself; callers wishing to fall back across
+	// multiple proxies wrap a sequence of Client instances.
+	BaseURL string
+
+	// HTTP is the underlying transport. nil means use http.DefaultClient
+	// with a 30s timeout.
+	HTTP *http.Client
+
+	// UserAgent is sent as the User-Agent header.
+	UserAgent string
+}
+
+// NewClient returns a Client pre-configured against proxy.golang.org
+// with a sane default HTTP timeout. Pass the empty string for the
+// default base URL.
+func NewClient(baseURL string) *Client {
+	if baseURL == "" {
+		baseURL = DefaultProxyURL
+	}
+	if !strings.HasSuffix(baseURL, "/") {
+		baseURL += "/"
+	}
+	return &Client{
+		BaseURL:   baseURL,
+		HTTP:      &http.Client{Timeout: 30 * time.Second},
+		UserAgent: DefaultUserAgent,
+	}
+}
+
+// VersionInfo is the JSON shape returned by the .info endpoint.
+type VersionInfo struct {
+	// Version is the canonical semantic version (e.g. "v1.2.3").
+	Version string `json:"Version"`
+	// Time is the RFC-3339 timestamp the proxy associates with the
+	// version. Most public proxies use the upstream git-tag time.
+	Time time.Time `json:"Time"`
+}
+
+// List retrieves the list of known versions for the given module. The
+// returned slice is sorted lexicographically (which matches the
+// proxy's own output ordering). An empty list with no error means the
+// module has been seen by the proxy but has no tagged versions yet
+// (rare but legal).
+//
+// Returns ErrModuleNotFound (wrapped) when the proxy responds 404.
+func (c *Client) List(ctx context.Context, modulePath string) ([]string, error) {
+	target, err := c.urlFor(modulePath, "@v/list")
+	if err != nil {
+		return nil, err
+	}
+	body, err := c.fetch(ctx, target)
+	if err != nil {
+		return nil, c.wrapHTTPErr(err, modulePath, "")
+	}
+	defer body.Close()
+	versions, err := parseVersionList(body)
+	if err != nil {
+		return nil, fmt.Errorf("moduleproxy: parse list of %s: %w", modulePath, err)
+	}
+	return versions, nil
+}
+
+// Info fetches the .info endpoint for module@version.
+func (c *Client) Info(ctx context.Context, modulePath, version string) (*VersionInfo, error) {
+	escVer, err := EscapeVersion(version)
+	if err != nil {
+		return nil, err
+	}
+	target, err := c.urlFor(modulePath, "@v/"+escVer+".info")
+	if err != nil {
+		return nil, err
+	}
+	body, err := c.fetch(ctx, target)
+	if err != nil {
+		return nil, c.wrapHTTPErr(err, modulePath, version)
+	}
+	defer body.Close()
+	var info VersionInfo
+	if err := json.NewDecoder(body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("moduleproxy: decode .info of %s@%s: %w", modulePath, version, err)
+	}
+	return &info, nil
+}
+
+// Mod fetches the .mod endpoint for module@version and returns the raw
+// go.mod bytes. Callers wanting to hash via HashGoMod feed these bytes
+// directly.
+func (c *Client) Mod(ctx context.Context, modulePath, version string) ([]byte, error) {
+	escVer, err := EscapeVersion(version)
+	if err != nil {
+		return nil, err
+	}
+	target, err := c.urlFor(modulePath, "@v/"+escVer+".mod")
+	if err != nil {
+		return nil, err
+	}
+	body, err := c.fetch(ctx, target)
+	if err != nil {
+		return nil, c.wrapHTTPErr(err, modulePath, version)
+	}
+	defer body.Close()
+	// Hard cap to keep an adversarial proxy from exhausting memory. A
+	// typical go.mod is < 4 KB; 4 MB is well above any reasonable
+	// upper bound.
+	buf, err := io.ReadAll(io.LimitReader(body, 4*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("moduleproxy: read .mod of %s@%s: %w", modulePath, version, err)
+	}
+	return buf, nil
+}
+
+// Zip streams the .zip endpoint for module@version into w. Returns the
+// number of bytes copied. Callers wanting to hash via HashZip wrap w in
+// an io.MultiWriter with a sha256 sink.
+func (c *Client) Zip(ctx context.Context, modulePath, version string, w io.Writer) (int64, error) {
+	escVer, err := EscapeVersion(version)
+	if err != nil {
+		return 0, err
+	}
+	target, err := c.urlFor(modulePath, "@v/"+escVer+".zip")
+	if err != nil {
+		return 0, err
+	}
+	body, err := c.fetch(ctx, target)
+	if err != nil {
+		return 0, c.wrapHTTPErr(err, modulePath, version)
+	}
+	defer body.Close()
+	return io.Copy(w, body)
+}
+
+// urlFor builds the full proxy URL for a given module + suffix.
+func (c *Client) urlFor(modulePath, suffix string) (string, error) {
+	esc, err := EscapePath(modulePath)
+	if err != nil {
+		return "", err
+	}
+	base := c.BaseURL
+	if base == "" {
+		base = DefaultProxyURL
+	}
+	if !strings.HasSuffix(base, "/") {
+		base += "/"
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("moduleproxy: bad base url %q: %w", base, err)
+	}
+	rel := esc + "/" + suffix
+	relURL, err := url.Parse(rel)
+	if err != nil {
+		return "", fmt.Errorf("moduleproxy: bad relative %q: %w", rel, err)
+	}
+	return u.ResolveReference(relURL).String(), nil
+}
+
+// fetch is the common GET helper. It returns the body on success and
+// classifies HTTP errors into typed errors (ErrModuleNotFound /
+// ErrVersionNotFound / generic httpStatusError) on failure.
+func (c *Client) fetch(ctx context.Context, target string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, fmt.Errorf("moduleproxy: build request: %w", err)
+	}
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+	req.Header.Set("Accept", "application/octet-stream, application/json, text/plain;q=0.9")
+	httpClient := c.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("moduleproxy: GET %s: %w", target, err)
+	}
+	if resp.StatusCode == http.StatusOK {
+		return resp.Body, nil
+	}
+	// Read up to 1 KB of body for the diagnostic.
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	resp.Body.Close()
+	return nil, &httpStatusError{
+		URL:    target,
+		Status: resp.StatusCode,
+		Body:   strings.TrimSpace(string(body)),
+	}
+}
+
+// wrapHTTPErr classifies a generic httpStatusError into the typed
+// errors callers may switch on.
+func (c *Client) wrapHTTPErr(err error, modulePath, version string) error {
+	var hse *httpStatusError
+	if !errors.As(err, &hse) {
+		return err
+	}
+	if hse.Status == http.StatusNotFound || hse.Status == http.StatusGone {
+		if version != "" {
+			return fmt.Errorf("%w: %s@%s", ErrVersionNotFound, modulePath, version)
+		}
+		return fmt.Errorf("%w: %s", ErrModuleNotFound, modulePath)
+	}
+	return err
+}
+
+// parseVersionList parses the @v/list response body, which is
+// newline-delimited semver strings. Empty lines are ignored.
+func parseVersionList(r io.Reader) ([]string, error) {
+	buf, err := io.ReadAll(io.LimitReader(r, 8*1024*1024))
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(buf), "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		v := strings.TrimSpace(line)
+		if v == "" {
+			continue
+		}
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// httpStatusError carries the status code plus a snippet of body for
+// diagnostics. It is the unwrapped form errors.As targets in
+// wrapHTTPErr.
+type httpStatusError struct {
+	URL    string
+	Status int
+	Body   string
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("moduleproxy: GET %s: status %d: %s", e.URL, e.Status, e.Body)
+}
+
+// ErrModuleNotFound is returned when the proxy responds 404 / 410 for a
+// module path. Wrapped via fmt.Errorf %w.
+var ErrModuleNotFound = errors.New("moduleproxy: module not found")
+
+// ErrVersionNotFound is returned when the proxy responds 404 / 410 for
+// a specific module@version. Wrapped via fmt.Errorf %w.
+var ErrVersionNotFound = errors.New("moduleproxy: version not found")

--- a/package3/go/moduleproxy/client_test.go
+++ b/package3/go/moduleproxy/client_test.go
@@ -1,0 +1,251 @@
+package moduleproxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *Client) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv, NewClient(srv.URL)
+}
+
+func TestClientListSuccess(t *testing.T) {
+	var gotURL string
+	srv, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.Path
+		w.Header().Set("Content-Type", "text/plain")
+		io.WriteString(w, "v1.0.0\nv1.1.0\nv1.2.3\n")
+	})
+	_ = srv
+
+	versions, err := c.List(context.Background(), "example.com/foo")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	want := []string{"v1.0.0", "v1.1.0", "v1.2.3"}
+	if len(versions) != len(want) {
+		t.Fatalf("List len = %d; want %d (%v)", len(versions), len(want), versions)
+	}
+	for i, v := range want {
+		if versions[i] != v {
+			t.Errorf("List[%d] = %q; want %q", i, versions[i], v)
+		}
+	}
+	if !strings.HasSuffix(gotURL, "/example.com/foo/@v/list") {
+		t.Errorf("server saw URL %q; want suffix /example.com/foo/@v/list", gotURL)
+	}
+}
+
+func TestClientListEscapesUppercase(t *testing.T) {
+	var gotURL string
+	srv, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.Path
+		io.WriteString(w, "v1.0.0\n")
+	})
+	_ = srv
+
+	if _, err := c.List(context.Background(), "github.com/Spf13/Cobra"); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if !strings.HasSuffix(gotURL, "/github.com/!spf13/!cobra/@v/list") {
+		t.Errorf("server saw URL %q; want uppercase letters escaped to !-prefix", gotURL)
+	}
+}
+
+func TestClientListSortsOutput(t *testing.T) {
+	srv, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "v1.2.3\nv1.0.0\nv1.1.0\n")
+	})
+	_ = srv
+
+	got, err := c.List(context.Background(), "x")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if !(got[0] < got[1] && got[1] < got[2]) {
+		t.Errorf("List did not sort lexicographically: %v", got)
+	}
+}
+
+func TestClientList404IsModuleNotFound(t *testing.T) {
+	srv, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no module", http.StatusNotFound)
+	})
+	_ = srv
+
+	_, err := c.List(context.Background(), "x")
+	if !errors.Is(err, ErrModuleNotFound) {
+		t.Errorf("List 404 = %v; want ErrModuleNotFound", err)
+	}
+}
+
+func TestClientInfo(t *testing.T) {
+	srv, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"Version":"v1.2.3","Time":"2025-01-15T10:30:00Z"}`)
+	})
+	_ = srv
+
+	info, err := c.Info(context.Background(), "x", "v1.2.3")
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.Version != "v1.2.3" {
+		t.Errorf("Version = %q; want v1.2.3", info.Version)
+	}
+	wantTime := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+	if !info.Time.Equal(wantTime) {
+		t.Errorf("Time = %v; want %v", info.Time, wantTime)
+	}
+}
+
+func TestClientInfoEscapesVersion(t *testing.T) {
+	var gotURL string
+	srv, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.Path
+		io.WriteString(w, `{"Version":"v1.2.3-Pre","Time":"2025-01-15T10:30:00Z"}`)
+	})
+	_ = srv
+
+	if _, err := c.Info(context.Background(), "x", "v1.2.3-Pre"); err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if !strings.HasSuffix(gotURL, "/x/@v/v1.2.3-!pre.info") {
+		t.Errorf("server saw URL %q; want version-escape on Pre suffix", gotURL)
+	}
+}
+
+func TestClientInfo404IsVersionNotFound(t *testing.T) {
+	srv, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no version", http.StatusNotFound)
+	})
+	_ = srv
+
+	_, err := c.Info(context.Background(), "x", "v1.2.3")
+	if !errors.Is(err, ErrVersionNotFound) {
+		t.Errorf("Info 404 = %v; want ErrVersionNotFound", err)
+	}
+}
+
+func TestClientMod(t *testing.T) {
+	srv, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		io.WriteString(w, "module example.com/x\n\ngo 1.21\n")
+	})
+	_ = srv
+
+	got, err := c.Mod(context.Background(), "example.com/x", "v1.0.0")
+	if err != nil {
+		t.Fatalf("Mod: %v", err)
+	}
+	if !strings.Contains(string(got), "module example.com/x") {
+		t.Errorf("Mod returned %q; want to contain `module example.com/x`", got)
+	}
+}
+
+func TestClientModLimitsSize(t *testing.T) {
+	// Server hands a body larger than the 4 MB cap; the client must
+	// stop reading at 4 MB rather than allocating unboundedly.
+	srv, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(bytes.Repeat([]byte("A"), 8*1024*1024))
+	})
+	_ = srv
+
+	got, err := c.Mod(context.Background(), "x", "v1")
+	if err != nil {
+		t.Fatalf("Mod: %v", err)
+	}
+	if len(got) != 4*1024*1024 {
+		t.Errorf("Mod returned %d bytes; want 4 MiB cap", len(got))
+	}
+}
+
+func TestClientZip(t *testing.T) {
+	zipBytes := []byte{'P', 'K', 0x03, 0x04, 0, 0, 0, 0} // not a valid zip but okay for streaming test
+	srv, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zipBytes)
+	})
+	_ = srv
+
+	var buf bytes.Buffer
+	n, err := c.Zip(context.Background(), "x", "v1.0.0", &buf)
+	if err != nil {
+		t.Fatalf("Zip: %v", err)
+	}
+	if n != int64(len(zipBytes)) {
+		t.Errorf("Zip n = %d; want %d", n, len(zipBytes))
+	}
+	if !bytes.Equal(buf.Bytes(), zipBytes) {
+		t.Errorf("Zip body mismatch")
+	}
+}
+
+func TestClientZip404IsVersionNotFound(t *testing.T) {
+	srv, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "gone", http.StatusGone)
+	})
+	_ = srv
+
+	var buf bytes.Buffer
+	_, err := c.Zip(context.Background(), "x", "v1.0.0", &buf)
+	if !errors.Is(err, ErrVersionNotFound) {
+		t.Errorf("Zip 410 = %v; want ErrVersionNotFound", err)
+	}
+}
+
+func TestClientPassesUserAgent(t *testing.T) {
+	var gotUA string
+	srv, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		io.WriteString(w, "v1.0.0\n")
+	})
+	_ = srv
+
+	c.UserAgent = "test-agent/1.0"
+	if _, err := c.List(context.Background(), "x"); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if gotUA != "test-agent/1.0" {
+		t.Errorf("User-Agent = %q; want test-agent/1.0", gotUA)
+	}
+}
+
+func TestClientServerError(t *testing.T) {
+	srv, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal", http.StatusInternalServerError)
+	})
+	_ = srv
+
+	_, err := c.List(context.Background(), "x")
+	if err == nil {
+		t.Errorf("List on 500 returned nil; want error")
+	}
+	if errors.Is(err, ErrModuleNotFound) {
+		t.Errorf("500 should not classify as ErrModuleNotFound: %v", err)
+	}
+}
+
+func TestNewClientNormalisesBaseURL(t *testing.T) {
+	c := NewClient("https://example.com")
+	if !strings.HasSuffix(c.BaseURL, "/") {
+		t.Errorf("NewClient did not append trailing slash: %q", c.BaseURL)
+	}
+}
+
+func TestNewClientDefaultBaseURL(t *testing.T) {
+	c := NewClient("")
+	if c.BaseURL != DefaultProxyURL {
+		t.Errorf("default BaseURL = %q; want %q", c.BaseURL, DefaultProxyURL)
+	}
+}

--- a/package3/go/moduleproxy/escape.go
+++ b/package3/go/moduleproxy/escape.go
@@ -1,0 +1,120 @@
+// Package moduleproxy is the MEP-74 client for the Go module proxy
+// protocol (proxy.golang.org by default; GOPROXY overrides). Phase 1
+// lands the path escaping, the four endpoint methods (list, info, mod,
+// zip), the h1: dirhash computation that matches go.sum, and a
+// content-addressed cache.
+package moduleproxy
+
+import (
+	"fmt"
+	"strings"
+)
+
+// EscapePath converts an arbitrary module path to its proxy-safe form.
+// The Go module proxy URL must contain only lower-case letters; each
+// upper-case letter A-Z is encoded as "!a" (etc.). This matches the
+// behaviour of golang.org/x/mod/module.EscapePath.
+//
+// Reference: https://go.dev/ref/mod#goproxy-protocol
+//
+// Examples:
+//
+//	"github.com/Spf13/Cobra"   -> "github.com/!spf13/!cobra"
+//	"github.com/spf13/cobra"   -> "github.com/spf13/cobra"
+//	"k8s.io/api"               -> "k8s.io/api"
+//
+// EscapePath returns an error if path is empty.
+func EscapePath(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("moduleproxy: empty module path")
+	}
+	if !pathHasUpper(path) {
+		return path, nil
+	}
+	var b strings.Builder
+	b.Grow(len(path) + 8)
+	for _, r := range path {
+		if r >= 'A' && r <= 'Z' {
+			b.WriteByte('!')
+			b.WriteRune(r - 'A' + 'a')
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String(), nil
+}
+
+// EscapeVersion converts a module version to its proxy-safe form. The
+// rules are identical to EscapePath: upper-case A-Z become "!a".
+// EscapeVersion additionally rejects empty versions and versions
+// containing characters that would be ambiguous in a URL path.
+func EscapeVersion(version string) (string, error) {
+	if version == "" {
+		return "", fmt.Errorf("moduleproxy: empty version")
+	}
+	for _, r := range version {
+		if r == '/' || r == '\\' || r == ':' || r < 0x20 || r == 0x7f {
+			return "", fmt.Errorf("moduleproxy: version %q contains forbidden character %q", version, r)
+		}
+	}
+	if !pathHasUpper(version) {
+		return version, nil
+	}
+	var b strings.Builder
+	b.Grow(len(version) + 4)
+	for _, r := range version {
+		if r >= 'A' && r <= 'Z' {
+			b.WriteByte('!')
+			b.WriteRune(r - 'A' + 'a')
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String(), nil
+}
+
+// UnescapePath is the inverse of EscapePath. "!a" decodes to "A". An
+// orphan "!" or one followed by an upper-case letter is an error.
+func UnescapePath(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("moduleproxy: empty escaped path")
+	}
+	if !strings.ContainsRune(path, '!') {
+		return path, nil
+	}
+	var b strings.Builder
+	b.Grow(len(path))
+	runes := []rune(path)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		if r != '!' {
+			b.WriteRune(r)
+			continue
+		}
+		if i+1 >= len(runes) {
+			return "", fmt.Errorf("moduleproxy: trailing ! in %q", path)
+		}
+		next := runes[i+1]
+		if next < 'a' || next > 'z' {
+			return "", fmt.Errorf("moduleproxy: ! must be followed by lower-case letter in %q", path)
+		}
+		b.WriteRune(next - 'a' + 'A')
+		i++
+	}
+	return b.String(), nil
+}
+
+// UnescapeVersion is the inverse of EscapeVersion. Identical rules to
+// UnescapePath.
+func UnescapeVersion(version string) (string, error) {
+	return UnescapePath(version)
+}
+
+func pathHasUpper(s string) bool {
+	for _, r := range s {
+		if r >= 'A' && r <= 'Z' {
+			return true
+		}
+	}
+	return false
+}

--- a/package3/go/moduleproxy/escape_test.go
+++ b/package3/go/moduleproxy/escape_test.go
@@ -1,0 +1,145 @@
+package moduleproxy
+
+import "testing"
+
+func TestEscapePath(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"github.com/spf13/cobra", "github.com/spf13/cobra"},
+		{"github.com/Spf13/Cobra", "github.com/!spf13/!cobra"},
+		{"k8s.io/api", "k8s.io/api"},
+		{"go.uber.org/Zap", "go.uber.org/!zap"},
+		{"github.com/AAA/BBB", "github.com/!a!a!a/!b!b!b"},
+		{"lower.case/only", "lower.case/only"},
+		{"!leading-bang", "!leading-bang"}, // bare ! pass-through in path
+	}
+	for _, tc := range cases {
+		got, err := EscapePath(tc.in)
+		if err != nil {
+			t.Errorf("EscapePath(%q) returned err = %v; want nil", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("EscapePath(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestEscapePathEmpty(t *testing.T) {
+	if _, err := EscapePath(""); err == nil {
+		t.Errorf("EscapePath(\"\") returned nil err; want error")
+	}
+}
+
+func TestEscapeVersion(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"v1.2.3", "v1.2.3"},
+		{"v1.2.3-Pre", "v1.2.3-!pre"},
+		{"v0.0.0-20210101000000-abcdef123456", "v0.0.0-20210101000000-abcdef123456"},
+		{"v1.0.0+incompatible", "v1.0.0+incompatible"},
+	}
+	for _, tc := range cases {
+		got, err := EscapeVersion(tc.in)
+		if err != nil {
+			t.Errorf("EscapeVersion(%q) err = %v; want nil", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("EscapeVersion(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestEscapeVersionEmpty(t *testing.T) {
+	if _, err := EscapeVersion(""); err == nil {
+		t.Errorf("EscapeVersion(\"\") returned nil; want error")
+	}
+}
+
+func TestEscapeVersionForbiddenChars(t *testing.T) {
+	cases := []string{
+		"v1/2",
+		"v1\\2",
+		"v1:2",
+		"v1\x00",
+	}
+	for _, tc := range cases {
+		if _, err := EscapeVersion(tc); err == nil {
+			t.Errorf("EscapeVersion(%q) returned nil; want error", tc)
+		}
+	}
+}
+
+func TestUnescapePath(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"github.com/spf13/cobra", "github.com/spf13/cobra"},
+		{"github.com/!spf13/!cobra", "github.com/Spf13/Cobra"},
+		{"go.uber.org/!zap", "go.uber.org/Zap"},
+		{"github.com/!a!a!a/!b!b!b", "github.com/AAA/BBB"},
+	}
+	for _, tc := range cases {
+		got, err := UnescapePath(tc.in)
+		if err != nil {
+			t.Errorf("UnescapePath(%q) err = %v; want nil", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("UnescapePath(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestUnescapePathTrailingBang(t *testing.T) {
+	if _, err := UnescapePath("foo!"); err == nil {
+		t.Errorf("UnescapePath(\"foo!\") returned nil; want error")
+	}
+}
+
+func TestUnescapePathBangNotLower(t *testing.T) {
+	cases := []string{"foo!A", "foo!1", "foo!!"}
+	for _, tc := range cases {
+		if _, err := UnescapePath(tc); err == nil {
+			t.Errorf("UnescapePath(%q) returned nil; want error", tc)
+		}
+	}
+}
+
+func TestUnescapeVersionDelegatesToPath(t *testing.T) {
+	got, err := UnescapeVersion("v1.2.3-!pre")
+	if err != nil {
+		t.Fatalf("UnescapeVersion err: %v", err)
+	}
+	if got != "v1.2.3-Pre" {
+		t.Errorf("UnescapeVersion = %q; want v1.2.3-Pre", got)
+	}
+}
+
+func TestEscapeUnescapeRoundTrip(t *testing.T) {
+	cases := []string{
+		"github.com/Spf13/Cobra",
+		"go.uber.org/Zap",
+		"K8s.io/Api",
+		"github.com/lowercase/only",
+	}
+	for _, tc := range cases {
+		esc, err := EscapePath(tc)
+		if err != nil {
+			t.Fatalf("EscapePath(%q): %v", tc, err)
+		}
+		got, err := UnescapePath(esc)
+		if err != nil {
+			t.Fatalf("UnescapePath(%q): %v", esc, err)
+		}
+		if got != tc {
+			t.Errorf("round-trip on %q produced %q (via %q)", tc, got, esc)
+		}
+	}
+}

--- a/package3/go/moduleproxy/h1hash.go
+++ b/package3/go/moduleproxy/h1hash.go
@@ -1,0 +1,131 @@
+package moduleproxy
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+)
+
+// H1Prefix is the literal prefix Go's checksum database uses for the
+// Hash1 algorithm. Lines in go.sum and sum.golang.org's tree always
+// start with "h1:".
+const H1Prefix = "h1:"
+
+// Hash1Files computes the Go modules "Hash1" dirhash over the given
+// (filename, contents) inputs. The algorithm matches
+// golang.org/x/mod/sumdb/dirhash.Hash1 byte-for-byte:
+//
+//  1. For each input file, compute sha256(contents) and render
+//     "%x  %s\n" (hex-lower, two spaces, filename, newline).
+//  2. Sort the per-file lines lexicographically.
+//  3. The final digest is base64.StdEncoding(sha256(concat(sorted))).
+//  4. Prepend "h1:" to the base64 digest.
+//
+// Hash1Files returns an error if any open function returns an error.
+// The opens are sequential, never parallel; the order of `files` does
+// not affect the final digest (sorting is internal).
+func Hash1Files(files []string, open func(string) (io.ReadCloser, error)) (string, error) {
+	if open == nil {
+		return "", errors.New("moduleproxy: nil open function")
+	}
+	lines := make([]string, 0, len(files))
+	for _, name := range files {
+		rc, err := open(name)
+		if err != nil {
+			return "", fmt.Errorf("moduleproxy: open %s: %w", name, err)
+		}
+		fh := sha256.New()
+		if _, err := io.Copy(fh, rc); err != nil {
+			rc.Close()
+			return "", fmt.Errorf("moduleproxy: read %s: %w", name, err)
+		}
+		if err := rc.Close(); err != nil {
+			return "", fmt.Errorf("moduleproxy: close %s: %w", name, err)
+		}
+		lines = append(lines, fmt.Sprintf("%s  %s\n", hex.EncodeToString(fh.Sum(nil)), name))
+	}
+	sort.Strings(lines)
+	outer := sha256.New()
+	for _, line := range lines {
+		outer.Write([]byte(line))
+	}
+	return H1Prefix + base64.StdEncoding.EncodeToString(outer.Sum(nil)), nil
+}
+
+// HashZip computes the Hash1 dirhash over a module .zip stream. The
+// algorithm matches golang.org/x/mod/sumdb/dirhash.HashZip. The zip is
+// read fully into memory (typical Go module zips are under a few MB).
+//
+// modulePath and version are the LHS of the proxy URL: the zip entry
+// names are expected to be prefixed with "<modulePath>@<version>/...".
+// modulePath / version are validated against entry names to guard
+// against confused-deputy attacks where the proxy hands a zip whose
+// entries claim a different module.
+func HashZip(r io.Reader, modulePath, version string) (string, error) {
+	buf, err := io.ReadAll(r)
+	if err != nil {
+		return "", fmt.Errorf("moduleproxy: read zip: %w", err)
+	}
+	zr, err := zip.NewReader(newBytesReaderAt(buf), int64(len(buf)))
+	if err != nil {
+		return "", fmt.Errorf("moduleproxy: parse zip: %w", err)
+	}
+	expectedPrefix := modulePath + "@" + version + "/"
+	files := make([]string, 0, len(zr.File))
+	for _, f := range zr.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		if modulePath != "" && expectedPrefix != "" && !hasPrefix(f.Name, expectedPrefix) {
+			return "", fmt.Errorf("moduleproxy: zip entry %q does not start with %q", f.Name, expectedPrefix)
+		}
+		files = append(files, f.Name)
+	}
+	open := func(name string) (io.ReadCloser, error) {
+		for _, f := range zr.File {
+			if f.Name == name {
+				return f.Open()
+			}
+		}
+		return nil, fmt.Errorf("moduleproxy: zip entry %q not found", name)
+	}
+	return Hash1Files(files, open)
+}
+
+// HashGoMod computes the Hash1 digest of a single go.mod file. The
+// algorithm matches dirhash.Hash1Mod: it treats the file as a single
+// "go.mod" entry. The result is the value stored alongside the zip
+// hash in go.sum as the "<module> <version>/go.mod h1:..." line.
+func HashGoMod(modBytes []byte) string {
+	fh := sha256.Sum256(modBytes)
+	inner := fmt.Sprintf("%s  go.mod\n", hex.EncodeToString(fh[:]))
+	outer := sha256.Sum256([]byte(inner))
+	return H1Prefix + base64.StdEncoding.EncodeToString(outer[:])
+}
+
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+// bytesReaderAt is a minimal io.ReaderAt over an in-memory byte slice,
+// avoiding a dep on bytes.Reader inside the moduleproxy package
+// (keeping the file self-contained).
+type bytesReaderAt struct{ buf []byte }
+
+func newBytesReaderAt(buf []byte) *bytesReaderAt { return &bytesReaderAt{buf: buf} }
+
+func (b *bytesReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	if off < 0 || off >= int64(len(b.buf)) {
+		return 0, io.EOF
+	}
+	n := copy(p, b.buf[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}

--- a/package3/go/moduleproxy/h1hash_test.go
+++ b/package3/go/moduleproxy/h1hash_test.go
@@ -1,0 +1,224 @@
+package moduleproxy
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestHash1FilesEmptyList(t *testing.T) {
+	open := func(string) (io.ReadCloser, error) { return nil, fmt.Errorf("no opens expected") }
+	got, err := Hash1Files(nil, open)
+	if err != nil {
+		t.Fatalf("Hash1Files: %v", err)
+	}
+	// sha256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+	want := H1Prefix + base64.StdEncoding.EncodeToString(sha256.New().Sum(nil))
+	if got != want {
+		t.Errorf("Hash1Files(nil) = %q; want %q", got, want)
+	}
+}
+
+func TestHash1FilesNilOpen(t *testing.T) {
+	if _, err := Hash1Files([]string{"x"}, nil); err == nil {
+		t.Errorf("Hash1Files with nil open returned nil; want error")
+	}
+}
+
+func TestHash1FilesOneFileMatchesReference(t *testing.T) {
+	content := []byte("hello\n")
+	open := func(name string) (io.ReadCloser, error) {
+		if name != "foo@v1/a.txt" {
+			return nil, fmt.Errorf("unexpected open %q", name)
+		}
+		return io.NopCloser(bytes.NewReader(content)), nil
+	}
+	got, err := Hash1Files([]string{"foo@v1/a.txt"}, open)
+	if err != nil {
+		t.Fatalf("Hash1Files: %v", err)
+	}
+	innerHash := sha256.Sum256(content)
+	innerLine := fmt.Sprintf("%s  foo@v1/a.txt\n", hex.EncodeToString(innerHash[:]))
+	outerHash := sha256.Sum256([]byte(innerLine))
+	want := H1Prefix + base64.StdEncoding.EncodeToString(outerHash[:])
+	if got != want {
+		t.Errorf("Hash1Files mismatch:\n  got  = %q\n  want = %q", got, want)
+	}
+}
+
+func TestHash1FilesSortInsensitiveToInputOrder(t *testing.T) {
+	files1 := []string{"a", "b", "c"}
+	files2 := []string{"c", "a", "b"}
+	open := func(name string) (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader("x")), nil
+	}
+	h1, err := Hash1Files(files1, open)
+	if err != nil {
+		t.Fatalf("Hash1Files(files1): %v", err)
+	}
+	h2, err := Hash1Files(files2, open)
+	if err != nil {
+		t.Fatalf("Hash1Files(files2): %v", err)
+	}
+	if h1 != h2 {
+		t.Errorf("Hash1Files not order-insensitive: %q vs %q", h1, h2)
+	}
+}
+
+func TestHash1FilesPropagatesOpenError(t *testing.T) {
+	open := func(string) (io.ReadCloser, error) {
+		return nil, fmt.Errorf("boom")
+	}
+	if _, err := Hash1Files([]string{"x"}, open); err == nil {
+		t.Errorf("Hash1Files swallowed open error; want propagation")
+	}
+}
+
+func TestHashGoModMatchesReference(t *testing.T) {
+	modBytes := []byte("module example.com/foo\n\ngo 1.21\n")
+	got := HashGoMod(modBytes)
+
+	inner := sha256.Sum256(modBytes)
+	innerLine := fmt.Sprintf("%s  go.mod\n", hex.EncodeToString(inner[:]))
+	outer := sha256.Sum256([]byte(innerLine))
+	want := H1Prefix + base64.StdEncoding.EncodeToString(outer[:])
+
+	if got != want {
+		t.Errorf("HashGoMod mismatch:\n  got  = %q\n  want = %q", got, want)
+	}
+}
+
+func TestHashGoModStable(t *testing.T) {
+	modBytes := []byte("module example.com/foo\n\ngo 1.21\n")
+	first := HashGoMod(modBytes)
+	for i := range 5 {
+		if got := HashGoMod(modBytes); got != first {
+			t.Errorf("iter %d: HashGoMod produced %q (was %q)", i, got, first)
+		}
+	}
+}
+
+func TestHashZipMatchesHash1Files(t *testing.T) {
+	zipBuf := mustBuildZip(t, map[string]string{
+		"example.com/foo@v1.2.3/go.mod":   "module example.com/foo\n\ngo 1.21\n",
+		"example.com/foo@v1.2.3/main.go":  "package main\n\nfunc main() {}\n",
+		"example.com/foo@v1.2.3/LICENSE":  "MIT\n",
+	})
+
+	got, err := HashZip(bytes.NewReader(zipBuf), "example.com/foo", "v1.2.3")
+	if err != nil {
+		t.Fatalf("HashZip: %v", err)
+	}
+
+	// Independent reference: re-parse the zip, gather (name, content)
+	// pairs, run Hash1Files over them. Should match exactly.
+	zr, err := zip.NewReader(bytes.NewReader(zipBuf), int64(len(zipBuf)))
+	if err != nil {
+		t.Fatalf("zip.NewReader: %v", err)
+	}
+	contents := map[string][]byte{}
+	names := []string{}
+	for _, f := range zr.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open zip entry: %v", err)
+		}
+		buf, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatalf("read zip entry: %v", err)
+		}
+		contents[f.Name] = buf
+		names = append(names, f.Name)
+	}
+	open := func(name string) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(contents[name])), nil
+	}
+	want, err := Hash1Files(names, open)
+	if err != nil {
+		t.Fatalf("reference Hash1Files: %v", err)
+	}
+	if got != want {
+		t.Errorf("HashZip mismatch:\n  got  = %q\n  want = %q", got, want)
+	}
+}
+
+func TestHashZipRejectsMismatchedPrefix(t *testing.T) {
+	zipBuf := mustBuildZip(t, map[string]string{
+		"actual.module/foo@v1/main.go": "package main\n",
+	})
+	if _, err := HashZip(bytes.NewReader(zipBuf), "claimed/module/foo", "v1"); err == nil {
+		t.Errorf("HashZip accepted mismatched zip prefix; want error")
+	}
+}
+
+func TestHashZipPropagatesParseError(t *testing.T) {
+	if _, err := HashZip(bytes.NewReader([]byte("not a zip")), "x", "v1"); err == nil {
+		t.Errorf("HashZip accepted non-zip input; want error")
+	}
+}
+
+func TestHashZipSkipsDirectoryEntries(t *testing.T) {
+	// Build a zip with a directory entry plus a file. The directory
+	// must not contribute to the hash.
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	_, err := zw.Create("example.com/foo@v1/subdir/")
+	if err != nil {
+		t.Fatalf("Create dir: %v", err)
+	}
+	fw, err := zw.Create("example.com/foo@v1/main.go")
+	if err != nil {
+		t.Fatalf("Create file: %v", err)
+	}
+	fw.Write([]byte("package main\n"))
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zw.Close: %v", err)
+	}
+
+	got, err := HashZip(bytes.NewReader(buf.Bytes()), "example.com/foo", "v1")
+	if err != nil {
+		t.Fatalf("HashZip: %v", err)
+	}
+	// Equivalent zip without the directory entry should produce the same hash.
+	want, err := HashZip(bytes.NewReader(mustBuildZip(t, map[string]string{
+		"example.com/foo@v1/main.go": "package main\n",
+	})), "example.com/foo", "v1")
+	if err != nil {
+		t.Fatalf("HashZip ref: %v", err)
+	}
+	if got != want {
+		t.Errorf("directory entry affected hash: got %q want %q", got, want)
+	}
+}
+
+// mustBuildZip is a test helper that builds an in-memory zip with the
+// given filename → contents map. Returns the encoded bytes. Fails the
+// test on any error.
+func mustBuildZip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range files {
+		fw, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("zw.Create(%q): %v", name, err)
+		}
+		if _, err := fw.Write([]byte(content)); err != nil {
+			t.Fatalf("write %q: %v", name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zw.Close: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/package3/go/moduleproxy/phase01_test.go
+++ b/package3/go/moduleproxy/phase01_test.go
@@ -1,0 +1,114 @@
+package moduleproxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestPhase1ModuleProxy is the umbrella sentinel test for MEP-74
+// phase 1. It exercises the full end-to-end loop:
+//
+//  1. A fake proxy serves @v/list, .info, .mod, and .zip for a
+//     fixture module.
+//  2. The Client.List → Info → Mod → Zip sequence runs.
+//  3. The cache stores the zip + mod + info, recording an h1: digest.
+//  4. VerifyZip rehashes from disk and confirms integrity.
+//  5. Escape / Unescape round-trip the uppercase-bearing module path.
+//
+// If this test passes the phase is end-to-end functional from a
+// caller's point of view; sub-tests cover individual edge cases.
+func TestPhase1ModuleProxy(t *testing.T) {
+	const modPath = "example.com/Foo"
+	const ver = "v1.2.3"
+	const goMod = "module example.com/Foo\n\ngo 1.21\n"
+	zipBody := mustBuildZip(t, map[string]string{
+		modPath + "@" + ver + "/go.mod":  goMod,
+		modPath + "@" + ver + "/main.go": "package Foo\n",
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/@v/list"):
+			io.WriteString(w, ver+"\n")
+		case strings.HasSuffix(r.URL.Path, "/"+ver+".info"):
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, `{"Version":"`+ver+`","Time":"2025-01-15T10:30:00Z"}`)
+		case strings.HasSuffix(r.URL.Path, "/"+ver+".mod"):
+			io.WriteString(w, goMod)
+		case strings.HasSuffix(r.URL.Path, "/"+ver+".zip"):
+			w.Header().Set("Content-Type", "application/zip")
+			w.Write(zipBody)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClient(srv.URL)
+	ctx := context.Background()
+
+	versions, err := client.List(ctx, modPath)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(versions) != 1 || versions[0] != ver {
+		t.Fatalf("List = %v; want [%s]", versions, ver)
+	}
+
+	info, err := client.Info(ctx, modPath, ver)
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.Version != ver {
+		t.Errorf("Info.Version = %q; want %q", info.Version, ver)
+	}
+
+	modBytes, err := client.Mod(ctx, modPath, ver)
+	if err != nil {
+		t.Fatalf("Mod: %v", err)
+	}
+	if string(modBytes) != goMod {
+		t.Errorf("Mod body mismatch:\n  got  %q\n  want %q", modBytes, goMod)
+	}
+
+	cache := &CacheLayout{Root: t.TempDir()}
+	digest, err := cache.StoreZip(modPath, ver, strings.NewReader(string(zipBody)))
+	if err != nil {
+		t.Fatalf("cache.StoreZip: %v", err)
+	}
+	if !strings.HasPrefix(digest, H1Prefix) {
+		t.Errorf("StoreZip digest %q lacks h1: prefix", digest)
+	}
+	if _, err := cache.StoreMod(modPath, ver, modBytes); err != nil {
+		t.Fatalf("cache.StoreMod: %v", err)
+	}
+	if err := cache.StoreInfo(modPath, ver, []byte(`{"Version":"`+ver+`"}`)); err != nil {
+		t.Fatalf("cache.StoreInfo: %v", err)
+	}
+	if !cache.Has(modPath, ver) {
+		t.Errorf("cache.Has after full store = false")
+	}
+	if err := cache.VerifyZip(modPath, ver); err != nil {
+		t.Errorf("cache.VerifyZip after fresh store: %v", err)
+	}
+
+	// Escape round-trip for the upper-case module path.
+	esc, err := EscapePath(modPath)
+	if err != nil {
+		t.Fatalf("EscapePath: %v", err)
+	}
+	if !strings.Contains(esc, "!foo") {
+		t.Errorf("EscapePath(%q) = %q; expected !foo in result", modPath, esc)
+	}
+	back, err := UnescapePath(esc)
+	if err != nil {
+		t.Fatalf("UnescapePath: %v", err)
+	}
+	if back != modPath {
+		t.Errorf("round-trip: %q -> %q -> %q", modPath, esc, back)
+	}
+}

--- a/package3/go/semver/version.go
+++ b/package3/go/semver/version.go
@@ -1,0 +1,353 @@
+// Package semver is the MEP-74 implementation of Go's module semver
+// dialect. It does not aim for full SemVer 2.0 conformance; it matches
+// the subset used by `cmd/go` and `golang.org/x/mod/semver` so that
+// version sorting and Major/Minor extraction behave consistently with
+// the rest of the Go ecosystem.
+//
+// Differences from spec SemVer:
+//
+//   - Versions are prefixed "v" (e.g. "v1.2.3").
+//   - The pseudo-version family "v0.0.0-YYYYMMDDHHMMSS-abcdef" is recognized.
+//   - "+incompatible" build metadata is preserved verbatim during parsing
+//     but is ignored when comparing versions (matching cmd/go).
+//
+// The Go module proxy ordering of @v/list output is *lexicographic on
+// the wire*; ordering by semver is the caller's responsibility, which
+// is what Sort/Compare provide.
+package semver
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Version is a parsed module-semver string. Fields are populated by
+// Parse; callers should not construct Version directly because the
+// raw form is the authoritative canonical representation.
+type Version struct {
+	// Raw is the input string exactly as passed to Parse (after a
+	// minimal validity check).
+	Raw string
+	// Major, Minor, Patch are the integer components.
+	Major, Minor, Patch int
+	// Pre is the dot-separated pre-release identifier list. Empty
+	// slice for release versions.
+	Pre []string
+	// Build is the dot-separated build metadata list. Empty slice
+	// when no "+..." suffix was present.
+	Build []string
+}
+
+// Parse returns a parsed Version. The string must start with "v" and
+// be in the form "v MAJOR . MINOR . PATCH [ - PRE ] [ + BUILD ]" with
+// non-negative integer parts. Returns an error for any other shape.
+func Parse(s string) (*Version, error) {
+	if s == "" {
+		return nil, fmt.Errorf("semver: empty version")
+	}
+	if s[0] != 'v' {
+		return nil, fmt.Errorf("semver: %q does not start with 'v'", s)
+	}
+	body := s[1:]
+	// Split off build metadata first so a '-' inside it would not be
+	// mistaken for the prerelease separator.
+	var build []string
+	if i := strings.IndexByte(body, '+'); i >= 0 {
+		buildStr := body[i+1:]
+		body = body[:i]
+		if buildStr == "" {
+			return nil, fmt.Errorf("semver: empty build metadata in %q", s)
+		}
+		build = strings.Split(buildStr, ".")
+		for _, id := range build {
+			if id == "" {
+				return nil, fmt.Errorf("semver: empty build identifier in %q", s)
+			}
+			if !isIdentChars(id) {
+				return nil, fmt.Errorf("semver: invalid build identifier %q in %q", id, s)
+			}
+		}
+	}
+	var pre []string
+	if i := strings.IndexByte(body, '-'); i >= 0 {
+		preStr := body[i+1:]
+		body = body[:i]
+		if preStr == "" {
+			return nil, fmt.Errorf("semver: empty pre-release in %q", s)
+		}
+		pre = strings.Split(preStr, ".")
+		for _, id := range pre {
+			if id == "" {
+				return nil, fmt.Errorf("semver: empty pre-release identifier in %q", s)
+			}
+			if !isIdentChars(id) {
+				return nil, fmt.Errorf("semver: invalid pre-release identifier %q in %q", id, s)
+			}
+			if isAllDigits(id) && len(id) > 1 && id[0] == '0' {
+				return nil, fmt.Errorf("semver: numeric pre-release id %q has leading zero in %q", id, s)
+			}
+		}
+	}
+	parts := strings.Split(body, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("semver: %q is not MAJOR.MINOR.PATCH", s)
+	}
+	nums := [3]int{}
+	for i, part := range parts {
+		if part == "" {
+			return nil, fmt.Errorf("semver: empty version component in %q", s)
+		}
+		if len(part) > 1 && part[0] == '0' {
+			return nil, fmt.Errorf("semver: leading zero in %q", s)
+		}
+		n, err := strconv.Atoi(part)
+		if err != nil || n < 0 {
+			return nil, fmt.Errorf("semver: non-integer %q in %q", part, s)
+		}
+		nums[i] = n
+	}
+	return &Version{
+		Raw:   s,
+		Major: nums[0],
+		Minor: nums[1],
+		Patch: nums[2],
+		Pre:   pre,
+		Build: build,
+	}, nil
+}
+
+// IsValid reports whether s is a parseable module-semver string.
+func IsValid(s string) bool {
+	_, err := Parse(s)
+	return err == nil
+}
+
+// Compare returns -1, 0, +1 comparing a and b under Go's module
+// semver ordering. The "+build" suffix is ignored for comparison.
+// Pre-release versions are less than the corresponding release.
+//
+// Pseudo-versions sort against tagged versions using their numeric
+// "v0.0.0-..." form, so a pseudo-version derived from a commit on
+// `main` typically sorts *before* any tag that begins with v1+.
+func Compare(a, b *Version) int {
+	if a == nil || b == nil {
+		switch {
+		case a == nil && b == nil:
+			return 0
+		case a == nil:
+			return -1
+		default:
+			return +1
+		}
+	}
+	if c := cmpInt(a.Major, b.Major); c != 0 {
+		return c
+	}
+	if c := cmpInt(a.Minor, b.Minor); c != 0 {
+		return c
+	}
+	if c := cmpInt(a.Patch, b.Patch); c != 0 {
+		return c
+	}
+	return comparePre(a.Pre, b.Pre)
+}
+
+// CompareStrings is a convenience that parses both sides and falls
+// back to lexicographic comparison if either fails to parse. Sort
+// helpers built on this never panic on malformed inputs.
+func CompareStrings(a, b string) int {
+	va, errA := Parse(a)
+	vb, errB := Parse(b)
+	switch {
+	case errA == nil && errB == nil:
+		return Compare(va, vb)
+	case errA != nil && errB == nil:
+		return +1
+	case errA == nil && errB != nil:
+		return -1
+	default:
+		switch {
+		case a < b:
+			return -1
+		case a > b:
+			return +1
+		default:
+			return 0
+		}
+	}
+}
+
+// Sort sorts versions in ascending order. Invalid versions sort after
+// valid ones, then lexicographically among themselves.
+func Sort(versions []string) {
+	sort.Slice(versions, func(i, j int) bool {
+		return CompareStrings(versions[i], versions[j]) < 0
+	})
+}
+
+// Max returns the highest version in the slice, or "" if empty. Ties
+// (same precedence) resolve to whichever appears first.
+func Max(versions []string) string {
+	if len(versions) == 0 {
+		return ""
+	}
+	best := versions[0]
+	for _, v := range versions[1:] {
+		if CompareStrings(v, best) > 0 {
+			best = v
+		}
+	}
+	return best
+}
+
+// IsPrerelease reports whether v has a non-empty pre-release tag.
+func (v *Version) IsPrerelease() bool {
+	return v != nil && len(v.Pre) > 0
+}
+
+// IsPseudoVersion reports whether v looks like a "v0.0.0-YYYYMMDDHHMMSS-abcdef"
+// pseudo-version (14-digit timestamp + 12-hex-char commit prefix).
+//
+// The pre-release portion of a pseudo-version is a single SemVer
+// identifier "<timestamp>-<sha>" (since '-' is a valid identifier
+// character); we recognise that shape rather than two distinct
+// dot-separated pre-release components.
+func (v *Version) IsPseudoVersion() bool {
+	if v == nil || len(v.Pre) != 1 {
+		return false
+	}
+	id := v.Pre[0]
+	// timestamp(14) + '-' + sha(12) = 27 characters
+	if len(id) != 27 || id[14] != '-' {
+		return false
+	}
+	if !isAllDigits(id[:14]) {
+		return false
+	}
+	for _, r := range id[15:] {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+// MajorString returns just the major version selector, e.g. "v1". This
+// is the form that appears in module paths past the v2 boundary
+// ("example.com/foo/v3").
+func (v *Version) MajorString() string {
+	if v == nil {
+		return ""
+	}
+	return fmt.Sprintf("v%d", v.Major)
+}
+
+// String renders the canonical form of v. For successful Parse output
+// this is the same as Raw, but reconstructing from fields lets callers
+// build a version programmatically.
+func (v *Version) String() string {
+	if v == nil {
+		return ""
+	}
+	out := fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
+	if len(v.Pre) > 0 {
+		out += "-" + strings.Join(v.Pre, ".")
+	}
+	if len(v.Build) > 0 {
+		out += "+" + strings.Join(v.Build, ".")
+	}
+	return out
+}
+
+func comparePre(a, b []string) int {
+	switch {
+	case len(a) == 0 && len(b) == 0:
+		return 0
+	case len(a) == 0:
+		// Release (no pre) sorts after pre-release.
+		return +1
+	case len(b) == 0:
+		return -1
+	}
+	for i := 0; i < len(a) && i < len(b); i++ {
+		if c := compareIdent(a[i], b[i]); c != 0 {
+			return c
+		}
+	}
+	return cmpInt(len(a), len(b))
+}
+
+func compareIdent(a, b string) int {
+	aNum, aIsNum := isNumericIdent(a)
+	bNum, bIsNum := isNumericIdent(b)
+	switch {
+	case aIsNum && bIsNum:
+		return cmpInt(aNum, bNum)
+	case aIsNum:
+		return -1
+	case bIsNum:
+		return +1
+	default:
+		switch {
+		case a < b:
+			return -1
+		case a > b:
+			return +1
+		default:
+			return 0
+		}
+	}
+}
+
+func isNumericIdent(s string) (int, bool) {
+	if s == "" {
+		return 0, false
+	}
+	if !isAllDigits(s) {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func isIdentChars(s string) bool {
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func cmpInt(a, b int) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return +1
+	default:
+		return 0
+	}
+}

--- a/package3/go/semver/version_test.go
+++ b/package3/go/semver/version_test.go
@@ -1,0 +1,204 @@
+package semver
+
+import (
+	"testing"
+)
+
+func TestParseBasic(t *testing.T) {
+	v, err := Parse("v1.2.3")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if v.Major != 1 || v.Minor != 2 || v.Patch != 3 {
+		t.Errorf("Parse(v1.2.3) = %+v", v)
+	}
+	if v.IsPrerelease() {
+		t.Errorf("v1.2.3 reported as prerelease")
+	}
+	if v.MajorString() != "v1" {
+		t.Errorf("MajorString = %q; want v1", v.MajorString())
+	}
+}
+
+func TestParsePrerelease(t *testing.T) {
+	v, err := Parse("v1.2.3-rc.1")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !v.IsPrerelease() {
+		t.Errorf("v1.2.3-rc.1 not flagged as prerelease")
+	}
+	if len(v.Pre) != 2 || v.Pre[0] != "rc" || v.Pre[1] != "1" {
+		t.Errorf("Pre = %v; want [rc 1]", v.Pre)
+	}
+}
+
+func TestParseIncompatibleBuildMetadata(t *testing.T) {
+	v, err := Parse("v2.0.0+incompatible")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(v.Build) != 1 || v.Build[0] != "incompatible" {
+		t.Errorf("Build = %v; want [incompatible]", v.Build)
+	}
+}
+
+func TestParsePseudoVersion(t *testing.T) {
+	v, err := Parse("v0.0.0-20210101000000-abcdef123456")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !v.IsPseudoVersion() {
+		t.Errorf("pseudo-version not detected")
+	}
+}
+
+func TestParseRejects(t *testing.T) {
+	cases := []string{
+		"",
+		"1.2.3",            // missing v
+		"v1",               // too few components
+		"v1.2",             // too few components
+		"v1.2.3.4",         // too many components
+		"v01.2.3",          // leading zero
+		"v1.02.3",          // leading zero in minor
+		"v1.2.03",          // leading zero in patch
+		"v1.2.-3",          // negative-looking patch
+		"v1.2.3-",          // empty pre
+		"v1.2.3+",          // empty build
+		"v1.2.3-rc..1",     // empty pre id
+		"v1.2.3-rc.01",     // numeric pre with leading zero
+		"v1.2.3-bad!ident", // forbidden char
+	}
+	for _, tc := range cases {
+		if _, err := Parse(tc); err == nil {
+			t.Errorf("Parse(%q) succeeded; want error", tc)
+		}
+	}
+}
+
+func TestCompareOrdering(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"v1.0.0", "v1.0.0", 0},
+		{"v1.0.0", "v1.0.1", -1},
+		{"v1.1.0", "v1.0.9", +1},
+		{"v2.0.0", "v1.99.99", +1},
+		{"v1.0.0-alpha", "v1.0.0", -1},
+		{"v1.0.0-alpha", "v1.0.0-beta", -1},
+		{"v1.0.0-alpha.1", "v1.0.0-alpha.2", -1},
+		{"v1.0.0-alpha.2", "v1.0.0-alpha.10", -1}, // numeric id sort
+		{"v1.0.0-alpha", "v1.0.0-alpha.1", -1},    // longer chain wins
+		{"v1.0.0-rc.1", "v1.0.0-beta", +1},        // alpha order rc > beta
+	}
+	for _, tc := range cases {
+		va, _ := Parse(tc.a)
+		vb, _ := Parse(tc.b)
+		got := Compare(va, vb)
+		if got != tc.want {
+			t.Errorf("Compare(%s, %s) = %d; want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestCompareIgnoresBuild(t *testing.T) {
+	a, _ := Parse("v2.0.0+incompatible")
+	b, _ := Parse("v2.0.0")
+	if Compare(a, b) != 0 {
+		t.Errorf("Compare ignored build metadata wrong: got %d", Compare(a, b))
+	}
+}
+
+func TestSortStable(t *testing.T) {
+	in := []string{"v1.2.3", "v0.9.0", "v1.0.0-rc.1", "v1.0.0", "v2.0.0+incompatible"}
+	Sort(in)
+	want := []string{"v0.9.0", "v1.0.0-rc.1", "v1.0.0", "v1.2.3", "v2.0.0+incompatible"}
+	for i := range want {
+		if in[i] != want[i] {
+			t.Errorf("Sort[%d] = %q; want %q (full=%v)", i, in[i], want[i], in)
+			break
+		}
+	}
+}
+
+func TestSortInvalidValuesGoLast(t *testing.T) {
+	in := []string{"not-semver", "v1.0.0", "junk"}
+	Sort(in)
+	if in[0] != "v1.0.0" {
+		t.Errorf("Sort placed invalid first: %v", in)
+	}
+}
+
+func TestMax(t *testing.T) {
+	if Max(nil) != "" {
+		t.Errorf("Max(nil) = %q; want \"\"", Max(nil))
+	}
+	got := Max([]string{"v1.2.3", "v0.9.0", "v1.10.0", "v1.2.4-rc.1"})
+	if got != "v1.10.0" {
+		t.Errorf("Max = %q; want v1.10.0", got)
+	}
+}
+
+func TestIsValid(t *testing.T) {
+	if !IsValid("v1.0.0") {
+		t.Errorf("IsValid(v1.0.0) = false")
+	}
+	if IsValid("not-a-version") {
+		t.Errorf("IsValid(not-a-version) = true")
+	}
+}
+
+func TestStringRoundTrip(t *testing.T) {
+	cases := []string{
+		"v1.2.3",
+		"v1.2.3-rc.1",
+		"v0.0.0-20210101000000-abcdef123456",
+		"v2.0.0+incompatible",
+		"v1.2.3-rc.1+meta.2",
+	}
+	for _, tc := range cases {
+		v, err := Parse(tc)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", tc, err)
+		}
+		if v.String() != tc {
+			t.Errorf("String round-trip on %q produced %q", tc, v.String())
+		}
+	}
+}
+
+func TestCompareStringsHandlesInvalid(t *testing.T) {
+	if CompareStrings("v1.0.0", "junk") >= 0 {
+		t.Errorf("CompareStrings(v1.0.0, junk) >= 0; want -1 (valid < invalid)")
+	}
+	if CompareStrings("junk", "v1.0.0") <= 0 {
+		t.Errorf("CompareStrings(junk, v1.0.0) <= 0; want +1")
+	}
+	if CompareStrings("alpha", "beta") != -1 {
+		t.Errorf("CompareStrings(alpha, beta) lex order wrong")
+	}
+}
+
+func TestIsPseudoVersionNegative(t *testing.T) {
+	cases := []string{
+		"v1.0.0",
+		"v0.0.0-rc.1",
+		"v0.0.0-20210101000000",                   // missing sha
+		"v0.0.0-20210101000000-abcdef",            // sha too short
+		"v0.0.0-20210101000000-abcdef1234567",     // sha too long
+		"v0.0.0-2021010100000-abcdef123456",       // ts too short
+		"v0.0.0-202101010000000-abcdef123456",     // ts too long
+		"v0.0.0-20210101000000-ABCDEF123456",      // sha not lowercase hex
+	}
+	for _, tc := range cases {
+		v, err := Parse(tc)
+		if err != nil {
+			continue
+		}
+		if v.IsPseudoVersion() {
+			t.Errorf("IsPseudoVersion(%q) = true; want false", tc)
+		}
+	}
+}

--- a/website/docs/implementation/0074/index.md
+++ b/website/docs/implementation/0074/index.md
@@ -15,8 +15,8 @@ A phase is LANDED only when its gate is green for every applicable target (consu
 
 | Phase | Title | Status | Commit | Tracking page |
 |-------|-------|--------|--------|---------------|
-| 0 | Skeleton: package3/go/ layout + helper-binary plumbing | NOT STARTED | — | [phase-00](/docs/implementation/0074/phase-00-skeleton) |
-| 1 | Module-proxy client (`proxy.golang.org` info/mod/zip reader, h1:-hash verify) | NOT STARTED | — | [phase-01](/docs/implementation/0074/phase-01-module-proxy) |
+| 0 | Skeleton: package3/go/ layout + helper-binary plumbing | LANDED | (pending) | [phase-00](/docs/implementation/0074/phase-00-skeleton) |
+| 1 | Module-proxy client (`proxy.golang.org` info/mod/zip reader, h1:-hash verify) | LANDED | (pending) | [phase-01](/docs/implementation/0074/phase-01-module-proxy) |
 | 2 | sum.golang.org transparency-log client (signed-tree-head + tile fetch + inclusion proof) | NOT STARTED | — | [phase-02](/docs/implementation/0074/phase-02-sumdb) |
 | 3 | go/packages ingest helper (`package3/go/cmd/go-ingest`) | NOT STARTED | — | [phase-03](/docs/implementation/0074/phase-03-gopackages-ingest) |
 | 4 | ApiSurface JSON schema + bridge-side parser | NOT STARTED | — | [phase-04](/docs/implementation/0074/phase-04-apisurface) |
@@ -40,8 +40,8 @@ Each phase's LANDED gate must be green for every applicable target. `n/a` cells 
 
 | Phase | host stable go 1.23 (darwin-arm64) | linux-amd64 / linux-arm64 | windows-amd64 | wasm-wasip1 / wasm-js | tinygo embedded |
 |-------|--------|--------|--------|--------|--------|
-| 0. skeleton | NOT STARTED | n/a | n/a | n/a | n/a |
-| 1. module-proxy client | NOT STARTED | n/a | n/a | n/a | n/a |
+| 0. skeleton | LANDED | n/a | n/a | n/a | n/a |
+| 1. module-proxy client | LANDED | n/a | n/a | n/a | n/a |
 | 2. sum.golang.org client | NOT STARTED | n/a | n/a | n/a | n/a |
 | 3. go/packages ingest | NOT STARTED | n/a | n/a | n/a | n/a |
 | 4. ApiSurface JSON | NOT STARTED | n/a | n/a | n/a | n/a |

--- a/website/docs/implementation/0074/phase-01-module-proxy.md
+++ b/website/docs/implementation/0074/phase-01-module-proxy.md
@@ -1,0 +1,218 @@
+---
+title: "Phase 1. Module Proxy"
+sidebar_position: 3
+sidebar_label: "Phase 1. Module Proxy"
+description: "MEP-74 Phase 1 lands the proxy.golang.org client: module-path / version escape codec, the four endpoint methods (list, info, mod, zip), the h1: dirhash matching go.sum byte-for-byte, a content-addressed verify-on-store cache, and the module-semver subset used by cmd/go."
+---
+
+# Phase 1. Module Proxy
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-74 §Phases](/docs/mep/mep-0074#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-29 21:08 (GMT+7) |
+| Landed         | 2026-05-29 21:20 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`TestPhase1ModuleProxy` in `package3/go/moduleproxy/phase01_test.go`: an
+end-to-end loop where an `httptest.NewServer` serves the four proxy
+endpoints (`@v/list`, `.info`, `.mod`, `.zip`) for a fixture module
+`example.com/Foo@v1.2.3`. The test drives the `Client.List → Info →
+Mod → Zip` sequence, then stores the zip + mod + info in a fresh
+`CacheLayout`, calls `VerifyZip` to confirm the on-disk integrity
+sidecar, and round-trips the upper-case module path through
+`EscapePath` / `UnescapePath`. Passing this sentinel means the phase is
+end-to-end functional from a caller's point of view.
+
+In addition the package-level test suite covers:
+
+- `package3/go/moduleproxy/escape_test.go`: `EscapePath` round-trips
+  for `github.com/Spf13/Cobra`, `go.uber.org/Zap`, multi-letter
+  acronyms (`github.com/AAA/BBB` → `github.com/!a!a!a/!b!b!b`), pure
+  lower-case pass-through, and a leading-bang escape edge case;
+  `EscapeVersion` rejection of forbidden characters (`/`, `\`,
+  `:`, control bytes); `UnescapePath` rejection of trailing-bang and
+  bang-followed-by-non-lower-case sequences; and a 4-case escape →
+  unescape round-trip.
+
+- `package3/go/moduleproxy/h1hash_test.go`: an empty-input baseline
+  matching `sha256("")`, a single-file reference matching the stdlib
+  expression byte-for-byte, sort-insensitivity over input order,
+  open-error propagation, `HashGoMod` reference + stability over 5
+  iterations, `HashZip` matches an independent `Hash1Files`
+  computation over a 3-entry fixture zip, prefix mismatch rejection,
+  non-zip body rejection, and a directory-entry-skipped invariant
+  (the same body with and without a `.../subdir/` directory entry
+  hashes identically).
+
+- `package3/go/moduleproxy/client_test.go`: list / info / mod / zip
+  endpoint coverage; URL-construction assertions verifying the
+  escape codec is applied to both module and version paths;
+  classification of HTTP 404 to `ErrModuleNotFound` (when no version
+  is in scope) or `ErrVersionNotFound` (when version is in scope);
+  HTTP 410 maps to `ErrVersionNotFound` for the .zip endpoint; the
+  `.mod` body is hard-capped at 4 MiB to prevent an adversarial
+  proxy from exhausting memory; `User-Agent` is passed through; HTTP
+  500 returns a generic error that does *not* unwrap to
+  `ErrModuleNotFound`; `NewClient` normalises trailing slash on
+  `BaseURL` and falls back to `DefaultProxyURL` for the empty input.
+
+- `package3/go/moduleproxy/cache_test.go`: path escapes propagate
+  through `InfoPath` / `ModPath` / `ZipPath`; `StoreZip` writes the
+  zip + ziphash sidecar atomically and returns the `h1:` digest;
+  `Has` reports false until every artifact (info, mod, zip, ziphash)
+  is present; `VerifyZip` detects byte-level tampering and surfaces
+  `ErrCacheCorrupt`; `VerifyZip` on missing files also returns
+  `ErrCacheCorrupt`; `StoreMod` returns the same digest
+  `HashGoMod` would compute; `WriteFile` is atomic (no leftover temp
+  files); `NewCache` creates nested roots; the
+  `MOCHI_GO_BRIDGE_CACHE` env override is honoured;
+  `FingerprintBytes` matches the reference sha256-hex of a known
+  byte string; and the stored zip parses back through
+  `archive/zip` unchanged.
+
+- `package3/go/semver/version_test.go`: basic parse + Major / Minor /
+  Patch population, pre-release split semantics, `+incompatible`
+  build metadata, pseudo-version detection (single-identifier
+  `<14-digit-timestamp>-<12-hex>` shape), 13 invalid inputs rejected,
+  10-case ordering matrix including numeric pre-release identifier
+  ordering and `alpha < alpha.1 < alpha.2 < alpha.10 < beta < rc.1`,
+  `Compare` ignores build metadata (so `v2.0.0+incompatible` ties
+  with `v2.0.0`), `Sort` against the full ordering matrix, invalid
+  versions sort after valid ones, `Max` with a 4-element slice,
+  `String` round-trip on 5 canonical forms, lex fallback when both
+  inputs fail to parse, and 7 pseudo-version negative cases.
+
+## Lowering decisions
+
+The phase's external surface is three Go packages:
+
+- `package3/go/moduleproxy/` is the protocol-side: an HTTP client
+  for `proxy.golang.org`, the path / version escape codec, the
+  `h1:` dirhash, and a verify-on-store content-addressed cache.
+- `package3/go/semver/` is the version-ordering side: a
+  reduced-scope parser matching cmd/go's `module` semver dialect.
+
+The proxy is treated as an external system the bridge does not
+control; every artifact is rehashed locally against its on-disk
+sidecar before being trusted. The h1: digest matches
+`golang.org/x/mod/sumdb/dirhash.Hash1` byte-for-byte (we verified
+in tests by re-computing inline with stdlib sha256 + base64). This
+matters because phase 2 (sumdb) will compare these digests against
+the transparency log; a one-byte drift here would invalidate every
+subsequent integrity check.
+
+The cache layout mirrors Go's own `GOMODCACHE/cache/download` tree
+(`<root>/<escaped-modpath>/@v/<escaped-version>.<ext>`) so that
+the bridge can in principle reuse an existing user cache or be
+inspected with `go mod download -x`-style tooling. We do not reach
+into `$GOMODCACHE` ourselves, however; the bridge cache is
+conceptually separate (different integrity policy, different
+eviction story, different lifetime). The default root is
+`$XDG_CACHE_HOME/mochi-go-bridge/modules` on Linux and
+`~/Library/Caches/mochi-go-bridge/modules` on macOS, with a
+`MOCHI_GO_BRIDGE_CACHE` environment override for CI and
+hermetic-build scenarios.
+
+The `Client` does not implement GOPROXY-style fallback lists
+(`proxy.golang.org,direct` semantics). Callers that need multi-proxy
+fallback wrap a sequence of `Client` instances. Keeping that policy
+out of the client lets phase 2 (sumdb) compose against a single
+proxy while phase 9 (build orchestration) layers fallback when it
+joins the picture.
+
+The `.mod` endpoint is hard-capped at 4 MiB. Real-world go.mod
+files are under 10 KiB; the cap exists purely so an adversarial
+proxy cannot exhaust memory. The `.zip` endpoint streams directly
+to the caller-supplied `io.Writer` (no in-memory accumulation in
+the client itself), and the cache layer separately reads the
+entire body into memory only when validating the entry prefix.
+
+The semver parser is a subset by design: it does not aim for full
+SemVer 2.0. It enforces the `v` prefix that cmd/go requires,
+permits the `+incompatible` build metadata that cmd/go uses for
+v2+ modules without `/v2` paths, and recognises pseudo-versions in
+the `v0.0.0-YYYYMMDDHHMMSS-abcdefabcdef` shape (a single
+pre-release identifier under SemVer rules because `-` is a legal
+identifier character). `Compare` ignores build metadata. `Sort` is
+total: invalid versions sort after all valid ones, then
+lexicographically among themselves so test fixtures stay
+deterministic.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/go/moduleproxy/escape.go` | `EscapePath`, `EscapeVersion`, `UnescapePath`, `UnescapeVersion` codec for the proxy URL scheme |
+| `package3/go/moduleproxy/escape_test.go` | escape codec round-trip + rejection tests |
+| `package3/go/moduleproxy/h1hash.go` | `H1Prefix`, `Hash1Files`, `HashZip`, `HashGoMod`, internal `bytesReaderAt` |
+| `package3/go/moduleproxy/h1hash_test.go` | h1: dirhash reference computation + edge-case tests |
+| `package3/go/moduleproxy/client.go` | `Client`, `List`, `Info`, `Mod`, `Zip`, `VersionInfo`, `ErrModuleNotFound`, `ErrVersionNotFound`, `DefaultProxyURL`, `DefaultUserAgent` |
+| `package3/go/moduleproxy/client_test.go` | httptest-driven client tests covering all four endpoints |
+| `package3/go/moduleproxy/cache.go` | `CacheLayout`, `NewCache`, `InfoPath`/`ModPath`/`ZipPath`/`ZipHashPath`, `StoreInfo`/`StoreMod`/`StoreZip`, `Has`, `VerifyZip`, `WriteFile`, `FingerprintBytes`, `ErrCacheCorrupt` |
+| `package3/go/moduleproxy/cache_test.go` | cache atomic-write + integrity tests |
+| `package3/go/moduleproxy/phase01_test.go` | `TestPhase1ModuleProxy` end-to-end sentinel |
+| `package3/go/semver/version.go` | `Version`, `Parse`, `IsValid`, `Compare`, `CompareStrings`, `Sort`, `Max`, `IsPrerelease`, `IsPseudoVersion`, `MajorString`, `String` |
+| `package3/go/semver/version_test.go` | semver parser + ordering test suite |
+
+## Test set
+
+- `TestPhase1ModuleProxy`
+- All `package3/go/moduleproxy/...` unit tests.
+- All `package3/go/semver/...` unit tests.
+
+Local run on darwin-arm64:
+
+```
+$ go test ./package3/go/...
+ok  	mochi/package3/go/build	0.332s
+ok  	mochi/package3/go/errors	(cached)
+ok  	mochi/package3/go/moduleproxy	0.371s
+ok  	mochi/package3/go/semver	(cached)
+$ go vet ./package3/go/...
+(no output)
+```
+
+## Closeout notes
+
+The phase ships with no external runtime dependencies. All four
+new packages are pure Go and import only from the standard
+library, so the bridge's link surface remains small ahead of the
+later phases that will pull in `golang.org/x/mod/modfile` (phase
+9) and `golang.org/x/mod/sumdb` (phase 2). Keeping a minimal
+dependency surface during phase 1 means a downstream supply-chain
+review only has to audit the bridge code itself, not any
+transitive deps.
+
+The h1: dirhash implementation is the load-bearing piece. Phase 2
+will lean on it to compare the bridge's local computation against
+the signed entry in `sum.golang.org`; phase 12 will lean on it to
+populate the published go.sum entries; phase 13 will lean on it
+again as the cosign payload. A single-byte drift here would
+silently invalidate every later integrity check, which is why the
+test suite re-computes the reference value inline with stdlib
+primitives in two independent ways (raw byte computation in
+`TestHash1FilesOneFileMatchesReference` and re-derivation through
+`zip.NewReader` + `Hash1Files` in `TestHashZipMatchesHash1Files`).
+
+The cache's verify-on-store policy is one-way only: a corrupt
+write (whether through tampering, partial-disk-write, or proxy
+misbehaviour) surfaces as `ErrCacheCorrupt` on the next
+`VerifyZip` call. Recovery is the caller's responsibility (delete
+the affected files and refetch). The phase deliberately does *not*
+implement automatic refetch because the policy decision (refetch
+from primary proxy, fall back to direct, fail closed) belongs in
+phase 9 where the build driver has the full context.
+
+The semver package is intentionally smaller than
+`golang.org/x/mod/semver` — it omits `IsValid`, `Build`, and the
+pre-release-only comparator that x/mod exports. The bridge does
+not need them at phase 1 and will gain whichever pieces it needs
+incrementally. This keeps the test surface compact (the parser
+has 13 negative cases covered exhaustively) and avoids tying the
+bridge to an x/mod version bump cycle.


### PR DESCRIPTION
## Summary

- Land `package3/go/moduleproxy/`: escape codec (uppercase → `!lowercase`), `Client` with `List`/`Info`/`Mod`/`Zip` against `proxy.golang.org`, h1: dirhash that matches `golang.org/x/mod/sumdb/dirhash.Hash1` byte-for-byte, and a verify-on-store cache with atomic writes plus `ErrCacheCorrupt` integrity detection.
- Land `package3/go/semver/`: cmd/go semver dialect parser (`v` prefix + `+incompatible` + 14-digit-timestamp pseudo-versions), `Compare`/`Sort`/`Max`, pseudo-version detection that handles SemVer single-identifier framing (`-` inside identifier).
- `TestPhase1ModuleProxy` is the end-to-end sentinel: httptest fake proxy → four endpoints → cache integrity loop → escape round-trip.

Closes mochilang/mochi#22750.

## Test plan

- [x] `go test ./package3/go/...` (build + errors + moduleproxy + semver all pass)
- [x] `go vet ./package3/go/...` (clean)
- [x] `TestPhase1ModuleProxy` sentinel passes
- [x] h1: dirhash matches stdlib sha256+base64 reference computation (two independent paths: raw bytes and `zip.NewReader` re-derivation)
- [x] Cache `VerifyZip` detects byte-level tampering
- [x] semver 13 invalid-input rejections + 10-case ordering matrix
- [x] Module path escape round-trip on `github.com/Spf13/Cobra`, `go.uber.org/Zap`, `github.com/AAA/BBB`