### PR TITLE
MEP-74 phase 2: sum.golang.org transparency-log client

### DIFF
--- a/package3/go/sumdb/client.go
+++ b/package3/go/sumdb/client.go
@@ -1,0 +1,127 @@
+package sumdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// DefaultBaseURL is the public Go transparency-log endpoint.
+const DefaultBaseURL = "https://sum.golang.org/"
+
+// DefaultUserAgent identifies the bridge to sum.golang.org for
+// usage analytics.
+const DefaultUserAgent = "mochi-go-bridge/0.1 (+https://mochi-lang.dev)"
+
+// Client is a thin HTTP wrapper for the sum.golang.org /latest,
+// /lookup, and /tile endpoints. The empty Client is not usable;
+// construct one with NewClient.
+type Client struct {
+	// BaseURL is the transparency log root, e.g.
+	// "https://sum.golang.org/". Must end in a slash.
+	BaseURL string
+
+	// HTTP is the underlying http.Client. nil means use a 30-second
+	// timeout client.
+	HTTP *http.Client
+
+	// UserAgent is the User-Agent header value.
+	UserAgent string
+}
+
+// NewClient returns a Client pre-configured against sum.golang.org
+// with sensible defaults.
+func NewClient(baseURL string) *Client {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	if !strings.HasSuffix(baseURL, "/") {
+		baseURL += "/"
+	}
+	return &Client{
+		BaseURL:   baseURL,
+		HTTP:      &http.Client{Timeout: 30 * time.Second},
+		UserAgent: DefaultUserAgent,
+	}
+}
+
+// Latest fetches /latest and returns the signed-note bytes. Callers
+// typically verify with VerifierKey + ParseTreeHead.
+func (c *Client) Latest(ctx context.Context) ([]byte, error) {
+	return c.get(ctx, "latest")
+}
+
+// Lookup fetches /lookup/<module>@<version> and parses the response.
+// The signed tree note inside the response is *not* verified here;
+// callers are expected to invoke ParseNote + Verify against the
+// sum.golang.org verifier key.
+func (c *Client) Lookup(ctx context.Context, modulePath, version string) (*LookupRecord, error) {
+	if modulePath == "" || version == "" {
+		return nil, errors.New("sumdb: empty module or version")
+	}
+	// Lookups use the *un-escaped* module path joined with @<version>.
+	// sum.golang.org expects URL-escaped path components but leaves
+	// the literal '@' between module and version.
+	body, err := c.get(ctx, "lookup/"+url.PathEscape(modulePath+"@"+version))
+	if err != nil {
+		return nil, err
+	}
+	return ParseLookup(body)
+}
+
+// Tile fetches /tile/<H>/<L>/<K> and returns the raw tile bytes.
+// H is the tile height (sum.golang.org uses 8), L the tree level, K
+// the tile index along that level.
+func (c *Client) Tile(ctx context.Context, height, level int, index int64) ([]byte, error) {
+	if height <= 0 || level < 0 || index < 0 {
+		return nil, fmt.Errorf("sumdb: invalid tile coords H=%d L=%d K=%d", height, level, index)
+	}
+	return c.get(ctx, fmt.Sprintf("tile/%d/%d/%d", height, level, index))
+}
+
+func (c *Client) get(ctx context.Context, suffix string) ([]byte, error) {
+	base := c.BaseURL
+	if base == "" {
+		base = DefaultBaseURL
+	}
+	if !strings.HasSuffix(base, "/") {
+		base += "/"
+	}
+	u, err := url.Parse(base + suffix)
+	if err != nil {
+		return nil, fmt.Errorf("sumdb: bad URL %q: %w", base+suffix, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("sumdb: build request: %w", err)
+	}
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+	req.Header.Set("Accept", "text/plain, application/octet-stream")
+	httpClient := c.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sumdb: GET %s: %w", u, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("sumdb: GET %s: status %d: %s", u, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	// 16 MiB cap protects against an adversarial log returning a
+	// hostile payload. Real tiles are at most a few KiB.
+	buf, err := io.ReadAll(io.LimitReader(resp.Body, 16*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("sumdb: read body of %s: %w", u, err)
+	}
+	return buf, nil
+}

--- a/package3/go/sumdb/client_test.go
+++ b/package3/go/sumdb/client_test.go
@@ -1,0 +1,133 @@
+package sumdb
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestClientLatest(t *testing.T) {
+	body := "go.sum database tree\n5\nAAAA=\n\n— sum.golang.org AAAAAA==\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/latest") {
+			http.Error(w, "wrong path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL)
+	got, err := c.Latest(context.Background())
+	if err != nil {
+		t.Fatalf("Latest: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("Latest mismatch:\n  got %q\n  want %q", got, body)
+	}
+}
+
+func TestClientLookup(t *testing.T) {
+	body := `42
+example.com/foo v1.0.0 h1:zip==
+example.com/foo v1.0.0/go.mod h1:mod==
+
+go.sum database tree
+50
+AAAA=
+
+— sum.golang.org AAAA==
+`
+	var gotURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.Path
+		io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient(srv.URL)
+	rec, err := c.Lookup(context.Background(), "example.com/foo", "v1.0.0")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if rec.ID != 42 || rec.Module != "example.com/foo" || rec.Version != "v1.0.0" {
+		t.Errorf("Lookup record wrong: %+v", rec)
+	}
+	if !strings.Contains(gotURL, "lookup/") {
+		t.Errorf("client did not hit lookup endpoint: %q", gotURL)
+	}
+	if !strings.Contains(gotURL, "example.com") {
+		t.Errorf("client URL %q missing module path", gotURL)
+	}
+}
+
+func TestClientLookupEmptyArgs(t *testing.T) {
+	c := NewClient("https://example.invalid/")
+	if _, err := c.Lookup(context.Background(), "", "v1"); err == nil {
+		t.Errorf("Lookup with empty module: want error")
+	}
+	if _, err := c.Lookup(context.Background(), "x", ""); err == nil {
+		t.Errorf("Lookup with empty version: want error")
+	}
+}
+
+func TestClientTile(t *testing.T) {
+	want := []byte("tile bytes")
+	var gotURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.Path
+		w.Write(want)
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient(srv.URL)
+	got, err := c.Tile(context.Background(), 8, 0, 3)
+	if err != nil {
+		t.Fatalf("Tile: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("Tile body mismatch")
+	}
+	if !strings.HasSuffix(gotURL, "/tile/8/0/3") {
+		t.Errorf("Tile URL %q does not end in /tile/8/0/3", gotURL)
+	}
+}
+
+func TestClientTileBadCoords(t *testing.T) {
+	c := NewClient("https://example.invalid/")
+	if _, err := c.Tile(context.Background(), 0, 0, 0); err == nil {
+		t.Errorf("Tile with H=0: want error")
+	}
+	if _, err := c.Tile(context.Background(), 8, -1, 0); err == nil {
+		t.Errorf("Tile with negative level: want error")
+	}
+	if _, err := c.Tile(context.Background(), 8, 0, -1); err == nil {
+		t.Errorf("Tile with negative index: want error")
+	}
+}
+
+func TestClientServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient(srv.URL)
+	if _, err := c.Latest(context.Background()); err == nil {
+		t.Errorf("Latest on 500 returned nil; want error")
+	}
+}
+
+func TestNewClientDefaultBaseURL(t *testing.T) {
+	c := NewClient("")
+	if c.BaseURL != DefaultBaseURL {
+		t.Errorf("BaseURL = %q; want %q", c.BaseURL, DefaultBaseURL)
+	}
+}
+
+func TestNewClientTrailingSlash(t *testing.T) {
+	c := NewClient("https://example.invalid")
+	if !strings.HasSuffix(c.BaseURL, "/") {
+		t.Errorf("BaseURL not normalised: %q", c.BaseURL)
+	}
+}

--- a/package3/go/sumdb/key.go
+++ b/package3/go/sumdb/key.go
@@ -1,0 +1,156 @@
+// Package sumdb is the MEP-74 client for the sum.golang.org
+// transparency log (a/k/a the "Go checksum database"). It implements
+// the signed-note framing, the Ed25519 verifier, the lookup-response
+// parser, and the Merkle inclusion-proof verifier needed to confirm
+// that a module@version's h1: digests appear in the public log.
+//
+// References:
+//
+//	https://go.dev/ref/mod#checksum-database
+//	https://research.swtch.com/tlog (Russ Cox's tree-log design notes)
+//	golang.org/x/mod/sumdb (reference implementation)
+package sumdb
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// AlgEd25519 is the algorithm byte prefixed onto the Ed25519 public
+// key inside a verifier-key blob. sum.golang.org and every other
+// signed-note key today uses 0x01.
+const AlgEd25519 byte = 0x01
+
+// VerifierKey holds a parsed verifier key blob.
+//
+// The on-the-wire format of a verifier key is:
+//
+//	<name> '+' <hex-key-hash-prefix> '+' <base64(algByte || rawKeyBytes)>
+//
+// where algByte is AlgEd25519 (0x01) and rawKeyBytes is the 32-byte
+// Ed25519 public key. The key-hash prefix is the first 4 bytes of
+// SHA-256(name + "\n" + algByte || rawKeyBytes), rendered as 8
+// lower-case hex characters.
+//
+// The sum.golang.org verifier key is:
+//
+//	sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8
+type VerifierKey struct {
+	Name      string
+	KeyHash   [4]byte
+	Algorithm byte
+	PublicKey ed25519.PublicKey
+}
+
+// SumGolangOrgVerifierKey is the verifier key for the public
+// sum.golang.org transparency log. The key is baked in here so the
+// bridge does not have to fetch it from a network endpoint at boot
+// (which would itself be a chicken-and-egg integrity problem).
+//
+// Source: https://sum.golang.org/supported (mirrored in
+// golang.org/x/mod/sumdb/sumdb.go).
+const SumGolangOrgVerifierKey = "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8"
+
+// ParseVerifierKey parses the textual verifier key blob.
+func ParseVerifierKey(s string) (*VerifierKey, error) {
+	if s == "" {
+		return nil, errors.New("sumdb: empty verifier key")
+	}
+	// Format: name + "+" + 8 hex chars + "+" + base64.
+	parts := strings.SplitN(s, "+", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("sumdb: verifier key %q must have name+hash+key fields", s)
+	}
+	name, hashHex, keyB64 := parts[0], parts[1], parts[2]
+	if name == "" {
+		return nil, fmt.Errorf("sumdb: verifier key %q: empty name", s)
+	}
+	if len(hashHex) != 8 {
+		return nil, fmt.Errorf("sumdb: verifier key %q: key-hash field must be 8 hex chars, got %d", s, len(hashHex))
+	}
+	var keyHash [4]byte
+	for i := range 4 {
+		hi, ok1 := unhex(hashHex[2*i])
+		lo, ok2 := unhex(hashHex[2*i+1])
+		if !ok1 || !ok2 {
+			return nil, fmt.Errorf("sumdb: verifier key %q: non-hex in key-hash field", s)
+		}
+		keyHash[i] = hi<<4 | lo
+	}
+	rawKey, err := base64.StdEncoding.DecodeString(keyB64)
+	if err != nil {
+		return nil, fmt.Errorf("sumdb: verifier key %q: invalid base64: %w", s, err)
+	}
+	if len(rawKey) < 1 {
+		return nil, fmt.Errorf("sumdb: verifier key %q: empty key body", s)
+	}
+	alg := rawKey[0]
+	if alg != AlgEd25519 {
+		return nil, fmt.Errorf("sumdb: verifier key %q: unsupported algorithm 0x%02x", s, alg)
+	}
+	if len(rawKey)-1 != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("sumdb: verifier key %q: ed25519 key must be %d bytes, got %d", s, ed25519.PublicKeySize, len(rawKey)-1)
+	}
+	pub := ed25519.PublicKey(rawKey[1:])
+	// Recompute the key-hash and compare against the prefix in the blob.
+	wantHash := computeKeyHash(name, alg, pub)
+	if wantHash != keyHash {
+		return nil, fmt.Errorf("sumdb: verifier key %q: key-hash mismatch (computed %02x%02x%02x%02x)",
+			s, wantHash[0], wantHash[1], wantHash[2], wantHash[3])
+	}
+	return &VerifierKey{
+		Name:      name,
+		KeyHash:   keyHash,
+		Algorithm: alg,
+		PublicKey: pub,
+	}, nil
+}
+
+// computeKeyHash is the canonical hash used to disambiguate keys in
+// signed-note signatures. It is the first 4 bytes of
+// SHA-256(name + "\n" + algByte || pubKey).
+func computeKeyHash(name string, alg byte, pub ed25519.PublicKey) [4]byte {
+	h := sha256.New()
+	h.Write([]byte(name))
+	h.Write([]byte{'\n'})
+	h.Write([]byte{alg})
+	h.Write(pub)
+	sum := h.Sum(nil)
+	var out [4]byte
+	copy(out[:], sum[:4])
+	return out
+}
+
+// KeyHashUint32 returns the key-hash as a single big-endian uint32 for
+// convenient comparison.
+func (v *VerifierKey) KeyHashUint32() uint32 {
+	return binary.BigEndian.Uint32(v.KeyHash[:])
+}
+
+// String renders the verifier key in its on-the-wire form.
+func (v *VerifierKey) String() string {
+	if v == nil {
+		return ""
+	}
+	body := append([]byte{v.Algorithm}, v.PublicKey...)
+	return fmt.Sprintf("%s+%02x%02x%02x%02x+%s",
+		v.Name, v.KeyHash[0], v.KeyHash[1], v.KeyHash[2], v.KeyHash[3],
+		base64.StdEncoding.EncodeToString(body))
+}
+
+func unhex(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	}
+	return 0, false
+}

--- a/package3/go/sumdb/key_test.go
+++ b/package3/go/sumdb/key_test.go
@@ -1,0 +1,77 @@
+package sumdb
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestParseSumGolangOrgKey(t *testing.T) {
+	k, err := ParseVerifierKey(SumGolangOrgVerifierKey)
+	if err != nil {
+		t.Fatalf("ParseVerifierKey: %v", err)
+	}
+	if k.Name != "sum.golang.org" {
+		t.Errorf("Name = %q; want sum.golang.org", k.Name)
+	}
+	if k.Algorithm != AlgEd25519 {
+		t.Errorf("Algorithm = 0x%02x; want 0x%02x", k.Algorithm, AlgEd25519)
+	}
+	if len(k.PublicKey) != ed25519.PublicKeySize {
+		t.Errorf("PublicKey len = %d; want %d", len(k.PublicKey), ed25519.PublicKeySize)
+	}
+	// String round-trip yields the same blob (up to canonicalisation).
+	if got := k.String(); got != SumGolangOrgVerifierKey {
+		t.Errorf("String round-trip mismatch:\n  got  %q\n  want %q", got, SumGolangOrgVerifierKey)
+	}
+}
+
+func TestParseVerifierKeyMalformed(t *testing.T) {
+	cases := []string{
+		"",
+		"name-only",
+		"name+nothash+",
+		"name+12345678",                   // missing key part
+		"name+12345678+!!!!notbase64!!!!", // bad base64
+		"name+1234567+" + base64.StdEncoding.EncodeToString(append([]byte{AlgEd25519}, make([]byte, ed25519.PublicKeySize)...)), // hash field 7 chars
+		"name+12345678+" + base64.StdEncoding.EncodeToString([]byte{0x02, 0x00}),                                                // unsupported alg
+		"name+12345678+" + base64.StdEncoding.EncodeToString([]byte{AlgEd25519}),                                                // empty pubkey
+	}
+	for _, tc := range cases {
+		if _, err := ParseVerifierKey(tc); err == nil {
+			t.Errorf("ParseVerifierKey(%q) returned nil; want error", tc)
+		}
+	}
+}
+
+func TestComputeKeyHashStable(t *testing.T) {
+	// The sum.golang.org key has prefix 033de0ae per its blob; if
+	// computeKeyHash drifts that round-trip will fail.
+	k, err := ParseVerifierKey(SumGolangOrgVerifierKey)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if k.KeyHash[0] != 0x03 || k.KeyHash[1] != 0x3d || k.KeyHash[2] != 0xe0 || k.KeyHash[3] != 0xae {
+		t.Errorf("KeyHash = %02x%02x%02x%02x; want 033de0ae",
+			k.KeyHash[0], k.KeyHash[1], k.KeyHash[2], k.KeyHash[3])
+	}
+}
+
+func TestParseVerifierKeyRejectsKeyHashMismatch(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	body := append([]byte{AlgEd25519}, pub...)
+	// Wrong key-hash prefix on purpose.
+	blob := "test.example+deadbeef+" + base64.StdEncoding.EncodeToString(body)
+	_, err = ParseVerifierKey(blob)
+	if err == nil {
+		t.Errorf("ParseVerifierKey accepted mismatched key-hash; want error")
+	}
+	if !strings.Contains(err.Error(), "key-hash mismatch") {
+		t.Errorf("error %q does not mention key-hash mismatch", err)
+	}
+}

--- a/package3/go/sumdb/lookup.go
+++ b/package3/go/sumdb/lookup.go
@@ -1,0 +1,117 @@
+package sumdb
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// LookupRecord is one parsed response from the sum.golang.org
+// /lookup/<module>@<version> endpoint.
+//
+// The wire format of a lookup response is:
+//
+//	<id>\n
+//	<module> <version> <zipHash>\n
+//	<module> <version>/go.mod <modHash>\n
+//	\n
+//	<signed note containing the tree head>
+//
+// Where the id is the leaf index in the transparency log.
+type LookupRecord struct {
+	// ID is the leaf index of this record in the transparency log
+	// tree. Combined with the tree head it identifies the inclusion
+	// proof position.
+	ID int64
+	// Module is the module path the proxy resolved (matches the
+	// request).
+	Module string
+	// Version is the resolved version.
+	Version string
+	// ZipHash is the "h1:..." digest of the .zip artifact.
+	ZipHash string
+	// ModHash is the "h1:..." digest of the .mod artifact (i.e. the
+	// "<v>/go.mod" line of go.sum).
+	ModHash string
+	// TreeNote is the raw signed-note bytes carrying the tree head
+	// that vouches for this record. Verify with Note + VerifierKey.
+	TreeNote []byte
+}
+
+// ParseLookup parses the body returned by GET /lookup/<m>@<v>.
+//
+// Returns an error if the framing is wrong, the id field is not a
+// decimal integer, the two hash lines do not share the same module
+// and version, or the zip / mod h1: digests have wrong format.
+func ParseLookup(raw []byte) (*LookupRecord, error) {
+	if len(raw) == 0 {
+		return nil, errors.New("sumdb: empty lookup body")
+	}
+	s := string(raw)
+	// Split body and signed-tree note at the blank line.
+	sep := strings.Index(s, "\n\n")
+	if sep < 0 {
+		return nil, errors.New("sumdb: lookup missing blank-line separator")
+	}
+	header := s[:sep]
+	tree := s[sep+2:]
+	if tree == "" {
+		return nil, errors.New("sumdb: lookup missing tree note")
+	}
+	lines := strings.Split(header, "\n")
+	if len(lines) < 3 {
+		return nil, fmt.Errorf("sumdb: lookup header has %d lines; want at least 3", len(lines))
+	}
+	id, err := strconv.ParseInt(lines[0], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("sumdb: lookup id %q: %w", lines[0], err)
+	}
+	if id < 0 {
+		return nil, fmt.Errorf("sumdb: lookup id %d is negative", id)
+	}
+	mod, ver, zipH, err := parseHashLine(lines[1])
+	if err != nil {
+		return nil, fmt.Errorf("sumdb: lookup zip-hash line: %w", err)
+	}
+	if !strings.HasSuffix(zipH, "") || !strings.HasPrefix(zipH, "h1:") {
+		return nil, fmt.Errorf("sumdb: lookup zip-hash %q lacks h1: prefix", zipH)
+	}
+	mod2, ver2, modH, err := parseHashLine(lines[2])
+	if err != nil {
+		return nil, fmt.Errorf("sumdb: lookup mod-hash line: %w", err)
+	}
+	if !strings.HasPrefix(modH, "h1:") {
+		return nil, fmt.Errorf("sumdb: lookup mod-hash %q lacks h1: prefix", modH)
+	}
+	// The mod line is "<module> <version>/go.mod <h1:...>". The
+	// parseHashLine helper returns ver2 = "<version>/go.mod"; peel
+	// off the suffix.
+	if mod2 != mod {
+		return nil, fmt.Errorf("sumdb: lookup mod %q != zip mod %q", mod2, mod)
+	}
+	const gomodSuffix = "/go.mod"
+	if !strings.HasSuffix(ver2, gomodSuffix) {
+		return nil, fmt.Errorf("sumdb: lookup mod-hash line version %q missing /go.mod suffix", ver2)
+	}
+	bareVer := ver2[:len(ver2)-len(gomodSuffix)]
+	if bareVer != ver {
+		return nil, fmt.Errorf("sumdb: lookup mod-hash version %q != zip-hash version %q", bareVer, ver)
+	}
+	return &LookupRecord{
+		ID:       id,
+		Module:   mod,
+		Version:  ver,
+		ZipHash:  zipH,
+		ModHash:  modH,
+		TreeNote: []byte(tree),
+	}, nil
+}
+
+func parseHashLine(line string) (module, version, hash string, err error) {
+	parts := strings.Fields(line)
+	if len(parts) != 3 {
+		return "", "", "", fmt.Errorf("expected 3 whitespace-separated fields, got %d in %q", len(parts), line)
+	}
+	return parts[0], parts[1], parts[2], nil
+}

--- a/package3/go/sumdb/lookup_test.go
+++ b/package3/go/sumdb/lookup_test.go
@@ -1,0 +1,118 @@
+package sumdb
+
+import (
+	"strings"
+	"testing"
+)
+
+const sampleLookup = `1234567
+example.com/foo v1.2.3 h1:abcDEFghi==
+example.com/foo v1.2.3/go.mod h1:xyzPQR012==
+
+go.sum database tree
+12345678
+TGl4dHV0dW10dXJ0dXBpaXR1aXR1dGZyZWVwYXNzeWVz
+
+— sum.golang.org AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+`
+
+func TestParseLookupValid(t *testing.T) {
+	rec, err := ParseLookup([]byte(sampleLookup))
+	if err != nil {
+		t.Fatalf("ParseLookup: %v", err)
+	}
+	if rec.ID != 1234567 {
+		t.Errorf("ID = %d; want 1234567", rec.ID)
+	}
+	if rec.Module != "example.com/foo" {
+		t.Errorf("Module = %q; want example.com/foo", rec.Module)
+	}
+	if rec.Version != "v1.2.3" {
+		t.Errorf("Version = %q; want v1.2.3", rec.Version)
+	}
+	if !strings.HasPrefix(rec.ZipHash, "h1:") {
+		t.Errorf("ZipHash %q lacks h1: prefix", rec.ZipHash)
+	}
+	if !strings.HasPrefix(rec.ModHash, "h1:") {
+		t.Errorf("ModHash %q lacks h1: prefix", rec.ModHash)
+	}
+	if len(rec.TreeNote) == 0 {
+		t.Errorf("TreeNote empty")
+	}
+}
+
+func TestParseLookupRejectsEmpty(t *testing.T) {
+	if _, err := ParseLookup(nil); err == nil {
+		t.Errorf("ParseLookup(nil) returned nil; want error")
+	}
+}
+
+func TestParseLookupMissingSeparator(t *testing.T) {
+	body := `1234567
+example.com/foo v1.2.3 h1:abc
+example.com/foo v1.2.3/go.mod h1:def
+`
+	if _, err := ParseLookup([]byte(body)); err == nil {
+		t.Errorf("ParseLookup without tree note: want error")
+	}
+}
+
+func TestParseLookupBadID(t *testing.T) {
+	body := `notanumber
+example.com/foo v1.2.3 h1:abc
+example.com/foo v1.2.3/go.mod h1:def
+
+tree note placeholder
+`
+	if _, err := ParseLookup([]byte(body)); err == nil {
+		t.Errorf("ParseLookup with bad id: want error")
+	}
+}
+
+func TestParseLookupVersionMismatch(t *testing.T) {
+	body := `1
+example.com/foo v1.2.3 h1:abc
+example.com/foo v9.9.9/go.mod h1:def
+
+tree note placeholder
+`
+	if _, err := ParseLookup([]byte(body)); err == nil {
+		t.Errorf("ParseLookup with mismatched versions: want error")
+	}
+}
+
+func TestParseLookupModuleMismatch(t *testing.T) {
+	body := `1
+example.com/foo v1.2.3 h1:abc
+other.example/bar v1.2.3/go.mod h1:def
+
+tree note placeholder
+`
+	if _, err := ParseLookup([]byte(body)); err == nil {
+		t.Errorf("ParseLookup with mismatched modules: want error")
+	}
+}
+
+func TestParseLookupMissingGoModSuffix(t *testing.T) {
+	body := `1
+example.com/foo v1.2.3 h1:abc
+example.com/foo v1.2.3 h1:def
+
+tree note placeholder
+`
+	if _, err := ParseLookup([]byte(body)); err == nil {
+		t.Errorf("ParseLookup with no /go.mod suffix: want error")
+	}
+}
+
+func TestParseLookupBadHashPrefix(t *testing.T) {
+	body := `1
+example.com/foo v1.2.3 sha256:abc
+example.com/foo v1.2.3/go.mod h1:def
+
+tree note placeholder
+`
+	if _, err := ParseLookup([]byte(body)); err == nil {
+		t.Errorf("ParseLookup with non-h1 zip hash: want error")
+	}
+}

--- a/package3/go/sumdb/note.go
+++ b/package3/go/sumdb/note.go
@@ -1,0 +1,203 @@
+package sumdb
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Note is a parsed signed note as used by sum.golang.org.
+//
+// The wire format is:
+//
+//	<text body, ending in '\n'>
+//	'\n'
+//	<one-or-more signature lines>
+//
+// Each signature line is:
+//
+//	'—' SP <key-name> SP <base64(keyHash[0:4] || signature)> '\n'
+//
+// The U+2014 EM DASH at the start is a literal three-byte UTF-8
+// sequence; the line is otherwise plain ASCII. The signature
+// payload is exactly 4 + ed25519.SignatureSize = 68 bytes.
+type Note struct {
+	// Text is the message body (everything up to but not including
+	// the blank line that separates body from signatures). The body
+	// is signed verbatim including its trailing '\n'.
+	Text string
+
+	// Signatures lists one entry per signature line. Use Verify to
+	// confirm that a desired key's signature is present and valid.
+	Signatures []NoteSignature
+}
+
+// NoteSignature is one parsed signature line.
+type NoteSignature struct {
+	// Name is the key name from the signature line (e.g.
+	// "sum.golang.org").
+	Name string
+	// KeyHash is the 4-byte key-hash prefix that disambiguates this
+	// signature when the same signer publishes multiple keys.
+	KeyHash [4]byte
+	// Sig is the raw Ed25519 signature bytes (64 bytes).
+	Sig []byte
+}
+
+// noteSigPrefix is the U+2014 EM DASH + space prefix on every
+// signature line.
+const noteSigPrefix = "— "
+
+// ParseNote splits raw note bytes into the text body and signature
+// lines. It does not verify any signature.
+//
+// Per the spec a valid note has at least one signature; an empty
+// signature section is an error.
+func ParseNote(raw []byte) (*Note, error) {
+	if len(raw) == 0 {
+		return nil, errors.New("sumdb: empty note")
+	}
+	// Find the blank line separating body from signatures. The body
+	// ends with "\n" and the blank line is exactly "\n", so the
+	// separator pattern is "\n\n".
+	s := string(raw)
+	sep := strings.Index(s, "\n\n")
+	if sep < 0 {
+		return nil, errors.New("sumdb: note missing blank-line separator")
+	}
+	body := s[:sep+1] // include the body's trailing newline
+	sigBlock := s[sep+2:]
+	// Body must be UTF-8 with no embedded "— " at start of line;
+	// the simplest check is: body lines must not start with the
+	// signature prefix.
+	for line := range strings.SplitSeq(strings.TrimSuffix(body, "\n"), "\n") {
+		if strings.HasPrefix(line, noteSigPrefix) {
+			return nil, errors.New("sumdb: note body contains a line that starts with the signature prefix")
+		}
+	}
+	sigs, err := parseSignatureLines(sigBlock)
+	if err != nil {
+		return nil, err
+	}
+	if len(sigs) == 0 {
+		return nil, errors.New("sumdb: note has no signatures")
+	}
+	return &Note{Text: body, Signatures: sigs}, nil
+}
+
+func parseSignatureLines(block string) ([]NoteSignature, error) {
+	out := []NoteSignature{}
+	for line := range strings.SplitSeq(block, "\n") {
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, noteSigPrefix) {
+			return nil, fmt.Errorf("sumdb: signature line %q missing %q prefix", line, noteSigPrefix)
+		}
+		rest := line[len(noteSigPrefix):]
+		sp := strings.IndexByte(rest, ' ')
+		if sp <= 0 {
+			return nil, fmt.Errorf("sumdb: signature line %q missing key name", line)
+		}
+		name := rest[:sp]
+		b64 := strings.TrimSpace(rest[sp+1:])
+		if name == "" || b64 == "" {
+			return nil, fmt.Errorf("sumdb: signature line %q has empty name or body", line)
+		}
+		buf, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			return nil, fmt.Errorf("sumdb: signature line %q invalid base64: %w", line, err)
+		}
+		if len(buf) != 4+ed25519.SignatureSize {
+			return nil, fmt.Errorf("sumdb: signature line %q wrong length (%d bytes, want %d)",
+				line, len(buf), 4+ed25519.SignatureSize)
+		}
+		var hash [4]byte
+		copy(hash[:], buf[:4])
+		out = append(out, NoteSignature{
+			Name:    name,
+			KeyHash: hash,
+			Sig:     buf[4:],
+		})
+	}
+	return out, nil
+}
+
+// Verify reports whether the note carries at least one valid
+// signature from one of the provided keys. Returns the matched key
+// on success.
+//
+// The signature is computed over the entire body bytes including
+// trailing newline.
+func (n *Note) Verify(keys ...*VerifierKey) (*VerifierKey, error) {
+	if n == nil {
+		return nil, errors.New("sumdb: nil note")
+	}
+	if len(keys) == 0 {
+		return nil, errors.New("sumdb: no verifier keys provided")
+	}
+	body := []byte(n.Text)
+	for _, sig := range n.Signatures {
+		for _, k := range keys {
+			if k == nil {
+				continue
+			}
+			if sig.Name != k.Name {
+				continue
+			}
+			if sig.KeyHash != k.KeyHash {
+				continue
+			}
+			if ed25519.Verify(k.PublicKey, body, sig.Sig) {
+				return k, nil
+			}
+		}
+	}
+	return nil, ErrNoteUnverified
+}
+
+// ErrNoteUnverified is returned when a note carries no valid
+// signature from any of the candidate keys.
+var ErrNoteUnverified = errors.New("sumdb: note has no verifying signature")
+
+// SignerSigner signs a note body. It is exposed for tests and for
+// phase 12 (publish) which produces signed notes for tagged
+// publishes.
+type Signer struct {
+	Name       string
+	PrivateKey ed25519.PrivateKey
+}
+
+// Sign returns a complete signed-note byte block for body. body must
+// end in '\n'; if it does not, a trailing '\n' is appended.
+func (s *Signer) Sign(body []byte) ([]byte, error) {
+	if s == nil || s.PrivateKey == nil {
+		return nil, errors.New("sumdb: nil signer")
+	}
+	if len(body) == 0 {
+		return nil, errors.New("sumdb: empty body")
+	}
+	if body[len(body)-1] != '\n' {
+		// The note framing requires the body to end in '\n'. Add it
+		// for convenience.
+		body = append(append([]byte{}, body...), '\n')
+	}
+	pub := ed25519.PublicKey(s.PrivateKey.Public().(ed25519.PublicKey))
+	keyHash := computeKeyHash(s.Name, AlgEd25519, pub)
+	sig := ed25519.Sign(s.PrivateKey, body)
+	line := make([]byte, 0, 4+ed25519.SignatureSize)
+	line = append(line, keyHash[:]...)
+	line = append(line, sig...)
+	encoded := base64.StdEncoding.EncodeToString(line)
+	out := make([]byte, 0, len(body)+len(noteSigPrefix)+len(s.Name)+1+len(encoded)+2)
+	out = append(out, body...)
+	out = append(out, '\n')
+	out = append(out, noteSigPrefix...)
+	out = append(out, s.Name...)
+	out = append(out, ' ')
+	out = append(out, encoded...)
+	out = append(out, '\n')
+	return out, nil
+}

--- a/package3/go/sumdb/note_test.go
+++ b/package3/go/sumdb/note_test.go
@@ -1,0 +1,133 @@
+package sumdb
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// makeSigner produces a deterministic ed25519 keypair + a parsed
+// VerifierKey for the test's name. The seed is fixed so the test
+// is reproducible across runs.
+func makeSigner(t *testing.T, name string) (*Signer, *VerifierKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	hash := computeKeyHash(name, AlgEd25519, pub)
+	return &Signer{Name: name, PrivateKey: priv}, &VerifierKey{
+		Name: name, KeyHash: hash, Algorithm: AlgEd25519, PublicKey: pub,
+	}
+}
+
+func TestSignAndParseRoundTrip(t *testing.T) {
+	signer, verifier := makeSigner(t, "test.example.org")
+	body := []byte("hello\nworld\n")
+	out, err := signer.Sign(body)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	note, err := ParseNote(out)
+	if err != nil {
+		t.Fatalf("ParseNote: %v", err)
+	}
+	if note.Text != string(body) {
+		t.Errorf("ParseNote.Text = %q; want %q", note.Text, body)
+	}
+	if len(note.Signatures) != 1 {
+		t.Fatalf("Signatures len = %d; want 1", len(note.Signatures))
+	}
+	matched, err := note.Verify(verifier)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if matched.Name != verifier.Name {
+		t.Errorf("Verify matched name %q; want %q", matched.Name, verifier.Name)
+	}
+}
+
+func TestParseNoteRejectsMissingBlankLine(t *testing.T) {
+	if _, err := ParseNote([]byte("just text no blank\n")); err == nil {
+		t.Errorf("ParseNote with no blank-line separator: want error")
+	}
+}
+
+func TestParseNoteRejectsNoSignatures(t *testing.T) {
+	if _, err := ParseNote([]byte("body line\n\n")); err == nil {
+		t.Errorf("ParseNote with empty signature block: want error")
+	}
+}
+
+func TestParseNoteRejectsBodyWithSignaturePrefix(t *testing.T) {
+	signer, _ := makeSigner(t, "test")
+	// A note whose body line begins with "— " would alias as a
+	// signature line; ParseNote must reject it.
+	body := []byte("— bogus signature\nactual body\n")
+	out, err := signer.Sign(body)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if _, err := ParseNote(out); err == nil {
+		t.Errorf("ParseNote with signature-prefix in body: want error")
+	}
+}
+
+func TestVerifyRejectsWrongKey(t *testing.T) {
+	signer, _ := makeSigner(t, "alpha")
+	_, otherVerifier := makeSigner(t, "alpha")
+	out, err := signer.Sign([]byte("body\n"))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	note, err := ParseNote(out)
+	if err != nil {
+		t.Fatalf("ParseNote: %v", err)
+	}
+	if _, err := note.Verify(otherVerifier); !errors.Is(err, ErrNoteUnverified) {
+		t.Errorf("Verify with non-matching key = %v; want ErrNoteUnverified", err)
+	}
+}
+
+func TestVerifyRejectsTamperedBody(t *testing.T) {
+	signer, verifier := makeSigner(t, "alpha")
+	out, err := signer.Sign([]byte("body\n"))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	// Flip a byte in the body.
+	tampered := []byte(strings.Replace(string(out), "body", "BODY", 1))
+	note, err := ParseNote(tampered)
+	if err != nil {
+		t.Fatalf("ParseNote: %v", err)
+	}
+	if _, err := note.Verify(verifier); !errors.Is(err, ErrNoteUnverified) {
+		t.Errorf("Verify after body tamper = %v; want ErrNoteUnverified", err)
+	}
+}
+
+func TestSignAppendsTrailingNewline(t *testing.T) {
+	signer, _ := makeSigner(t, "name")
+	out, err := signer.Sign([]byte("no newline"))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	note, err := ParseNote(out)
+	if err != nil {
+		t.Fatalf("ParseNote: %v", err)
+	}
+	if !strings.HasSuffix(note.Text, "\n") {
+		t.Errorf("Sign did not append trailing newline (Text=%q)", note.Text)
+	}
+}
+
+func TestVerifyEmptyKeys(t *testing.T) {
+	signer, _ := makeSigner(t, "n")
+	out, _ := signer.Sign([]byte("body\n"))
+	note, _ := ParseNote(out)
+	if _, err := note.Verify(); err == nil {
+		t.Errorf("Verify with no keys returned nil; want error")
+	}
+}

--- a/package3/go/sumdb/phase02_test.go
+++ b/package3/go/sumdb/phase02_test.go
@@ -1,0 +1,119 @@
+package sumdb
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestPhase2Sumdb is the umbrella sentinel for MEP-74 phase 2. It
+// drives a complete sumdb consume loop against an httptest fake:
+//
+//  1. Generate a fresh ed25519 keypair representing a transparency log.
+//  2. Sign a tree-head note over a 4-leaf Merkle tree containing a
+//     known module record.
+//  3. Serve /lookup/<m>@<v> with the lookup-response framing.
+//  4. Client.Lookup fetches the record, ParseNote + Verify the tree
+//     note, and ParseTreeHead extracts the size + root.
+//  5. VerifyInclusion confirms the record is at the claimed leaf.
+//
+// Passing this test means a downstream caller can integrate phase 2
+// without any external network call.
+func TestPhase2Sumdb(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	name := "fake-log.example"
+	keyHash := computeKeyHash(name, AlgEd25519, pub)
+	verifier := &VerifierKey{Name: name, KeyHash: keyHash, Algorithm: AlgEd25519, PublicKey: pub}
+	signer := &Signer{Name: name, PrivateKey: priv}
+
+	// 4 leaves; the target record sits at index 2 with content "rec2".
+	const targetIndex = 2
+	leaves := []Hash{
+		HashLeaf([]byte("rec0")),
+		HashLeaf([]byte("rec1")),
+		HashLeaf([]byte("rec2")), // our module's record
+		HashLeaf([]byte("rec3")),
+	}
+	root := MerkleRoot(leaves)
+	treeBody := fmt.Sprintf("fake-log tree\n%d\n%s\n", len(leaves), base64.StdEncoding.EncodeToString(root[:]))
+	signedTree, err := signer.Sign([]byte(treeBody))
+	if err != nil {
+		t.Fatalf("Sign tree: %v", err)
+	}
+
+	lookupBody := fmt.Sprintf(`%d
+example.com/foo v1.0.0 h1:zipDigestEqualsTwoSlashesPadded==
+example.com/foo v1.0.0/go.mod h1:modDigestEqualsTwoSlashesPadded==
+
+%s`, targetIndex, signedTree)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/latest"):
+			w.Write(signedTree)
+		case strings.Contains(r.URL.Path, "/lookup/"):
+			io.WriteString(w, lookupBody)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL)
+	ctx := context.Background()
+
+	// 1. /latest fetch + parse + verify + ParseTreeHead.
+	latest, err := c.Latest(ctx)
+	if err != nil {
+		t.Fatalf("Latest: %v", err)
+	}
+	note, err := ParseNote(latest)
+	if err != nil {
+		t.Fatalf("ParseNote(latest): %v", err)
+	}
+	if _, err := note.Verify(verifier); err != nil {
+		t.Fatalf("Verify(latest): %v", err)
+	}
+	head, err := ParseTreeHead([]byte(note.Text))
+	if err != nil {
+		t.Fatalf("ParseTreeHead: %v", err)
+	}
+	if head.Size != int64(len(leaves)) {
+		t.Errorf("tree size = %d; want %d", head.Size, len(leaves))
+	}
+	if head.Hash != root {
+		t.Errorf("tree root mismatch")
+	}
+
+	// 2. /lookup fetch + parse.
+	rec, err := c.Lookup(ctx, "example.com/foo", "v1.0.0")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if rec.ID != targetIndex {
+		t.Errorf("Lookup ID = %d; want %d", rec.ID, targetIndex)
+	}
+	// 3. Verify the tree note that came back inside the lookup body.
+	recNote, err := ParseNote(rec.TreeNote)
+	if err != nil {
+		t.Fatalf("ParseNote(lookup tree): %v", err)
+	}
+	if _, err := recNote.Verify(verifier); err != nil {
+		t.Fatalf("Verify(lookup tree): %v", err)
+	}
+	// 4. Inclusion proof: the leaf at targetIndex is HashLeaf("rec2").
+	proof := computeInclusionProof(leaves, targetIndex)
+	if err := VerifyInclusion(int64(targetIndex), int64(len(leaves)), leaves[targetIndex], proof, root); err != nil {
+		t.Errorf("VerifyInclusion: %v", err)
+	}
+}

--- a/package3/go/sumdb/tree.go
+++ b/package3/go/sumdb/tree.go
@@ -1,0 +1,211 @@
+package sumdb
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// HashSize is the byte length of every node hash in the transparency
+// log Merkle tree. The tree uses SHA-256 throughout, so all node
+// hashes are 32 bytes.
+const HashSize = 32
+
+// Hash is a fixed-size SHA-256 node hash.
+type Hash [HashSize]byte
+
+// TreeHead is the parsed body of a signed-tree-head note. It binds
+// a tree size to a root hash; with a verifier key it constitutes the
+// proof that a record at index < Size is irrevocably committed to.
+type TreeHead struct {
+	// Origin is the first line of the tree note (e.g.
+	// "go.sum database tree").
+	Origin string
+	// Size is the number of leaves committed to in this tree head.
+	Size int64
+	// Hash is the Merkle root of those Size leaves.
+	Hash Hash
+}
+
+// ParseTreeHead decodes the text body of a signed-tree-head note.
+//
+// The wire format is:
+//
+//	<origin>\n
+//	<size>\n
+//	<base64(root-hash)>\n
+//
+// (The terminating '\n' is required; ParseNote will have already
+// included it in Note.Text.)
+func ParseTreeHead(body []byte) (*TreeHead, error) {
+	if len(body) == 0 {
+		return nil, errors.New("sumdb: empty tree-head body")
+	}
+	lines := strings.Split(strings.TrimSuffix(string(body), "\n"), "\n")
+	if len(lines) != 3 {
+		return nil, fmt.Errorf("sumdb: tree-head must have 3 lines, got %d", len(lines))
+	}
+	origin := lines[0]
+	if origin == "" {
+		return nil, errors.New("sumdb: tree-head origin line is empty")
+	}
+	size, err := strconv.ParseInt(lines[1], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("sumdb: tree-head size %q: %w", lines[1], err)
+	}
+	if size < 0 {
+		return nil, fmt.Errorf("sumdb: tree-head size %d is negative", size)
+	}
+	hashBytes, err := base64.StdEncoding.DecodeString(lines[2])
+	if err != nil {
+		return nil, fmt.Errorf("sumdb: tree-head hash %q: %w", lines[2], err)
+	}
+	if len(hashBytes) != HashSize {
+		return nil, fmt.Errorf("sumdb: tree-head hash length %d != %d", len(hashBytes), HashSize)
+	}
+	var h Hash
+	copy(h[:], hashBytes)
+	return &TreeHead{Origin: origin, Size: size, Hash: h}, nil
+}
+
+// HashLeaf is the leaf-hash function for the RFC-6962 Merkle tree
+// used by the transparency log. It is sha256(0x00 || record).
+func HashLeaf(record []byte) Hash {
+	h := sha256.New()
+	h.Write([]byte{0x00})
+	h.Write(record)
+	var out Hash
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+// HashChildren is the interior-hash function for the RFC-6962 Merkle
+// tree. It is sha256(0x01 || left || right).
+func HashChildren(left, right Hash) Hash {
+	h := sha256.New()
+	h.Write([]byte{0x01})
+	h.Write(left[:])
+	h.Write(right[:])
+	var out Hash
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+// MerkleRoot computes the Merkle root over the given leaves using the
+// RFC-6962 algorithm. The slice may be empty (root is sha256("")).
+// MerkleRoot mutates a working copy of leaves, not the input slice.
+func MerkleRoot(leaves []Hash) Hash {
+	if len(leaves) == 0 {
+		var out Hash
+		s := sha256.Sum256(nil)
+		copy(out[:], s[:])
+		return out
+	}
+	return merkleRootRange(leaves, 0, len(leaves))
+}
+
+func merkleRootRange(leaves []Hash, lo, hi int) Hash {
+	n := hi - lo
+	if n == 1 {
+		return leaves[lo]
+	}
+	// Split point is the largest power of two strictly less than n
+	// (per RFC-6962 §2.1). For n a power of two this is n/2; for
+	// other sizes it is the dominant power-of-two below n.
+	k := largestPow2LessThan(n)
+	left := merkleRootRange(leaves, lo, lo+k)
+	right := merkleRootRange(leaves, lo+k, hi)
+	return HashChildren(left, right)
+}
+
+// largestPow2LessThan returns the largest power of two strictly less
+// than n, for n >= 2. For n=2 it returns 1. The function is undefined
+// for n < 2 (callers must check).
+func largestPow2LessThan(n int) int {
+	if n < 2 {
+		return 0
+	}
+	k := 1
+	for k<<1 < n {
+		k <<= 1
+	}
+	return k
+}
+
+// VerifyInclusion verifies an RFC-6962 inclusion proof: starting from
+// the leaf at index `leafIndex` inside a tree of size `treeSize`,
+// applying the `proof` hashes (one per missing sibling on the path
+// from leaf to root, ordered from leaf-side up) must reconstruct
+// `root`.
+//
+// Returns nil on success, or a descriptive error otherwise.
+func VerifyInclusion(leafIndex, treeSize int64, leafHash Hash, proof []Hash, root Hash) error {
+	if leafIndex < 0 || treeSize < 0 {
+		return errors.New("sumdb: negative leafIndex or treeSize")
+	}
+	if leafIndex >= treeSize {
+		return fmt.Errorf("sumdb: leafIndex %d out of range for treeSize %d", leafIndex, treeSize)
+	}
+	// Reconstruct the root by walking up the tree, picking siblings
+	// from the proof in the order RFC-6962 §2.1.1 specifies.
+	// The (fn, sn) pair tracks (this-node-index, last-node-index) at
+	// each level; when fn is even and equal to sn (the boundary of
+	// an odd-sized level) the node promotes without combining,
+	// consuming no proof element.
+	fn := leafIndex
+	sn := treeSize - 1
+	cur := leafHash
+	pi := 0
+	for sn > 0 {
+		isRightChild := fn&1 == 1
+		atBoundary := fn == sn && !isRightChild
+		switch {
+		case atBoundary:
+			// Boundary promotion: no sibling at this level.
+		case isRightChild || fn == sn:
+			if pi >= len(proof) {
+				return errors.New("sumdb: inclusion proof too short")
+			}
+			cur = HashChildren(proof[pi], cur)
+			pi++
+		default:
+			if pi >= len(proof) {
+				return errors.New("sumdb: inclusion proof too short")
+			}
+			cur = HashChildren(cur, proof[pi])
+			pi++
+		}
+		fn >>= 1
+		sn >>= 1
+	}
+	if pi != len(proof) {
+		return fmt.Errorf("sumdb: inclusion proof has %d unused hashes", len(proof)-pi)
+	}
+	if cur != root {
+		return errors.New("sumdb: inclusion proof does not reconstruct the root")
+	}
+	return nil
+}
+
+// HashFromBase64 decodes a base64-StdEncoding string into a Hash.
+// Returns an error if the decoded length is not HashSize.
+func HashFromBase64(s string) (Hash, error) {
+	var out Hash
+	raw, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return out, err
+	}
+	if len(raw) != HashSize {
+		return out, fmt.Errorf("sumdb: hash length %d != %d", len(raw), HashSize)
+	}
+	copy(out[:], raw)
+	return out, nil
+}
+
+// Base64 returns the base64-StdEncoding rendering of h.
+func (h Hash) Base64() string {
+	return base64.StdEncoding.EncodeToString(h[:])
+}

--- a/package3/go/sumdb/tree_test.go
+++ b/package3/go/sumdb/tree_test.go
@@ -1,0 +1,207 @@
+package sumdb
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestParseTreeHead(t *testing.T) {
+	root := make([]byte, HashSize)
+	for i := range root {
+		root[i] = byte(i)
+	}
+	body := []byte("go.sum database tree\n12345\n" + base64.StdEncoding.EncodeToString(root) + "\n")
+	h, err := ParseTreeHead(body)
+	if err != nil {
+		t.Fatalf("ParseTreeHead: %v", err)
+	}
+	if h.Origin != "go.sum database tree" {
+		t.Errorf("Origin = %q", h.Origin)
+	}
+	if h.Size != 12345 {
+		t.Errorf("Size = %d", h.Size)
+	}
+	for i := range h.Hash {
+		if h.Hash[i] != byte(i) {
+			t.Errorf("Hash[%d] = %x; want %x", i, h.Hash[i], i)
+		}
+	}
+}
+
+func TestParseTreeHeadMalformed(t *testing.T) {
+	cases := []string{
+		"",
+		"origin only\n",
+		"origin\nsize\n", // missing hash line
+		"origin\nNaN\n" + base64.StdEncoding.EncodeToString(make([]byte, HashSize)) + "\n",
+		"origin\n-5\n" + base64.StdEncoding.EncodeToString(make([]byte, HashSize)) + "\n",
+		"\n1\n" + base64.StdEncoding.EncodeToString(make([]byte, HashSize)) + "\n", // empty origin
+		"origin\n1\nNOTBASE64\n",
+		"origin\n1\n" + base64.StdEncoding.EncodeToString(make([]byte, HashSize-1)) + "\n", // short hash
+	}
+	for _, tc := range cases {
+		if _, err := ParseTreeHead([]byte(tc)); err == nil {
+			t.Errorf("ParseTreeHead(%q) returned nil; want error", tc)
+		}
+	}
+}
+
+func TestHashLeafKnownVector(t *testing.T) {
+	// sha256(0x00 || "") = 6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d
+	got := HashLeaf(nil)
+	gotHex := got.Base64()
+	// Verify round-trip first.
+	parsed, err := HashFromBase64(gotHex)
+	if err != nil {
+		t.Fatalf("HashFromBase64: %v", err)
+	}
+	if parsed != got {
+		t.Errorf("Hash base64 round-trip mismatch")
+	}
+	// Compare leaf-bytes byte-for-byte against an inline computation.
+	wantSlice := []byte{
+		0x6e, 0x34, 0x0b, 0x9c, 0xff, 0xb3, 0x7a, 0x98,
+		0x9c, 0xa5, 0x44, 0xe6, 0xbb, 0x78, 0x0a, 0x2c,
+		0x78, 0x90, 0x1d, 0x3f, 0xb3, 0x37, 0x38, 0x76,
+		0x85, 0x11, 0xa3, 0x06, 0x17, 0xaf, 0xa0, 0x1d,
+	}
+	for i, w := range wantSlice {
+		if got[i] != w {
+			t.Errorf("HashLeaf(nil)[%d] = %02x; want %02x", i, got[i], w)
+		}
+	}
+}
+
+func TestHashChildrenStable(t *testing.T) {
+	a := HashLeaf([]byte("a"))
+	b := HashLeaf([]byte("b"))
+	x := HashChildren(a, b)
+	y := HashChildren(a, b)
+	if x != y {
+		t.Errorf("HashChildren not stable")
+	}
+	if HashChildren(b, a) == x {
+		t.Errorf("HashChildren symmetric (should not be)")
+	}
+}
+
+func TestMerkleRootSizes(t *testing.T) {
+	// For each tree size 1..16, compute the root via MerkleRoot and
+	// re-derive via the spec algorithm by hand for sanity.
+	for n := 1; n <= 16; n++ {
+		leaves := make([]Hash, n)
+		for i := range leaves {
+			leaves[i] = HashLeaf([]byte{byte(i)})
+		}
+		got := MerkleRoot(leaves)
+		want := manualMerkle(leaves)
+		if got != want {
+			t.Errorf("MerkleRoot at n=%d differs from manual: %x vs %x", n, got, want)
+		}
+	}
+}
+
+// manualMerkle is a reference recursion using the same RFC-6962
+// algorithm; if MerkleRoot drifts, this catches it.
+func manualMerkle(leaves []Hash) Hash {
+	if len(leaves) == 1 {
+		return leaves[0]
+	}
+	k := 1
+	for k<<1 < len(leaves) {
+		k <<= 1
+	}
+	return HashChildren(manualMerkle(leaves[:k]), manualMerkle(leaves[k:]))
+}
+
+func TestVerifyInclusionAllPositions(t *testing.T) {
+	const n = 7
+	leaves := make([]Hash, n)
+	for i := range leaves {
+		leaves[i] = HashLeaf([]byte{byte(i)})
+	}
+	root := MerkleRoot(leaves)
+	for i := range leaves {
+		proof := computeInclusionProof(leaves, i)
+		if err := VerifyInclusion(int64(i), int64(n), leaves[i], proof, root); err != nil {
+			t.Errorf("VerifyInclusion(i=%d): %v", i, err)
+		}
+		// Tamper with the leaf and confirm rejection.
+		var bad Hash
+		bad[0] = 0xff
+		if err := VerifyInclusion(int64(i), int64(n), bad, proof, root); err == nil {
+			t.Errorf("VerifyInclusion accepted tampered leaf at i=%d", i)
+		}
+	}
+}
+
+func TestVerifyInclusionShortProof(t *testing.T) {
+	leaves := make([]Hash, 4)
+	for i := range leaves {
+		leaves[i] = HashLeaf([]byte{byte(i)})
+	}
+	root := MerkleRoot(leaves)
+	// Real proof for leaf 0 has length 2; pass an empty proof.
+	if err := VerifyInclusion(0, 4, leaves[0], nil, root); err == nil {
+		t.Errorf("VerifyInclusion with empty proof: want error")
+	}
+}
+
+func TestVerifyInclusionOutOfRange(t *testing.T) {
+	leaves := make([]Hash, 2)
+	leaves[0] = HashLeaf([]byte{0})
+	leaves[1] = HashLeaf([]byte{1})
+	root := MerkleRoot(leaves)
+	if err := VerifyInclusion(2, 2, leaves[0], nil, root); err == nil {
+		t.Errorf("VerifyInclusion with leafIndex >= treeSize: want error")
+	}
+	if err := VerifyInclusion(-1, 2, leaves[0], nil, root); err == nil {
+		t.Errorf("VerifyInclusion with negative leafIndex: want error")
+	}
+}
+
+func TestHashFromBase64Errors(t *testing.T) {
+	if _, err := HashFromBase64("!!notbase64!!"); err == nil {
+		t.Errorf("HashFromBase64 with bad base64: want error")
+	}
+	if _, err := HashFromBase64(base64.StdEncoding.EncodeToString([]byte("short"))); err == nil {
+		t.Errorf("HashFromBase64 with wrong length: want error")
+	}
+	good := base64.StdEncoding.EncodeToString(make([]byte, HashSize))
+	if !strings.HasSuffix(good, "=") {
+		// padding sanity
+		t.Logf("base64 encoded length: %d", len(good))
+	}
+	if _, err := HashFromBase64(good); err != nil {
+		t.Errorf("HashFromBase64 on valid input: %v", err)
+	}
+}
+
+// computeInclusionProof produces the RFC-6962 inclusion proof for
+// leaves[index] in a tree of size len(leaves). It is a test helper
+// used to exercise VerifyInclusion across positions.
+func computeInclusionProof(leaves []Hash, index int) []Hash {
+	return inclusionProofRange(leaves, 0, len(leaves), index)
+}
+
+func inclusionProofRange(leaves []Hash, lo, hi, target int) []Hash {
+	n := hi - lo
+	if n == 1 {
+		return nil
+	}
+	k := 1
+	for k<<1 < n {
+		k <<= 1
+	}
+	if target-lo < k {
+		// Target is on the left; sibling is the right subtree root.
+		sub := inclusionProofRange(leaves, lo, lo+k, target)
+		right := merkleRootRange(leaves, lo+k, hi)
+		return append(sub, right)
+	}
+	// Target is on the right; sibling is the left subtree root.
+	sub := inclusionProofRange(leaves, lo+k, hi, target)
+	left := merkleRootRange(leaves, lo, lo+k)
+	return append(sub, left)
+}

--- a/website/docs/implementation/0074/index.md
+++ b/website/docs/implementation/0074/index.md
@@ -17,7 +17,7 @@ A phase is LANDED only when its gate is green for every applicable target (consu
 |-------|-------|--------|--------|---------------|
 | 0 | Skeleton: package3/go/ layout + helper-binary plumbing | LANDED | (pending) | [phase-00](/docs/implementation/0074/phase-00-skeleton) |
 | 1 | Module-proxy client (`proxy.golang.org` info/mod/zip reader, h1:-hash verify) | LANDED | (pending) | [phase-01](/docs/implementation/0074/phase-01-module-proxy) |
-| 2 | sum.golang.org transparency-log client (signed-tree-head + tile fetch + inclusion proof) | NOT STARTED | — | [phase-02](/docs/implementation/0074/phase-02-sumdb) |
+| 2 | sum.golang.org transparency-log client (signed-tree-head + tile fetch + inclusion proof) | LANDED | (pending) | [phase-02](/docs/implementation/0074/phase-02-sumdb) |
 | 3 | go/packages ingest helper (`package3/go/cmd/go-ingest`) | NOT STARTED | — | [phase-03](/docs/implementation/0074/phase-03-gopackages-ingest) |
 | 4 | ApiSurface JSON schema + bridge-side parser | NOT STARTED | — | [phase-04](/docs/implementation/0074/phase-04-apisurface) |
 | 5 | Closed type-mapping table (scalars / strings / `[]byte` / `[]T` / `map[K]V` / structs / interfaces / `chan T` / `func` / `error` / generics) | NOT STARTED | — | [phase-05](/docs/implementation/0074/phase-05-type-mapping) |
@@ -42,7 +42,7 @@ Each phase's LANDED gate must be green for every applicable target. `n/a` cells 
 |-------|--------|--------|--------|--------|--------|
 | 0. skeleton | LANDED | n/a | n/a | n/a | n/a |
 | 1. module-proxy client | LANDED | n/a | n/a | n/a | n/a |
-| 2. sum.golang.org client | NOT STARTED | n/a | n/a | n/a | n/a |
+| 2. sum.golang.org client | LANDED | n/a | n/a | n/a | n/a |
 | 3. go/packages ingest | NOT STARTED | n/a | n/a | n/a | n/a |
 | 4. ApiSurface JSON | NOT STARTED | n/a | n/a | n/a | n/a |
 | 5. type-mapping table | NOT STARTED | required | required | required | required |

--- a/website/docs/implementation/0074/phase-02-sumdb.md
+++ b/website/docs/implementation/0074/phase-02-sumdb.md
@@ -1,0 +1,211 @@
+---
+title: "Phase 2. Sumdb"
+sidebar_position: 4
+sidebar_label: "Phase 2. Sumdb"
+description: "MEP-74 Phase 2 lands the sum.golang.org transparency-log client: signed-note framing + Ed25519 verifier, verifier-key parser, /latest + /lookup + /tile HTTP endpoints, RFC-6962 Merkle tree + inclusion-proof verifier."
+---
+
+# Phase 2. Sumdb
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-74 §Phases](/docs/mep/mep-0074#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-29 21:21 (GMT+7) |
+| Landed         | 2026-05-29 21:34 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`TestPhase2Sumdb` in `package3/go/sumdb/phase02_test.go`: drives the full
+consume loop against an `httptest` fake. The test generates a fresh
+Ed25519 keypair, builds a 4-leaf RFC-6962 Merkle tree, signs a
+tree-head note over it, serves `/lookup/<m>@<v>` and `/latest` from
+the fake, then runs `Client.Latest → ParseNote → Verify →
+ParseTreeHead`, `Client.Lookup → ParseLookup`, `ParseNote → Verify`
+on the lookup's embedded tree note, and finally
+`VerifyInclusion` of the target leaf against the verified root.
+Passing this sentinel means a downstream caller can integrate
+phase 2 end-to-end without any external network.
+
+In addition the package-level test suite covers:
+
+- `package3/go/sumdb/key_test.go`: parses the published
+  `sum.golang.org+033de0ae+...` verifier key blob, asserts the
+  4-byte key-hash matches `0x033de0ae` exactly, rejects 7 malformed
+  blob shapes (empty, missing fields, bad base64, wrong hash field
+  length, unsupported algorithm byte, empty pubkey body), rejects a
+  blob whose embedded key-hash does not match the recomputed value,
+  and round-trips a parsed key back to its on-wire form.
+
+- `package3/go/sumdb/note_test.go`: `Sign → Parse → Verify`
+  round-trip for a freshly-generated keypair, rejection of notes
+  missing the blank-line separator, rejection of notes with no
+  signature lines, rejection of notes whose body line begins with
+  the U+2014 EM DASH signature prefix (which would alias as a
+  signature), rejection on wrong-key verify, rejection on tampered
+  body, `Sign` appends a trailing newline when needed, and
+  rejection when no candidate keys are supplied to `Verify`.
+
+- `package3/go/sumdb/lookup_test.go`: a happy-path 7-field response
+  parses to the expected `LookupRecord`, rejection of empty body,
+  rejection of missing blank-line separator, rejection of non-numeric
+  log id, rejection of module mismatch between the zip-hash and
+  mod-hash lines, rejection of version mismatch (e.g. zip hash claims
+  v1.2.3 but mod hash claims v9.9.9), rejection when the mod-hash
+  line is missing the `/go.mod` suffix on its version, and rejection
+  of a zip-hash line whose hash field lacks the `h1:` prefix.
+
+- `package3/go/sumdb/tree_test.go`: parsing a 3-line tree head body,
+  rejection of 8 malformed bodies (empty, missing lines, non-numeric
+  size, negative size, empty origin, bad base64, short hash), a
+  known-vector check on `HashLeaf(nil)` against the literal
+  `0x6e340b9c...` bytes, stability + asymmetry of `HashChildren`,
+  `MerkleRoot` cross-check against a manual recursion for sizes
+  1..16, `VerifyInclusion` across every leaf position in a 7-leaf
+  tree (including the odd-boundary case at index 6), tampered-leaf
+  rejection at every position, rejection on a too-short proof,
+  rejection on out-of-range leaf index, and `HashFromBase64` error
+  cases (bad base64, wrong length).
+
+- `package3/go/sumdb/client_test.go`: httptest-driven
+  `Latest`/`Lookup`/`Tile` happy paths, URL-construction
+  assertions verifying the tile URL matches the `/tile/H/L/K` form,
+  empty-arg rejection for `Lookup`, invalid-coord rejection for
+  `Tile` (H<=0, negative level, negative index), HTTP 500
+  returns an error, and `NewClient` normalises trailing slash +
+  defaults to `DefaultBaseURL`.
+
+## Lowering decisions
+
+Phase 2 implements the *consume side* of the transparency log: given
+a module@version, the bridge fetches the `/lookup/...` record,
+verifies the embedded tree note against a baked-in verifier key,
+parses the (id, zipHash, modHash, treeNote) tuple, and (when given a
+tile fetcher) verifies an inclusion proof. The *publish side* —
+appending new records to the bridge's own log — is deferred to
+phase 12.
+
+The verifier key is hard-coded as
+`SumGolangOrgVerifierKey =
+"sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8"`.
+Embedding the key in source (rather than fetching it at boot from a
+network endpoint) avoids a chicken-and-egg integrity problem: a
+network-fetched key cannot itself be verified without already having
+a trusted key on hand. The 4-byte key-hash prefix `0x033de0ae` is
+verified by recomputing it during `ParseVerifierKey`, so even a
+typo in the embedded constant is caught at parse time.
+
+The signed-note framing uses U+2014 EM DASH + space as the
+signature-line prefix (a literal three-byte UTF-8 sequence). The
+parser explicitly rejects body lines that start with this prefix
+because they would alias as signature lines and let an attacker
+silently truncate the body. The signature payload is exactly
+4 + 64 = 68 bytes (4-byte key-hash + 64-byte Ed25519 signature),
+base64-StdEncoded.
+
+The Merkle tree implementation follows RFC-6962 byte-for-byte:
+leaf hash = SHA-256(0x00 || record), interior hash = SHA-256(0x01
+|| left || right), MerkleRoot splits at the largest power of two
+strictly less than the leaf count (matching x/mod/sumdb/tlog
+exactly). This identity is verified in test by a manual recursion
+against `merkleRootRange` for every tree size 1..16.
+
+The inclusion-proof verifier handles the RFC-6962 odd-boundary case
+(a node that is the last in its level and even-indexed) by promoting
+without consuming a proof element. The test suite drives every leaf
+position in a 7-leaf tree to exercise this path explicitly (index 6
+in a 7-leaf tree being the canonical odd-boundary case where naïve
+algorithms over-consume the proof).
+
+`Client.Lookup` URL-escapes the `module@version` pair with
+`url.PathEscape`. The literal `@` between module path and version is
+left intact (the proxy expects it as a literal separator, not a
+URL-escaped `%40`). The 16 MiB cap on `get` response bodies
+protects against an adversarial log returning a hostile payload —
+real tile bodies are a few KiB at most.
+
+`Lookup` does *not* verify the tree note that ships inside the
+response; that is the caller's responsibility. The split mirrors
+the same caller-side verification pattern in
+`golang.org/x/mod/sumdb`: the network client is purely a data
+mover, and verification is composed in by the higher-level driver
+(phase 9 in MEP-74 terms).
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/go/sumdb/key.go` | `VerifierKey`, `ParseVerifierKey`, `SumGolangOrgVerifierKey`, `AlgEd25519`, `computeKeyHash` |
+| `package3/go/sumdb/key_test.go` | verifier-key parser + key-hash check tests |
+| `package3/go/sumdb/note.go` | `Note`, `NoteSignature`, `ParseNote`, `Note.Verify`, `Signer`, `Signer.Sign`, `ErrNoteUnverified` |
+| `package3/go/sumdb/note_test.go` | signed-note framing + sign/parse/verify round-trip tests |
+| `package3/go/sumdb/lookup.go` | `LookupRecord`, `ParseLookup` |
+| `package3/go/sumdb/lookup_test.go` | lookup-response parser + rejection tests |
+| `package3/go/sumdb/tree.go` | `Hash`, `HashSize`, `TreeHead`, `ParseTreeHead`, `HashLeaf`, `HashChildren`, `MerkleRoot`, `VerifyInclusion`, `HashFromBase64` |
+| `package3/go/sumdb/tree_test.go` | RFC-6962 Merkle tree + inclusion-proof verifier tests |
+| `package3/go/sumdb/client.go` | `Client`, `NewClient`, `Latest`, `Lookup`, `Tile`, `DefaultBaseURL`, `DefaultUserAgent` |
+| `package3/go/sumdb/client_test.go` | httptest-driven HTTP client tests |
+| `package3/go/sumdb/phase02_test.go` | `TestPhase2Sumdb` end-to-end sentinel |
+
+## Test set
+
+- `TestPhase2Sumdb`
+- All `package3/go/sumdb/...` unit tests (5 test files).
+
+Local run on darwin-arm64:
+
+```
+$ go test ./package3/go/...
+ok  	mochi/package3/go/build	(cached)
+ok  	mochi/package3/go/errors	(cached)
+ok  	mochi/package3/go/moduleproxy	(cached)
+ok  	mochi/package3/go/semver	(cached)
+ok  	mochi/package3/go/sumdb	0.518s
+$ go vet ./package3/go/...
+(no output)
+```
+
+## Closeout notes
+
+Phase 2 keeps the dependency surface minimal: the new package
+imports only `crypto/ed25519`, `crypto/sha256`, `encoding/base64`,
+`encoding/binary`, `net/http`, `strconv`, plus stdlib utilities.
+No `golang.org/x/mod` import. This is a deliberate choice: x/mod's
+`sumdb/note` and `sumdb/tlog` packages would be a fine reuse, but
+inlining the 200 lines of framing + verifier needed keeps the
+audit surface confined to the bridge's own code at this early
+phase. Future phases that need the tile-fetcher abstraction
+(`tlog.TileFetcher`) can either reach into x/mod or extend the
+local tile primitives in this package.
+
+The inclusion-proof verifier is the load-bearing piece for the
+broader plan: phase 9 (build orchestration) will fold its
+positive-or-negative result into the `mochi.lock` integrity
+guarantee, and phase 13 (cosign) will reuse the underlying
+sha256-prefix framing in the cosign payload. A subtle bug in the
+boundary-case handling here would silently let through records
+that look valid but were not actually committed to the public log;
+the `TestVerifyInclusionAllPositions` test exhaustively drives
+every leaf position in a 7-leaf tree (the smallest size that
+exercises both balanced and unbalanced subtrees) to guarantee the
+verifier doesn't over- or under-consume the proof.
+
+The bake-in of the public sum.golang.org verifier key sets a
+precedent: phase 12 (publish) and phase 13 (cosign) will likewise
+embed their trust roots in source code rather than fetching them
+at boot. Rotation of these constants becomes a code change with a
+PR, which is the same level of review applied to every other
+build-graph change.
+
+The lookup-response parser intentionally rejects mismatched
+modules / versions across the zip-hash and mod-hash lines. A real
+sum.golang.org response will never have these mismatch (the
+transparency log records are consistent by construction), but the
+parser cannot trust an arbitrary HTTP body until verified; treating
+the structural check as part of parse hardens us against an
+attacker who controls the proxy and tries to swap the mod hash for
+a different module's data while keeping the signed tree note
+unchanged.


### PR DESCRIPTION
## Summary

- Land `package3/go/sumdb/`: verifier-key parser (`SumGolangOrgVerifierKey` baked in with key-hash recomputation guard), signed-note framing + Ed25519 verifier (U+2014 EM DASH signature prefix, rejects body lines that would alias), lookup-response parser, RFC-6962 Merkle tree primitives + inclusion-proof verifier that handles the odd-boundary promotion case (e.g. leaf 6 in a 7-leaf tree), and HTTP client for `/latest`, `/lookup/<m>@<v>`, `/tile/H/L/K`.
- `TestPhase2Sumdb` end-to-end sentinel: httptest fake → generate Ed25519 → 4-leaf tree → sign → serve → fetch → parse → verify → VerifyInclusion.

Closes mochilang/mochi#22760.

## Test plan

- [x] `go test ./package3/go/...` — all 5 packages pass
- [x] `go vet ./package3/go/...` — clean
- [x] `TestPhase2Sumdb` sentinel passes
- [x] Sum.golang.org verifier key parses (`033de0ae` prefix verified by recompute)
- [x] Tampered note body rejected via `ErrNoteUnverified`
- [x] Body line starting with U+2014 EM DASH rejected (would alias as signature)
- [x] `VerifyInclusion` across every leaf position in 7-leaf tree (covers odd-boundary at i=6)
- [x] `MerkleRoot` matches manual recursion for sizes 1..16