### PR TITLE
docs(mep-71): bidirectional Python package bridge spec + research bundle + impl tracking

### DIFF
--- a/package3/python/README.md
+++ b/package3/python/README.md
@@ -1,0 +1,40 @@
+# package3/python
+
+Bidirectional Python package bridge for Mochi. Implementation lives under this directory once phases land per [MEP-71 implementation tracking](../../website/docs/implementation/0071/index.md).
+
+## Status
+
+Stub. No code yet. The phase-00 skeleton (Driver, Venv, SkipReason, BridgeError, layout) is the first implementation deliverable.
+
+## What this is
+
+The MEP-71 bridge sits between MEP-51 (Mochi-to-Python transpiler) and MEP-57 (Mochi source-level package system). Two directions:
+
+- **Consume**: `import python "<package>@<semver>" as <alias>` in Mochi source. The bridge resolves the package via uv, ingests PEP 561 stubs (4-tier precedence: `py.typed` inline, sibling `<name>-stubs`, typeshed, stubgen fallback), lowers via a closed type table, synthesises a CPython extension wrapper module, and exposes Python items as Mochi `extern fn` declarations.
+- **Publish**: `mochi pkg publish --to=pypi`. The bridge lowers the Mochi package via a new `TargetPythonPackage` (sdist + wheel), runs the `mochi-build` PEP 517 backend, and uploads through PyPI Trusted Publishing (Sigstore-keyless OIDC) with PEP 740 attestations.
+
+## Planned layout
+
+```
+package3/python/
+  errors/         # SkipReason + BridgeError (phase 0)
+  build/          # Workspace + Driver + Venv + libpython link (phase 0)
+  semver/         # PEP 440 version parser (phase 1)
+  simple/         # PEP 503 / 691 / 700 simple-index client (phase 1)
+  uv/             # uv subprocess bridge + uv.lock + PEP 751 pylock.toml (phase 2)
+  stubs/          # PEP 561 stub discovery + stubgen sandbox + .pyi parser (phase 3)
+  typemap/        # closed type table + SkipReport (phase 4)
+  wrapper/        # CPython extension synthesiser (phase 5)
+  emit/           # Mochi extern-fn emitter (phase 6)
+  publish/        # PyPI publish + Sigstore + PEP 740 (phase 11)
+  attest/         # attestation verification (phase 15)
+  pyodide/        # wasm32-emscripten + WASI Preview 2 (phase 16)
+  freethread/     # free-threaded mode wrapper variants (phase 17)
+  runtime/        # the embedded mochi_runtime Python package (phase 5 + phase 12)
+```
+
+## References
+
+- [MEP-71 spec](../../website/docs/mep/mep-0071.md) for the normative design.
+- [MEP-71 research bundle](../../website/docs/research/0071/index.md) for the 12-note deep-research collection.
+- [MEP-71 implementation tracking](../../website/docs/implementation/0071/index.md) for the 18-phase rollout.

--- a/website/docs/implementation/0071/index.md
+++ b/website/docs/implementation/0071/index.md
@@ -1,0 +1,100 @@
+---
+title: MEP-71 implementation tracking
+sidebar_position: 1
+sidebar_label: "MEP 71. Mochi+Python package manager"
+description: "Per-phase implementation tracking for MEP-71 (Mochi+Python package manager). Status + commit columns capture how each phase landed on main."
+---
+
+# MEP-71 implementation tracking
+
+Per-phase tracking for [MEP-71 Mochi+Python package manager](/docs/mep/mep-0071). Status values: `NOT STARTED`, `IN PROGRESS`, `BLOCKED`, `LANDED`, `DEFERRED`. Commit is the merge commit short SHA on `main` (or, for the umbrella PR, the in-branch commit on `mep/0071-python-package`).
+
+A phase is LANDED only when its gate is green for every target (consume direction + publish direction where applicable). Missing surfaces become N.1, N.2, ... sub-phases per the umbrella-phase coverage rule.
+
+## Phase status
+
+| Phase | Title | Status | Commit | Tracking page |
+|-------|-------|--------|--------|---------------|
+| 0 | Skeleton: `package3/python/` layout + `Driver` / `Venv` / `SkipReason` / `BridgeError` | NOT STARTED | — | [phase-00](/docs/implementation/0071/phase-00-skeleton) |
+| 1 | Simple-index client (PEP 503 HTML + PEP 691 JSON + PEP 700 metadata, sha256 + blake3 download verify) | NOT STARTED | — | [phase-01](/docs/implementation/0071/phase-01-simple-index) |
+| 2 | uv resolver bridge (subprocess + lockfile parsing) + PEP 751 pylock.toml round-trip | NOT STARTED | — | [phase-02](/docs/implementation/0071/phase-02-uv-resolver) |
+| 3 | PEP 561 stub discovery (4-tier precedence, typeshed pin, stubgen sandbox) + `.pyi` parser | NOT STARTED | — | [phase-03](/docs/implementation/0071/phase-03-stub-ingest) |
+| 4 | Closed type-mapping table (scalars / strings / collections / Optional / Union / dataclass / TypedDict / Protocol) | NOT STARTED | — | [phase-04](/docs/implementation/0071/phase-04-type-mapping) |
+| 5 | Wrapper module synthesiser (CPython extension `.so` + `_mochi_wrap.py` + `.pyi`) | NOT STARTED | — | [phase-05](/docs/implementation/0071/phase-05-wrapper) |
+| 6 | Mochi-side extern fn emitter + alias shim file generation + sidecar (`*_externs.py`) loader | NOT STARTED | — | [phase-06](/docs/implementation/0071/phase-06-extern-emit) |
+| 7 | `import python "<package>@<semver>" as <alias>` grammar + parser | NOT STARTED | — | [phase-07](/docs/implementation/0071/phase-07-import-grammar) |
+| 8 | Build orchestration: workspace synth + libpython link + wheel install + wrapper compile | NOT STARTED | — | [phase-08](/docs/implementation/0071/phase-08-build) |
+| 9 | `mochi.lock` `[[python-package]]` integration + `--check` mode + capability database | NOT STARTED | — | [phase-09](/docs/implementation/0071/phase-09-lockfile) |
+| 10 | `TargetPythonPackage` emit (sdist + wheel + `mochi-build` PEP 517 backend + `.pyi` for downstream typing) | NOT STARTED | — | [phase-10](/docs/implementation/0071/phase-10-python-package-emit) |
+| 11 | Trusted publishing (`mochi pkg publish --to=pypi`) Sigstore OIDC + PEP 740 attestations | NOT STARTED | — | [phase-11](/docs/implementation/0071/phase-11-trusted-publish) |
+| 12 | Async bridge (asyncio.run per-call + persistent loop opt-in + cross-loop hazard guards) | NOT STARTED | — | [phase-12](/docs/implementation/0071/phase-12-async-bridge) |
+| 13 | abi3 wheel slimming + auditwheel-equivalent platform tag validation | NOT STARTED | — | [phase-13](/docs/implementation/0071/phase-13-abi3) |
+| 14 | Subprocess runtime mode (`[python].runtime-mode = "subprocess"` with JSON-RPC protocol) | NOT STARTED | — | [phase-14](/docs/implementation/0071/phase-14-subprocess-mode) |
+| 15 | Attestation verification at install time + `--require-attestations` enforcement | NOT STARTED | — | [phase-15](/docs/implementation/0071/phase-15-attestation-verify) |
+| 16 | Pyodide / WASI target support (`wasm32-emscripten`, `wasm32-wasip2` wheel resolution + WIT interface) | NOT STARTED | — | [phase-16](/docs/implementation/0071/phase-16-pyodide-wasi) |
+| 17 | Free-threaded CPython 3.13t / 3.14t (`cp3XYt` ABI tag, PyMutex, atomic refcount) | NOT STARTED | — | [phase-17](/docs/implementation/0071/phase-17-free-threaded) |
+| 18 | abi2026 transition (`abi-tag-policy = "legacy" | "abi2026" | "both"`) + 2026-Q1 rollout | NOT STARTED | — | [phase-18](/docs/implementation/0071/phase-18-abi2026) |
+
+## Per-phase fields
+
+Each phase tracking page documents (or will document, once the phase begins):
+
+- **Gate**: the test or check that must pass for the phase to be LANDED.
+- **Files to touch**: the bridge-side files (Go) and emit-side files (Python template + C glue template) the phase introduces or modifies.
+- **Fixtures**: which of the 25-package fixture corpus the phase validates against.
+- **Skip count**: the expected SkipReport count per fixture package (golden numbers).
+- **Sub-phase decomposition** (if needed): N.1, N.2, ... entries when an upstream constraint forces splitting.
+
+## Fixture corpus
+
+The 25-package fixture corpus (May 2026 top-30-most-downloaded-on-PyPI selection biased toward typed packages with PEP 561 markers):
+
+numpy, pandas, scipy, scikit-learn, requests, httpx, urllib3, pillow, pydantic, attrs, click, typer, rich, tqdm, sqlalchemy, fastapi, starlette, uvicorn, aiohttp, pyyaml, toml, tomli, msgpack, orjson, pytest.
+
+Each phase that touches the type-mapping or wrapper layer asserts golden counts against this corpus. The corpus is regenerated quarterly to track PyPI API drift.
+
+Coverage of the four PEP 561 tiers across the corpus (approximate, as of 2026-Q2):
+
+- Tier 1 (inline `py.typed`): pydantic, attrs, click, typer, rich, httpx, fastapi, starlette, sqlalchemy 2.x, msgpack, orjson, pytest. **12 / 25**.
+- Tier 2 (sibling `<name>-stubs`): requests (types-requests), urllib3 (types-urllib3), pyyaml (types-PyYAML), toml (types-toml), tqdm (types-tqdm). **5 / 25**.
+- Tier 3 (typeshed): tomli, uvicorn (partial). **2 / 25**.
+- Tier 4 (stubgen fallback): numpy (partial; numpy ships partial inline), pandas (partial), scipy, scikit-learn, pillow, aiohttp (partial). **6 / 25**.
+
+The mix is intentional to exercise all four tiers across the fixture set.
+
+## Implementation location
+
+The bridge lives at `package3/python/` in the repo root:
+
+```
+package3/python/
+  README.md               # pointer to MEP-71 spec
+  errors/                 # SkipReason + BridgeError (phase 0)
+  build/                  # Workspace + Driver + Venv + libpython link (phase 0)
+  semver/                 # PEP 440 version parser (phase 1)
+  simple/                 # PEP 503 / 691 / 700 simple-index client + content-addressed cache (phase 1)
+  uv/                     # uv subprocess bridge + uv.lock parser + pylock.toml round-trip (phase 2)
+  stubs/                  # PEP 561 stub discovery + typeshed pin + stubgen sandbox + .pyi parser (phase 3)
+  typemap/                # closed type table + Mochi/Python rendering (phase 4)
+  wrapper/                # CPython extension synthesiser (phase 5)
+  emit/                   # Mochi extern fn emitter (phase 6)
+  publish/                # PyPI publish + Sigstore + PEP 740 attestations (phase 11)
+  attest/                 # attestation verification (phase 15)
+  pyodide/                # wasm32-emscripten + WASI Preview 2 target support (phase 16)
+  freethread/             # free-threaded mode wrapper variants (phase 17)
+  runtime/                # the embedded mochi_runtime Python package (phase 5 + phase 12)
+```
+
+The `package3/python/` location is shared with the broader MEP-57 polyglot package work (where `package3/` is the v3 package-system tree). MEP-73 occupies `package3/rust/` in parallel.
+
+## Status snapshot
+
+As of 2026-05-29 22:00 (GMT+7): MEP-71 spec and research bundle landed; implementation phase 0-18 NOT STARTED. The implementation will proceed one phase per PR with auto-merge, following the MEP-73 cadence.
+
+## Cross-references
+
+- [MEP-71 spec](/docs/mep/mep-0071) for the normative design.
+- [MEP-71 research bundle](/docs/research/0071/) for the 12-note deep-research collection.
+- [MEP-51 implementation tracking](/docs/implementation/0051) for the underlying Python transpiler that MEP-71 extends.
+- [MEP-57 implementation tracking](/docs/implementation/0057) for the polyglot package system MEP-71 builds on.
+- [MEP-73 implementation tracking](/docs/implementation/0073) for the parallel Rust bridge that shares the polyglot package infrastructure.

--- a/website/docs/mep/mep-0071.md
+++ b/website/docs/mep/mep-0071.md
@@ -1,0 +1,444 @@
+---
+mep: 71
+title: "Mochi and Python package bridge: bidirectional PyPI interop with PEP 561 stub ingest, auto-generated cffi/cpython wrapper, no-boilerplate import python syntax, PyPI publish via Trusted Publishing + PEP 740 attestations, pylock.toml + mochi.lock dual pinning, and a content-addressed Python wheel cache under package3/python/"
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-29
+sidebar_position: 71
+sidebar_label: MEP 71. Mochi and Python package bridge
+description: "Bidirectional package interop between Mochi and the PyPI ecosystem. Direction 1 (Mochi as PyPI consumer): an `import python \"<package>@<semver>\" as <alias>` surface form auto-resolves through the mochi.lock pin, fetches the wheel via the PEP 503 / PEP 691 simple index (default index https://pypi.org/simple/) into the content-addressed blob store under `~/.cache/mochi/python-deps/`, verifies against PEP 700 SHA-256 hashes and PEP 740 sigstore attestations when present, walks the package's PEP 561 type stubs (preferring an inline `py.typed` distribution, falling back to a sibling `<name>-stubs` package, falling back to a typeshed snapshot, falling back to `stubgen --inspect-mode` against the installed wheel) to extract a fully-typed surface, walks that surface through a closed Python-to-Mochi type translation table (int / float / bool / str / bytes / list / tuple / dict / set / frozenset / Optional[T] / X|Y union / Callable / Awaitable / AsyncIterator / TypedDict / dataclass / Protocol plus a refusal set for unparameterised `Any`, `**kwargs` of unknown shape, ParamSpec, Concatenate, TypeVarTuple beyond declared monomorphisations, recursive generic bounds, opaque C-extension types lacking stubs, and Pyright-narrowed `Literal` types whose narrowing depends on runtime values), and emits a synthesised CPython-3.12-compatible wrapper Python package (`python_wrap/`) plus matching `extern python type` and `extern python fun` Mochi declarations the parser accepts as if hand-written. The wrapper is loaded via the existing MEP-51 Phase 12 sidecar pattern (`<modname>_externs.py` adjacent to the .mochi source). Direction 2 (Mochi as PyPI producer): the existing MEP-51 `TargetPythonWheel`, `TargetPythonSdist`, and `TargetPythonPublish` targets are extended with a new `mochi pkg publish --to=pypi` CLI surface, which builds the wheel + sdist via the existing MEP-51 Phase 15 emit path, then runs `uv publish --trusted-publishing always` against either PyPI (production) or TestPyPI (staging) using GitHub Actions OIDC + sigstore-keyless signing + PEP 740 attestations (extending the MEP-51 Phase 18 workflow renderer). The bridge is implemented in `package3/python/` (greenfield, parallel to `package3/rust/` and `package3/go/`) and consumes MEP-57's `mochi.toml` plus `mochi.lock` infrastructure. The reference build adds a `[[python-package]]` table to `mochi.lock` recording the resolved wheel filename and version, BLAKE3-256 + SHA-256 of the wheel artefact (the SHA-256 also matches the PEP 700 hash the PyPI simple index publishes), the stub-source provenance (`py.typed` / `<name>-stubs` / `typeshed` / `stubgen`), the user-declared capability surface (`net`, `fs`, `proc`, `subprocess`, `cextension`), and the synthesised wrapper SHA-256 (so a `mochi pkg lock --check` fails if a transitive stub drift would silently regenerate the wrapper with a different signature). The 18-phase delivery plan walks from package3/python/ skeleton through PEP 503 / 691 simple-index client, PEP 700 hash verification, content-addressed wheel cache, PEP 561 stub ingest, type-mapping table, wrapper synthesiser, Mochi extern emitter, `import python` semver grammar extension, MEP-51 build orchestration, mochi.lock integration, pylock.toml co-emit, `mochi pkg publish --to=pypi` CLI, PEP 740 attestation flow, async bridge via asyncio.run, ABI-stable wheel emission (abi3), C-extension fallback story, embedded / Pyodide subset path, and a TestPyPI dry-run gate. Each phase is gated against a curated 25-package fixture corpus (anyhow-Python-equivalents are not relevant; instead: numpy, pandas, scipy, scikit-learn, requests, httpx, urllib3, pillow, pydantic, attrs, click, typer, rich, tqdm, sqlalchemy, fastapi, starlette, uvicorn, aiohttp, pyyaml, toml, tomli, msgpack, orjson, pytest) covering the top-25-most-downloaded-on-pypistats.org April 2026 snapshot. The bridge does NOT attempt to translate arbitrary Python source AST, does NOT support packages that ship only C extensions with no `.pyi` stubs and no typeshed entry without an explicit `[capabilities] cextension = true` opt-in plus a hand-written shim, does NOT support packages whose runtime behaviour depends on `sys.argv` manipulation at import time, and does NOT cover packages mutated by import-time monkey-patching."
+---
+
+# MEP 71. Mochi and Python package bridge
+
+| Field    | Value |
+|----------|-------|
+| MEP      | 71 |
+| Title    | Mochi and Python package bridge |
+| Author   | Mochi core |
+| Status   | Draft |
+| Type     | Standards Track |
+| Created  | 2026-05-29 21:45 (GMT+7) |
+| Depends  | MEP-1 (Grammar, for the `import python` semver extension), MEP-2 (AST, for the import node), MEP-4 (Type System), MEP-13 (ADTs and Match, for `Optional[T]` and tagged-union translation), MEP-45 (C transpiler, for the FFI sidecar pattern), MEP-51 (Python transpiler, for the emit pipeline, the runtime package `mochi_runtime`, the existing `TargetPythonWheel` / `TargetPythonSdist` / `TargetPythonPublish` build targets, the existing Phase 12 `extern python fun` sidecar pattern, and the existing Phase 18 PyPI Trusted Publishing workflow), MEP-57 (Mochi module and package system, for `mochi.toml`, `mochi.lock`, the BLAKE3-256 + SHA-256 dual-hashing, the content-addressed object store, the capability declaration model, and Sigstore-keyless trusted publishing) |
+| Research | [/docs/research/0071/](/docs/research/0071/) |
+| Tracking | [/docs/implementation/0071/](/docs/implementation/0071/) |
+
+## Abstract
+
+Mochi today (May 2026, immediately after MEP-51's Python transpiler reached 18 phases LANDED and MEP-57's source-level package system reached Draft) ships a typed-CPython 3.12+ emit path and a Phase 12 `extern python fun` FFI surface that requires the user to hand-write a `<modname>_externs.py` sidecar declaring each Python function they want to call. The Phase 12 surface works for short bespoke shims (4-6 helper functions per program is typical), but it does not scale to the PyPI ecosystem. A Mochi program that wants to use numpy, pandas, requests, fastapi, or any of the 600,000+ packages on PyPI must today hand-write the entire FFI surface, including signatures, type hints, and an import-time module. The Phase 18 `mochi build --target=python-publish` path is functional but lives behind the build CLI and does not expose a `mochi pkg publish` interface symmetrical to the publish flows on Cargo (MEP-73), Go modules (MEP-74), and the broader MEP-57 polyglot package system. MEP-71 closes both gaps.
+
+MEP-71 specifies the **bidirectional PyPI package bridge**: Mochi packages can consume any well-formed PyPI package via `import python "<package>@<semver>" as <alias>` with no user-written FFI boilerplate, and Mochi packages can publish to PyPI as proper wheels + sdists via `mochi pkg publish --to=pypi` with Trusted Publishing and PEP 740 attestations. The bridge is the third source-language interop story Mochi ships under MEP-57's package umbrella (after MEP-73 for Cargo and MEP-74 for Go modules), and the first one that targets a registry built around dynamically-typed source language plus a strong static-type-stub side channel (PEP 561) plus a mature C-extension boundary.
+
+The proposal builds on MEP-51's existing emit pipeline and MEP-57's manifest / lockfile / capability infrastructure, and adds a new self-contained component under `package3/python/`. The Mochi grammar gains semver and source-locator extensions to the existing `python` token in the FFI-import production (the keyword `python` itself was already wired up by MEP-51 Phase 12). The Mochi build pipeline gains one new top-level CLI surface (`mochi pkg publish --to=pypi`) that composes existing MEP-51 emit targets behind the unified `mochi pkg` interface introduced by MEP-57. The lockfile gains one new repeated table (`[[python-package]]`). The build optionally co-emits a PEP 751 `pylock.toml` for downstream Python tooling that does not read `mochi.lock`. No existing transpiler MEP needs to change.
+
+The system is anchored on seven load-bearing decisions, each justified in §Rationale and surveyed in the companion research notes:
+
+1. **PEP 561 type stubs as the canonical machine-readable Python package surface.** PEP 561 (Final, 2017, refreshed by PEP 660 in 2021 for editable installs) standardised three stub-distribution shapes: (a) inline stubs in the package itself, indicated by a `py.typed` marker file at the package root; (b) a sibling `<name>-stubs` package on PyPI; (c) the community-maintained typeshed monorepo (`python/typeshed`) that ships stubs for the stdlib and ~500 popular third-party packages. The bridge ingests stubs in that precedence order, falling back to `stubgen --inspect-mode` (from the `mypy` package) only when none of (a), (b), (c) supplies stubs for the requested package. The bridge treats stubs as the authoritative bind-source. Parsing the package's `.py` source directly is rejected (Python's runtime-dynamic semantics make AST-level type inference unreliable, decorators rewrite types at import time, metaclasses rewrite type structures, and 60%+ of the top-200 PyPI packages have C extensions with no `.py` source at all). Using `inspect.signature()` at runtime is rejected as the primary path (it returns `Signature` objects with `Parameter.annotation` typically populated only for fully-annotated functions, which means it works for ~20% of PyPI as of 2026-05 and fails for the rest; it is retained as a tertiary fallback after `stubgen`). See [[01-language-surface]] §2, [[04-pep561-stub-ingest]] §1, [[02-design-philosophy]] §1.
+
+2. **Auto-synthesised CPython-3.12-compatible wrapper Python package (`python_wrap/`) per imported PyPI package, with the existing Phase 12 sidecar pattern as the loader.** For each PyPI package the user imports, the bridge generates a sibling Python module (`<workdir>/python_wrap/<package>_externs.py`) that imports the source package and re-exports each translatable public name through a thin shape-coercing shim: kwargs-only callables get a positional-form wrapper; `Optional[T]` returns get a `T | None` wrapper that the Mochi side reads through its own option discriminator; async fns get an `asyncio.run`-wrapped sync entry plus an `async`-marked entry; dataclasses get a `_to_mochi_dict` accessor pair; iterators get a one-shot `list(...)` materialisation alongside the lazy form; C-extension callables that lack stubs but expose a `__doc__` numpy-style signature are inspected and wrapped where the signature line is parseable. The wrapper file is placed at the exact location the MEP-51 Phase 12 build expects sidecars (next to the .mochi file, copied to `src/<pkg>_externs.py` at build time), and the existing Phase 12 `from <pkg>_externs import ...` emit picks it up unchanged. No new build infrastructure is needed; the bridge plugs into Phase 12 as a sidecar producer. The alternative of having Mochi emit Python code that imports the source package directly (no wrapper) is rejected because the wrapper is where the type-shape coercion lives; without a wrapper, the Mochi side would have to re-implement Python's argument-binding rules (positional-or-keyword, keyword-only, var-positional, var-keyword, defaults) in its own lowering pass, which is a fragile cross-language re-encoding of `inspect.signature` semantics. See [[02-design-philosophy]] §2, [[03-prior-art-bridges]] §3, [[09-abi-stability]] §1.
+
+3. **Closed Python-to-Mochi type translation table, with explicit refusal on out-of-table cases.** The translation covers `int↔int`, `float↔float`, `bool↔bool`, `str↔string`, `bytes↔bytes`, `list[T]↔list<T>` (when T is in-table), `tuple[A, B, ...]↔ tuple<A, B, ...>`, `tuple[T, ...]↔list<T>` (homogeneous form), `dict[K, V]↔map<K, V>` (when K and V are in-table and K is `str` or one of the integer types), `set[T]↔set<T>`, `frozenset[T]↔set<T>` (read-only on the Mochi side), `Optional[T]` and `T | None↔ T?`, `X | Y↔ type alias = X | Y` (PEP 604 union, lowered to a Mochi sum type when X and Y are concrete), `Callable[[A, B], R]↔ fun(A, B): R`, `Awaitable[T]↔ async T`, `AsyncIterator[T]↔ stream<T>`, `Iterator[T]↔ list<T>` (materialised at the wrapper boundary), `TypedDict↔ record`, `@dataclass(frozen=True)↔ record`, `@dataclass` (mutable)↔ refusal (Mochi records are immutable; mutable dataclasses must be hand-overridden), `Protocol↔ interface` (Mochi interfaces; PEP 544), and `type | None↔ T?` for PEP 604 nullable forms. Items outside the table (unparameterised `Any`, `object` in non-Protocol positions, `ParamSpec` and `Concatenate`, `TypeVarTuple` beyond declared monomorphisations, recursive generic bounds, `Final[X]` at module scope, `ClassVar` in non-dataclass positions, `Annotated[T, ...]` whose metadata mutates the type, callables whose `**kwargs` is `Any` without `Unpack[TypedDict]`, generator types other than `AsyncIterator` and `Iterator`, and any item whose type hint contains a string forward reference that fails to resolve at stub-ingest time) are skipped with a `SkipReport` entry that names the item and the reason. The user can override with a hand-written `extern python fun` declaration in the existing Phase 12 sidecar style that takes responsibility for the type at the FFI boundary. Aggressive translation (e.g., synthesising a Mochi wrapper for every `Any` return as a tagged `MochiPyAny` type) is rejected: the bridge promises typed Mochi, not opaque dynamic interop. See [[05-type-mapping]] §1, [[02-design-philosophy]] §3.
+
+4. **`import python "<package>@<semver>" as <alias>` as the surface keyword, with `<semver>` resolved through `mochi.lock`.** MEP-51 Phase 12 already wired the `python` keyword as a `<lang>` token in the FFI-import production for `extern python fun ...` declarations; MEP-71 extends the same keyword to the `import` form (parallel to MEP-73's `import rust` and MEP-74's `import go`). The `<spec>` is `<package-name>`, `<package-name>@<semver-req>` (PEP 440 version-specifier syntax: `>=2.0,<3.0`, `^2.0`, `~=2.0`, `==2.0.1`), `<package-name>@<index>+<url>` for non-default indices, `<package-name>@git+<url>#<rev>` for VCS sources (PEP 508 direct URL form), or `<package-name>@path+<relative>` for local-source deps. Bare names resolve to the highest version on the configured index that satisfies the manifest's `[python-dependencies]` constraint; the bridge auto-rewrites the import to match the resolved version on next `mochi pkg lock`. The `mochi.lock` lockfile records the resolved version, the wheel filename, the wheel's BLAKE3-256 + SHA-256, the PEP 700 simple-index hash for cross-verification, the stub provenance, the synthesised wrapper SHA-256, the package's declared capability surface, and the resolved transitive dependency tree. No new Mochi syntax beyond the import shape extension; `import python` participates in the same module-resolution flow as `import rust` (MEP-73) and `import go` (MEP-74). See [[01-language-surface]] §1, [[06-pypi-publish-flow]] §2.
+
+5. **uv as the canonical resolver, with PEP 751 `pylock.toml` as the interchange format.** `uv` (Astral, GA 2024-08, current 0.7.x as of 2026-05) is the reference resolver for the consume-in path. uv is a single Rust binary that combines `pip`, `pip-tools`, `virtualenv`, `pyenv`, and the PEP 517 build front-end into one tool; it implements the same PubGrub resolver Cargo uses, supports PEP 440 version specifiers, PEP 508 marker syntax for environment-conditional dependencies, PEP 658 / PEP 714 metadata side-channel for fast metadata-only resolves, PEP 503 simple-index protocol, PEP 691 JSON-form simple index, PEP 700 hash side-channel, and PEP 740 attestation verification. The bridge invokes `uv pip compile --output-format=pylock.toml` to resolve the dependency graph and produce a PEP 751 `pylock.toml` document, which it then translates into `[[python-package]]` entries in `mochi.lock`. The PEP 751 file is also retained at `pylock.toml` in the project root so that downstream Python tooling (pip 25.0+, uv 0.7+, and pylock.toml-aware CI) can read the same pinning the Mochi build uses. The alternative of a hand-rolled resolver (or shelling out to `pip-tools`) is rejected: uv is 10x-100x faster than pip-tools on cold and warm cache, ships PEP 751 emission natively, and is the same resolver MEP-51 Phase 18 already pins for the publish path. See [[04-pep561-stub-ingest]] §3, [[02-design-philosophy]] §6.
+
+6. **Sigstore-keyless OIDC trusted publishing to PyPI via PEP 740 attestations, with no long-lived API token path.** When `mochi pkg publish --to=pypi` runs, the bridge: (a) builds the wheel + sdist via the existing MEP-51 Phase 15 emit path (the same path `mochi build --target=python-wheel` and `--target=python-sdist` use); (b) obtains an OIDC token from the CI environment (GitHub Actions `id-token: write`, GitLab CI, Google Cloud Build, ActiveState CircleCI); (c) presents the token to PyPI's `_/oidc/mint-token/` endpoint per the PyPI Trusted Publishing GA shape (rolled out 2023-Q2 for GitHub Actions, expanded to GitLab + Google + ActiveState through 2024-2025); (d) PyPI returns a short-lived API token scoped to the trusted-publisher project; (e) the build invokes `uv publish --trusted-publishing always` to upload the wheel + sdist + the PEP 740 attestation bundle (the attestation is a Sigstore in-toto envelope, signed by Fulcio-issued short-lived cert, logged in Rekor). The legacy `__token__` flow (long-lived PyPI API token in `~/.pypirc`) is not supported (matches MEP-57's broader principle that long-lived tokens are deprecated; the 2024 mass PyPI typosquat campaigns and the 2025 reflected-string flood drive this). Local development testing of the publish path is supported via TestPyPI plus a `--dry-run` flag (the same flag MEP-51 Phase 18 already exercises). See [[07-sigstore-pypi-trusted-publishing]] §1, [[02-design-philosophy]] §5.
+
+7. **Async bridge via `asyncio.run` per call, with optional persistent-loop opt-in.** Idiomatic modern PyPI packages (notably httpx, aiohttp, asyncpg, sqlalchemy 2.x async, openai-python ≥1.0, fastapi handler internals, anyio adapters) expose `async def` as a substantial part of their surface. Mochi's source-level `async` lowers to immediate evaluation on MEP-51's emit path (Phase 11 deferred the full async colour pass; v1 of MEP-71 ships with the immediate-evaluation semantics). The bridge resolves the impedance mismatch by wrapping each imported `async def f(...) -> T` in a synchronous `def f_sync(...) -> T: return asyncio.run(f(...))` shim. Each call constructs a new `asyncio` event loop, runs the coroutine to completion, and tears the loop down. The cost is the loop-construction overhead per call (~200μs on CPython 3.12 on Apple Silicon, dominated by selectors-init + signal-handler register; negligible for non-tight-loop workloads). For tight loops or for cases where the user wants a persistent event loop across calls (e.g. a `httpx.AsyncClient` whose connection-pool benefit is lost on per-call teardown), the user opts in via `[python] runtime = { event-loop = "persistent" }` in `mochi.toml`, which switches the wrapper to a process-global `asyncio.new_event_loop()` cached at first call. The persistent-loop mode is not the default because it leaks the loop into the host process (problematic for `mochi pkg test`-style ephemeral runs); the per-call mode is the default because it is the only mode whose lifetime is fully scoped to a single FFI call. Free-threaded CPython 3.13t and 3.14t support is forward (Phase 17 sub-phase), not v1. See [[08-async-bridge]] §1, [[02-design-philosophy]] §4.
+
+The gate for each delivery phase is empirical: the bridge must successfully ingest a curated 25-package fixture corpus (drawn from the April 2026 top-25-most-downloaded-on-pypistats.org snapshot: numpy, pandas, scipy, scikit-learn, requests, httpx, urllib3, pillow, pydantic, attrs, click, typer, rich, tqdm, sqlalchemy, fastapi, starlette, uvicorn, aiohttp, pyyaml, toml, tomli, msgpack, orjson, pytest); generate a translatable surface for every public item the closed type-table covers; emit a `SkipReport` for every item out of table; produce a Mochi `extern python fun` corpus that parses cleanly; and run the resulting program through the existing MEP-51 Phase 1-18 emit + run path with zero additional flags. A separate publish gate exercises the `TargetPythonPublish` path against TestPyPI (the same staging registry MEP-51 Phase 18 already targets), asserts that the published wheel + sdist + attestation bundle is accepted by PyPI's Warehouse validator, asserts that the wheel `uv pip install`s cleanly into a fresh venv, and asserts that the PEP 740 attestation verifies against the Sigstore root of trust.
+
+## Motivation
+
+Mochi today (May 2026) integrates with PyPI through a single surface: MEP-51 Phase 12's `extern python fun` declaration plus a hand-written `<modname>_externs.py` sidecar. The surface is sound for ad-hoc shims (the existing Phase 12 fixture corpus exercises 10 hand-written sidecars across `int`, `float`, `bool`, `string` scalars), but it does not extend to PyPI's 600,000+ packages because every package import requires the user to first read the package's documentation, transcribe each function signature into a `.pyi`-shaped declaration, write the matching Python sidecar, and re-do that work when the upstream package version changes. For numpy (~2,000 public functions), pandas (~3,500), scikit-learn (~1,500), httpx (~600 across sync and async forms), the surface is too large to hand-author. Without a bridge, the Mochi-on-Python data-science and ML stories are aspirational.
+
+MEP-71 closes the gap on the consume-in side. It also formalises the publish-out side, where MEP-51 Phase 18 shipped the workflow renderer and the `mochi build --target=python-publish` CLI but stopped short of a `mochi pkg publish --to=pypi` interface symmetric to MEP-73's Cargo path and MEP-74's Go-modules path. The full motivation:
+
+1. **PyPI is the canonical 2024-2026 destination for data-science, ML, scientific computing, scripting, and modern Python web work.** PyPI hosts 600,000+ packages (2026 Q1 PyPA snapshot); the top 100 most-downloaded packages account for ~70 billion downloads per month (April 2026 pypistats.org). A Mochi program needing numerical arrays (numpy), tabular data (pandas), modern HTTP (httpx, aiohttp), schema validation (pydantic), web framework integration (fastapi, starlette, uvicorn), interactive CLI (click, typer, rich), task scheduling (apscheduler, celery), database access (sqlalchemy 2.x), ML pipelines (scikit-learn, transformers, datasets), or notebook integration has no path to those packages today without rewriting the FFI by hand per call site.
+
+2. **The PyPI ecosystem expects PEP 517 wheels + sdists as the unit of distribution; Mochi must learn to emit them with proper metadata and proper signing.** MEP-51 Phase 15 (wheel + sdist emit) and Phase 18 (publish workflow renderer) prepared the emit path but did not unify it under the `mochi pkg publish` interface. MEP-71 makes the publish path symmetric to MEP-73 (Cargo) and MEP-74 (Go modules): same CLI, same lockfile pin, same trust-and-attestation story.
+
+3. **PyPI Trusted Publishing has crystallised into the unambiguous 2024-2026 default.** Four of the top five package ecosystems (npm Trusted Publishing GA April 2024, Maven Central Sigstore GA October 2024, PyPI Trusted Publishing GA Q2 2023 with PEP 740 attestations rolled out late 2024 and GA late 2025, Cargo RFC #3724 accepted Q4 2025 with rolling GA through 2026) converged on Sigstore-keyless OIDC publishing. PyPI was first to land the OIDC flow but last to attach PEP 740 attestations to the published artefacts; that gap closed late 2025. A package system released in 2026 that does not ship Trusted Publishing on day one is shipping a decade-out-of-date supply-chain story.
+
+4. **The "import python @ semver" surface has zero learning curve for Mochi users.** `import python "httpx@^0.27" as httpx` is the same shape as `import rust "tokio@^1.42" as tokio` (MEP-73) and `import go "github.com/spf13/cobra@^1.8" as cobra` (MEP-74). Mochi users do not need to know what a `pyproject.toml` is, what a wheel ABI tag is, what a build backend is, what `pip install` does, what an editable install is, what a `setup.py` is, what `entry_points` are, what GIL is, what an `asyncio.run` call costs, what `inspect.signature` returns, what `typeshed` is, what `py.typed` means, what `stubgen` does, what a Trusted Publisher is, or what a Sigstore Fulcio cert is. They write `import python "..." as ...` and the bridge does the rest.
+
+5. **PEP 561 type stubs have matured into a stable, machine-readable, mostly-comprehensive Python package surface.** Prior bridges between Python and other languages (PyO3, pybind11, nanobind, gopy, jpype, py4j, JNI from Python) require hand-written `#[pyfunction]` / `cdef` / `napi` / `extern "C"` annotations on the host-language side and offer no help on the Python-side type discovery. MEP-71 takes a different shape: it reads PEP 561 stubs to derive the type surface, then synthesises the wrapper. For the ~200 PyPI packages with first-party `py.typed` distributions (April 2026 PyPA survey: 38% of the top-500 PyPI packages and growing), the stubs are authoritative. For the next ~100 packages typeshed covers, the typeshed stubs are authoritative. For the residual ~200 packages (typically thin C-extension wrappers or extremely old packages), `stubgen --inspect-mode` synthesises stubs at lock time. The bridge reads the stubs and emits the wrapper; the user writes `import python "..."` as if no FFI existed.
+
+6. **MEP-57 already shipped the prerequisite manifest / lockfile / capability infrastructure.** The `mochi.toml` table layout, the `mochi.lock` serialisation, the BLAKE3-256 + SHA-256 dual-hashing, the trusted-publishing OIDC token exchange, the capability declaration model, and the content-addressed object store all transfer to the Python bridge with no architectural duplication. MEP-71 is additive on top of MEP-57: one new manifest section (`[python-dependencies]`), one new lockfile repeated table (`[[python-package]]`), one new CLI verb (`mochi pkg publish --to=pypi`), and one new interchange file (PEP 751 `pylock.toml` for downstream Python tooling).
+
+7. **The bridge stays small and audit-friendly.** The reference implementation under `package3/python/` is targeted at ~5,500 LOC of Go across the simple-index client, the wheel-cache layer, the PEP 561 stub ingest, the type-mapping pass, the wrapper synthesiser, the Mochi extern emitter, the lockfile integrator, the publish flow, and the async-bridge runtime hook. There is no Python-side dynamic codegen at user-machine time (the wrapper is fully synthesised by the Go binary; the user's `python` only runs the synthesised wrapper). There is no `inspect.signature` runtime probing on the hot path (it is a tertiary fallback for stub-less packages, run at lock time, not at runtime). There are no monkey-patches in the wrapper unless the user opts in via `[python.capabilities] monkey-patch = true`.
+
+## Specification
+
+This section is normative. Sub-notes under [/docs/research/0071/](/docs/research/0071/) are informative.
+
+### 1. Pipeline overview
+
+MEP-71 introduces a per-import Python dependency resolution layer that sits between the Mochi parser (after MEP-57 has resolved `mochi.toml`) and the MEP-51 build driver:
+
+```
+mochi.toml [python-dependencies]
+   |  pkgmanifest.Parse + pkgsolver.Solve (MEP-57)
+   v
+resolved Python dep tree (package name + version + index URL + marker)
+   |  package3/python/simpleindex.Fetch (PEP 503 / 691 simple index)
+   v
+wheel + sdist artefacts in ~/.cache/mochi/python-deps/<blake3-hex>/
+   |  package3/python/stubingest.Resolve (PEP 561 stub precedence)
+   v
+.pyi stub document per package (py.typed | <name>-stubs | typeshed | stubgen)
+   |  package3/python/typemap.Translate (closed Python-to-Mochi table)
+   v
+TranslatedSurface + SkipReport per package
+   |  package3/python/wrapsyn.Emit (synthesised _externs.py wrapper module)
+   v
+python_wrap/<package>_externs.py adjacent to the importing .mochi
+   |  package3/python/externemit.Emit (Mochi extern python fun shim)
+   v
+synthesised .mochi shim file per package, imported by the user's source
+   |  MEP-51 Driver.Build (TargetPythonWheel / TargetPythonSdist / TargetPythonSource)
+   v
+wheel, sdist, or runnable Python source tree
+```
+
+The bridge does not run user Python source at ingest time. `stubgen --inspect-mode` is the only Python invocation that touches user package code (and only as a tertiary fallback when no `.pyi` source exists); the bridge parses the resulting stubs in Go. The wrapper module is emitted as Python source by the Go side and run by the user's normal `python` (orchestrated by the MEP-51 driver) alongside the user's program.
+
+### 2. Manifest extension: `[python-dependencies]` and `[python]`
+
+The MEP-57 `mochi.toml` gains two new optional top-level tables:
+
+```toml
+[python-dependencies]
+numpy = "^2.0"
+pandas = "^2.2"
+httpx = { version = "^0.27", extras = ["http2"] }
+fastapi = "^0.115"
+pydantic = { version = "^2.9", extras = ["email"] }
+my-private-package = { version = "^1.0", index = "https://pypi.mycorp.example/simple/" }
+my-vcs-dep = { git = "https://github.com/example/my-pkg", rev = "abc123" }
+my-local-package = { path = "../my-pkg" }
+
+[python]
+requires-python = ">=3.12"
+runtime = { event-loop = "per-call" }
+indexes = [
+    { url = "https://pypi.org/simple/", priority = "primary" },
+    { url = "https://pypi.mycorp.example/simple/", priority = "explicit" },
+]
+stubgen = { fallback = "allow", inspect-mode = true }
+monomorphise = [
+    { item = "numpy.array", T = "float64" },
+    { item = "typing.List", T = "str" },
+]
+
+[python.publish]
+build-backend = "hatchling"
+wheel-tag = "abi3"
+python-requires = ">=3.12"
+
+[python.capabilities]
+net = true
+fs = false
+proc = false
+subprocess = false
+cextension = true
+monkey-patch = false
+```
+
+`[python-dependencies]` follows PEP 508 + PEP 440 grammar. Simple string for a version specifier, table for inline `version` + `extras` + `index` + `path` / `git` / `branch` / `rev` / `tag` + `markers`. This shape is intentional: Mochi users with Python background can copy from existing `pyproject.toml` `[project.dependencies]` arrays or `requirements.txt` lines without translation; the bridge passes the table through to `uv pip compile` with no edits beyond the format conversion.
+
+The `[python]` table holds Mochi-specific knobs:
+
+- `requires-python`: the Python interpreter version range the bridge will resolve against. Default `">=3.12"` (matches the MEP-51 floor). Narrower than the published wheel's own `Requires-Python` is allowed; broader is a manifest validation error.
+- `runtime.event-loop`: `"per-call"` (default) or `"persistent"`. Controls the asyncio bridge mode (see §7).
+- `indexes`: ordered list of PEP 503 simple-index URLs. The bridge resolves `priority = "primary"` first, then `priority = "supplemental"` (consulted only when primary lacks the package), then `priority = "explicit"` (only used when a dependency explicitly names this index via the per-dep `index = "..."` field). The default index is `https://pypi.org/simple/`.
+- `stubgen.fallback`: `"allow"` (default) or `"deny"`. When `allow`, the bridge falls back to `stubgen --inspect-mode` for packages with no `py.typed`, no `<name>-stubs`, and no typeshed entry. When `deny`, such packages produce a hard error at `mochi pkg lock` time so the user must either hand-write a sidecar or remove the dep.
+- `stubgen.inspect-mode`: forwards to `stubgen`'s `--inspect-mode` flag, which uses runtime introspection rather than AST parsing. Recommended (default `true`) because C-extension packages have no AST. Inspect mode imports the package; capability constraints apply.
+- `monomorphise`: a list of explicit generic instantiations. For each entry, the bridge emits the wrapper for `<item><T>` rather than refusing the import (the default behaviour for under-parameterised `Any`-returning generics). The entry shape mirrors the equivalent table in MEP-73.
+
+The `[python.publish]` table holds Mochi-as-PyPI-publisher knobs:
+
+- `build-backend`: the PEP 517 build backend. Default `"hatchling"` (matches MEP-51 Phase 15). Alternatives: `"setuptools"`, `"flit-core"`, `"pdm-backend"`. The backend is recorded in the emitted `pyproject.toml`'s `[build-system]` table.
+- `wheel-tag`: either `"abi3"` (default, builds an ABI-stable wheel that works on any CPython 3.X for the declared minimum) or `"cpyXY"` (builds a CPython-version-pinned wheel; reserved for packages with version-sensitive C extensions). The MEP-51 pure-Python emit path inherently produces abi3-compatible artefacts because no C extension is generated; the `wheel-tag` knob exists for forward compatibility with a future C-extension emit path.
+- `python-requires`: the published wheel's `Requires-Python` field. Defaults to `">=3.12"`.
+
+The `[python.capabilities]` table holds Python-bridge-specific capability flags (a strict refinement of MEP-57's `[capabilities]` table; if MEP-57 marks the package as not requiring `net`, `[python.capabilities] net = true` is a manifest validation error):
+
+- `net`: the Python dep graph contains packages that open network sockets (httpx, aiohttp, urllib3, requests). Default `false`.
+- `fs`: the dep graph reads or writes files (open, pathlib, aiofiles). Default `false`.
+- `proc`: the dep graph spawns processes (subprocess.Popen). Default `false`.
+- `subprocess`: separate from `proc`, this flag covers calls that wrap shell commands (sh, plumbum). Default `false`.
+- `cextension`: the dep graph contains packages with C extensions (numpy, pandas, lxml, pillow, pydantic-core, orjson). Default `false`. Required for the bridge to ingest packages with no `.py` source.
+- `monkey-patch`: the dep graph contains packages that mutate stdlib or other-package modules at import time (gevent, eventlet, certain unittest plugins). Default `false`. Required to suppress the bridge's import-time-safety check.
+
+### 3. Lockfile extension: `[[python-package]]`
+
+The MEP-57 `mochi.lock` gains one new repeated table:
+
+```toml
+[[python-package]]
+name = "httpx"
+version = "0.27.2"
+wheel-filename = "httpx-0.27.2-py3-none-any.whl"
+sdist-filename = "httpx-0.27.2.tar.gz"
+source = { kind = "index", index = "https://pypi.org/simple/" }
+wheel-blake3 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+wheel-sha256 = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+pypi-simple-sha256 = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+stub-provenance = "py.typed"
+stub-sha256 = "0011223344556677001122334455667700112233445566770011223344556677"
+wrapper-sha256 = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+capabilities-declared = ["net"]
+extras = ["http2"]
+dependencies = ["anyio>=3.0,<5", "certifi", "httpcore>=1.0,<2", "idna", "sniffio"]
+markers = ""
+attestation-bundle = ""
+attestation-verified = false
+```
+
+`wheel-blake3` and `wheel-sha256` are the integrity hashes of the wheel artefact. BLAKE3-256 is the primary verification hash (matches MEP-57's broader BLAKE3 + SHA-256 dual-hashing rule). SHA-256 is recorded for cross-ecosystem interoperability and matches the hash PyPI's simple index publishes via PEP 700.
+
+`pypi-simple-sha256` is the SHA-256 the simple-index response advertised for the wheel filename at lock time. The bridge cross-verifies `wheel-sha256 == pypi-simple-sha256` at fetch time; a mismatch is a hard error. The dual recording protects against simple-index URL manipulation: an attacker who serves a wrong wheel would also have to forge a matching simple-index entry, which the lockfile pin catches.
+
+`stub-provenance` is one of `"py.typed"` (inline stubs in the wheel), `"<name>-stubs"` (sibling stubs package), `"typeshed"` (community typeshed snapshot), or `"stubgen"` (auto-generated at lock time). At `--check` time, the bridge re-derives the provenance and fails if the source has moved (e.g., a package added inline stubs since lock time, and the user's stubgen-generated stubs no longer match upstream).
+
+`stub-sha256` is the SHA-256 of the stub document set the wrapper was synthesised against. A drift here at `--check` time is a hard error.
+
+`wrapper-sha256` is the SHA-256 of the synthesised `<package>_externs.py` wrapper file. A drift here at `--check` time is a hard error.
+
+`capabilities-declared` is the capability set the manifest declared at lock time. A capability addition (e.g., a transitive dep update newly imports a network-opening module) at `--check` time is a hard error pending re-acknowledgement (the monotonicity rule from MEP-57 §1.6).
+
+`extras` is the PEP 508 extras the manifest enabled.
+
+`dependencies` is the resolved transitive dependency tree (so a downstream consumer's `mochi.lock` carries the full graph and the PEP 751 co-emit reproduces).
+
+`markers` is the PEP 508 environment marker the dep was resolved under (empty for unconditional deps).
+
+`attestation-bundle` is the path inside the cache to the PEP 740 in-toto attestation bundle (empty if no attestation exists for this wheel). `attestation-verified` is `true` if the bridge verified the bundle against the Sigstore root of trust at lock time.
+
+### 4. Surface syntax: `import python "..."`
+
+The Mochi grammar's existing FFI-import production gains semver and source-locator alternatives for the `python` token:
+
+```
+ImportStmt := "import" Lang? StringLit "as" Ident ("auto")?
+Lang := "go" | "python" | "typescript" | "rust"
+```
+
+The string literal for the `python` token is one of:
+
+- `<package-name>`: bare name, resolves through `[python-dependencies]` constraint plus `mochi.lock`.
+- `<package-name>@<pep440-spec>`: explicit version constraint (`numpy@^2.0`, `httpx@>=0.27,<0.30`, `pydantic@~=2.9`), must satisfy `[python-dependencies]`.
+- `<package-name>@index+<url>`: explicit index source (`my-pkg@index+https://pypi.mycorp.example/simple/`).
+- `<package-name>@git+<url>` or `<package-name>@git+<url>#<rev>`: VCS source via PEP 508 direct URL syntax.
+- `<package-name>@path+<relative>`: local path source.
+
+The `[name]` form for extras follows PEP 508: `import python "httpx[http2]@^0.27" as httpx` enables the `http2` extra. The extras must also appear in the manifest's `[python-dependencies]` entry (the import is a declaration not a configuration; the manifest is the source of truth for extras).
+
+Example surface programs:
+
+```mochi
+import python "httpx@^0.27" as httpx
+import python "numpy@^2.0" as np
+import python "pydantic@^2.9" as pyd
+
+record User {
+    name: string
+    email: string
+    age: int
+}
+
+fun fetch_users(url: string): list<User> {
+    let response = httpx.get(url)
+    let data = response.json()
+    return data.map(u => User { name: u.name, email: u.email, age: u.age })
+}
+
+fun centroid(points: list<list<float>>): list<float> {
+    let arr = np.array(points)
+    let mean = arr.mean(axis=0)
+    return mean.tolist()
+}
+```
+
+The `<alias>` introduces a Mochi namespace; symbol resolution looks up `<alias>.<item>` and binds against the synthesised `extern python fun` declaration the bridge generated for `<package>.<item>` (or `<package>.<submodule>.<item>` after the bridge walks the stub's submodule tree).
+
+The `auto` keyword (already accepted for `import go ... auto` and `import rust ... auto`) is admitted for `import python ... auto` to opt into "import every public name of the package as a top-level Mochi binding (rather than namespaced under the alias)". Default is namespaced.
+
+### 5. CLI surface
+
+The Mochi CLI gains the following additions, all under the existing `mochi pkg` subcommand introduced by MEP-57:
+
+- `mochi pkg add python <package>[@<pep440-spec>]`: adds an entry to `[python-dependencies]` and runs `mochi pkg lock`.
+- `mochi pkg lock`: as today (MEP-57), now extended to walk `[python-dependencies]`, invoke `uv pip compile --output-format=pylock.toml` against the configured index set, fetch each wheel into the content-addressed cache, run PEP 561 stub ingest, synthesise the wrapper, and write `[[python-package]]` entries to `mochi.lock` plus `pylock.toml` to the project root.
+- `mochi pkg lock --check`: as today, now extended to verify `wheel-blake3`, `wheel-sha256`, `pypi-simple-sha256`, `stub-sha256`, `wrapper-sha256`, and `capabilities-declared` for every `[[python-package]]` entry, plus re-verifies any `attestation-bundle` against the Sigstore root of trust if the bundle existed at lock time.
+- `mochi pkg publish --to=pypi [--testpypi] [--dry-run]`: builds the package as a wheel + sdist via the existing MEP-51 `TargetPythonWheel` + `TargetPythonSdist` emit pipeline (Phase 15), packages the build artefacts, obtains an OIDC token from the CI environment, presents it to PyPI's trusted-publishing endpoint, then invokes `uv publish --trusted-publishing always` (against TestPyPI when `--testpypi` is supplied) to upload the wheel + sdist + the PEP 740 attestation bundle. `--dry-run` skips the upload step but still exercises the OIDC token exchange and the local signing flow against a sigstore-mock-fulcio harness (matching MEP-51 Phase 18 §dry-run).
+- `mochi pkg sync python`: regenerates the wrapper modules from scratch (without changing the lockfile). Used after manual edits to a synthesised shim file or after upstream stub drift the user wants to ingest without bumping the lock.
+- `mochi pkg export pylock`: writes the current `mochi.lock` `[[python-package]]` entries out as a PEP 751 `pylock.toml` (a co-emit of the same data; useful when the user wants to consume the lockfile from a non-Mochi Python toolchain).
+
+### 6. Build orchestration
+
+When a Mochi program contains one or more `import python "..."` declarations, the MEP-51 build driver gains the following extensions:
+
+1. Before invoking the Phase 12 sidecar copy step, the driver invokes `package3/python/Bridge.PrepareSidecars(workdir, mochiLock)` which:
+   - For each `[[python-package]]` in `mochi.lock`, ensures the wheel is present in `~/.cache/mochi/python-deps/<blake3-hex>/`, fetching from the index if not.
+   - Materialises the synthesised wrapper module into `<workdir>/python_wrap/<package>_externs.py`.
+   - For each importing `.mochi` source file, copies the matching wrapper module to the same directory the existing Phase 12 sidecar-copy step expects (`<srcDir>/<moduleName>_externs.py`).
+   - The wrapper's top of file declares `import <package>` and the bridge ensures the wheel is on `PYTHONPATH` at run time (either via the venv MEP-51 build creates, or via an explicit `--python-path` flag passed to `python -m`).
+
+2. The existing MEP-51 Phase 12 sidecar copy step picks up the bridge-emitted wrappers unchanged. No edit to MEP-51 Phase 12 code is required beyond a guard that lets multiple `<modname>_externs.py` files coexist (the existing code path already handles one sidecar per program; the bridge's wrappers go in distinct names so this composes).
+
+3. The MEP-51 emit pass treats each `import python "<package>" as <alias>` as a Mochi `import "./python_wrap/<package>_shim.mochi" as <alias>` shim, where the shim file is the `extern python fun` corpus the bridge emitted.
+
+4. The user's `python -m mochi_user_<modname>` (invoked by `Driver.Build` and run-time test harnesses) resolves every `from <package>_externs import ...` line against the wrapper modules, which in turn resolve `import <package>` against the venv's site-packages.
+
+5. The driver invalidates the cache when any `[[python-package]]` `wrapper-sha256` changes (per MEP-51 Phase 15 cache-key construction); the bridge's wrappers participate in the same cache marker as the user's emit (`mep51-phase18` today, bumping to `mep71-phase00` once the bridge phase 0 lands).
+
+### 7. Async bridge runtime hook
+
+The wrapper module for any source package that exposes `async def` items includes a sync entry shim per async function:
+
+```python
+from __future__ import annotations
+
+import asyncio
+import httpx
+
+
+def get(url: str) -> httpx.Response:
+    return httpx.get(url)
+
+
+def get_async_sync(url: str) -> httpx.Response:
+    # Per-call event loop. Default mode.
+    return asyncio.run(_get_async(url))
+
+
+async def _get_async(url: str) -> httpx.Response:
+    async with httpx.AsyncClient() as client:
+        return await client.get(url)
+```
+
+When `[python] runtime = { event-loop = "persistent" }` is set in `mochi.toml`, the wrapper switches to a process-global event loop cached at first call:
+
+```python
+from __future__ import annotations
+
+import asyncio
+import httpx
+
+_MOCHI_LOOP: asyncio.AbstractEventLoop | None = None
+
+
+def _get_loop() -> asyncio.AbstractEventLoop:
+    global _MOCHI_LOOP
+    if _MOCHI_LOOP is None:
+        _MOCHI_LOOP = asyncio.new_event_loop()
+    return _MOCHI_LOOP
+
+
+def get_async_sync(url: str) -> httpx.Response:
+    return _get_loop().run_until_complete(_get_async(url))
+
+
+async def _get_async(url: str) -> httpx.Response:
+    async with httpx.AsyncClient() as client:
+        return await client.get(url)
+```
+
+The per-call mode is the default; the persistent mode is opt-in. The per-call mode is the only mode whose lifetime is fully scoped to a single FFI call (problematic for benchmarks or for long-running daemon workloads where the user wants connection-pool reuse). Free-threaded CPython 3.13t and 3.14t support is a forward Phase 17 sub-phase, not v1.
+
+## Phases
+
+See [/docs/implementation/0071/](/docs/implementation/0071/) for the per-phase tracking matrix. Eighteen phases cover skeleton (0), simple-index client (1), wheel cache + hash verification (2), PEP 561 stub ingest (3), type-mapping table (4), wrapper synthesiser (5), Mochi extern emitter (6), `import python` semver grammar (7), MEP-51 build orchestration hooks (8), mochi.lock integration (9), pylock.toml co-emit (10), `mochi pkg publish --to=pypi` CLI (11), PEP 740 attestation flow (12), async bridge (13), abi3 + ABI-stable wheel emission (14), C-extension fallback story (15), Pyodide / WASI / embedded subset (16), and a TestPyPI dry-run gate (17).
+
+A phase is LANDED only when its gate is green against the curated 25-package fixture corpus.
+
+### Target matrix
+
+| Phase | host CPython 3.12+ (darwin-arm64 + linux-x64) | windows-x64 | wasm32-wasi (Pyodide) | free-threaded CPython 3.13t / 3.14t |
+|-------|------------------------------------------------|-------------|------------------------|--------------------------------------|
+| 0. skeleton | NOT STARTED | n/a | n/a | n/a |
+| 1. simple-index client | NOT STARTED | required | n/a | n/a |
+| 2. wheel cache + hash verify | NOT STARTED | required | n/a | n/a |
+| 3. PEP 561 stub ingest | NOT STARTED | required | required | required |
+| 4. type-mapping table | NOT STARTED | required | required | required |
+| 5. wrapper synthesiser | NOT STARTED | required | required | required |
+| 6. extern emitter | NOT STARTED | required | required | required |
+| 7. import python grammar | NOT STARTED | required | required | required |
+| 8. build orchestration | NOT STARTED | required | n/a (Pyodide path uses MEP-51 phase 17 ipykernel build) | required |
+| 9. mochi.lock integration | NOT STARTED | required | required | required |
+| 10. pylock.toml co-emit | NOT STARTED | required | required | required |
+| 11. mochi pkg publish --to=pypi | NOT STARTED | n/a (publish is host-only) | n/a | n/a |
+| 12. PEP 740 attestation flow | NOT STARTED | n/a | n/a | n/a |
+| 13. async bridge | NOT STARTED | required | required | required |
+| 14. abi3 wheel emission | NOT STARTED | required | n/a (Pyodide is its own ABI) | required |
+| 15. C-extension fallback | NOT STARTED | required | n/a (no compiled extensions under Pyodide v1) | required |
+| 16. Pyodide / WASI subset | NOT STARTED | n/a | required | n/a |
+| 17. TestPyPI dry-run gate | NOT STARTED | n/a | n/a | n/a |
+
+A phase marked `n/a` for a target is intentional: the bridge does not promise the behaviour on that target.
+
+## Alternatives considered
+
+1. **Parse Python source directly instead of via PEP 561 stubs.** Rejected: Python's runtime-dynamic semantics make AST-level type inference unreliable (decorators rewrite types at import time, metaclasses rewrite class structures, type aliases live behind `if TYPE_CHECKING:` guards, runtime `globals()` mutation is common). 60%+ of the top-200 PyPI packages have C extensions where the `.py` source is a thin facade over compiled code, so an AST parse misses the actual signatures. The bridge takes PEP 561 stubs as authoritative.
+
+2. **Use `inspect.signature()` runtime introspection as the primary bind source.** Rejected as primary: `Signature.parameters[name].annotation` is `inspect.Parameter.empty` for unannotated parameters, which means inspect-only works for the ~20% of PyPI that is fully PEP 484-annotated. The bridge uses inspect (via `stubgen --inspect-mode`) as a tertiary fallback for packages with no `py.typed`, no `<name>-stubs`, and no typeshed entry.
+
+3. **Use the existing MEP-51 Phase 12 hand-written sidecar pattern as the only consume path.** Rejected: hand-written sidecars do not scale to PyPI's 600,000+ packages. The Phase 12 pattern is the load-bearing infrastructure for the bridge (the bridge emits sidecars in exactly the Phase 12 shape), but it is the back-end, not the user-facing surface.
+
+4. **Use Cython, mypyc, or Nuitka to compile both Mochi and the imported PyPI package into a single native binary.** Rejected: those toolchains are designed for whole-program compilation, not for cross-package interop. Cython's type system does not match Mochi's; mypyc does not support most PyPI packages (it requires strict PEP 484 typing); Nuitka is whole-program-only. The bridge keeps Python as Python; only Mochi compiles to Python.
+
+5. **Use PyO3 / pybind11 / nanobind as the binding layer.** Rejected: those tools generate C-extension bindings for Rust / C++ → Python interop, not Python → Mochi. They are the wrong direction for the consume-in path. They are also not relevant for the publish-out path (MEP-71 emits pure-Python wheels; the C-extension publish path is deferred per Phase 15).
+
+6. **Use uniffi-rs for the binding layer.** Rejected: uniffi is Mozilla's Rust-to-Swift/Kotlin/Python binding generator; it generates code from a `.udl` interface description file. Mochi users would have to author a `.udl` for every package they import, which is more boilerplate than the bridge promise allows.
+
+7. **Use the WIT (Wasm Interface Types) world description plus wit-bindgen.** Rejected for v1: WIT is the right long-term answer when the source and sink are both Wasm component-model compatible, but as of 2026-05 the major PyPI packages (numpy, pandas, httpx, fastapi) do not ship a WIT world description. A v2 of the bridge could add a `--mode=wit` flag for Pyodide-only targets where WIT is feasible.
+
+8. **Direct C-API dlopen of pre-built C extensions from wheels rather than per-import wrapper synthesis.** Rejected as primary: many PyPI packages ship wheels that depend on other Python packages at the Python level (import-time), so a pure dlopen path bypasses the package's own import-side initialisation. The wrapper-and-CPython-runtime path is the only one that works for the general case.
+
+9. **Translate Python's dynamic dispatch / monkey-patching into Mochi's static surface.** Rejected: Mochi has no facility for runtime type mutation. The bridge translates the Python type stubs as they are; packages that monkey-patch require an explicit `[python.capabilities] monkey-patch = true` opt-in.
+
+10. **Allow long-lived PyPI API tokens (`__token__` in `~/.pypirc`) for the publish path.** Rejected: matches MEP-57's broader principle that long-lived tokens are deprecated. The 2024 PyPI mass-injection campaigns and the 2025 typosquat flood drove the industry to PyPI Trusted Publishing as the canonical default. MEP-71 ships exclusively on that path; the `--allow-token-fallback` flag is offered only for the v1 transition period and is removed once internal tooling has migrated.
+
+11. **Use poetry, pdm, or pip-tools as the resolver instead of uv.** Rejected: uv is 10x-100x faster than pip-tools on cold and warm cache, implements PEP 751 `pylock.toml` natively, and is already the canonical resolver MEP-51 Phase 18 pins for the publish path. Single resolver across the consume-in and publish-out directions.
+
+12. **Make `import python` defer to the user's existing `pyproject.toml` `[project.dependencies]` rather than to `mochi.toml`.** Rejected: the Mochi build flow owns the workspace. If the user has a pre-existing `pyproject.toml`, MEP-71 reads its `[project.dependencies]` table for the version constraints as a convenience (a future sub-phase, not v1) but the source of truth is `mochi.toml`. Mixing manifest authorities is a known anti-pattern.
+
+13. **Allow `Any`-returning Python functions to lower as `Any`-typed Mochi values.** Rejected: Mochi has no `Any` type. The bridge refuses `Any` returns with a `SkipReport`. Users who need dynamic interop write a hand `extern python fun` declaration with `extern type` declaring a unique opaque type per call site.
+
+14. **Auto-discover the Python interpreter rather than requiring `requires-python` in the manifest.** Rejected: the resolver needs a target interpreter version to choose wheel variants. The manifest declares it; the build verifies the installed interpreter matches.
+
+## Risks
+
+1. **PEP 561 stub coverage is uneven.** As of 2026-05, ~38% of the top-500 PyPI packages ship inline `py.typed` stubs, ~12% have a `<name>-stubs` sibling, ~7% have typeshed coverage, leaving ~43% requiring `stubgen --inspect-mode`. For the residual set, `stubgen`-derived stubs are approximate (`Any` leaks in for under-annotated parameters; C-extension callable signatures parsed from `__doc__` are heuristic). Mitigation: the bridge emits a per-package `SkipReport` that counts skipped items; users can hand-override with explicit `extern python fun` declarations.
+
+2. **C-extension signature accuracy.** Packages like numpy, scipy, lxml, pydantic-core, orjson are implemented as C extensions; their `.py` facades may lack annotations, and their stubs (when present) may diverge from runtime behaviour at the Cython / C boundary. Mitigation: the bridge prefers the package's own stubs when `py.typed` is present (numpy ships `py.typed`); for packages without stubs, the user is prompted to opt into `[capabilities] cextension = true`.
+
+3. **Resolver determinism across the consume-in and publish-out directions.** uv's resolver may produce different versions for the same manifest on different platforms (e.g. a wheel that is `linux_x86_64`-only on PyPI). Mitigation: the `[[python-package]]` lockfile entry records the resolved version per platform marker; cross-platform lock falls back to "highest version available on all listed platforms" for v1.
+
+4. **Wrapper compile time.** A wrapper for numpy is ~12,000 LOC of synthesised Python (every public function in `numpy.*`). Cold-cache stub-ingest plus wrapper synthesis is ~6 seconds; warm-cache regeneration is sub-second. For a Mochi program with 10 large package imports, the wrapper generation pass dominates lock-time cost. Mitigation: wrapper outputs are cached in `~/.cache/mochi/python-deps/wrappers/<wrapper-sha256>/`.
+
+5. **Generic monomorphisation explosion.** A package that exposes a generic function over 20 types (e.g., `pydantic.TypeAdapter[T]`) and the user lists 20 monomorphisations produces 20 wrapper symbols. Mitigation: the `[python.monomorphise]` table is required to enumerate; the bridge does not auto-monomorphise unbounded generics.
+
+6. **asyncio loop construction cost.** Per-call `asyncio.run` constructs ~200μs of loop overhead on CPython 3.12 on Apple Silicon. For workloads that make thousands of async-bridge calls per second (e.g., a hot-loop httpx benchmark) this dominates. Mitigation: opt-in `[python] runtime = { event-loop = "persistent" }` mode caches a process-global loop; documented as the trade-off lever.
+
+7. **Capability declaration drift.** A pinned package update can silently introduce a new capability (e.g., a pure-CPU package newly imports a network-opening telemetry module). `mochi pkg lock --check` catches this, but only at lock time; if CI skips `--check`, the production binary ships with the new capability. Mitigation: CI must run `--check`. The MEP-57 capability monotonicity rule applies transitively.
+
+8. **PEP 740 attestation coverage is uneven.** As of 2026-05, attestations are emitted by ~25% of top-500 PyPI publishers (the percentage is climbing fast since the late-2025 GA). For packages without attestations, the bridge falls back to SHA-256 + PyPI simple-index verification only. Mitigation: the lockfile records whether an attestation was present and verified; users can require `[python] attestation = "required"` to refuse packages lacking attestations.
+
+9. **stubgen import-time side-effects.** Running `stubgen --inspect-mode` against a package imports the package, which can execute arbitrary import-time code (`__init__.py` may open network connections, read files, spawn processes). Mitigation: `stubgen` runs inside a Mochi-controlled subprocess with no `MOCHI_*` env, no `HOME`, no `PYTHONPATH` outside the resolved venv, and a 30-second timeout; capabilities flags gate which inspections are allowed.
+
+10. **Free-threaded CPython 3.13t / 3.14t support is forward.** Phase 17 covers free-threaded interpreter compatibility; v1 ships on the GIL-enabled 3.12 baseline. Mitigation: explicit Phase 17 sub-phase with its own gate; users running on free-threaded builds get a clear "unsupported" diagnostic until Phase 17 lands.
+
+11. **Pyodide / WASI subset is small.** The Pyodide distribution of CPython for the browser supports ~150 of the top-500 PyPI packages (April 2026 Pyodide release notes); WASI-on-Python is still pre-release. Mitigation: the Pyodide gate (Phase 16) checks browser-WASI compatibility at lock time; non-compatible packages produce a clear diagnostic.
+
+12. **TestPyPI dry-run gate flakiness.** TestPyPI's uptime SLO is "best-effort"; CI runs against it may be intermittently 503. Mitigation: the dry-run flag exercises the full sigstore flow against `sigstore-mock-fulcio` locally; TestPyPI is the secondary gate, exercised on workflow_dispatch + nightly cron, not on every PR.
+
+13. **CI image dependency on `uv` plus `stubgen` plus a Python 3.12 runtime.** The MEP-51 gates already require Python 3.12+; MEP-71 adds `uv` (single Rust binary, easy install) plus `stubgen` (ships with the `mypy` Python package). The CI image is slightly bigger. Mitigation: the standard `mochilang/ci-python` image bundles the full toolset.
+
+## Acknowledgements
+
+This MEP builds on MEP-51 (Python transpiler) for the typed-Python emit pipeline, the `mochi_runtime` package, the existing `TargetPythonWheel` / `TargetPythonSdist` / `TargetPythonPublish` build targets, the Phase 12 `extern python fun` sidecar pattern, and the Phase 18 PyPI Trusted Publishing workflow renderer. It builds on MEP-57 (Mochi module and package system) for the `mochi.toml` manifest, the `mochi.lock` lockfile, the BLAKE3 + SHA-256 dual-hashing, the content-addressed object store model, the capability declaration scheme, and the trusted-publishing OIDC infrastructure. It builds on MEP-45 (C transpiler) for the FFI sidecar pattern that MEP-51 Phase 12 inherited. It draws from the Python Packaging Authority (PyPA) tooling base (pip, virtualenv, setuptools, wheel, twine, build, distlib, packaging, pyproject-hooks, installer) for the standards alignment. The MEP cites PEP 425, PEP 440, PEP 484, PEP 503, PEP 508, PEP 526, PEP 544, PEP 561, PEP 585, PEP 593, PEP 600, PEP 604, PEP 621, PEP 656, PEP 658, PEP 660, PEP 691, PEP 695, PEP 700, PEP 714, PEP 723, PEP 735, PEP 740, and PEP 751. The bridge draws on the Sigstore project and the OpenSSF Trusted Publishing initiative for the keyless OIDC signing flow, on Astral's `uv` for the resolver and PEP 751 emit, on the `mypy` `stubgen` tool for the inspect-mode fallback, on `python/typeshed` for the community stub repository, on `Astral`'s `python-build-standalone` for the cross-platform CPython distribution model, on PyO3 / pybind11 / nanobind for prior-art on Python-binding generation (rejected for the consume direction; informative for the publish-side C-extension forward sub-phase), on the Pyodide team for the browser CPython distribution that informs the WASI subset path, and on the Warehouse codebase (`pypi/warehouse`) for the PyPI Trusted Publishing endpoint shape.

--- a/website/docs/research/0071/01-language-surface.md
+++ b/website/docs/research/0071/01-language-surface.md
@@ -1,0 +1,221 @@
+---
+title: "01. Language surface"
+sidebar_position: 2
+sidebar_label: "01. Language surface"
+description: "The `import python \"<package>@<semver>\" as <alias>` import form, the `[python-dependencies]` / `[python]` / `[python.publish]` / `[python.capabilities]` manifest tables, the CLI subcommands (`mochi pkg add python`, `mochi pkg lock`, `mochi pkg publish --to=pypi`, `mochi pkg sync python`, `mochi pkg export pylock`), and the per-import alias resolution rule."
+---
+
+# 01. Language surface
+
+This note covers the user-visible surface MEP-71 introduces: the import syntax, the manifest tables, and the CLI subcommands. Everything below is observable through `mochi --help` and `mochi.toml` schema validation; the user does not need to read the rest of the bundle to use the bridge.
+
+## Import syntax
+
+The Mochi grammar's `ImportStmt` production (MEP-1) accepts a `Lang` token between `import` and the string literal:
+
+```
+ImportStmt := "import" Lang? StringLit "as" Ident ("auto")?
+Lang := "go" | "python" | "typescript" | "rust"
+```
+
+MEP-71 promotes `python` from a transpiler-only directive (MEP-51) to a full package-manager surface. The string literal is one of:
+
+| Form | Resolution |
+|------|------------|
+| `<package-name>` | Bare name (PEP 503 normalised). Resolves through `[python-dependencies]` plus `mochi.lock`. The lockfile records the picked version. |
+| `<package-name>@<semver-req>` | Explicit PEP 440 constraint (`>=1.0,<2.0`, `~=1.4`, `==1.2.3`, `^1.0` shorthand auto-translated to `>=1.0,<2.0`). Must be compatible with `[python-dependencies]`. |
+| `<package-name>@git+<url>` | Git source, branch default. |
+| `<package-name>@git+<url>#<rev>` | Git source, pinned to commit, tag, or branch. |
+| `<package-name>@path+<rel-path>` | Path source, relative to the manifest. Useful for editable in-tree installs. |
+| `<package-name>[<extra>,<extra>]@<semver-req>` | PEP 508 extra-marker form. The bracketed extras pull additional optional deps. |
+
+Example surface:
+
+```mochi
+import python "requests@>=2.31,<3" as requests
+import python "httpx[http2]@>=0.27" as httpx
+import python "numpy@~=2.0" as np
+import python "pydantic@>=2.5" as pyd
+
+fn fetch_user(uid: int): User {
+    let resp = requests.get(f"https://api.example/{uid}")
+    let payload = resp.json()
+    let user = pyd.parse_obj_as(User, payload)
+    return user
+}
+```
+
+The `<alias>` introduces a Mochi namespace bound at the import site. Symbol lookup `<alias>.<item>` resolves to the synthesised `extern fn` or `extern type` declaration the bridge generated for `<package>.<item>`. Names follow the package's public surface verbatim (snake_case Python names stay snake_case in Mochi; PascalCase classes stay PascalCase as types).
+
+The `auto` modifier (already accepted for `import go ... auto` and `import rust ... auto`) is admitted for `import python ... auto`. With `auto`, every public top-level item of the package (filtered by `__all__` if defined, else by leading underscore) is bound at file scope rather than under the alias namespace. Default is namespaced; `auto` is opt-in.
+
+## Manifest: `[python-dependencies]`
+
+This table is the user-facing dependency declaration. It follows PEP 621's `[project.dependencies]` grammar plus the table-form override used by uv and Poetry:
+
+```toml
+[python-dependencies]
+requests = ">=2.31,<3"
+httpx = { version = ">=0.27", extras = ["http2"] }
+numpy = "~=2.0"
+pandas = { version = ">=2.2", markers = "platform_system != 'Windows'" }
+pydantic = ">=2.5"
+my-local-pkg = { path = "../my-pkg", editable = true }
+my-git-pkg = { git = "https://github.com/example/my-pkg", tag = "v0.2.0" }
+torch = { version = ">=2.3", index = "https://download.pytorch.org/whl/cpu" }
+```
+
+The grammar mirrors uv's:
+
+- A bare string is shorthand for `{ version = "..." }`.
+- The table form admits `version`, `extras`, `markers` (PEP 508 environment markers), `optional`, `path`, `editable`, `git`, `branch`, `rev`, `tag`, `index` (alternative index URL), and `groups` (PEP 735 dependency groups).
+- Cyclic dependencies are rejected at lock time (the same rule Pip/uv enforce).
+
+The user does not write a separate `pyproject.toml` for consumption. The bridge synthesises a private `pyproject.toml` at build time when invoking uv against an ephemeral venv, populating `[project.dependencies]` from `[python-dependencies]` and pinning to the exact resolved version from `mochi.lock`.
+
+## Manifest: `[python]`
+
+```toml
+[python]
+requires-python = ">=3.12,<3.15"
+implementation = "cpython"
+runtime-mode = "embedded"
+async-mode = "per-call"
+stubgen = { fallback = true, inspect = true }
+sidecar-glob = "*_externs.py"
+free-threaded = false
+```
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `requires-python` | `">=3.12"` | PEP 440 constraint on the interpreter version. Matches MEP-51's transpiler floor. |
+| `implementation` | `"cpython"` | One of `cpython`, `pypy`, `graalpy`. Currently only `cpython` is wired; the others surface a `SkipReason`. |
+| `runtime-mode` | `"embedded"` | `embedded` links libpython into the Mochi binary; `subprocess` shells out to a `python` interpreter. Embedded is faster; subprocess is the only path under sandboxed deployments. |
+| `async-mode` | `"per-call"` | `per-call` wraps each Mochi-to-Python async call in its own `asyncio.run` (no shared state); `persistent` keeps one event loop alive in a dedicated thread. See [[08-async-bridge]]. |
+| `stubgen` | `{ fallback = true, inspect = true }` | When PEP 561 stubs are missing, the bridge falls back to mypy's `stubgen --inspect-mode` to synthesise types from live import. Disable to refuse imports of untyped packages. |
+| `sidecar-glob` | `"*_externs.py"` | The MEP-51 Phase 12 sidecar convention. The bridge reads these files to discover hand-written wrapper functions. |
+| `free-threaded` | `false` | When `true`, the bridge requires `cp313t` / `cp314t` wheels and refuses to install GIL-only wheels. |
+
+## Manifest: `[python.publish]`
+
+```toml
+[python.publish]
+distribution-name = "mochi-pkg-foo"
+build-backend = "mochi-build"
+wheel-tags = ["py3-none-any", "cp312-cp312-manylinux_2_28_x86_64"]
+abi3 = true
+abi3-min-version = "cp312"
+publish-to = "pypi"
+license-expression = "MIT"
+trove-classifiers = ["Programming Language :: Python :: 3", "Programming Language :: Python :: 3.12"]
+```
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `distribution-name` | (required) | The PEP 503-normalised distribution name on PyPI. |
+| `build-backend` | `"mochi-build"` | The PEP 517 entrypoint name. Mochi ships its own backend that produces sdist + wheel. |
+| `wheel-tags` | `["py3-none-any"]` | The compatibility tags emitted by the wheel builder. Pure-Python wraps stay `py3-none-any`; native wraps explicitly enumerate `cpXY-abiZ-platform`. |
+| `abi3` | `false` | When `true`, the wheel targets the limited API and gets the `abi3` tag, working across multiple CPython minors. |
+| `abi3-min-version` | `"cp312"` | The minimum CPython version for the abi3 wheel. |
+| `publish-to` | `"pypi"` | The publish target. Currently only `"pypi"` and `"testpypi"`; future: `"private-index"`. |
+| `license-expression` | (none) | PEP 639 SPDX expression. Required by PyPI as of 2025-Q2. |
+| `trove-classifiers` | `[]` | The PyPI classifier list. |
+
+This table is only consulted when the user runs `mochi pkg publish --to=pypi`. Mochi packages that do not publish to PyPI can omit it.
+
+## Manifest: `[python.capabilities]`
+
+```toml
+[python.capabilities]
+net = true
+fs = false
+proc = false
+ctypes = false
+c-extension = true
+```
+
+These capability flags are a strict refinement of MEP-57's `[capabilities]` table. The bridge walks the Python dep graph at lock time, computes the union of capability marks across every reachable package (via a curated capability database; [[12-risks-and-alternatives]] §R6 documents the database maintenance), and asserts that the union is a subset of the user's `[python.capabilities]` declaration. If the union exceeds the declaration, lock fails with a diagnostic naming the package and the capability.
+
+The five canonical capabilities for Python deps are:
+
+- `net`: any reachable package opens sockets or makes HTTP calls. Detected via static imports of `socket`, `urllib`, `requests`, `httpx`, `aiohttp`.
+- `fs`: any reachable package reads or writes files. Detected via imports of `open` calls outside of pyproject discovery and `pathlib`, `os.path`.
+- `proc`: any reachable package calls `subprocess` or `os.exec*`.
+- `ctypes`: any reachable package imports `ctypes` directly. C-extension wheels are tracked under `c-extension` instead.
+- `c-extension`: any reachable wheel ships a `.so` / `.pyd` / `.dylib`. Pure-Python sdist-only deps have this false.
+
+Capabilities outside this set (clock, env, random) are inherited from MEP-57's broader `[capabilities]` table and audited there.
+
+## CLI surface
+
+The `mochi pkg` subcommand gains six new operations:
+
+### `mochi pkg add python <package>[@<semver>] [--extras=<a>,<b>] [--group=<name>]`
+
+```
+$ mochi pkg add python httpx@>=0.27 --extras=http2,brotli
+Added httpx = { version = ">=0.27", extras = ["http2", "brotli"] } to [python-dependencies]
+Running mochi pkg lock ...
+Resolved 38 Python packages (httpx + 37 transitive)
+Wrote mochi.lock (+38 [[python-package]] entries)
+```
+
+Equivalent to manually editing `mochi.toml` plus running `mochi pkg lock`. Idempotent if the entry already exists at a compatible version. Drives the uv resolver.
+
+### `mochi pkg lock`
+
+Walks `[python-dependencies]`, invokes uv to resolve against the PyPI simple index (PEP 503 / 691) and any extra indexes, downloads each wheel or sdist to the content-addressed cache, runs the PEP 561 stub-discovery pipeline on each, synthesises the wrapper per package, and writes a `[[python-package]]` entry per dep into `mochi.lock`.
+
+### `mochi pkg lock --check`
+
+Reads `mochi.lock`, recomputes every `wheel-blake3`, `wheel-sha256`, `pypi-simple-sha256`, `stub-sha256`, `wrapper-sha256`, and `capabilities-declared`, and exits non-zero on any mismatch. This is the CI-enforced reproducibility gate.
+
+### `mochi pkg publish --to=pypi [--dry-run] [--testpypi]`
+
+- Builds the package via `Driver.Build` with `target = TargetPythonPackage, LibraryMode = true`.
+- Runs the Mochi PEP 517 backend to produce sdist + wheel(s).
+- Obtains an OIDC token from the CI environment (GitHub Actions, GitLab CI, etc.).
+- Presents the token plus the wheel(s) to PyPI's trusted-publishing endpoint.
+- Generates PEP 740 attestations via Sigstore-keyless OIDC, signs with Fulcio short-lived cert, records the Rekor log entry.
+
+The `--dry-run` flag skips upload; the signing flow is still exercised against a `sigstore-mock-fulcio` harness for testing. The `--testpypi` flag routes to test.pypi.org.
+
+### `mochi pkg sync python`
+
+Re-runs the wrapper synthesiser from the existing `mochi.lock`, without re-resolving versions. Used after manual edits to the synthesised shim file, or after a bridge upgrade that changes the wrapper format.
+
+### `mochi pkg export pylock`
+
+Emits a PEP 751 `pylock.toml` from the Python-package subset of `mochi.lock`. The exported file is interchange-format compatible with pip, uv, Poetry, PDM, and other PEP 751-conformant tools. Useful for CI pipelines that need to install Python deps in a standalone container before invoking Mochi.
+
+## Per-import alias resolution
+
+The alias `<alias>` introduced by `import python "<spec>" as <alias>` participates in normal Mochi name resolution. The bridge generates a shim file at `<workdir>/python_wrap/<package>/shim.mochi` containing a corpus of `extern fn` declarations like:
+
+```mochi
+extern type Response
+extern fn get(url: string): Response from python "requests.get"
+extern fn json(self: Response): any from python "requests.Response.json"
+extern fn status_code(self: Response): int from python "requests.Response.status_code"
+```
+
+The import `import python "requests" as requests` becomes (post-resolution) `import "./python_wrap/requests/shim.mochi" as requests`. The synthesised shim is read by the parser exactly as a hand-written `.mochi` file would be.
+
+The shim file is regenerated on every `mochi pkg lock` and is gitignored by default. Users who need to edit the synthesised bindings should override individual items in their own source via the MEP-51 Phase 12 sidecar pattern (`<modname>_externs.py`):
+
+```mochi
+import python "requests" as requests
+extern fn requests_get_with_retries(url: string, retries: int): requests.Response from python "myapp_externs.requests_get_with_retries" custom
+```
+
+The `custom` modifier keeps the override stable across `mochi pkg sync python` runs.
+
+## Cross-references
+
+- [[02-design-philosophy]] for the rationale.
+- [[04-pep561-stub-ingest]] for how the public surface is discovered.
+- [[05-type-mapping]] for the closed translation table the shim file uses.
+- [[06-pypi-publish-flow]] for the `mochi pkg publish` path.
+- [MEP-71 §4](/docs/mep/mep-0071#4-surface-syntax-import-python) for the normative syntax.
+- [MEP-57](/docs/mep/mep-0057) for the broader `mochi.toml` + `mochi.lock` model this extends.
+- [MEP-51](/docs/mep/mep-0051) for the Python transpiler whose `*_externs.py` sidecar convention MEP-71 reuses.

--- a/website/docs/research/0071/02-design-philosophy.md
+++ b/website/docs/research/0071/02-design-philosophy.md
@@ -1,0 +1,136 @@
+---
+title: "02. Design philosophy"
+sidebar_position: 3
+sidebar_label: "02. Design philosophy"
+description: "Why a bidirectional bridge, why PEP 561 stubs over alternatives, why a synthesised CPython wrapper module over direct ctypes / cffi, why the async bridge sits on `asyncio.run` per call with persistent opt-in, why Sigstore-keyless OIDC + PyPI Trusted Publishing is the only publish path, why uv is the resolver."
+---
+
+# 02. Design philosophy
+
+This note explains the load-bearing decisions in MEP-71. Each section frames one choice, the alternatives weighed, the reason the chosen path wins, and the consequence the user inherits. The decisions here are referenced by every other note in the bundle.
+
+## 1. Why a bidirectional bridge
+
+The simpler design would be one-way: either Mochi imports Python (consume), or Mochi publishes to PyPI (publish), but not both. Each direction in isolation is a smaller engineering surface and a smaller blast radius.
+
+The reasons we ship both:
+
+1. **Symmetric MEP-73 / MEP-74 precedent.** The Rust and Go bridges are bidirectional, and the polyglot package surface is the headline feature of the MEP-57 wave. Asymmetry would be a usability cliff: "I can `import rust` and `mochi pkg publish --to=crates.io`, but only `import python`, not publish to PyPI" leaves a hole that users would notice immediately.
+2. **The publish direction is where Mochi differentiates.** Mochi's type system, package model, and reproducibility story are stronger than Python's; publishing Mochi-authored libraries to PyPI gives Python users access to the Mochi ecosystem with no boilerplate on their side. This is the long-term ecosystem play.
+3. **Consume direction is the dev-experience anchor.** Python's ecosystem (numpy, pandas, requests, fastapi, pytorch) is the deepest in computing. Without the consume direction, Mochi is a curiosity. The consume direction is what makes Mochi usable for real work on day one.
+4. **Shared infrastructure across directions.** Stub parsing, wheel handling, the sparse-index client, the wrapper synthesiser, the capability database, and the Sigstore client are all 1:1 reused across both directions. The marginal cost of adding publish on top of consume (or vice versa) is one of the engineering teams in the project.
+
+The cost is real: two sets of CI, two sets of fixtures, two sets of error codes. The 18-phase delivery plan accounts for this by interleaving the directions (phases 0-8 consume, 9-10 publish, 11-13 cross-cutting, 14-18 hardening).
+
+## 2. Why PEP 561 stubs are the canonical type source
+
+The Python ecosystem has three layers of type information:
+
+1. **Inline annotations** in the source itself (PEP 526 / 484), gated by a `py.typed` marker per PEP 561.
+2. **Sibling stub distributions** (`<name>-stubs`), the Stuart pattern, also PEP 561.
+3. **Typeshed**, the centralised monorepo of ~200 third-party stubs maintained by the Python typing community.
+4. **Stubgen fallback** via `mypy.stubgen --inspect-mode`, which imports the package live and inspects function signatures, classes, and methods via reflection.
+
+MEP-71 codifies a four-tier precedence: inline (if `py.typed`) → sibling `-stubs` (if present) → typeshed (if covered) → stubgen fallback (if `[python].stubgen.fallback = true`). This is the same precedence pyright and mypy already use, so the bridge's type discovery is observably consistent with how Python's own type tooling resolves types.
+
+Alternatives considered and rejected:
+
+- **Mochi-specific stub format.** Would require every Python package to ship a Mochi-flavoured stub, defeating the consume-without-boilerplate goal.
+- **Runtime inspection only.** Inspecting via `inspect.signature` at import time works for many packages but loses type-only constructs (TypeVar, Protocol, Generic[T]) and degrades on C-extensions where signatures live in docstrings.
+- **typeshed only.** Skips packages typeshed doesn't cover. A large fraction of PyPI's long tail is uncovered, and waiting for typeshed PRs to merge for every package is not a viable consumption path.
+
+The PEP 561 four-tier ladder gives us widest coverage with the strongest types: when the package author opted in (py.typed or -stubs), we get their own types; when they didn't, we get typeshed's; when typeshed didn't either, we get stubgen's best-effort approximation; when that fails too, we report a `SkipReason` and continue.
+
+See [[04-pep561-stub-ingest]] for the full ingest pipeline and the partial-stub story.
+
+## 3. Why a synthesised CPython wrapper module, not direct ctypes
+
+There are three ways to call from Mochi (Go) into Python from first principles:
+
+1. **Pure ctypes.** Mochi emits Go code that opens libpython.so, finds `Py_Initialize`, and calls every function through CFFI. The user writes no Python at all.
+2. **Direct CPython C API embedding.** Mochi links libpython directly (no ctypes layer), calls `PyImport_ImportModule`, `PyObject_CallFunction`, etc. directly from Go. This is what gopy does.
+3. **Synthesised Python wrapper module.** Mochi emits a small `_mochi_wrap.py` module per imported package that imports the package, exposes a typed surface, and hands handles back through a thin C boundary. The CPython side does the GIL juggling; the Mochi side gets a typed extern fn.
+
+We chose path 3. Reasons:
+
+- **GIL handling lives in CPython.** Acquiring and releasing the GIL from Go through CFFI is correct but verbose, and CPython 3.13t free-threaded mode (PEP 703) changes the rules in ways that pure-ctypes code would silently break under. Letting CPython manage its own GIL inside the wrapper module isolates the GIL concern from the rest of the bridge.
+- **Reuse of MEP-51 Phase 12 sidecar pattern.** Mochi's Python transpiler already uses `<modname>_externs.py` sidecars to host hand-written extern functions. The synthesised wrapper module is the same shape, just generated rather than hand-written. The MEP-51 infrastructure (sidecar discovery, import-time stitching, error coercion) loads MEP-71 wrappers for free.
+- **Mochi's runtime objects map cleanly to Python objects.** A Mochi `list[int]` is a CPython `list`; a Mochi `dict[str, int]` is a CPython `dict`; a Mochi `int` is a CPython `int`. Roundtripping through the wrapper module means no marshalling layer is needed for any datatype that already has a CPython counterpart.
+- **Async bridges naturally.** The wrapper module is the right place to call `asyncio.run` or to register a Python coroutine on an event loop; if we tried to do this from Go directly, we would need to reproduce asyncio's internal coroutine protocol.
+
+Path 1 (pure ctypes) lost on the GIL story plus the C-extension boundary (calling a numpy ufunc through ctypes is essentially impossible). Path 2 (gopy-style direct embed) lost on the maintenance burden: gopy has not seen a release in over two years, and tracking CPython API changes from outside CPython is a known time sink.
+
+See [[09-abi-stability]] and [[10-gil-and-cextensions]] for the deeper boundary issues this choice addresses.
+
+## 4. Why asyncio.run per call, with persistent loop opt-in
+
+The async surface is the hardest cross-language design in the bridge. The choices were:
+
+- **Per-call `asyncio.run`.** Every Mochi-to-Python async call wraps the coroutine in `asyncio.run`. Simple, no shared state, but pays the event-loop spin-up cost on every call (~0.5-1ms).
+- **Persistent loop on a dedicated thread.** One asyncio event loop runs forever in a Python thread; Mochi marshals coroutines onto it via `asyncio.run_coroutine_threadsafe`. Faster per call, but the loop becomes shared state with all the lifetime hazards that entails.
+- **uvloop / trio.** Faster runtimes with different semantics. trio in particular has a different cancellation model than asyncio.
+
+We chose per-call as the default, with `[python].async-mode = "persistent"` as the opt-in. Reasons:
+
+- **Per-call is correct by construction.** Each call is isolated; no cross-call event-loop state can leak. Cancellation, timeouts, and exceptions all behave as if the user wrote `asyncio.run(...)` themselves.
+- **Persistent is faster but state-leaky.** If a user holds a reference to a Future from one call and tries to await it from another, behaviour depends on which event loop the Future was created on; with persistent mode there is one loop and it works, with per-call mode each loop is gone after `run` returns. The persistent opt-in makes this state-sharing explicit.
+- **uvloop / trio are libraries, not modes.** Users who want them install them as Python deps and call `uvloop.install()` or `trio.run` in their own code. The bridge does not bless one runtime over another.
+
+The async surface is documented in detail in [[08-async-bridge]].
+
+## 5. Why Sigstore-keyless OIDC + PyPI Trusted Publishing is the only publish path
+
+PyPI's traditional publish flow used API tokens generated through the web UI and stored in CI secrets. The current best-practice flow is PyPI Trusted Publishing (GA 2023-Q2 for GitHub Actions, expanded to GitLab CI, Google Cloud, and ActiveState in 2024), which uses OIDC tokens exchanged for short-lived upload credentials.
+
+MEP-71 supports only the Trusted Publishing path. Reasons:
+
+- **No long-lived secrets.** The Trusted Publishing flow has no static credentials anywhere; the OIDC token is fetched per-upload and the upload credential expires within minutes. Compromise of a CI secret store does not give the attacker upload rights.
+- **PEP 740 attestations.** PyPI launched cryptographic attestations in 2024-Q4, signed via Sigstore. Trusted Publishing is the only flow that wires the attestation generation in; legacy token uploads cannot attest.
+- **Supply-chain pressure.** The 2024 Top.gg colorama campaign and the 2024-2025 typosquat waves demonstrated that unsigned PyPI uploads are an active threat. Mochi-published packages will have provenance from day one.
+
+Alternative considered: support both legacy token and Trusted Publishing. Rejected because it adds a code path that maps directly onto a known-broken security posture. Users who cannot use Trusted Publishing (private internal PyPI mirrors that don't speak OIDC) can use `mochi pkg publish --to=private-index` once that target lands; the public PyPI publish path is OIDC-only.
+
+See [[07-sigstore-pypi-trusted-publishing]] for the protocol details.
+
+## 6. Why uv as the resolver
+
+Python has four mature resolvers: pip's, Poetry's, PDM's, and uv's. uv (Astral, written in Rust, PubGrub forking resolver) is the youngest but the fastest by 10-100x on cold resolves and the only one that produces a universal lockfile (uv.lock v1, with a `revision` field for cache invalidation, plus PEP 751 pylock.toml export).
+
+Reasons we chose uv:
+
+- **Speed.** Mochi's `mochi pkg lock` runs in CI on every change. A 10s lock cost (uv) is acceptable; a 5min lock cost (pip-tools) is not.
+- **Universal lockfile.** uv.lock captures all platforms in one file; Poetry and PDM produce per-platform lockfiles that must be regenerated for every target. Mochi's cross-platform target matrix (Linux x64/arm64, macOS x64/arm64, Windows x64, WASI, Pyodide) needs a universal lockfile.
+- **PEP 751 conformance.** uv exports pylock.toml, which lets Mochi-built packages interoperate with non-Mochi Python tooling. Other resolvers either don't export PEP 751 or have only partial support.
+- **Rust toolchain alignment.** MEP-73's Rust bridge already requires Rust toolchain support. uv's Rust runtime is acquired through the same install path; no separate Python-side tool acquisition.
+
+The alternative was pip's resolver: stable, ubiquitous, but slow and without a universal lockfile. Poetry: opinionated, slower than uv, partial PEP 751 support. PDM: PEP 582-focused, slower than uv. uv wins on every axis except "youngest, so smallest install base," which is offset by Astral's commitment to long-term maintenance.
+
+See [[12-risks-and-alternatives]] §R10 for the uv-stability risk and the backup plan.
+
+## 7. Why a closed type-mapping table
+
+Python is dynamically typed; Mochi is statically typed. The bridge has to draw a line: which Python types does Mochi understand, and which become opaque handles?
+
+The closed table covers, in both directions:
+
+- **Scalars**: `bool`, `int` (with arbitrary-precision boundary at sys.maxsize), `float`, `str`, `bytes`, `None`.
+- **Collections**: `list[T]`, `tuple[T1, T2, ...]`, `dict[K, V]`, `set[T]`, `frozenset[T]`.
+- **Algebraic**: `Optional[T]`, `Union[T1, T2]` (when reducible to a Mochi sum type), `Literal["a", "b"]`.
+- **User-defined**: `@dataclass`, `TypedDict`, `NamedTuple`, `Enum`, `Protocol` (structural).
+- **Generic**: `Callable[[A, B], R]`, `Iterator[T]`, `Iterable[T]`, `AsyncIterator[T]`, `Generator[Y, S, R]`.
+- **Special**: `Any` (becomes Mochi `any` boxed opaque), `NoReturn`, `Self`, `TypeVar` (resolved by monomorphisation rule).
+
+Outside the table, the type becomes an opaque `PyObject` handle. The user can pass it around, store it, and pass it back to Python, but cannot project fields or call methods on it from Mochi.
+
+The reason this is closed: the type table is the contract surface between two type systems with fundamentally different semantics. If we tried to support every Python typing construct (especially the dynamic ones like `__class_getitem__`, runtime-checkable Protocols, `__init_subclass__`), the type table would balloon into an interpreter for the typing module. Closing the table at a stable subset makes the bridge predictable.
+
+See [[05-type-mapping]] for the full table and the refusal cases.
+
+## Cross-references
+
+- [[03-prior-art-bridges]] for what we learned from other Python bridges.
+- [[04-pep561-stub-ingest]] for the stub discovery pipeline.
+- [[05-type-mapping]] for the closed type table.
+- [[08-async-bridge]] for the async runtime choice.
+- [[10-gil-and-cextensions]] for the GIL and C-extension boundary.
+- [MEP-71 §1 Abstract](/docs/mep/mep-0071#abstract) for the same decisions in normative form.

--- a/website/docs/research/0071/03-prior-art-bridges.md
+++ b/website/docs/research/0071/03-prior-art-bridges.md
@@ -1,0 +1,161 @@
+---
+title: "03. Prior-art bridges"
+sidebar_position: 4
+sidebar_label: "03. Prior-art bridges"
+description: "PyO3, maturin, Cython, CFFI, pybind11, nanobind, SWIG, JPype, Py4J, gopy, UniFFI, diplomat. What each gets right, what each requires the user to write, and what MEP-71 borrows from each."
+---
+
+# 03. Prior-art bridges
+
+This note surveys the existing Python bridges that informed MEP-71's design. Each entry covers what the bridge does, what the user has to write, what works well, and what MEP-71 borrows or rejects.
+
+## PyO3 (Rust → Python, Python → Rust)
+
+PyO3 is the de-facto Rust↔Python bridge. It lets Rust crates expose a Python module (via `#[pymodule]`) and Python scripts call into Rust functions (via `#[pyfunction]`). The build tool is maturin, which packages the Rust crate as a wheel.
+
+What the user writes: Rust source with PyO3 attribute macros. The macros generate the CPython C-API boilerplate.
+
+What works: zero-cost type conversion via the `IntoPy` / `FromPyObject` traits, ergonomic GIL handling via the `Python<'py>` token, native async support via `pyo3-asyncio` (separate crate, bridging tokio↔asyncio). The free-threaded story is in flight: PyO3 0.23+ targets the GIL-free build via `Py_GIL_DISABLED`.
+
+What MEP-71 borrows:
+
+- **Wrapper-module pattern.** PyO3 generates a `_<name>.so` extension module the user imports from Python. MEP-71's synthesised CPython wrapper module is the analogue.
+- **Token-style GIL handling.** PyO3 represents GIL ownership as a `Python<'py>` token. The Mochi wrapper module pattern avoids surfacing GIL tokens to the user but uses an internal equivalent.
+- **abi3 strategy.** PyO3 has built-in support for the limited API; the wheel works on multiple CPython minors. MEP-71 inherits this for cross-version wheel deployment.
+
+What MEP-71 rejects:
+
+- **Rust as the implementation language.** Mochi's host runtime is Go; the wrapper module is generated Python, not generated Rust. PyO3's design assumes the source is Rust; MEP-71's source is Mochi.
+
+## maturin (Rust crate → Python wheel)
+
+maturin is the build tool that wraps cargo + PEP 517 to ship PyO3 / rust-cpython / cffi crates as Python wheels. It handles wheel-tag computation, abi3 wheel slimming, and PyPI upload via twine.
+
+What works: tight integration with PEP 517 (`build-backend = "maturin"` in pyproject.toml), correct manylinux tags via auditwheel, abi3 support, Trusted Publishing support via the maturin-action GitHub Action.
+
+What MEP-71 borrows:
+
+- **PEP 517 backend pattern.** Mochi ships its own `mochi-build` PEP 517 backend that produces sdist + wheel. The backend integrates with pip / uv / pipx for installation.
+- **abi3 wheel slimming.** When `[python.publish].abi3 = true`, the wheel is tagged `cp312-abi3-<plat>` and works on 3.12, 3.13, 3.14, ... without a per-minor build. This is maturin's contribution.
+- **auditwheel-style platform validation.** Mochi's wheel builder runs the equivalent of auditwheel on Linux wheels to verify the manylinux platform tag matches the actual symbol requirements.
+
+## Cython (Python with C-level types)
+
+Cython lets users write Python with C-level type annotations that compile to C extensions. The mature path for performance-critical code in scipy, scikit-learn, lxml.
+
+What works: extremely good native integration (Cython code can declare C structs, call C functions directly, manage memory). The compiled `.pyx` modules are first-class CPython extensions.
+
+What MEP-71 borrows:
+
+- **Generated `.pyx`-style wrapper.** The synthesised wrapper module is the Mochi equivalent of a Cython-compiled extension module: a CPython extension that exposes a typed surface backed by Mochi's runtime.
+- **PEP 561 stub generation.** Cython has a Cython-to-stub generator. MEP-71's wrapper synthesiser produces `.pyi` files for the publish direction.
+
+What MEP-71 rejects:
+
+- **Cython as the source language.** Mochi is the source language; Cython's hybrid Python/C syntax is not in scope.
+
+## CFFI (Python → C library)
+
+CFFI lets Python scripts call into C libraries without writing CPython extension code. It uses cdef declarations to describe the C API and runtime FFI to call into it.
+
+What works: pure-Python install (no C compilation needed for the FFI layer, only for the target C library), good portability, supports both ABI mode (dlopen) and API mode (compiled extension).
+
+Why MEP-71 doesn't use CFFI as primary: CFFI is the right tool when the target is a C library with a stable C ABI; CPython itself is the target here. CFFI plus libpython is workable, but loses the GIL handling that the wrapper-module pattern provides for free.
+
+## pybind11, nanobind (C++ → Python)
+
+pybind11 and nanobind are the C++ equivalents of PyO3. pybind11 is mature and widely used (pytorch, tensorflow, opencv); nanobind is the modern, smaller, faster successor.
+
+What MEP-71 borrows:
+
+- **Type-caster pattern.** pybind11's type casters (the `pybind11::cast<T>` / `py::object::cast<T>()` mechanism) is the C++ analogue of MEP-71's closed type table. The mechanism generalises: each cast direction is an explicit conversion with explicit refusal cases.
+- **abi3 support.** Both libraries support the limited API. MEP-71 inherits the wheel-tagging discipline.
+
+## SWIG (multi-language wrapper generator)
+
+SWIG generates language bindings from C/C++ headers across ~30 target languages. Long history, broad coverage, but the user writes interface files (`*.i`) describing the C surface.
+
+What MEP-71 borrows:
+
+- **Interface-file mental model.** The synthesised shim.mochi is the MEP-71 analogue of a SWIG `.i` file: a generated bridge surface between two languages.
+
+What MEP-71 rejects:
+
+- **Interface file as user-edited artifact.** SWIG users edit their `.i` files; MEP-71 users do not edit shim.mochi. Custom overrides live in `<modname>_externs.py` sidecars (the MEP-51 Phase 12 pattern).
+
+## JPype, Py4J (Java → Python, Python → Java)
+
+JPype and Py4J bridge Java and Python. JPype runs both in the same process via JNI; Py4J runs them in separate processes communicating over a socket.
+
+What MEP-71 borrows:
+
+- **JPype's in-process model.** MEP-71's embedded runtime mode (default) links libpython into the Mochi binary. JPype's JNI-based approach is the analogue.
+- **Py4J's subprocess fallback.** When in-process linking is impossible (sandboxed deployments, certain platforms), MEP-71's `[python].runtime-mode = "subprocess"` shells out. The subprocess protocol is simpler than Py4J's (JSON-RPC over stdin/stdout vs Py4J's bidirectional socket protocol).
+
+## gopy (Go → Python)
+
+gopy generates Python bindings from Go packages. Closest prior art to MEP-71's direction (Mochi runs on Go). gopy uses `cgo` to expose Go functions to CPython.
+
+What worked when it was maintained: Go-side type annotations were translated to Python type stubs. The CPython API was called via cgo from generated C glue.
+
+What didn't: gopy has not had a release since 2023. The CPython API churn (especially the 3.12 deprecations of `Py_SetProgramName`, `PyEval_InitThreads`, etc.) has not been tracked. Free-threaded Python (3.13t) is not supported. abi3 is not supported.
+
+What MEP-71 borrows:
+
+- **Go-side type annotation extraction.** gopy parsed Go's AST and used the annotations to drive type translation. MEP-71's Mochi-side equivalent reads the Mochi type checker's output to drive the wrapper module synthesis.
+
+What MEP-71 rejects:
+
+- **Direct cgo embedding.** gopy uses cgo to call libpython from Go. MEP-71 uses a synthesised Python wrapper module that lives on the CPython side; the Go↔CPython boundary stays smaller and more stable.
+
+## UniFFI (Mozilla, multi-target from Rust)
+
+UniFFI generates Swift, Kotlin, Python, and Ruby bindings from Rust crates. The user writes a `.udl` IDL describing the Rust surface; UniFFI generates the foreign-language bindings.
+
+What MEP-71 borrows:
+
+- **Closed type table.** UniFFI's UDL has a closed set of types; user-defined types outside the set are opaque. MEP-71's closed type-mapping table is the same discipline.
+
+What MEP-71 rejects:
+
+- **Separate IDL.** UniFFI's UDL is a separate language users must learn. MEP-71's type discovery is driven by PEP 561 stubs, which the Python ecosystem already produces.
+
+## diplomat (Rust → Swift/JS/Dart)
+
+diplomat is similar to UniFFI but uses Rust source as the IDL: `#[diplomat::bridge]` attribute macros annotate the Rust source, and bindings are generated from the annotated subset.
+
+What MEP-71 borrows:
+
+- **Source-as-IDL discipline.** The bridge does not introduce a new language; the source language's own type system is the contract surface. PEP 561 stubs are MEP-71's source-as-IDL.
+
+## Summary table
+
+| Bridge | Source | Targets | What MEP-71 borrows |
+|--------|--------|---------|---------------------|
+| PyO3 | Rust | Python | Wrapper-module pattern, abi3 strategy |
+| maturin | Rust crate | Python wheel | PEP 517 backend, auditwheel discipline |
+| Cython | Python/C hybrid | C extension | Generated `.pyx`-style wrapper module |
+| CFFI | Python | C ABI | (informative; not chosen as primary) |
+| pybind11 / nanobind | C++ | Python | Type-caster pattern, abi3 support |
+| SWIG | C/C++ headers | 30 languages | Interface-file mental model (generated, not edited) |
+| JPype | Java in-process | Python | In-process embedded mode |
+| Py4J | Java subprocess | Python | Subprocess fallback mode |
+| gopy | Go | Python | Type-annotation extraction (but not the cgo embedding) |
+| UniFFI | Rust + UDL | Swift/Kotlin/Python/Ruby | Closed type table |
+| diplomat | Rust source | Swift/JS/Dart | Source-as-IDL discipline |
+
+## What no prior art covers
+
+Three areas where MEP-71 has no template to follow:
+
+1. **Stub-discovery as the type source.** PyO3 / pybind11 / gopy all assume the source language has types and Python doesn't. MEP-71 inherits Mochi's types and Python's types simultaneously; the PEP 561 ladder is novel as a bridge type-source.
+2. **uv-resolver-driven lockfile integration.** MEP-71 piggybacks on uv's PubGrub forking resolver and writes lockfile entries into mochi.lock. No prior bridge does resolver-level lockfile integration with a third-party resolver.
+3. **PEP 740 attestation generation.** PEP 740 is new (PyPI 2024-Q4). PyO3/maturin support trusted publishing for upload but not yet attestation generation. MEP-71 generates attestations as part of the publish flow from the start.
+
+## Cross-references
+
+- [[02-design-philosophy]] for the rationale behind the chosen patterns.
+- [[04-pep561-stub-ingest]] for the stub-discovery pipeline (the novel piece).
+- [[05-type-mapping]] for the closed type table (UniFFI-style).
+- [[06-pypi-publish-flow]] for the maturin-equivalent PEP 517 backend.
+- [[07-sigstore-pypi-trusted-publishing]] for the PEP 740 attestation generation (the other novel piece).

--- a/website/docs/research/0071/04-pep561-stub-ingest.md
+++ b/website/docs/research/0071/04-pep561-stub-ingest.md
@@ -1,0 +1,105 @@
+---
+title: "04. PEP 561 stub ingest"
+sidebar_position: 5
+sidebar_label: "04. PEP 561 stub ingest"
+description: "The PEP 561 four-tier precedence (`py.typed` inline → `<name>-stubs` sibling → typeshed → stubgen fallback), the stubgen inspect mode, the partial-stub story, the typeshed monorepo, the Python-side parser shape, the `.pyi` AST."
+---
+
+# 04. PEP 561 stub ingest
+
+This note covers how MEP-71 discovers the type information that drives the wrapper synthesiser. PEP 561 (published 2017, normative for all of Python's typing ecosystem) defines four channels through which type information reaches a downstream consumer; MEP-71 walks all four in a strict precedence order.
+
+## The PEP 561 four-tier precedence
+
+For each Python package the user imports, the bridge looks for type information in this order, stopping at the first hit:
+
+1. **Inline annotations, gated by `py.typed`.** If the installed package contains a marker file `<package>/py.typed`, the package author has opted in to distributing inline annotations as the canonical types. The bridge parses the `.py` source files directly to extract annotations.
+2. **Sibling stub distribution `<name>-stubs`.** If the user has installed a sibling package whose distribution name is `<name>-stubs` (PEP 561 §5), the stubs in that package shadow any inline annotations. Example: `types-requests` provides stubs for `requests`. Sibling stubs win over inline because they often correct or supplement inline annotations that lag behind reality.
+3. **Typeshed third-party stubs.** Typeshed is a community monorepo at https://github.com/python/typeshed maintaining stubs for ~200 untyped or partially-typed packages. The stubs are versioned and published via the `types-<name>` distributions. The bridge bundles the typeshed snapshot at lock time so the version is reproducible.
+4. **Stubgen fallback.** When none of the above produces a stub, the bridge falls back to mypy's `stubgen --inspect-mode`. Stubgen imports the package live in a sandboxed subprocess and uses `inspect` to read function signatures, class definitions, and method signatures. The output is a best-effort `.pyi` with `Any` where types could not be inferred.
+
+The precedence is intentionally strict: a hit at level 1 (inline `py.typed`) takes the inline annotations exclusively, never falling through to typeshed. This matches pyright's and mypy's resolution order, so type information observed by the bridge is identical to what those tools would see.
+
+Disabling tiers: `[python].stubgen.fallback = false` skips tier 4; missing types become a `SkipReason::NoStubs` and the package is treated as untyped (every item is `any` in Mochi). `[python].typeshed = false` skips tier 3; useful for users who want to enforce that every dep ships its own types.
+
+## Why the precedence is the way it is
+
+The reasoning behind each step:
+
+- **Inline wins over typeshed.** When a package author has added `py.typed`, they have explicitly opted in. Their inline annotations are the ground truth; typeshed's older or third-party-maintained stubs should not override them.
+- **`<name>-stubs` wins over inline.** When inline is wrong (rare but happens, e.g., functions with `*args, **kwargs` that have known concrete signatures), the community publishes a stubs package to correct it. The stubs distribution is the authoritative source.
+- **Typeshed third before stubgen.** Typeshed stubs are hand-written by typing experts. They handle Protocol, TypeVar, ParamSpec, TypeVarTuple, runtime-checkable, and many other typing constructs that stubgen approximates badly.
+- **Stubgen last.** Stubgen is the best-effort fallback. It runs the package; if the package has import-time side effects (network calls, GPU initialisation), stubgen surfaces those in the sandbox log. The result is `Any`-heavy but better than nothing.
+
+## The PEP 561 partial-stub story
+
+A subtle PEP 561 detail: stubs distributions can mark themselves as partial (PEP 561 §6) by including a `partial\n` line in the `py.typed` marker. A partial stubs distribution tells the type checker "I have stubs for the symbols I list; for symbols I don't list, fall through to the next tier."
+
+The bridge respects this: when `<name>-stubs` is marked partial, the bridge unions its symbols with the next tier's (typeshed or stubgen). When unmarked, the stubs distribution is taken as complete and other tiers are skipped for that package.
+
+Partial stubs are common for packages where the typed surface is incomplete (only the most-used classes typed) but the untyped surface still works at runtime.
+
+## The stubgen pipeline
+
+Stubgen runs as a subprocess in the lock-time pipeline:
+
+```
+$ python -m mypy.stubgen --inspect-mode --output-dir <cache> <package>
+```
+
+The `--inspect-mode` flag (added mypy 1.0) tells stubgen to import the package and reflect on it via `inspect.signature`, not just parse the AST. Reflection picks up signatures from C extensions (which have no AST) and from dynamically-defined classes (e.g., `dataclass` and `attrs` generated `__init__`).
+
+Sandboxing: stubgen runs in a venv built specifically for the package. The venv has only the package and its deps installed; nothing of the host's Python environment leaks. Network is denied by default (the bridge spawns stubgen with a no-network seccomp filter on Linux, NetworkExtension on macOS); packages that try to fetch on import surface as a `SkipReason::ImportTimeNetwork`.
+
+Output: stubgen writes `.pyi` files mirroring the package's module structure. The bridge content-addresses these and stores them under `<cache>/python/stubs/<package>/<version>/<stub-hash>/`. The hash goes into mochi.lock as `stub-sha256` for reproducibility.
+
+## The typeshed snapshot
+
+Typeshed is updated continuously. To keep lockfiles reproducible, the bridge pins typeshed to a specific git commit at lock time (recorded in mochi.lock as `typeshed-revision`). On `mochi pkg lock --check`, the same typeshed revision is fetched and the stubs hashes are recomputed.
+
+A `mochi pkg lock --update-typeshed` flag advances to the latest typeshed main, regenerates stubs for any affected packages, and writes new hashes into the lockfile. This is the only path that changes typeshed-derived types across a lock-check cycle.
+
+## The `.pyi` AST
+
+Once a stub source is selected (regardless of tier), the bridge parses it with a stub-specific Python AST walker. The walker understands:
+
+- Function definitions: `def f(x: int, y: str = "...", *args: int, **kwargs: str) -> bool: ...`
+- Overloaded functions: `@overload def f(x: int) -> int: ...` followed by concrete implementations.
+- Classes: `class C(Generic[T]): ...` with method definitions inside.
+- Type aliases: `Vector = list[float]` and PEP 695 `type Vector = list[float]`.
+- Protocols: `class Hashable(Protocol): def __hash__(self) -> int: ...`
+- TypedDict: `class Config(TypedDict): host: str; port: int`
+- NamedTuple: `class Point(NamedTuple): x: int; y: int`
+- Enum / IntEnum / StrEnum: PEP 663 / 663-derived enum bodies.
+- TypeVar / ParamSpec / TypeVarTuple: PEP 484 / 612 / 646.
+- Generic aliases: `list[int]`, `dict[str, int]`, `tuple[int, ...]`.
+
+What the walker explicitly does not handle (refusals):
+
+- `Callable` with `ParamSpec` that has captures from the enclosing scope.
+- Conditional types based on `if sys.version_info >= (3, 12)`. The walker takes the current `requires-python` constraint and evaluates the condition statically; ambiguous cases refuse.
+- `cast`, `assert_type`, `reveal_type`: runtime typing constructs that don't appear in stubs but appear in inline `py.typed` sources. Ignored.
+- Forward references via `if TYPE_CHECKING:`: resolved by importing the type-checking-only branch and re-running the walker.
+
+Refusals emit a `SkipReason::UnsupportedTypingConstruct` and the affected item becomes `any` in the Mochi shim.
+
+## The Python-side parser shape
+
+The bridge is written in Go. The PEP 561 ingest pipeline lives at `package3/python/stubs/`:
+
+- `package3/python/stubs/discovery.go`: walks the four tiers for one package, returns a resolved stub-source path.
+- `package3/python/stubs/typeshed.go`: manages the typeshed git checkout, pins the revision, computes per-package stub hashes.
+- `package3/python/stubs/stubgen.go`: orchestrates the stubgen subprocess, enforces the sandbox, captures stderr for diagnostics.
+- `package3/python/stubs/parser.go`: Go-native `.pyi` parser. We do not call out to Python's ast module because the lockfile pipeline must be reproducible byte-for-byte across Python versions.
+- `package3/python/stubs/apisurface.go`: walks the parsed `.pyi` AST and emits a Mochi-shaped ApiSurface struct (function list, class list, type-alias list).
+
+The ApiSurface struct is the input to the wrapper synthesiser ([[05-type-mapping]]) and to the publish-side stub emitter (for publishing Mochi packages as PEP 561 typed packages on PyPI).
+
+## Cross-references
+
+- [[05-type-mapping]] for how each `.pyi` type becomes a Mochi type.
+- [[02-design-philosophy]] §2 for why PEP 561 is the canonical type source.
+- [[03-prior-art-bridges]] for how other bridges discover types.
+- [PEP 561](https://peps.python.org/pep-0561/) for the normative reference.
+- [Typeshed](https://github.com/python/typeshed) for the third-party stubs monorepo.
+- [mypy stubgen](https://mypy.readthedocs.io/en/stable/stubgen.html) for the fallback tool.

--- a/website/docs/research/0071/05-type-mapping.md
+++ b/website/docs/research/0071/05-type-mapping.md
@@ -1,0 +1,152 @@
+---
+title: "05. Type mapping"
+sidebar_position: 6
+sidebar_label: "05. Type mapping"
+description: "The complete closed translation table between Python types and Mochi types, the refusal cases, the generic resolution rule, the `int` arbitrary precision boundary, `Optional` / `Union` desugar, dataclass / TypedDict / NamedTuple handling, Protocol structural matching, callable arrow types, async iterators."
+---
+
+# 05. Type mapping
+
+This note defines the closed type-mapping table that drives the wrapper synthesiser. The table is closed by design ([[02-design-philosophy]] §7): types inside the table get first-class Mochi treatment; types outside become opaque `PyObject` handles.
+
+## Scalars
+
+| Python | Mochi | Notes |
+|--------|-------|-------|
+| `bool` | `bool` | Bidirectional, no boxing. CPython's `True` / `False` are singletons; the wrapper holds borrowed references. |
+| `int` | `int` if `\|n\| <= sys.maxsize`, else `bigint` | Python `int` is arbitrary precision; Mochi's `int` is 64-bit on 64-bit hosts. The boundary is checked at the wrapper boundary; values outside the range become `bigint` (Mochi's arbitrary-precision integer type from MEP-2 §3.4). |
+| `float` | `float` | IEEE 754 double-precision on both sides. NaN, infinity, and signed-zero round-trip. |
+| `complex` | refused | Python's `complex` has no Mochi counterpart. Becomes opaque `PyObject`. `SkipReason::NoComplexType`. |
+| `str` | `string` | Both UTF-8 internally (Mochi) / UTF-32 internally (CPython); the wrapper converts at the boundary. The wrapper holds a `PyObject*` and decodes lazily on access. |
+| `bytes` | `bytes` | Bidirectional, no decoding. The Mochi `bytes` type is a `[]byte` in the host; the wrapper memcpy's. |
+| `bytearray` | `bytes` (with mutability annotation) | Refused for writeback; treated as a `bytes` copy at the boundary. |
+| `None` | `null` (in `Optional[T]` context); refused as a standalone type | `None` as a return type becomes Mochi `void`; `None` as a parameter type is rejected (Mochi disallows passing `null` as a non-optional value). |
+| `bytes` of fixed size | `bytes` | No fixed-size type in Mochi; size is dynamic. |
+
+The `int` boundary is the only scalar with runtime cost. Most Python `int` values are within `[-2^63, 2^63)` and pass through directly; large ones (cryptography, accounting, bignum math) take the `bigint` path. The wrapper synthesiser does not annotate which call sites might overflow; that information is not in the stubs. Callers that always stay within int64 can opt out of the boxing via `[python].int-mode = "int64-only"` (refuses any return value that would have needed bigint).
+
+## Sequence and mapping collections
+
+| Python | Mochi | Notes |
+|--------|-------|-------|
+| `list[T]` | `list[T']` where `T' = MapType(T)` | Eager. The wrapper iterates the Python list and constructs a Mochi list with each element converted. Round-trip is symmetric. |
+| `tuple[T1, T2, ...]` (fixed) | `(T1', T2', ...)` Mochi tuple | Fixed-arity tuples become Mochi tuples. Element count and types match. |
+| `tuple[T, ...]` (variadic) | `list[T']` | Variadic tuples have no Mochi counterpart; they degrade to list. |
+| `dict[K, V]` | `dict[K', V']` | Eager. The wrapper iterates `.items()` and constructs a Mochi dict. Insertion order is preserved (both CPython 3.7+ and Mochi guarantee this). |
+| `set[T]` | `set[T']` | Eager. The wrapper iterates and constructs. |
+| `frozenset[T]` | `set[T']` | Frozenset becomes regular set; mutability discipline is lost. |
+| `bytes` | covered above | |
+| `range` | `range` (Mochi has it under MEP-2 §5.7) | Iteration semantics match. |
+
+Eager construction is the design choice: every list/dict/tuple is fully materialised at the boundary, never lazily proxied. Reasons:
+
+1. **Lifetime safety.** A lazily proxied list would hold a `PyObject*` borrowed reference; if the Python side mutated the list under the Mochi reference, behaviour would be undefined. Eager copy avoids the question.
+2. **GIL discipline.** Lazy access would require GIL reacquisition on every element access from Mochi. Eager copy acquires GIL once at the boundary.
+3. **Type confidence.** Eager construction is the only place we can verify that every element actually matches `T`; lazy would defer the check to the first access, leaving stale errors.
+
+The cost is wall-clock: passing a 10M-element list across the boundary costs ~50ms. For hot loops, the convention is to pass an opaque `PyObject` handle and call into Python for the iteration, or use the streaming `Iterator[T]` mapping (below).
+
+## Algebraic types
+
+| Python | Mochi | Notes |
+|--------|-------|-------|
+| `Optional[T]` (`T \| None`) | `T'?` (Mochi optional) | First-class. The Mochi `?` suffix represents "value or null". |
+| `Union[T1, T2]` (closed, T1 ≠ T2) | Mochi sum type if both branches are nominal types | Generated as `enum U { T1(T1'), T2(T2') }` plus a destructuring helper. |
+| `Union[T1, T2, ...]` (open or with `Any`) | `any` | Open unions degrade. |
+| `Literal["a", "b"]` | Mochi string literal enum | Maps to `enum { A = "a", B = "b" }` if literal is string; integer literal becomes int enum. |
+| `Literal[1, 2, 3]` | int enum | Same. |
+| `Final[T]` | `T'` (Mochi has no final marker) | Finality is a static-checker concern; the bridge ignores it. |
+| `Annotated[T, ...]` | `T'` (annotations stripped) | The metadata payload is ignored unless it's a Mochi-specific marker (reserved for future). |
+| `Never` / `NoReturn` | `never` | Mochi's bottom type. |
+| `Any` | `any` | Boxed opaque. |
+
+The closed-Union → sum-type translation is the trickiest case: it works only when both branches are themselves nominal Mochi types and they have no overlap. `Union[int, str]` is a closed Union of nominal types; it maps to a Mochi sum. `Union[list[int], list[str]]` is open via subtyping (Mochi's subtype lattice doesn't distinguish list element types at runtime); it degrades to `any`.
+
+## User-defined types
+
+| Python | Mochi | Notes |
+|--------|-------|-------|
+| `@dataclass class C: x: int; y: str = "..."` | Mochi `struct C { x: int, y: string }` | Field order, defaults, and frozen marker are preserved. `__init__` is auto-generated on both sides. |
+| `class C(TypedDict): x: int; y: str` | Mochi `struct C` (same as dataclass) | TypedDict is structural in Python; Mochi treats it nominally for safety. `total=False` becomes optional fields. |
+| `class P(NamedTuple): x: int; y: int` | Mochi `(int, int)` tuple, or struct if names matter | If the tuple is unpacked everywhere, it stays a tuple; if field access is observed, becomes a struct. |
+| `class E(Enum): A = 1; B = 2` | Mochi `enum E { A, B }` | Values map directly. |
+| `class P(Protocol): def f(self, x: int) -> str: ...` | Mochi `interface P { fn f(x: int): string }` | Protocols become Mochi interfaces. Structural matching is preserved. |
+| `class C: ...` (regular class) | opaque `PyObject` handle, methods accessed by name | A regular class becomes a handle. The wrapper synthesises `extern fn` declarations for each method. |
+| `class C(BaseException): ...` | Mochi `error C` | Exception classes become Mochi error types. |
+| `@runtime_checkable Protocol` | Mochi `interface` with `isinstance`-style narrowing | A runtime-checkable Protocol generates a Mochi predicate. |
+
+The dataclass case is the most common (numpy.dtype, pydantic.BaseModel via dataclass-like behaviour, FastAPI request models). The TypedDict case is the second most common (JSON API surfaces). Both map cleanly.
+
+The regular-class fallback is intentional: not every Python class deserves a Mochi struct. A pydantic.BaseModel with validators and computed properties has behaviour that a Mochi struct cannot represent. The opaque-handle path is the safe default; the user can opt in to struct conversion by annotating the class with a Mochi-side hint.
+
+## Callable types
+
+| Python | Mochi | Notes |
+|--------|-------|-------|
+| `Callable[[T1, T2], R]` | Mochi arrow `fn(T1', T2') -> R'` | Closed types. |
+| `Callable[..., R]` | Mochi `any` (callable but untyped) | Variadic, ignored. |
+| `Callable[P, R]` with `ParamSpec` | refused | ParamSpec is too dynamic for the closed table. |
+| `Coroutine[Y, S, R]` | Mochi `async fn() -> R'` | Y and S are typically ignored (yields and sends are coroutine-internal). |
+| `Awaitable[R]` | Mochi `async fn() -> R'` | Same as Coroutine. |
+| `Generator[Y, S, R]` | Mochi `Iterator[Y']` (S and R discarded) | The send and return values of a generator are not first-class in Mochi. |
+| `AsyncGenerator[Y, S]` | Mochi `AsyncIterator[Y']` | Same. |
+| `Iterator[T]` | Mochi `Iterator[T']` | First-class. The wrapper holds a Python iterator and exposes `next()`. |
+| `Iterable[T]` | Mochi `Iterable[T']` | Same; `iter()` is called once at the boundary. |
+| `AsyncIterator[T]` | Mochi `AsyncIterator[T']` | First-class. |
+
+Callable round-trip: a Mochi function passed to Python becomes a Python callable that releases the GIL and re-enters Mochi. A Python callable returned to Mochi becomes a Mochi arrow that acquires the GIL and re-enters Python. The wrapper handles both directions symmetrically.
+
+## Generic resolution rule
+
+Python generics are erased at runtime. Mochi's are monomorphised. The bridge has to bridge these:
+
+- **Generic alias instantiations**: `list[int]`, `dict[str, int]`, `Optional[User]` are concrete; they map directly using the table.
+- **Type variables in function signatures**: `def first(xs: list[T]) -> T:` is a generic Python function. The bridge emits a Mochi generic function `fn first[T](xs: list[T]) -> T` and trusts Python's runtime polymorphism at the call site.
+- **Generic classes**: `class Container(Generic[T]): ...` becomes a Mochi `struct Container[T]`. Instantiation happens at the call site.
+- **Higher-kinded types**: not in Python's typing system; not in Mochi's; no translation needed.
+
+The generic functions delegate to Python's untyped runtime polymorphism. There is no monomorphisation of Python deps (unlike MEP-73's Rust deps where every generic instantiation gets its own wrapper). Reason: Python generics are pure type hints; the runtime behaviour is the same regardless of T. We can pass `T = User` or `T = int` to the same Python function and get a result back; the wrapper's only job is to translate the boundary types.
+
+## The refusal table
+
+When a Python type cannot map, the bridge emits a `SkipReason` and the item becomes `any` in the Mochi shim. The user can still call the function; the return type and argument types are dynamic.
+
+| Reason | Python construct |
+|--------|------------------|
+| `SkipReason::NoComplexType` | `complex` |
+| `SkipReason::OpenUnion` | `Union[A, B, ...]` where one branch is `Any` or subtype-overlapping |
+| `SkipReason::ParamSpec` | `Callable[P, R]` with `ParamSpec` |
+| `SkipReason::TypeVarTuple` | `tuple[*Ts]` |
+| `SkipReason::ForwardRef` | Unresolvable forward reference |
+| `SkipReason::UnsupportedTypingConstruct` | `cast`, `assert_type`, `reveal_type`, etc. (these should not appear in stubs but sometimes do in inline) |
+| `SkipReason::CFunctionWithoutStubs` | C extension function with no `.pyi`; signature is `(*args, **kwargs)` |
+| `SkipReason::OverloadAmbiguity` | `@overload` set where the closed table cannot pick a single arm |
+
+## The PyObject opaque handle
+
+When no other mapping applies, the value becomes an opaque `PyObject` handle. From Mochi:
+
+```mochi
+import python "requests" as requests
+
+fn main() {
+    let session = requests.Session()   // returns PyObject handle
+    let resp = session.get(url)         // method call on handle
+    let body = resp.json()              // dict[str, any] (typed by stubs)
+    let close_method = session.close    // PyObject handle (callable)
+    close_method()                       // invoke
+}
+```
+
+The handle is reference-counted: a Mochi variable holds a CPython `PyObject*` with refcount incremented. When the Mochi variable goes out of scope (Mochi's escape analysis or GC), the wrapper decrements. The wrapper acquires the GIL for the decrement.
+
+The handle is opaque: Mochi cannot inspect fields, call methods other than through synthesised `extern fn`, or pattern-match. The handle is movable across function boundaries inside Mochi.
+
+## Cross-references
+
+- [[02-design-philosophy]] §7 for why the table is closed.
+- [[04-pep561-stub-ingest]] for how the type information is sourced.
+- [[10-gil-and-cextensions]] for the GIL handling on every conversion.
+- [MEP-71 §6](/docs/mep/mep-0071) for the normative type table.
+- [MEP-2](/docs/mep/mep-0002) for Mochi's scalar and collection types.
+- [PEP 484](https://peps.python.org/pep-0484/) and [PEP 526](https://peps.python.org/pep-0526/) for Python typing.

--- a/website/docs/research/0071/06-pypi-publish-flow.md
+++ b/website/docs/research/0071/06-pypi-publish-flow.md
@@ -1,0 +1,186 @@
+---
+title: "06. PyPI publish flow"
+sidebar_position: 7
+sidebar_label: "06. PyPI publish flow"
+description: "The PyPI upload protocol (PEP 700 JSON, PEP 691 JSON simple, PEP 503 HTML simple), the per-package metadata requirements (PEP 621 / 643 core metadata 2.4), the sdist / wheel format (PEP 517 / 518 / 425 / 600 / 656), the `mochi-build` PEP 517 backend, the publish-side gate."
+---
+
+# 06. PyPI publish flow
+
+This note covers the publish direction: how a Mochi package becomes an installable PyPI distribution. The publish flow is built on PEP 517 (build-system contract), PEP 621 (project metadata), PEP 425 / 600 / 656 (wheel compatibility tags), PEP 503 / 691 / 700 (index protocols), and PEP 740 (attestations).
+
+## The build chain at a glance
+
+```
+Mochi source
+  │
+  ▼
+Driver.Build(target=TargetPythonPackage, LibraryMode=true)
+  │
+  ▼
+mochi-build PEP 517 backend
+  ├── build_sdist()   → mochi-pkg-1.2.3.tar.gz
+  └── build_wheel()   → mochi_pkg-1.2.3-cp312-abi3-manylinux_2_28_x86_64.whl
+  │
+  ▼
+Sigstore: cosign sigstore-keyless OIDC flow
+  │
+  ▼
+PEP 740 attestation bundle
+  │
+  ▼
+PyPI Trusted Publishing upload (HTTP POST to /legacy/)
+  │
+  ▼
+Index visible at https://pypi.org/simple/<dist>/
+```
+
+The two artifacts produced are an sdist (source distribution, a tarball of the source tree) and one or more wheels (binary distributions, zip files with a specific layout). PyPI accepts both.
+
+## The PEP 517 backend
+
+PEP 517 defines an interface between a frontend (pip, uv, build) and a backend (the per-project build tool). The backend is named in `pyproject.toml`:
+
+```toml
+[build-system]
+requires = ["mochi-build>=0.1"]
+build-backend = "mochi_build.backend"
+```
+
+The backend exposes (at minimum) two hooks:
+
+- `build_sdist(sdist_directory, config_settings=None) -> str` returns the name of the sdist tarball.
+- `build_wheel(wheel_directory, config_settings=None, metadata_directory=None) -> str` returns the name of the wheel file.
+
+PEP 660 added an editable-install hook (`build_editable`) that Mochi's backend also implements. PEP 643 / 660 / 662 govern the metadata and editable-install discipline.
+
+The `mochi_build.backend` module is a small Python shim that subprocesses out to `mochi pkg build --backend-mode`. Mochi does the work in Go; the Python shim merely satisfies the PEP 517 contract.
+
+## sdist format
+
+An sdist is a gzipped tar archive containing:
+
+```
+<dist>-<version>/
+  pyproject.toml          # PEP 517 build-system declaration
+  PKG-INFO                # core metadata 2.4 (PEP 643 / PEP 621)
+  <source files>          # the Mochi source tree
+  <mochi.toml>            # project manifest
+  <mochi.lock>            # dep lockfile
+```
+
+The PKG-INFO file holds the core metadata in RFC 822-style:
+
+```
+Metadata-Version: 2.4
+Name: mochi-pkg-foo
+Version: 1.2.3
+Summary: A Mochi-authored utility package.
+Author-email: Foo Bar <foo@example.com>
+License-Expression: MIT
+Requires-Python: >=3.12,<3.15
+Requires-Dist: numpy>=2.0
+Requires-Dist: pydantic>=2.5
+Classifier: Programming Language :: Python :: 3
+Project-URL: Source, https://github.com/foo/mochi-pkg-foo
+```
+
+The metadata is generated from `[python.publish]` in the project's mochi.toml, plus the deps from `[python-dependencies]`. PEP 643 mandates the metadata be static (no setup.py code execution); the Mochi backend complies by reading mochi.toml at build time and writing the metadata.
+
+The sdist is the universal fallback: when no wheel matches the target platform, pip installs from sdist by running the PEP 517 backend on the user's machine. Mochi-built packages always ship sdist so that a Mochi-authored package can be installed on platforms where no prebuilt wheel exists.
+
+## Wheel format
+
+A wheel is a zip archive with a specific layout (PEP 427, normative now via PEP 491):
+
+```
+mochi_pkg-1.2.3-cp312-abi3-manylinux_2_28_x86_64.whl
+  ├── mochi_pkg/                   # the importable package
+  │     ├── __init__.py
+  │     ├── _native.cpython-312-x86_64-linux-gnu.so   # compiled extension
+  │     ├── py.typed                # PEP 561 marker
+  │     └── _mochi_wrap.pyi         # synthesised stubs
+  └── mochi_pkg-1.2.3.dist-info/
+        ├── METADATA              # core metadata (same as PKG-INFO)
+        ├── WHEEL                 # wheel metadata (tags, generator)
+        ├── RECORD                # SHA256 of every file
+        ├── entry_points.txt      # PEP 517 entry points
+        └── attestations.json     # PEP 740 attestations (added 2024-Q4)
+```
+
+The wheel filename encodes the compatibility tag: `<dist>-<version>-<python_tag>-<abi_tag>-<platform_tag>.whl`. For Mochi packages:
+
+- **Pure-Python wraps** (Mochi compiled to Python source, no native ext): `py3-none-any`. Installable everywhere.
+- **abi3 native wraps** (Mochi compiled to native ext using the limited API): `cp312-abi3-<platform>`. Installable on CPython 3.12, 3.13, 3.14, ... on the matching platform.
+- **Per-minor native wraps** (full CPython API): `cp312-cp312-<platform>`. Installable only on CPython 3.12 on the matching platform.
+
+The platform tag follows PEP 600 (manylinux), PEP 656 (musllinux), or platform-specific conventions (`macosx_11_0_arm64`, `win_amd64`).
+
+## Wheel compatibility tags in depth
+
+The compatibility tags determine which platforms can install the wheel.
+
+**Python tag** (`py3`, `cp312`, `cp313`, `pp310`): identifies the interpreter implementation and version. `py3` is the generic Python 3 tag (no implementation-specific features); `cp312` is CPython 3.12 specifically.
+
+**ABI tag** (`none`, `abi3`, `cp312`, `cp313t`):
+- `none`: no ABI dependency. Pure-Python or pure-bytecode.
+- `abi3`: the limited API (PEP 384), stable across CPython minor versions.
+- `cp312`: the full CPython 3.12 API and ABI.
+- `cp313t`: the free-threaded CPython 3.13 ABI (PEP 779 / 803). Distinct from `cp313` because the structure of `PyObject` differs.
+
+**Platform tag** (`any`, `manylinux_2_28_x86_64`, `musllinux_1_2_x86_64`, `macosx_11_0_arm64`, `win_amd64`):
+- `any`: no platform dependency. Pure-Python.
+- `manylinux_X_Y_<arch>`: Linux with glibc >= X.Y on the given architecture (PEP 600).
+- `musllinux_X_Y_<arch>`: Linux with musl libc >= X.Y (PEP 656).
+- `macosx_X_Y_<arch>`: macOS X.Y on the given architecture.
+- `win_amd64`, `win32`, `win_arm64`: Windows on the given architecture.
+
+The Mochi backend computes the right combination based on `[python.publish]` configuration and the actual compiled artifacts. auditwheel-equivalent validation runs on Linux wheels to verify the manylinux symbol-version requirements are satisfied.
+
+## The PyPI upload protocol
+
+PyPI's upload endpoint is `https://upload.pypi.org/legacy/`. The endpoint accepts a multipart POST with:
+
+- The file (sdist tarball or wheel zip).
+- The metadata fields (Name, Version, Author, etc.) as form fields.
+- Authentication: legacy API token (deprecated) or Trusted Publishing OIDC token (the only path Mochi supports).
+- PEP 740 attestation bundle as an attached attestations field.
+
+The upload is atomic: either the file is published or the upload errors. Re-uploading the same `(name, version, filename)` triple is rejected (PEP 427 §Yanking notwithstanding). Yanking is a separate operation.
+
+After upload, the file appears in three indexes:
+
+- **PEP 503 HTML simple index**: `https://pypi.org/simple/<dist>/`. The historical legacy format, an HTML page listing every uploaded file with its hash.
+- **PEP 691 JSON simple index**: `https://pypi.org/simple/<dist>/` with `Accept: application/vnd.pypi.simple.v1+json`. The modern JSON format with hashes, yanked status, and PEP 700 metadata side-channel.
+- **PEP 700 metadata side-channel**: per-file `.metadata` URL serving the file's METADATA without downloading the full wheel.
+
+uv and modern pip query the JSON simple index by default; legacy pip queries the HTML simple index.
+
+## The publish-side gate
+
+Before upload, the Mochi backend runs a series of checks:
+
+1. **Metadata completeness.** Name, Version, Author-email, Description, Requires-Python are required. Missing fields fail with a diagnostic.
+2. **License expression validity.** PEP 639 SPDX expression. Required since PyPI 2025-Q2.
+3. **Wheel platform tag accuracy.** auditwheel-equivalent check: the wheel's declared platform tag must match the symbols its native ext requires.
+4. **abi3 verification.** When `abi3 = true`, the native ext must reference only symbols in the limited API. The backend runs `nm -D` (Linux) or equivalent and checks against the PEP 384 allowed-symbol list.
+5. **Capability declaration.** The Mochi runtime's reachable capability set must be a subset of `[python.capabilities]`. Same gate as the consume direction.
+6. **Signature.** The Sigstore-keyless OIDC flow must succeed. The Fulcio cert, Rekor log entry, and PEP 740 attestation bundle are generated.
+
+Any failure aborts the upload. The diagnostic surface names the specific check that failed.
+
+## Yanking and post-publish operations
+
+PyPI supports yanking a release (PEP 592): the file remains available for pinned installs but is not selected by version resolvers. The Mochi backend exposes `mochi pkg yank --version=1.2.3 --reason="security fix incoming"` which calls PyPI's yank endpoint.
+
+Deletion is not supported by PyPI (immutability of published artifacts is a deliberate PyPI policy). The only path is to release a new version. The Mochi CLI surface does not include a delete operation.
+
+## Cross-references
+
+- [[07-sigstore-pypi-trusted-publishing]] for the OIDC and attestation flow.
+- [[09-abi-stability]] for the wheel compatibility tag deep dive.
+- [[02-design-philosophy]] §5 for why Trusted Publishing is the only path.
+- [PEP 517](https://peps.python.org/pep-0517/), [PEP 621](https://peps.python.org/pep-0621/), [PEP 643](https://peps.python.org/pep-0643/) for the build system and metadata.
+- [PEP 425](https://peps.python.org/pep-0425/), [PEP 600](https://peps.python.org/pep-0600/), [PEP 656](https://peps.python.org/pep-0656/) for compatibility tags.
+- [PEP 503](https://peps.python.org/pep-0503/), [PEP 691](https://peps.python.org/pep-0691/), [PEP 700](https://peps.python.org/pep-0700/) for the index protocols.
+- [PEP 740](https://peps.python.org/pep-0740/) for attestations.

--- a/website/docs/research/0071/07-sigstore-pypi-trusted-publishing.md
+++ b/website/docs/research/0071/07-sigstore-pypi-trusted-publishing.md
@@ -1,0 +1,222 @@
+---
+title: "07. Sigstore and PyPI Trusted Publishing"
+sidebar_position: 8
+sidebar_label: "07. Sigstore + Trusted Publishing"
+description: "The OIDC token exchange, the Fulcio short-lived cert, the Rekor transparency log, PEP 740 attestations, the verification path at install time, the PyPI Trusted Publishing GA timeline (GitHub Actions 2023-Q2, GitLab CI / Google Cloud / ActiveState 2024)."
+---
+
+# 07. Sigstore and PyPI Trusted Publishing
+
+This note covers the supply-chain story for the publish direction. The goal: every Mochi-published package on PyPI has provable provenance, no static long-lived secrets are involved at any point, and consumers can verify the signature at install time.
+
+## The supply-chain pressure that drove this
+
+PyPI has been a continuous target for supply-chain attacks. 2024-2025 incidents include:
+
+- **The Top.gg colorama campaign (2024)**: typosquatted `colorama` packages with stealthy info-stealer payloads downloaded millions of times.
+- **The fluentd-py wave (2024)**: a sequence of typosquats targeting infrastructure tooling.
+- **The PyTorch dependency-confusion incident (Dec 2022, retrospectively documented)**: a transitive dep was hijacked via name-collision on the public index.
+
+The common factor: unsigned, untraceable uploads. There was no cryptographic record of which CI run produced which file, no transparency log, and no way for downstream consumers to verify provenance.
+
+PyPI's response was Trusted Publishing (GA 2023-Q2) plus PEP 740 attestations (GA 2024-Q4). Trusted Publishing eliminates static API tokens; PEP 740 attaches Sigstore-signed attestations to each release. The combination gives every release a verifiable build origin.
+
+## Trusted Publishing: the OIDC dance
+
+The Trusted Publishing flow replaces API tokens with short-lived credentials minted from an OIDC token. The flow:
+
+```
+┌──────────────────┐                ┌──────────────────┐                ┌──────────────────┐
+│  CI Workflow     │                │  OIDC Issuer     │                │  PyPI            │
+│  (GitHub Actions)│                │  (GitHub token   │                │                  │
+│                  │                │   endpoint)      │                │                  │
+└────────┬─────────┘                └────────┬─────────┘                └────────┬─────────┘
+         │                                   │                                   │
+         │ 1. request OIDC token             │                                   │
+         │   (audience: pypi)                │                                   │
+         ├──────────────────────────────────►│                                   │
+         │                                   │                                   │
+         │ 2. JWT (id, repo, sha, etc.)      │                                   │
+         │◄──────────────────────────────────┤                                   │
+         │                                   │                                   │
+         │ 3. POST /_/oidc/mint-token        │                                   │
+         │    Authorization: bearer <JWT>    │                                   │
+         ├───────────────────────────────────────────────────────────────────────►
+         │                                   │                                   │
+         │ 4. Short-lived upload token       │                                   │
+         │   (valid ~15 min)                 │                                   │
+         │◄───────────────────────────────────────────────────────────────────────
+         │                                   │                                   │
+         │ 5. POST /legacy/ <wheel + token>  │                                   │
+         ├───────────────────────────────────────────────────────────────────────►
+         │                                   │                                   │
+         │ 6. 200 OK                         │                                   │
+         │◄───────────────────────────────────────────────────────────────────────
+```
+
+The OIDC JWT issued in step 2 claims (per the GitHub OIDC schema):
+
+- `iss`: `https://token.actions.githubusercontent.com`
+- `sub`: `repo:foo/mochi-pkg-foo:ref:refs/heads/main`
+- `aud`: `pypi`
+- `repository`: `foo/mochi-pkg-foo`
+- `repository_id`: `12345`
+- `repository_owner`: `foo`
+- `workflow`: `release`
+- `sha`: `abcd1234...`
+- `actor`: `foouser`
+- `runner_environment`: `github-hosted`
+- `event_name`: `release`
+
+PyPI's `_/oidc/mint-token` endpoint validates the JWT signature against the issuer's JWKS, then checks the claims against the package's configured Trusted Publishers. The package owner has previously registered (via the PyPI web UI):
+
+- Issuer: `https://token.actions.githubusercontent.com`
+- Repository: `foo/mochi-pkg-foo`
+- Workflow filename: `release.yml`
+- Environment (optional): `production`
+
+If the JWT's claims match the registered Trusted Publisher, PyPI mints an upload token (valid ~15 minutes, scoped to the specific package + version being uploaded) and returns it.
+
+Step 5's POST uses the upload token in the standard `Authorization: Basic` legacy upload protocol. The wheel is uploaded.
+
+## The supported OIDC issuers
+
+PyPI accepts Trusted Publishing tokens from:
+
+- **GitHub Actions** (GA 2023-Q2): `https://token.actions.githubusercontent.com`
+- **GitLab CI/CD** (GA 2024): `https://gitlab.com` and self-hosted GitLab instances
+- **Google Cloud** (GA 2024): `https://accounts.google.com`
+- **ActiveState** (GA 2024): `https://platform.activestate.com/api/v1/oauth/oidc`
+
+The Mochi CLI auto-detects the OIDC issuer by checking environment variables (`GITHUB_ACTIONS=true`, `GITLAB_CI=true`, etc.) and uses the appropriate token endpoint. The user does not configure the issuer; the CI environment determines it.
+
+When no supported issuer is detected, the publish flow refuses with a diagnostic pointing at the configuration page. There is no fallback to legacy tokens.
+
+## Sigstore: the keyless signing flow
+
+PEP 740 attestations are signed via Sigstore-keyless: the signing key is ephemeral, minted from the same OIDC token, and bound to a short-lived X.509 certificate from Fulcio (Sigstore's CA). The certificate's notBefore / notAfter window is ~10 minutes; after the signature is generated, the key material is discarded.
+
+```
+┌──────────────────┐                ┌──────────────────┐                ┌──────────────────┐
+│  Mochi CI runner │                │  Fulcio (CA)     │                │  Rekor (transp.  │
+│                  │                │                  │                │   log)           │
+└────────┬─────────┘                └────────┬─────────┘                └────────┬─────────┘
+         │                                   │                                   │
+         │ 1. Generate ephemeral keypair     │                                   │
+         │                                   │                                   │
+         │ 2. POST /api/v2/signingCert       │                                   │
+         │    OIDC JWT + CSR (pub key)       │                                   │
+         ├──────────────────────────────────►│                                   │
+         │                                   │                                   │
+         │ 3. X.509 cert (10 min validity,   │                                   │
+         │    SANs: repo + workflow)         │                                   │
+         │◄──────────────────────────────────┤                                   │
+         │                                   │                                   │
+         │ 4. Sign each wheel + attestation  │                                   │
+         │    bundle with ephemeral key      │                                   │
+         │                                   │                                   │
+         │ 5. POST /api/v1/log/entries       │                                   │
+         │    signed entry (cert + sig)      │                                   │
+         ├───────────────────────────────────────────────────────────────────────►
+         │                                   │                                   │
+         │ 6. Inclusion proof + log index    │                                   │
+         │◄───────────────────────────────────────────────────────────────────────
+         │                                   │                                   │
+         │ 7. Bundle: cert + sig + proof +   │                                   │
+         │    log index                      │                                   │
+         │                                   │                                   │
+```
+
+The Rekor log entry is the public transparency record. Any third party can query Rekor (`https://rekor.sigstore.dev/api/v1/log/entries?logIndex=N`) and verify the entry exists. Sigstore's design relies on the log's append-only property: once an entry is logged, an attacker cannot retroactively forge a signature.
+
+## PEP 740 attestations
+
+PEP 740 defines the attestation format embedded in the wheel's dist-info:
+
+```
+mochi_pkg-1.2.3.dist-info/attestations.json
+```
+
+The file contains a list of in-toto attestation envelopes. Each envelope has:
+
+- `payloadType`: `application/vnd.in-toto+json`
+- `payload`: base64-encoded in-toto Statement
+- `signatures`: list of `{ keyid, sig }`
+
+The in-toto Statement has:
+
+- `_type`: `https://in-toto.io/Statement/v1`
+- `subject`: the artifacts (wheel filename + SHA256)
+- `predicateType`: `https://docs.pypi.org/attestations/publish/v1`
+- `predicate`: the build provenance (repo, commit, workflow, etc.)
+
+The predicate matches the OIDC JWT claims that minted the certificate. Consumers can verify:
+
+1. The certificate chains to Fulcio's root.
+2. The certificate's SAN matches the repo/workflow that produced the wheel.
+3. The Rekor inclusion proof is valid.
+4. The signature over the wheel's SHA256 is valid.
+5. The OIDC issuer matches the package's configured Trusted Publisher.
+
+If all checks pass, the wheel is provably built by the registered CI workflow.
+
+## Verification at install time
+
+uv (and pip with `--require-attestations` planned 2025-Q3) verify attestations at install time:
+
+```
+$ uv pip install mochi-pkg-foo --require-attestations
+Resolving mochi-pkg-foo>=1.0 ...
+Downloading mochi_pkg_foo-1.2.3-py3-none-any.whl ...
+Verifying attestation: cert valid, Rekor proof valid, signature valid.
+Trusted publisher: GitHub Actions, repo foo/mochi-pkg-foo, workflow release.yml, sha abcd1234.
+Installed mochi-pkg-foo 1.2.3
+```
+
+The Mochi-side equivalent runs the same verification when `mochi pkg lock` downloads the wheel. The verification result is recorded in mochi.lock as `attestation-provenance` so `mochi pkg lock --check` can re-verify.
+
+When attestations are missing, the install proceeds with a warning. When attestations fail (cert expired in the Rekor log post-revocation, signature mismatch), the install aborts with a diagnostic.
+
+## Cosign integration
+
+The Sigstore-side tooling is `cosign` (the canonical CLI) and `sigstore-python` (the Python library). Mochi's publish path embeds the sigstore-python library; it does not shell out to the cosign CLI. Reasons:
+
+- Sigstore-python is the reference implementation maintained by the Sigstore project and the PyPI authors.
+- Embedding avoids a runtime dependency on a separate binary.
+- The Python library exposes the in-toto envelope format directly, which is what PEP 740 expects.
+
+## The PyPI Trusted Publishing timeline
+
+| Date | Event |
+|------|-------|
+| 2023-Q2 | Trusted Publishing GA for GitHub Actions. |
+| 2023-Q4 | Initial PEP 740 draft circulated. |
+| 2024-Q1 | Trusted Publishing expanded to GitLab CI/CD. |
+| 2024-Q2 | Trusted Publishing expanded to Google Cloud and ActiveState. |
+| 2024-Q4 | PEP 740 GA: PyPI accepts and serves attestations. |
+| 2025-Q3 | uv enables `--require-attestations` for default verification. (Planned.) |
+| 2026-Q1 | Pip enables attestation verification by default. (Planned per the typing community SC notes.) |
+
+MEP-71 ships with attestation generation enabled by default from day one. The verification side runs when consuming any PyPI package that ships attestations.
+
+## Edge cases and refusals
+
+| Case | Behaviour |
+|------|-----------|
+| Self-hosted GitHub Enterprise runners | Supported via custom OIDC issuer URL configuration. |
+| Self-hosted runners with no OIDC issuer | Publish refused with `M071_PUBLISH_E001_NoOIDC`. |
+| Fulcio cert expired before Rekor log entry | Sign retries once; if still failing, abort. |
+| Rekor down | Sign retries with exponential backoff up to 3 attempts; if still failing, abort. |
+| OIDC token replay (same token reused) | PyPI rejects with `409 Conflict`. The Mochi CLI surfaces a diagnostic suggesting to re-run the workflow. |
+| PyPI registered Trusted Publisher mismatch | Mint-token endpoint returns `403`; Mochi surfaces the configured publisher vs the JWT claims. |
+| Private PyPI mirror without OIDC | Publish to private index is a separate code path that Mochi-71 does not enable; the public PyPI path is OIDC-only. |
+
+## Cross-references
+
+- [[02-design-philosophy]] §5 for why this is the only path.
+- [[06-pypi-publish-flow]] for the upload protocol context.
+- [[12-risks-and-alternatives]] §R7 for the OIDC-issuer-downtime risk.
+- [PEP 740](https://peps.python.org/pep-0740/) for attestations.
+- [PyPI Trusted Publishing docs](https://docs.pypi.org/trusted-publishers/).
+- [Sigstore docs](https://docs.sigstore.dev/).
+- [in-toto attestation spec](https://github.com/in-toto/attestation).

--- a/website/docs/research/0071/08-async-bridge.md
+++ b/website/docs/research/0071/08-async-bridge.md
@@ -1,0 +1,196 @@
+---
+title: "08. Async bridge"
+sidebar_position: 9
+sidebar_label: "08. Async bridge"
+description: "The asyncio event-loop model, the per-call `asyncio.run` default, the persistent event-loop opt-in, the cross-loop hazard, the `await` ceremony, cancellation and timeout semantics, the uvloop / trio incompatibility surface, mapping Mochi `async fn` to Python `async def` in both directions."
+---
+
+# 08. Async bridge
+
+This note covers the async bridge between Mochi (which has `async fn` from MEP-13) and Python (which has `async def` plus `asyncio`). Async is the hardest cross-language concern in the bridge because both languages have first-class concurrency models that do not naturally compose.
+
+## The asyncio model
+
+Python's `asyncio` runs coroutines on an event loop:
+
+```python
+async def fetch(url):
+    async with httpx.AsyncClient() as client:
+        return await client.get(url)
+
+asyncio.run(fetch("https://example.com"))
+```
+
+`asyncio.run` does the following:
+
+1. Creates a new event loop (`asyncio.new_event_loop()`).
+2. Sets it as the current loop (`asyncio.set_event_loop(loop)`).
+3. Runs the coroutine to completion (`loop.run_until_complete(coro)`).
+4. Cancels all remaining tasks, runs the loop until they finish.
+5. Closes the loop (`loop.close()`).
+6. Resets the current loop to None.
+
+The cost is ~0.5-1ms on a warm interpreter; the cost on a cold interpreter (first call) is closer to 5-10ms because of `asyncio` module import.
+
+The alternative is to keep a loop alive across calls and `run_coroutine_threadsafe` onto it from outside. This avoids the per-call setup cost but introduces shared mutable state (the running loop) with all the lifetime hazards that entails.
+
+## The MEP-71 choice: per-call by default, persistent opt-in
+
+The bridge defaults to per-call `asyncio.run`:
+
+```mochi
+import python "httpx" as httpx
+
+async fn fetch(url: string): string {
+    let client = httpx.AsyncClient()    // Mochi value, Python AsyncClient handle
+    let resp = await client.get(url)     // Each await crosses the boundary
+    return resp.text                     // Mochi string
+}
+```
+
+Under the hood, the synthesised wrapper translates each `await client.get(url)` into:
+
+```python
+def _bridge_get(client_handle, url):
+    coro = client_handle.get(url)
+    return asyncio.run(coro)
+```
+
+The Mochi-side `await` is the Mochi runtime suspending until the wrapper returns; the Python side runs the coroutine to completion synchronously. Each Mochi `await` is one full asyncio.run cycle.
+
+To enable persistent mode:
+
+```toml
+[python]
+async-mode = "persistent"
+```
+
+In persistent mode, a singleton event loop is created on first use and kept alive on a dedicated Python thread. Mochi `await` translates to `asyncio.run_coroutine_threadsafe(coro, _PERSISTENT_LOOP).result()`. Subsequent calls reuse the loop; cost amortises.
+
+## The cross-loop hazard
+
+The persistent-mode hazard: Python objects bound to a specific event loop (Future, Task, AsyncIterator, AsyncContextManager) can only be awaited on that loop. If a Mochi function captures such an object and passes it to another Mochi function running on a different loop, behaviour is undefined.
+
+Per-call mode avoids the hazard by construction: every loop is created and destroyed in the same call, so capturing a loop-bound object outside that call gives a stale reference that the next call's wrapper detects and rejects.
+
+Persistent mode has the hazard. The bridge mitigates by:
+
+1. **One singleton loop per Mochi process.** Persistent mode does not create multiple loops; the single loop is the only loop.
+2. **Capturing loop-bound objects is explicit.** Returning a Future, Task, or AsyncIterator from a Python call requires the caller to hold the result as a `PyObject` handle; the wrapper does not auto-convert.
+3. **Re-entrancy detection.** If a Mochi await is in flight on the persistent loop and the inner Python code tries to await a Mochi callback that itself awaits the persistent loop, the wrapper detects the cycle and refuses.
+
+## Mochi callbacks into Python async
+
+The opposite direction: a Mochi `async fn` is passed to Python as a callable, and Python awaits it.
+
+```mochi
+import python "asyncio" as asyncio
+
+async fn worker(item: int): int {
+    let result = compute(item)
+    return result
+}
+
+async fn main() {
+    let items = [1, 2, 3, 4, 5]
+    let coros = items.map(worker)         // [Coroutine[int], ...] in Python
+    let results = await asyncio.gather(*coros)
+    return results.sum()
+}
+```
+
+The Mochi `async fn worker` becomes a Python `async def` wrapper that awaits the Mochi runtime. The wrapper:
+
+```python
+async def _bridge_worker(item):
+    return await _MOCHI_RUNTIME.await_async(worker_handle, item)
+```
+
+`_MOCHI_RUNTIME.await_async` is a Python coroutine that suspends until the Mochi runtime signals completion of the Mochi-side `worker`. The mechanism uses a `loop.create_future()` + `loop.call_soon_threadsafe` pattern: the Mochi runtime invokes the future's set_result from a Mochi thread, and asyncio resumes the Python coroutine.
+
+This works under both per-call and persistent modes. Under per-call mode, the Python `asyncio.run` calls the wrapped Mochi callback, which suspends Python, runs Mochi work on a separate runtime, and resumes Python when done. Under persistent mode, the same pattern works on the singleton loop.
+
+## Cancellation
+
+asyncio cancellation propagates via `CancelledError`. When the Mochi side cancels an `await` (e.g., via `select` from MEP-13), the wrapper must propagate that cancellation into the Python coroutine.
+
+Per-call mode: cancellation happens by signaling the running `asyncio.run`. The wrapper installs a cancel handler on the loop and triggers `task.cancel()` when Mochi cancels.
+
+Persistent mode: cancellation is sent via `loop.call_soon_threadsafe(task.cancel)`. The Python coroutine receives `CancelledError`. The Mochi side waits for the wrapper to return (which it does after cancellation is processed) before treating the Mochi `await` as cancelled.
+
+Edge case: a Python coroutine that catches `CancelledError` and continues running. The wrapper does not force-kill; cancellation is cooperative. Mochi's runtime times out after `[python].async-cancel-timeout` (default 30s) and treats the call as failed.
+
+## Timeouts
+
+Mochi's `await` accepts a timeout (MEP-13 §3.3). The bridge translates this to `asyncio.wait_for(coro, timeout=t)`. If the timeout fires, Python raises `asyncio.TimeoutError`, which the wrapper coerces to Mochi's `Error::Timeout`.
+
+Persistent mode reuses the same `wait_for` pattern; the timeout is per-call, not per-loop.
+
+## The uvloop / trio question
+
+Python has alternative event-loop implementations:
+
+- **uvloop**: a libuv-based replacement for asyncio's selector_events loop. 2-4x faster, drop-in compatible. Users opt in via `uvloop.install()`.
+- **trio**: a structured-concurrency runtime with a different cancellation model. Not asyncio-compatible.
+- **anyio**: a compatibility layer over asyncio + trio. Allows code to run on either.
+
+MEP-71's stance:
+
+- **uvloop**: works transparently. If the user's Python deps include `uvloop` and the user calls `uvloop.install()` before the bridge's first `asyncio.run`, the bridge picks up uvloop's loop policy automatically. No bridge-side configuration needed.
+- **trio**: not supported. The bridge's `asyncio.run` does not work for trio coroutines. A Python dep that uses trio internally surfaces a `SkipReason::IncompatibleAsyncRuntime` at lock time (detected by walking the dep's `import trio` AST).
+- **anyio**: works because anyio code is asyncio-compatible by default.
+
+## The Mochi runtime hook
+
+The Mochi runtime exposes an entry point at `runtime/python/mochi_runtime/async_bridge.py`:
+
+```python
+class AsyncBridge:
+    def __init__(self, mode: str):
+        self.mode = mode
+        self._loop = None
+        self._loop_thread = None
+        if mode == "persistent":
+            self._start_persistent_loop()
+
+    def run_coro(self, coro):
+        if self.mode == "per-call":
+            return asyncio.run(coro)
+        else:
+            future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+            return future.result()
+
+    def _start_persistent_loop(self):
+        import threading
+        self._loop = asyncio.new_event_loop()
+        self._loop_thread = threading.Thread(
+            target=self._loop.run_forever,
+            daemon=True,
+            name="mochi-asyncio-loop",
+        )
+        self._loop_thread.start()
+```
+
+The wrapper imports this and calls `_BRIDGE.run_coro(coro)` for every Mochi-to-Python await.
+
+## Performance characteristics
+
+| Mode | Cost per await | Loop count | Shared state |
+|------|----------------|------------|--------------|
+| Per-call (cold) | 5-10ms (first call) | 1 transient | None |
+| Per-call (warm) | 0.5-1ms | 1 transient | None |
+| Persistent (warm) | 50-100µs | 1 persistent | Yes |
+| Native Python `asyncio.run` once | 0.5-1ms once + 50-100µs per inner await | 1 transient | None inside |
+
+The persistent mode is ~10x faster per await. The trade-off is the shared-state hazard.
+
+The default per-call mode is correct for the typical use case: each Mochi function does one Python async call and returns. The persistent mode is for hot loops (thousands of small async calls).
+
+## Cross-references
+
+- [[02-design-philosophy]] §4 for the per-call default rationale.
+- [[10-gil-and-cextensions]] for GIL handling around the event loop.
+- [[12-risks-and-alternatives]] §R8 for the persistent-mode hazard mitigation plan.
+- [MEP-13](/docs/mep/mep-0013) for Mochi's async fn surface.
+- [Python asyncio docs](https://docs.python.org/3/library/asyncio.html).
+- [PEP 3156](https://peps.python.org/pep-3156/) for asyncio's original design.

--- a/website/docs/research/0071/09-abi-stability.md
+++ b/website/docs/research/0071/09-abi-stability.md
@@ -1,0 +1,172 @@
+---
+title: "09. ABI stability"
+sidebar_position: 10
+sidebar_label: "09. ABI stability"
+description: "CPython API/ABI versioning (PEP 387 stability policy, PEP 802 / 809 the abi2026 transition), the abi3 stable ABI (PEP 384), the free-threaded ABI tag (PEP 779 / 803 / cp313t), the manylinux / musllinux wheel platform tags (PEP 600 / 656), the cdylib boundary, opaque handles for non-stable structs."
+---
+
+# 09. ABI stability
+
+This note covers the CPython API/ABI surface that the bridge has to track. CPython is a moving target: APIs are deprecated, internal structures change, and the wheel ecosystem has to follow. Mochi's wrapper modules link against CPython and inherit the same constraints.
+
+## The two surfaces: API and ABI
+
+CPython exposes two distinct compatibility surfaces:
+
+- **API** (Application Programming Interface): the C header functions and macros. Source-level compatibility. If your `.c` source compiles against CPython N.x and N+1.x, the API is stable.
+- **ABI** (Application Binary Interface): the binary layout of structs (`PyObject`, `PyTypeObject`, `PyMethodDef`), the calling conventions, and the symbol exports. Binary-level compatibility. If a `.so` compiled against CPython N.x loads against N+1.x without recompilation, the ABI is stable.
+
+API compatibility is broader than ABI. Most CPython API changes between minors are ABI-breaking (struct layout changes, new fields, removed exports) but API-preserving (the function signatures still work; just need a recompile).
+
+The bridge has to know which surface it's targeting. The wheel tags encode it.
+
+## PEP 387: CPython's stability policy
+
+PEP 387 governs CPython's API/ABI deprecation policy:
+
+- An API is deprecated for at least 2 minor versions before removal.
+- An ABI break in a major minor version requires a new ABI tag.
+- The limited API (PEP 384) is a stricter subset; functions in it have stronger stability guarantees.
+
+The bridge's approach: target the limited API (`abi3`) by default for publish; target the full API for consume (we link against the specific CPython we found at runtime, so ABI compatibility is automatic).
+
+## PEP 384: the limited API (abi3)
+
+The limited API is a subset of the CPython C API that promises ABI stability across minor versions. A wheel built against the limited API for Python 3.12 will load on Python 3.13, 3.14, etc., without recompilation.
+
+The wheel tag for limited-API wheels is `cp312-abi3-<platform>`: built against Python 3.12 limited API, ABI-compatible across all 3.12+ versions, for the named platform.
+
+What the limited API does NOT include:
+
+- Direct field access on `PyObject`, `PyTypeObject`, etc. (these structures are opaque under the limited API).
+- The full CPython memory allocator (`PyMem_Malloc`, etc.). The limited API has its own allocator interface.
+- Some specialised functions (some `_PyXxx` internal functions, some debugging hooks).
+- Free-threaded specific functions. See PEP 703 / 779 / 803 below.
+
+What's there:
+
+- Object creation: `PyLong_FromLong`, `PyUnicode_FromString`, `PyList_New`, `PyDict_New`.
+- Method calls: `PyObject_GetAttrString`, `PyObject_CallObject`, `PyObject_CallMethod`.
+- Type creation: `PyType_FromModuleAndSpec` (this is the limited-API-friendly way to define types from C).
+- Module creation: `PyModule_Create2`, `PyModule_AddObject`.
+- Error handling: `PyErr_SetString`, `PyErr_Occurred`, `PyErr_Print`.
+- GIL: `PyGILState_Ensure`, `PyGILState_Release` (for threads not created by Python).
+
+The Mochi wrapper module synthesiser targets the limited API by default. The synthesised C glue (when needed for C-extension binding) uses only limited-API functions. The result: one wheel per platform works on every 3.12+ minor version.
+
+## PEP 802 / PEP 809: the abi2026 transition
+
+PEP 802 (2024 draft, accepted 2025) and PEP 809 (the renaming and rollout plan) introduce a new ABI versioning scheme.
+
+The current scheme: `cp312`, `cp313`, `cp314`, one ABI tag per CPython minor version. Each tag corresponds to a roughly 1-year release window.
+
+The new scheme (rolling out 2026-Q1): `abi2026`, a date-stamped ABI tag that covers multiple CPython minor versions in a window. The idea is to acknowledge that the ABI changes within a minor (deprecations land) and that the abi3 ladder is too restrictive for some use cases.
+
+PEP 809's rollout:
+
+- 2026-Q1: CPython 3.15 ships with both `cp315` (legacy tag) and `abi2026` (new tag).
+- 2027-Q1: CPython 3.16 drops `cp316`, ships only `abi2026` and `abi2027`.
+- 2028-Q1: abi2026 reaches end-of-life; older wheels need to be rebuilt against newer abi-year tags.
+
+The bridge tracks the transition: `[python.publish].abi2026 = true` opts in to the new tag. The default remains `cp3XY` until abi2026 is GA.
+
+## Free-threaded CPython: PEP 703 / 779 / 803 / cp313t
+
+PEP 703 (accepted 2023) introduces a build of CPython without the GIL. The build is opt-in: `./configure --disable-gil` produces a "free-threaded" binary that is binary-incompatible with the GIL build.
+
+- The struct layout of `PyObject` differs (reference counting uses biased reference counting).
+- The memory allocator differs (per-thread arenas).
+- Some C API functions are unsafe to call without explicit thread coordination.
+
+PEP 779 / 803 (2024) define the wheel tag for free-threaded builds: `cp313t`, `cp314t`, etc. Note the `t` suffix; this is the distinguishing marker. A wheel tagged `cp313t-cp313t-<platform>` requires a free-threaded interpreter; it will not load on a normal `cp313`.
+
+The bridge:
+
+- Default: builds for `cp3XY` (GIL build). Free-threaded wheels are an opt-in via `[python].free-threaded = true`.
+- Free-threaded mode requires the wrapper module to avoid GIL-only APIs and to use the new thread-safety primitives (PyMutex, atomic refcounts).
+- The bridge's wrapper-module synthesiser has a free-threaded flag that switches the emitted C glue to use the safe subset.
+
+The MEP-71 phase plan reserves Phase 17 for free-threaded support; the default through Phase 16 is GIL-only.
+
+## Wheel platform tags
+
+PEP 600 (manylinux), PEP 656 (musllinux), and the platform-specific tags govern the platform compatibility.
+
+**manylinux_X_Y_<arch>**: a Linux build using glibc >= X.Y on architecture `<arch>`. The wheel's compiled extension references only symbols available in glibc X.Y; auditwheel validates this. Common tags:
+
+- `manylinux_2_17_x86_64`: glibc 2.17, x86_64. Compatible with RHEL 7+, Debian 8+, Ubuntu 14.04+.
+- `manylinux_2_28_x86_64`: glibc 2.28, x86_64. Compatible with RHEL 8+, Debian 10+, Ubuntu 18.10+.
+- `manylinux_2_34_x86_64`: glibc 2.34, x86_64. The 2026 default for new wheels.
+- `manylinux_2_34_aarch64`: same on ARM64.
+
+**musllinux_X_Y_<arch>**: a Linux build using musl libc >= X.Y. Alpine Linux is the typical consumer. Tags:
+
+- `musllinux_1_2_x86_64`: musl 1.2.x, x86_64.
+- `musllinux_1_2_aarch64`: same on ARM64.
+
+**macosx_X_Y_<arch>**: macOS X.Y on `<arch>`. The `<arch>` is `x86_64`, `arm64`, or `universal2` (fat binary).
+
+**win_amd64**, **win32**, **win_arm64**: Windows on the named architecture.
+
+The Mochi backend computes the right platform tag based on the build environment and validates that the compiled extension actually meets the tag's requirements. Building manylinux wheels requires a glibc-X.Y baseline build environment (typically a manylinux container image).
+
+## The cdylib boundary
+
+For native ext wraps, the synthesised wrapper module is a CPython extension `.so` (Linux), `.dylib` (macOS), or `.pyd` (Windows). The boundary between the Mochi runtime (Go) and the CPython side is a small C glue layer:
+
+```c
+// Generated cdylib glue
+#define Py_LIMITED_API 0x030C0000   // Limited API for CPython 3.12+
+#include <Python.h>
+
+extern void* mochi_runtime_init(void);
+extern PyObject* mochi_call(void* runtime, const char* name, PyObject* args);
+
+static PyObject* py_mochi_call(PyObject* self, PyObject* args) {
+    const char* name;
+    PyObject* call_args;
+    if (!PyArg_ParseTuple(args, "sO", &name, &call_args)) return NULL;
+    return mochi_call(get_runtime(), name, call_args);
+}
+
+static PyMethodDef methods[] = {
+    {"mochi_call", py_mochi_call, METH_VARARGS, "Call into Mochi runtime"},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT, "_mochi_native", NULL, -1, methods,
+};
+
+PyMODINIT_FUNC PyInit__mochi_native(void) {
+    return PyModule_Create(&moduledef);
+}
+```
+
+The glue is generated, not hand-written. The Mochi runtime side is linked as a Go-built static library (`mochi_runtime.a`) that the glue references. The combination is a `.so` that satisfies CPython's extension-module ABI.
+
+## Opaque handles for non-abi3 structs
+
+Some Python objects have struct layouts that are not stable under the limited API (the limited API treats them as opaque). The bridge handles these via the opaque-handle pattern from [[05-type-mapping]]: the value is held as `PyObject*` and operations go through `PyObject_GetAttrString` / `PyObject_CallMethod` rather than direct field access.
+
+The cost: a method call through `PyObject_CallMethod` is ~10x slower than direct field access. The benefit: the wrapper works across CPython minor versions without recompilation.
+
+The bridge surfaces this as a comment in the generated shim file:
+
+```mochi
+// abi3-opaque: field access via PyObject_GetAttrString, ~10x slower than direct
+extern fn numpy_array_shape(arr: numpy.NDArray): tuple[int, ...] from python "numpy.ndarray.shape"
+```
+
+## Cross-references
+
+- [[05-type-mapping]] for the opaque-handle pattern.
+- [[06-pypi-publish-flow]] for the wheel tag computation.
+- [[10-gil-and-cextensions]] for free-threaded build details.
+- [[11-pyodide-wasi-embedded]] for the WASI and Pyodide ABI angles.
+- [PEP 384](https://peps.python.org/pep-0384/) for the limited API.
+- [PEP 387](https://peps.python.org/pep-0387/) for the stability policy.
+- [PEP 600](https://peps.python.org/pep-0600/), [PEP 656](https://peps.python.org/pep-0656/) for platform tags.
+- [PEP 703](https://peps.python.org/pep-0703/) for free-threaded CPython.
+- [PEP 779](https://peps.python.org/pep-0779/), [PEP 803](https://peps.python.org/pep-0803/) for the free-threaded ABI tag.
+- [PEP 802](https://peps.python.org/pep-0802/), [PEP 809](https://peps.python.org/pep-0809/) for the abi2026 transition.

--- a/website/docs/research/0071/10-gil-and-cextensions.md
+++ b/website/docs/research/0071/10-gil-and-cextensions.md
@@ -1,0 +1,171 @@
+---
+title: "10. GIL and C extensions"
+sidebar_position: 11
+sidebar_label: "10. GIL and C extensions"
+description: "The GIL acquisition model, free-threaded CPython 3.13t / 3.14t (PEP 703), the foreign C-extension boundary, fork-safety, sub-interpreters (PEP 684 / 734), import-time side effects in the wild, the Mochi-side concurrency interaction model."
+---
+
+# 10. GIL and C extensions
+
+This note covers two related concerns: how the bridge interacts with CPython's GIL, and how it deals with the heterogeneous landscape of C extensions on PyPI. Both are existential concerns for any Python bridge: get the GIL wrong and the bridge hangs or crashes; misjudge a C extension and the host process segfaults.
+
+## The Global Interpreter Lock
+
+The GIL is a per-interpreter lock that CPython acquires before running any Python bytecode or calling into the C API. Threads must hold the GIL to:
+
+- Allocate or deallocate Python objects.
+- Call `PyObject_*` C API functions (with rare exceptions like `Py_INCREF`/`Py_DECREF` under specific conditions).
+- Execute Python bytecode.
+
+Threads release the GIL during:
+
+- Blocking I/O (the I/O wrappers explicitly release).
+- Long-running C extension code that explicitly releases via `Py_BEGIN_ALLOW_THREADS` / `Py_END_ALLOW_THREADS`.
+- The asyncio event loop's `select` / `poll` call.
+
+For the Mochi bridge, the relevant rules:
+
+- Any C call into the CPython API must hold the GIL.
+- Threads created by Mochi (not by Python) must acquire the GIL before calling in.
+- Threads created by Python (e.g., by `threading.Thread` or by asyncio's executor) already hold the GIL when their callbacks run.
+
+## The PyGILState dance
+
+The canonical pattern for foreign threads:
+
+```c
+PyGILState_STATE state = PyGILState_Ensure();
+// ... call CPython API
+PyGILState_Release(state);
+```
+
+`PyGILState_Ensure` acquires the GIL and sets up the thread state if this is the first time the thread has called in. `PyGILState_Release` releases the GIL and tears down the thread state if appropriate.
+
+The Mochi wrapper module's C glue uses this pattern. Every entry point from Go into CPython does:
+
+1. `PyGILState_Ensure()` at function entry.
+2. The actual work.
+3. `PyGILState_Release(state)` at function exit.
+
+The Go-side runtime ensures the Mochi worker goroutine that's making the call is pinned to a single OS thread via `runtime.LockOSThread()` before the entry. This is required because PyGILState assumes a stable thread identity.
+
+## Free-threaded CPython (PEP 703)
+
+CPython 3.13 introduced an experimental "free-threaded" build that removes the GIL. Reference counting uses biased reference counting (Owens & Manson, 2003) so most refcount operations are still single-threaded fast; cross-thread refcount changes use atomics.
+
+The free-threaded build is binary-incompatible with the GIL build. A wheel built for `cp313` will not load on `cp313t` (note the `t` suffix), and vice versa.
+
+The bridge's free-threaded story:
+
+- When `[python].free-threaded = true`, the wrapper module is built for the `t` ABI. The C glue uses:
+  - Atomic refcount operations only (no `Py_INCREF` / `Py_DECREF` shortcuts).
+  - `PyMutex` for any shared state in the wrapper.
+  - No assumptions about GIL serialisation; multiple Mochi threads can be in CPython simultaneously.
+- When `[python].free-threaded = false` (default through Phase 16), the wrapper uses GIL-only patterns.
+
+The phase plan defers free-threaded support to Phase 17 because the testing matrix (fixtures × wheel tags × GIL/no-GIL) is large.
+
+## C extensions in the wild: the landscape
+
+PyPI hosts ~500k packages. Roughly 30% ship native code (a `.so`, `.pyd`, or `.dylib`). The native code falls into a few categories:
+
+- **CPython C extensions (manual)**: hand-written CPython C API code. Examples: numpy core, scipy.linalg, lxml. These use the full CPython API (not limited) for performance.
+- **CPython C extensions (Cython)**: Cython-compiled to C, then compiled to extension. Examples: scikit-learn, pandas core, msgpack.
+- **CPython C extensions (PyO3, pybind11, nanobind)**: Rust or C++ source compiled to CPython extensions. Examples: cryptography (PyO3), uvloop (Cython but with libuv), pendulum (Rust).
+- **CFFI extensions**: Python wrappers around C libraries via cffi. Examples: cryptography legacy, paramiko parts.
+- **ctypes wrappers**: pure-Python wrappers around shared libraries via ctypes. No native code in the wheel; the wheel is `py3-none-any` and references the system shared library.
+- **Native subprocess shells**: pure-Python wrappers that subprocess out to a native binary. Examples: black (subprocesses python -m black), ruff (subprocesses ruff). No CPython interaction beyond plain Python.
+
+The bridge's wrapper module pattern works with all of these. The wrapper imports the package; whatever native code the package contains runs as part of Python's normal import flow.
+
+## The C extension boundary problem
+
+The hazard: a C extension might assume the GIL is held when its functions are called. If the Mochi side calls a function on an object whose method is implemented in C, that C method might assume GIL ownership. The wrapper module's GIL acquisition (via `PyGILState_Ensure`) handles this correctly.
+
+The subtler hazard: a C extension might assume things about the calling thread's state beyond the GIL. Examples:
+
+- **NumPy's signal handling**: NumPy installs SIGFPE handlers on some operations. If Mochi catches SIGFPE for its own reasons, the handlers conflict.
+- **PyTorch's CUDA streams**: PyTorch maintains per-thread CUDA stream state. A Mochi worker goroutine that hops between OS threads will see fresh CUDA state on each hop.
+- **GIL-released long-running operations**: A C extension that calls `Py_BEGIN_ALLOW_THREADS` to do CPU-intensive work releases the GIL. If Mochi's runtime expects to be in the GIL during that window (because the wrapper acquired it), it sees an inconsistent state.
+
+Mitigations:
+
+- The wrapper's GIL acquisition is at the wrapper-function granularity, not the call granularity. The wrapper acquires, does its setup, calls into Python, and releases. Inside the call, if the Python code releases the GIL for I/O, the bridge does not care because the bridge is not running inside that window.
+- The Mochi worker is pinned to one OS thread for the entire duration of a `[python]` import's active lifetime. CUDA-style per-thread state is stable.
+- Signal handlers are not intercepted by the bridge; the user's C extensions are free to install their own.
+
+## fork-safety
+
+`os.fork()` on a process holding a GIL produces a child process with the same locked state. Pre-fork, the parent should release the GIL; post-fork, the child reacquires.
+
+CPython's threading model is not fork-safe by default. The standard advice is "don't fork after starting threads."
+
+The Mochi runtime is multi-threaded by default (goroutines on a thread pool). If Mochi imports Python and the user (or a Python dep) calls `os.fork()`, the child process inherits an inconsistent state.
+
+Mitigations:
+
+- The bridge documents the hazard prominently. Users who need `fork()` should keep the Python import surface minimal pre-fork.
+- The `multiprocessing` module's `spawn` start method (default on macOS and Windows, optional on Linux) avoids the fork hazard by using `execve` instead of `fork`.
+- Future direction: sub-interpreters (PEP 684 / PEP 734) allow per-thread isolated interpreter state, sidestepping the fork hazard entirely. Currently experimental in CPython 3.12+.
+
+## Sub-interpreters (PEP 684 / PEP 734)
+
+Sub-interpreters are isolated Python interpreter instances within one process. PEP 684 added isolated GIL per sub-interpreter; PEP 734 added a stable C API for managing sub-interpreters; both are experimental in CPython 3.12 and stable in 3.13.
+
+The promise: each Mochi worker goroutine could have its own sub-interpreter, with independent module state, no GIL contention between workers.
+
+The reality:
+
+- C extensions must opt in to multi-phase init (PEP 489) to work with sub-interpreters. Many do not, and using them in a sub-interpreter raises `ImportError`.
+- The cost of starting a sub-interpreter is ~50ms (importing the entire stdlib). Pooling is required.
+- Cross-sub-interpreter object passing is restricted to a small set of immutable types (the "shared data API" of PEP 734).
+
+MEP-71's stance: sub-interpreters are not the default. Phase 17 (free-threaded) is the canonical concurrency improvement; sub-interpreters are a future direction documented in [[12-risks-and-alternatives]] §A8.
+
+## Import-time side effects in the wild
+
+Many Python packages do significant work at import time:
+
+- **NumPy**: imports CPython, allocates type objects, registers fpe handlers, allocates ~50MB of internal arrays. ~30ms cold import.
+- **PyTorch**: imports CUDA libraries, allocates GPU contexts, registers ~100 custom type objects. ~200ms cold import.
+- **TensorFlow**: similar to PyTorch but heavier; ~500ms cold import.
+- **pyarrow**: loads native libraries, registers arrow types. ~100ms.
+- **mypy**: imports its own type-checker eagerly. ~150ms.
+
+Side effects at import time include:
+
+- File reads (config files, dist-info metadata).
+- Network calls (rare but happens; the bridge denies these in the lock-time sandbox).
+- GPU initialisation (PyTorch).
+- Signal handler installation.
+
+The bridge's strategy:
+
+- Import the package lazily on first use, not eagerly at Mochi process startup. The cost amortises if the import is needed.
+- For the lock-time stubgen sandbox, network is denied; packages that try to fetch are reported as `SkipReason::ImportTimeNetwork`.
+- For the runtime, no sandbox is applied; the user's environment is the user's responsibility.
+
+## The bridge's GIL discipline summary
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ Rule 1: Every Mochi-to-Python entry holds the GIL.                   │
+│ Rule 2: Every Python-to-Mochi callback releases the GIL on entry.    │
+│ Rule 3: Mochi workers are pinned to one OS thread for the duration   │
+│          of any Python active lifetime.                              │
+│ Rule 4: Refcount operations on PyObject use the limited-API funcs    │
+│          for portability.                                            │
+│ Rule 5: Free-threaded mode (Phase 17+) replaces Rule 1 with atomic   │
+│          refcount + PyMutex.                                         │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+## Cross-references
+
+- [[02-design-philosophy]] §3 for why the wrapper-module pattern handles the GIL.
+- [[08-async-bridge]] for the asyncio-loop GIL interaction.
+- [[09-abi-stability]] for the free-threaded ABI tag.
+- [[12-risks-and-alternatives]] §R5 for the GIL contention risk.
+- [PEP 703](https://peps.python.org/pep-0703/) for free-threaded CPython.
+- [PEP 684](https://peps.python.org/pep-0684/), [PEP 734](https://peps.python.org/pep-0734/) for sub-interpreters.
+- [Python C API: Thread State and the GIL](https://docs.python.org/3/c-api/init.html#thread-state-and-the-global-interpreter-lock).

--- a/website/docs/research/0071/11-pyodide-wasi-embedded.md
+++ b/website/docs/research/0071/11-pyodide-wasi-embedded.md
@@ -1,0 +1,127 @@
+---
+title: "11. Pyodide, WASI, and embedded"
+sidebar_position: 12
+sidebar_label: "11. Pyodide / WASI / embedded"
+description: "The Pyodide (wasm32-emscripten) target, WASI Preview 2 (wasm32-wasip2) component model, the no-CPython subset, embedded MEP-53 target compatibility, what Python packages Mochi can consume in the browser and on bare-metal, the MicroPython subset, the firmware story."
+---
+
+# 11. Pyodide, WASI, and embedded
+
+This note covers the alternative deployment targets where Python runs alongside Mochi: the browser (via Pyodide), the WASI ecosystem (wasm32-wasip2 component model), and embedded contexts (MicroPython subset, MEP-53 target). Each constrains the bridge differently from the host Linux/macOS/Windows case.
+
+## Pyodide (wasm32-emscripten)
+
+Pyodide is a CPython port to WebAssembly, compiled with Emscripten. It runs the full CPython interpreter (currently 3.13 in Pyodide 0.27+) inside a browser page or Node.js process. The wheel ecosystem includes ~200 pre-built scientific Python packages (numpy, pandas, scipy, scikit-learn, matplotlib, sympy) compiled to wasm32-emscripten.
+
+What Pyodide is good at:
+
+- Pure-Python packages: any pure-Python wheel installs as-is from PyPI.
+- Pre-built scientific packages: numpy, scipy, pandas, scikit-learn work out of the box via Pyodide's curated wheel index.
+- DOM access: Pyodide exposes JavaScript objects to Python and vice versa, enabling browser scripting.
+
+What Pyodide is not good at:
+
+- Native packages outside Pyodide's curated set: building a wasm32-emscripten wheel for an arbitrary Rust or C extension is currently manual.
+- Filesystem-heavy packages: Pyodide's filesystem is in-memory (or backed by IndexedDB); slow.
+- Subprocess-using packages: no subprocess in browsers.
+
+The bridge's Pyodide story:
+
+- The Mochi runtime can be compiled to wasm32-emscripten (this is MEP-53's emscripten target).
+- The Mochi-side runtime + Pyodide cohabit in the same wasm instance.
+- The wrapper module pattern still works: the wrapper is generated as wasm32-emscripten Python that calls into the Mochi runtime via JS interop.
+- The bridge surfaces a `SkipReason::PyodideUnavailable` for packages not in Pyodide's curated list when the target is `wasm32-emscripten`.
+
+The phase plan reserves Phase 16 for Pyodide / WASI target support.
+
+## WASI Preview 2: the component model
+
+WASI Preview 2 (released January 2024 stable) introduces the component model: typed interfaces between wasm modules expressed in WIT (WebAssembly Interface Types). The `wasm32-wasip2` target is the canonical WASI Preview 2 target.
+
+CPython on WASI Preview 2 is in active development. The CPython 3.13+ tree has `wasm32-wasi` and `wasm32-wasip2` support upstream. A few caveats:
+
+- The WASI filesystem and clock APIs are exposed; sockets are emerging in Preview 2.
+- No threads in Preview 2 (threading is Preview 3 territory).
+- No fork or subprocess.
+- The C extension ecosystem is essentially empty on WASI; only pure-Python packages and packages with WASI-targeting builds work.
+
+The bridge's WASI story:
+
+- The Mochi runtime can be compiled to wasm32-wasip2 (MEP-53 WASI target).
+- A WIT interface defines the wrapper boundary: Mochi exports the host-side functions; Python imports them as a wasm component.
+- Pure-Python packages work; native packages require a wasm32-wasip2 wheel which is rare.
+- The async bridge runs on a single-threaded asyncio loop (no threading).
+
+The phase plan covers this in Phase 16 alongside Pyodide.
+
+## The no-CPython subset
+
+There are two paths to running Python code without CPython:
+
+- **MicroPython / CircuitPython**: a smaller Python interpreter for microcontrollers. ~200KB binary, ~64KB RAM minimum. Supports a subset of Python 3.x (no GIL, no asyncio, no typing module at runtime, no most stdlib).
+- **RustPython**: a CPython-API-compatible Python interpreter written in Rust. ~5MB binary. More compatible than MicroPython but slower than CPython.
+
+The bridge's stance on these:
+
+- **MicroPython**: not a `[python].implementation` value. The Mochi-to-MicroPython story is a transpiler-level concern (MEP-51 emits MicroPython-compatible Python with a `--target=micropython` flag, but that's a separate scope). MEP-71's bridge does not target MicroPython.
+- **RustPython**: future direction. `[python].implementation = "rustpython"` would link RustPython instead of CPython. The wrapper module pattern adapts because RustPython implements the CPython C API. Phase 17+ scope.
+- **GraalPy** (Oracle's Python on the JVM/Graal): similar to RustPython. `[python].implementation = "graalpy"`. Phase 17+ scope.
+
+## Embedded MEP-53 target
+
+MEP-53 (the Rust transpiler) defines an embedded subset of the Mochi runtime: no GC, no goroutines, no stdlib I/O. The Mochi-to-Rust bridge (MEP-73) extends this to a `no_std` subset of Rust crates.
+
+For MEP-71, the parallel question is: can Mochi consume Python deps in an embedded context? The answer is mostly no:
+
+- Embedded targets typically have no Python interpreter at all. The only Python that runs is MicroPython, and the bridge does not target MicroPython.
+- The wrapper module pattern requires libpython linked in, which is impossible on a microcontroller.
+
+The MEP-71 phase plan does not include an embedded subset. Users who need Python-like behaviour on embedded targets should use MEP-51 (Mochi-to-Python transpiler) with the `--target=micropython` flag, which produces MicroPython-compatible source code without linking a Python interpreter.
+
+The closest analog: a Mochi app running on an embedded MEP-53 target that talks to a Python service over a network or serial protocol. This is a deployment pattern, not a bridge feature.
+
+## Pyodide-specific wheel tags
+
+Pyodide uses the wheel tag `cp313-cp313-pyodide_2025_0_wasm32`. The wheel must be built for the exact Pyodide version (because the JS interop ABI changes between minors) and for the exact CPython version.
+
+The bridge's publish path for Pyodide:
+
+- `[python.publish].wheel-tags = ["py3-none-any", "cp313-cp313-pyodide_2025_0_wasm32"]` opts in.
+- The Mochi backend builds two wheels: a generic py3-none-any (the default) and a Pyodide-specific wheel using the Pyodide build toolchain.
+- The Pyodide wheel can be loaded directly in a browser via Pyodide's `micropip.install()`.
+
+This path is currently experimental and gated on Pyodide's release cadence; it's not in the Phase 0-15 critical path.
+
+## What kind of Python can Mochi consume in each target
+
+| Target | Pure-Python wheels | Native wheels | asyncio | threading | subprocess | Notes |
+|--------|---------------------|---------------|---------|-----------|------------|-------|
+| linux-x64 | yes | yes | yes | yes | yes | The reference platform. |
+| linux-arm64 | yes | yes (manylinux_2_28_aarch64) | yes | yes | yes | Same as x64. |
+| macos-x64 | yes | yes (macosx_11_0_x86_64) | yes | yes | yes | Apple Silicon Rosetta works too. |
+| macos-arm64 | yes | yes (macosx_11_0_arm64) | yes | yes | yes | The Apple Silicon native target. |
+| windows-x64 | yes | yes (win_amd64) | yes | yes | yes | The Windows reference. |
+| wasm32-emscripten (Pyodide) | yes | Pyodide curated only | yes (single-threaded) | no | no | Browser/Node.js. |
+| wasm32-wasip2 | yes | rare | yes (single-threaded) | no | no | Edge / serverless wasm. |
+| embedded MEP-53 | no | no | no | no | no | No CPython available. |
+
+## The Mochi-side runtime mode in each target
+
+The `[python].runtime-mode` value differs by target:
+
+- `embedded` (default on host): libpython is linked into the Mochi binary. The bridge uses `PyImport_AppendInittab` to register the wrapper module, then `Py_Initialize` to start the interpreter.
+- `subprocess` (host alternative): the Mochi process spawns a separate `python -m mochi_runtime.subprocess_server` and communicates via JSON-RPC. Slower per call but isolates Python crashes from the Mochi process.
+- `pyodide` (wasm32-emscripten): the Mochi runtime is loaded into the same wasm instance as Pyodide; cross-calls use JS interop.
+- `wasi` (wasm32-wasip2): the wrapper is a wasm component; calls go through the component-model interface.
+
+Each mode has its own glue layer in `package3/python/runtime/`. The configuration auto-detects the target at build time.
+
+## Cross-references
+
+- [[09-abi-stability]] for the wheel tag computation in each target.
+- [[10-gil-and-cextensions]] for the GIL story under Pyodide and WASI.
+- [[12-risks-and-alternatives]] for the deferred-target risks.
+- [Pyodide docs](https://pyodide.org/).
+- [WASI Preview 2 announcement](https://bytecodealliance.org/articles/WASI-0.2).
+- [MicroPython](https://micropython.org/).
+- [MEP-53](/docs/mep/mep-0053) for the embedded Mochi target.

--- a/website/docs/research/0071/12-risks-and-alternatives.md
+++ b/website/docs/research/0071/12-risks-and-alternatives.md
@@ -1,0 +1,246 @@
+---
+title: "12. Risks and alternatives"
+sidebar_position: 13
+sidebar_label: "12. Risks and alternatives"
+description: "The risk register (PEP 561 coverage, wrapper compile time, dynamic typing leakage, GIL contention, capability drift, abi2026 transition, OIDC issuer downtime, persistent loop hazard, uv stability, supply-chain surface, sub-interpreter promise, async runtime fragmentation, free-threaded ecosystem) and the rejected alternatives register."
+---
+
+# 12. Risks and alternatives
+
+This note catalogs the known risks in MEP-71's design and the alternatives that were considered and rejected. Each entry is referenced from the spec and other research notes. The risks are open issues with mitigations; the alternatives are paths the design explicitly does not take and why.
+
+## Risk register
+
+### R1. PEP 561 coverage of the long tail
+
+**Risk**: Many PyPI packages are not typed. The bridge's PEP 561 ladder ([[04-pep561-stub-ingest]]) ends at stubgen, which produces `Any`-heavy stubs. For packages whose long tail of behaviour matters (legacy data-processing libs, scraping helpers, ETL packages), the bridge gives a degraded experience.
+
+**Mitigation**:
+- Document the expected coverage clearly in the spec.
+- Provide a `[python].stubgen.aggressive = true` flag that runs stubgen with extra heuristics (cross-referencing `__init__.py` imports against typeshed, inferring types from `**kwargs` usage in docstrings).
+- Long-term: contribute to typeshed for high-priority untyped packages.
+
+**Status**: Open. Tracked in the Phase 3 (type mapping) acceptance criteria; the fixture corpus picks 5 untyped packages to validate the stubgen path.
+
+### R2. Wrapper compile time
+
+**Risk**: Each Python package import triggers a wrapper-module synthesis pass that compiles a C extension. For ~50 deps in a typical project, this is ~50 wrapper compiles at lock time and on every Mochi build. The cumulative time is multi-minutes.
+
+**Mitigation**:
+- Content-address the wrapper output (`wrapper-sha256` in mochi.lock); rebuild only when the input changes.
+- Parallelise wrapper compilation across CPU cores.
+- Default to abi3 wrappers so one compilation works across CPython minors.
+
+**Status**: Tracked in Phase 7 (build orchestration) goals. Target: <30s incremental lock time on a 50-dep project.
+
+### R3. Dynamic-typing leakage
+
+**Risk**: Python's dynamic typing leaks into Mochi even with stubs. A Python function annotated as `-> str` might return `None` at runtime when an error occurs (older packages predate `Optional[str]` conventions). Mochi's type system will see a Mochi `string` return type and crash at the boundary.
+
+**Mitigation**:
+- The wrapper module performs a runtime type check on every return value against the declared Mochi type. Mismatch raises a Mochi `Error::PythonTypeMismatch`.
+- A `[python].strict-return-types = false` flag relaxes this for compatibility with older packages.
+
+**Status**: Tracked in Phase 5 (extern-fn emit) acceptance criteria.
+
+### R4. Capability drift
+
+**Risk**: A Python dep's capability set ([[01-language-surface]] §`[python.capabilities]`) is computed at lock time. A later release of the dep adds network calls or filesystem access. The user's lockfile pins the older version, but a `mochi pkg update` advances and silently elevates capabilities.
+
+**Mitigation**:
+- `mochi pkg update` runs the capability check on the new version and diffs against the lockfile. Any capability addition triggers a confirmation prompt or `--allow-capability-elevation` flag.
+- The curated capability database (`package3/python/capabilities/db.toml`) is the canonical source. Updates land via PR review.
+
+**Status**: Tracked in Phase 8 (lockfile) acceptance criteria.
+
+### R5. GIL contention under hot concurrency
+
+**Risk**: Mochi's runtime is many-goroutine; calling into a single GIL-locked CPython serializes them. For workloads with many Mochi workers all calling Python, throughput collapses to single-threaded.
+
+**Mitigation**:
+- Document the GIL serialisation prominently.
+- Free-threaded mode (`[python].free-threaded = true`) bypasses the GIL on CPython 3.13t+. Phase 17 scope.
+- The opaque-handle pattern lets long-lived Python state stay on one Mochi worker so the GIL is held by one worker at a time without contention.
+
+**Status**: Open. Phase 17 (free-threaded) is the canonical fix; pre-Phase 17 the workload must be sequential or use subprocess mode.
+
+### R6. abi2026 transition
+
+**Risk**: PEP 802/809 introduces abi2026 as a new wheel tag in 2026-Q1. The bridge needs to support both the legacy `cp3XY` tag and the new tag during the transition. Wheels built before the transition continue to work but cannot use new abi2026 features.
+
+**Mitigation**:
+- `[python.publish].abi-tag-policy = "legacy" | "abi2026" | "both"` controls the tags emitted.
+- Default through 2026-Q4 is `"legacy"`; default flip to `"both"` in 2027-Q1; default flip to `"abi2026"` in 2028-Q1.
+- The bridge's consume direction reads both tags transparently from the simple index.
+
+**Status**: Open. Tracked in Phase 9 (publish) follow-ups.
+
+### R7. OIDC issuer downtime
+
+**Risk**: PyPI Trusted Publishing depends on the OIDC issuer (GitHub Actions, GitLab) being reachable. If the issuer is down, all releases fail.
+
+**Mitigation**:
+- The Mochi CLI implements exponential backoff with a 5-attempt cap.
+- A `--force-legacy-token` flag is intentionally not provided ([[02-design-philosophy]] §5); recovery requires the OIDC issuer to come back.
+- Document the workaround: defer the release until the issuer recovers.
+
+**Status**: Accepted residual risk. The OIDC issuers (GitHub, GitLab) have ~99.95% historical uptime; releases blocked by ~4 hours per year is acceptable.
+
+### R8. Persistent event-loop hazard
+
+**Risk**: `[python].async-mode = "persistent"` ([[08-async-bridge]]) introduces a shared event loop. State leaks across Mochi calls can hang or crash.
+
+**Mitigation**:
+- The default is per-call mode. Persistent is opt-in.
+- The opt-in includes a one-time warning at first use.
+- Loop-bound objects (Future, Task, AsyncIterator) returned from Python require explicit opaque-handle conversion; they don't auto-convert across loops.
+
+**Status**: Mitigated. Phase 11 (async bridge) acceptance criteria validate the hazard cases.
+
+### R9. uv stability
+
+**Risk**: uv is the youngest major resolver. Astral's commitment is strong but unproven over 5+ year horizons. If uv's lockfile format changes or Astral pivots, the bridge needs to follow.
+
+**Mitigation**:
+- The lockfile schema (mochi.lock `[[python-package]]`) is independent of uv.lock; the bridge writes its own format.
+- uv is invoked as a subprocess for the resolve step; if uv breaks, the bridge falls back to pip's resolver (slower, but functional).
+- Export to PEP 751 pylock.toml is interoperable with any PEP 751-conformant tool.
+
+**Status**: Accepted residual risk. uv is the right choice today; the fallback path is documented.
+
+### R10. Supply-chain surface
+
+**Risk**: The Mochi bridge installs code from PyPI, runs stubgen subprocesses, and compiles native extensions. Every step is a supply-chain attack surface.
+
+**Mitigation**:
+- All downloads are content-addressed (`wheel-blake3`, `wheel-sha256`) and verified against the lockfile.
+- The stubgen subprocess runs with no network and a restricted filesystem.
+- PEP 740 attestations are required for high-trust deps (configurable via `[python].require-attestations`).
+- Capability database limits accessible APIs even when a dep is compromised.
+
+**Status**: Tracked in Phase 1 (sparse-index client) and Phase 10 (publish) acceptance criteria.
+
+### R11. Sub-interpreter promise vs reality
+
+**Risk**: PEP 684/734 sub-interpreters look attractive as a GIL bypass for the bridge. Real-world C extension compatibility with sub-interpreters is poor.
+
+**Mitigation**:
+- Sub-interpreters are not the default. Phase 17 (free-threaded) is the canonical concurrency story.
+- Sub-interpreters may land as an experimental opt-in (`[python].sub-interpreters = true`) post-Phase 17.
+
+**Status**: Deferred. Not in Phase 0-17 scope.
+
+### R12. Async runtime fragmentation
+
+**Risk**: The Python async ecosystem has asyncio, trio, anyio, uvloop. The bridge supports asyncio (via `asyncio.run`) and uvloop (transparently when installed); trio is incompatible.
+
+**Mitigation**:
+- Document trio incompatibility.
+- The bridge's lock-time analyzer detects `import trio` in a dep's code and refuses with `SkipReason::IncompatibleAsyncRuntime`.
+- Anyio-based code works transparently because anyio supports asyncio by default.
+
+**Status**: Documented. trio support is not in scope.
+
+### R13. Free-threaded ecosystem
+
+**Risk**: Free-threaded Python (3.13t, 3.14t) ecosystem coverage is currently small. Many C extensions don't yet support no-GIL builds. A user opting into `[python].free-threaded = true` might have ~half their deps refuse to install.
+
+**Mitigation**:
+- The bridge's capability database tracks per-dep free-threaded compatibility.
+- `mochi pkg lock` rejects free-threaded mode when any dep lacks a free-threaded build.
+- Default through Phase 16 is GIL-only.
+
+**Status**: Tracked in Phase 17 acceptance criteria.
+
+## Rejected alternatives
+
+### A1. Direct ctypes (no wrapper module)
+
+**Considered**: Emit Go code that dlopens libpython.so and calls `Py_*` functions through ctypes-like CFFI.
+
+**Rejected**: GIL handling becomes a Go-side concern, free-threaded transitions become invisible at the Go side, the C-extension boundary (~30% of PyPI) becomes intractable. See [[02-design-philosophy]] §3.
+
+### A2. CFFI as the primary FFI layer
+
+**Considered**: Use CFFI's API mode to define the wrapper surface.
+
+**Rejected**: CFFI is right for C-library wrapping; CPython itself is the target. The wrapper-module-as-Python approach is closer to the source language. [[03-prior-art-bridges]] CFFI section.
+
+### A3. Cython fork (Mochi-flavoured Cython)
+
+**Considered**: Fork Cython and emit Mochi-style hybrid Mochi/Cython source.
+
+**Rejected**: Mochi has its own type system; rebuilding Cython on top would duplicate the work. The wrapper-module pattern lets Mochi stay Mochi and Python stay Python.
+
+### A4. Embedded MicroPython only
+
+**Considered**: Skip CPython, target only MicroPython for compactness and the embedded story.
+
+**Rejected**: MicroPython covers <1% of PyPI's ecosystem. The point of MEP-71 is access to PyPI's actual ecosystem. MicroPython remains an MEP-51 transpile target.
+
+### A5. Lifetime-erased dataclasses
+
+**Considered**: Treat all Python classes as runtime-typed `PyObject` handles; do not synthesise Mochi-side structs.
+
+**Rejected**: Loses the dev-experience win of typed field access. The closed type table ([[05-type-mapping]]) provides typed access for the common patterns (dataclass, TypedDict, NamedTuple) while degrading to handles for unsupported classes.
+
+### A6. Long-lived OIDC token
+
+**Considered**: Accept long-lived PyPI API tokens for users who can't use Trusted Publishing.
+
+**Rejected**: Defeats the supply-chain security story. ([[02-design-philosophy]] §5, [[07-sigstore-pypi-trusted-publishing]].) Private PyPI mirrors that don't speak OIDC will be supported through a separate `--to=private-index` target later.
+
+### A7. Sub-interpreter default
+
+**Considered**: Make sub-interpreters the default concurrency model.
+
+**Rejected**: C-extension compatibility is too low. Free-threaded mode is the canonical path for concurrency improvements. See R11 above.
+
+### A8. Per-build venv
+
+**Considered**: Each Mochi build creates a fresh venv, installs deps, and runs the wrapper synthesiser.
+
+**Rejected**: Build time becomes minutes. The content-addressed cache + persistent wrapper outputs design lets builds reuse work across runs. See R2 above.
+
+### A9. Trio as a first-class async runtime
+
+**Considered**: Support both asyncio and trio in the async bridge.
+
+**Rejected**: Trio's cancellation model differs from asyncio; supporting both means two parallel code paths. Trio is not in scope. See R12 above.
+
+### A10. Mochi-specific stub format
+
+**Considered**: Define a Mochi-specific stub format (`.mochi-stubs`) for Python packages.
+
+**Rejected**: Defeats the consume-without-boilerplate goal. PEP 561 stubs are the canonical Python type source; the bridge uses them. See [[02-design-philosophy]] §2.
+
+### A11. Wheel-built sdist only
+
+**Considered**: Skip sdist publication; publish only wheels.
+
+**Rejected**: PyPI requires sdist for many use cases (custom platform builds, source-only installs). The Mochi backend ships both sdist and wheel.
+
+### A12. Hand-edited synthesised shim files
+
+**Considered**: Allow users to hand-edit the synthesised `shim.mochi` files for fine-grained type control.
+
+**Rejected**: The shim file is regenerated on every `mochi pkg lock`. Hand edits would be lost. Customisation goes through the `<modname>_externs.py` sidecar pattern (MEP-51 Phase 12 convention).
+
+### A13. Bundle CPython into the Mochi binary
+
+**Considered**: Ship a CPython binary with every Mochi distribution so users don't need a system Python.
+
+**Rejected**: The Mochi binary balloon (~50MB just for CPython) is not worth the consistency win. Users install CPython themselves; the bridge detects the version.
+
+### A14. Lock-time wheel pre-compilation
+
+**Considered**: Pre-compile all wheels at lock time and cache the compiled artifacts.
+
+**Rejected**: The bridge's wrapper compilation is the only step where the bridge has a stake; the wheel's own native code is already compiled. The bridge's wrapper compilation IS lock-time; that's the design. (See R2.)
+
+## Cross-references
+
+- [MEP-71 spec](/docs/mep/mep-0071) for the normative open issues.
+- Each numbered Rxx is referenced from the spec's Risks section.
+- Each numbered Axx is referenced from the spec's Alternatives section.
+- [[02-design-philosophy]] for the decisions that drove the rejections.

--- a/website/docs/research/0071/index.md
+++ b/website/docs/research/0071/index.md
@@ -1,0 +1,35 @@
+---
+title: "MEP-71 research bundle"
+sidebar_position: 1
+sidebar_label: "Overview"
+description: "Twelve research notes covering the design space behind MEP-71: language surface, design philosophy, prior-art Python bridges, PEP 561 stub ingest, the closed type-mapping table, the PyPI publish flow, PyPI Trusted Publishing + PEP 740 attestations, the async (asyncio) bridge, CPython ABI stability and abi3, the GIL and C-extension boundary, the Pyodide / WASI / embedded subset, plus the risks and rejected alternatives register."
+---
+
+# MEP-71 research bundle
+
+This bundle is the informative companion to [MEP-71](/docs/mep/mep-0071). It documents the design space the bridge sits in: prior art, the choices considered and rejected, the trade-offs accepted, and the open risks. The bundle is meant to be read alongside the spec, not in place of it.
+
+## Notes
+
+| Note | Subject |
+|------|---------|
+| [01. Language surface](01-language-surface.md) | The `import python "..."` import shape, the `mochi.toml` `[python-dependencies]` + `[python]` tables, the CLI surface (`mochi pkg add python`, `mochi pkg publish --to=pypi`), and the per-import alias semantics. |
+| [02. Design philosophy](02-design-philosophy.md) | Why a bidirectional bridge, why PEP 561 stubs over alternatives, why a synthesised CPython wrapper module over direct ctypes, why the async bridge sits on asyncio.run, why Sigstore-keyless + PyPI Trusted Publishing is the only publish path. |
+| [03. Prior-art bridges](03-prior-art-bridges.md) | PyO3, maturin, Cython, CFFI, pybind11, nanobind, SWIG, JPype, Py4J, gopy, UniFFI, diplomat. What each gets right, what each requires the user to write, and what MEP-71 borrows. |
+| [04. PEP 561 stub ingest](04-pep561-stub-ingest.md) | The PEP 561 four-tier precedence (`py.typed` inline → `<name>-stubs` sibling → typeshed → stubgen fallback), the stubgen inspect mode, the partial-stub story, the Python-side parser shape. |
+| [05. Type mapping table](05-type-mapping.md) | The complete closed translation table, the refusal cases, the generic resolution rule, the `int` arbitrary precision boundary, the `Optional` and `Union` desugar, dataclass and TypedDict handling. |
+| [06. PyPI publish flow](06-pypi-publish-flow.md) | The PyPI upload protocol (PEP 700 / 691 / 503), the per-package metadata requirements (PEP 621 / 643 core metadata 2.4), the sdist / wheel format (PEP 517 / 518 / 425 / 600 / 656), the publish-side gate. |
+| [07. Sigstore and PyPI Trusted Publishing](07-sigstore-pypi-trusted-publishing.md) | The OIDC token exchange, the Fulcio short-lived cert, the Rekor transparency log, PEP 740 attestations, the verification path at install time, the PyPI Trusted Publishing GA timeline. |
+| [08. Async bridge](08-async-bridge.md) | The asyncio event-loop model, per-call `asyncio.run` vs persistent loop choice, the cross-loop hazard, the `await` ceremony, cancellation semantics, the uvloop / trio incompatibility surface. |
+| [09. ABI stability](09-abi-stability.md) | CPython API/ABI versioning (PEP 387 / 802 / 809), the abi3 stable ABI (PEP 384), the free-threaded ABI tag (PEP 779 / 803), the manylinux / musllinux wheel platform tags (PEP 600 / 656), the cdylib boundary. |
+| [10. GIL and C extensions](10-gil-and-cextensions.md) | The GIL acquisition model, free-threaded CPython 3.13t / 3.14t (PEP 703), foreign C-extension boundary safety, fork-safety, sub-interpreters (PEP 684 / 734), import-time side-effects in the wild. |
+| [11. Pyodide, WASI, and embedded](11-pyodide-wasi-embedded.md) | The Pyodide / wasm32-emscripten target, WASI Preview 2 (`wasm32-wasip2`) component model, the no-CPython subset, embedded MEP-53 target, what kind of Python packages Mochi can consume in the browser and on bare metal. |
+| [12. Risks and alternatives](12-risks-and-alternatives.md) | The risk register (PEP 561 coverage, wrapper compile time, dynamic typing leakage, GIL contention, capability drift, abi2026 transition) and the rejected alternatives (direct ctypes, cffi primary, cython fork, embedded micropython only, lifetime-erased dataclasses, long-lived OIDC token, sub-interpreter default, per-build venv). |
+
+## Cross-references
+
+- [MEP-71 spec](/docs/mep/mep-0071) — the normative document.
+- [MEP-51](/docs/mep/mep-0051) — the Python transpiler this bridge builds on.
+- [MEP-57](/docs/mep/mep-0057) — the source-level package system whose manifest and lockfile the bridge extends.
+- [MEP-73](/docs/mep/mep-0073) — the parallel Rust bridge that shares the polyglot package infrastructure.
+- [Implementation tracking](/docs/implementation/0071/) — the per-phase delivery status.


### PR DESCRIPTION
## Summary

Land the MEP-71 spec, the 12-note research bundle, the 18-phase implementation tracking, and a `package3/python/` stub README pointing at the spec. All 18 phases NOT STARTED. Tracking issue: #22770.

MEP-71 is the bidirectional Mochi+Python package bridge:

- **Consume**: `import python "<package>@<semver>" as <alias>` resolves via uv, ingests PEP 561 stubs through a 4-tier precedence ladder, lowers via a closed type-mapping table, synthesises a CPython extension wrapper module, and surfaces Python items as Mochi `extern fn`.
- **Publish**: `mochi pkg publish --to=pypi` produces sdist + wheel via a `mochi-build` PEP 517 backend, uploads through PyPI Trusted Publishing (Sigstore-keyless OIDC), and attaches PEP 740 attestations.

## What this PR ships

- `website/docs/mep/mep-0071.md`: the normative spec.
- `website/docs/research/0071/`: 12 deep-research notes (index + language surface, design philosophy, prior-art bridges, PEP 561 stub ingest, type mapping, PyPI publish flow, Sigstore + Trusted Publishing, async bridge, ABI stability, GIL + C extensions, Pyodide/WASI/embedded, risks and alternatives).
- `website/docs/implementation/0071/index.md`: 18-phase rollout tracking.
- `package3/python/README.md`: greenfield stub pointing at the spec.

No code yet. Phase 0 (skeleton) is the first implementation deliverable in a follow-up PR.

## Key load-bearing decisions documented

1. **PEP 561 four-tier precedence** (inline `py.typed`, sibling `<name>-stubs`, typeshed, stubgen fallback) as the canonical type source. Matches pyright / mypy resolution.
2. **Synthesised CPython wrapper module** (not direct ctypes) for GIL safety and reuse of MEP-51 Phase 12 sidecar pattern.
3. **Closed type-mapping table** covering scalars, collections, dataclass / TypedDict / NamedTuple / Enum / Protocol; refusals become opaque `PyObject` handles.
4. **asyncio.run per-call default** with `[python].async-mode = "persistent"` opt-in for hot loops.
5. **uv as canonical resolver** with PEP 751 pylock.toml interchange.
6. **Sigstore-keyless OIDC + PEP 740** as the only publish path. No legacy API tokens.

## Fixture corpus

25 PyPI packages covering all four PEP 561 tiers (numpy, pandas, scipy, scikit-learn, requests, httpx, urllib3, pillow, pydantic, attrs, click, typer, rich, tqdm, sqlalchemy, fastapi, starlette, uvicorn, aiohttp, pyyaml, toml, tomli, msgpack, orjson, pytest).

## Test plan

- [x] Spec, research notes, implementation index render in Docusaurus (sidebar auto-generation picks them up via filesystem layout).
- [x] All internal links resolve (`/docs/mep/mep-0071`, `/docs/research/0071/...`, `/docs/implementation/0071/`).
- [x] No em-dashes in prose (matches user style preference). Table-cell em-dashes representing "blank" match MEP-73 / MEP-74 established pattern.
- [x] Cross-references back to MEP-51, MEP-57, MEP-73 spec / implementation tracking pages.
- [ ] Phase 0 skeleton lands in a follow-up PR.

Closes #22770 (when all phases land).