### PR TITLE
docs(mep-55): fix audit PR count (11 -> 14)

### DIFF
--- a/website/docs/implementation/0055/index.md
+++ b/website/docs/implementation/0055/index.md
@@ -39,7 +39,7 @@ All 18 phases shipped together on `impl/mep-0055-php`, merged to `main` via [PR 
 
 ## Audit follow-up PRs
 
-Eleven post-merge audits caught soft spots that the umbrella PR's CI did not. Each landed as its own PR on `main`:
+Fourteen post-merge audit PRs (rounds 1 through 6) caught soft spots that the umbrella PR's CI did not. Each landed as its own PR on `main`:
 
 | Round | PR     | Issue   | Fix                                                                                           |
 |-------|--------|---------|-----------------------------------------------------------------------------------------------|

--- a/website/docs/mep/mep-0055.md
+++ b/website/docs/mep/mep-0055.md
@@ -16,7 +16,7 @@ description: "Standalone pipeline that lowers a type-checked Mochi program to PH
 
 **Final.** All 18 phases landed via umbrella PR [#22481](https://github.com/mochilang/mochi/pull/22481), merged to `main` on 2026-05-29 at 07:35 UTC (merge commit `7c72ebaae9`).
 
-Eleven post-merge audit follow-ups (rounds 1 through 5, plus round 6) landed afterwards. See [implementation tracking](/docs/implementation/0055/) for the full per-phase commit list.
+Fourteen post-merge audit follow-ups across rounds 1 through 6 landed afterwards. See [implementation tracking](/docs/implementation/0055/) for the full per-phase commit list.
 
 ## Motivation
 


### PR DESCRIPTION
Audit found the prose said 'Eleven post-merge audits' but the table has 14 rows (rounds 1-6). Fix both mep-0055.md and implementation/0055/index.md.