### PR TITLE
feat(mep-73 p6): import rust grammar + path validator

### DIFF
--- a/parser/normalize.go
+++ b/parser/normalize.go
@@ -25,12 +25,17 @@ var (
 	errUnknownImportLang = diagnostic.Template{
 		Code:    "P064",
 		Message: "unknown import language: %q",
-		Help:    "The supported languages are `go`, `python`, `typescript`, `zig`, `lua`, `clj`, and `clojure`. Omit the language to use the Mochi default, or check the spelling.",
+		Help:    "The supported languages are `go`, `python`, `typescript`, `zig`, `lua`, `clj`, `clojure`, and `rust`. Omit the language to use the Mochi default, or check the spelling.",
 	}
 	errUselessExprStmt = diagnostic.Template{
 		Code:    "P065",
 		Message: "expression statement has no observable effect",
 		Help:    "An expression used as a statement must perform I/O or call a function. Bare values, arithmetic, and field/index access compute a result that nothing reads. Use `let _ = ...` if you need to evaluate for a side effect inside an argument, or remove the line.",
+	}
+	errInvalidRustImportPath = diagnostic.Template{
+		Code:    "P066",
+		Message: "rust import path %q is not in `<crate>@<semver>` form",
+		Help:    "An `import rust \"...\" as <alias>` statement names a crates.io crate plus a version, eg. `import rust \"hex@0.4.3\" as hex`. The version is required because MEP-73 binds the synthesised wrapper crate to an exact upstream version.",
 	}
 )
 
@@ -48,6 +53,7 @@ var knownImportLangs = map[string]struct{}{
 	"lua":        {},
 	"clj":        {},
 	"clojure":    {},
+	"rust":       {},
 }
 
 // normalizeProgram performs the post-parse pass that turns the raw
@@ -170,6 +176,9 @@ func normalizeStatement(s *Statement) error {
 		}
 	case s.Import != nil:
 		if err := validateImportLang(s.Import); err != nil {
+			return err
+		}
+		if err := validateRustImport(s.Import); err != nil {
 			return err
 		}
 	case s.Expr != nil:
@@ -354,6 +363,23 @@ func validateImportLang(im *ImportStmt) error {
 		return nil
 	}
 	return errUnknownImportLang.New(im.Pos, *im.Lang)
+}
+
+// validateRustImport rejects `import rust "..." as <alias>` whose path is
+// not in `<crate>@<semver>` form. The path string is required to carry the
+// version because the MEP-73 bridge binds the synthesised wrapper crate to
+// an exact upstream version (the rustdoc-JSON the wrapper is built against
+// is version-specific). The grammar accepts an arbitrary string here; this
+// validator turns a malformed path into a parse-time diagnostic instead of
+// a later "crate not found" or wrapper-build failure.
+func validateRustImport(im *ImportStmt) error {
+	if im == nil || im.Lang == nil || *im.Lang != "rust" {
+		return nil
+	}
+	if _, _, ok := RustImportRef(im.Path); !ok {
+		return errInvalidRustImportPath.New(im.Pos, im.Path)
+	}
+	return nil
 }
 
 // validateIndexOp rejects `xs[]`, `xs[:]`, and `xs[::]`. The grammar

--- a/parser/rust_import.go
+++ b/parser/rust_import.go
@@ -1,0 +1,61 @@
+package parser
+
+import "strings"
+
+// RustImportRef parses the path of `import rust "<crate>@<semver>" as
+// <alias>` into its (crate, version) pair.
+//
+// The string is expected to carry exactly one `@`, with non-empty parts
+// on either side. The crate part must additionally be a syntactically
+// valid Cargo identifier: lowercase ASCII letters, digits, `_`, and `-`,
+// starting with a letter. The version part is left to the bridge's
+// semver parser (package3/rust/semver); this routine only enforces the
+// `<crate>@<rest>` shape so a malformed path produces a parse-time
+// diagnostic rather than a later wrapper-build failure.
+//
+// On success ok is true; on any structural problem ok is false and the
+// returned crate / version are empty.
+func RustImportRef(path string) (crate, version string, ok bool) {
+	s := strings.Trim(path, "\"")
+	i := strings.Index(s, "@")
+	if i <= 0 || i == len(s)-1 {
+		return "", "", false
+	}
+	c := s[:i]
+	if !isCargoCrateName(c) {
+		return "", "", false
+	}
+	v := s[i+1:]
+	if strings.ContainsAny(v, " \t\n") {
+		return "", "", false
+	}
+	return c, v, true
+}
+
+// isCargoCrateName implements the conservative subset of Cargo's crate
+// naming rules that we accept here: ASCII lowercase letters, digits, `_`,
+// `-`; must start with a letter; length 1..64.
+//
+// Cargo itself accepts a slightly wider set (the upper-case path was
+// retired in 2018), but every crates.io publish since then is in the
+// strict subset. The parser stays strict so we catch typos.
+func isCargoCrateName(s string) bool {
+	if len(s) == 0 || len(s) > 64 {
+		return false
+	}
+	if !isLowerLetter(s[0]) {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case isLowerLetter(c), c >= '0' && c <= '9', c == '_', c == '-':
+			// ok
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func isLowerLetter(c byte) bool { return c >= 'a' && c <= 'z' }

--- a/parser/rust_import_test.go
+++ b/parser/rust_import_test.go
@@ -1,0 +1,71 @@
+package parser
+
+import "testing"
+
+func TestRustImportRef(t *testing.T) {
+	cases := []struct {
+		name             string
+		in               string
+		wantCrate, wantV string
+		wantOK           bool
+	}{
+		{"plain hex", `hex@0.4.3`, "hex", "0.4.3", true},
+		{"quoted hex", `"hex@0.4.3"`, "hex", "0.4.3", true},
+		{"once_cell with underscore", `once_cell@1.19.0`, "once_cell", "1.19.0", true},
+		{"hyphenated crate", `rand-chacha@0.3.1`, "rand-chacha", "0.3.1", true},
+		{"caret range", `serde@^1.0`, "serde", "^1.0", true},
+		{"tilde range", `serde@~1.0.195`, "serde", "~1.0.195", true},
+		{"semver pre", `tokio@1.40.0-rc.1`, "tokio", "1.40.0-rc.1", true},
+		{"semver build", `tokio@1.40.0+meta`, "tokio", "1.40.0+meta", true},
+
+		{"missing version", `hex`, "", "", false},
+		{"empty crate", `@1.0`, "", "", false},
+		{"empty version", `hex@`, "", "", false},
+		{"uppercase crate", `Hex@1.0`, "", "", false},
+		{"digit start crate", `4hex@1.0`, "", "", false},
+		{"dot in crate", `hex.helper@1.0`, "", "", false},
+		{"space in version", `hex@1.0 alpha`, "", "", false},
+		{"empty", ``, "", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotC, gotV, ok := RustImportRef(c.in)
+			if ok != c.wantOK {
+				t.Fatalf("RustImportRef(%q) ok = %v; want %v", c.in, ok, c.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if gotC != c.wantCrate || gotV != c.wantV {
+				t.Errorf("RustImportRef(%q) = (%q, %q); want (%q, %q)", c.in, gotC, gotV, c.wantCrate, c.wantV)
+			}
+		})
+	}
+}
+
+func TestIsCargoCrateName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"hex", true},
+		{"once_cell", true},
+		{"rand-chacha", true},
+		{"a", true},
+		{"a1", true},
+		{"a_b-c", true},
+
+		{"", false},
+		{"1abc", false},
+		{"_abc", false},
+		{"-abc", false},
+		{"Hex", false},
+		{"foo.bar", false},
+		{"foo bar", false},
+	}
+	for _, c := range cases {
+		if got := isCargoCrateName(c.in); got != c.want {
+			t.Errorf("isCargoCrateName(%q) = %v; want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/tests/parser/errors/import_rust_bad_crate.err
+++ b/tests/parser/errors/import_rust_bad_crate.err
@@ -1,0 +1,8 @@
+error[P066]: rust import path "Hex@1.0" is not in `<crate>@<semver>` form
+  --> tests/parser/errors/import_rust_bad_crate.mochi:1:1
+
+  1 | import rust "Hex@1.0" as hex
+    | ^
+
+help:
+  An `import rust "..." as <alias>` statement names a crates.io crate plus a version, eg. `import rust "hex@0.4.3" as hex`. The version is required because MEP-73 binds the synthesised wrapper crate to an exact upstream version.

--- a/tests/parser/errors/import_rust_bad_crate.mochi
+++ b/tests/parser/errors/import_rust_bad_crate.mochi
@@ -1,0 +1,1 @@
+import rust "Hex@1.0" as hex

--- a/tests/parser/errors/import_rust_missing_version.err
+++ b/tests/parser/errors/import_rust_missing_version.err
@@ -1,0 +1,8 @@
+error[P066]: rust import path "hex" is not in `<crate>@<semver>` form
+  --> tests/parser/errors/import_rust_missing_version.mochi:1:1
+
+  1 | import rust "hex" as hex
+    | ^
+
+help:
+  An `import rust "..." as <alias>` statement names a crates.io crate plus a version, eg. `import rust "hex@0.4.3" as hex`. The version is required because MEP-73 binds the synthesised wrapper crate to an exact upstream version.

--- a/tests/parser/errors/import_rust_missing_version.mochi
+++ b/tests/parser/errors/import_rust_missing_version.mochi
@@ -1,0 +1,1 @@
+import rust "hex" as hex

--- a/tests/parser/errors/import_unknown_lang.err
+++ b/tests/parser/errors/import_unknown_lang.err
@@ -5,4 +5,4 @@ error[P064]: unknown import language: "pythn"
     | ^
 
 help:
-  The supported languages are `go`, `python`, `typescript`, `zig`, `lua`, `clj`, and `clojure`. Omit the language to use the Mochi default, or check the spelling.
+  The supported languages are `go`, `python`, `typescript`, `zig`, `lua`, `clj`, `clojure`, and `rust`. Omit the language to use the Mochi default, or check the spelling.

--- a/tests/parser/valid/import_rust.golden
+++ b/tests/parser/valid/import_rust.golden
@@ -1,0 +1,5 @@
+(program
+  (import "hex@0.4.3" (lang rust) (as hex))
+  (import "once_cell@1.19.0" (lang rust) (as once_cell))
+  (import "serde@^1.0" (lang rust) (as serde))
+)

--- a/tests/parser/valid/import_rust.mochi
+++ b/tests/parser/valid/import_rust.mochi
@@ -1,0 +1,3 @@
+import rust "hex@0.4.3" as hex
+import rust "once_cell@1.19.0" as once_cell
+import rust "serde@^1.0" as serde

--- a/website/docs/implementation/0073/index.md
+++ b/website/docs/implementation/0073/index.md
@@ -20,8 +20,8 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | 2 | Rustdoc-JSON ingest + ApiSurface emit | LANDED | [1cd97c1b](https://github.com/mochilang/mochi/commit/1cd97c1b) | [phase-02](/docs/implementation/0073/phase-02-rustdoc-ingest) |
 | 3 | Closed type-mapping table (scalars / strings / collections / Option / Result / Tuple / Struct / Enum) | LANDED | [0be87e7f](https://github.com/mochilang/mochi/commit/0be87e7f) | [phase-03](/docs/implementation/0073/phase-03-type-mapping) |
 | 4 | Wrapper crate synthesiser (extern "C" surface, MochiString / MochiSlice / opaque handles) | LANDED | [2bf1474c](https://github.com/mochilang/mochi/commit/2bf1474c) | [phase-04](/docs/implementation/0073/phase-04-wrapper) |
-| 5 | Mochi-side extern fn emitter + alias shim file generation | LANDED | (pending) | [phase-05](/docs/implementation/0073/phase-05-extern-emit) |
-| 6 | `import rust "<crate>@<semver>" as <alias>` grammar + parser | NOT STARTED | — | [phase-06](/docs/implementation/0073/phase-06-import-grammar) |
+| 5 | Mochi-side extern fn emitter + alias shim file generation | LANDED | [6da45d5d](https://github.com/mochilang/mochi/commit/6da45d5d) | [phase-05](/docs/implementation/0073/phase-05-extern-emit) |
+| 6 | `import rust "<crate>@<semver>" as <alias>` grammar + parser | LANDED | (pending) | [phase-06](/docs/implementation/0073/phase-06-import-grammar) |
 | 7 | Build orchestration: workspace synth + cargo build invocation + artifact link | NOT STARTED | — | [phase-07](/docs/implementation/0073/phase-07-build) |
 | 8 | mochi.lock `[[rust-package]]` integration + `--check` mode | NOT STARTED | — | [phase-08](/docs/implementation/0073/phase-08-lockfile) |
 | 9 | `TargetRustLibrary` emit (rlib + cdylib + Cargo.toml + cbindgen) | NOT STARTED | — | [phase-09](/docs/implementation/0073/phase-09-rust-library-emit) |
@@ -71,7 +71,7 @@ The `package3/rust/` location is shared with the broader MEP-57 polyglot package
 
 ## Status snapshot
 
-As of 2026-05-29 22:03 (GMT+7): phases 0, 1, 2, 3, 4, and 5 LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest + closed type-mapping table + extern-C wrapper synthesiser + Mochi extern-fn emitter). Phases 6-13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
+As of 2026-05-29 22:42 (GMT+7): phases 0, 1, 2, 3, 4, 5, and 6 LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest + closed type-mapping table + extern-C wrapper synthesiser + Mochi extern-fn emitter + `import rust` grammar). Phases 7-13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
 
 ## Cross-references
 

--- a/website/docs/implementation/0073/phase-06-import-grammar.md
+++ b/website/docs/implementation/0073/phase-06-import-grammar.md
@@ -1,0 +1,78 @@
+---
+title: "Phase 6. import rust grammar"
+sidebar_position: 8
+sidebar_label: "Phase 6. import rust grammar"
+description: "MEP-73 Phase 6 lands the parser side of the bridge: `import rust \"<crate>@<semver>\" as <alias>` is admitted by the grammar, the path is validated at parse time against the `<crate>@<semver>` shape, and a `parser.RustImportRef` helper exposes the (crate, version) pair to downstream phases."
+---
+
+# Phase 6. import rust grammar
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-73 §Phases](/docs/mep/mep-0073#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-29 22:30 (GMT+7) |
+| Landed         | 2026-05-29 22:42 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+The Mochi parser admits `import rust "<crate>@<semver>" as <alias>` as a first-class form, on par with `import python "..." as ...` and `import go "..." as ...`. Three pieces:
+
+1. `"rust"` joins `knownImportLangs` in `parser/normalize.go`. The grammar already admits any identifier in the lang slot; the validator just stops rejecting `rust` as a typo.
+2. A new validator `validateRustImport` (P066) rejects paths that are not in `<crate>@<semver>` form. Catching the typo at parse time turns `import rust "hex" as hex` (missing version) or `import rust "Hex@1.0" as hex` (upper-case crate name) into a positioned diagnostic instead of a far-later "crate not found" or wrapper-build failure.
+3. A new helper `parser.RustImportRef(path) (crate, version string, ok bool)` exposes the parsed pair to downstream phases (the build driver in Phase 7 consumes it to look up the wrapper crate in the cache).
+
+## Path validation
+
+`RustImportRef` accepts strings of the shape `<crate>@<version>` with:
+
+- Crate name: lower-case ASCII letters, digits, `_`, `-`; 1..64 chars; must start with a letter.
+- Version: any non-empty token with no whitespace. Semver parsing itself lives in `package3/rust/semver` (Phase 1); the parser only enforces the `<crate>@<rest>` shape so a malformed path doesn't reach the bridge.
+
+The crate-name rule is the conservative subset of Cargo's naming rules. Every crate published since 2018 fits this subset (upper-case names and dotted names were retired by Cargo before then). Staying strict keeps the parser diagnostic on the user's side rather than silently passing typos through.
+
+Cargo accepts a range of version specifiers (`=1.0.0`, `1.0`, `^1.0`, `~1.0`, `1.0.0-rc.1`, `1.0.0+meta`); the parser admits all of them without trying to interpret them. The bridge's semver parser (`package3/rust/semver`) is the source of truth.
+
+## Test surface
+
+Parser unit tests in `parser/rust_import_test.go` cover every shape: plain `hex@0.4.3`, quoted strings, `once_cell` (underscore), `rand-chacha` (hyphen), `serde@^1.0` (caret), `serde@~1.0.195` (tilde), `tokio@1.40.0-rc.1` (pre-release), `tokio@1.40.0+meta` (build metadata), plus 8 negative cases (missing version, empty crate, empty version, uppercase, digit-start, dotted name, space in version, empty string).
+
+Golden tests in `tests/parser/valid/import_rust.mochi` and `tests/parser/errors/import_rust_*.mochi` lock the AST shape and the P066 diagnostic against the rest of the parser corpus. The existing `import_unknown_lang.err` golden was updated to include `rust` in the supported-languages help line.
+
+## What this does NOT do
+
+- It does NOT fetch the crate. That is Phase 1 (sparse-index client, already landed) wired up by Phase 7 (build orchestration).
+- It does NOT type-check the alias namespace. The downstream module resolver (Phase 8 will integrate with `mochi.lock`) ties the alias to the synthesised Phase 5 alias-module file.
+- It does NOT consume the `package3/rust/semver` package directly. The parser stays free of bridge-implementation dependencies; structural shape validation here, semver semantics in the bridge.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `parser/normalize.go` | adds `"rust"` to `knownImportLangs`, adds `errInvalidRustImportPath` (P066) template + `validateRustImport`, wires the validator into `normalizeStatement` |
+| `parser/rust_import.go` | `RustImportRef(path) (crate, version string, ok bool)` + `isCargoCrateName` helper |
+| `parser/rust_import_test.go` | 16 cases for `RustImportRef` + 13 cases for `isCargoCrateName` |
+| `tests/parser/valid/import_rust.mochi` (+ `.golden`) | three valid forms: `hex@0.4.3`, `once_cell@1.19.0`, `serde@^1.0` |
+| `tests/parser/errors/import_rust_missing_version.mochi` (+ `.err`) | rejects `import rust "hex" as hex` |
+| `tests/parser/errors/import_rust_bad_crate.mochi` (+ `.err`) | rejects `import rust "Hex@1.0" as hex` |
+| `tests/parser/errors/import_unknown_lang.err` | help text updated to include `rust` |
+| `website/docs/implementation/0073/phase-06-import-grammar.md` | this page |
+| `website/docs/implementation/0073/index.md` | mark Phase 6 LANDED, backfill Phase 5 SHA |
+| `website/docs/mep/mep-0073.md` | mark Phase 6 LANDED in target matrix |
+
+## Test set
+
+- `go test ./parser/...` (all green)
+- `go test ./package3/rust/...` (regression: 8 packages green)
+- `go test ./types/...` (regression: green)
+
+## Closeout notes
+
+Phase 6 introduces no external dependencies and no Rust code. The parser stays free of `package3/rust/*` imports; the path validator only enforces the structural shape (`<crate>@<version>` with a non-empty crate name in the conservative subset and a non-empty version with no whitespace).
+
+Phase 7 (build orchestration) consumes `RustImportRef` to dispatch each `import rust` to the sparse-index client (Phase 1) + rustdoc ingest (Phase 2) + typemap (Phase 3) + wrapper synth (Phase 4) + extern-emit (Phase 5) pipeline. The alias module file emitted by Phase 5 is loaded under the `<alias>` name from the import statement.
+
+The version-required rule (`<crate>@<version>`, not just `<crate>`) is deliberate. MEP-73 binds the synthesised wrapper crate to an exact upstream version because the rustdoc-JSON it consumes is version-specific. A `mochi.lock`-style ranged constraint (Phase 8) layers on top: the lock file pins the exact version that satisfied the import constraint, and `mochi pkg lock --check` fails if the lock drifted.

--- a/website/docs/mep/mep-0073.md
+++ b/website/docs/mep/mep-0073.md
@@ -302,7 +302,7 @@ A phase is LANDED only when its gate is green against the curated 24-crate fixtu
 | 3. type-mapping table | LANDED | n/a | n/a | n/a |
 | 4. wrapper synthesiser | LANDED | required | n/a (no cc on wasm32) | required (no_std subset only) |
 | 5. extern emitter | LANDED | required | required | required |
-| 6. import rust grammar | NOT STARTED | required | required | required |
+| 6. import rust grammar | LANDED | required | required | required |
 | 7. build orchestration | NOT STARTED | required | n/a (cargo workspace required) | n/a |
 | 8. mochi.lock integration | NOT STARTED | required | required | required |
 | 9. TargetRustLibrary emit | NOT STARTED | required | n/a (lib is rlib + cdylib for native) | n/a |

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -336,7 +336,8 @@
       "implementation/0073/phase-02-rustdoc-ingest",
       "implementation/0073/phase-03-type-mapping",
       "implementation/0073/phase-04-wrapper",
-      "implementation/0073/phase-05-extern-emit"
+      "implementation/0073/phase-05-extern-emit",
+      "implementation/0073/phase-06-import-grammar"
     ]
   },
   "implementation/0074/index",


### PR DESCRIPTION
## Summary

- Admits `import rust "<crate>@<semver>" as <alias>` at the parser layer by adding `"rust"` to `knownImportLangs` in `parser/normalize.go`.
- New validator `validateRustImport` (diagnostic P066) rejects paths not in `<crate>@<semver>` form, so a missing version or upper-case crate name produces a parse-time diagnostic instead of a far-later wrapper-build failure.
- New helper `parser.RustImportRef(path) (crate, version, ok)` exposes the parsed pair to downstream phases. Crate name is the conservative Cargo subset; version is any non-empty whitespace-free token (full semver parsing stays in `package3/rust/semver`).

## Test surface

- 29 unit-test cases in `parser/rust_import_test.go` for `RustImportRef` + `isCargoCrateName` covering plain/quoted/underscore/hyphen/caret/tilde/pre-release/build-metadata forms plus 8 negative cases.
- Golden fixtures: `tests/parser/valid/import_rust.mochi` + `.golden` for `hex@0.4.3`, `once_cell@1.19.0`, `serde@^1.0`. Error fixtures: `import_rust_missing_version`, `import_rust_bad_crate`.
- Updates the unknown-import-lang help text to include `rust`.

## Spec sync

- Backfills the Phase 5 commit SHA (6da45d5d) on the index.
- Marks Phase 6 LANDED on the MEP-73 spec target matrix.
- Adds phase-06 to the sidebar JSON.

## Test plan

- [x] `go test ./parser/...` (green)
- [x] `go test ./package3/rust/...` (regression: 8 packages green)
- [x] `go test ./types/...` (regression: green)

Closes #22782.