### PR TITLE
feat(mep-73 p3): closed type-mapping table

### DIFF
--- a/package3/rust/typemap/kind.go
+++ b/package3/rust/typemap/kind.go
@@ -1,0 +1,109 @@
+// Package typemap is the closed type-mapping table for MEP-73. It
+// consumes rustdoc.Type values (the output of phase 2's walker) and
+// either returns a structured Mapping describing the Mochi-side type
+// and FFI representation, or an errors.SkipReason explaining why no
+// mapping exists.
+//
+// The table is "closed": every rustdoc-types Type variant either has
+// a documented mapping rule or a documented refusal class. There is
+// no fallthrough that silently produces approximated types. See
+// research note 05 ("Type mapping") for the design rationale.
+package typemap
+
+// Kind is the high-level Mochi type a Rust type lowers to. Each Kind
+// corresponds to a section of the closed table.
+type Kind int
+
+const (
+	// KindInvalid is the zero value; a Mapping with KindInvalid is a
+	// programming error and must never escape the package.
+	KindInvalid Kind = iota
+	KindUnit
+	KindBool
+	KindInt
+	KindInt64
+	KindUInt
+	KindUInt64
+	KindFloat
+	KindFloat64
+	KindByte
+	KindChar
+	KindString
+	KindBytes
+	KindList
+	KindMap
+	KindOption
+	KindResult
+	KindTuple
+	KindStruct
+	KindEnum
+	KindHandle
+)
+
+// String renders a Kind as the lower-case Mochi token used by golden
+// fixtures and SKIPPED diagnostics.
+func (k Kind) String() string {
+	switch k {
+	case KindUnit:
+		return "unit"
+	case KindBool:
+		return "bool"
+	case KindInt:
+		return "int"
+	case KindInt64:
+		return "int64"
+	case KindUInt:
+		return "uint"
+	case KindUInt64:
+		return "uint64"
+	case KindFloat:
+		return "float"
+	case KindFloat64:
+		return "float64"
+	case KindByte:
+		return "byte"
+	case KindChar:
+		return "char"
+	case KindString:
+		return "string"
+	case KindBytes:
+		return "bytes"
+	case KindList:
+		return "list"
+	case KindMap:
+		return "map"
+	case KindOption:
+		return "option"
+	case KindResult:
+		return "result"
+	case KindTuple:
+		return "tuple"
+	case KindStruct:
+		return "struct"
+	case KindEnum:
+		return "enum"
+	case KindHandle:
+		return "handle"
+	default:
+		return "invalid"
+	}
+}
+
+// Direction is the position of a type in a function signature. Some
+// rules differ between input and output positions, principally for
+// borrowed references and unit returns.
+type Direction int
+
+const (
+	DirectionIn Direction = iota
+	DirectionOut
+)
+
+// String renders a Direction as the lower-case token used by tests
+// and skip diagnostics.
+func (d Direction) String() string {
+	if d == DirectionOut {
+		return "out"
+	}
+	return "in"
+}

--- a/package3/rust/typemap/kind_test.go
+++ b/package3/rust/typemap/kind_test.go
@@ -1,0 +1,46 @@
+package typemap
+
+import "testing"
+
+func TestKindString(t *testing.T) {
+	cases := []struct {
+		k    Kind
+		want string
+	}{
+		{KindUnit, "unit"},
+		{KindBool, "bool"},
+		{KindInt, "int"},
+		{KindInt64, "int64"},
+		{KindUInt, "uint"},
+		{KindUInt64, "uint64"},
+		{KindFloat, "float"},
+		{KindFloat64, "float64"},
+		{KindByte, "byte"},
+		{KindChar, "char"},
+		{KindString, "string"},
+		{KindBytes, "bytes"},
+		{KindList, "list"},
+		{KindMap, "map"},
+		{KindOption, "option"},
+		{KindResult, "result"},
+		{KindTuple, "tuple"},
+		{KindStruct, "struct"},
+		{KindEnum, "enum"},
+		{KindHandle, "handle"},
+		{KindInvalid, "invalid"},
+	}
+	for _, c := range cases {
+		if got := c.k.String(); got != c.want {
+			t.Errorf("Kind(%d).String() = %q; want %q", c.k, got, c.want)
+		}
+	}
+}
+
+func TestDirectionString(t *testing.T) {
+	if DirectionIn.String() != "in" {
+		t.Errorf("DirectionIn.String() = %q; want in", DirectionIn.String())
+	}
+	if DirectionOut.String() != "out" {
+		t.Errorf("DirectionOut.String() = %q; want out", DirectionOut.String())
+	}
+}

--- a/package3/rust/typemap/map.go
+++ b/package3/rust/typemap/map.go
@@ -1,0 +1,252 @@
+package typemap
+
+import (
+	"fmt"
+	"strings"
+
+	"mochi/package3/rust/errors"
+	"mochi/package3/rust/rustdoc"
+)
+
+// primitiveKind is the closed table of Rust primitive names to Mochi
+// kinds. Anything outside this table is treated as "unmodelled
+// primitive" and returns SkipUnknown.
+var primitiveKind = map[string]Kind{
+	"bool":  KindBool,
+	"i8":    KindInt,
+	"i16":   KindInt,
+	"i32":   KindInt,
+	"i64":   KindInt64,
+	"i128":  KindInt64,
+	"u8":    KindByte,
+	"u16":   KindUInt,
+	"u32":   KindUInt,
+	"u64":   KindUInt64,
+	"u128":  KindUInt64,
+	"isize": KindInt64,
+	"usize": KindUInt64,
+	"f32":   KindFloat,
+	"f64":   KindFloat64,
+	"char":  KindChar,
+	"str":   KindString,
+	"never": KindUnit,
+	"!":     KindUnit,
+}
+
+// Map lowers a rustdoc.Type into a Mapping or returns an
+// errors.SkipReason explaining why no mapping exists. The Direction
+// parameter affects borrowed-reference handling: output positions
+// reject non-'static lifetimes, while input positions accept them
+// and copy through the FFI.
+//
+// Map's return convention: when SkipReason == errors.SkipUnknown
+// AND detail == "", the Mapping is valid. Any non-zero SkipReason
+// indicates failure. (SkipUnknown is otherwise valid for genuine
+// unknown-variant failures; the detail string distinguishes them.)
+func Map(t rustdoc.Type, dir Direction) (*Mapping, errors.SkipReason, string) {
+	// The unit type `()` arrives from rustdoc as {"tuple": []}; the
+	// rustdoc.Type.Kind() helper reports that as "empty" because it
+	// gates on len > 0. Recognise the non-nil empty slice as unit
+	// before the main switch.
+	if t.Tuple != nil && len(t.Tuple) == 0 {
+		return &Mapping{Kind: KindUnit, Rust: "()"}, errors.SkipUnknown, ""
+	}
+	switch t.Kind() {
+	case "primitive":
+		return mapPrimitive(t.Primitive)
+	case "resolved_path":
+		return mapPath(t.ResolvedPath, dir)
+	case "tuple":
+		return mapTuple(t.Tuple, dir)
+	case "slice":
+		if t.Slice == nil {
+			return nil, errors.SkipUnknown, "slice missing element type"
+		}
+		return mapSlice(*t.Slice, dir)
+	case "array":
+		return mapArray(t.Array, dir)
+	case "borrowed_ref":
+		return mapBorrowed(t.BorrowedRef, dir)
+	case "raw_pointer":
+		return nil, errors.SkipRawPointer, "raw pointer requires unsafe capability opt-in"
+	case "generic":
+		return nil, errors.SkipGeneric, fmt.Sprintf("unresolved generic %q; declare under [rust.monomorphise]", t.Generic)
+	case "dyn_trait":
+		return nil, errors.SkipDynTrait, "dyn Trait has no Mochi surface in v1"
+	case "impl_trait":
+		return nil, errors.SkipImplTrait, "impl Trait return position requires explicit monomorphisation"
+	case "qualified_path":
+		return nil, errors.SkipQualifiedPath, "qualified path (<T as Trait>::Item) has no Mochi surface"
+	case "function_pointer":
+		return nil, errors.SkipUnknown, "function pointer types are not mapped in v1"
+	case "infer":
+		return nil, errors.SkipUnknown, "inference placeholder cannot appear in a public signature"
+	case "pat":
+		return nil, errors.SkipUnknown, "pattern types are an unstable rustc feature"
+	case "empty":
+		return nil, errors.SkipUnknown, "empty type variant"
+	}
+	if strings.HasPrefix(t.Kind(), "unknown:") {
+		return nil, errors.SkipUnknown, fmt.Sprintf("unmodelled rustdoc-types variant %s", t.Kind())
+	}
+	return nil, errors.SkipUnknown, fmt.Sprintf("unhandled type kind %s", t.Kind())
+}
+
+func mapPrimitive(name string) (*Mapping, errors.SkipReason, string) {
+	if name == "()" {
+		return &Mapping{Kind: KindUnit, Rust: "()"}, errors.SkipUnknown, ""
+	}
+	k, ok := primitiveKind[name]
+	if !ok {
+		return nil, errors.SkipUnknown, fmt.Sprintf("unmodelled primitive %q", name)
+	}
+	return &Mapping{Kind: k, Rust: name}, errors.SkipUnknown, ""
+}
+
+func mapPath(p *rustdoc.PathType, dir Direction) (*Mapping, errors.SkipReason, string) {
+	if p == nil {
+		return nil, errors.SkipUnknown, "resolved_path missing payload"
+	}
+	last := LastSegment(p.Path)
+	switch last {
+	case "String":
+		return &Mapping{Kind: KindString, Rust: p.Path}, errors.SkipUnknown, ""
+	case "Vec":
+		elem, sr, det := mapPathArg(p, 0, dir)
+		if sr != errors.SkipUnknown || det != "" {
+			return nil, sr, det
+		}
+		if elem.Kind == KindByte {
+			return &Mapping{Kind: KindBytes, Rust: p.Path}, errors.SkipUnknown, ""
+		}
+		return &Mapping{Kind: KindList, Rust: p.Path, Elem: elem}, errors.SkipUnknown, ""
+	case "Option":
+		elem, sr, det := mapPathArg(p, 0, dir)
+		if sr != errors.SkipUnknown || det != "" {
+			return nil, sr, det
+		}
+		return &Mapping{Kind: KindOption, Rust: p.Path, Elem: elem}, errors.SkipUnknown, ""
+	case "Result":
+		ok, sr, det := mapPathArg(p, 0, dir)
+		if sr != errors.SkipUnknown || det != "" {
+			return nil, sr, det
+		}
+		er, sr2, det2 := mapPathArg(p, 1, dir)
+		if sr2 != errors.SkipUnknown || det2 != "" {
+			return nil, sr2, det2
+		}
+		return &Mapping{Kind: KindResult, Rust: p.Path, OK: ok, Err: er}, errors.SkipUnknown, ""
+	case "HashMap", "BTreeMap":
+		k, sr, det := mapPathArg(p, 0, dir)
+		if sr != errors.SkipUnknown || det != "" {
+			return nil, sr, det
+		}
+		v, sr2, det2 := mapPathArg(p, 1, dir)
+		if sr2 != errors.SkipUnknown || det2 != "" {
+			return nil, sr2, det2
+		}
+		return &Mapping{Kind: KindMap, Rust: p.Path, Key: k, Value: v}, errors.SkipUnknown, ""
+	case "HashSet", "BTreeSet":
+		elem, sr, det := mapPathArg(p, 0, dir)
+		if sr != errors.SkipUnknown || det != "" {
+			return nil, sr, det
+		}
+		return &Mapping{Kind: KindList, Rust: p.Path, Elem: elem}, errors.SkipUnknown, ""
+	case "Box", "Rc", "Arc":
+		return mapPathArg(p, 0, dir)
+	case "Cow":
+		return nil, errors.SkipCow, "Cow<T> is not directly mappable; pass owned type"
+	case "OsString", "OsStr", "PathBuf", "Path", "CString", "CStr":
+		return nil, errors.SkipOsString, fmt.Sprintf("%s requires platform-specific encoding", last)
+	case "Pin":
+		return nil, errors.SkipPin, "Pin<T> requires custom lifetime contracts"
+	}
+	return &Mapping{Kind: KindStruct, Rust: p.Path, PathID: p.ID, PathName: p.Path}, errors.SkipUnknown, ""
+}
+
+// mapPathArg pulls the idx-th type argument from a PathType's
+// AngleBracketed args list (skipping lifetime args) and recursively
+// maps it.
+func mapPathArg(p *rustdoc.PathType, idx int, dir Direction) (*Mapping, errors.SkipReason, string) {
+	if p.Args == nil || p.Args.AngleBracketed == nil {
+		return nil, errors.SkipUnknown, "missing generic arguments"
+	}
+	typeArgs := make([]rustdoc.GenericArg, 0, len(p.Args.AngleBracketed.Args))
+	for _, a := range p.Args.AngleBracketed.Args {
+		if a.Type != nil {
+			typeArgs = append(typeArgs, a)
+		}
+	}
+	if idx >= len(typeArgs) {
+		return nil, errors.SkipUnknown, fmt.Sprintf("missing generic argument %d", idx)
+	}
+	return Map(*typeArgs[idx].Type, dir)
+}
+
+func mapTuple(elems []rustdoc.Type, dir Direction) (*Mapping, errors.SkipReason, string) {
+	if len(elems) == 0 {
+		return &Mapping{Kind: KindUnit, Rust: "()"}, errors.SkipUnknown, ""
+	}
+	fields := make([]Mapping, 0, len(elems))
+	parts := make([]string, 0, len(elems))
+	for i, e := range elems {
+		m, sr, det := Map(e, dir)
+		if sr != errors.SkipUnknown || det != "" {
+			return nil, sr, fmt.Sprintf("tuple field %d: %s", i, det)
+		}
+		fields = append(fields, *m)
+		parts = append(parts, m.Rust)
+	}
+	return &Mapping{Kind: KindTuple, Rust: "(" + strings.Join(parts, ", ") + ")", Fields: fields}, errors.SkipUnknown, ""
+}
+
+func mapSlice(elem rustdoc.Type, dir Direction) (*Mapping, errors.SkipReason, string) {
+	em, sr, det := Map(elem, dir)
+	if sr != errors.SkipUnknown || det != "" {
+		return nil, sr, det
+	}
+	if em.Kind == KindByte {
+		return &Mapping{Kind: KindBytes, Rust: "[u8]"}, errors.SkipUnknown, ""
+	}
+	return &Mapping{Kind: KindList, Rust: "[" + em.Rust + "]", Elem: em}, errors.SkipUnknown, ""
+}
+
+func mapArray(a *rustdoc.ArrayType, dir Direction) (*Mapping, errors.SkipReason, string) {
+	if a == nil {
+		return nil, errors.SkipUnknown, "array missing payload"
+	}
+	em, sr, det := Map(a.Type, dir)
+	if sr != errors.SkipUnknown || det != "" {
+		return nil, sr, det
+	}
+	if em.Kind == KindByte {
+		return &Mapping{Kind: KindBytes, Rust: fmt.Sprintf("[u8; %s]", a.Len)}, errors.SkipUnknown, ""
+	}
+	return &Mapping{Kind: KindList, Rust: fmt.Sprintf("[%s; %s]", em.Rust, a.Len), Elem: em}, errors.SkipUnknown, ""
+}
+
+func mapBorrowed(b *rustdoc.BorrowedRefType, dir Direction) (*Mapping, errors.SkipReason, string) {
+	if b == nil {
+		return nil, errors.SkipUnknown, "borrowed_ref missing payload"
+	}
+	if b.IsMutable {
+		return nil, errors.SkipUnknown, "&mut T requires capability opt-in (no v1 mapping)"
+	}
+	if dir == DirectionOut && b.Lifetime != "" && b.Lifetime != "'static" {
+		return nil, errors.SkipLifetime, fmt.Sprintf("output borrows %s; only 'static borrows can be returned", b.Lifetime)
+	}
+	inner, sr, det := Map(b.Type, dir)
+	if sr != errors.SkipUnknown || det != "" {
+		return nil, sr, det
+	}
+	return inner, errors.SkipUnknown, ""
+}
+
+// LastSegment returns the last "::"-delimited segment of a Rust
+// path. Used to canonicalise std/alloc/core qualifications.
+func LastSegment(path string) string {
+	if i := strings.LastIndex(path, "::"); i >= 0 {
+		return path[i+2:]
+	}
+	return path
+}

--- a/package3/rust/typemap/map_test.go
+++ b/package3/rust/typemap/map_test.go
@@ -1,0 +1,454 @@
+package typemap
+
+import (
+	"testing"
+
+	"mochi/package3/rust/errors"
+	"mochi/package3/rust/rustdoc"
+)
+
+// primT builds a primitive Type for tests.
+func primT(name string) rustdoc.Type {
+	return rustdoc.Type{Primitive: name}
+}
+
+// pathT builds a resolved_path Type with optional type args.
+func pathT(path string, args ...rustdoc.Type) rustdoc.Type {
+	pt := &rustdoc.PathType{ID: "id:" + path, Path: path}
+	if len(args) > 0 {
+		ga := &rustdoc.GenericArgs{AngleBracketed: &rustdoc.AngleBracketedArgs{}}
+		for i := range args {
+			a := args[i]
+			ga.AngleBracketed.Args = append(ga.AngleBracketed.Args,
+				rustdoc.GenericArg{Type: &a})
+		}
+		pt.Args = ga
+	}
+	return rustdoc.Type{ResolvedPath: pt}
+}
+
+// borrowT builds a borrowed_ref Type.
+func borrowT(lifetime string, mut bool, inner rustdoc.Type) rustdoc.Type {
+	return rustdoc.Type{BorrowedRef: &rustdoc.BorrowedRefType{
+		Lifetime:  lifetime,
+		IsMutable: mut,
+		Type:      inner,
+	}}
+}
+
+func sliceT(elem rustdoc.Type) rustdoc.Type {
+	return rustdoc.Type{Slice: &elem}
+}
+
+func arrayT(elem rustdoc.Type, length string) rustdoc.Type {
+	return rustdoc.Type{Array: &rustdoc.ArrayType{Type: elem, Len: length}}
+}
+
+func tupleT(elems ...rustdoc.Type) rustdoc.Type {
+	if len(elems) == 0 {
+		// Preserve a non-nil empty slice so the unit type round-trips.
+		return rustdoc.Type{Tuple: []rustdoc.Type{}}
+	}
+	return rustdoc.Type{Tuple: elems}
+}
+
+// expectMapping asserts a successful Map call.
+func expectMapping(t *testing.T, name string, m *Mapping, sr errors.SkipReason, det string) *Mapping {
+	t.Helper()
+	if sr != errors.SkipUnknown {
+		t.Fatalf("%s: SkipReason = %s; want SkipUnknown (success), detail=%q", name, sr, det)
+	}
+	if det != "" {
+		t.Fatalf("%s: detail = %q; want empty (success)", name, det)
+	}
+	if m == nil {
+		t.Fatalf("%s: nil Mapping on success", name)
+	}
+	return m
+}
+
+// expectSkip asserts a failed Map call with a specific reason.
+func expectSkip(t *testing.T, name string, want errors.SkipReason, sr errors.SkipReason, det string) {
+	t.Helper()
+	if sr != want {
+		t.Errorf("%s: SkipReason = %s; want %s (detail=%q)", name, sr, want, det)
+	}
+	if det == "" {
+		t.Errorf("%s: empty detail on skip", name)
+	}
+}
+
+func TestMapPrimitives(t *testing.T) {
+	cases := []struct {
+		rust string
+		want Kind
+	}{
+		{"bool", KindBool},
+		{"i8", KindInt},
+		{"i16", KindInt},
+		{"i32", KindInt},
+		{"i64", KindInt64},
+		{"i128", KindInt64},
+		{"u8", KindByte},
+		{"u16", KindUInt},
+		{"u32", KindUInt},
+		{"u64", KindUInt64},
+		{"u128", KindUInt64},
+		{"isize", KindInt64},
+		{"usize", KindUInt64},
+		{"f32", KindFloat},
+		{"f64", KindFloat64},
+		{"char", KindChar},
+		{"str", KindString},
+		{"never", KindUnit},
+		{"!", KindUnit},
+	}
+	for _, c := range cases {
+		m, sr, det := Map(primT(c.rust), DirectionIn)
+		got := expectMapping(t, "primitive "+c.rust, m, sr, det)
+		if got.Kind != c.want {
+			t.Errorf("primitive %s -> %s; want %s", c.rust, got.Kind, c.want)
+		}
+	}
+}
+
+func TestMapPrimitiveUnknown(t *testing.T) {
+	_, sr, det := Map(primT("future_prim_42"), DirectionIn)
+	expectSkip(t, "unknown primitive", errors.SkipUnknown, sr, det)
+}
+
+func TestMapUnit(t *testing.T) {
+	m, sr, det := Map(primT("()"), DirectionIn)
+	mp := expectMapping(t, "unit", m, sr, det)
+	if mp.Kind != KindUnit {
+		t.Errorf("() -> %s; want unit", mp.Kind)
+	}
+}
+
+func TestMapString(t *testing.T) {
+	m, sr, det := Map(pathT("std::string::String"), DirectionIn)
+	mp := expectMapping(t, "String", m, sr, det)
+	if mp.Kind != KindString {
+		t.Errorf("String -> %s; want string", mp.Kind)
+	}
+}
+
+func TestMapVecBytes(t *testing.T) {
+	m, sr, det := Map(pathT("std::vec::Vec", primT("u8")), DirectionIn)
+	mp := expectMapping(t, "Vec<u8>", m, sr, det)
+	if mp.Kind != KindBytes {
+		t.Errorf("Vec<u8> -> %s; want bytes", mp.Kind)
+	}
+}
+
+func TestMapVecList(t *testing.T) {
+	m, sr, det := Map(pathT("alloc::vec::Vec", primT("i64")), DirectionIn)
+	mp := expectMapping(t, "Vec<i64>", m, sr, det)
+	if mp.Kind != KindList || mp.Elem == nil || mp.Elem.Kind != KindInt64 {
+		t.Errorf("Vec<i64> -> %+v", mp)
+	}
+}
+
+func TestMapVecNested(t *testing.T) {
+	inner := pathT("std::vec::Vec", primT("i32"))
+	m, sr, det := Map(pathT("std::vec::Vec", inner), DirectionIn)
+	mp := expectMapping(t, "Vec<Vec<i32>>", m, sr, det)
+	if mp.Kind != KindList || mp.Elem == nil || mp.Elem.Kind != KindList {
+		t.Fatalf("Vec<Vec<i32>> -> %+v", mp)
+	}
+	if mp.MochiType() != "list[list[int]]" {
+		t.Errorf("Vec<Vec<i32>> MochiType = %q", mp.MochiType())
+	}
+}
+
+func TestMapOption(t *testing.T) {
+	m, sr, det := Map(pathT("core::option::Option", primT("i32")), DirectionIn)
+	mp := expectMapping(t, "Option<i32>", m, sr, det)
+	if mp.Kind != KindOption || mp.Elem == nil || mp.Elem.Kind != KindInt {
+		t.Errorf("Option<i32> -> %+v", mp)
+	}
+	if mp.MochiType() != "?int" {
+		t.Errorf("Option<i32> MochiType = %q", mp.MochiType())
+	}
+}
+
+func TestMapResult(t *testing.T) {
+	m, sr, det := Map(pathT("core::result::Result", pathT("std::string::String"), primT("i32")), DirectionIn)
+	mp := expectMapping(t, "Result<String,i32>", m, sr, det)
+	if mp.Kind != KindResult || mp.OK.Kind != KindString || mp.Err.Kind != KindInt {
+		t.Errorf("Result -> %+v", mp)
+	}
+	if mp.MochiType() != "result[string,int]" {
+		t.Errorf("Result MochiType = %q", mp.MochiType())
+	}
+}
+
+func TestMapHashMap(t *testing.T) {
+	m, sr, det := Map(pathT("std::collections::HashMap", pathT("std::string::String"), primT("i64")), DirectionIn)
+	mp := expectMapping(t, "HashMap<String,i64>", m, sr, det)
+	if mp.Kind != KindMap {
+		t.Fatalf("HashMap -> %+v", mp)
+	}
+	if mp.Key.Kind != KindString || mp.Value.Kind != KindInt64 {
+		t.Errorf("HashMap K/V = %s/%s", mp.Key.Kind, mp.Value.Kind)
+	}
+	if mp.MochiType() != "map[string]int64" {
+		t.Errorf("HashMap MochiType = %q", mp.MochiType())
+	}
+}
+
+func TestMapBTreeMap(t *testing.T) {
+	m, sr, det := Map(pathT("std::collections::BTreeMap", primT("i32"), primT("bool")), DirectionIn)
+	mp := expectMapping(t, "BTreeMap<i32,bool>", m, sr, det)
+	if mp.Kind != KindMap {
+		t.Errorf("BTreeMap -> %+v", mp)
+	}
+}
+
+func TestMapHashSet(t *testing.T) {
+	m, sr, det := Map(pathT("std::collections::HashSet", primT("i32")), DirectionIn)
+	mp := expectMapping(t, "HashSet<i32>", m, sr, det)
+	if mp.Kind != KindList || mp.Elem.Kind != KindInt {
+		t.Errorf("HashSet -> %+v", mp)
+	}
+}
+
+func TestMapBTreeSet(t *testing.T) {
+	m, sr, det := Map(pathT("std::collections::BTreeSet", primT("u64")), DirectionIn)
+	mp := expectMapping(t, "BTreeSet<u64>", m, sr, det)
+	if mp.Kind != KindList {
+		t.Errorf("BTreeSet -> %+v", mp)
+	}
+}
+
+func TestMapBoxTransparent(t *testing.T) {
+	m, sr, det := Map(pathT("alloc::boxed::Box", primT("i64")), DirectionIn)
+	mp := expectMapping(t, "Box<i64>", m, sr, det)
+	if mp.Kind != KindInt64 {
+		t.Errorf("Box<i64> -> %s; want int64 (transparent)", mp.Kind)
+	}
+}
+
+func TestMapRcArcTransparent(t *testing.T) {
+	m, sr, det := Map(pathT("alloc::rc::Rc", pathT("std::string::String")), DirectionIn)
+	mp := expectMapping(t, "Rc<String>", m, sr, det)
+	if mp.Kind != KindString {
+		t.Errorf("Rc<String> -> %s; want string", mp.Kind)
+	}
+	m2, sr2, det2 := Map(pathT("alloc::sync::Arc", primT("u32")), DirectionIn)
+	mp2 := expectMapping(t, "Arc<u32>", m2, sr2, det2)
+	if mp2.Kind != KindUInt {
+		t.Errorf("Arc<u32> -> %s; want uint", mp2.Kind)
+	}
+}
+
+func TestMapCowSkip(t *testing.T) {
+	_, sr, det := Map(pathT("std::borrow::Cow", primT("str")), DirectionIn)
+	expectSkip(t, "Cow<str>", errors.SkipCow, sr, det)
+}
+
+func TestMapOsStringSkip(t *testing.T) {
+	for _, name := range []string{"OsString", "OsStr", "PathBuf", "Path", "CString", "CStr"} {
+		_, sr, det := Map(pathT("std::ffi::"+name), DirectionIn)
+		expectSkip(t, name, errors.SkipOsString, sr, det)
+	}
+}
+
+func TestMapPinSkip(t *testing.T) {
+	_, sr, det := Map(pathT("core::pin::Pin", pathT("alloc::boxed::Box", primT("i32"))), DirectionIn)
+	expectSkip(t, "Pin", errors.SkipPin, sr, det)
+}
+
+func TestMapTuple(t *testing.T) {
+	m, sr, det := Map(tupleT(primT("i32"), pathT("std::string::String")), DirectionIn)
+	mp := expectMapping(t, "(i32, String)", m, sr, det)
+	if mp.Kind != KindTuple || len(mp.Fields) != 2 {
+		t.Errorf("tuple -> %+v", mp)
+	}
+	if mp.MochiType() != "tuple[int,string]" {
+		t.Errorf("tuple MochiType = %q", mp.MochiType())
+	}
+}
+
+func TestMapEmptyTupleIsUnit(t *testing.T) {
+	m, sr, det := Map(tupleT(), DirectionIn)
+	mp := expectMapping(t, "()", m, sr, det)
+	if mp.Kind != KindUnit {
+		t.Errorf("empty tuple -> %s; want unit", mp.Kind)
+	}
+}
+
+func TestMapSliceBytes(t *testing.T) {
+	m, sr, det := Map(sliceT(primT("u8")), DirectionIn)
+	mp := expectMapping(t, "[u8]", m, sr, det)
+	if mp.Kind != KindBytes {
+		t.Errorf("[u8] -> %s; want bytes", mp.Kind)
+	}
+}
+
+func TestMapSliceList(t *testing.T) {
+	m, sr, det := Map(sliceT(primT("i32")), DirectionIn)
+	mp := expectMapping(t, "[i32]", m, sr, det)
+	if mp.Kind != KindList || mp.Elem.Kind != KindInt {
+		t.Errorf("[i32] -> %+v", mp)
+	}
+}
+
+func TestMapArrayBytes(t *testing.T) {
+	m, sr, det := Map(arrayT(primT("u8"), "32"), DirectionIn)
+	mp := expectMapping(t, "[u8;32]", m, sr, det)
+	if mp.Kind != KindBytes {
+		t.Errorf("[u8;32] -> %s; want bytes", mp.Kind)
+	}
+}
+
+func TestMapArrayList(t *testing.T) {
+	m, sr, det := Map(arrayT(primT("i32"), "4"), DirectionIn)
+	mp := expectMapping(t, "[i32;4]", m, sr, det)
+	if mp.Kind != KindList {
+		t.Errorf("[i32;4] -> %s; want list", mp.Kind)
+	}
+}
+
+func TestMapBorrowedRefStrInput(t *testing.T) {
+	m, sr, det := Map(borrowT("'a", false, primT("str")), DirectionIn)
+	mp := expectMapping(t, "&'a str input", m, sr, det)
+	if mp.Kind != KindString {
+		t.Errorf("&str -> %s; want string", mp.Kind)
+	}
+}
+
+func TestMapBorrowedRefOutputNonStatic(t *testing.T) {
+	_, sr, det := Map(borrowT("'a", false, primT("str")), DirectionOut)
+	expectSkip(t, "&'a str output", errors.SkipLifetime, sr, det)
+}
+
+func TestMapBorrowedRefOutputStatic(t *testing.T) {
+	m, sr, det := Map(borrowT("'static", false, primT("str")), DirectionOut)
+	mp := expectMapping(t, "&'static str output", m, sr, det)
+	if mp.Kind != KindString {
+		t.Errorf("&'static str output -> %s", mp.Kind)
+	}
+}
+
+func TestMapMutBorrowSkip(t *testing.T) {
+	_, sr, det := Map(borrowT("'a", true, primT("i32")), DirectionIn)
+	if sr == errors.SkipUnknown && det == "" {
+		t.Errorf("&mut should not produce a successful mapping")
+	}
+}
+
+func TestMapRawPointerSkip(t *testing.T) {
+	rp := rustdoc.Type{RawPointer: &rustdoc.RawPointerType{IsMutable: false, Type: primT("u8")}}
+	_, sr, det := Map(rp, DirectionIn)
+	expectSkip(t, "*const u8", errors.SkipRawPointer, sr, det)
+}
+
+func TestMapGenericSkip(t *testing.T) {
+	_, sr, det := Map(rustdoc.Type{Generic: "T"}, DirectionIn)
+	expectSkip(t, "generic T", errors.SkipGeneric, sr, det)
+}
+
+func TestMapDynTraitSkip(t *testing.T) {
+	dt := rustdoc.Type{DynTrait: &rustdoc.DynTraitType{
+		Traits: []rustdoc.PolyTrait{{Trait: rustdoc.PathType{Path: "core::fmt::Debug"}}},
+	}}
+	_, sr, det := Map(dt, DirectionIn)
+	expectSkip(t, "dyn Trait", errors.SkipDynTrait, sr, det)
+}
+
+func TestMapImplTraitSkip(t *testing.T) {
+	it := rustdoc.Type{ImplTrait: []rustdoc.GenericBound{
+		{TraitBound: &rustdoc.TraitBound{Trait: rustdoc.PathType{Path: "core::iter::Iterator"}}},
+	}}
+	_, sr, det := Map(it, DirectionOut)
+	expectSkip(t, "impl Trait", errors.SkipImplTrait, sr, det)
+}
+
+func TestMapQualifiedPathSkip(t *testing.T) {
+	qp := rustdoc.Type{QualifiedPath: &rustdoc.QualifiedPathType{
+		Name:     "Item",
+		SelfType: primT("u8"),
+	}}
+	_, sr, det := Map(qp, DirectionIn)
+	expectSkip(t, "<T as Trait>::Item", errors.SkipQualifiedPath, sr, det)
+}
+
+func TestMapFunctionPointerSkip(t *testing.T) {
+	fp := rustdoc.Type{FunctionPointer: &rustdoc.FunctionPointer{}}
+	_, sr, det := Map(fp, DirectionIn)
+	if sr != errors.SkipUnknown || det == "" {
+		t.Errorf("function_pointer: sr=%s det=%q", sr, det)
+	}
+}
+
+func TestMapInferSkip(t *testing.T) {
+	_, sr, det := Map(rustdoc.Type{Infer: true}, DirectionIn)
+	if sr != errors.SkipUnknown || det == "" {
+		t.Errorf("infer: sr=%s det=%q", sr, det)
+	}
+}
+
+func TestMapPatSkip(t *testing.T) {
+	_, sr, det := Map(rustdoc.Type{Pat: &rustdoc.PatType{Base: primT("u8")}}, DirectionIn)
+	if sr != errors.SkipUnknown || det == "" {
+		t.Errorf("pat: sr=%s det=%q", sr, det)
+	}
+}
+
+func TestMapUnknownVariant(t *testing.T) {
+	_, sr, det := Map(rustdoc.Type{Unknown: "weird_future_kind"}, DirectionIn)
+	if sr != errors.SkipUnknown || det == "" {
+		t.Errorf("unknown variant: sr=%s det=%q", sr, det)
+	}
+}
+
+func TestMapUserStructHandle(t *testing.T) {
+	m, sr, det := Map(pathT("tokio::sync::Mutex", primT("i32")), DirectionIn)
+	mp := expectMapping(t, "tokio::sync::Mutex", m, sr, det)
+	if mp.Kind != KindStruct {
+		t.Errorf("user path -> %s; want struct (opaque handle)", mp.Kind)
+	}
+	if mp.PathName != "tokio::sync::Mutex" || mp.PathID == "" {
+		t.Errorf("user path PathName=%q PathID=%q", mp.PathName, mp.PathID)
+	}
+}
+
+func TestMapEmptyType(t *testing.T) {
+	_, sr, det := Map(rustdoc.Type{}, DirectionIn)
+	if sr != errors.SkipUnknown || det == "" {
+		t.Errorf("empty: sr=%s det=%q", sr, det)
+	}
+}
+
+func TestMapPropagatesNestedSkip(t *testing.T) {
+	// Vec<dyn Trait> -> nested SkipDynTrait
+	dt := rustdoc.Type{DynTrait: &rustdoc.DynTraitType{
+		Traits: []rustdoc.PolyTrait{{Trait: rustdoc.PathType{Path: "core::fmt::Debug"}}},
+	}}
+	_, sr, det := Map(pathT("std::vec::Vec", dt), DirectionIn)
+	expectSkip(t, "Vec<dyn Trait>", errors.SkipDynTrait, sr, det)
+}
+
+func TestMapPropagatesTupleSkip(t *testing.T) {
+	// (i32, *const u8) -> SkipRawPointer
+	rp := rustdoc.Type{RawPointer: &rustdoc.RawPointerType{Type: primT("u8")}}
+	_, sr, det := Map(tupleT(primT("i32"), rp), DirectionIn)
+	if sr != errors.SkipRawPointer || det == "" {
+		t.Errorf("(i32, *const u8): sr=%s det=%q", sr, det)
+	}
+}
+
+func TestLastSegment(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"std::vec::Vec", "Vec"},
+		{"Vec", "Vec"},
+		{"core::option::Option", "Option"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := LastSegment(c.in); got != c.want {
+			t.Errorf("LastSegment(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/package3/rust/typemap/mapping.go
+++ b/package3/rust/typemap/mapping.go
@@ -1,0 +1,169 @@
+package typemap
+
+import "strings"
+
+// Mapping is a successful translation from a Rust type to a Mochi
+// type plus its FFI representation. Failed translations return an
+// errors.SkipReason; see map.go.
+//
+// Compound mappings (List, Map, Option, Result, Tuple) carry their
+// child Mappings by pointer or slice. Reference types are folded
+// into the child Mapping at lowering time, so a Mapping never
+// carries borrow metadata.
+type Mapping struct {
+	Kind Kind
+
+	// Rust is the canonical Rust source rendering of the input type
+	// (e.g. "Vec<i64>", "Option<String>", "core::option::Option<T>").
+	// Kept for SKIPPED diagnostics and wrapper-crate code generation.
+	Rust string
+
+	// Elem is the element Mapping for List, Bytes (nil since Bytes
+	// is a primitive), and Option.
+	Elem *Mapping
+
+	// Key, Value are populated for Map.
+	Key   *Mapping
+	Value *Mapping
+
+	// OK, Err are populated for Result.
+	OK  *Mapping
+	Err *Mapping
+
+	// Fields is populated for Tuple in positional order.
+	Fields []Mapping
+
+	// PathID and PathName are populated for Struct, Enum, and Handle.
+	// PathID is the rustdoc Item ID; PathName is the rendered Rust
+	// path (e.g. "tokio::sync::Mutex"). Both are empty for everything
+	// else.
+	PathID   string
+	PathName string
+}
+
+// MochiType returns the Mochi-side rendering of this Mapping. The
+// output is used by phase 5 (Mochi extern fn emitter) and is stable
+// for golden-fixture diffs.
+func (m Mapping) MochiType() string {
+	switch m.Kind {
+	case KindUnit:
+		return "unit"
+	case KindBool:
+		return "bool"
+	case KindInt:
+		return "int"
+	case KindInt64:
+		return "int64"
+	case KindUInt:
+		return "uint"
+	case KindUInt64:
+		return "uint64"
+	case KindFloat:
+		return "float"
+	case KindFloat64:
+		return "float64"
+	case KindByte:
+		return "byte"
+	case KindChar:
+		return "char"
+	case KindString:
+		return "string"
+	case KindBytes:
+		return "bytes"
+	case KindList:
+		if m.Elem != nil {
+			return "list[" + m.Elem.MochiType() + "]"
+		}
+		return "list[?]"
+	case KindMap:
+		if m.Key != nil && m.Value != nil {
+			return "map[" + m.Key.MochiType() + "]" + m.Value.MochiType()
+		}
+		return "map[?]?"
+	case KindOption:
+		if m.Elem != nil {
+			return "?" + m.Elem.MochiType()
+		}
+		return "?"
+	case KindResult:
+		ok := "?"
+		er := "?"
+		if m.OK != nil {
+			ok = m.OK.MochiType()
+		}
+		if m.Err != nil {
+			er = m.Err.MochiType()
+		}
+		return "result[" + ok + "," + er + "]"
+	case KindTuple:
+		parts := make([]string, len(m.Fields))
+		for i, f := range m.Fields {
+			parts[i] = f.MochiType()
+		}
+		return "tuple[" + strings.Join(parts, ",") + "]"
+	case KindStruct, KindEnum, KindHandle:
+		if m.PathName != "" {
+			return m.PathName
+		}
+		return m.Kind.String()
+	}
+	return "invalid"
+}
+
+// FFIRepr returns the C-ABI rendering used by the phase 4 wrapper
+// synthesiser. The rendering deliberately matches the wrapper-side
+// header that phase 4 will generate, so the typemap output is the
+// single source of truth for layout decisions.
+func (m Mapping) FFIRepr() string {
+	switch m.Kind {
+	case KindUnit:
+		return "void"
+	case KindBool:
+		return "bool"
+	case KindInt:
+		return "int32_t"
+	case KindInt64:
+		return "int64_t"
+	case KindUInt:
+		return "uint32_t"
+	case KindUInt64:
+		return "uint64_t"
+	case KindFloat:
+		return "float"
+	case KindFloat64:
+		return "double"
+	case KindByte:
+		return "uint8_t"
+	case KindChar:
+		return "uint32_t"
+	case KindString:
+		return "MochiString"
+	case KindBytes:
+		return "MochiSlice"
+	case KindList:
+		return "MochiSlice"
+	case KindMap:
+		return "MochiMap"
+	case KindOption:
+		return "MochiOption"
+	case KindResult:
+		return "MochiResult"
+	case KindTuple:
+		return "MochiTuple"
+	case KindStruct, KindEnum, KindHandle:
+		return "MochiHandle"
+	}
+	return "void"
+}
+
+// IsScalar reports whether the Mapping holds a primitive scalar that
+// crosses the FFI boundary by value (i.e. without an indirection
+// through MochiString / MochiSlice / MochiHandle).
+func (m Mapping) IsScalar() bool {
+	switch m.Kind {
+	case KindBool, KindInt, KindInt64, KindUInt, KindUInt64,
+		KindFloat, KindFloat64, KindByte, KindChar, KindUnit:
+		return true
+	}
+	return false
+}

--- a/package3/rust/typemap/mapping_test.go
+++ b/package3/rust/typemap/mapping_test.go
@@ -1,0 +1,151 @@
+package typemap
+
+import "testing"
+
+func TestMappingMochiTypeScalars(t *testing.T) {
+	cases := []struct {
+		m    Mapping
+		want string
+	}{
+		{Mapping{Kind: KindUnit}, "unit"},
+		{Mapping{Kind: KindBool}, "bool"},
+		{Mapping{Kind: KindInt}, "int"},
+		{Mapping{Kind: KindInt64}, "int64"},
+		{Mapping{Kind: KindUInt}, "uint"},
+		{Mapping{Kind: KindUInt64}, "uint64"},
+		{Mapping{Kind: KindFloat}, "float"},
+		{Mapping{Kind: KindFloat64}, "float64"},
+		{Mapping{Kind: KindByte}, "byte"},
+		{Mapping{Kind: KindChar}, "char"},
+		{Mapping{Kind: KindString}, "string"},
+		{Mapping{Kind: KindBytes}, "bytes"},
+	}
+	for _, c := range cases {
+		if got := c.m.MochiType(); got != c.want {
+			t.Errorf("MochiType(%s) = %q; want %q", c.m.Kind, got, c.want)
+		}
+	}
+}
+
+func TestMappingMochiTypeList(t *testing.T) {
+	m := Mapping{Kind: KindList, Elem: &Mapping{Kind: KindInt64}}
+	if got := m.MochiType(); got != "list[int64]" {
+		t.Errorf("list[int64] MochiType = %q", got)
+	}
+	// nested
+	nested := Mapping{Kind: KindList, Elem: &Mapping{Kind: KindList, Elem: &Mapping{Kind: KindString}}}
+	if got := nested.MochiType(); got != "list[list[string]]" {
+		t.Errorf("list[list[string]] MochiType = %q", got)
+	}
+	// nil elem (degenerate)
+	deg := Mapping{Kind: KindList}
+	if got := deg.MochiType(); got != "list[?]" {
+		t.Errorf("nil-elem list MochiType = %q", got)
+	}
+}
+
+func TestMappingMochiTypeMap(t *testing.T) {
+	m := Mapping{
+		Kind:  KindMap,
+		Key:   &Mapping{Kind: KindString},
+		Value: &Mapping{Kind: KindInt},
+	}
+	if got := m.MochiType(); got != "map[string]int" {
+		t.Errorf("map[string]int MochiType = %q", got)
+	}
+}
+
+func TestMappingMochiTypeOption(t *testing.T) {
+	m := Mapping{Kind: KindOption, Elem: &Mapping{Kind: KindString}}
+	if got := m.MochiType(); got != "?string" {
+		t.Errorf("?string MochiType = %q", got)
+	}
+}
+
+func TestMappingMochiTypeResult(t *testing.T) {
+	m := Mapping{Kind: KindResult, OK: &Mapping{Kind: KindString}, Err: &Mapping{Kind: KindInt}}
+	if got := m.MochiType(); got != "result[string,int]" {
+		t.Errorf("result MochiType = %q", got)
+	}
+}
+
+func TestMappingMochiTypeTuple(t *testing.T) {
+	m := Mapping{Kind: KindTuple, Fields: []Mapping{
+		{Kind: KindInt},
+		{Kind: KindString},
+		{Kind: KindBool},
+	}}
+	if got := m.MochiType(); got != "tuple[int,string,bool]" {
+		t.Errorf("tuple MochiType = %q", got)
+	}
+}
+
+func TestMappingMochiTypeStructEnumHandle(t *testing.T) {
+	s := Mapping{Kind: KindStruct, PathName: "serde::de::Error"}
+	if got := s.MochiType(); got != "serde::de::Error" {
+		t.Errorf("struct MochiType = %q", got)
+	}
+	e := Mapping{Kind: KindEnum, PathName: "syn::Item"}
+	if got := e.MochiType(); got != "syn::Item" {
+		t.Errorf("enum MochiType = %q", got)
+	}
+	h := Mapping{Kind: KindHandle, PathName: "tokio::sync::Mutex"}
+	if got := h.MochiType(); got != "tokio::sync::Mutex" {
+		t.Errorf("handle MochiType = %q", got)
+	}
+}
+
+func TestMappingFFIRepr(t *testing.T) {
+	cases := []struct {
+		m    Mapping
+		want string
+	}{
+		{Mapping{Kind: KindUnit}, "void"},
+		{Mapping{Kind: KindBool}, "bool"},
+		{Mapping{Kind: KindInt}, "int32_t"},
+		{Mapping{Kind: KindInt64}, "int64_t"},
+		{Mapping{Kind: KindUInt}, "uint32_t"},
+		{Mapping{Kind: KindUInt64}, "uint64_t"},
+		{Mapping{Kind: KindFloat}, "float"},
+		{Mapping{Kind: KindFloat64}, "double"},
+		{Mapping{Kind: KindByte}, "uint8_t"},
+		{Mapping{Kind: KindChar}, "uint32_t"},
+		{Mapping{Kind: KindString}, "MochiString"},
+		{Mapping{Kind: KindBytes}, "MochiSlice"},
+		{Mapping{Kind: KindList}, "MochiSlice"},
+		{Mapping{Kind: KindMap}, "MochiMap"},
+		{Mapping{Kind: KindOption}, "MochiOption"},
+		{Mapping{Kind: KindResult}, "MochiResult"},
+		{Mapping{Kind: KindTuple}, "MochiTuple"},
+		{Mapping{Kind: KindStruct}, "MochiHandle"},
+		{Mapping{Kind: KindEnum}, "MochiHandle"},
+		{Mapping{Kind: KindHandle}, "MochiHandle"},
+		{Mapping{Kind: KindInvalid}, "void"},
+	}
+	for _, c := range cases {
+		if got := c.m.FFIRepr(); got != c.want {
+			t.Errorf("FFIRepr(%s) = %q; want %q", c.m.Kind, got, c.want)
+		}
+	}
+}
+
+func TestMappingIsScalar(t *testing.T) {
+	scalars := []Kind{
+		KindUnit, KindBool, KindInt, KindInt64, KindUInt, KindUInt64,
+		KindFloat, KindFloat64, KindByte, KindChar,
+	}
+	for _, k := range scalars {
+		if !(Mapping{Kind: k}).IsScalar() {
+			t.Errorf("%s should be scalar", k)
+		}
+	}
+	nonScalars := []Kind{
+		KindString, KindBytes, KindList, KindMap, KindOption,
+		KindResult, KindTuple, KindStruct, KindEnum, KindHandle,
+	}
+	for _, k := range nonScalars {
+		if (Mapping{Kind: k}).IsScalar() {
+			t.Errorf("%s should not be scalar", k)
+		}
+	}
+}

--- a/website/docs/implementation/0073/index.md
+++ b/website/docs/implementation/0073/index.md
@@ -17,8 +17,8 @@ A phase is LANDED only when its gate is green for every target (consume directio
 |-------|-------|--------|--------|---------------|
 | 0 | Skeleton: package3/rust/ layout + cargo workspace plumbing | LANDED | [2dc3b34f](https://github.com/mochilang/mochi/commit/2dc3b34f) | [phase-00](/docs/implementation/0073/phase-00-skeleton) |
 | 1 | Sparse-index client (`index.crates.io` reader, sha256 + blake3 download verify) | LANDED | [a3c263fb](https://github.com/mochilang/mochi/commit/a3c263fb) | [phase-01](/docs/implementation/0073/phase-01-sparse-index) |
-| 2 | Rustdoc-JSON ingest + ApiSurface emit | LANDED | (pending) | [phase-02](/docs/implementation/0073/phase-02-rustdoc-ingest) |
-| 3 | Closed type-mapping table (scalars / strings / collections / Option / Result / Tuple / Struct / Enum) | NOT STARTED | — | [phase-03](/docs/implementation/0073/phase-03-type-mapping) |
+| 2 | Rustdoc-JSON ingest + ApiSurface emit | LANDED | [1cd97c1b](https://github.com/mochilang/mochi/commit/1cd97c1b) | [phase-02](/docs/implementation/0073/phase-02-rustdoc-ingest) |
+| 3 | Closed type-mapping table (scalars / strings / collections / Option / Result / Tuple / Struct / Enum) | LANDED | (pending) | [phase-03](/docs/implementation/0073/phase-03-type-mapping) |
 | 4 | Wrapper crate synthesiser (extern "C" surface, MochiString / MochiSlice / opaque handles) | NOT STARTED | — | [phase-04](/docs/implementation/0073/phase-04-wrapper) |
 | 5 | Mochi-side extern fn emitter + alias shim file generation | NOT STARTED | — | [phase-05](/docs/implementation/0073/phase-05-extern-emit) |
 | 6 | `import rust "<crate>@<semver>" as <alias>` grammar + parser | NOT STARTED | — | [phase-06](/docs/implementation/0073/phase-06-import-grammar) |
@@ -60,7 +60,7 @@ package3/rust/
   semver/                 # cargo-flavoured semver parser (phase 1)
   sparse/                 # sparse-index client + content-addressed cache (phase 1)
   rustdoc/                # rustdoc-types Go parser + ApiSurface walker (phase 2)
-  typemap/                # closed type table (phase 3)
+  typemap/                # closed type table + Mochi/FFI rendering (phase 3)
   wrapper/                # extern-C wrapper synthesiser (phase 4)
   emit/                   # Mochi extern fn emitter (phase 5)
   publish/                # crates.io publish + Sigstore (phase 10)
@@ -71,7 +71,7 @@ The `package3/rust/` location is shared with the broader MEP-57 polyglot package
 
 ## Status snapshot
 
-As of 2026-05-29 21:17 (GMT+7): phases 0, 1, and 2 LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest). Phases 3-13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
+As of 2026-05-29 21:30 (GMT+7): phases 0, 1, 2, and 3 LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest + closed type-mapping table). Phases 4-13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
 
 ## Cross-references
 

--- a/website/docs/implementation/0073/phase-03-type-mapping.md
+++ b/website/docs/implementation/0073/phase-03-type-mapping.md
@@ -1,0 +1,150 @@
+---
+title: "Phase 3. Closed type-mapping table"
+sidebar_position: 5
+sidebar_label: "Phase 3. Type-mapping table"
+description: "MEP-73 Phase 3 lands the package3/rust/typemap/ closed table: scalars, strings, collections, Option, Result, Tuple, Struct, Enum mappings between rustdoc.Type and Mochi types plus an explicit SkipReason for every refusal class."
+---
+
+# Phase 3. Closed type-mapping table
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-73 §Phases](/docs/mep/mep-0073#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-29 21:23 (GMT+7) |
+| Landed         | 2026-05-29 21:30 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`package3/rust/typemap/` exposes a single `Map(t rustdoc.Type, dir Direction) (*Mapping, errors.SkipReason, string)` entry point. The function returns a structured `Mapping` describing the Mochi-side type and its FFI representation when a closed-table rule applies, or an `errors.SkipReason` plus a free-text detail when none exists. The contract is "closed": every rustdoc-types `Type` variant either has a documented rule or a documented refusal reason. There is no silent fallthrough that emits an approximated mapping.
+
+The 53 test functions across `kind_test.go`, `mapping_test.go`, and `map_test.go` pin the closed table. The full `package3/rust/...` suite (6 packages: errors, build, semver, sparse, rustdoc, typemap) is green.
+
+## Closed-table rules
+
+### Primitives
+
+| Rust | Mochi `Kind` | Mochi rendering | FFI repr |
+|------|--------------|-----------------|----------|
+| `bool` | `KindBool` | `bool` | `bool` |
+| `i8`, `i16`, `i32` | `KindInt` | `int` | `int32_t` |
+| `i64`, `i128`, `isize` | `KindInt64` | `int64` | `int64_t` |
+| `u8` | `KindByte` | `byte` | `uint8_t` |
+| `u16`, `u32` | `KindUInt` | `uint` | `uint32_t` |
+| `u64`, `u128`, `usize` | `KindUInt64` | `uint64` | `uint64_t` |
+| `f32` | `KindFloat` | `float` | `float` |
+| `f64` | `KindFloat64` | `float64` | `double` |
+| `char` | `KindChar` | `char` | `uint32_t` (codepoint) |
+| `str` | `KindString` | `string` | `MochiString` |
+| `()`, `never`, `!` | `KindUnit` | `unit` | `void` |
+
+The `i128`/`u128` folding into 64-bit kinds is provisional, gated by a Phase 4 wrapper rule that emits a guard rejecting values outside `[i64::MIN, i64::MAX]` (resp. `u64`). Phase 4 may promote `i128`/`u128` to a `MochiBigInt` slot if the polish lands; this phase only commits to the lower-bound mapping so the table is closed.
+
+### Strings
+
+`std::string::String`, `alloc::string::String`, and any `&str` (immutable borrow of the `str` primitive) all map to `KindString` with `FFIRepr = "MochiString"`. The bridge always copies the bytes; nothing crosses the FFI as a borrow.
+
+### Collections
+
+| Rust | Mochi |
+|------|-------|
+| `Vec<u8>`, `&[u8]`, `[u8; N]` | `bytes` |
+| `Vec<T>`, `&[T]`, `[T; N]` | `list[T]` |
+| `HashMap<K, V>`, `BTreeMap<K, V>` | `map[K]V` |
+| `HashSet<T>`, `BTreeSet<T>` | `list[T]` (Mochi has no set primitive) |
+
+Path matching strips the `std::`, `alloc::`, `core::` qualifiers via `LastSegment`, so a `Vec<i64>` referenced as `std::vec::Vec<i64>` or `alloc::vec::Vec<i64>` produces the same `KindList`. The `Vec<u8>` and `[u8]` specialisations to `bytes` are detected after the element mapping resolves to `KindByte`; this keeps the rule local to `mapPath` / `mapSlice` / `mapArray` rather than a separate path table.
+
+### Algebraic types
+
+- `Option<T>` (any `::option::Option` path) → `KindOption` with `Elem = T`.
+- `Result<T, E>` → `KindResult` with `OK = T`, `Err = E`.
+- `(T1, T2, ...)` → `KindTuple` with `Fields = [T1, T2, ...]`.
+- `()` (empty tuple) → `KindUnit`. The rustdoc encoding `{"tuple": []}` is detected by checking for a non-nil empty `Tuple` slice before the main dispatch, because `Type.Kind()` reports the empty-slice form as `"empty"`.
+
+### Smart pointers
+
+`Box<T>`, `Rc<T>`, and `Arc<T>` are transparent: their inner `T` is the result of `Map`. The wrapper layer (Phase 4) decides whether to clone (`Rc`/`Arc`) or deref-move (`Box`) at the FFI boundary; the surface mapping only sees the inner type.
+
+### User-defined paths
+
+Any `resolved_path` that does not match a known std container falls through to `KindStruct` with the `PathID` and `PathName` filled from the rustdoc `PathType`. Phase 4 (wrapper synth) resolves whether the path points at a struct, enum, or opaque type via the `ApiSurface.Structs` / `Enums` slices captured in Phase 2.
+
+### Borrowed references
+
+| Form | Direction `In` | Direction `Out` |
+|------|----------------|-----------------|
+| `&T` | recurse into `T` | recurse into `T` if lifetime is `'static`, else `SkipLifetime` |
+| `&'static T` | recurse into `T` | recurse into `T` |
+| `&mut T` | `SkipUnknown` (no v1 mapping) | `SkipUnknown` |
+
+The `&mut T` refusal uses `SkipUnknown` because the enum has no dedicated `SkipMutBorrow` variant; the detail string carries the explanation. A future enum bump will promote this to a named reason without changing the rule.
+
+### Refusal classes
+
+| rustdoc kind | Reason | Detail |
+|--------------|--------|--------|
+| `raw_pointer` | `SkipRawPointer` | requires unsafe capability opt-in |
+| `generic` | `SkipGeneric` | unresolved generic; declare under `[rust.monomorphise]` |
+| `dyn_trait` | `SkipDynTrait` | dyn Trait has no Mochi surface |
+| `impl_trait` | `SkipImplTrait` | impl Trait return position requires explicit monomorphisation |
+| `qualified_path` | `SkipQualifiedPath` | `<T as Trait>::Item` not mappable |
+| `function_pointer` | `SkipUnknown` | function pointer types are not mapped in v1 |
+| `infer` | `SkipUnknown` | inference placeholder forbidden in public sig |
+| `pat` | `SkipUnknown` | pattern types are unstable rustc feature |
+| `Cow<T>` | `SkipCow` | not directly mappable; pass owned type |
+| `OsString`/`OsStr`/`PathBuf`/`Path`/`CString`/`CStr` | `SkipOsString` | platform-specific encoding |
+| `Pin<T>` | `SkipPin` | requires custom lifetime contracts |
+| unknown rustdoc-types variant | `SkipUnknown` | detail names the variant tag |
+
+### Composition propagation
+
+Skip propagation is bottom-up: `Vec<dyn Trait>` returns `SkipDynTrait` from the inner mapping; `(i32, *const u8)` returns `SkipRawPointer`. Top-level callers see the most specific reason from the deepest unmappable subterm. The detail string is prefixed with `"tuple field N: "` etc. so the error surface tells the user which subterm failed.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/rust/typemap/kind.go` | `Kind` enum (21 variants + `KindInvalid`), `Direction` enum + `String()` methods |
+| `package3/rust/typemap/mapping.go` | `Mapping` struct, `MochiType()`, `FFIRepr()`, `IsScalar()` |
+| `package3/rust/typemap/map.go` | `Map(t, dir)` dispatch, primitive table, path table, `LastSegment`, all sub-maps |
+| `package3/rust/typemap/kind_test.go` | `Kind` and `Direction` rendering |
+| `package3/rust/typemap/mapping_test.go` | `MochiType` / `FFIRepr` / `IsScalar` coverage for every Kind |
+| `package3/rust/typemap/map_test.go` | 42 dispatch tests covering every rule plus refusal classes and skip propagation |
+| `website/docs/implementation/0073/phase-03-type-mapping.md` | this page |
+
+## Test set
+
+- All `package3/rust/typemap/...` unit tests (53 functions: 2 in kind_test, 9 in mapping_test, 42 in map_test).
+- Full `go test ./package3/rust/...` regression across all 6 packages.
+
+## Lowering decisions
+
+### Why u8 maps to byte and not int
+
+The Mochi byte type is a distinct primitive used by I/O, hashing, and binary protocols. Mapping every `u8` to `int` would erase semantics at the surface: callers passing `Vec<u8>` would lose the `bytes` literal form. The byte mapping survives into the `Vec<u8> → bytes` and `&[u8] → bytes` specialisations, which the wrapper layer relies on to skip the per-element FFI marshalling cost.
+
+### Why Box, Rc, Arc are transparent at the surface
+
+Smart pointers carry no value-type information at the Mochi surface; they only affect ownership and refcount handling, both of which are FFI-layer concerns. Folding them into the inner type lets Mochi callers see the underlying value type while the wrapper layer (Phase 4) emits the correct clone/move on each crossing. This matches research note 05 §"Smart pointer folding" and avoids exposing `Rc<T>` vs `Arc<T>` distinctions in import-site signatures.
+
+### Why HashSet/BTreeSet map to list
+
+Mochi has no first-class set type. Mapping `HashSet<T>` to `list[T]` preserves the element type and lets callers use list-style iteration. The wrapper layer materialises the set as a `Vec<T>` on entry and rebuilds the set on call; the order is not preserved, but `HashSet` callers do not expect order anyway. A future Mochi `set` primitive can promote this without changing the SkipReason taxonomy.
+
+### Why empty tuple is unit, but Type.Kind() reports "empty"
+
+The rustdoc-types JSON encoding for `()` is `{"tuple": []}`. `rustdoc.Type.Kind()` uses `len(t.Tuple) > 0` as the discriminator, so the empty form falls through to `"empty"`. The fix lives in `typemap.Map`: a pre-dispatch check for `t.Tuple != nil && len(t.Tuple) == 0` produces a `KindUnit` Mapping. The rustdoc parser is intentionally not changed; downstream consumers can rely on `Kind() == "empty"` continuing to mean "no payload at all" for genuine empty Type values.
+
+### Why &mut T uses SkipUnknown
+
+The `errors.SkipReason` enum (Phase 0) does not yet carry a `SkipMutBorrow` variant. Adding one mid-stream would break the fixture-count golden files in earlier phases. The Phase 4 wrapper synth will batch enum additions, at which point `&mut T` will get a named reason; today it surfaces as `SkipUnknown` with a clear Detail string.
+
+## Closeout notes
+
+Phase 3 introduces no new external dependencies; the package depends only on `mochi/package3/rust/errors` and `mochi/package3/rust/rustdoc`. The closed table is the single source of truth consumed by Phase 4 (wrapper synth), Phase 5 (extern-fn emitter), and Phase 12 (monomorphisation). A regression in any future rustdoc-types schema bump that adds a new `Type` variant will produce a `SkipUnknown` skip rather than a crash, exactly as Phase 2's `Type.Unknown` catch-all guarantees.
+
+Phase 4 will consume `Mapping.FFIRepr()` to emit the extern-C wrapper function signatures, and `Mapping.MochiType()` to populate the SkipReport detail strings when a containing function fails to lower.


### PR DESCRIPTION
Closes #22758.

## Summary

- Adds `package3/rust/typemap/`: the closed table that lowers `rustdoc.Type` values into a structured `Mapping` carrying both the Mochi-side type rendering and the FFI representation.
- 19 Rust primitives map to 11 Mochi Kinds; collections (Vec / slice / array / HashMap / BTreeMap / HashSet / BTreeSet) lower with byte-buffer specialisations; algebraic types (Option / Result / Tuple) preserve their element types; smart pointers (Box / Rc / Arc) are transparent.
- Each refusal class (Cow, OsString family, Pin, dyn Trait, impl Trait, raw_pointer, generic, qualified_path, function_pointer, &mut, pat, infer, unknown variant) returns a specific SkipReason plus a free-text detail. Skip propagation is bottom-up through composite types.

## Test plan

- [x] `go test ./package3/rust/typemap/...` (53 functions across kind_test, mapping_test, map_test) green.
- [x] `go test ./package3/rust/...` (all 6 packages: errors, build, semver, sparse, rustdoc, typemap) green.
- [x] Phase tracking page added at `website/docs/implementation/0073/phase-03-type-mapping.md`; index marks phases 0-3 LANDED.

Part of MEP-73 multi-phase delivery (see `website/docs/implementation/0073/index.md`).