### PR TITLE
MEP-74 phase 3: go/packages ApiSurface ingest

### DIFF
--- a/package3/go/apisurface/ingest.go
+++ b/package3/go/apisurface/ingest.go
@@ -1,0 +1,450 @@
+package apisurface
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// IngestOptions controls Ingest.
+type IngestOptions struct {
+	// Module is the canonical module path the ingest is associated
+	// with. Populates File.Module verbatim. Required.
+	Module string
+	// Version is the resolved version. Optional; left empty when
+	// ingesting a source tree without a known semver.
+	Version string
+	// GeneratedBy is the producer identifier written into the JSON.
+	// Defaults to "mochi-go-bridge go-ingest".
+	GeneratedBy string
+}
+
+// Ingest converts a list of go/packages.Package values into a File
+// ready for JSON serialisation. The packages are typically the
+// result of packages.Load(LoadAllSyntax) over a module root.
+//
+// Ingest is pure (no I/O): all data is read from the loaded packages.
+// The caller is responsible for invoking packages.Load.
+func Ingest(pkgs []*packages.Package, opts IngestOptions) (*File, error) {
+	if opts.Module == "" {
+		return nil, fmt.Errorf("apisurface: ingest: Module is required")
+	}
+	out := &File{
+		SchemaVersion: SchemaVersion,
+		Module:        opts.Module,
+		Version:       opts.Version,
+		GoVersion:     runtime.Version(),
+		GeneratedBy:   opts.GeneratedBy,
+	}
+	if out.GeneratedBy == "" {
+		out.GeneratedBy = "mochi-go-bridge go-ingest"
+	}
+	for _, pkg := range pkgs {
+		if pkg == nil || pkg.Types == nil {
+			continue
+		}
+		ap, err := ingestPackage(pkg)
+		if err != nil {
+			return nil, fmt.Errorf("apisurface: ingest %s: %w", pkg.PkgPath, err)
+		}
+		out.Packages = append(out.Packages, *ap)
+	}
+	sort.Slice(out.Packages, func(i, j int) bool {
+		return out.Packages[i].ImportPath < out.Packages[j].ImportPath
+	})
+	return out, nil
+}
+
+func ingestPackage(p *packages.Package) (*Package, error) {
+	ap := &Package{
+		ImportPath: p.PkgPath,
+		Name:       p.Types.Name(),
+		IsMain:     p.Types.Name() == "main",
+	}
+	if p.Fset == nil {
+		p.Fset = token.NewFileSet()
+	}
+	docMap := collectDocs(p)
+	ap.Doc = docMap.pkgDoc
+	importSet := make(map[string]struct{})
+
+	scope := p.Types.Scope()
+	for _, name := range scope.Names() {
+		obj := scope.Lookup(name)
+		if !obj.Exported() {
+			ap.Skipped = append(ap.Skipped, SkipNote{
+				Kind:     objKind(obj),
+				Name:     name,
+				Position: posOf(p, obj.Pos()),
+				Reason:   "Unexported",
+			})
+			continue
+		}
+		pos := posOf(p, obj.Pos())
+		switch o := obj.(type) {
+		case *types.Func:
+			ap.Funcs = append(ap.Funcs, funcFromObj(o, pos, docMap.funcDoc[name], importSet))
+		case *types.TypeName:
+			t := typeFromObj(o, pos, docMap.typeDoc[name], p, importSet)
+			ap.Types = append(ap.Types, t)
+		case *types.Const:
+			ap.Consts = append(ap.Consts, Value{
+				Name:     name,
+				Type:     typeString(o.Type(), p.PkgPath, importSet),
+				Doc:      docMap.constDoc[name],
+				Position: pos,
+				Const:    o.Val().ExactString(),
+			})
+		case *types.Var:
+			ap.Vars = append(ap.Vars, Value{
+				Name:     name,
+				Type:     typeString(o.Type(), p.PkgPath, importSet),
+				Doc:      docMap.varDoc[name],
+				Position: pos,
+			})
+		default:
+			ap.Skipped = append(ap.Skipped, SkipNote{
+				Kind:     "unknown",
+				Name:     name,
+				Position: pos,
+				Reason:   "UnknownObject",
+			})
+		}
+	}
+
+	// Attach methods to types. types.NewMethodSet over each named
+	// type's pointer or value receiver gathers everything declared
+	// on it. We render the un-pointer'd version because the
+	// receiver-pointer flag on Func captures that distinction.
+	for i := range ap.Types {
+		obj := scope.Lookup(ap.Types[i].Name)
+		if obj == nil {
+			continue
+		}
+		named, ok := obj.Type().(*types.Named)
+		if !ok {
+			continue
+		}
+		methods := []Func{}
+		seen := map[string]bool{}
+		for j := 0; j < named.NumMethods(); j++ {
+			m := named.Method(j)
+			if !m.Exported() {
+				continue
+			}
+			if seen[m.Name()] {
+				continue
+			}
+			seen[m.Name()] = true
+			methods = append(methods, funcFromObj(m, posOf(p, m.Pos()), docMap.methodDoc[ap.Types[i].Name+"."+m.Name()], importSet))
+		}
+		sort.Slice(methods, func(a, b int) bool { return methods[a].Name < methods[b].Name })
+		ap.Types[i].Methods = methods
+	}
+
+	// Sorted imports of the exported surface.
+	if len(importSet) > 0 {
+		ap.Imports = make([]string, 0, len(importSet))
+		for k := range importSet {
+			ap.Imports = append(ap.Imports, k)
+		}
+		sort.Strings(ap.Imports)
+	}
+	// Deterministic ordering across the rest of the surface too.
+	sort.Slice(ap.Funcs, func(i, j int) bool { return ap.Funcs[i].Name < ap.Funcs[j].Name })
+	sort.Slice(ap.Types, func(i, j int) bool { return ap.Types[i].Name < ap.Types[j].Name })
+	sort.Slice(ap.Consts, func(i, j int) bool { return ap.Consts[i].Name < ap.Consts[j].Name })
+	sort.Slice(ap.Vars, func(i, j int) bool { return ap.Vars[i].Name < ap.Vars[j].Name })
+	sort.Slice(ap.Skipped, func(i, j int) bool {
+		if ap.Skipped[i].Name != ap.Skipped[j].Name {
+			return ap.Skipped[i].Name < ap.Skipped[j].Name
+		}
+		return ap.Skipped[i].Kind < ap.Skipped[j].Kind
+	})
+	return ap, nil
+}
+
+// objKind maps a types.Object to a SkipNote.Kind token.
+func objKind(obj types.Object) string {
+	switch obj.(type) {
+	case *types.Func:
+		return "func"
+	case *types.TypeName:
+		return "type"
+	case *types.Const:
+		return "const"
+	case *types.Var:
+		return "var"
+	default:
+		return "unknown"
+	}
+}
+
+func funcFromObj(o *types.Func, pos, doc string, importSet map[string]struct{}) Func {
+	sig := o.Type().(*types.Signature)
+	out := Func{
+		Name:     o.Name(),
+		Doc:      doc,
+		Position: pos,
+		Variadic: sig.Variadic(),
+	}
+	if recv := sig.Recv(); recv != nil {
+		out.Receiver, out.ReceiverPointer = receiverName(recv.Type())
+	}
+	if tp := sig.TypeParams(); tp != nil {
+		out.TypeParams = make([]TypeParam, tp.Len())
+		for i := range out.TypeParams {
+			tparam := tp.At(i)
+			out.TypeParams[i] = TypeParam{
+				Name:       tparam.Obj().Name(),
+				Constraint: typeString(tparam.Constraint(), "", importSet),
+			}
+		}
+	}
+	for i := 0; i < sig.Params().Len(); i++ {
+		p := sig.Params().At(i)
+		out.Params = append(out.Params, Param{
+			Name: p.Name(),
+			Type: typeString(p.Type(), o.Pkg().Path(), importSet),
+		})
+	}
+	for i := 0; i < sig.Results().Len(); i++ {
+		p := sig.Results().At(i)
+		out.Results = append(out.Results, Param{
+			Name: p.Name(),
+			Type: typeString(p.Type(), o.Pkg().Path(), importSet),
+		})
+	}
+	return out
+}
+
+func typeFromObj(o *types.TypeName, pos, doc string, p *packages.Package, importSet map[string]struct{}) Type {
+	t := Type{
+		Name:     o.Name(),
+		Position: pos,
+		Doc:      doc,
+	}
+	if o.IsAlias() {
+		t.Kind = KindAlias
+		t.AliasOf = typeString(types.Unalias(o.Type()), p.PkgPath, importSet)
+		return t
+	}
+	named, ok := o.Type().(*types.Named)
+	if !ok {
+		t.Kind = KindNamed
+		t.Underlying = typeString(o.Type(), p.PkgPath, importSet)
+		return t
+	}
+	if tp := named.TypeParams(); tp != nil {
+		t.TypeParams = make([]TypeParam, tp.Len())
+		for i := range t.TypeParams {
+			tparam := tp.At(i)
+			t.TypeParams[i] = TypeParam{
+				Name:       tparam.Obj().Name(),
+				Constraint: typeString(tparam.Constraint(), "", importSet),
+			}
+		}
+	}
+	u := named.Underlying()
+	t.Underlying = typeString(u, p.PkgPath, importSet)
+	switch ut := u.(type) {
+	case *types.Struct:
+		t.Kind = KindStruct
+		for i := 0; i < ut.NumFields(); i++ {
+			f := ut.Field(i)
+			fld := Field{
+				Name:     f.Name(),
+				Type:     typeString(f.Type(), p.PkgPath, importSet),
+				Tag:      ut.Tag(i),
+				Exported: f.Exported(),
+				Embedded: f.Embedded(),
+			}
+			t.Fields = append(t.Fields, fld)
+		}
+	case *types.Interface:
+		t.Kind = KindInterface
+		for i := 0; i < ut.NumExplicitMethods(); i++ {
+			m := ut.ExplicitMethod(i)
+			t.InterfaceMethods = append(t.InterfaceMethods, funcFromObj(m, posOf(p, m.Pos()), "", importSet))
+		}
+		for i := 0; i < ut.NumEmbeddeds(); i++ {
+			e := ut.EmbeddedType(i)
+			t.EmbeddedTypes = append(t.EmbeddedTypes, typeString(e, p.PkgPath, importSet))
+		}
+	case *types.Basic:
+		t.Kind = KindBasic
+	case *types.Slice:
+		t.Kind = KindSlice
+	case *types.Map:
+		t.Kind = KindMap
+	case *types.Chan:
+		t.Kind = KindChan
+	case *types.Signature:
+		t.Kind = KindFunc
+	case *types.Array:
+		t.Kind = KindArray
+	case *types.Pointer:
+		t.Kind = KindPointer
+	default:
+		t.Kind = KindNamed
+	}
+	return t
+}
+
+// receiverName extracts the named-type name from a method receiver
+// type. Returns the name and whether the receiver was a pointer
+// type. For an unexpected shape, returns "" and false.
+func receiverName(t types.Type) (string, bool) {
+	if ptr, ok := t.(*types.Pointer); ok {
+		if named, ok := ptr.Elem().(*types.Named); ok {
+			return named.Obj().Name(), true
+		}
+		return "", true
+	}
+	if named, ok := t.(*types.Named); ok {
+		return named.Obj().Name(), false
+	}
+	return "", false
+}
+
+// typeString renders a go/types.Type as its source-level string,
+// with import paths rewritten to be valid in the *consuming*
+// context. References to types defined in selfPkg are rendered
+// without a package qualifier; references to types from other
+// packages are rendered with their full import path (e.g.
+// "io.Reader" → "io.Reader", "github.com/foo/bar.Baz" → that path).
+//
+// The importSet is populated as a side effect with every external
+// package referenced by the rendered type.
+func typeString(t types.Type, selfPkg string, importSet map[string]struct{}) string {
+	if t == nil {
+		return ""
+	}
+	q := func(p *types.Package) string {
+		if p == nil {
+			return ""
+		}
+		if p.Path() == selfPkg {
+			return ""
+		}
+		if importSet != nil {
+			importSet[p.Path()] = struct{}{}
+		}
+		return p.Path()
+	}
+	return types.TypeString(t, q)
+}
+
+// posOf renders an obj.Pos() as "file:line:col" relative to the
+// package directory. Returns "" if the position is invalid.
+func posOf(p *packages.Package, pos token.Pos) string {
+	if !pos.IsValid() || p.Fset == nil {
+		return ""
+	}
+	fp := p.Fset.Position(pos)
+	if !fp.IsValid() {
+		return ""
+	}
+	rel := fp.Filename
+	if p.Dir != "" && strings.HasPrefix(rel, p.Dir) {
+		rel = strings.TrimPrefix(rel, p.Dir+string(filepath.Separator))
+	}
+	return fmt.Sprintf("%s:%d:%d", rel, fp.Line, fp.Column)
+}
+
+// docCollector accumulates godoc strings for top-level declarations
+// in a package. The fields are populated by walking each file's AST.
+type docCollector struct {
+	pkgDoc    string
+	funcDoc   map[string]string
+	typeDoc   map[string]string
+	constDoc  map[string]string
+	varDoc    map[string]string
+	methodDoc map[string]string // "TypeName.MethodName" -> doc
+}
+
+func collectDocs(p *packages.Package) *docCollector {
+	dc := &docCollector{
+		funcDoc:   make(map[string]string),
+		typeDoc:   make(map[string]string),
+		constDoc:  make(map[string]string),
+		varDoc:    make(map[string]string),
+		methodDoc: make(map[string]string),
+	}
+	for _, f := range p.Syntax {
+		if f.Doc != nil && dc.pkgDoc == "" {
+			dc.pkgDoc = strings.TrimSpace(f.Doc.Text())
+		}
+		for _, decl := range f.Decls {
+			switch d := decl.(type) {
+			case *ast.FuncDecl:
+				if d.Doc == nil {
+					continue
+				}
+				doc := strings.TrimSpace(d.Doc.Text())
+				if d.Recv != nil && len(d.Recv.List) == 1 {
+					rt := recvTypeName(d.Recv.List[0].Type)
+					if rt != "" {
+						dc.methodDoc[rt+"."+d.Name.Name] = doc
+					}
+				} else {
+					dc.funcDoc[d.Name.Name] = doc
+				}
+			case *ast.GenDecl:
+				groupDoc := ""
+				if d.Doc != nil {
+					groupDoc = strings.TrimSpace(d.Doc.Text())
+				}
+				for _, spec := range d.Specs {
+					switch s := spec.(type) {
+					case *ast.TypeSpec:
+						doc := groupDoc
+						if s.Doc != nil {
+							doc = strings.TrimSpace(s.Doc.Text())
+						}
+						if doc != "" {
+							dc.typeDoc[s.Name.Name] = doc
+						}
+					case *ast.ValueSpec:
+						doc := groupDoc
+						if s.Doc != nil {
+							doc = strings.TrimSpace(s.Doc.Text())
+						}
+						for _, name := range s.Names {
+							if doc == "" {
+								continue
+							}
+							if d.Tok == token.CONST {
+								dc.constDoc[name.Name] = doc
+							} else if d.Tok == token.VAR {
+								dc.varDoc[name.Name] = doc
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return dc
+}
+
+func recvTypeName(e ast.Expr) string {
+	switch t := e.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return recvTypeName(t.X)
+	case *ast.IndexExpr: // generic, e.g. Foo[T]
+		return recvTypeName(t.X)
+	case *ast.IndexListExpr: // generic, e.g. Foo[T, U]
+		return recvTypeName(t.X)
+	}
+	return ""
+}

--- a/package3/go/apisurface/ingest_test.go
+++ b/package3/go/apisurface/ingest_test.go
@@ -1,0 +1,417 @@
+package apisurface
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// loadFixture writes a tiny Go module to a temp dir, runs go/packages
+// against it, and returns the loaded packages. Each fixture has a
+// "go.mod" with module path "fixture.test/x" so packages can resolve
+// without external network access.
+func loadFixture(t *testing.T, files map[string]string) []*packages.Package {
+	t.Helper()
+	dir := t.TempDir()
+	if _, ok := files["go.mod"]; !ok {
+		files["go.mod"] = "module fixture.test/x\n\ngo 1.21\n"
+	}
+	for name, body := range files {
+		full := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
+			packages.NeedImports | packages.NeedTypes | packages.NeedSyntax |
+			packages.NeedTypesInfo | packages.NeedDeps | packages.NeedModule,
+		Dir:   dir,
+		Tests: false,
+	}
+	pkgs, err := packages.Load(cfg, "./...")
+	if err != nil {
+		t.Fatalf("packages.Load: %v", err)
+	}
+	for _, p := range pkgs {
+		for _, e := range p.Errors {
+			t.Fatalf("package %s error: %v", p.PkgPath, e)
+		}
+	}
+	return pkgs
+}
+
+func TestIngestRequiresModule(t *testing.T) {
+	if _, err := Ingest(nil, IngestOptions{}); err == nil {
+		t.Errorf("Ingest with empty Module: want error")
+	}
+}
+
+func TestIngestFuncsAndSkipped(t *testing.T) {
+	pkgs := loadFixture(t, map[string]string{
+		"foo.go": `// Package foo is a fixture.
+package foo
+
+// Hello returns a greeting.
+func Hello(name string) string { return "hi " + name }
+
+// internal is unexported and should be Skipped.
+func internal() {}
+
+// Multi returns two values; the second is variadic.
+func Multi(a int, b ...string) (int, error) { return a, nil }
+`,
+	})
+	f, err := Ingest(pkgs, IngestOptions{Module: "fixture.test/x"})
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if len(f.Packages) != 1 {
+		t.Fatalf("Packages len = %d, want 1", len(f.Packages))
+	}
+	pkg := f.Packages[0]
+	if pkg.Doc != "Package foo is a fixture." {
+		t.Errorf("Doc = %q", pkg.Doc)
+	}
+	if len(pkg.Funcs) != 2 {
+		t.Fatalf("Funcs len = %d, want 2 (Hello, Multi)", len(pkg.Funcs))
+	}
+	var hello, multi *Func
+	for i := range pkg.Funcs {
+		switch pkg.Funcs[i].Name {
+		case "Hello":
+			hello = &pkg.Funcs[i]
+		case "Multi":
+			multi = &pkg.Funcs[i]
+		}
+	}
+	if hello == nil || multi == nil {
+		t.Fatalf("missing Hello or Multi: %+v", pkg.Funcs)
+	}
+	if hello.Doc != "Hello returns a greeting." {
+		t.Errorf("Hello.Doc = %q", hello.Doc)
+	}
+	if len(hello.Params) != 1 || hello.Params[0].Type != "string" {
+		t.Errorf("Hello.Params = %+v", hello.Params)
+	}
+	if len(hello.Results) != 1 || hello.Results[0].Type != "string" {
+		t.Errorf("Hello.Results = %+v", hello.Results)
+	}
+	if !multi.Variadic {
+		t.Errorf("Multi.Variadic = false; want true")
+	}
+	if len(multi.Results) != 2 || multi.Results[1].Type != "error" {
+		t.Errorf("Multi.Results = %+v", multi.Results)
+	}
+	foundSkipped := false
+	for _, s := range pkg.Skipped {
+		if s.Name == "internal" && s.Reason == "Unexported" && s.Kind == "func" {
+			foundSkipped = true
+		}
+	}
+	if !foundSkipped {
+		t.Errorf("unexported func 'internal' not in Skipped: %+v", pkg.Skipped)
+	}
+}
+
+func TestIngestStruct(t *testing.T) {
+	pkgs := loadFixture(t, map[string]string{
+		"types.go": `package foo
+
+// Greeter is a polite greeter.
+type Greeter struct {
+	// Name is who to greet.
+	Name string ` + "`json:\"name\"`" + `
+	hidden int
+}
+
+// Hello greets.
+func (g *Greeter) Hello() string { return "hi " + g.Name }
+
+// Reset resets the greeter (value receiver).
+func (g Greeter) Reset() {}
+`,
+	})
+	f, _ := Ingest(pkgs, IngestOptions{Module: "fixture.test/x"})
+	pkg := f.Packages[0]
+	if len(pkg.Types) != 1 {
+		t.Fatalf("Types len = %d, want 1", len(pkg.Types))
+	}
+	g := pkg.Types[0]
+	if g.Name != "Greeter" || g.Kind != KindStruct {
+		t.Errorf("Greeter: name=%q kind=%q", g.Name, g.Kind)
+	}
+	if g.Doc != "Greeter is a polite greeter." {
+		t.Errorf("Greeter.Doc = %q", g.Doc)
+	}
+	if len(g.Fields) != 2 {
+		t.Fatalf("Greeter.Fields len = %d, want 2", len(g.Fields))
+	}
+	var nameField *Field
+	for i := range g.Fields {
+		if g.Fields[i].Name == "Name" {
+			nameField = &g.Fields[i]
+		}
+	}
+	if nameField == nil {
+		t.Fatalf("no Name field")
+	}
+	if !nameField.Exported {
+		t.Errorf("Name.Exported = false")
+	}
+	if !strings.Contains(nameField.Tag, "json:") {
+		t.Errorf("Name.Tag = %q", nameField.Tag)
+	}
+	if len(g.Methods) != 2 {
+		t.Fatalf("Greeter.Methods len = %d, want 2", len(g.Methods))
+	}
+	var hello, reset *Func
+	for i := range g.Methods {
+		switch g.Methods[i].Name {
+		case "Hello":
+			hello = &g.Methods[i]
+		case "Reset":
+			reset = &g.Methods[i]
+		}
+	}
+	if hello == nil || reset == nil {
+		t.Fatalf("missing methods")
+	}
+	if hello.Receiver != "Greeter" || !hello.ReceiverPointer {
+		t.Errorf("Hello receiver = %q ptr=%v", hello.Receiver, hello.ReceiverPointer)
+	}
+	if reset.Receiver != "Greeter" || reset.ReceiverPointer {
+		t.Errorf("Reset receiver = %q ptr=%v", reset.Receiver, reset.ReceiverPointer)
+	}
+}
+
+func TestIngestInterface(t *testing.T) {
+	pkgs := loadFixture(t, map[string]string{
+		"iface.go": `package foo
+
+// Reader reads bytes.
+type Reader interface {
+	Read(p []byte) (int, error)
+}
+
+// ReadCloser composes Reader and Closer.
+type ReadCloser interface {
+	Reader
+	Close() error
+}
+`,
+	})
+	f, _ := Ingest(pkgs, IngestOptions{Module: "fixture.test/x"})
+	pkg := f.Packages[0]
+	if len(pkg.Types) != 2 {
+		t.Fatalf("Types len = %d, want 2", len(pkg.Types))
+	}
+	var reader, rc *Type
+	for i := range pkg.Types {
+		switch pkg.Types[i].Name {
+		case "Reader":
+			reader = &pkg.Types[i]
+		case "ReadCloser":
+			rc = &pkg.Types[i]
+		}
+	}
+	if reader == nil || rc == nil {
+		t.Fatalf("missing interfaces")
+	}
+	if reader.Kind != KindInterface {
+		t.Errorf("Reader.Kind = %q", reader.Kind)
+	}
+	if len(reader.InterfaceMethods) != 1 || reader.InterfaceMethods[0].Name != "Read" {
+		t.Errorf("Reader.InterfaceMethods = %+v", reader.InterfaceMethods)
+	}
+	if len(rc.EmbeddedTypes) != 1 || !strings.HasSuffix(rc.EmbeddedTypes[0], "Reader") {
+		t.Errorf("ReadCloser.EmbeddedTypes = %+v", rc.EmbeddedTypes)
+	}
+}
+
+func TestIngestConstsVars(t *testing.T) {
+	pkgs := loadFixture(t, map[string]string{
+		"vals.go": `package foo
+
+// Version is the schema version.
+const Version = "1.0.0"
+
+// Defaults are the default settings.
+var Defaults = []string{"a", "b"}
+`,
+	})
+	f, _ := Ingest(pkgs, IngestOptions{Module: "fixture.test/x"})
+	pkg := f.Packages[0]
+	if len(pkg.Consts) != 1 || pkg.Consts[0].Name != "Version" {
+		t.Fatalf("Consts = %+v", pkg.Consts)
+	}
+	if pkg.Consts[0].Doc != "Version is the schema version." {
+		t.Errorf("Version.Doc = %q", pkg.Consts[0].Doc)
+	}
+	if !strings.Contains(pkg.Consts[0].Const, "1.0.0") {
+		t.Errorf("Version.Const = %q", pkg.Consts[0].Const)
+	}
+	if len(pkg.Vars) != 1 || pkg.Vars[0].Name != "Defaults" {
+		t.Errorf("Vars = %+v", pkg.Vars)
+	}
+}
+
+func TestIngestAlias(t *testing.T) {
+	pkgs := loadFixture(t, map[string]string{
+		"alias.go": `package foo
+
+// MyString is an alias for string.
+type MyString = string
+`,
+	})
+	f, _ := Ingest(pkgs, IngestOptions{Module: "fixture.test/x"})
+	pkg := f.Packages[0]
+	if len(pkg.Types) != 1 {
+		t.Fatalf("Types len = %d", len(pkg.Types))
+	}
+	a := pkg.Types[0]
+	if a.Kind != KindAlias {
+		t.Errorf("Kind = %q, want alias", a.Kind)
+	}
+	if a.AliasOf != "string" {
+		t.Errorf("AliasOf = %q", a.AliasOf)
+	}
+}
+
+func TestIngestGenericType(t *testing.T) {
+	pkgs := loadFixture(t, map[string]string{
+		"gen.go": `package foo
+
+// Box holds a value of any type.
+type Box[T any] struct {
+	V T
+}
+
+// Take returns the held value.
+func (b *Box[T]) Take() T { return b.V }
+
+// MapKeys returns keys.
+func MapKeys[K comparable, V any](m map[K]V) []K {
+	r := make([]K, 0, len(m))
+	for k := range m { r = append(r, k) }
+	return r
+}
+`,
+	})
+	f, _ := Ingest(pkgs, IngestOptions{Module: "fixture.test/x"})
+	pkg := f.Packages[0]
+	var box *Type
+	for i := range pkg.Types {
+		if pkg.Types[i].Name == "Box" {
+			box = &pkg.Types[i]
+		}
+	}
+	if box == nil {
+		t.Fatalf("Box type missing")
+	}
+	if len(box.TypeParams) != 1 || box.TypeParams[0].Name != "T" {
+		t.Errorf("Box.TypeParams = %+v", box.TypeParams)
+	}
+	if len(box.Methods) != 1 || box.Methods[0].Name != "Take" {
+		t.Errorf("Box.Methods = %+v", box.Methods)
+	}
+	var mk *Func
+	for i := range pkg.Funcs {
+		if pkg.Funcs[i].Name == "MapKeys" {
+			mk = &pkg.Funcs[i]
+		}
+	}
+	if mk == nil {
+		t.Fatalf("MapKeys func missing")
+	}
+	if len(mk.TypeParams) != 2 {
+		t.Errorf("MapKeys.TypeParams = %+v", mk.TypeParams)
+	}
+}
+
+func TestIngestImportsTracked(t *testing.T) {
+	pkgs := loadFixture(t, map[string]string{
+		"imp.go": `package foo
+
+import "io"
+
+// Get returns a reader.
+func Get() io.Reader { return nil }
+`,
+	})
+	f, _ := Ingest(pkgs, IngestOptions{Module: "fixture.test/x"})
+	pkg := f.Packages[0]
+	found := false
+	for _, imp := range pkg.Imports {
+		if imp == "io" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Imports does not contain io: %+v", pkg.Imports)
+	}
+}
+
+func TestIngestMultiPackage(t *testing.T) {
+	pkgs := loadFixture(t, map[string]string{
+		"a/a.go":   "package a\n\nfunc AFn() {}\n",
+		"b/b.go":   "package b\n\nfunc BFn() {}\n",
+		"main.go":  "package x\n\nfunc XFn() {}\n",
+	})
+	f, _ := Ingest(pkgs, IngestOptions{Module: "fixture.test/x"})
+	if len(f.Packages) < 2 {
+		t.Fatalf("expected >= 2 packages, got %d", len(f.Packages))
+	}
+	// Sorted by ImportPath.
+	for i := 1; i < len(f.Packages); i++ {
+		if f.Packages[i].ImportPath < f.Packages[i-1].ImportPath {
+			t.Errorf("Packages not sorted: %v before %v", f.Packages[i-1].ImportPath, f.Packages[i].ImportPath)
+		}
+	}
+}
+
+func TestIngestDeterminism(t *testing.T) {
+	pkgs := loadFixture(t, map[string]string{
+		"a.go": `package foo
+
+func Zeta() {}
+func Alpha() {}
+func Mu() {}
+`,
+	})
+	f1, _ := Ingest(pkgs, IngestOptions{Module: "fixture.test/x"})
+	f2, _ := Ingest(pkgs, IngestOptions{Module: "fixture.test/x"})
+	b1, _ := f1.Encode()
+	b2, _ := f2.Encode()
+	if string(b1) != string(b2) {
+		t.Errorf("two ingests produced different JSON")
+	}
+	pkg := f1.Packages[0]
+	for i := 1; i < len(pkg.Funcs); i++ {
+		if pkg.Funcs[i].Name < pkg.Funcs[i-1].Name {
+			t.Errorf("Funcs not sorted: %v before %v", pkg.Funcs[i-1].Name, pkg.Funcs[i].Name)
+		}
+	}
+}
+
+func TestIngestMainPackage(t *testing.T) {
+	pkgs := loadFixture(t, map[string]string{
+		"main.go": `package main
+
+func main() {}
+`,
+	})
+	f, _ := Ingest(pkgs, IngestOptions{Module: "fixture.test/x"})
+	if len(f.Packages) != 1 {
+		t.Fatalf("Packages len = %d", len(f.Packages))
+	}
+	if !f.Packages[0].IsMain {
+		t.Errorf("IsMain = false; want true")
+	}
+}

--- a/package3/go/apisurface/phase03_test.go
+++ b/package3/go/apisurface/phase03_test.go
@@ -1,0 +1,158 @@
+package apisurface
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPhase3Ingest is the umbrella sentinel for MEP-74 phase 3.
+// Drives a complete pipeline: synthesise an in-memory two-package
+// fixture, load it via go/packages, run Ingest, Encode the result
+// to JSON, Decode it back, and verify every observable assertion.
+//
+// Passing this sentinel means a downstream caller can integrate
+// phase 3 end-to-end: produce a stable ApiSurface JSON document
+// from a Go source tree, and parse it back via Decode.
+func TestPhase3Ingest(t *testing.T) {
+	pkgs := loadFixture(t, map[string]string{
+		"go.mod": "module fixture.test/m\n\ngo 1.21\n",
+		"app/app.go": `// Package app is a fixture entry point.
+package app
+
+import "io"
+
+// Greeter is the central type.
+type Greeter struct {
+	// Name is who to greet.
+	Name string ` + "`json:\"name\"`" + `
+}
+
+// Hello returns a greeting.
+func (g *Greeter) Hello() string { return "hi " + g.Name }
+
+// New returns a new Greeter.
+func New(name string) *Greeter { return &Greeter{Name: name} }
+
+// Stream copies r into a discard.
+func Stream(r io.Reader) error { return nil }
+
+// Version of the fixture.
+const Version = "1.0.0"
+
+// Default is a default Greeter.
+var Default = &Greeter{Name: "world"}
+`,
+		"util/util.go": `// Package util has helpers.
+package util
+
+// Add returns the sum.
+func Add[T int | float64](a, b T) T { return a + b }
+
+// Stringer is an interface.
+type Stringer interface {
+	String() string
+}
+`,
+	})
+
+	f, err := Ingest(pkgs, IngestOptions{
+		Module:      "fixture.test/m",
+		Version:     "v0.1.0",
+		GeneratedBy: "phase03_test",
+	})
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+
+	// Encode then Decode to exercise the JSON path.
+	buf, err := f.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	decoded, err := Decode(buf)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+
+	if decoded.Module != "fixture.test/m" {
+		t.Errorf("Module = %q", decoded.Module)
+	}
+	if decoded.Version != "v0.1.0" {
+		t.Errorf("Version = %q", decoded.Version)
+	}
+	if decoded.GeneratedBy != "phase03_test" {
+		t.Errorf("GeneratedBy = %q", decoded.GeneratedBy)
+	}
+	if !strings.HasPrefix(decoded.GoVersion, "go") {
+		t.Errorf("GoVersion = %q", decoded.GoVersion)
+	}
+	if len(decoded.Packages) != 2 {
+		t.Fatalf("Packages len = %d, want 2", len(decoded.Packages))
+	}
+
+	var app, util *Package
+	for i := range decoded.Packages {
+		switch {
+		case strings.HasSuffix(decoded.Packages[i].ImportPath, "/app"):
+			app = &decoded.Packages[i]
+		case strings.HasSuffix(decoded.Packages[i].ImportPath, "/util"):
+			util = &decoded.Packages[i]
+		}
+	}
+	if app == nil || util == nil {
+		t.Fatalf("missing fixture packages: %+v", decoded.Packages)
+	}
+
+	// app: 1 type with 1 method, 2 funcs, 1 const, 1 var, io import.
+	if got, want := len(app.Types), 1; got != want {
+		t.Errorf("app.Types len = %d, want %d", got, want)
+	}
+	if app.Types[0].Name != "Greeter" {
+		t.Errorf("app.Types[0].Name = %q", app.Types[0].Name)
+	}
+	// New + Stream; Hello is a method, lives on Greeter.Methods.
+	if got, want := len(app.Funcs), 2; got != want {
+		t.Errorf("app.Funcs len = %d, want %d", got, want)
+	}
+	if got, want := len(app.Types[0].Methods), 1; got != want {
+		t.Errorf("Greeter.Methods len = %d, want %d", got, want)
+	}
+	if got, want := len(app.Consts), 1; got != want {
+		t.Errorf("app.Consts len = %d, want %d", got, want)
+	}
+	if got, want := len(app.Vars), 1; got != want {
+		t.Errorf("app.Vars len = %d, want %d", got, want)
+	}
+	foundIO := false
+	for _, imp := range app.Imports {
+		if imp == "io" {
+			foundIO = true
+		}
+	}
+	if !foundIO {
+		t.Errorf("app.Imports missing io: %+v", app.Imports)
+	}
+
+	// util: 1 generic func + 1 interface type.
+	if got, want := len(util.Funcs), 1; got != want {
+		t.Errorf("util.Funcs len = %d, want %d", got, want)
+	}
+	if got := util.Funcs[0]; len(got.TypeParams) != 1 {
+		t.Errorf("util.Funcs[0].TypeParams = %+v", got.TypeParams)
+	}
+	if got, want := len(util.Types), 1; got != want {
+		t.Errorf("util.Types len = %d, want %d", got, want)
+	}
+	if util.Types[0].Kind != KindInterface {
+		t.Errorf("util.Types[0].Kind = %q", util.Types[0].Kind)
+	}
+
+	// Re-encoding must produce identical bytes (canonical form).
+	buf2, err := decoded.Encode()
+	if err != nil {
+		t.Fatalf("re-Encode: %v", err)
+	}
+	if string(buf) != string(buf2) {
+		t.Errorf("Encode round-trip is not byte-stable")
+	}
+}

--- a/package3/go/apisurface/types.go
+++ b/package3/go/apisurface/types.go
@@ -1,0 +1,234 @@
+// Package apisurface is the MEP-74 schema for the JSON document
+// produced by the `go-ingest` helper and consumed by every later
+// phase of the bridge. The schema captures the exported surface of a
+// Go module — package list, exported funcs / types / consts / vars,
+// methods, fields, and a SkipReport-style record of anything the
+// ingester deliberately omitted.
+//
+// The schema version is locked in code: ingester and parser must
+// agree on it. Backwards-incompatible changes bump SchemaVersion;
+// additive changes (new optional fields) leave it untouched.
+package apisurface
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// SchemaVersion is the wire-format version. Bumped on any
+// backwards-incompatible change; both producer (cmd/go-ingest) and
+// consumer (bridge build driver) pin it.
+const SchemaVersion = 1
+
+// File is the top-level JSON document. One file per module@version.
+type File struct {
+	// SchemaVersion is the literal SchemaVersion constant. Parsers
+	// reject documents with a mismatched value.
+	SchemaVersion int `json:"schema_version"`
+	// Module is the resolved module path (e.g. "github.com/spf13/cobra").
+	Module string `json:"module"`
+	// Version is the resolved semver (e.g. "v1.0.0"). May be empty
+	// for source-tree ingests where no version is known.
+	Version string `json:"version,omitempty"`
+	// GoVersion is the toolchain version the ingester ran under
+	// (e.g. "go1.21.5"). Useful when reproducing the surface.
+	GoVersion string `json:"go_version,omitempty"`
+	// GeneratedBy is a free-form identifier for the producing tool.
+	GeneratedBy string `json:"generated_by,omitempty"`
+	// Packages is the list of public packages in the module.
+	Packages []Package `json:"packages"`
+}
+
+// Package is one importable Go package.
+type Package struct {
+	// ImportPath is the canonical import path, e.g. "example.com/foo/sub".
+	ImportPath string `json:"import_path"`
+	// Name is the package clause name (often the last path element,
+	// but may differ — e.g. "yaml" in gopkg.in/yaml.v3).
+	Name string `json:"name"`
+	// Doc is the godoc string for the package, joined with newlines.
+	Doc string `json:"doc,omitempty"`
+	// IsMain reports whether the package's name is "main". main
+	// packages are kept in the surface so callers can detect that a
+	// module has no library API.
+	IsMain bool `json:"is_main,omitempty"`
+	// Imports is the de-duplicated list of import paths referenced by
+	// the package's exported surface. Sorted lexicographically.
+	Imports []string `json:"imports,omitempty"`
+	// Funcs lists exported top-level functions (not methods; methods
+	// live on Type).
+	Funcs []Func `json:"funcs,omitempty"`
+	// Types lists exported named types in declaration order.
+	Types []Type `json:"types,omitempty"`
+	// Consts lists exported constants (named or anonymous, but with
+	// an exported identifier).
+	Consts []Value `json:"consts,omitempty"`
+	// Vars lists exported package-level variables.
+	Vars []Value `json:"vars,omitempty"`
+	// Skipped collects everything the ingester deliberately omitted
+	// from the surface, with a stable reason string.
+	Skipped []SkipNote `json:"skipped,omitempty"`
+}
+
+// Func is an exported function or method.
+type Func struct {
+	// Name is the function identifier (no package prefix).
+	Name string `json:"name"`
+	// Doc is the godoc string.
+	Doc string `json:"doc,omitempty"`
+	// Position is "file:line:col" relative to the package directory.
+	Position string `json:"position,omitempty"`
+	// TypeParams lists generic type parameters, if any.
+	TypeParams []TypeParam `json:"type_params,omitempty"`
+	// Receiver is the method receiver type (named, no pointer
+	// prefix). Empty for top-level functions.
+	Receiver string `json:"receiver,omitempty"`
+	// ReceiverPointer reports whether the receiver is a pointer (i.e.
+	// "func (*Foo) M()" vs "func (Foo) M()"). Always false for
+	// non-method funcs.
+	ReceiverPointer bool `json:"receiver_pointer,omitempty"`
+	// Params lists function parameters in declaration order.
+	Params []Param `json:"params,omitempty"`
+	// Results lists return values in declaration order. Empty
+	// when the function has no return.
+	Results []Param `json:"results,omitempty"`
+	// Variadic reports whether the last parameter is variadic
+	// (uses `...T`).
+	Variadic bool `json:"variadic,omitempty"`
+}
+
+// Param is a function parameter or result. The Name is empty for
+// anonymous results (e.g. `func() error`).
+type Param struct {
+	Name string `json:"name,omitempty"`
+	Type string `json:"type"`
+}
+
+// TypeParam is a generic type parameter.
+type TypeParam struct {
+	Name       string `json:"name"`
+	Constraint string `json:"constraint,omitempty"`
+}
+
+// TypeKind names the high-level shape of a named type.
+type TypeKind string
+
+const (
+	KindStruct    TypeKind = "struct"
+	KindInterface TypeKind = "interface"
+	KindAlias     TypeKind = "alias"
+	KindBasic     TypeKind = "basic"
+	KindSlice     TypeKind = "slice"
+	KindMap       TypeKind = "map"
+	KindChan      TypeKind = "chan"
+	KindFunc      TypeKind = "func"
+	KindArray     TypeKind = "array"
+	KindPointer   TypeKind = "pointer"
+	KindNamed     TypeKind = "named"
+)
+
+// Type is a named exported type declaration.
+type Type struct {
+	// Name is the declared identifier (e.g. "Reader").
+	Name string `json:"name"`
+	// Kind is the high-level shape (struct, interface, alias, etc.).
+	Kind TypeKind `json:"kind"`
+	// Doc is the godoc string.
+	Doc string `json:"doc,omitempty"`
+	// Position is "file:line:col" relative to the package directory.
+	Position string `json:"position,omitempty"`
+	// TypeParams lists generic type parameters, if any.
+	TypeParams []TypeParam `json:"type_params,omitempty"`
+	// Underlying is the string form of the underlying type (e.g.
+	// "struct { A int; B string }"). May be elided for opaque named
+	// types.
+	Underlying string `json:"underlying,omitempty"`
+	// AliasOf, when Kind == KindAlias, is the right-hand side of the
+	// type alias declaration.
+	AliasOf string `json:"alias_of,omitempty"`
+	// Fields lists struct fields (Kind == KindStruct).
+	Fields []Field `json:"fields,omitempty"`
+	// Methods lists declared methods on the type (declaration order;
+	// independent of receiver-pointer-ness).
+	Methods []Func `json:"methods,omitempty"`
+	// InterfaceMethods lists method *signatures* an interface type
+	// requires. Kind == KindInterface only.
+	InterfaceMethods []Func `json:"interface_methods,omitempty"`
+	// EmbeddedTypes lists embedded named types (for struct or
+	// interface).
+	EmbeddedTypes []string `json:"embedded_types,omitempty"`
+}
+
+// Field is a struct field.
+type Field struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Tag      string `json:"tag,omitempty"`
+	Doc      string `json:"doc,omitempty"`
+	Exported bool   `json:"exported"`
+	// Embedded reports whether the field is an embedded type (no
+	// explicit name).
+	Embedded bool `json:"embedded,omitempty"`
+}
+
+// Value is a top-level const or var.
+type Value struct {
+	Name     string `json:"name"`
+	Type     string `json:"type,omitempty"`
+	Doc      string `json:"doc,omitempty"`
+	Position string `json:"position,omitempty"`
+	// Const is the textual form of the constant value (e.g. "42",
+	// `"hello"`). Empty for vars.
+	Const string `json:"const,omitempty"`
+}
+
+// SkipNote records one item the ingester deliberately omitted from
+// the surface. Reason values are stable strings — phase 4 (parser)
+// matches them via a closed switch.
+type SkipNote struct {
+	// Kind is one of "func", "type", "const", "var", "method",
+	// "field".
+	Kind string `json:"kind"`
+	// Name is the declared identifier (or "" for anonymous items).
+	Name string `json:"name"`
+	// Position is "file:line:col" if known.
+	Position string `json:"position,omitempty"`
+	// Reason is a stable token. See package3/go/errors.SkipReason
+	// for the canonical list.
+	Reason string `json:"reason"`
+}
+
+// Encode serialises f as canonical JSON with 2-space indent and a
+// trailing newline. The output is byte-stable across runs because
+// (a) every list field is sorted by the ingester and (b)
+// encoding/json honours field ordering by declaration.
+func (f *File) Encode() ([]byte, error) {
+	if f == nil {
+		return nil, errors.New("apisurface: nil file")
+	}
+	buf, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("apisurface: marshal: %w", err)
+	}
+	return append(buf, '\n'), nil
+}
+
+// Decode parses an ApiSurface JSON document and validates the schema
+// version. Returns ErrSchemaVersion when the document was emitted by
+// a producer the current build does not know how to consume.
+func Decode(data []byte) (*File, error) {
+	var f File
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("apisurface: unmarshal: %w", err)
+	}
+	if f.SchemaVersion != SchemaVersion {
+		return nil, fmt.Errorf("%w: got %d, want %d", ErrSchemaVersion, f.SchemaVersion, SchemaVersion)
+	}
+	return &f, nil
+}
+
+// ErrSchemaVersion is returned by Decode when the document's
+// schema_version field does not match the SchemaVersion constant the
+// bridge was built against.
+var ErrSchemaVersion = errors.New("apisurface: incompatible schema_version")

--- a/package3/go/apisurface/types_test.go
+++ b/package3/go/apisurface/types_test.go
@@ -1,0 +1,162 @@
+package apisurface
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	in := &File{
+		SchemaVersion: SchemaVersion,
+		Module:        "example.com/foo",
+		Version:       "v1.2.3",
+		GoVersion:     "go1.21.0",
+		GeneratedBy:   "go-ingest test",
+		Packages: []Package{
+			{
+				ImportPath: "example.com/foo",
+				Name:       "foo",
+				Doc:        "Package foo is a fixture.",
+				Imports:    []string{"io"},
+				Funcs: []Func{
+					{
+						Name:    "Hello",
+						Doc:     "Hello returns greeting.",
+						Params:  []Param{{Name: "name", Type: "string"}},
+						Results: []Param{{Type: "string"}},
+					},
+				},
+				Types: []Type{
+					{
+						Name: "Greeter",
+						Kind: KindStruct,
+						Fields: []Field{
+							{Name: "Name", Type: "string", Exported: true},
+						},
+					},
+				},
+				Consts: []Value{
+					{Name: "Version", Type: "string", Const: "\"1\""},
+				},
+				Vars: []Value{
+					{Name: "Default", Type: "*Greeter"},
+				},
+				Skipped: []SkipNote{
+					{Kind: "func", Name: "unexported", Reason: "Unexported"},
+				},
+			},
+		},
+	}
+
+	buf, err := in.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if !bytes.HasSuffix(buf, []byte("\n")) {
+		t.Errorf("Encode output missing trailing newline")
+	}
+	if !bytes.Contains(buf, []byte("\"schema_version\": 1")) {
+		t.Errorf("Encode output missing schema_version: %s", buf)
+	}
+
+	out, err := Decode(buf)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if out.Module != in.Module {
+		t.Errorf("Module mismatch: %q vs %q", out.Module, in.Module)
+	}
+	if len(out.Packages) != 1 {
+		t.Fatalf("Packages len = %d, want 1", len(out.Packages))
+	}
+	if out.Packages[0].Funcs[0].Name != "Hello" {
+		t.Errorf("Funcs[0].Name = %q", out.Packages[0].Funcs[0].Name)
+	}
+}
+
+func TestDecodeRejectsSchemaVersionMismatch(t *testing.T) {
+	bad := []byte(`{"schema_version":99,"module":"x"}`)
+	_, err := Decode(bad)
+	if err == nil {
+		t.Fatalf("Decode: want error, got nil")
+	}
+	if !errors.Is(err, ErrSchemaVersion) {
+		t.Errorf("error not ErrSchemaVersion: %v", err)
+	}
+	if !strings.Contains(err.Error(), "99") {
+		t.Errorf("error should mention bad version: %v", err)
+	}
+}
+
+func TestDecodeRejectsMalformedJSON(t *testing.T) {
+	_, err := Decode([]byte("not json"))
+	if err == nil {
+		t.Fatalf("Decode: want error, got nil")
+	}
+}
+
+func TestEncodeNil(t *testing.T) {
+	var f *File
+	if _, err := f.Encode(); err == nil {
+		t.Errorf("Encode on nil receiver: want error, got nil")
+	}
+}
+
+func TestEncodeOmitemptyFields(t *testing.T) {
+	in := &File{SchemaVersion: SchemaVersion, Module: "m"}
+	buf, err := in.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	// Optional fields with empty values must not appear.
+	for _, k := range []string{"\"version\"", "\"go_version\"", "\"generated_by\"", "\"packages\":["} {
+		if bytes.Contains(buf, []byte(k)) {
+			// "packages":[ may appear as "packages":null — both omitted
+			// would be acceptable, but the JSON marshaller emits null
+			// for a nil slice on a non-omitempty field. Confirm that's
+			// not the case here.
+			if k == "\"packages\":[" {
+				continue
+			}
+			t.Errorf("unexpected key %s in minimal Encode output: %s", k, buf)
+		}
+	}
+}
+
+func TestSchemaVersionConstant(t *testing.T) {
+	// If anyone bumps this constant, every cached ApiSurface JSON
+	// becomes invalid, so guard the bump explicitly.
+	if SchemaVersion != 1 {
+		t.Errorf("SchemaVersion = %d; want 1 (bump requires bridge cache invalidation)", SchemaVersion)
+	}
+}
+
+func TestEncodeStableJSON(t *testing.T) {
+	in := &File{SchemaVersion: SchemaVersion, Module: "m"}
+	a, err := in.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	b, err := in.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Errorf("Encode is not deterministic")
+	}
+}
+
+func TestEncodeValidJSON(t *testing.T) {
+	in := &File{SchemaVersion: SchemaVersion, Module: "m"}
+	buf, err := in.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(buf, &raw); err != nil {
+		t.Errorf("Encoded output is not valid JSON: %v", err)
+	}
+}

--- a/package3/go/cmd/go-ingest/main.go
+++ b/package3/go/cmd/go-ingest/main.go
@@ -1,0 +1,98 @@
+// Command go-ingest reads a Go module's source tree and emits an
+// ApiSurface JSON document describing its exported surface. The
+// document is consumed by later phases of the MEP-74 bridge.
+//
+// Usage:
+//
+//	go-ingest -module <path> [-version <semver>] [-dir <dir>] [-output <file>] [pattern]
+//
+// If pattern is omitted, "./..." is used. If -output is "-" or
+// omitted, the JSON is written to stdout. Exit code is non-zero on
+// load or ingest failure.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+
+	"mochi/package3/go/apisurface"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "go-ingest: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout, stderr *os.File) error {
+	fs := flag.NewFlagSet("go-ingest", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		module      = fs.String("module", "", "canonical module path (required)")
+		version     = fs.String("version", "", "resolved semver (optional)")
+		dir         = fs.String("dir", ".", "directory to load packages from")
+		output      = fs.String("output", "-", "output file path; \"-\" for stdout")
+		generatedBy = fs.String("generated-by", "mochi-go-bridge go-ingest", "producer identifier")
+	)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *module == "" {
+		return fmt.Errorf("-module is required")
+	}
+	pattern := "./..."
+	if rest := fs.Args(); len(rest) > 0 {
+		pattern = rest[0]
+	}
+
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
+			packages.NeedImports | packages.NeedTypes | packages.NeedSyntax |
+			packages.NeedTypesInfo | packages.NeedDeps | packages.NeedModule,
+		Dir:   *dir,
+		Tests: false,
+	}
+	pkgs, err := packages.Load(cfg, pattern)
+	if err != nil {
+		return fmt.Errorf("packages.Load: %w", err)
+	}
+	var loadErrs []string
+	for _, p := range pkgs {
+		for _, e := range p.Errors {
+			loadErrs = append(loadErrs, fmt.Sprintf("%s: %v", p.PkgPath, e))
+		}
+	}
+	if len(loadErrs) > 0 {
+		return fmt.Errorf("load errors:\n  %s", joinLines(loadErrs))
+	}
+
+	f, err := apisurface.Ingest(pkgs, apisurface.IngestOptions{
+		Module:      *module,
+		Version:     *version,
+		GeneratedBy: *generatedBy,
+	})
+	if err != nil {
+		return err
+	}
+
+	buf, err := f.Encode()
+	if err != nil {
+		return err
+	}
+	if *output == "-" || *output == "" {
+		if _, err := stdout.Write(buf); err != nil {
+			return err
+		}
+		return nil
+	}
+	return os.WriteFile(*output, buf, 0o644)
+}
+
+func joinLines(s []string) string {
+	return strings.Join(s, "\n  ")
+}

--- a/package3/go/cmd/go-ingest/main_test.go
+++ b/package3/go/cmd/go-ingest/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestGoIngestCLI builds the binary and runs it against a tiny
+// in-memory fixture, asserting the output parses as ApiSurface JSON.
+func TestGoIngestCLI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short mode")
+	}
+
+	dir := t.TempDir()
+	// Build the binary.
+	bin := filepath.Join(dir, "go-ingest")
+	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
+		t.Fatalf("go build: %v\n%s", err, out)
+	}
+
+	// Write a fixture module.
+	mod := filepath.Join(dir, "fixture")
+	if err := os.MkdirAll(mod, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mod, "go.mod"), []byte("module fixture.test/m\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	body := `package m
+
+// Greeting returns hi.
+func Greeting() string { return "hi" }
+`
+	if err := os.WriteFile(filepath.Join(mod, "lib.go"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run the binary.
+	out := filepath.Join(dir, "out.json")
+	cmd := exec.Command(bin, "-module", "fixture.test/m", "-version", "v0.1.0", "-dir", mod, "-output", out)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("go-ingest: %v", err)
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.HasSuffix(data, []byte("\n")) {
+		t.Errorf("output missing trailing newline")
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if raw["module"] != "fixture.test/m" {
+		t.Errorf("module = %v", raw["module"])
+	}
+	if raw["version"] != "v0.1.0" {
+		t.Errorf("version = %v", raw["version"])
+	}
+	if v, ok := raw["schema_version"].(float64); !ok || int(v) != 1 {
+		t.Errorf("schema_version = %v", raw["schema_version"])
+	}
+}
+
+func TestGoIngestRequiresModule(t *testing.T) {
+	err := run([]string{}, os.Stdout, os.Stderr)
+	if err == nil {
+		t.Errorf("run with no args: want error")
+	}
+}

--- a/website/docs/implementation/0074/index.md
+++ b/website/docs/implementation/0074/index.md
@@ -18,7 +18,7 @@ A phase is LANDED only when its gate is green for every applicable target (consu
 | 0 | Skeleton: package3/go/ layout + helper-binary plumbing | LANDED | (pending) | [phase-00](/docs/implementation/0074/phase-00-skeleton) |
 | 1 | Module-proxy client (`proxy.golang.org` info/mod/zip reader, h1:-hash verify) | LANDED | (pending) | [phase-01](/docs/implementation/0074/phase-01-module-proxy) |
 | 2 | sum.golang.org transparency-log client (signed-tree-head + tile fetch + inclusion proof) | LANDED | (pending) | [phase-02](/docs/implementation/0074/phase-02-sumdb) |
-| 3 | go/packages ingest helper (`package3/go/cmd/go-ingest`) | NOT STARTED | — | [phase-03](/docs/implementation/0074/phase-03-gopackages-ingest) |
+| 3 | go/packages ingest helper (`package3/go/cmd/go-ingest`) | LANDED | (pending) | [phase-03](/docs/implementation/0074/phase-03-gopackages-ingest) |
 | 4 | ApiSurface JSON schema + bridge-side parser | NOT STARTED | — | [phase-04](/docs/implementation/0074/phase-04-apisurface) |
 | 5 | Closed type-mapping table (scalars / strings / `[]byte` / `[]T` / `map[K]V` / structs / interfaces / `chan T` / `func` / `error` / generics) | NOT STARTED | — | [phase-05](/docs/implementation/0074/phase-05-type-mapping) |
 | 6 | Cgo wrapper synthesiser (`//export` directives + `c-archive` + handle pool) | NOT STARTED | — | [phase-06](/docs/implementation/0074/phase-06-wrapper) |
@@ -43,7 +43,7 @@ Each phase's LANDED gate must be green for every applicable target. `n/a` cells 
 | 0. skeleton | LANDED | n/a | n/a | n/a | n/a |
 | 1. module-proxy client | LANDED | n/a | n/a | n/a | n/a |
 | 2. sum.golang.org client | LANDED | n/a | n/a | n/a | n/a |
-| 3. go/packages ingest | NOT STARTED | n/a | n/a | n/a | n/a |
+| 3. go/packages ingest | LANDED | n/a | n/a | n/a | n/a |
 | 4. ApiSurface JSON | NOT STARTED | n/a | n/a | n/a | n/a |
 | 5. type-mapping table | NOT STARTED | required | required | required | required |
 | 6. cgo wrapper synthesiser | NOT STARTED | required | required | n/a (cgo off on wasm) | required (no_cgo subset) |

--- a/website/docs/implementation/0074/phase-03-gopackages-ingest.md
+++ b/website/docs/implementation/0074/phase-03-gopackages-ingest.md
@@ -1,0 +1,229 @@
+---
+title: "Phase 3. go/packages ingest"
+sidebar_position: 5
+sidebar_label: "Phase 3. go/packages ingest"
+description: "MEP-74 Phase 3 lands the go/packages ApiSurface emitter: schema-locked JSON document describing every exported func/type/const/var of a loaded module, plus the standalone go-ingest CLI that drives packages.Load and writes the document to disk."
+---
+
+# Phase 3. go/packages ingest
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-74 §Phases](/docs/mep/mep-0074#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-29 21:35 (GMT+7) |
+| Landed         | 2026-05-29 21:54 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`TestPhase3Ingest` in `package3/go/apisurface/phase03_test.go`: drives
+the full ingest loop against an in-memory fixture. The test
+synthesises a two-package fixture module (`app` with a struct +
+method + two funcs + const + var + io import, plus `util` with a
+generic func + interface type), loads it via `packages.Load`, runs
+`Ingest`, `Encode`s to JSON, `Decode`s back, and verifies every
+observable assertion: module/version/go_version/generated_by
+round-trip, package count, type count, func count, method
+attachment, import tracking, and byte-stable re-encode.
+
+In addition the package-level test suite covers:
+
+- `package3/go/apisurface/types_test.go`: encode/decode round-trip
+  for a fully-populated File, schema-version-mismatch rejection
+  (`ErrSchemaVersion`), malformed-JSON rejection, nil-receiver
+  Encode rejection, omitempty-field handling on a minimal File,
+  byte-stable repeat encoding, and a guard that `SchemaVersion ==
+  1` (any bump invalidates every cached ApiSurface JSON).
+
+- `package3/go/apisurface/ingest_test.go`: 11 fixture-driven
+  scenarios -- empty-Module rejection, top-level Funcs with
+  variadic detection + unexported-skip note, struct fields with
+  tag preservation + value-and-pointer method receiver disambig,
+  interface explicit-methods + embedded-types extraction, const +
+  var collection with doc-comment carry-over, type-alias
+  recognition (alias_of populated via `types.Unalias`), generic
+  type + generic func with TypeParams, import-set population for
+  external package references, multi-package sorting by import
+  path, two-ingest determinism check, and IsMain detection.
+
+- `package3/go/cmd/go-ingest/main_test.go`: builds the CLI binary
+  in a tempdir, runs it against a fixture module, and asserts the
+  output file is valid JSON with the correct module / version /
+  schema_version fields. A second test verifies that `-module ""`
+  produces a non-zero exit.
+
+## Lowering decisions
+
+Phase 3 produces the *bridge-facing* data document for everything
+downstream: phase 4 parses it back into a typed AST, phase 5 maps
+the type strings to Mochi types, phase 6 walks the func list to
+synthesise cgo wrappers, phase 7 emits the Mochi-side extern fn
+declarations. Every later phase consumes the JSON; no later phase
+re-walks Go AST. This means the schema must be expressive enough
+to recover everything the later phases need, but the schema is
+locked at version 1 -- any backwards-incompatible change requires
+bumping `SchemaVersion` and refusing to read old caches.
+
+The ingest pipeline is split into two layers:
+
+1. `package3/go/apisurface` (library) -- pure, no I/O. Takes
+   already-loaded `*packages.Package` slices and returns a
+   `*File`. This is the unit under test for the ingest behaviour.
+2. `package3/go/cmd/go-ingest` (binary) -- the I/O boundary. Parses
+   flags, runs `packages.Load`, calls `Ingest`, and writes the
+   output. The library can be reused from phase 9 (build
+   orchestration) without the CLI overhead.
+
+The library is invoked with an `IngestOptions{Module, Version,
+GeneratedBy}` struct rather than positional args. Module is
+required (the loaded packages do not always tell us the canonical
+module path, especially when ingesting a vendored or replaced
+module). Version is optional because not every ingest has a
+resolved semver (source-tree development builds).
+
+The schema represents types via source-form strings rendered by
+`go/types.TypeString` with a custom qualifier that strips the
+self-package prefix and records every other referenced package in
+an import set. This means the parser in phase 4 needs to handle
+strings of the form `io.Reader`, `[]string`, `map[string]int`,
+`func(int) (string, error)`, `chan int`, etc. -- the closed set of
+type expressions Go permits. Phase 5 does the actual type-string
+parsing into a typed AST. Embedding the raw source form here
+keeps phase 3 simple and lets phase 5 own the closed-form parser.
+
+Generic types and functions are captured with `TypeParams` (name +
+constraint string). The constraint is rendered with the same
+qualifier as other types. Method receivers on generic types use
+the un-parameterised receiver name (e.g. `Box`, not `Box[T]`):
+phase 5 reconstructs the parameterisation from the type's own
+`TypeParams` list.
+
+Methods are attached to their owning Type rather than living in a
+flat list. Phase 4's parser sorts them by receiver-then-name, but
+the JSON stores them under the Type for compactness and to make
+the JSON pleasant to diff manually. Value vs. pointer receivers
+are distinguished by `Func.ReceiverPointer`; the un-pointer'd
+receiver name itself is the same for both. Type-alias
+representation uses `types.Unalias` to recover the right-hand side
+of the alias -- a plain `types.TypeString` on an alias object
+renders the alias name itself, defeating the purpose.
+
+Aliased types (`type MyString = string`) get `kind: "alias"` and
+populate `alias_of` with the target. Non-alias named types get
+`kind` reflecting the underlying type-kind (struct, interface,
+slice, map, etc.). The `underlying` field always carries the
+source form of the underlying type, regardless of kind, so phase 5
+has a single field to consult for "what shape does this name
+unfold to."
+
+Unexported scope entries are recorded in `Skipped` with
+`reason: "Unexported"` rather than silently dropped. This makes
+audit-time diffing more useful: a Mochi-side caller can see *what*
+was omitted, which is the same shape as the SkipNote mechanism in
+phase 4. Skipped notes also cover unknown object kinds (a forward
+hook for future Go versions introducing new top-level object
+kinds).
+
+`Ingest` sorts every output list lexicographically: packages by
+import path, funcs/types/consts/vars/skipped/methods by name,
+imports by path. This makes the JSON output byte-stable across
+runs, which is required for cache-key derivation in phase 9 (the
+SHA-256 of the JSON document is the cache key).
+
+The CLI writes the JSON document to a file (or stdout when
+`-output=-`). Output is 2-space-indented with a trailing newline,
+matching Go's `gofmt`-friendly conventions. The trailing newline
+is significant: it makes shell tooling (`< file.json`, `cat
+file.json | jq`) happy and lets `git diff` produce minimal
+hunks on subsequent re-emits.
+
+The CLI runs `packages.Load` with a comprehensive Mode mask
+covering NeedName, NeedFiles, NeedCompiledGoFiles, NeedImports,
+NeedTypes, NeedSyntax, NeedTypesInfo, NeedDeps, NeedModule. The
+Deps + TypesInfo bits are required for cross-package type
+resolution. The Module bit lets us validate the supplied -module
+flag against the loaded packages in a future phase (currently the
+flag is trusted, since the ingest may be intentionally renamed via
+go.mod replace).
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/go/apisurface/types.go` | `File`, `Package`, `Func`, `Param`, `TypeParam`, `Type`, `Field`, `Value`, `SkipNote`, `TypeKind` constants, `SchemaVersion`, `Encode`, `Decode`, `ErrSchemaVersion` |
+| `package3/go/apisurface/types_test.go` | encode/decode round-trip + schema-version rejection tests |
+| `package3/go/apisurface/ingest.go` | `Ingest`, `IngestOptions`, internal `ingestPackage` / `funcFromObj` / `typeFromObj` / `typeString` / `posOf` / `collectDocs` / `recvTypeName` / `receiverName` |
+| `package3/go/apisurface/ingest_test.go` | 11 fixture-driven scenarios via `loadFixture` helper |
+| `package3/go/apisurface/phase03_test.go` | `TestPhase3Ingest` end-to-end sentinel |
+| `package3/go/cmd/go-ingest/main.go` | CLI driver: `-module`, `-version`, `-dir`, `-output`, `-generated-by` |
+| `package3/go/cmd/go-ingest/main_test.go` | CLI smoke test against a tempdir fixture |
+
+## Test set
+
+- `TestPhase3Ingest`
+- All `package3/go/apisurface/...` unit tests (3 test files).
+- All `package3/go/cmd/go-ingest/...` CLI smoke tests.
+
+Local run on darwin-arm64:
+
+```
+$ go test ./package3/go/...
+ok  	mochi/package3/go/apisurface	23.865s
+ok  	mochi/package3/go/build	0.640s
+ok  	mochi/package3/go/cmd/go-ingest	23.808s
+ok  	mochi/package3/go/errors	1.214s
+ok  	mochi/package3/go/moduleproxy	2.170s
+ok  	mochi/package3/go/semver	0.395s
+ok  	mochi/package3/go/sumdb	0.935s
+$ go vet ./package3/go/...
+(no output)
+```
+
+## Closeout notes
+
+Phase 3 deliberately keeps the schema fields conservative: every
+field has an explicit, documented purpose, and the closed
+`TypeKind` enumeration prevents phase 4 from inventing new kinds.
+Future extensions (cgo-specific annotations, build-tag
+expressions, struct-field alignment) should land as additive
+fields with appropriate `omitempty` tags, bumping
+`SchemaVersion` only if the change is actually
+backwards-incompatible.
+
+The deliberate split between library (`apisurface`) and CLI
+(`cmd/go-ingest`) anticipates phase 9's build-orchestration
+needs: phase 9 will call `apisurface.Ingest` directly from the
+build driver process, avoiding an exec round-trip for the common
+case where the bridge is building a freshly fetched module. The
+standalone binary remains useful for ad-hoc debugging, golden-file
+generation, and CI workflows that want to re-emit the JSON for
+visual inspection.
+
+The fixture-corpus matrix in `index.md` lists 24 real-world Go
+modules (testify, cobra, viper, ...) that subsequent phases will
+golden-check against. Phase 3 itself does not consume the corpus
+(no semantic-equivalence check yet); the corpus's role here is to
+validate that `Ingest` handles every shape the corpus contains
+without panic or err. Phase 4 will fold the corpus into its
+golden-file suite proper. Re-running phase-3 ingest over the
+corpus is the first acceptance test phase 4 will perform.
+
+Decision: the schema does not carry the entire `go/ast` tree, only
+flat descriptive fields. The trade-off is that any phase-5+
+behaviour that needs full AST resolution (e.g. introspecting the
+default value expression of a struct field initializer) must run
+its own re-parse. This was judged worth it: the corpus's largest
+module (klauspost/compress) produces a ~6 MiB ApiSurface JSON at
+the proposed schema-1 detail level, vs. tens of MiB if the AST
+were embedded. Recompute cost of a re-parse is cheap at phase 5
+time and the saved disk-cache pressure pays off in the build
+critical path.
+
+The CLI deliberately surfaces load errors as a single concatenated
+multi-line string rather than failing on the first error. This
+mirrors how `go build` reports multi-package load failures and
+makes it easier for users to see the full picture when a module
+has compile-broken sub-packages.

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -314,7 +314,10 @@
   {
     "label": "MEP-74 phases",
     "items": [
-      "implementation/0074/phase-00-skeleton"
+      "implementation/0074/phase-00-skeleton",
+      "implementation/0074/phase-01-module-proxy",
+      "implementation/0074/phase-02-sumdb",
+      "implementation/0074/phase-03-gopackages-ingest"
     ]
   }
 ]


### PR DESCRIPTION
## Summary

Lands phase 3 of MEP-74 (Mochi+Go bidirectional bridge): the go/packages
ingest helper that produces ApiSurface JSON documents describing exported
module surfaces, plus the standalone `go-ingest` CLI.

- `package3/go/apisurface`: schema-locked JSON document (SchemaVersion=1)
  with Encode/Decode + ErrSchemaVersion guard.
- `package3/go/apisurface/ingest.go`: pure `*packages.Package -> *File`
  converter. Byte-stable sorted output. Tracks external imports through a
  custom `types.TypeString` qualifier. Records unexported symbols in
  Skipped with reason=Unexported. Handles type aliases (via
  `types.Unalias`), generic type/func TypeParams, value-vs-pointer
  method receivers.
- `package3/go/cmd/go-ingest`: CLI driver wrapping `packages.Load`.

Refs #22765.

## Test plan

- [x] `go test ./package3/go/...` (apisurface 23.8s, cmd/go-ingest 23.8s,
      every other package green)
- [x] `go vet ./package3/go/...` (no output)
- [x] `TestPhase3Ingest` end-to-end sentinel green
- [x] Schema-version mismatch rejected by `Decode`
- [x] Two-ingest determinism check green (byte-stable JSON)