### PR TITLE
fix(website/gen-releases): support standalone docs repo layout

### DIFF
--- a/website/scripts/gen-releases.js
+++ b/website/scripts/gen-releases.js
@@ -13,7 +13,10 @@ const path = require('path');
 
 const root = path.resolve(__dirname, '..');
 const repoRoot = path.resolve(root, '..');
-const sourceDir = path.join(repoRoot, 'releases');
+// Support both mochi monorepo layout (../../releases) and standalone docs repo (./releases).
+const sourceDir = fs.existsSync(path.join(repoRoot, 'releases'))
+  ? path.join(repoRoot, 'releases')
+  : path.join(root, 'releases');
 const docsOutDir = path.join(root, 'docs', 'releases');
 const dataOut = path.join(root, 'src', 'data', 'releases.json');
 const sidebarOut = path.join(root, 'src', 'data', 'release-sidebar.json');


### PR DESCRIPTION
Closes #22778

gen-releases.js looked for `../../releases` which only works in the mochi monorepo. When website/ is synced to mochilang/docs as a standalone repo the same directory is at `./releases`. The fix checks both paths.