### PR TITLE
infra: sync docs to mochilang/docs repo to isolate deploys from CI

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,21 +1,10 @@
-name: Deploy website to Cloudflare Pages
+name: Sync docs to mochilang/docs
 
-# Deploy only on push to main (or manual trigger).
+# Syncs website/ to mochilang/docs on push to main, which then triggers
+# the deploy workflow there (isolated from all other mochi CI runners).
 #
-# PR builds were removed because they were the primary cause of runner
-# queue starvation: every website-touching PR triggered a full deploy,
-# creating 10-20 concurrent jobs and 25-50 min queue waits. Cloudflare
-# Pages provides native branch-preview URLs without needing Actions.
-#
-# Build time budget (target <5 min end-to-end):
-#   checkout:          ~5s   (fetch-depth: 1, no full history)
-#   node setup:        ~3s   (npm cache hit)
-#   npm ci:            ~8s   (node_modules cached)
-#   docusaurus build: ~45s   (webpack cache hit: .docusaurus + node_modules/.cache)
-#   wrangler deploy:  ~20s
-#   total:            ~81s   well under 5 min even on cold cache
-#
-# First run after cache miss: ~3.5 min (webpack cold build ~140s).
+# Required secret in mochilang/mochi:
+#   DOCS_DEPLOY_TOKEN — fine-grained PAT with Contents:Write on mochilang/docs
 
 on:
   push:
@@ -27,60 +16,49 @@ on:
 
 permissions:
   contents: read
-  deployments: write
 
-# Only one production deploy at a time; cancel any superseded run.
 concurrency:
-  group: cloudflare-pages-deploy
+  group: sync-docs
   cancel-in-progress: true
 
 jobs:
-  deploy:
-    name: Build and deploy website
+  sync:
+    name: Sync website to mochilang/docs
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: website
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - name: Checkout mochi
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
+      - name: Checkout mochilang/docs
+        uses: actions/checkout@v4
         with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: website/package-lock.json
+          repository: mochilang/docs
+          token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
+          path: docs-repo
+          fetch-depth: 1
 
-      - name: Install dependencies
-        run: npm ci --prefer-offline
+      - name: Sync website/ content
+        run: |
+          rsync -a --delete \
+            --exclude='.git' \
+            --exclude='node_modules' \
+            --exclude='.docusaurus' \
+            --exclude='build' \
+            website/ docs-repo/
 
-      # Cache the Docusaurus webpack incremental build artefacts.
-      # Key rotates when package-lock.json changes (new deps = cold build).
-      # The fallback key reuses the most recent build cache on cache miss
-      # so even a package bump only does an incremental rebuild.
-      - name: Restore Docusaurus build cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            website/.docusaurus
-            website/node_modules/.cache
-          key: docusaurus-build-${{ runner.os }}-${{ hashFiles('website/package-lock.json') }}-${{ hashFiles('website/docs/**', 'website/src/**', 'website/docusaurus.config.js', 'website/sidebars.js') }}
-          restore-keys: |
-            docusaurus-build-${{ runner.os }}-${{ hashFiles('website/package-lock.json') }}-
-            docusaurus-build-${{ runner.os }}-
-
-      - name: Build website
-        run: npm run build
-
-      - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v4
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy website/build --project-name=mochi-lang --branch=main
-          workingDirectory: .
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit and push
+        run: |
+          cd docs-repo
+          git config user.name "mochi-bot"
+          git config user.email "bot@mochi-lang.dev"
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No changes — docs repo already up to date."
+            exit 0
+          fi
+          MOCHI_SHA="${{ github.sha }}"
+          git commit -m "sync: website from mochi@${MOCHI_SHA:0:8}"
+          git push

--- a/scripts/deploy-website.sh
+++ b/scripts/deploy-website.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Syncs website/ from mochilang/mochi to mochilang/docs and triggers deploy.
+#
+# Usage:
+#   ./scripts/deploy-website.sh                  # local run (uses gh auth)
+#   GH_TOKEN=<pat> ./scripts/deploy-website.sh   # CI run
+#
+# Requires: git, rsync
+set -euo pipefail
+
+MOCHI_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+WEBSITE_SRC="$MOCHI_ROOT/website"
+DOCS_REPO="mochilang/docs"
+
+# Build authenticated URL when token is provided
+if [ -n "${GH_TOKEN:-}" ]; then
+  REPO_URL="https://x-access-token:${GH_TOKEN}@github.com/${DOCS_REPO}.git"
+else
+  REPO_URL="https://github.com/${DOCS_REPO}.git"
+fi
+
+TMPDIR_WORK="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+echo "==> Cloning mochilang/docs..."
+git clone --depth=1 "$REPO_URL" "$TMPDIR_WORK/docs"
+
+echo "==> Syncing website/ content..."
+rsync -a --delete \
+  --exclude='.git' \
+  --exclude='node_modules' \
+  --exclude='.docusaurus' \
+  --exclude='build' \
+  "$WEBSITE_SRC/" \
+  "$TMPDIR_WORK/docs/"
+
+cd "$TMPDIR_WORK/docs"
+git config user.name "mochi-bot"
+git config user.email "bot@mochi-lang.dev"
+git add -A
+
+if git diff --staged --quiet; then
+  echo "==> No changes to sync, docs repo is up to date."
+  exit 0
+fi
+
+MOCHI_SHA="$(git -C "$MOCHI_ROOT" rev-parse --short HEAD)"
+git commit -m "sync: website from mochi@${MOCHI_SHA}"
+git push
+echo "==> Pushed. Deploy triggered on mochilang/docs."


### PR DESCRIPTION
Closes #22756

## Problem

The `deploy-website.yml` workflow in `mochilang/mochi` shares GitHub runner capacity with dozens of other CI workflows (BEAM, JVM, Kotlin, .NET, Go, Ruby, Cross Tier-1, Reproducibility Gate, etc.). When multiple PRs merge in a burst, all those CI jobs saturate the runner pool and the deploy job sits queued for 25+ minutes — or gets continuously cancelled by new pushes (concurrency group `cancel-in-progress: true`).

## Solution

Decouple the website deploy into its own isolated repo: `mochilang/docs`.

- `mochilang/docs` has **only one workflow** (deploy.yml), so its runners are never contended.
- The `deploy-website.yml` in mochi is now a **sync job**: it rsyncs `website/` to a checkout of `mochilang/docs` and pushes a commit. That push triggers the deploy there.
- `scripts/deploy-website.sh` provides the same sync for local/manual runs.

## Setup required (one-time)

Three secrets need to be set:

**1. In `mochilang/mochi`:**
```
DOCS_DEPLOY_TOKEN  — fine-grained PAT: Contents:Write on mochilang/docs
```

**2. In `mochilang/docs`:**
```
CLOUDFLARE_API_TOKEN   — same value as in mochilang/mochi
CLOUDFLARE_ACCOUNT_ID  — same value as in mochilang/mochi
```

**Initial content** already pushed to `mochilang/docs` main (latest website from mochi main as of this PR).