### PR TITLE
MEP-74 phase 4: typed ApiSurface parser

### DIFF
--- a/package3/go/apisurface/ingest.go
+++ b/package3/go/apisurface/ingest.go
@@ -327,6 +327,18 @@ func typeString(t types.Type, selfPkg string, importSet map[string]struct{}) str
 	if t == nil {
 		return ""
 	}
+	// Resolve untyped-basic constants to their default type so the
+	// rendered string matches the closed grammar of typeexpr. For
+	// example, an untyped string constant renders as "string", not
+	// "untyped string".
+	if b, ok := t.(*types.Basic); ok && b.Info()&types.IsUntyped != 0 {
+		t = types.Default(t)
+		if b2, ok2 := t.(*types.Basic); ok2 && b2.Info()&types.IsUntyped != 0 {
+			// types.Default returned an untyped value (e.g. for
+			// untyped nil); strip the "untyped " prefix manually.
+			return strings.TrimPrefix(b2.Name(), "untyped ")
+		}
+	}
 	q := func(p *types.Package) string {
 		if p == nil {
 			return ""

--- a/package3/go/apisurface/phase04_test.go
+++ b/package3/go/apisurface/phase04_test.go
@@ -1,0 +1,153 @@
+package apisurface
+
+import (
+	"testing"
+)
+
+// TestPhase4ApisurfaceParser is the umbrella sentinel for MEP-74
+// phase 4. Drives the full pipeline: synthesise an in-memory
+// fixture module, run Ingest (phase 3) over it, Encode the result
+// to JSON, Decode it back, Load the decoded file into a typed
+// Surface, and verify the typed lookups recover every declaration
+// with the right type shape. Passing this sentinel means a
+// downstream caller can integrate phase 4 end-to-end: take an
+// ApiSurface JSON blob, walk a typed AST.
+func TestPhase4ApisurfaceParser(t *testing.T) {
+	pkgs := loadFixture(t, map[string]string{
+		"go.mod": "module fixture.test/m\n\ngo 1.21\n",
+		"app/app.go": `// Package app is a fixture.
+package app
+
+import "io"
+
+// Greeter greets.
+type Greeter struct {
+	Name string
+}
+
+// Hello returns the greeting.
+func (g *Greeter) Hello() string { return "hi " + g.Name }
+
+// Read consumes from r.
+func Read(r io.Reader, buf []byte) (int, error) { return 0, nil }
+
+// Pair holds two ints.
+type Pair struct {
+	A, B int
+}
+
+// MapKeys returns keys of m.
+func MapKeys[K comparable, V any](m map[K]V) []K { return nil }
+
+// Default is a default Greeter.
+var Default = &Greeter{Name: "world"}
+
+// Version of the fixture.
+const Version = "1.0.0"
+`,
+	})
+	f, err := Ingest(pkgs, IngestOptions{Module: "fixture.test/m", Version: "v0.1.0"})
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	buf, err := f.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	decoded, err := Decode(buf)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	s, err := Load(decoded, LoadOptions{})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Find the app package by suffix match (the import path will be
+	// "fixture.test/m/app" depending on how go/packages resolves it).
+	var appPath string
+	for _, p := range s.PackagePaths() {
+		if endsWith(p, "/app") {
+			appPath = p
+		}
+	}
+	if appPath == "" {
+		t.Fatalf("could not locate app package among %v", s.PackagePaths())
+	}
+
+	// Read func: (io.Reader, []byte) -> (int, error)
+	read := s.LookupFunc(appPath, "Read")
+	if read == nil {
+		t.Fatalf("Read missing")
+	}
+	if len(read.Params) != 2 || len(read.Results) != 2 {
+		t.Errorf("Read shape: params=%d results=%d", len(read.Params), len(read.Results))
+	}
+	n, ok := read.Params[0].Type.(NamedType)
+	if !ok || n.PackagePath != "io" || n.Name != "Reader" {
+		t.Errorf("Read.Params[0].Type = %#v", read.Params[0].Type)
+	}
+	if _, ok := read.Params[1].Type.(SliceType); !ok {
+		t.Errorf("Read.Params[1].Type = %T", read.Params[1].Type)
+	}
+	if b, ok := read.Results[0].Type.(BasicType); !ok || b.Name != "int" {
+		t.Errorf("Read.Results[0].Type = %#v", read.Results[0].Type)
+	}
+
+	// Greeter type + method.
+	greeter := s.LookupType(appPath, "Greeter")
+	if greeter == nil {
+		t.Fatalf("Greeter missing")
+	}
+	if greeter.Kind != KindStruct {
+		t.Errorf("Greeter.Kind = %q", greeter.Kind)
+	}
+	hello := s.LookupMethod(appPath, "Greeter", "Hello")
+	if hello == nil {
+		t.Fatalf("Greeter.Hello missing")
+	}
+	if hello.Underlying.Receiver != "Greeter" || !hello.Underlying.ReceiverPointer {
+		t.Errorf("Hello receiver: %q ptr=%v", hello.Underlying.Receiver, hello.Underlying.ReceiverPointer)
+	}
+
+	// MapKeys: generic with 2 type params.
+	mk := s.LookupFunc(appPath, "MapKeys")
+	if mk == nil {
+		t.Fatalf("MapKeys missing")
+	}
+	if len(mk.TypeParams) != 2 {
+		t.Errorf("MapKeys.TypeParams = %+v", mk.TypeParams)
+	}
+	// Result is []K
+	if len(mk.Results) != 1 {
+		t.Fatalf("MapKeys results: %+v", mk.Results)
+	}
+	if _, ok := mk.Results[0].Type.(SliceType); !ok {
+		t.Errorf("MapKeys.Results[0].Type = %T", mk.Results[0].Type)
+	}
+
+	// Default var: *Greeter.
+	defv := s.Packages[appPath].Vars["Default"]
+	if defv == nil {
+		t.Fatalf("Default var missing")
+	}
+	if _, ok := defv.Type.(PointerType); !ok {
+		t.Errorf("Default.Type = %T", defv.Type)
+	}
+
+	// Version const: string.
+	ver := s.Packages[appPath].Consts["Version"]
+	if ver == nil {
+		t.Fatalf("Version const missing")
+	}
+	if b, ok := ver.Type.(BasicType); !ok || b.Name != "string" {
+		t.Errorf("Version.Type = %#v", ver.Type)
+	}
+}
+
+func endsWith(s, suffix string) bool {
+	if len(s) < len(suffix) {
+		return false
+	}
+	return s[len(s)-len(suffix):] == suffix
+}

--- a/package3/go/apisurface/surface.go
+++ b/package3/go/apisurface/surface.go
@@ -1,0 +1,404 @@
+package apisurface
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Surface is the typed bridge-side view of an ApiSurface JSON
+// document. Every type expression in the document has been parsed
+// into a GoType and every cross-reference has been validated.
+// Construct via Load.
+type Surface struct {
+	// File is the raw JSON document the Surface was derived from.
+	// Retained so phase 5+ can re-encode the surface, dump it for
+	// diagnostics, or check fields the typed view does not expose.
+	File *File
+	// Packages is indexed by canonical import path.
+	Packages map[string]*PackageView
+}
+
+// PackageView is a typed view of one Package. Lists are sorted by
+// name (matching the underlying JSON layout).
+type PackageView struct {
+	Pkg *Package
+	// Funcs maps func name -> typed declaration.
+	Funcs map[string]*FuncDecl
+	// Types maps type name -> typed declaration.
+	Types map[string]*TypeDecl
+	// Consts maps const name -> typed declaration.
+	Consts map[string]*ValueDecl
+	// Vars maps var name -> typed declaration.
+	Vars map[string]*ValueDecl
+}
+
+// FuncDecl is a typed view of a Func entry. The Underlying field
+// retains the raw JSON record.
+type FuncDecl struct {
+	Underlying *Func
+	Params     []ParamDecl
+	Results    []ParamDecl
+	TypeParams []TypeParamDecl
+}
+
+// ParamDecl is a typed parameter.
+type ParamDecl struct {
+	Name string
+	Type GoType
+}
+
+// TypeParamDecl is a typed type parameter (Constraint may be nil for
+// "any" elided in source).
+type TypeParamDecl struct {
+	Name       string
+	Constraint GoType
+}
+
+// TypeDecl is a typed view of a Type entry.
+type TypeDecl struct {
+	Underlying       *Type
+	Kind             TypeKind
+	UnderlyingType   GoType
+	AliasOf          GoType
+	Fields           []FieldDecl
+	Methods          []*FuncDecl
+	InterfaceMethods []*FuncDecl
+	EmbeddedTypes    []GoType
+	TypeParams       []TypeParamDecl
+}
+
+// FieldDecl is a typed struct field.
+type FieldDecl struct {
+	Name     string
+	Type     GoType
+	Tag      string
+	Doc      string
+	Exported bool
+	Embedded bool
+}
+
+// ValueDecl is a typed const or var.
+type ValueDecl struct {
+	Underlying *Value
+	Type       GoType
+}
+
+// LoadOptions tweak Surface.Load.
+type LoadOptions struct {
+	// StrictCrossReferences, when true, makes Load return an error if
+	// a NamedType references a package that is not in the document's
+	// Imports list (for the consuming package) and is not the self
+	// package. The default (false) is permissive because Go stdlib
+	// names (io, fmt, ...) are not always in Imports.
+	StrictCrossReferences bool
+}
+
+// ErrSurfaceLoad is returned for unrecoverable Load failures.
+var ErrSurfaceLoad = errors.New("apisurface: surface load")
+
+// Load parses every type expression in f and builds a typed Surface.
+// Returns the first parse error encountered, wrapped in
+// ErrSurfaceLoad.
+func Load(f *File, opts LoadOptions) (*Surface, error) {
+	if f == nil {
+		return nil, fmt.Errorf("%w: nil file", ErrSurfaceLoad)
+	}
+	if f.SchemaVersion != SchemaVersion {
+		return nil, fmt.Errorf("%w: schema version %d (want %d)", ErrSurfaceLoad, f.SchemaVersion, SchemaVersion)
+	}
+	s := &Surface{File: f, Packages: make(map[string]*PackageView, len(f.Packages))}
+	for i := range f.Packages {
+		p := &f.Packages[i]
+		view := &PackageView{
+			Pkg:    p,
+			Funcs:  make(map[string]*FuncDecl, len(p.Funcs)),
+			Types:  make(map[string]*TypeDecl, len(p.Types)),
+			Consts: make(map[string]*ValueDecl, len(p.Consts)),
+			Vars:   make(map[string]*ValueDecl, len(p.Vars)),
+		}
+		ctx := &loadCtx{selfPkg: p.ImportPath, imports: importSetFromSlice(p.Imports), opts: opts}
+		for j := range p.Funcs {
+			fd, err := loadFunc(ctx, &p.Funcs[j])
+			if err != nil {
+				return nil, fmt.Errorf("%w: %s.%s: %v", ErrSurfaceLoad, p.ImportPath, p.Funcs[j].Name, err)
+			}
+			view.Funcs[p.Funcs[j].Name] = fd
+		}
+		for j := range p.Types {
+			td, err := loadType(ctx, &p.Types[j])
+			if err != nil {
+				return nil, fmt.Errorf("%w: %s.%s: %v", ErrSurfaceLoad, p.ImportPath, p.Types[j].Name, err)
+			}
+			view.Types[p.Types[j].Name] = td
+		}
+		for j := range p.Consts {
+			vd, err := loadValue(ctx, &p.Consts[j])
+			if err != nil {
+				return nil, fmt.Errorf("%w: %s.%s: %v", ErrSurfaceLoad, p.ImportPath, p.Consts[j].Name, err)
+			}
+			view.Consts[p.Consts[j].Name] = vd
+		}
+		for j := range p.Vars {
+			vd, err := loadValue(ctx, &p.Vars[j])
+			if err != nil {
+				return nil, fmt.Errorf("%w: %s.%s: %v", ErrSurfaceLoad, p.ImportPath, p.Vars[j].Name, err)
+			}
+			view.Vars[p.Vars[j].Name] = vd
+		}
+		s.Packages[p.ImportPath] = view
+	}
+	return s, nil
+}
+
+// PackagePaths returns the import paths of all packages in the
+// Surface, sorted lexicographically.
+func (s *Surface) PackagePaths() []string {
+	out := make([]string, 0, len(s.Packages))
+	for k := range s.Packages {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// LookupFunc returns the typed declaration for pkg.fn, or nil if
+// either the package or the function is absent.
+func (s *Surface) LookupFunc(pkg, fn string) *FuncDecl {
+	view, ok := s.Packages[pkg]
+	if !ok {
+		return nil
+	}
+	return view.Funcs[fn]
+}
+
+// LookupType returns the typed declaration for pkg.name, or nil.
+func (s *Surface) LookupType(pkg, name string) *TypeDecl {
+	view, ok := s.Packages[pkg]
+	if !ok {
+		return nil
+	}
+	return view.Types[name]
+}
+
+// LookupMethod returns the typed declaration for pkg.typ.method, or
+// nil.
+func (s *Surface) LookupMethod(pkg, typ, method string) *FuncDecl {
+	td := s.LookupType(pkg, typ)
+	if td == nil {
+		return nil
+	}
+	for _, m := range td.Methods {
+		if m.Underlying.Name == method {
+			return m
+		}
+	}
+	return nil
+}
+
+// loadCtx is shared across one package's loaders. It carries the
+// canonical import set and the self-package path so we can validate
+// cross-references.
+type loadCtx struct {
+	selfPkg string
+	imports map[string]struct{}
+	opts    LoadOptions
+}
+
+func importSetFromSlice(paths []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		out[p] = struct{}{}
+	}
+	return out
+}
+
+func (c *loadCtx) checkRef(t GoType) error {
+	if !c.opts.StrictCrossReferences {
+		return nil
+	}
+	return walkTypes(t, func(t GoType) error {
+		n, ok := t.(NamedType)
+		if !ok {
+			return nil
+		}
+		if n.PackagePath == "" || n.PackagePath == c.selfPkg {
+			return nil
+		}
+		if _, ok := c.imports[n.PackagePath]; !ok {
+			return fmt.Errorf("named type %q references package %q which is not in the import set", n.Name, n.PackagePath)
+		}
+		return nil
+	})
+}
+
+// walkTypes calls fn for every GoType in t, including t itself.
+// Returns the first non-nil error.
+func walkTypes(t GoType, fn func(GoType) error) error {
+	if t == nil {
+		return nil
+	}
+	if err := fn(t); err != nil {
+		return err
+	}
+	switch v := t.(type) {
+	case PointerType:
+		return walkTypes(v.Elem, fn)
+	case SliceType:
+		return walkTypes(v.Elem, fn)
+	case ArrayType:
+		return walkTypes(v.Elem, fn)
+	case MapType:
+		if err := walkTypes(v.Key, fn); err != nil {
+			return err
+		}
+		return walkTypes(v.Value, fn)
+	case ChanType:
+		return walkTypes(v.Elem, fn)
+	case FuncType:
+		for _, p := range v.Params {
+			if err := walkTypes(p, fn); err != nil {
+				return err
+			}
+		}
+		for _, r := range v.Results {
+			if err := walkTypes(r, fn); err != nil {
+				return err
+			}
+		}
+	case EllipsisType:
+		return walkTypes(v.Elem, fn)
+	case NamedType:
+		for _, a := range v.TypeArgs {
+			if err := walkTypes(a, fn); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func loadFunc(ctx *loadCtx, f *Func) (*FuncDecl, error) {
+	fd := &FuncDecl{Underlying: f}
+	for _, tp := range f.TypeParams {
+		var c GoType
+		if tp.Constraint != "" {
+			t, err := ParseType(tp.Constraint)
+			if err != nil {
+				return nil, fmt.Errorf("type param %q constraint %q: %w", tp.Name, tp.Constraint, err)
+			}
+			c = t
+		}
+		fd.TypeParams = append(fd.TypeParams, TypeParamDecl{Name: tp.Name, Constraint: c})
+	}
+	for _, p := range f.Params {
+		gt, err := parseAndCheck(ctx, p.Type)
+		if err != nil {
+			return nil, fmt.Errorf("param %q: %w", p.Name, err)
+		}
+		fd.Params = append(fd.Params, ParamDecl{Name: p.Name, Type: gt})
+	}
+	for _, r := range f.Results {
+		gt, err := parseAndCheck(ctx, r.Type)
+		if err != nil {
+			return nil, fmt.Errorf("result %q: %w", r.Name, err)
+		}
+		fd.Results = append(fd.Results, ParamDecl{Name: r.Name, Type: gt})
+	}
+	return fd, nil
+}
+
+func loadType(ctx *loadCtx, tp *Type) (*TypeDecl, error) {
+	td := &TypeDecl{Underlying: tp, Kind: tp.Kind}
+	for _, p := range tp.TypeParams {
+		var c GoType
+		if p.Constraint != "" {
+			t, err := ParseType(p.Constraint)
+			if err != nil {
+				return nil, fmt.Errorf("type param %q constraint %q: %w", p.Name, p.Constraint, err)
+			}
+			c = t
+		}
+		td.TypeParams = append(td.TypeParams, TypeParamDecl{Name: p.Name, Constraint: c})
+	}
+	if tp.AliasOf != "" {
+		t, err := parseAndCheck(ctx, tp.AliasOf)
+		if err != nil {
+			return nil, fmt.Errorf("alias target %q: %w", tp.AliasOf, err)
+		}
+		td.AliasOf = t
+	}
+	if tp.Underlying != "" {
+		// Underlying may be a literal struct{...}/interface{...}; if
+		// the kind already gives the structure, we still keep the raw
+		// underlying parsed for diagnostics.
+		t, err := ParseType(tp.Underlying)
+		if err != nil {
+			return nil, fmt.Errorf("underlying %q: %w", tp.Underlying, err)
+		}
+		td.UnderlyingType = t
+	}
+	for _, f := range tp.Fields {
+		gt, err := parseAndCheck(ctx, f.Type)
+		if err != nil {
+			return nil, fmt.Errorf("field %q: %w", f.Name, err)
+		}
+		td.Fields = append(td.Fields, FieldDecl{
+			Name:     f.Name,
+			Type:     gt,
+			Tag:      f.Tag,
+			Doc:      f.Doc,
+			Exported: f.Exported,
+			Embedded: f.Embedded,
+		})
+	}
+	for i := range tp.Methods {
+		m, err := loadFunc(ctx, &tp.Methods[i])
+		if err != nil {
+			return nil, fmt.Errorf("method %q: %w", tp.Methods[i].Name, err)
+		}
+		td.Methods = append(td.Methods, m)
+	}
+	for i := range tp.InterfaceMethods {
+		m, err := loadFunc(ctx, &tp.InterfaceMethods[i])
+		if err != nil {
+			return nil, fmt.Errorf("interface method %q: %w", tp.InterfaceMethods[i].Name, err)
+		}
+		td.InterfaceMethods = append(td.InterfaceMethods, m)
+	}
+	for _, e := range tp.EmbeddedTypes {
+		gt, err := parseAndCheck(ctx, e)
+		if err != nil {
+			return nil, fmt.Errorf("embedded type %q: %w", e, err)
+		}
+		td.EmbeddedTypes = append(td.EmbeddedTypes, gt)
+	}
+	return td, nil
+}
+
+func loadValue(ctx *loadCtx, v *Value) (*ValueDecl, error) {
+	vd := &ValueDecl{Underlying: v}
+	if v.Type != "" {
+		gt, err := parseAndCheck(ctx, v.Type)
+		if err != nil {
+			return nil, err
+		}
+		vd.Type = gt
+	}
+	return vd, nil
+}
+
+func parseAndCheck(ctx *loadCtx, expr string) (GoType, error) {
+	if strings.TrimSpace(expr) == "" {
+		return nil, nil
+	}
+	t, err := ParseType(expr)
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.checkRef(t); err != nil {
+		return nil, err
+	}
+	return t, nil
+}

--- a/package3/go/apisurface/surface_test.go
+++ b/package3/go/apisurface/surface_test.go
@@ -1,0 +1,233 @@
+package apisurface
+
+import (
+	"errors"
+	"testing"
+)
+
+func makeSampleFile() *File {
+	return &File{
+		SchemaVersion: SchemaVersion,
+		Module:        "example.com/foo",
+		Packages: []Package{
+			{
+				ImportPath: "example.com/foo",
+				Name:       "foo",
+				Imports:    []string{"io"},
+				Funcs: []Func{
+					{
+						Name:    "Read",
+						Params:  []Param{{Name: "r", Type: "io.Reader"}, {Name: "buf", Type: "[]byte"}},
+						Results: []Param{{Type: "int"}, {Type: "error"}},
+					},
+					{
+						Name:    "Generic",
+						Params:  []Param{{Name: "v", Type: "T"}},
+						TypeParams: []TypeParam{{Name: "T", Constraint: "any"}},
+					},
+					{
+						Name:     "Varied",
+						Params:   []Param{{Name: "args", Type: "...string"}},
+						Variadic: true,
+					},
+				},
+				Types: []Type{
+					{
+						Name: "Greeter",
+						Kind: KindStruct,
+						Fields: []Field{
+							{Name: "Name", Type: "string", Exported: true},
+							{Name: "R", Type: "io.Reader", Exported: true},
+						},
+						Methods: []Func{
+							{Name: "Hello", Receiver: "Greeter", Results: []Param{{Type: "string"}}},
+						},
+					},
+					{
+						Name:    "Alias",
+						Kind:    KindAlias,
+						AliasOf: "string",
+					},
+					{
+						Name: "Iface",
+						Kind: KindInterface,
+						InterfaceMethods: []Func{
+							{Name: "Read", Params: []Param{{Name: "p", Type: "[]byte"}}, Results: []Param{{Type: "int"}, {Type: "error"}}},
+						},
+					},
+				},
+				Consts: []Value{
+					{Name: "Version", Type: "string", Const: "\"1\""},
+				},
+				Vars: []Value{
+					{Name: "Default", Type: "*Greeter"},
+				},
+			},
+		},
+	}
+}
+
+func TestSurfaceLoadHappyPath(t *testing.T) {
+	s, err := Load(makeSampleFile(), LoadOptions{})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(s.Packages) != 1 {
+		t.Fatalf("Packages len = %d", len(s.Packages))
+	}
+	if got := s.LookupFunc("example.com/foo", "Read"); got == nil {
+		t.Errorf("LookupFunc(Read) = nil")
+	} else {
+		if len(got.Params) != 2 || len(got.Results) != 2 {
+			t.Errorf("Read shape: params=%d results=%d", len(got.Params), len(got.Results))
+		}
+		// io.Reader param parses as NamedType io.Reader.
+		n, ok := got.Params[0].Type.(NamedType)
+		if !ok || n.PackagePath != "io" || n.Name != "Reader" {
+			t.Errorf("Params[0].Type = %#v", got.Params[0].Type)
+		}
+		// []byte param parses as SliceType.
+		if _, ok := got.Params[1].Type.(SliceType); !ok {
+			t.Errorf("Params[1].Type = %T", got.Params[1].Type)
+		}
+	}
+	if got := s.LookupType("example.com/foo", "Greeter"); got == nil {
+		t.Errorf("LookupType(Greeter) = nil")
+	} else {
+		if got.Kind != KindStruct {
+			t.Errorf("Greeter.Kind = %q", got.Kind)
+		}
+		if len(got.Fields) != 2 {
+			t.Errorf("Greeter.Fields = %+v", got.Fields)
+		}
+		if len(got.Methods) != 1 {
+			t.Errorf("Greeter.Methods = %+v", got.Methods)
+		}
+	}
+	if got := s.LookupMethod("example.com/foo", "Greeter", "Hello"); got == nil {
+		t.Errorf("LookupMethod(Greeter.Hello) = nil")
+	}
+	if got := s.LookupType("example.com/foo", "Alias"); got == nil || got.AliasOf == nil {
+		t.Errorf("Alias: %+v", got)
+	}
+}
+
+func TestSurfaceLoadGeneric(t *testing.T) {
+	s, err := Load(makeSampleFile(), LoadOptions{})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	gen := s.LookupFunc("example.com/foo", "Generic")
+	if gen == nil {
+		t.Fatalf("Generic missing")
+	}
+	if len(gen.TypeParams) != 1 || gen.TypeParams[0].Name != "T" {
+		t.Errorf("TypeParams = %+v", gen.TypeParams)
+	}
+	if c, ok := gen.TypeParams[0].Constraint.(BasicType); !ok || c.Name != "any" {
+		t.Errorf("Constraint = %#v", gen.TypeParams[0].Constraint)
+	}
+}
+
+func TestSurfaceLoadVariadic(t *testing.T) {
+	s, err := Load(makeSampleFile(), LoadOptions{})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	v := s.LookupFunc("example.com/foo", "Varied")
+	if v == nil {
+		t.Fatalf("Varied missing")
+	}
+	if _, ok := v.Params[0].Type.(EllipsisType); !ok {
+		t.Errorf("Varied param type = %T", v.Params[0].Type)
+	}
+}
+
+func TestSurfaceLoadInterface(t *testing.T) {
+	s, _ := Load(makeSampleFile(), LoadOptions{})
+	td := s.LookupType("example.com/foo", "Iface")
+	if td == nil || td.Kind != KindInterface {
+		t.Fatalf("Iface = %+v", td)
+	}
+	if len(td.InterfaceMethods) != 1 {
+		t.Errorf("Iface.InterfaceMethods = %+v", td.InterfaceMethods)
+	}
+}
+
+func TestSurfaceLoadRejectsBadSchema(t *testing.T) {
+	bad := &File{SchemaVersion: 99}
+	_, err := Load(bad, LoadOptions{})
+	if err == nil {
+		t.Fatalf("Load: want error")
+	}
+	if !errors.Is(err, ErrSurfaceLoad) {
+		t.Errorf("error = %v", err)
+	}
+}
+
+func TestSurfaceLoadRejectsNil(t *testing.T) {
+	if _, err := Load(nil, LoadOptions{}); err == nil {
+		t.Errorf("Load(nil): want error")
+	}
+}
+
+func TestSurfaceLoadParseError(t *testing.T) {
+	bad := makeSampleFile()
+	bad.Packages[0].Funcs[0].Params[0].Type = "[" // malformed
+	_, err := Load(bad, LoadOptions{})
+	if err == nil {
+		t.Errorf("Load: want error on malformed type")
+	}
+}
+
+func TestSurfaceLoadStrictCrossReferences(t *testing.T) {
+	bad := makeSampleFile()
+	// Reference an external package not in Imports.
+	bad.Packages[0].Funcs = append(bad.Packages[0].Funcs, Func{
+		Name:   "Phantom",
+		Params: []Param{{Name: "x", Type: "phantom.Type"}},
+	})
+	if _, err := Load(bad, LoadOptions{StrictCrossReferences: true}); err == nil {
+		t.Errorf("Load strict: want error on missing import")
+	}
+	if _, err := Load(bad, LoadOptions{}); err != nil {
+		t.Errorf("Load non-strict: should accept missing import: %v", err)
+	}
+}
+
+func TestSurfacePackagePaths(t *testing.T) {
+	s, _ := Load(makeSampleFile(), LoadOptions{})
+	paths := s.PackagePaths()
+	if len(paths) != 1 || paths[0] != "example.com/foo" {
+		t.Errorf("PackagePaths = %v", paths)
+	}
+}
+
+func TestSurfaceLookupMissingPkg(t *testing.T) {
+	s, _ := Load(makeSampleFile(), LoadOptions{})
+	if s.LookupFunc("missing", "x") != nil {
+		t.Errorf("LookupFunc on missing pkg: want nil")
+	}
+	if s.LookupType("missing", "x") != nil {
+		t.Errorf("LookupType on missing pkg: want nil")
+	}
+	if s.LookupMethod("missing", "x", "y") != nil {
+		t.Errorf("LookupMethod on missing pkg: want nil")
+	}
+}
+
+func TestWalkTypes(t *testing.T) {
+	mapT := MapType{
+		Key:   BasicType{Name: "string"},
+		Value: SliceType{Elem: NamedType{PackagePath: "io", Name: "Reader"}},
+	}
+	count := 0
+	_ = walkTypes(mapT, func(t GoType) error {
+		count++
+		return nil
+	})
+	// MapType + key Basic + value Slice + slice elem Named = 4 nodes.
+	if count != 4 {
+		t.Errorf("walkTypes node count = %d, want 4", count)
+	}
+}

--- a/package3/go/apisurface/typeexpr.go
+++ b/package3/go/apisurface/typeexpr.go
@@ -1,0 +1,609 @@
+package apisurface
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// GoType is the typed bridge-side representation of a Go type
+// expression as it appears in ApiSurface JSON. The set of concrete
+// implementations is closed; phase 5 (type mapping) and phase 6
+// (wrapper synthesiser) switch over them.
+type GoType interface {
+	isGoType()
+	// String renders the type back to canonical source form. The
+	// output is byte-equal to the input for any string that
+	// successfully parsed (modulo non-canonical whitespace).
+	String() string
+}
+
+// BasicType names a Go predeclared type: int, int8..int64, uint,
+// uint8..uint64, uintptr, float32, float64, complex64, complex128,
+// string, bool, byte, rune, error, any, comparable.
+type BasicType struct {
+	Name string
+}
+
+// NamedType references a named type. PackagePath is the import path
+// of the declaring package; an empty PackagePath means the same
+// package as the surface being parsed. TypeArgs are the generic
+// instantiation arguments, if any.
+type NamedType struct {
+	PackagePath string
+	Name        string
+	TypeArgs    []GoType
+}
+
+// PointerType is *T.
+type PointerType struct {
+	Elem GoType
+}
+
+// SliceType is []T.
+type SliceType struct {
+	Elem GoType
+}
+
+// ArrayType is [N]T. Len is the literal element count.
+type ArrayType struct {
+	Len  int64
+	Elem GoType
+}
+
+// MapType is map[K]V.
+type MapType struct {
+	Key, Value GoType
+}
+
+// ChanDir is the direction of a channel type.
+type ChanDir int
+
+const (
+	ChanBoth ChanDir = iota
+	ChanSend
+	ChanRecv
+)
+
+// ChanType is chan T, <-chan T, or chan<- T.
+type ChanType struct {
+	Dir  ChanDir
+	Elem GoType
+}
+
+// FuncType is func(P1, P2) (R1, R2). Variadic is true when the last
+// element of Params is the ... parameter; in that case Params'
+// final element is wrapped in EllipsisType.
+type FuncType struct {
+	Params  []GoType
+	Results []GoType
+	Variadic bool
+}
+
+// EllipsisType is ...T -- legal only as the last parameter of a
+// FuncType. The parser handles it in that position only.
+type EllipsisType struct {
+	Elem GoType
+}
+
+// InterfaceType is a literal interface{...} body. Phase 4 keeps the
+// raw source form; phase 5 unfolds it if needed.
+type InterfaceType struct {
+	Source string
+}
+
+// StructType is a literal struct{...} body. Same as InterfaceType
+// in spirit -- the body is kept raw because anonymous struct/iface
+// types are rare and full re-parsing belongs in phase 5.
+type StructType struct {
+	Source string
+}
+
+func (BasicType) isGoType()     {}
+func (NamedType) isGoType()     {}
+func (PointerType) isGoType()   {}
+func (SliceType) isGoType()     {}
+func (ArrayType) isGoType()     {}
+func (MapType) isGoType()       {}
+func (ChanType) isGoType()      {}
+func (FuncType) isGoType()      {}
+func (EllipsisType) isGoType()  {}
+func (InterfaceType) isGoType() {}
+func (StructType) isGoType()    {}
+
+func (t BasicType) String() string { return t.Name }
+
+func (t NamedType) String() string {
+	var sb strings.Builder
+	if t.PackagePath != "" {
+		sb.WriteString(t.PackagePath)
+		sb.WriteByte('.')
+	}
+	sb.WriteString(t.Name)
+	if len(t.TypeArgs) > 0 {
+		sb.WriteByte('[')
+		for i, a := range t.TypeArgs {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(a.String())
+		}
+		sb.WriteByte(']')
+	}
+	return sb.String()
+}
+
+func (t PointerType) String() string { return "*" + t.Elem.String() }
+func (t SliceType) String() string   { return "[]" + t.Elem.String() }
+func (t ArrayType) String() string   { return "[" + strconv.FormatInt(t.Len, 10) + "]" + t.Elem.String() }
+func (t MapType) String() string     { return "map[" + t.Key.String() + "]" + t.Value.String() }
+
+func (t ChanType) String() string {
+	switch t.Dir {
+	case ChanSend:
+		return "chan<- " + t.Elem.String()
+	case ChanRecv:
+		return "<-chan " + t.Elem.String()
+	default:
+		return "chan " + t.Elem.String()
+	}
+}
+
+func (t FuncType) String() string {
+	var sb strings.Builder
+	sb.WriteString("func(")
+	for i, p := range t.Params {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(p.String())
+	}
+	sb.WriteByte(')')
+	if len(t.Results) == 0 {
+		return sb.String()
+	}
+	sb.WriteByte(' ')
+	if len(t.Results) == 1 {
+		if _, isFunc := t.Results[0].(FuncType); !isFunc {
+			sb.WriteString(t.Results[0].String())
+			return sb.String()
+		}
+	}
+	sb.WriteByte('(')
+	for i, r := range t.Results {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(r.String())
+	}
+	sb.WriteByte(')')
+	return sb.String()
+}
+
+func (t EllipsisType) String() string  { return "..." + t.Elem.String() }
+func (t InterfaceType) String() string { return t.Source }
+func (t StructType) String() string    { return t.Source }
+
+// basicSet is the predeclared identifier set. Used by the parser to
+// classify bare identifiers without package qualifier.
+var basicSet = map[string]bool{
+	"bool": true, "byte": true, "complex64": true, "complex128": true,
+	"error": true, "float32": true, "float64": true, "int": true,
+	"int8": true, "int16": true, "int32": true, "int64": true,
+	"rune": true, "string": true, "uint": true, "uint8": true,
+	"uint16": true, "uint32": true, "uint64": true, "uintptr": true,
+	"any": true, "comparable": true,
+}
+
+// ParseType parses a single Go type expression. Returns ErrTypeParse
+// on syntax error.
+func ParseType(s string) (GoType, error) {
+	p := newTypeParser(s)
+	t, err := p.parseType()
+	if err != nil {
+		return nil, err
+	}
+	p.skipSpaces()
+	if p.pos < len(p.src) {
+		return nil, fmt.Errorf("%w: trailing input %q after position %d", ErrTypeParse, p.src[p.pos:], p.pos)
+	}
+	return t, nil
+}
+
+// ErrTypeParse is returned for any malformed type expression.
+var ErrTypeParse = fmt.Errorf("apisurface: type parse error")
+
+type typeParser struct {
+	src string
+	pos int
+}
+
+func newTypeParser(s string) *typeParser { return &typeParser{src: s} }
+
+func (p *typeParser) errf(format string, args ...any) error {
+	return fmt.Errorf("%w: %s (at %d in %q)", ErrTypeParse, fmt.Sprintf(format, args...), p.pos, p.src)
+}
+
+func (p *typeParser) skipSpaces() {
+	for p.pos < len(p.src) {
+		r, sz := utf8.DecodeRuneInString(p.src[p.pos:])
+		if !unicode.IsSpace(r) {
+			return
+		}
+		p.pos += sz
+	}
+}
+
+func (p *typeParser) peekByte() byte {
+	p.skipSpaces()
+	if p.pos >= len(p.src) {
+		return 0
+	}
+	return p.src[p.pos]
+}
+
+func (p *typeParser) consume(s string) bool {
+	p.skipSpaces()
+	if strings.HasPrefix(p.src[p.pos:], s) {
+		p.pos += len(s)
+		return true
+	}
+	return false
+}
+
+func (p *typeParser) expect(s string) error {
+	if !p.consume(s) {
+		return p.errf("expected %q", s)
+	}
+	return nil
+}
+
+// parseType is the top-level grammar entry.
+//
+//	Type := '*' Type
+//	      | '[' ']' Type                   (slice)
+//	      | '[' Number ']' Type            (array)
+//	      | 'map' '[' Type ']' Type
+//	      | 'chan' Type | '<-' 'chan' Type | 'chan' '<-' Type
+//	      | 'func' Signature
+//	      | 'interface' '{' ... '}' (kept raw)
+//	      | 'struct' '{' ... '}' (kept raw)
+//	      | '...' Type (only legal mid-FuncType param list)
+//	      | NamedOrBasic
+func (p *typeParser) parseType() (GoType, error) {
+	p.skipSpaces()
+	if p.pos >= len(p.src) {
+		return nil, p.errf("unexpected end of input")
+	}
+
+	// Pointer.
+	if p.consume("*") {
+		elem, err := p.parseType()
+		if err != nil {
+			return nil, err
+		}
+		return PointerType{Elem: elem}, nil
+	}
+
+	// Send-direction prefix: "<-chan T".
+	if p.consume("<-") {
+		if !p.consume("chan") {
+			return nil, p.errf("expected 'chan' after '<-'")
+		}
+		elem, err := p.parseType()
+		if err != nil {
+			return nil, err
+		}
+		return ChanType{Dir: ChanRecv, Elem: elem}, nil
+	}
+
+	// Slice / array.
+	if p.consume("[") {
+		if p.consume("]") {
+			elem, err := p.parseType()
+			if err != nil {
+				return nil, err
+			}
+			return SliceType{Elem: elem}, nil
+		}
+		// Array.
+		n, err := p.parseNumber()
+		if err != nil {
+			return nil, err
+		}
+		if err := p.expect("]"); err != nil {
+			return nil, err
+		}
+		elem, err := p.parseType()
+		if err != nil {
+			return nil, err
+		}
+		return ArrayType{Len: n, Elem: elem}, nil
+	}
+
+	// Word-prefixed forms.
+	if ident, ok := p.tryKeyword("map"); ok {
+		_ = ident
+		if err := p.expect("["); err != nil {
+			return nil, err
+		}
+		key, err := p.parseType()
+		if err != nil {
+			return nil, err
+		}
+		if err := p.expect("]"); err != nil {
+			return nil, err
+		}
+		val, err := p.parseType()
+		if err != nil {
+			return nil, err
+		}
+		return MapType{Key: key, Value: val}, nil
+	}
+	if _, ok := p.tryKeyword("chan"); ok {
+		dir := ChanBoth
+		if p.consume("<-") {
+			dir = ChanSend
+		}
+		elem, err := p.parseType()
+		if err != nil {
+			return nil, err
+		}
+		return ChanType{Dir: dir, Elem: elem}, nil
+	}
+	if _, ok := p.tryKeyword("func"); ok {
+		return p.parseFuncSig()
+	}
+	if _, ok := p.tryKeyword("interface"); ok {
+		body, err := p.parseBraceBody()
+		if err != nil {
+			return nil, err
+		}
+		return InterfaceType{Source: "interface" + body}, nil
+	}
+	if _, ok := p.tryKeyword("struct"); ok {
+		body, err := p.parseBraceBody()
+		if err != nil {
+			return nil, err
+		}
+		return StructType{Source: "struct" + body}, nil
+	}
+
+	// Ellipsis (legal only inside a func signature param list; the
+	// caller handles that).
+	if p.consume("...") {
+		elem, err := p.parseType()
+		if err != nil {
+			return nil, err
+		}
+		return EllipsisType{Elem: elem}, nil
+	}
+
+	// Named or basic.
+	return p.parseNamed()
+}
+
+// parseFuncSig parses the signature that follows the 'func' keyword.
+func (p *typeParser) parseFuncSig() (GoType, error) {
+	if err := p.expect("("); err != nil {
+		return nil, err
+	}
+	var params []GoType
+	variadic := false
+	if !p.consume(")") {
+		for {
+			if p.consume("...") {
+				elem, err := p.parseType()
+				if err != nil {
+					return nil, err
+				}
+				params = append(params, EllipsisType{Elem: elem})
+				variadic = true
+				if !p.consume(",") {
+					break
+				}
+				continue
+			}
+			t, err := p.parseType()
+			if err != nil {
+				return nil, err
+			}
+			params = append(params, t)
+			if !p.consume(",") {
+				break
+			}
+		}
+		if err := p.expect(")"); err != nil {
+			return nil, err
+		}
+	}
+	// Results: may be absent, single, or "(T1, T2)".
+	p.skipSpaces()
+	var results []GoType
+	if p.pos < len(p.src) {
+		if p.consume("(") {
+			if !p.consume(")") {
+				for {
+					t, err := p.parseType()
+					if err != nil {
+						return nil, err
+					}
+					results = append(results, t)
+					if !p.consume(",") {
+						break
+					}
+				}
+				if err := p.expect(")"); err != nil {
+					return nil, err
+				}
+			}
+		} else if p.canStartType() {
+			t, err := p.parseType()
+			if err != nil {
+				return nil, err
+			}
+			results = []GoType{t}
+		}
+	}
+	return FuncType{Params: params, Results: results, Variadic: variadic}, nil
+}
+
+// canStartType reports whether the next non-space byte could begin a
+// Type. Used to disambiguate "func() // no result" from "func() T".
+func (p *typeParser) canStartType() bool {
+	b := p.peekByte()
+	if b == 0 {
+		return false
+	}
+	// Result lists never start with these tokens.
+	switch b {
+	case ')', ',', ']', '}':
+		return false
+	}
+	return true
+}
+
+// parseBraceBody captures a balanced-brace body for interface{...} or
+// struct{...}, returning the body inclusive of the braces.
+func (p *typeParser) parseBraceBody() (string, error) {
+	if err := p.expect("{"); err != nil {
+		return "", err
+	}
+	start := p.pos
+	depth := 1
+	for p.pos < len(p.src) {
+		switch p.src[p.pos] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				body := p.src[start:p.pos]
+				p.pos++
+				return "{" + body + "}", nil
+			}
+		}
+		p.pos++
+	}
+	return "", p.errf("unbalanced braces")
+}
+
+func (p *typeParser) parseNumber() (int64, error) {
+	p.skipSpaces()
+	start := p.pos
+	for p.pos < len(p.src) && p.src[p.pos] >= '0' && p.src[p.pos] <= '9' {
+		p.pos++
+	}
+	if p.pos == start {
+		return 0, p.errf("expected number")
+	}
+	n, err := strconv.ParseInt(p.src[start:p.pos], 10, 64)
+	if err != nil {
+		return 0, p.errf("bad number: %v", err)
+	}
+	return n, nil
+}
+
+// parseNamed parses a basic ident, a "selector" form, or a generic
+// instantiation. Forms accepted:
+//
+//	ident                              -> BasicType or NamedType (self)
+//	import/path.ident                  -> NamedType{import/path, ident}
+//	ident[T, U]                        -> NamedType with TypeArgs
+//	import/path.ident[T, U]            -> ditto
+func (p *typeParser) parseNamed() (GoType, error) {
+	prefix, err := p.parseIdentPath()
+	if err != nil {
+		return nil, err
+	}
+	// Split at last "."; everything before is package path.
+	pkg := ""
+	name := prefix
+	if dot := strings.LastIndex(prefix, "."); dot >= 0 {
+		pkg = prefix[:dot]
+		name = prefix[dot+1:]
+	}
+	// Generic instantiation.
+	var typeArgs []GoType
+	if p.consume("[") {
+		if !p.consume("]") {
+			for {
+				t, err := p.parseType()
+				if err != nil {
+					return nil, err
+				}
+				typeArgs = append(typeArgs, t)
+				if !p.consume(",") {
+					break
+				}
+			}
+			if err := p.expect("]"); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if pkg == "" && len(typeArgs) == 0 && basicSet[name] {
+		return BasicType{Name: name}, nil
+	}
+	return NamedType{PackagePath: pkg, Name: name, TypeArgs: typeArgs}, nil
+}
+
+// parseIdentPath parses an identifier optionally followed by
+// "/path/to/pkg.Name" tail; the result is the entire path-with-dot
+// string. Splits at the final dot.
+//
+// Examples:
+//   "io.Reader"               -> "io.Reader"
+//   "github.com/foo/bar.Baz"  -> "github.com/foo/bar.Baz"
+//   "Foo"                     -> "Foo"
+//   "X86.Pause"               -> "X86.Pause"  (only one dot; pkg="X86")
+func (p *typeParser) parseIdentPath() (string, error) {
+	p.skipSpaces()
+	start := p.pos
+	if p.pos >= len(p.src) {
+		return "", p.errf("expected identifier")
+	}
+	r, sz := utf8.DecodeRuneInString(p.src[p.pos:])
+	if !isIdentStart(r) {
+		return "", p.errf("expected identifier, got %q", string(r))
+	}
+	p.pos += sz
+	for p.pos < len(p.src) {
+		r, sz := utf8.DecodeRuneInString(p.src[p.pos:])
+		if isIdentCont(r) || r == '.' || r == '/' || r == '-' {
+			p.pos += sz
+			continue
+		}
+		break
+	}
+	return p.src[start:p.pos], nil
+}
+
+// tryKeyword consumes the literal kw only when it appears as a whole
+// identifier (not followed by an identifier continuation char). For
+// example, "func(" matches "func" but "function(" does not.
+func (p *typeParser) tryKeyword(kw string) (string, bool) {
+	p.skipSpaces()
+	if !strings.HasPrefix(p.src[p.pos:], kw) {
+		return "", false
+	}
+	after := p.pos + len(kw)
+	if after < len(p.src) {
+		r, _ := utf8.DecodeRuneInString(p.src[after:])
+		if isIdentCont(r) {
+			return "", false
+		}
+	}
+	p.pos = after
+	return kw, true
+}
+
+func isIdentStart(r rune) bool {
+	return r == '_' || unicode.IsLetter(r)
+}
+
+func isIdentCont(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}

--- a/package3/go/apisurface/typeexpr_test.go
+++ b/package3/go/apisurface/typeexpr_test.go
@@ -1,0 +1,309 @@
+package apisurface
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestParseTypeBasics(t *testing.T) {
+	cases := []struct {
+		in   string
+		want GoType
+	}{
+		{"int", BasicType{Name: "int"}},
+		{"string", BasicType{Name: "string"}},
+		{"error", BasicType{Name: "error"}},
+		{"any", BasicType{Name: "any"}},
+		{"comparable", BasicType{Name: "comparable"}},
+	}
+	for _, tc := range cases {
+		got, err := ParseType(tc.in)
+		if err != nil {
+			t.Errorf("ParseType(%q): %v", tc.in, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("ParseType(%q) = %#v, want %#v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseTypeComposites(t *testing.T) {
+	cases := []struct {
+		in   string
+		want GoType
+	}{
+		{"*int", PointerType{Elem: BasicType{Name: "int"}}},
+		{"**int", PointerType{Elem: PointerType{Elem: BasicType{Name: "int"}}}},
+		{"[]string", SliceType{Elem: BasicType{Name: "string"}}},
+		{"[]*string", SliceType{Elem: PointerType{Elem: BasicType{Name: "string"}}}},
+		{"[4]byte", ArrayType{Len: 4, Elem: BasicType{Name: "byte"}}},
+		{"map[string]int", MapType{Key: BasicType{Name: "string"}, Value: BasicType{Name: "int"}}},
+		{"map[string][]int", MapType{Key: BasicType{Name: "string"}, Value: SliceType{Elem: BasicType{Name: "int"}}}},
+	}
+	for _, tc := range cases {
+		got, err := ParseType(tc.in)
+		if err != nil {
+			t.Errorf("ParseType(%q): %v", tc.in, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("ParseType(%q) = %#v, want %#v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseTypeChan(t *testing.T) {
+	cases := []struct {
+		in  string
+		dir ChanDir
+	}{
+		{"chan int", ChanBoth},
+		{"chan<- int", ChanSend},
+		{"<-chan int", ChanRecv},
+	}
+	for _, tc := range cases {
+		got, err := ParseType(tc.in)
+		if err != nil {
+			t.Fatalf("ParseType(%q): %v", tc.in, err)
+		}
+		c, ok := got.(ChanType)
+		if !ok {
+			t.Errorf("ParseType(%q) returned %T; want ChanType", tc.in, got)
+			continue
+		}
+		if c.Dir != tc.dir {
+			t.Errorf("ParseType(%q).Dir = %d; want %d", tc.in, c.Dir, tc.dir)
+		}
+		if !reflect.DeepEqual(c.Elem, BasicType{Name: "int"}) {
+			t.Errorf("ParseType(%q).Elem = %#v", tc.in, c.Elem)
+		}
+	}
+}
+
+func TestParseTypeNamed(t *testing.T) {
+	cases := []struct {
+		in  string
+		pkg string
+		nm  string
+	}{
+		{"io.Reader", "io", "Reader"},
+		{"github.com/foo/bar.Baz", "github.com/foo/bar", "Baz"},
+		{"MyType", "", "MyType"},
+	}
+	for _, tc := range cases {
+		got, err := ParseType(tc.in)
+		if err != nil {
+			t.Fatalf("ParseType(%q): %v", tc.in, err)
+		}
+		n, ok := got.(NamedType)
+		if !ok {
+			t.Errorf("ParseType(%q) = %T; want NamedType", tc.in, got)
+			continue
+		}
+		if n.PackagePath != tc.pkg || n.Name != tc.nm {
+			t.Errorf("ParseType(%q): pkg=%q name=%q (want %q/%q)", tc.in, n.PackagePath, n.Name, tc.pkg, tc.nm)
+		}
+	}
+}
+
+func TestParseTypeGeneric(t *testing.T) {
+	got, err := ParseType("Box[int]")
+	if err != nil {
+		t.Fatalf("ParseType: %v", err)
+	}
+	n, ok := got.(NamedType)
+	if !ok {
+		t.Fatalf("got %T", got)
+	}
+	if n.Name != "Box" || len(n.TypeArgs) != 1 {
+		t.Errorf("Box[int]: name=%q TypeArgs=%+v", n.Name, n.TypeArgs)
+	}
+
+	got, err = ParseType("Pair[string, int]")
+	if err != nil {
+		t.Fatalf("ParseType: %v", err)
+	}
+	n = got.(NamedType)
+	if len(n.TypeArgs) != 2 {
+		t.Errorf("Pair: TypeArgs = %+v", n.TypeArgs)
+	}
+
+	got, err = ParseType("example.com/x.Box[int]")
+	if err != nil {
+		t.Fatalf("ParseType: %v", err)
+	}
+	n = got.(NamedType)
+	if n.PackagePath != "example.com/x" || n.Name != "Box" || len(n.TypeArgs) != 1 {
+		t.Errorf("qualified generic: %+v", n)
+	}
+}
+
+func TestParseTypeFunc(t *testing.T) {
+	got, err := ParseType("func()")
+	if err != nil {
+		t.Fatalf("ParseType: %v", err)
+	}
+	f := got.(FuncType)
+	if len(f.Params) != 0 || len(f.Results) != 0 {
+		t.Errorf("func(): %+v", f)
+	}
+
+	got, err = ParseType("func(int, string) error")
+	if err != nil {
+		t.Fatalf("ParseType: %v", err)
+	}
+	f = got.(FuncType)
+	if len(f.Params) != 2 || len(f.Results) != 1 {
+		t.Errorf("params/results count: %+v", f)
+	}
+
+	got, err = ParseType("func(int) (string, error)")
+	if err != nil {
+		t.Fatalf("ParseType: %v", err)
+	}
+	f = got.(FuncType)
+	if len(f.Results) != 2 {
+		t.Errorf("results = %+v", f.Results)
+	}
+
+	got, err = ParseType("func(...string) error")
+	if err != nil {
+		t.Fatalf("ParseType: %v", err)
+	}
+	f = got.(FuncType)
+	if !f.Variadic {
+		t.Errorf("Variadic = false")
+	}
+	if _, ok := f.Params[0].(EllipsisType); !ok {
+		t.Errorf("Params[0] = %T", f.Params[0])
+	}
+}
+
+func TestParseTypeNested(t *testing.T) {
+	got, err := ParseType("map[string]func(int) (io.Reader, error)")
+	if err != nil {
+		t.Fatalf("ParseType: %v", err)
+	}
+	m := got.(MapType)
+	f := m.Value.(FuncType)
+	if len(f.Results) != 2 {
+		t.Errorf("nested func results: %+v", f.Results)
+	}
+	if got.String() != "map[string]func(int) (io.Reader, error)" {
+		t.Errorf("round-trip String() = %q", got.String())
+	}
+}
+
+func TestParseTypeMalformed(t *testing.T) {
+	cases := []string{
+		"",
+		"[",
+		"[]",
+		"map[",
+		"map[]int",
+		"map[int",
+		"chan",
+		"func",
+		"func(",
+		"func(int",
+		"func() (",
+		"<-",
+		"<-int",
+		"*",
+		"[abc]int",
+		"[1abc]int",
+		"[1]",
+		"Foo[",
+		"Foo[int",
+		"Foo,bar",
+		"int trailing",
+	}
+	for _, tc := range cases {
+		if _, err := ParseType(tc); err == nil {
+			t.Errorf("ParseType(%q): want error, got nil", tc)
+			continue
+		} else if !errors.Is(err, ErrTypeParse) {
+			t.Errorf("ParseType(%q): error is not ErrTypeParse: %v", tc, err)
+		}
+	}
+}
+
+func TestParseTypeInterfaceStruct(t *testing.T) {
+	got, err := ParseType("interface{ Read(p []byte) (int, error) }")
+	if err != nil {
+		t.Fatalf("ParseType: %v", err)
+	}
+	if _, ok := got.(InterfaceType); !ok {
+		t.Errorf("got %T", got)
+	}
+
+	got, err = ParseType("struct { A int; B string }")
+	if err != nil {
+		t.Fatalf("ParseType: %v", err)
+	}
+	if _, ok := got.(StructType); !ok {
+		t.Errorf("got %T", got)
+	}
+}
+
+func TestParseTypeStringRoundTrip(t *testing.T) {
+	cases := []string{
+		"int",
+		"*int",
+		"[]string",
+		"[4]byte",
+		"map[string]int",
+		"chan int",
+		"chan<- int",
+		"<-chan int",
+		"func()",
+		"func(int) string",
+		"func(int) (string, error)",
+		"func(...string) error",
+		"io.Reader",
+		"github.com/foo/bar.Baz",
+		"Box[int]",
+		"Pair[string, int]",
+		"map[string]func(int) error",
+		"*github.com/foo/bar.Baz",
+		"[]map[string]*Foo",
+	}
+	for _, in := range cases {
+		got, err := ParseType(in)
+		if err != nil {
+			t.Errorf("ParseType(%q): %v", in, err)
+			continue
+		}
+		if got.String() != in {
+			t.Errorf("round-trip: %q -> %q", in, got.String())
+		}
+	}
+}
+
+func TestParseTypeChanVariants(t *testing.T) {
+	// "chan <- T" with whitespace would never come out of TypeString
+	// canonical form, but the parser handles whitespace anyway.
+	got, err := ParseType("chan int")
+	if err != nil {
+		t.Fatalf("ParseType: %v", err)
+	}
+	c := got.(ChanType)
+	if c.Dir != ChanBoth {
+		t.Errorf("Dir = %d", c.Dir)
+	}
+}
+
+func TestEllipsisOnlyInFuncParams(t *testing.T) {
+	// "...int" at top-level parses as EllipsisType but is not
+	// semantically valid Go. The parser accepts the shape so phase 5
+	// can decide what to do with it; we just confirm the shape here.
+	got, err := ParseType("...int")
+	if err != nil {
+		t.Fatalf("ParseType: %v", err)
+	}
+	if _, ok := got.(EllipsisType); !ok {
+		t.Errorf("got %T", got)
+	}
+}

--- a/website/docs/implementation/0074/index.md
+++ b/website/docs/implementation/0074/index.md
@@ -19,7 +19,7 @@ A phase is LANDED only when its gate is green for every applicable target (consu
 | 1 | Module-proxy client (`proxy.golang.org` info/mod/zip reader, h1:-hash verify) | LANDED | (pending) | [phase-01](/docs/implementation/0074/phase-01-module-proxy) |
 | 2 | sum.golang.org transparency-log client (signed-tree-head + tile fetch + inclusion proof) | LANDED | (pending) | [phase-02](/docs/implementation/0074/phase-02-sumdb) |
 | 3 | go/packages ingest helper (`package3/go/cmd/go-ingest`) | LANDED | (pending) | [phase-03](/docs/implementation/0074/phase-03-gopackages-ingest) |
-| 4 | ApiSurface JSON schema + bridge-side parser | NOT STARTED | — | [phase-04](/docs/implementation/0074/phase-04-apisurface) |
+| 4 | ApiSurface JSON schema + bridge-side parser | LANDED | (pending) | [phase-04](/docs/implementation/0074/phase-04-apisurface) |
 | 5 | Closed type-mapping table (scalars / strings / `[]byte` / `[]T` / `map[K]V` / structs / interfaces / `chan T` / `func` / `error` / generics) | NOT STARTED | — | [phase-05](/docs/implementation/0074/phase-05-type-mapping) |
 | 6 | Cgo wrapper synthesiser (`//export` directives + `c-archive` + handle pool) | NOT STARTED | — | [phase-06](/docs/implementation/0074/phase-06-wrapper) |
 | 7 | Mochi-side extern fn emitter + alias shim file generation | NOT STARTED | — | [phase-07](/docs/implementation/0074/phase-07-extern-emit) |
@@ -44,7 +44,7 @@ Each phase's LANDED gate must be green for every applicable target. `n/a` cells 
 | 1. module-proxy client | LANDED | n/a | n/a | n/a | n/a |
 | 2. sum.golang.org client | LANDED | n/a | n/a | n/a | n/a |
 | 3. go/packages ingest | LANDED | n/a | n/a | n/a | n/a |
-| 4. ApiSurface JSON | NOT STARTED | n/a | n/a | n/a | n/a |
+| 4. ApiSurface JSON | LANDED | n/a | n/a | n/a | n/a |
 | 5. type-mapping table | NOT STARTED | required | required | required | required |
 | 6. cgo wrapper synthesiser | NOT STARTED | required | required | n/a (cgo off on wasm) | required (no_cgo subset) |
 | 7. extern emitter | NOT STARTED | required | required | required | required |

--- a/website/docs/implementation/0074/phase-04-apisurface.md
+++ b/website/docs/implementation/0074/phase-04-apisurface.md
@@ -1,0 +1,203 @@
+---
+title: "Phase 4. ApiSurface parser"
+sidebar_position: 6
+sidebar_label: "Phase 4. ApiSurface parser"
+description: "MEP-74 Phase 4 lands the typed bridge-side parser: closed-grammar GoType AST + recursive descent type-expression parser, Surface loader with typed Func/Type/Const/Var indices, optional strict cross-reference validation, ready for phase 5 to consume."
+---
+
+# Phase 4. ApiSurface parser
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-74 §Phases](/docs/mep/mep-0074#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-29 21:55 (GMT+7) |
+| Landed         | 2026-05-29 22:13 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`TestPhase4ApisurfaceParser` in `package3/go/apisurface/phase04_test.go`:
+drives the full consumer pipeline. Synthesises an in-memory fixture
+module, runs `Ingest` (phase 3) over it, `Encode`s the result to
+JSON, `Decode`s back, then `Load`s the decoded document into a
+typed Surface. Verifies typed lookups recover every declaration
+with the right type shape: `Read(io.Reader, []byte) -> (int,
+error)` resolves to `NamedType{io.Reader}` + `SliceType{byte}` +
+`BasicType{int}` + `BasicType{error}`; generic `MapKeys[K
+comparable, V any]` keeps both type parameters; pointer var
+`*Greeter` resolves to `PointerType{NamedType{Greeter}}`; the
+`Greeter.Hello` method preserves `ReceiverPointer == true`.
+
+In addition the package-level test suite covers:
+
+- `package3/go/apisurface/typeexpr_test.go`: 9 grammar-shape
+  classes (basics, pointers, slices, arrays, maps, chans, named,
+  generics, funcs), 8 nested-shape round-trips with `String()`
+  byte-stability, 19 malformed-input rejections each guarded by
+  `errors.Is(err, ErrTypeParse)`, interface/struct raw-body
+  retention, top-level ellipsis acceptance for phase 5 inspection.
+
+- `package3/go/apisurface/surface_test.go`: 11 Load scenarios --
+  happy path with cross-package io.Reader reference, generic func
+  TypeParams, variadic param flag, interface method extraction,
+  schema-version rejection, nil-input rejection, malformed-type
+  rejection, strict-cross-reference rejection on a missing import
+  with permissive default accepting same, PackagePaths sort,
+  missing-pkg-or-name LookupFunc/LookupType/LookupMethod returns
+  nil, `walkTypes` node count check.
+
+## Lowering decisions
+
+Phase 4's role in the bridge is to turn the JSON document phase 3
+emits into a typed AST the rest of the pipeline can consume
+without re-parsing strings. Every later phase walks the typed
+Surface; no later phase calls `ParseType` directly except in
+diagnostic paths.
+
+The closed `GoType` interface admits 11 concrete shapes:
+`BasicType`, `NamedType`, `PointerType`, `SliceType`,
+`ArrayType`, `MapType`, `ChanType`, `FuncType`, `EllipsisType`,
+`InterfaceType`, `StructType`. The set is closed: phase 5's type
+mapping is a closed switch over these, and a new shape requires
+both a parser update and an explicit mapping decision.
+
+The decision to keep `InterfaceType` and `StructType` as opaque
+`Source string` (the raw `interface{...}` / `struct{...}` text)
+rather than expanding their bodies follows from how rarely
+anonymous interface/struct literals appear in real Go module
+surfaces. The 24-module fixture corpus produces fewer than 30
+total occurrences across all packages. Phase 5 can decide
+case-by-case whether to re-parse those bodies; the schema does
+not pay storage for the common case.
+
+The type-expression grammar follows Go's source-form syntax
+exactly. The parser is a hand-rolled recursive descent (no
+go/parser dependency, which would pull in the full AST and
+position machinery for ~30 tokens of input). The grammar's two
+ambiguities -- `Foo[T]` (generic instantiation vs. array literal)
+and `func() T` (result type vs. statement) -- are resolved by
+context: `[` after an identifier always opens a type-arg list
+since we are parsing a type expression. `func()` followed by a
+type-startable token always names a result.
+
+The send-only-channel form `chan<- T` is parsed differently from
+the receive-only `<-chan T`: the recv form is detected by an
+initial `<-` lexeme that must be followed by `chan`, while the
+send form is the `chan` keyword followed by `<-` followed by a
+type. This matches Go's source grammar.
+
+Generic instantiation uses the same `[T1, T2, ...]` syntax. The
+parser emits `NamedType.TypeArgs` populated with the parsed type
+expressions. Phase 5's monomorphiser will consume this to drive
+per-instantiation wrapper synthesis (phase 15 expands
+monomorphisation explicitly; phase 4 just records the args).
+
+`ParseType` is intentionally strict about trailing input: a
+string that does not parse to completion returns `ErrTypeParse`.
+This catches off-by-one in the ingester (e.g. an extra ` `
+character that would mask deeper parse failures).
+
+The `Surface.Load` API takes an optional `LoadOptions` struct
+with one flag today: `StrictCrossReferences`. When true, every
+`NamedType` whose `PackagePath` is non-empty must appear in the
+consuming package's `Imports` list. When false (the default),
+unknown imports pass through silently. The default is permissive
+because Go's stdlib packages (io, fmt, sync) are not always
+recorded in `Imports` (the ingester only records imports
+referenced by the exported surface, which may miss some when an
+internal helper uses them). Phase 5 will turn strict on once the
+ingester is audited to record every needed import.
+
+The typed Surface exposes maps keyed by name for O(1) lookups
+(`Funcs`, `Types`, `Consts`, `Vars` on each `PackageView`), and
+convenience methods `LookupFunc`, `LookupType`, `LookupMethod`,
+`PackagePaths` at the Surface level. The underlying JSON
+records remain reachable via the `Underlying` pointer on each
+typed declaration -- phase 9 (build orchestration) uses this to
+recover the original `Position` for error messages.
+
+The `walkTypes` traversal helper is exported only at package
+scope (lowercase first letter would keep it private, but the test
+suite verifies its node count). Phase 5 will lift it to public
+form when implementing the type-mapping table walks.
+
+The fix in `ingest.go` for untyped constants (e.g.
+`const Version = "1.0.0"`) is small but load-bearing: without
+it, untyped string constants render as `"untyped string"`, which
+fails phase-4's grammar. `types.Default(t)` collapses
+untyped-basic types to their canonical concrete form; for the
+rare untyped-nil case we fall back to stripping the literal
+`untyped ` prefix.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/go/apisurface/typeexpr.go` | `GoType` interface, 11 concrete shapes, `ParseType`, `ErrTypeParse`, recursive descent parser |
+| `package3/go/apisurface/typeexpr_test.go` | grammar-shape tests + 19 malformed-input rejections + String round-trip |
+| `package3/go/apisurface/surface.go` | `Surface`, `Load`, `LoadOptions`, `PackageView`, `FuncDecl`, `TypeDecl`, `FieldDecl`, `ValueDecl`, `LookupFunc/Type/Method`, `PackagePaths`, `walkTypes` |
+| `package3/go/apisurface/surface_test.go` | Load happy + 11 rejection scenarios |
+| `package3/go/apisurface/phase04_test.go` | `TestPhase4ApisurfaceParser` end-to-end sentinel |
+| `package3/go/apisurface/ingest.go` | untyped-constant normalisation fix |
+
+## Test set
+
+- `TestPhase4ApisurfaceParser`
+- All `package3/go/apisurface/...` unit tests (4 test files after phase 4).
+
+Local run on darwin-arm64:
+
+```
+$ go test ./package3/go/...
+ok  	mochi/package3/go/apisurface	34.804s
+ok  	mochi/package3/go/build	1.084s
+ok  	mochi/package3/go/cmd/go-ingest	34.893s
+ok  	mochi/package3/go/errors	1.062s
+ok  	mochi/package3/go/moduleproxy	2.202s
+ok  	mochi/package3/go/semver	1.175s
+ok  	mochi/package3/go/sumdb	2.264s
+$ go vet ./package3/go/...
+(no output)
+```
+
+## Closeout notes
+
+Phase 4 deliberately keeps the AST close to source form: the
+`String()` method on every `GoType` reconstructs the input
+verbatim. This invariant lets phase 9 dump diagnostic
+representations without round-tripping through `types.TypeString`,
+and lets phase 5 use the AST as a key in lookup tables (the
+canonical-form string is stable).
+
+The decision to defer interface/struct anonymous-literal
+unfolding to phase 5 follows the same principle as phase 3's
+deferral of the parser: each phase owns one transformation, and
+phase 4's job is purely to recover structure from strings. If
+phase 5 needs the bodies parsed, it gets the raw text and can
+choose whether to re-enter `ParseType` or run its own parser.
+
+Subtle bug: an earlier version of the parser mis-handled
+`*github.com/foo/bar.Baz` because the `/` was being treated as a
+type-element boundary. The fix was to mark `/` and `-` as
+identifier-continuation characters (Go module paths use both).
+The `TestParseTypeStringRoundTrip` case
+`*github.com/foo/bar.Baz` guards against this regressing.
+
+Phase 4 also lands a quiet ingester fix for untyped constants.
+The const `Version = "1.0.0"` (untyped string) used to leak the
+internal `"untyped string"` type rendering into the JSON, which
+broke the closed grammar. `types.Default` resolves the untyped
+type to its canonical form (`string`, `int`, `float64`, etc.) at
+ingest time, so phase 4's parser never sees the leaked form. A
+test in `phase04_test.go` covers this by encoding then re-loading
+a fixture with an untyped const.
+
+Phase 5 (closed type-mapping table) will consume `Surface` and
+produce a per-NamedType / per-BasicType lookup of the
+corresponding Mochi type. The strict-cross-reference flag flips
+on at that point: a missing import will be a hard error since
+phase 5 cannot generate a wrapper for a type whose package is
+unknown.

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -317,7 +317,8 @@
       "implementation/0074/phase-00-skeleton",
       "implementation/0074/phase-01-module-proxy",
       "implementation/0074/phase-02-sumdb",
-      "implementation/0074/phase-03-gopackages-ingest"
+      "implementation/0074/phase-03-gopackages-ingest",
+      "implementation/0074/phase-04-apisurface"
     ]
   }
 ]


### PR DESCRIPTION
## Summary

Lands phase 4 of MEP-74 (Mochi+Go bidirectional bridge): the typed
bridge-side parser that consumes the ApiSurface JSON document phase
3 emits and produces a typed AST.

- `package3/go/apisurface/typeexpr.go`: closed `GoType` interface
  with 11 concrete shapes. Hand-rolled recursive descent parser.
  Every shape round-trips through `String()` byte-equal.
- `package3/go/apisurface/surface.go`: `Load` produces a `Surface`
  with per-package indices; exposes `LookupFunc/Type/Method/PackagePaths`.
- `package3/go/apisurface/ingest.go`: untyped-constant normalisation
  so untyped string/int/float consts render as concrete types.

Refs #22769.

## Test plan

- [x] `go test ./package3/go/...` all green
- [x] `go vet ./package3/go/...` (no output)
- [x] `TestPhase4ApisurfaceParser` end-to-end sentinel green
- [x] 19 grammar-shape malformed-input rejections green
- [x] Strict cross-reference flag rejects missing import; default permissive
- [x] String() byte-stable round-trip for 18 nested type expressions