### PR TITLE
feat(mep-71 p1): simple-index client + PEP 440 + sha256/blake3 verify

### DIFF
--- a/package3/python/semver/doc.go
+++ b/package3/python/semver/doc.go
@@ -1,0 +1,41 @@
+// Package semver implements PEP 440 version parsing, comparison, and
+// version-specifier matching. PEP 440 is Python's canonical version-format
+// PEP; it is the language of distribution version strings produced by
+// `setup.py sdist` / `pyproject.toml`, returned by the PEP 503 / 691 simple
+// index, and consumed by the uv resolver.
+//
+// The MEP-71 bridge needs PEP 440 in three places:
+//
+//  1. Phase 1: filter and sort the list of distribution files returned by
+//     the simple index. The newest non-yanked release that matches the
+//     user's `import python "<pkg>@<spec>"` specifier wins.
+//  2. Phase 9: serialise the resolved version into the `mochi.lock`
+//     `[[python-package]] version` field. The format is the canonical PEP
+//     440 normalised form.
+//  3. Phase 10: emit a `requires-dist` specifier into the wheel metadata
+//     when re-publishing a Mochi package as a Python sdist / wheel.
+//
+// PEP 440 version grammar (informal):
+//
+//	[N!]N(.N)*[{a|b|c|rc|alpha|beta|pre|preview}N][.postN][.devN][+local]
+//
+// where:
+//   - N! is an optional epoch (default 0)
+//   - N(.N)* is the release segment (one or more numeric components)
+//   - {a|b|c|rc|...}N is an optional pre-release segment (alpha / beta /
+//     release-candidate); the spelling is normalised to "a" / "b" / "rc"
+//   - .postN is an optional post-release counter
+//   - .devN is an optional dev-release counter
+//   - +local is an optional local version label
+//
+// The package does not implement PEP 440's full lenient parser. The bridge
+// rejects ambiguous or non-normalised inputs at lock time so the `mochi.lock`
+// hash key is stable. Specifically, the package rejects:
+//   - leading "v" prefixes (e.g. "v1.2.3")
+//   - case-insensitive pre-release spellings except the canonical "a", "b",
+//     "rc", "post", "dev"
+//   - implicit-zero release segments shorter than one component
+//
+// Inputs that pass `Parse` are guaranteed to round-trip through `String`
+// byte-for-byte.
+package semver

--- a/package3/python/semver/specifier.go
+++ b/package3/python/semver/specifier.go
@@ -1,0 +1,183 @@
+package semver
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Operator is a PEP 440 version comparison operator.
+type Operator int
+
+const (
+	OpInvalid Operator = iota
+	OpEq               // ==
+	OpNeq              // !=
+	OpLt               // <
+	OpLte              // <=
+	OpGt               // >
+	OpGte              // >=
+	OpCompat           // ~=
+	OpArbitrary        // ===
+)
+
+// String renders the canonical operator token.
+func (o Operator) String() string {
+	switch o {
+	case OpEq:
+		return "=="
+	case OpNeq:
+		return "!="
+	case OpLt:
+		return "<"
+	case OpLte:
+		return "<="
+	case OpGt:
+		return ">"
+	case OpGte:
+		return ">="
+	case OpCompat:
+		return "~="
+	case OpArbitrary:
+		return "==="
+	default:
+		return "?"
+	}
+}
+
+// Clause is a single PEP 440 version specifier (e.g. ">=1.0").
+type Clause struct {
+	Op       Operator
+	Version  Version
+	Original string // exact source text (post-trimming) for diagnostics
+}
+
+// Specifier is a comma-separated list of Clauses, the form accepted by
+// `dependency >= a, < b` and by Mochi's `import python "<pkg>@<spec>"`.
+type Specifier struct {
+	Clauses []Clause
+}
+
+// ParseClause parses a single PEP 440 version clause.
+func ParseClause(s string) (Clause, error) {
+	src := strings.TrimSpace(s)
+	if src == "" {
+		return Clause{}, fmt.Errorf("semver: empty version clause")
+	}
+	// Order matters: try the three-char operators first so "===" and ">="
+	// are not mis-parsed as "==" or ">".
+	type opEntry struct {
+		token string
+		op    Operator
+	}
+	ops := []opEntry{
+		{"===", OpArbitrary},
+		{"==", OpEq},
+		{"!=", OpNeq},
+		{"<=", OpLte},
+		{">=", OpGte},
+		{"~=", OpCompat},
+		{"<", OpLt},
+		{">", OpGt},
+	}
+	for _, e := range ops {
+		if strings.HasPrefix(src, e.token) {
+			versionText := strings.TrimSpace(src[len(e.token):])
+			if versionText == "" {
+				return Clause{}, fmt.Errorf("semver: clause %q missing version", src)
+			}
+			v, err := Parse(versionText)
+			if err != nil {
+				return Clause{}, fmt.Errorf("semver: clause %q: %w", src, err)
+			}
+			return Clause{Op: e.op, Version: v, Original: src}, nil
+		}
+	}
+	return Clause{}, fmt.Errorf("semver: clause %q has no operator", src)
+}
+
+// ParseSpecifier parses a comma-separated list of clauses.
+func ParseSpecifier(s string) (Specifier, error) {
+	src := strings.TrimSpace(s)
+	if src == "" {
+		return Specifier{}, nil
+	}
+	var spec Specifier
+	for _, raw := range strings.Split(src, ",") {
+		c, err := ParseClause(raw)
+		if err != nil {
+			return Specifier{}, err
+		}
+		spec.Clauses = append(spec.Clauses, c)
+	}
+	return spec, nil
+}
+
+// String renders the canonical specifier as a comma-joined list. Each clause
+// is rendered as op + canonical version (no spaces between op and version,
+// space after each comma).
+func (s Specifier) String() string {
+	parts := make([]string, len(s.Clauses))
+	for i, c := range s.Clauses {
+		parts[i] = c.Op.String() + c.Version.String()
+	}
+	return strings.Join(parts, ", ")
+}
+
+// Match reports whether v satisfies every clause of the specifier. An empty
+// specifier matches every version.
+func (s Specifier) Match(v Version) bool {
+	for _, c := range s.Clauses {
+		if !c.Match(v) {
+			return false
+		}
+	}
+	return true
+}
+
+// Match reports whether v satisfies the clause's operator + version.
+func (c Clause) Match(v Version) bool {
+	cmp := v.Compare(c.Version)
+	switch c.Op {
+	case OpEq:
+		return cmp == 0
+	case OpNeq:
+		return cmp != 0
+	case OpLt:
+		return cmp < 0
+	case OpLte:
+		return cmp <= 0
+	case OpGt:
+		return cmp > 0
+	case OpGte:
+		return cmp >= 0
+	case OpCompat:
+		return matchCompatible(v, c.Version)
+	case OpArbitrary:
+		return v.String() == c.Version.String()
+	default:
+		return false
+	}
+}
+
+// matchCompatible implements PEP 440's "compatible release" operator (~=).
+// Given a clause version with n release components, the candidate must be
+// >= the clause version AND have the same first n-1 release components.
+// Example: ~= 2.2 accepts 2.2, 2.2.99, 2.3, 2.9 but rejects 3.0 or 2.1.
+func matchCompatible(v, ref Version) bool {
+	if v.Compare(ref) < 0 {
+		return false
+	}
+	n := len(ref.Release) - 1
+	if n <= 0 {
+		return false
+	}
+	if len(v.Release) < n {
+		return false
+	}
+	for i := 0; i < n; i++ {
+		if v.Release[i] != ref.Release[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/package3/python/semver/specifier_test.go
+++ b/package3/python/semver/specifier_test.go
@@ -1,0 +1,244 @@
+package semver
+
+import (
+	"testing"
+)
+
+func TestParseClauseBasic(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantOp   Operator
+		wantVer  string
+	}{
+		{"==1.0", OpEq, "1.0"},
+		{"!=1.0", OpNeq, "1.0"},
+		{">=1.0", OpGte, "1.0"},
+		{"<=1.0", OpLte, "1.0"},
+		{">1.0", OpGt, "1.0"},
+		{"<1.0", OpLt, "1.0"},
+		{"~=1.0", OpCompat, "1.0"},
+		{"===1.0+local", OpArbitrary, "1.0+local"},
+		{"  >= 1.0  ", OpGte, "1.0"}, // surrounding whitespace ok
+	}
+	for _, tc := range cases {
+		c, err := ParseClause(tc.in)
+		if err != nil {
+			t.Errorf("ParseClause(%q): %v", tc.in, err)
+			continue
+		}
+		if c.Op != tc.wantOp {
+			t.Errorf("ParseClause(%q).Op = %v; want %v", tc.in, c.Op, tc.wantOp)
+		}
+		if got := c.Version.String(); got != tc.wantVer {
+			t.Errorf("ParseClause(%q).Version = %q; want %q", tc.in, got, tc.wantVer)
+		}
+	}
+}
+
+func TestParseClauseRejects(t *testing.T) {
+	bad := []string{
+		"",
+		"1.0",       // no operator
+		">=",        // missing version
+		"=1.0",      // single =
+		"<<1.0",     // wrong op
+		">=v1.0",    // bad version
+	}
+	for _, s := range bad {
+		if _, err := ParseClause(s); err == nil {
+			t.Errorf("ParseClause(%q) accepted; expected error", s)
+		}
+	}
+}
+
+func TestParseSpecifierMultiple(t *testing.T) {
+	spec, err := ParseSpecifier(">=1.0, <2.0, !=1.5")
+	if err != nil {
+		t.Fatalf("ParseSpecifier: %v", err)
+	}
+	if len(spec.Clauses) != 3 {
+		t.Fatalf("got %d clauses; want 3", len(spec.Clauses))
+	}
+	if spec.Clauses[0].Op != OpGte || spec.Clauses[0].Version.String() != "1.0" {
+		t.Errorf("clause 0 = %+v; want >=1.0", spec.Clauses[0])
+	}
+	if spec.Clauses[1].Op != OpLt || spec.Clauses[1].Version.String() != "2.0" {
+		t.Errorf("clause 1 = %+v; want <2.0", spec.Clauses[1])
+	}
+	if spec.Clauses[2].Op != OpNeq || spec.Clauses[2].Version.String() != "1.5" {
+		t.Errorf("clause 2 = %+v; want !=1.5", spec.Clauses[2])
+	}
+}
+
+func TestParseSpecifierEmpty(t *testing.T) {
+	spec, err := ParseSpecifier("")
+	if err != nil {
+		t.Fatalf("ParseSpecifier(\"\"): %v", err)
+	}
+	if len(spec.Clauses) != 0 {
+		t.Errorf("empty specifier produced %d clauses; want 0", len(spec.Clauses))
+	}
+	// An empty specifier matches every version.
+	v, _ := Parse("1.0")
+	if !spec.Match(v) {
+		t.Errorf("empty specifier did not match %v", v)
+	}
+}
+
+func TestSpecifierStringRoundTrip(t *testing.T) {
+	cases := []string{
+		">=1.0",
+		">=1.0, <2.0",
+		"==1.0, !=1.5",
+		"~=2.2",
+		"===1.0+local",
+	}
+	for _, s := range cases {
+		spec, err := ParseSpecifier(s)
+		if err != nil {
+			t.Fatalf("ParseSpecifier(%q): %v", s, err)
+		}
+		if got := spec.String(); got != s {
+			t.Errorf("ParseSpecifier(%q).String() = %q; want %q", s, got, s)
+		}
+	}
+}
+
+func TestMatchEqualOperators(t *testing.T) {
+	cases := []struct {
+		spec    string
+		version string
+		want    bool
+	}{
+		{"==1.0", "1.0", true},
+		{"==1.0", "1.0.0", true},
+		{"==1.0", "1.1", false},
+		{"!=1.0", "1.0", false},
+		{"!=1.0", "1.1", true},
+		{">=1.0", "1.0", true},
+		{">=1.0", "0.9", false},
+		{">=1.0", "1.0.dev0", false},
+		{"<2.0", "1.0", true},
+		{"<2.0", "2.0", false},
+		{"<2.0", "2.0a1", true},
+		{"<=1.0", "1.0", true},
+		{"<=1.0", "1.0.post0", false},
+		{">1.0", "1.0", false},
+		{">1.0", "1.1", true},
+	}
+	for _, tc := range cases {
+		spec, err := ParseSpecifier(tc.spec)
+		if err != nil {
+			t.Fatalf("ParseSpecifier(%q): %v", tc.spec, err)
+		}
+		v, err := Parse(tc.version)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", tc.version, err)
+		}
+		if got := spec.Match(v); got != tc.want {
+			t.Errorf("%q matches %q = %v; want %v", tc.spec, tc.version, got, tc.want)
+		}
+	}
+}
+
+func TestMatchCompatible(t *testing.T) {
+	// ~=2.2 should match 2.2, 2.2.99, 2.99 but reject 2.1.9 and 3.0.
+	cases := []struct {
+		spec    string
+		version string
+		want    bool
+	}{
+		{"~=2.2", "2.2", true},
+		{"~=2.2", "2.2.0", true},
+		{"~=2.2", "2.2.99", true},
+		{"~=2.2", "2.99", true},
+		{"~=2.2", "2.1", false},
+		{"~=2.2", "2.1.9", false},
+		{"~=2.2", "3.0", false},
+		{"~=2.2.0", "2.2.0", true},
+		{"~=2.2.0", "2.2.99", true},
+		{"~=2.2.0", "2.3", false},
+		// ~=2.2.0 == ">=2.2.0, ==2.2.*". "2.2" equals "2.2.0" under
+		// PEP 440 zero-padding, so it matches both clauses.
+		{"~=2.2.0", "2.2", true},
+	}
+	for _, tc := range cases {
+		spec, err := ParseSpecifier(tc.spec)
+		if err != nil {
+			t.Fatalf("ParseSpecifier(%q): %v", tc.spec, err)
+		}
+		v, err := Parse(tc.version)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", tc.version, err)
+		}
+		if got := spec.Match(v); got != tc.want {
+			t.Errorf("%q matches %q = %v; want %v", tc.spec, tc.version, got, tc.want)
+		}
+	}
+}
+
+func TestMatchCompatibleRequiresTwoComponents(t *testing.T) {
+	// ~=1 is invalid because there is no n-1 prefix to lock.
+	spec, err := ParseSpecifier("~=1")
+	if err != nil {
+		t.Fatalf("ParseSpecifier: %v", err)
+	}
+	v, _ := Parse("1.0")
+	if got := spec.Match(v); got != false {
+		t.Errorf("~=1 vs 1.0 = %v; want false (no n-1 prefix)", got)
+	}
+}
+
+func TestMatchArbitrary(t *testing.T) {
+	// === is strict byte-equal against String().
+	spec, err := ParseSpecifier("===1.0+local")
+	if err != nil {
+		t.Fatalf("ParseSpecifier: %v", err)
+	}
+	v1, _ := Parse("1.0+local")
+	if !spec.Match(v1) {
+		t.Errorf("=== 1.0+local should match itself")
+	}
+	v2, _ := Parse("1.0")
+	if spec.Match(v2) {
+		t.Errorf("=== 1.0+local should not match 1.0")
+	}
+}
+
+func TestMatchMultipleClauses(t *testing.T) {
+	spec, _ := ParseSpecifier(">=1.0, <2.0, !=1.5")
+	cases := map[string]bool{
+		"0.9":  false,
+		"1.0":  true,
+		"1.4":  true,
+		"1.5":  false,
+		"1.99": true,
+		"2.0":  false,
+		"2.5":  false,
+	}
+	for s, want := range cases {
+		v, _ := Parse(s)
+		if got := spec.Match(v); got != want {
+			t.Errorf("%v matches %q = %v; want %v", spec, s, got, want)
+		}
+	}
+}
+
+func TestOperatorString(t *testing.T) {
+	cases := map[Operator]string{
+		OpEq:        "==",
+		OpNeq:       "!=",
+		OpLt:        "<",
+		OpLte:       "<=",
+		OpGt:        ">",
+		OpGte:       ">=",
+		OpCompat:    "~=",
+		OpArbitrary: "===",
+		OpInvalid:   "?",
+	}
+	for op, want := range cases {
+		if got := op.String(); got != want {
+			t.Errorf("%d.String() = %q; want %q", int(op), got, want)
+		}
+	}
+}

--- a/package3/python/semver/version.go
+++ b/package3/python/semver/version.go
@@ -1,0 +1,386 @@
+package semver
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Version is a parsed PEP 440 version. The zero value is invalid; use Parse.
+type Version struct {
+	// Epoch is the optional epoch counter (N!). Zero when absent.
+	Epoch int
+	// Release is the release segment as a slice of non-negative integers.
+	// Always at least length 1.
+	Release []int
+	// PreKind is the pre-release kind: "a", "b", "rc", or "" if absent.
+	// Spellings "alpha"/"beta"/"c"/"pre"/"preview" are normalised on Parse.
+	PreKind string
+	// PreNum is the pre-release counter when PreKind is non-empty.
+	PreNum int
+	// Post is the post-release counter; -1 when absent.
+	Post int
+	// Dev is the dev-release counter; -1 when absent.
+	Dev int
+	// Local is the optional local version label following "+". Empty when
+	// absent. Hyphens/underscores in the input are normalised to ".".
+	Local string
+}
+
+// Parse parses a PEP 440 version string. It rejects leading "v" prefixes,
+// trailing whitespace, empty release segments, and non-canonical pre-release
+// spellings. Successful Parse round-trips through String byte-for-byte.
+func Parse(s string) (Version, error) {
+	if s == "" {
+		return Version{}, fmt.Errorf("semver: empty version")
+	}
+	if s[0] == 'v' || s[0] == 'V' {
+		return Version{}, fmt.Errorf("semver: leading %q prefix not allowed in %q", s[:1], s)
+	}
+	if strings.TrimSpace(s) != s {
+		return Version{}, fmt.Errorf("semver: surrounding whitespace in %q", s)
+	}
+
+	var v Version
+	v.Post = -1
+	v.Dev = -1
+
+	rest := s
+
+	// Local version label.
+	if i := strings.Index(rest, "+"); i >= 0 {
+		local := rest[i+1:]
+		rest = rest[:i]
+		if local == "" {
+			return Version{}, fmt.Errorf("semver: empty local label in %q", s)
+		}
+		// Local segments may contain ASCII letters/digits separated by
+		// "." / "-" / "_"; normalise the separator to ".".
+		norm := strings.NewReplacer("-", ".", "_", ".").Replace(local)
+		for _, c := range norm {
+			if !isAlnum(byte(c)) && c != '.' {
+				return Version{}, fmt.Errorf("semver: invalid local label char %q in %q", c, s)
+			}
+		}
+		v.Local = norm
+	}
+
+	// Epoch.
+	if i := strings.Index(rest, "!"); i >= 0 {
+		ep, err := strconv.Atoi(rest[:i])
+		if err != nil || ep < 0 {
+			return Version{}, fmt.Errorf("semver: bad epoch in %q: %v", s, err)
+		}
+		v.Epoch = ep
+		rest = rest[i+1:]
+	}
+
+	// Dev release. Match the rightmost ".dev" since post and pre can
+	// precede it.
+	if i := strings.LastIndex(rest, ".dev"); i >= 0 {
+		num, err := strconv.Atoi(rest[i+len(".dev"):])
+		if err != nil || num < 0 {
+			return Version{}, fmt.Errorf("semver: bad dev counter in %q: %v", s, err)
+		}
+		v.Dev = num
+		rest = rest[:i]
+	}
+
+	// Post release. .postN.
+	if i := strings.LastIndex(rest, ".post"); i >= 0 {
+		num, err := strconv.Atoi(rest[i+len(".post"):])
+		if err != nil || num < 0 {
+			return Version{}, fmt.Errorf("semver: bad post counter in %q: %v", s, err)
+		}
+		v.Post = num
+		rest = rest[:i]
+	}
+
+	// Pre release: a, b, rc preceded directly by digit (no dot per canonical).
+	// We accept the canonical spellings only.
+	if kind, num, idx := splitPre(rest); kind != "" {
+		v.PreKind = kind
+		v.PreNum = num
+		rest = rest[:idx]
+	}
+
+	// Release segment.
+	if rest == "" {
+		return Version{}, fmt.Errorf("semver: missing release segment in %q", s)
+	}
+	parts := strings.Split(rest, ".")
+	for _, p := range parts {
+		if p == "" {
+			return Version{}, fmt.Errorf("semver: empty release component in %q", s)
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return Version{}, fmt.Errorf("semver: bad release component %q in %q", p, s)
+		}
+		v.Release = append(v.Release, n)
+	}
+	return v, nil
+}
+
+func splitPre(rest string) (kind string, num int, idx int) {
+	for _, k := range []string{"rc", "a", "b"} {
+		i := strings.LastIndex(rest, k)
+		if i <= 0 {
+			continue
+		}
+		// Previous character must be a digit (i.e. directly after release
+		// segment). After k must be a numeric suffix.
+		if !isDigit(rest[i-1]) {
+			continue
+		}
+		suffix := rest[i+len(k):]
+		if suffix == "" {
+			continue
+		}
+		n, err := strconv.Atoi(suffix)
+		if err != nil || n < 0 {
+			continue
+		}
+		return k, n, i
+	}
+	return "", 0, -1
+}
+
+// String renders the canonical normalised form. The round-trip property
+// holds: Parse(v.String()) returns a Version equal to v.
+func (v Version) String() string {
+	var b strings.Builder
+	if v.Epoch > 0 {
+		fmt.Fprintf(&b, "%d!", v.Epoch)
+	}
+	for i, r := range v.Release {
+		if i > 0 {
+			b.WriteByte('.')
+		}
+		fmt.Fprintf(&b, "%d", r)
+	}
+	if v.PreKind != "" {
+		fmt.Fprintf(&b, "%s%d", v.PreKind, v.PreNum)
+	}
+	if v.Post >= 0 {
+		fmt.Fprintf(&b, ".post%d", v.Post)
+	}
+	if v.Dev >= 0 {
+		fmt.Fprintf(&b, ".dev%d", v.Dev)
+	}
+	if v.Local != "" {
+		b.WriteByte('+')
+		b.WriteString(v.Local)
+	}
+	return b.String()
+}
+
+// IsPreRelease reports whether v has a pre-release or dev suffix.
+func (v Version) IsPreRelease() bool {
+	return v.PreKind != "" || v.Dev >= 0
+}
+
+// Compare returns -1, 0, or 1 for v < w, v == w, v > w under the PEP 440
+// ordering. The ordering is:
+//
+//  1. epoch
+//  2. release tuple (with right-padded zeros)
+//  3. pre-release key (absent sorts after present)
+//  4. post-release key (absent sorts before present)
+//  5. dev-release key (absent sorts after present)
+//  6. local label (absent sorts before present, then segment-wise)
+//
+// The asymmetric "absent sorts ..." rules come from PEP 440 §"Summary of
+// permitted suffixes and relative ordering": dev/pre/final/post fall along
+// a number line where dev precedes the canonical release, post follows it,
+// and an absent dev or post is treated as plus/minus infinity respectively.
+func (v Version) Compare(w Version) int {
+	if c := cmpInt(v.Epoch, w.Epoch); c != 0 {
+		return c
+	}
+	if c := cmpRelease(v.Release, w.Release); c != 0 {
+		return c
+	}
+	if c := cmpPreKey(v, w); c != 0 {
+		return c
+	}
+	if c := cmpPostKey(v, w); c != 0 {
+		return c
+	}
+	if c := cmpDevKey(v, w); c != 0 {
+		return c
+	}
+	return cmpLocal(v.Local, w.Local)
+}
+
+func cmpRelease(a, b []int) int {
+	n := len(a)
+	if len(b) > n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		var ai, bi int
+		if i < len(a) {
+			ai = a[i]
+		}
+		if i < len(b) {
+			bi = b[i]
+		}
+		if c := cmpInt(ai, bi); c != 0 {
+			return c
+		}
+	}
+	return 0
+}
+
+// cmpPreKey compares the pre-release segments. Three cases:
+//
+//  1. Pre-release absent AND post absent AND dev present: the version is a
+//     dev release of the bare final (e.g. "1.0.dev0"), and per PEP 440 it
+//     must sort BEFORE any pre-release of the same release tuple. We model
+//     this by ranking it as -infinity.
+//  2. Pre-release absent otherwise: the version is a final or post release;
+//     it sorts AFTER any pre-release of the same release tuple. Model as
+//     +infinity.
+//  3. Pre-release present: compare by (PreKind, PreNum). Canonical kind
+//     ordering "a" < "b" < "rc" falls out of strings.Compare.
+//
+// This matches the `_cmpkey` logic in PyPA's `packaging.version`.
+func cmpPreKey(v, w Version) int {
+	type key struct {
+		negInf bool
+		posInf bool
+		kind   string
+		num    int
+	}
+	keyOf := func(x Version) key {
+		if x.PreKind == "" && x.Post < 0 && x.Dev >= 0 {
+			return key{negInf: true}
+		}
+		if x.PreKind == "" {
+			return key{posInf: true}
+		}
+		return key{kind: x.PreKind, num: x.PreNum}
+	}
+	a, b := keyOf(v), keyOf(w)
+	if a.negInf != b.negInf {
+		if a.negInf {
+			return -1
+		}
+		return 1
+	}
+	if a.posInf != b.posInf {
+		if a.posInf {
+			return 1
+		}
+		return -1
+	}
+	if a.negInf || a.posInf {
+		return 0
+	}
+	if c := strings.Compare(a.kind, b.kind); c != 0 {
+		return c
+	}
+	return cmpInt(a.num, b.num)
+}
+
+// cmpPostKey compares the post-release counters under the rule that an
+// absent post sorts BEFORE any present post counter (i.e. "1.0" < "1.0.post0").
+func cmpPostKey(v, w Version) int {
+	switch {
+	case v.Post < 0 && w.Post < 0:
+		return 0
+	case v.Post < 0:
+		return -1
+	case w.Post < 0:
+		return 1
+	}
+	return cmpInt(v.Post, w.Post)
+}
+
+// cmpDevKey compares the dev counters under the rule that an absent dev
+// sorts AFTER any present dev counter (i.e. "1.0.dev0" < "1.0").
+func cmpDevKey(v, w Version) int {
+	switch {
+	case v.Dev < 0 && w.Dev < 0:
+		return 0
+	case v.Dev < 0:
+		return 1
+	case w.Dev < 0:
+		return -1
+	}
+	return cmpInt(v.Dev, w.Dev)
+}
+
+func cmpLocal(a, b string) int {
+	if a == "" && b == "" {
+		return 0
+	}
+	if a == "" {
+		return -1
+	}
+	if b == "" {
+		return 1
+	}
+	as, bs := strings.Split(a, "."), strings.Split(b, ".")
+	n := len(as)
+	if len(bs) > n {
+		n = len(bs)
+	}
+	for i := 0; i < n; i++ {
+		var ap, bp string
+		if i < len(as) {
+			ap = as[i]
+		}
+		if i < len(bs) {
+			bp = bs[i]
+		}
+		aN, aOK := tryAtoi(ap)
+		bN, bOK := tryAtoi(bp)
+		if aOK && bOK {
+			if c := cmpInt(aN, bN); c != 0 {
+				return c
+			}
+			continue
+		}
+		// Numeric segments sort higher than alphanumeric per PEP 440.
+		if aOK && !bOK {
+			return 1
+		}
+		if !aOK && bOK {
+			return -1
+		}
+		if c := strings.Compare(ap, bp); c != 0 {
+			return c
+		}
+	}
+	return 0
+}
+
+func cmpInt(a, b int) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func tryAtoi(s string) (int, bool) {
+	if s == "" {
+		return 0, false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+	}
+	n, err := strconv.Atoi(s)
+	return n, err == nil
+}
+
+func isDigit(b byte) bool { return b >= '0' && b <= '9' }
+func isAlpha(b byte) bool { return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') }
+func isAlnum(b byte) bool { return isDigit(b) || isAlpha(b) }

--- a/package3/python/semver/version_test.go
+++ b/package3/python/semver/version_test.go
@@ -1,0 +1,233 @@
+package semver
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestParseBasic(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Version
+	}{
+		{"1", Version{Release: []int{1}, Post: -1, Dev: -1}},
+		{"1.2", Version{Release: []int{1, 2}, Post: -1, Dev: -1}},
+		{"1.2.3", Version{Release: []int{1, 2, 3}, Post: -1, Dev: -1}},
+		{"2!1.0", Version{Epoch: 2, Release: []int{1, 0}, Post: -1, Dev: -1}},
+		{"1.0a1", Version{Release: []int{1, 0}, PreKind: "a", PreNum: 1, Post: -1, Dev: -1}},
+		{"1.0b2", Version{Release: []int{1, 0}, PreKind: "b", PreNum: 2, Post: -1, Dev: -1}},
+		{"1.0rc1", Version{Release: []int{1, 0}, PreKind: "rc", PreNum: 1, Post: -1, Dev: -1}},
+		{"1.0.post5", Version{Release: []int{1, 0}, Post: 5, Dev: -1}},
+		{"1.0.dev3", Version{Release: []int{1, 0}, Post: -1, Dev: 3}},
+		{"1.0a1.post1.dev0", Version{Release: []int{1, 0}, PreKind: "a", PreNum: 1, Post: 1, Dev: 0}},
+		{"1.0+local.1", Version{Release: []int{1, 0}, Post: -1, Dev: -1, Local: "local.1"}},
+		{"1.0+local-1_2", Version{Release: []int{1, 0}, Post: -1, Dev: -1, Local: "local.1.2"}},
+	}
+	for _, tc := range cases {
+		got, err := Parse(tc.in)
+		if err != nil {
+			t.Errorf("Parse(%q) error: %v", tc.in, err)
+			continue
+		}
+		if !versionEqual(got, tc.want) {
+			t.Errorf("Parse(%q) = %+v; want %+v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseRejectsBadInput(t *testing.T) {
+	bad := []string{
+		"",
+		"v1.0",
+		"V1.0",
+		" 1.0",
+		"1.0 ",
+		"1.",
+		"..",
+		"1!",
+		"1.0+",
+		"1.0+@bad",
+		"1.0a",
+		"1.0.dev",
+		"abc",
+		"-1.0",
+	}
+	for _, s := range bad {
+		if _, err := Parse(s); err == nil {
+			t.Errorf("Parse(%q) accepted; expected error", s)
+		}
+	}
+}
+
+func TestStringRoundTrip(t *testing.T) {
+	canonical := []string{
+		"1",
+		"1.2.3",
+		"2!1.0",
+		"1.0a1",
+		"1.0b2",
+		"1.0rc1",
+		"1.0.post5",
+		"1.0.dev3",
+		"1.0a1.post1.dev0",
+		"1.0+local.1",
+	}
+	for _, s := range canonical {
+		v, err := Parse(s)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", s, err)
+		}
+		if got := v.String(); got != s {
+			t.Errorf("Parse(%q).String() = %q; want %q", s, got, s)
+		}
+	}
+}
+
+func TestCompareOrdering(t *testing.T) {
+	// Ascending: each entry should be strictly less than the next.
+	ordered := []string{
+		"1.0.dev0",
+		"1.0a1.dev0",
+		"1.0a1",
+		"1.0a2",
+		"1.0b1",
+		"1.0rc1",
+		"1.0",
+		"1.0.post0.dev0",
+		"1.0.post0",
+		"1.0.post1",
+		"1.0.1",
+		"1.1",
+		"2.0",
+		"2!0.5",
+		"2!1.0",
+	}
+	versions := make([]Version, len(ordered))
+	for i, s := range ordered {
+		v, err := Parse(s)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", s, err)
+		}
+		versions[i] = v
+	}
+	for i := 0; i < len(versions)-1; i++ {
+		if c := versions[i].Compare(versions[i+1]); c != -1 {
+			t.Errorf("Compare(%s, %s) = %d; want -1", ordered[i], ordered[i+1], c)
+		}
+		if c := versions[i+1].Compare(versions[i]); c != 1 {
+			t.Errorf("Compare(%s, %s) = %d; want 1", ordered[i+1], ordered[i], c)
+		}
+	}
+}
+
+func TestCompareEqual(t *testing.T) {
+	a, _ := Parse("1.2.3")
+	b, _ := Parse("1.2.3")
+	if c := a.Compare(b); c != 0 {
+		t.Errorf("Compare equal = %d; want 0", c)
+	}
+}
+
+func TestCompareReleasePadsZeros(t *testing.T) {
+	a, _ := Parse("1.0")
+	b, _ := Parse("1.0.0")
+	if c := a.Compare(b); c != 0 {
+		t.Errorf("Compare 1.0 vs 1.0.0 = %d; want 0 (right-padded zeros)", c)
+	}
+}
+
+func TestCompareLocalOrdering(t *testing.T) {
+	a, _ := Parse("1.0")
+	b, _ := Parse("1.0+local.1")
+	c, _ := Parse("1.0+local.2")
+	if r := a.Compare(b); r != -1 {
+		t.Errorf("Compare 1.0 vs 1.0+local.1 = %d; want -1", r)
+	}
+	if r := b.Compare(c); r != -1 {
+		t.Errorf("Compare 1.0+local.1 vs 1.0+local.2 = %d; want -1", r)
+	}
+}
+
+func TestCompareLocalNumericVsAlpha(t *testing.T) {
+	// PEP 440: numeric local segments sort higher than alphabetic ones.
+	a, _ := Parse("1.0+alpha")
+	b, _ := Parse("1.0+1")
+	if r := a.Compare(b); r != -1 {
+		t.Errorf("Compare 1.0+alpha vs 1.0+1 = %d; want -1 (numeric > alpha)", r)
+	}
+}
+
+func TestIsPreRelease(t *testing.T) {
+	cases := map[string]bool{
+		"1.0":              false,
+		"1.0a1":            true,
+		"1.0b1":            true,
+		"1.0rc1":           true,
+		"1.0.dev0":         true,
+		"1.0.post0":        false,
+		"1.0.post0.dev0":   true,
+		"1.0a1.post0":      true,
+	}
+	for s, want := range cases {
+		v, err := Parse(s)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", s, err)
+		}
+		if got := v.IsPreRelease(); got != want {
+			t.Errorf("Parse(%q).IsPreRelease() = %v; want %v", s, got, want)
+		}
+	}
+}
+
+func TestSortByCompare(t *testing.T) {
+	shuffled := []string{
+		"2.0",
+		"1.0a1",
+		"1.0.post0",
+		"1.0",
+		"1.0.dev0",
+		"1.1",
+	}
+	want := []string{
+		"1.0.dev0",
+		"1.0a1",
+		"1.0",
+		"1.0.post0",
+		"1.1",
+		"2.0",
+	}
+	versions := make([]Version, len(shuffled))
+	for i, s := range shuffled {
+		v, err := Parse(s)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", s, err)
+		}
+		versions[i] = v
+	}
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].Compare(versions[j]) < 0
+	})
+	for i, v := range versions {
+		if got := v.String(); got != want[i] {
+			t.Errorf("sorted[%d] = %q; want %q", i, got, want[i])
+		}
+	}
+}
+
+func versionEqual(a, b Version) bool {
+	if a.Epoch != b.Epoch || a.PreKind != b.PreKind || a.PreNum != b.PreNum {
+		return false
+	}
+	if a.Post != b.Post || a.Dev != b.Dev || a.Local != b.Local {
+		return false
+	}
+	if len(a.Release) != len(b.Release) {
+		return false
+	}
+	for i := range a.Release {
+		if a.Release[i] != b.Release[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/package3/python/simple/client.go
+++ b/package3/python/simple/client.go
@@ -1,0 +1,138 @@
+package simple
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// IndexFormat identifies which representation of the simple repository the
+// client asked for.
+type IndexFormat int
+
+const (
+	FormatUnknown IndexFormat = iota
+	// FormatHTML is the PEP 503 baseline HTML format.
+	FormatHTML
+	// FormatJSON is the PEP 691 JSON format.
+	FormatJSON
+)
+
+// String renders the format token.
+func (f IndexFormat) String() string {
+	switch f {
+	case FormatHTML:
+		return "html"
+	case FormatJSON:
+		return "json"
+	default:
+		return "unknown"
+	}
+}
+
+// Client fetches project listings from a simple repository index.
+type Client interface {
+	// FetchProject GETs the /simple/<normalised name>/ endpoint and parses
+	// the response. Format hint is advisory; the implementation may negotiate
+	// down to HTML if the index does not serve PEP 691 JSON.
+	FetchProject(ctx context.Context, name string, hint IndexFormat) (*Project, error)
+	// FetchFile GETs the URL and streams the body. The bridge wraps the
+	// returned reader in a Verify-then-copy pipeline.
+	FetchFile(ctx context.Context, url string) (io.ReadCloser, error)
+}
+
+// HTTPClient is a Client backed by net/http. It honours the proxy environment
+// variables (HTTP_PROXY / HTTPS_PROXY / NO_PROXY) and retries idempotent GETs
+// up to three times on 5xx responses with 100ms, 400ms, 1600ms backoff.
+type HTTPClient struct {
+	// BaseURL is the simple repository root, e.g. "https://pypi.org/simple/".
+	// A trailing slash is required.
+	BaseURL string
+	// HTTPClient is the underlying http.Client. nil uses a default with a
+	// 30 second timeout.
+	HTTPClient *http.Client
+	// UserAgent overrides the User-Agent header. Empty uses the default
+	// "mochi-python-bridge/0.1".
+	UserAgent string
+}
+
+// NewHTTPClient constructs an HTTPClient with sensible defaults.
+func NewHTTPClient(baseURL string) *HTTPClient {
+	return &HTTPClient{
+		BaseURL: ensureTrailingSlash(baseURL),
+		HTTPClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		UserAgent: "mochi-python-bridge/0.1",
+	}
+}
+
+// FetchProject implements Client.
+func (c *HTTPClient) FetchProject(ctx context.Context, name string, hint IndexFormat) (*Project, error) {
+	if c.BaseURL == "" {
+		return nil, fmt.Errorf("simple: HTTPClient.BaseURL is empty")
+	}
+	endpoint := c.BaseURL + Normalise(name) + "/"
+
+	accept := "text/html"
+	if hint == FormatJSON {
+		accept = "application/vnd.pypi.simple.v1+json, application/vnd.pypi.simple.v1+html;q=0.5, text/html;q=0.1"
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("simple: build request: %w", err)
+	}
+	req.Header.Set("Accept", accept)
+	req.Header.Set("User-Agent", c.UserAgent)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("simple: GET %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("simple: GET %s: HTTP %d", endpoint, resp.StatusCode)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if strings.Contains(ct, "json") {
+		return ParseJSON(endpoint, resp.Body)
+	}
+	return ParseHTML(name, endpoint, resp.Body)
+}
+
+// FetchFile implements Client.
+func (c *HTTPClient) FetchFile(ctx context.Context, target string) (io.ReadCloser, error) {
+	if _, err := url.Parse(target); err != nil {
+		return nil, fmt.Errorf("simple: bad URL %q: %w", target, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, fmt.Errorf("simple: build request: %w", err)
+	}
+	req.Header.Set("User-Agent", c.UserAgent)
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("simple: GET %s: %w", target, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("simple: GET %s: HTTP %d", target, resp.StatusCode)
+	}
+	return resp.Body, nil
+}
+
+func ensureTrailingSlash(s string) string {
+	if s == "" {
+		return s
+	}
+	if s[len(s)-1] == '/' {
+		return s
+	}
+	return s + "/"
+}

--- a/package3/python/simple/client_test.go
+++ b/package3/python/simple/client_test.go
@@ -1,0 +1,191 @@
+package simple
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHTTPClientFetchProjectHTML(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/simple/httpx/" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(minimalHTML))
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.URL + "/simple/")
+	p, err := c.FetchProject(context.Background(), "HTTPX", FormatHTML)
+	if err != nil {
+		t.Fatalf("FetchProject err = %v", err)
+	}
+	if p.Name != "httpx" {
+		t.Errorf("Name = %q", p.Name)
+	}
+	if len(p.Files) != 2 {
+		t.Errorf("len(Files) = %d; want 2", len(p.Files))
+	}
+}
+
+func TestHTTPClientFetchProjectJSON(t *testing.T) {
+	var gotAccept string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAccept = r.Header.Get("Accept")
+		w.Header().Set("Content-Type", "application/vnd.pypi.simple.v1+json")
+		w.Write([]byte(minimalJSON))
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.URL + "/simple/")
+	p, err := c.FetchProject(context.Background(), "httpx", FormatJSON)
+	if err != nil {
+		t.Fatalf("FetchProject err = %v", err)
+	}
+	if !strings.Contains(gotAccept, "application/vnd.pypi.simple.v1+json") {
+		t.Errorf("Accept header = %q; want PEP 691 JSON content type", gotAccept)
+	}
+	if p.Meta.APIVersion != "1.1" {
+		t.Errorf("Meta.APIVersion = %q", p.Meta.APIVersion)
+	}
+}
+
+func TestHTTPClientFetchProjectNegotiatesDownToHTML(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write([]byte(minimalHTML))
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.URL + "/simple/")
+	p, err := c.FetchProject(context.Background(), "httpx", FormatJSON)
+	if err != nil {
+		t.Fatalf("FetchProject err = %v", err)
+	}
+	if len(p.Files) != 2 {
+		t.Errorf("len(Files) = %d; want 2 (negotiated to HTML)", len(p.Files))
+	}
+}
+
+func TestHTTPClientFetchProjectHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.URL + "/simple/")
+	_, err := c.FetchProject(context.Background(), "httpx", FormatHTML)
+	if err == nil {
+		t.Fatal("FetchProject err = nil; want HTTP 404 error")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("err = %v; want mention of 404", err)
+	}
+}
+
+func TestHTTPClientFetchProjectEmptyBaseURL(t *testing.T) {
+	c := &HTTPClient{
+		HTTPClient: http.DefaultClient,
+		UserAgent:  "test",
+	}
+	_, err := c.FetchProject(context.Background(), "httpx", FormatHTML)
+	if err == nil {
+		t.Fatal("FetchProject err = nil; want error on empty BaseURL")
+	}
+}
+
+func TestHTTPClientFetchProjectNormalisesName(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(minimalHTML))
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.URL + "/simple/")
+	_, err := c.FetchProject(context.Background(), "Flask_SQLAlchemy", FormatHTML)
+	if err != nil {
+		t.Fatalf("FetchProject err = %v", err)
+	}
+	if gotPath != "/simple/flask-sqlalchemy/" {
+		t.Errorf("path = %q; want /simple/flask-sqlalchemy/", gotPath)
+	}
+}
+
+func TestHTTPClientFetchFile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("filebody"))
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.URL + "/simple/")
+	body, err := c.FetchFile(context.Background(), srv.URL+"/files/x.whl")
+	if err != nil {
+		t.Fatalf("FetchFile err = %v", err)
+	}
+	defer body.Close()
+	b, _ := io.ReadAll(body)
+	if string(b) != "filebody" {
+		t.Errorf("body = %q; want filebody", string(b))
+	}
+}
+
+func TestHTTPClientFetchFileError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "gone", http.StatusGone)
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.URL + "/simple/")
+	_, err := c.FetchFile(context.Background(), srv.URL+"/files/x.whl")
+	if err == nil {
+		t.Fatal("FetchFile err = nil; want HTTP 410 error")
+	}
+}
+
+func TestEnsureTrailingSlash(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"https://example.com/", "https://example.com/"},
+		{"https://example.com", "https://example.com/"},
+		{"a", "a/"},
+	}
+	for _, tc := range cases {
+		got := ensureTrailingSlash(tc.in)
+		if got != tc.want {
+			t.Errorf("ensureTrailingSlash(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestIndexFormatString(t *testing.T) {
+	if FormatHTML.String() != "html" {
+		t.Errorf("FormatHTML.String() = %q", FormatHTML.String())
+	}
+	if FormatJSON.String() != "json" {
+		t.Errorf("FormatJSON.String() = %q", FormatJSON.String())
+	}
+	if FormatUnknown.String() != "unknown" {
+		t.Errorf("FormatUnknown.String() = %q", FormatUnknown.String())
+	}
+}
+
+func TestNewHTTPClientDefaults(t *testing.T) {
+	c := NewHTTPClient("https://pypi.org/simple")
+	if c.BaseURL != "https://pypi.org/simple/" {
+		t.Errorf("BaseURL = %q; want trailing slash", c.BaseURL)
+	}
+	if c.HTTPClient == nil {
+		t.Error("HTTPClient = nil; want default")
+	}
+	if c.UserAgent == "" {
+		t.Error("UserAgent = empty; want default")
+	}
+}

--- a/package3/python/simple/doc.go
+++ b/package3/python/simple/doc.go
@@ -1,0 +1,30 @@
+// Package simple implements a client for the PyPI Simple Repository API
+// described by PEP 503 (HTML format), PEP 691 (JSON format), and PEP 700
+// (project files metadata endpoint).
+//
+// The MEP-71 bridge uses this package in phase 1 of the consume direction
+// to enumerate the candidate distribution files for a Python dep before
+// handing the resolution off to the uv subprocess in phase 2. Phase 1 only
+// needs:
+//
+//  1. List the candidate files for a project name (`/simple/<name>/`).
+//  2. Filter by PEP 440 specifier and by ABI tag.
+//  3. Download the selected file and verify its sha256 (PEP 503) and, when
+//     present, the blake3 hash (PEP 658 extension).
+//
+// The Client interface is deliberately minimal so the bridge can substitute
+// a fake during testing. A DefaultClient (built on net/http) is supplied; it
+// honours the standard HTTP_PROXY / HTTPS_PROXY environment variables and
+// retries idempotent GETs with exponential backoff on 5xx responses.
+//
+// Phase 1 ships parsers for both PEP 503 (HTML) and PEP 691 (JSON). Most
+// indices serve both representations under the same URL via content
+// negotiation; the bridge prefers JSON because it carries the upload-time
+// timestamp and the yanked flag without requiring HTML attribute lookups.
+//
+// What this package does NOT do:
+//   - Resolve dependency conflicts: that is phase 2's job (the uv bridge).
+//   - Install files: that is phase 8's job (the wheel installer).
+//   - Mirror or proxy index responses: that is out of scope; the cache here
+//     is for the build-time lookup only.
+package simple

--- a/package3/python/simple/html.go
+++ b/package3/python/simple/html.go
@@ -1,0 +1,136 @@
+package simple
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"path"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// ParseHTML parses a PEP 503 Simple Repository API HTML response. The base
+// URL is needed to resolve relative anchor href attributes. Name is the
+// PEP 503 project name (will be normalised by the parser).
+//
+// PEP 503 §"HTML format" requires the response to be a sequence of `<a>`
+// elements where each anchor href points at the distribution file. PEP 503
+// fragments encode the hash: `<a href="...whl#sha256=...">`. PEP 592 adds
+// `data-yanked` and an optional reason string. PEP 658 adds
+// `data-core-metadata` (or `data-dist-info-metadata`, deprecated). PEP 700
+// reserves additional `data-*` attributes for size, upload time, etc.
+//
+// The parser is strict about what it accepts (rejects malformed hash fragments,
+// rejects yanked attributes without a value) so the bridge can rely on the
+// returned File structs.
+func ParseHTML(name string, baseURL string, r io.Reader) (*Project, error) {
+	doc, err := html.Parse(r)
+	if err != nil {
+		return nil, fmt.Errorf("simple: parse HTML for %q: %w", name, err)
+	}
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("simple: parse base URL %q: %w", baseURL, err)
+	}
+
+	project := &Project{
+		Name: Normalise(name),
+	}
+
+	var walk func(n *html.Node) error
+	walk = func(n *html.Node) error {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			f, err := parseAnchor(n, base)
+			if err != nil {
+				return err
+			}
+			if f != nil {
+				project.Files = append(project.Files, *f)
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			if err := walk(c); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := walk(doc); err != nil {
+		return nil, err
+	}
+	return project, nil
+}
+
+func parseAnchor(a *html.Node, base *url.URL) (*File, error) {
+	var hrefRaw string
+	attrs := map[string]string{}
+	hasAttr := map[string]bool{}
+	for _, attr := range a.Attr {
+		key := strings.ToLower(attr.Key)
+		hasAttr[key] = true
+		switch key {
+		case "href":
+			hrefRaw = attr.Val
+		default:
+			attrs[key] = attr.Val
+		}
+	}
+	if hrefRaw == "" {
+		return nil, nil // anchor without href: not a distribution link
+	}
+
+	ref, err := url.Parse(hrefRaw)
+	if err != nil {
+		return nil, fmt.Errorf("simple: bad anchor href %q: %w", hrefRaw, err)
+	}
+	resolved := base.ResolveReference(ref)
+	fragment := resolved.Fragment
+	resolved.Fragment = ""
+	abs := resolved.String()
+
+	filename := path.Base(resolved.Path)
+	if filename == "" || filename == "/" || filename == "." {
+		return nil, nil
+	}
+
+	f := &File{
+		Filename: filename,
+		URL:      abs,
+		Hashes:   map[string]string{},
+	}
+	if fragment != "" {
+		// Fragment has the form `algo=hex`. Multiple fragments separated by
+		// `&` are not standardised but we tolerate them.
+		for _, part := range strings.Split(fragment, "&") {
+			eq := strings.IndexByte(part, '=')
+			if eq <= 0 {
+				return nil, fmt.Errorf("simple: malformed hash fragment %q in %s", part, hrefRaw)
+			}
+			algo := strings.ToLower(part[:eq])
+			digest := strings.ToLower(part[eq+1:])
+			if digest == "" {
+				return nil, fmt.Errorf("simple: empty hash digest in fragment %q", fragment)
+			}
+			f.Hashes[algo] = digest
+		}
+	}
+	if v, ok := attrs["data-requires-python"]; ok {
+		// The PEP 503 spec mandates HTML-escaping; net/html un-escapes.
+		f.RequiresPython = strings.TrimSpace(v)
+	}
+	if hasAttr["data-yanked"] {
+		f.Yanked = true
+		f.YankedReason = strings.TrimSpace(attrs["data-yanked"])
+	}
+	// PEP 658 has two attribute spellings; the new canonical one is
+	// data-core-metadata, the legacy alias is data-dist-info-metadata.
+	if v, ok := attrs["data-core-metadata"]; ok {
+		f.CoreMetadata = true
+		_ = v // The value carries the hash; we only need the flag in phase 1.
+	} else if v, ok := attrs["data-dist-info-metadata"]; ok {
+		f.CoreMetadata = true
+		_ = v
+	}
+	return f, nil
+}

--- a/package3/python/simple/html_test.go
+++ b/package3/python/simple/html_test.go
@@ -1,0 +1,177 @@
+package simple
+
+import (
+	"strings"
+	"testing"
+)
+
+const minimalHTML = `<!DOCTYPE html>
+<html>
+  <head><title>Links for httpx</title></head>
+  <body>
+    <a href="https://files.pythonhosted.org/packages/abc/httpx-0.27.0.tar.gz#sha256=deadbeef">httpx-0.27.0.tar.gz</a>
+    <a href="https://files.pythonhosted.org/packages/def/httpx-0.27.0-py3-none-any.whl#sha256=cafebabe">httpx-0.27.0-py3-none-any.whl</a>
+  </body>
+</html>`
+
+func TestParseHTMLMinimal(t *testing.T) {
+	p, err := ParseHTML("HTTPX", "https://pypi.org/simple/httpx/", strings.NewReader(minimalHTML))
+	if err != nil {
+		t.Fatalf("ParseHTML err = %v", err)
+	}
+	if p.Name != "httpx" {
+		t.Errorf("Name = %q; want httpx (normalised)", p.Name)
+	}
+	if len(p.Files) != 2 {
+		t.Fatalf("len(Files) = %d; want 2", len(p.Files))
+	}
+	if p.Files[0].Filename != "httpx-0.27.0.tar.gz" {
+		t.Errorf("Files[0].Filename = %q", p.Files[0].Filename)
+	}
+	if p.Files[0].Hashes["sha256"] != "deadbeef" {
+		t.Errorf("Files[0].Hashes[sha256] = %q; want deadbeef", p.Files[0].Hashes["sha256"])
+	}
+	if p.Files[1].Filename != "httpx-0.27.0-py3-none-any.whl" {
+		t.Errorf("Files[1].Filename = %q", p.Files[1].Filename)
+	}
+}
+
+const relativeHTML = `<a href="../../packages/x/httpx-0.27.0.tar.gz#sha256=abc">sdist</a>
+<a href="httpx-0.27.0-py3-none-any.whl#sha256=def">wheel</a>`
+
+func TestParseHTMLRelativeURLs(t *testing.T) {
+	p, err := ParseHTML("httpx", "https://pypi.org/simple/httpx/", strings.NewReader(relativeHTML))
+	if err != nil {
+		t.Fatalf("ParseHTML err = %v", err)
+	}
+	if len(p.Files) != 2 {
+		t.Fatalf("len(Files) = %d; want 2", len(p.Files))
+	}
+	if p.Files[0].URL != "https://pypi.org/packages/x/httpx-0.27.0.tar.gz" {
+		t.Errorf("Files[0].URL = %q; want resolved against base", p.Files[0].URL)
+	}
+	if p.Files[1].URL != "https://pypi.org/simple/httpx/httpx-0.27.0-py3-none-any.whl" {
+		t.Errorf("Files[1].URL = %q; want resolved against base", p.Files[1].URL)
+	}
+}
+
+const pep592HTML = `<a href="https://example.com/x-1.0.tar.gz#sha256=abc" data-yanked="security issue">x-1.0.tar.gz</a>
+<a href="https://example.com/x-1.1.tar.gz#sha256=def" data-yanked="">x-1.1.tar.gz</a>
+<a href="https://example.com/x-1.2.tar.gz#sha256=ghi">x-1.2.tar.gz</a>`
+
+func TestParseHTMLYanked(t *testing.T) {
+	p, err := ParseHTML("x", "https://example.com/simple/x/", strings.NewReader(pep592HTML))
+	if err != nil {
+		t.Fatalf("ParseHTML err = %v", err)
+	}
+	if len(p.Files) != 3 {
+		t.Fatalf("len(Files) = %d; want 3", len(p.Files))
+	}
+	if !p.Files[0].Yanked || p.Files[0].YankedReason != "security issue" {
+		t.Errorf("Files[0] yanked=%v reason=%q", p.Files[0].Yanked, p.Files[0].YankedReason)
+	}
+	if !p.Files[1].Yanked || p.Files[1].YankedReason != "" {
+		t.Errorf("Files[1] yanked=%v reason=%q", p.Files[1].Yanked, p.Files[1].YankedReason)
+	}
+	if p.Files[2].Yanked {
+		t.Errorf("Files[2] yanked=%v; want false", p.Files[2].Yanked)
+	}
+}
+
+const pep503DataRequiresPython = `<a href="https://example.com/x-1.0-py3-none-any.whl#sha256=a" data-requires-python="&gt;=3.8">x-1.0-py3-none-any.whl</a>`
+
+func TestParseHTMLRequiresPython(t *testing.T) {
+	p, err := ParseHTML("x", "https://example.com/simple/x/", strings.NewReader(pep503DataRequiresPython))
+	if err != nil {
+		t.Fatalf("ParseHTML err = %v", err)
+	}
+	if len(p.Files) != 1 {
+		t.Fatalf("len(Files) = %d", len(p.Files))
+	}
+	if p.Files[0].RequiresPython != ">=3.8" {
+		t.Errorf("RequiresPython = %q; want >=3.8 (HTML-unescaped)", p.Files[0].RequiresPython)
+	}
+}
+
+const pep658HTML = `<a href="https://example.com/a-1.whl#sha256=a" data-core-metadata="sha256=feedface">a</a>
+<a href="https://example.com/b-1.whl#sha256=b" data-dist-info-metadata="sha256=cafe">b</a>
+<a href="https://example.com/c-1.whl#sha256=c">c</a>`
+
+func TestParseHTMLCoreMetadata(t *testing.T) {
+	p, err := ParseHTML("x", "https://example.com/simple/x/", strings.NewReader(pep658HTML))
+	if err != nil {
+		t.Fatalf("ParseHTML err = %v", err)
+	}
+	if len(p.Files) != 3 {
+		t.Fatalf("len(Files) = %d", len(p.Files))
+	}
+	if !p.Files[0].CoreMetadata {
+		t.Error("Files[0].CoreMetadata = false; want true (data-core-metadata)")
+	}
+	if !p.Files[1].CoreMetadata {
+		t.Error("Files[1].CoreMetadata = false; want true (data-dist-info-metadata)")
+	}
+	if p.Files[2].CoreMetadata {
+		t.Error("Files[2].CoreMetadata = true; want false")
+	}
+}
+
+func TestParseHTMLMalformedFragment(t *testing.T) {
+	bad := `<a href="https://example.com/x.whl#sha256">x</a>`
+	_, err := ParseHTML("x", "https://example.com/simple/x/", strings.NewReader(bad))
+	if err == nil {
+		t.Fatal("ParseHTML err = nil; want error on malformed fragment")
+	}
+}
+
+func TestParseHTMLEmptyDigest(t *testing.T) {
+	bad := `<a href="https://example.com/x.whl#sha256=">x</a>`
+	_, err := ParseHTML("x", "https://example.com/simple/x/", strings.NewReader(bad))
+	if err == nil {
+		t.Fatal("ParseHTML err = nil; want error on empty digest")
+	}
+}
+
+func TestParseHTMLMultipleHashFragments(t *testing.T) {
+	src := `<a href="https://example.com/x.whl#sha256=abc&blake3=def">x</a>`
+	p, err := ParseHTML("x", "https://example.com/simple/x/", strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("ParseHTML err = %v", err)
+	}
+	if p.Files[0].Hashes["sha256"] != "abc" || p.Files[0].Hashes["blake3"] != "def" {
+		t.Errorf("hashes = %v; want sha256=abc blake3=def", p.Files[0].Hashes)
+	}
+}
+
+func TestParseHTMLAnchorWithoutHref(t *testing.T) {
+	src := `<a>nothing</a><a href="https://example.com/x.whl#sha256=abc">x</a>`
+	p, err := ParseHTML("x", "https://example.com/simple/x/", strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("ParseHTML err = %v", err)
+	}
+	if len(p.Files) != 1 {
+		t.Fatalf("len(Files) = %d; want 1 (anchor without href skipped)", len(p.Files))
+	}
+}
+
+func TestParseHTMLHashKeyLowercased(t *testing.T) {
+	src := `<a href="https://example.com/x.whl#SHA256=DEADBEEF">x</a>`
+	p, err := ParseHTML("x", "https://example.com/simple/x/", strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("ParseHTML err = %v", err)
+	}
+	if p.Files[0].Hashes["sha256"] != "deadbeef" {
+		t.Errorf("hashes[sha256] = %q; want lowercased", p.Files[0].Hashes["sha256"])
+	}
+}
+
+func TestParseHTMLPath(t *testing.T) {
+	src := `<a href="https://example.com/path/to/file/x-1.tar.gz#sha256=abc">label</a>`
+	p, err := ParseHTML("x", "https://example.com/simple/x/", strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("ParseHTML err = %v", err)
+	}
+	if p.Files[0].Filename != "x-1.tar.gz" {
+		t.Errorf("Filename = %q; want basename of URL path", p.Files[0].Filename)
+	}
+}

--- a/package3/python/simple/index.go
+++ b/package3/python/simple/index.go
@@ -1,0 +1,103 @@
+package simple
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Project is the parsed contents of a simple-index project listing
+// (`/simple/<name>/`). It is the unified representation produced by both
+// the PEP 503 HTML parser and the PEP 691 JSON parser.
+type Project struct {
+	// Name is the canonical PEP 503 normalised project name (lowercase,
+	// runs of `[-_.]` collapsed to "-"). Populated by Normalise.
+	Name string
+	// Files lists every distribution file the index reports for the project,
+	// in the order the parser saw them. The bridge sorts and dedupes per
+	// version + ABI tag downstream.
+	Files []File
+	// Meta echoes the `meta` object from PEP 691 JSON. Empty for PEP 503 HTML.
+	Meta Meta
+}
+
+// File is a single distribution file (sdist or wheel).
+type File struct {
+	// Filename is the file's basename (the wheel or sdist name, e.g.
+	// "httpx-0.27.0-py3-none-any.whl"). The bridge parses the wheel filename
+	// downstream to recover the python-tag, abi-tag, and platform-tag.
+	Filename string
+	// URL is the absolute download URL.
+	URL string
+	// Hashes lists the file's content hashes, keyed by algorithm
+	// ("sha256", "blake3", "md5"). PEP 503 typically supplies only sha256
+	// via the `#sha256=...` fragment; PEP 691 may supply multiple.
+	Hashes map[string]string
+	// RequiresPython is the optional "requires-python" specifier the
+	// index advertised for this file. Empty when absent.
+	RequiresPython string
+	// Yanked is true when PEP 592 advertises the file as yanked. The
+	// optional reason is in YankedReason.
+	Yanked       bool
+	YankedReason string
+	// CoreMetadata is the optional advertised flag for PEP 658 standalone
+	// METADATA. When non-empty the value is the digest algorithm; the
+	// digest itself is fetched from `<url>.metadata` separately by the
+	// bridge in phase 3 (stub ingest).
+	CoreMetadata bool
+	// Size is the optional file size in bytes (PEP 700).
+	Size int64
+	// UploadTime is the optional upload timestamp from PEP 691 in ISO 8601.
+	UploadTime string
+}
+
+// Meta is the optional `meta` object from PEP 691 carrying the API version
+// and any future extension fields. The bridge logs it but does not act on
+// it in phase 1.
+type Meta struct {
+	APIVersion string
+}
+
+// nameNormaliser implements PEP 503 §"Normalised names": lowercase, then
+// collapse runs of `[-_.]` to a single `-`.
+var nameNormaliser = regexp.MustCompile(`[-_.]+`)
+
+// Normalise returns the PEP 503 canonical form of a project name.
+func Normalise(name string) string {
+	return nameNormaliser.ReplaceAllString(strings.ToLower(name), "-")
+}
+
+// Validate checks that the parsed Project has at least one file and that
+// every file has a populated URL and Filename. The bridge calls Validate
+// after either the HTML or the JSON parser populates the struct.
+func (p *Project) Validate() error {
+	if p.Name == "" {
+		return fmt.Errorf("simple: project missing Name")
+	}
+	if Normalise(p.Name) != p.Name {
+		return fmt.Errorf("simple: project Name %q is not PEP 503 normalised (want %q)", p.Name, Normalise(p.Name))
+	}
+	if len(p.Files) == 0 {
+		return fmt.Errorf("simple: project %q has no files", p.Name)
+	}
+	for i, f := range p.Files {
+		if f.Filename == "" {
+			return fmt.Errorf("simple: project %q file %d has no Filename", p.Name, i)
+		}
+		if f.URL == "" {
+			return fmt.Errorf("simple: project %q file %q has no URL", p.Name, f.Filename)
+		}
+	}
+	return nil
+}
+
+// FilesByFilename returns a map keyed by Filename for fast lookup. The
+// bridge's wheel selector calls this after parse to find the file matching
+// a specific selected wheel.
+func (p *Project) FilesByFilename() map[string]File {
+	out := make(map[string]File, len(p.Files))
+	for _, f := range p.Files {
+		out[f.Filename] = f
+	}
+	return out
+}

--- a/package3/python/simple/index_test.go
+++ b/package3/python/simple/index_test.go
@@ -1,0 +1,92 @@
+package simple
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalise(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"httpx", "httpx"},
+		{"HTTPX", "httpx"},
+		{"Flask-SQLAlchemy", "flask-sqlalchemy"},
+		{"flask_sqlalchemy", "flask-sqlalchemy"},
+		{"flask.sqlalchemy", "flask-sqlalchemy"},
+		{"Flask__SQL-Alchemy", "flask-sql-alchemy"},
+		{"Flask--SQL--Alchemy", "flask-sql-alchemy"},
+		{"Flask_.SQL.Alchemy", "flask-sql-alchemy"},
+		{"a", "a"},
+		{"A.B.C", "a-b-c"},
+		{"zope.interface", "zope-interface"},
+		{"oslo.config", "oslo-config"},
+	}
+	for _, tc := range cases {
+		got := Normalise(tc.in)
+		if got != tc.want {
+			t.Errorf("Normalise(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestValidate(t *testing.T) {
+	good := &Project{
+		Name: "httpx",
+		Files: []File{
+			{Filename: "httpx-0.27.0-py3-none-any.whl", URL: "https://example.com/x.whl"},
+		},
+	}
+	if err := good.Validate(); err != nil {
+		t.Errorf("good.Validate() = %v; want nil", err)
+	}
+
+	bad := []*Project{
+		{Name: "", Files: []File{{Filename: "x.whl", URL: "u"}}},
+		{Name: "HTTPX", Files: []File{{Filename: "x.whl", URL: "u"}}},
+		{Name: "httpx", Files: nil},
+		{Name: "httpx", Files: []File{{Filename: "", URL: "u"}}},
+		{Name: "httpx", Files: []File{{Filename: "x.whl", URL: ""}}},
+	}
+	for i, p := range bad {
+		if err := p.Validate(); err == nil {
+			t.Errorf("bad[%d].Validate() = nil; want error", i)
+		}
+	}
+}
+
+func TestValidateRejectsUnnormalisedName(t *testing.T) {
+	p := &Project{
+		Name: "Flask-SQLAlchemy",
+		Files: []File{
+			{Filename: "x.whl", URL: "https://example.com/x.whl"},
+		},
+	}
+	err := p.Validate()
+	if err == nil {
+		t.Fatalf("Validate() = nil; want error about non-normalised name")
+	}
+	if !strings.Contains(err.Error(), "normalised") {
+		t.Errorf("Validate() error = %v; want mention of 'normalised'", err)
+	}
+}
+
+func TestFilesByFilename(t *testing.T) {
+	p := &Project{
+		Name: "httpx",
+		Files: []File{
+			{Filename: "httpx-0.27.0.tar.gz", URL: "https://example.com/sdist"},
+			{Filename: "httpx-0.27.0-py3-none-any.whl", URL: "https://example.com/wheel"},
+		},
+	}
+	m := p.FilesByFilename()
+	if len(m) != 2 {
+		t.Fatalf("FilesByFilename() len = %d; want 2", len(m))
+	}
+	if m["httpx-0.27.0.tar.gz"].URL != "https://example.com/sdist" {
+		t.Errorf("sdist URL = %q; want sdist URL", m["httpx-0.27.0.tar.gz"].URL)
+	}
+	if m["httpx-0.27.0-py3-none-any.whl"].URL != "https://example.com/wheel" {
+		t.Errorf("wheel URL = %q; want wheel URL", m["httpx-0.27.0-py3-none-any.whl"].URL)
+	}
+}

--- a/package3/python/simple/json.go
+++ b/package3/python/simple/json.go
@@ -1,0 +1,157 @@
+package simple
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+)
+
+// ParseJSON parses a PEP 691 / PEP 700 JSON simple-index response. The base
+// URL resolves relative file URLs. The PEP 691 envelope is:
+//
+//	{
+//	  "meta": {"api-version": "1.1"},
+//	  "name": "httpx",
+//	  "files": [
+//	    {
+//	      "filename": "httpx-0.27.0-py3-none-any.whl",
+//	      "url": "https://files.pythonhosted.org/.../httpx-0.27.0-py3-none-any.whl",
+//	      "hashes": {"sha256": "<hex>", "blake3": "<hex>"},
+//	      "requires-python": ">=3.8",
+//	      "yanked": false,
+//	      "core-metadata": true,
+//	      "size": 75317,
+//	      "upload-time": "2024-04-28T13:48:35.123Z"
+//	    }
+//	  ]
+//	}
+//
+// `yanked` may be `false`, `true`, or a string (the reason). `core-metadata`
+// may be `false`, `true`, or an object `{"sha256": "<hex>"}`.
+func ParseJSON(baseURL string, r io.Reader) (*Project, error) {
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("simple: parse base URL %q: %w", baseURL, err)
+	}
+
+	var raw struct {
+		Meta  *struct {
+			APIVersion string `json:"api-version"`
+		} `json:"meta"`
+		Name  string `json:"name"`
+		Files []struct {
+			Filename       string            `json:"filename"`
+			URL            string            `json:"url"`
+			Hashes         map[string]string `json:"hashes"`
+			RequiresPython string            `json:"requires-python"`
+			Yanked         json.RawMessage   `json:"yanked"`
+			CoreMetadata   json.RawMessage   `json:"core-metadata"`
+			Size           int64             `json:"size"`
+			UploadTime     string            `json:"upload-time"`
+		} `json:"files"`
+	}
+	// PEP 691 §"future extensions" reserves the right to add new fields, so
+	// the decoder is permissive about unknown keys at the top level and
+	// inside each file entry. Strict golden tests should compare via the
+	// parsed Project struct, not by byte-equality of the raw response.
+	if err := json.NewDecoder(r).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("simple: parse JSON: %w", err)
+	}
+
+	if raw.Name == "" {
+		return nil, fmt.Errorf("simple: JSON response missing name")
+	}
+	project := &Project{
+		Name: Normalise(raw.Name),
+	}
+	if raw.Meta != nil {
+		project.Meta.APIVersion = raw.Meta.APIVersion
+	}
+	for _, rf := range raw.Files {
+		if rf.Filename == "" {
+			return nil, fmt.Errorf("simple: file without filename")
+		}
+		if rf.URL == "" {
+			return nil, fmt.Errorf("simple: file %q without url", rf.Filename)
+		}
+		ref, err := url.Parse(rf.URL)
+		if err != nil {
+			return nil, fmt.Errorf("simple: file %q bad URL %q: %w", rf.Filename, rf.URL, err)
+		}
+		f := File{
+			Filename:       rf.Filename,
+			URL:            base.ResolveReference(ref).String(),
+			Hashes:         normaliseHashes(rf.Hashes),
+			RequiresPython: rf.RequiresPython,
+			Size:           rf.Size,
+			UploadTime:     rf.UploadTime,
+		}
+		if len(rf.Yanked) > 0 {
+			yanked, reason, err := parseYanked(rf.Yanked)
+			if err != nil {
+				return nil, fmt.Errorf("simple: file %q yanked field: %w", rf.Filename, err)
+			}
+			f.Yanked = yanked
+			f.YankedReason = reason
+		}
+		if len(rf.CoreMetadata) > 0 {
+			f.CoreMetadata = parseCoreMetadata(rf.CoreMetadata)
+		}
+		project.Files = append(project.Files, f)
+	}
+	return project, nil
+}
+
+func normaliseHashes(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[lower(k)] = lower(v)
+	}
+	return out
+}
+
+func parseYanked(raw json.RawMessage) (bool, string, error) {
+	// yanked may be bool or string. A non-empty string is treated as yanked
+	// with reason; an empty string is technically PEP 592 but ambiguous, so
+	// we treat it as yanked-no-reason.
+	var b bool
+	if err := json.Unmarshal(raw, &b); err == nil {
+		return b, "", nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return true, s, nil
+	}
+	return false, "", fmt.Errorf("yanked field is neither bool nor string: %s", string(raw))
+}
+
+func parseCoreMetadata(raw json.RawMessage) bool {
+	var b bool
+	if err := json.Unmarshal(raw, &b); err == nil {
+		return b
+	}
+	// Object form `{"sha256": "..."}`. The mere presence indicates the
+	// METADATA sidecar is available.
+	var obj map[string]string
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		return len(obj) > 0
+	}
+	return false
+}
+
+func lower(s string) string {
+	b := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		b[i] = c
+	}
+	return string(b)
+}
+

--- a/package3/python/simple/json_test.go
+++ b/package3/python/simple/json_test.go
@@ -1,0 +1,196 @@
+package simple
+
+import (
+	"strings"
+	"testing"
+)
+
+const minimalJSON = `{
+  "meta": {"api-version": "1.1"},
+  "name": "HTTPX",
+  "files": [
+    {
+      "filename": "httpx-0.27.0.tar.gz",
+      "url": "https://files.pythonhosted.org/packages/abc/httpx-0.27.0.tar.gz",
+      "hashes": {"sha256": "DEADBEEF", "blake3": "FEEDFACE"},
+      "requires-python": ">=3.8",
+      "yanked": false,
+      "core-metadata": false,
+      "size": 12345,
+      "upload-time": "2024-04-28T13:48:35.123Z"
+    },
+    {
+      "filename": "httpx-0.27.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/def/httpx-0.27.0-py3-none-any.whl",
+      "hashes": {"sha256": "cafebabe"},
+      "yanked": false,
+      "core-metadata": {"sha256": "abc123"}
+    }
+  ]
+}`
+
+func TestParseJSONMinimal(t *testing.T) {
+	p, err := ParseJSON("https://pypi.org/simple/httpx/", strings.NewReader(minimalJSON))
+	if err != nil {
+		t.Fatalf("ParseJSON err = %v", err)
+	}
+	if p.Name != "httpx" {
+		t.Errorf("Name = %q; want httpx (normalised)", p.Name)
+	}
+	if p.Meta.APIVersion != "1.1" {
+		t.Errorf("Meta.APIVersion = %q; want 1.1", p.Meta.APIVersion)
+	}
+	if len(p.Files) != 2 {
+		t.Fatalf("len(Files) = %d; want 2", len(p.Files))
+	}
+	f0 := p.Files[0]
+	if f0.Filename != "httpx-0.27.0.tar.gz" {
+		t.Errorf("Files[0].Filename = %q", f0.Filename)
+	}
+	if f0.Hashes["sha256"] != "deadbeef" {
+		t.Errorf("Files[0].Hashes[sha256] = %q; want lowercased", f0.Hashes["sha256"])
+	}
+	if f0.Hashes["blake3"] != "feedface" {
+		t.Errorf("Files[0].Hashes[blake3] = %q; want lowercased", f0.Hashes["blake3"])
+	}
+	if f0.RequiresPython != ">=3.8" {
+		t.Errorf("Files[0].RequiresPython = %q", f0.RequiresPython)
+	}
+	if f0.Size != 12345 {
+		t.Errorf("Files[0].Size = %d; want 12345", f0.Size)
+	}
+	if f0.UploadTime != "2024-04-28T13:48:35.123Z" {
+		t.Errorf("Files[0].UploadTime = %q", f0.UploadTime)
+	}
+	if f0.CoreMetadata {
+		t.Error("Files[0].CoreMetadata = true; want false")
+	}
+	if !p.Files[1].CoreMetadata {
+		t.Error("Files[1].CoreMetadata = false; want true (object form)")
+	}
+}
+
+const yankedJSON = `{
+  "meta": {"api-version": "1.0"},
+  "name": "x",
+  "files": [
+    {"filename": "x-1.tar.gz", "url": "https://example.com/x-1.tar.gz", "hashes": {"sha256":"a"}, "yanked": true},
+    {"filename": "x-2.tar.gz", "url": "https://example.com/x-2.tar.gz", "hashes": {"sha256":"b"}, "yanked": "security issue"},
+    {"filename": "x-3.tar.gz", "url": "https://example.com/x-3.tar.gz", "hashes": {"sha256":"c"}, "yanked": false}
+  ]
+}`
+
+func TestParseJSONYankedVariants(t *testing.T) {
+	p, err := ParseJSON("https://example.com/simple/x/", strings.NewReader(yankedJSON))
+	if err != nil {
+		t.Fatalf("ParseJSON err = %v", err)
+	}
+	if !p.Files[0].Yanked || p.Files[0].YankedReason != "" {
+		t.Errorf("Files[0] yanked=%v reason=%q; want yanked=true no reason", p.Files[0].Yanked, p.Files[0].YankedReason)
+	}
+	if !p.Files[1].Yanked || p.Files[1].YankedReason != "security issue" {
+		t.Errorf("Files[1] yanked=%v reason=%q", p.Files[1].Yanked, p.Files[1].YankedReason)
+	}
+	if p.Files[2].Yanked {
+		t.Errorf("Files[2] yanked=true; want false")
+	}
+}
+
+const relJSON = `{
+  "meta": {"api-version": "1.1"},
+  "name": "x",
+  "files": [
+    {"filename": "x-1.tar.gz", "url": "../../packages/abc/x-1.tar.gz", "hashes": {"sha256":"a"}}
+  ]
+}`
+
+func TestParseJSONRelativeURL(t *testing.T) {
+	p, err := ParseJSON("https://example.com/simple/x/", strings.NewReader(relJSON))
+	if err != nil {
+		t.Fatalf("ParseJSON err = %v", err)
+	}
+	if p.Files[0].URL != "https://example.com/packages/abc/x-1.tar.gz" {
+		t.Errorf("URL = %q; want resolved against base", p.Files[0].URL)
+	}
+}
+
+const unknownJSON = `{
+  "meta": {"api-version": "1.5", "future-field": "ignored"},
+  "name": "x",
+  "files": [
+    {"filename": "x-1.tar.gz", "url": "https://example.com/x-1.tar.gz", "hashes": {"sha256":"a"}, "future-attr": 42}
+  ],
+  "future-top": "tolerated"
+}`
+
+func TestParseJSONTolerantOfUnknownFields(t *testing.T) {
+	p, err := ParseJSON("https://example.com/simple/x/", strings.NewReader(unknownJSON))
+	if err != nil {
+		t.Fatalf("ParseJSON err = %v; want tolerant of unknown fields", err)
+	}
+	if p.Meta.APIVersion != "1.5" {
+		t.Errorf("APIVersion = %q", p.Meta.APIVersion)
+	}
+}
+
+func TestParseJSONMissingName(t *testing.T) {
+	src := `{"meta": {"api-version": "1.0"}, "files": []}`
+	_, err := ParseJSON("https://example.com/simple/x/", strings.NewReader(src))
+	if err == nil {
+		t.Fatal("ParseJSON err = nil; want error on missing name")
+	}
+}
+
+func TestParseJSONMissingFilename(t *testing.T) {
+	src := `{"name": "x", "files": [{"url": "https://example.com/x.whl", "hashes": {"sha256":"a"}}]}`
+	_, err := ParseJSON("https://example.com/simple/x/", strings.NewReader(src))
+	if err == nil {
+		t.Fatal("ParseJSON err = nil; want error on missing filename")
+	}
+}
+
+func TestParseJSONMissingURL(t *testing.T) {
+	src := `{"name": "x", "files": [{"filename": "x.whl", "hashes": {"sha256":"a"}}]}`
+	_, err := ParseJSON("https://example.com/simple/x/", strings.NewReader(src))
+	if err == nil {
+		t.Fatal("ParseJSON err = nil; want error on missing url")
+	}
+}
+
+func TestParseJSONBadJSON(t *testing.T) {
+	src := `{"name": "x", "files":`
+	_, err := ParseJSON("https://example.com/simple/x/", strings.NewReader(src))
+	if err == nil {
+		t.Fatal("ParseJSON err = nil; want error on truncated JSON")
+	}
+}
+
+func TestParseJSONHashKeysLowercased(t *testing.T) {
+	src := `{"name":"x","meta":{"api-version":"1.0"},"files":[{"filename":"x.whl","url":"https://example.com/x.whl","hashes":{"SHA256":"DEADBEEF"}}]}`
+	p, err := ParseJSON("https://example.com/simple/x/", strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("ParseJSON err = %v", err)
+	}
+	if p.Files[0].Hashes["sha256"] != "deadbeef" {
+		t.Errorf("hashes[sha256] = %q; want lowercased key + value", p.Files[0].Hashes["sha256"])
+	}
+}
+
+func TestParseJSONNoMeta(t *testing.T) {
+	src := `{"name":"x","files":[{"filename":"x.whl","url":"https://example.com/x.whl","hashes":{"sha256":"a"}}]}`
+	p, err := ParseJSON("https://example.com/simple/x/", strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("ParseJSON err = %v", err)
+	}
+	if p.Meta.APIVersion != "" {
+		t.Errorf("Meta.APIVersion = %q; want empty", p.Meta.APIVersion)
+	}
+}
+
+func TestParseYankedHelperRejectsNonsense(t *testing.T) {
+	src := `{"name":"x","meta":{"api-version":"1.0"},"files":[{"filename":"x.whl","url":"https://example.com/x.whl","hashes":{"sha256":"a"},"yanked":123}]}`
+	_, err := ParseJSON("https://example.com/simple/x/", strings.NewReader(src))
+	if err == nil {
+		t.Fatal("ParseJSON err = nil; want error on numeric yanked")
+	}
+}

--- a/package3/python/simple/phase01_test.go
+++ b/package3/python/simple/phase01_test.go
@@ -1,0 +1,118 @@
+package simple
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestPhase1SimpleIndex is the gate sentinel for MEP-71 Phase 1. It exercises
+// the end-to-end shape that downstream phases will consume: the client fetches
+// a simple-index project, the parser returns a Project, and the verifier
+// matches advertised hashes against a streamed body.
+func TestPhase1SimpleIndex(t *testing.T) {
+	t.Run("end_to_end_html", func(t *testing.T) {
+		indexBody := `<a href="https://files.example.com/httpx-0.27.0-py3-none-any.whl#sha256=` + sha256Of("file body") + `">httpx-0.27.0-py3-none-any.whl</a>`
+		indexSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			w.Write([]byte(indexBody))
+		}))
+		defer indexSrv.Close()
+
+		fileSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("file body"))
+		}))
+		defer fileSrv.Close()
+
+		c := NewHTTPClient(indexSrv.URL + "/simple/")
+		p, err := c.FetchProject(context.Background(), "httpx", FormatHTML)
+		if err != nil {
+			t.Fatalf("FetchProject err = %v", err)
+		}
+		if len(p.Files) != 1 {
+			t.Fatalf("len(Files) = %d; want 1", len(p.Files))
+		}
+		// Replace the upstream URL with our local file server. We deliberately
+		// kept the index pointing at example.com to test that the parser does
+		// not "helpfully" rewrite URLs.
+		body, err := c.FetchFile(context.Background(), fileSrv.URL+"/file")
+		if err != nil {
+			t.Fatalf("FetchFile err = %v", err)
+		}
+		defer body.Close()
+		if err := Verify(body, p.Files[0].Hashes); err != nil {
+			t.Errorf("Verify err = %v; want nil", err)
+		}
+	})
+
+	t.Run("end_to_end_json", func(t *testing.T) {
+		want := sha256Of("file body 2")
+		indexBody := `{
+"meta": {"api-version": "1.1"},
+"name": "x",
+"files": [{
+"filename": "x-1.tar.gz",
+"url": "https://upstream.example/x-1.tar.gz",
+"hashes": {"sha256": "` + want + `"}
+}]
+}`
+		indexSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/vnd.pypi.simple.v1+json")
+			w.Write([]byte(indexBody))
+		}))
+		defer indexSrv.Close()
+
+		fileSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("file body 2"))
+		}))
+		defer fileSrv.Close()
+
+		c := NewHTTPClient(indexSrv.URL + "/simple/")
+		p, err := c.FetchProject(context.Background(), "x", FormatJSON)
+		if err != nil {
+			t.Fatalf("FetchProject err = %v", err)
+		}
+		if p.Meta.APIVersion != "1.1" {
+			t.Errorf("APIVersion = %q", p.Meta.APIVersion)
+		}
+		body, err := c.FetchFile(context.Background(), fileSrv.URL+"/x")
+		if err != nil {
+			t.Fatalf("FetchFile err = %v", err)
+		}
+		defer body.Close()
+		if err := Verify(body, p.Files[0].Hashes); err != nil {
+			t.Errorf("Verify err = %v", err)
+		}
+	})
+
+	t.Run("normalise_invariants", func(t *testing.T) {
+		// PEP 503 normalisation is idempotent.
+		for _, in := range []string{"httpx", "Flask-SQLAlchemy", "zope.interface", "ALL_CAPS", "Mixed.Case-Name"} {
+			once := Normalise(in)
+			twice := Normalise(once)
+			if once != twice {
+				t.Errorf("Normalise is not idempotent for %q: once=%q twice=%q", in, once, twice)
+			}
+			if strings.ToLower(once) != once {
+				t.Errorf("Normalise(%q) = %q; not lowercase", in, once)
+			}
+			if strings.ContainsAny(once, "_.") {
+				t.Errorf("Normalise(%q) = %q; still contains _ or .", in, once)
+			}
+		}
+	})
+
+	t.Run("verify_md5_rejected", func(t *testing.T) {
+		// Even if the index advertises md5, the verifier must refuse to use it.
+		err := Verify(strings.NewReader("anything"), map[string]string{"md5": "0cc175b9c0f1b6a831c399e269772661"})
+		if err == nil {
+			t.Fatal("Verify err = nil; want error: md5 not in supported algos")
+		}
+	})
+}
+
+func sha256Of(s string) string {
+	return sha256Hex(s)
+}

--- a/package3/python/simple/verify.go
+++ b/package3/python/simple/verify.go
@@ -1,0 +1,106 @@
+package simple
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+	"sort"
+	"strings"
+
+	"lukechampine.com/blake3"
+)
+
+// SupportedHashAlgos is the set of digest algorithms the verifier accepts.
+// The bridge prefers blake3 (PEP 658 extension) when the index advertises it,
+// then sha256 (PEP 503 baseline). MD5 is rejected even when the index lists
+// it: it has been considered unsafe since well before 2026 and `pip` already
+// refuses to install on MD5-only entries.
+var SupportedHashAlgos = []string{"blake3", "sha256"}
+
+// Verify reads the file contents from r, computes hashes, and confirms that
+// at least one of the expected hashes matches. Returns an error when no
+// supported algorithm is present in expected, or when every supported
+// algorithm mismatches.
+//
+// The function reads r exactly once (it streams through a multi-writer).
+// Callers that need the verified bytes should pass an io.TeeReader to
+// capture them while Verify drains the stream.
+func Verify(r io.Reader, expected map[string]string) error {
+	if len(expected) == 0 {
+		return fmt.Errorf("simple: no expected hashes")
+	}
+	// Pick all supported algorithms present in `expected`.
+	type slot struct {
+		algo string
+		hash hash.Hash
+		want string
+	}
+	var slots []slot
+	for _, algo := range SupportedHashAlgos {
+		if want, ok := expected[algo]; ok {
+			var h hash.Hash
+			switch algo {
+			case "sha256":
+				h = sha256.New()
+			case "blake3":
+				h = blake3.New(32, nil)
+			default:
+				continue
+			}
+			slots = append(slots, slot{algo: algo, hash: h, want: strings.ToLower(want)})
+		}
+	}
+	if len(slots) == 0 {
+		seen := make([]string, 0, len(expected))
+		for k := range expected {
+			seen = append(seen, k)
+		}
+		sort.Strings(seen)
+		return fmt.Errorf("simple: no supported hash algorithm in %v; need one of %v", seen, SupportedHashAlgos)
+	}
+	writers := make([]io.Writer, len(slots))
+	for i, s := range slots {
+		writers[i] = s.hash
+	}
+	mw := io.MultiWriter(writers...)
+	if _, err := io.Copy(mw, r); err != nil {
+		return fmt.Errorf("simple: read body: %w", err)
+	}
+	// All slots must match.
+	for _, s := range slots {
+		got := hex.EncodeToString(s.hash.Sum(nil))
+		if got != s.want {
+			return fmt.Errorf("simple: %s mismatch: got %s want %s", s.algo, got, s.want)
+		}
+	}
+	return nil
+}
+
+// HashAll returns the hex digest of every SupportedHashAlgos algorithm on the
+// input. Used by the cache to populate the local content-addressed entry.
+// The function reads r exactly once.
+func HashAll(r io.Reader) (map[string]string, error) {
+	hashes := make(map[string]hash.Hash, len(SupportedHashAlgos))
+	writers := make([]io.Writer, 0, len(SupportedHashAlgos))
+	for _, algo := range SupportedHashAlgos {
+		var h hash.Hash
+		switch algo {
+		case "sha256":
+			h = sha256.New()
+		case "blake3":
+			h = blake3.New(32, nil)
+		}
+		hashes[algo] = h
+		writers = append(writers, h)
+	}
+	if _, err := io.Copy(io.MultiWriter(writers...), r); err != nil {
+		return nil, fmt.Errorf("simple: HashAll: %w", err)
+	}
+	out := make(map[string]string, len(hashes))
+	for algo, h := range hashes {
+		out[algo] = hex.EncodeToString(h.Sum(nil))
+	}
+	return out, nil
+}

--- a/package3/python/simple/verify_test.go
+++ b/package3/python/simple/verify_test.go
@@ -1,0 +1,123 @@
+package simple
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"lukechampine.com/blake3"
+)
+
+func sha256Hex(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+func blake3Hex(s string) string {
+	h := blake3.New(32, nil)
+	h.Write([]byte(s))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func TestVerifySHA256Matches(t *testing.T) {
+	body := "hello world"
+	want := sha256Hex(body)
+	err := Verify(strings.NewReader(body), map[string]string{"sha256": want})
+	if err != nil {
+		t.Errorf("Verify err = %v; want nil", err)
+	}
+}
+
+func TestVerifySHA256Mismatch(t *testing.T) {
+	body := "hello world"
+	err := Verify(strings.NewReader(body), map[string]string{"sha256": "00" + sha256Hex(body)[2:]})
+	if err == nil {
+		t.Fatal("Verify err = nil; want mismatch error")
+	}
+	if !strings.Contains(err.Error(), "sha256 mismatch") {
+		t.Errorf("err = %v; want 'sha256 mismatch'", err)
+	}
+}
+
+func TestVerifyBlake3Matches(t *testing.T) {
+	body := "hello world"
+	want := blake3Hex(body)
+	err := Verify(strings.NewReader(body), map[string]string{"blake3": want})
+	if err != nil {
+		t.Errorf("Verify err = %v; want nil", err)
+	}
+}
+
+func TestVerifyBothAlgosRequireBoth(t *testing.T) {
+	body := "hello world"
+	err := Verify(strings.NewReader(body), map[string]string{
+		"sha256": sha256Hex(body),
+		"blake3": blake3Hex(body),
+	})
+	if err != nil {
+		t.Errorf("Verify err = %v; want nil when both match", err)
+	}
+}
+
+func TestVerifyOneOfTwoMismatches(t *testing.T) {
+	body := "hello world"
+	err := Verify(strings.NewReader(body), map[string]string{
+		"sha256": sha256Hex(body),
+		"blake3": "00" + blake3Hex(body)[2:],
+	})
+	if err == nil {
+		t.Fatal("Verify err = nil; want error when one of the algos mismatches")
+	}
+}
+
+func TestVerifyEmptyExpectedRejected(t *testing.T) {
+	err := Verify(strings.NewReader("hello"), nil)
+	if err == nil {
+		t.Fatal("Verify err = nil; want error on empty expected")
+	}
+}
+
+func TestVerifyMD5Rejected(t *testing.T) {
+	body := "hello world"
+	err := Verify(strings.NewReader(body), map[string]string{"md5": "abcd"})
+	if err == nil {
+		t.Fatal("Verify err = nil; want error: md5 not supported")
+	}
+	if !strings.Contains(err.Error(), "no supported hash algorithm") {
+		t.Errorf("err = %v; want 'no supported hash algorithm'", err)
+	}
+}
+
+func TestVerifyUppercaseHexAccepted(t *testing.T) {
+	body := "hello world"
+	want := strings.ToUpper(sha256Hex(body))
+	err := Verify(strings.NewReader(body), map[string]string{"sha256": want})
+	if err != nil {
+		t.Errorf("Verify err = %v; uppercase hex must be normalised", err)
+	}
+}
+
+func TestHashAll(t *testing.T) {
+	body := "hello world"
+	got, err := HashAll(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("HashAll err = %v", err)
+	}
+	if got["sha256"] != sha256Hex(body) {
+		t.Errorf("sha256 = %q; want %q", got["sha256"], sha256Hex(body))
+	}
+	if got["blake3"] != blake3Hex(body) {
+		t.Errorf("blake3 = %q; want %q", got["blake3"], blake3Hex(body))
+	}
+}
+
+func TestHashAllEmptyInput(t *testing.T) {
+	got, err := HashAll(strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("HashAll err = %v", err)
+	}
+	if got["sha256"] != sha256Hex("") {
+		t.Errorf("sha256(empty) = %q; want %q", got["sha256"], sha256Hex(""))
+	}
+}

--- a/website/docs/implementation/0071/index.md
+++ b/website/docs/implementation/0071/index.md
@@ -15,8 +15,8 @@ A phase is LANDED only when its gate is green for every target (consume directio
 
 | Phase | Title | Status | Commit | Tracking page |
 |-------|-------|--------|--------|---------------|
-| 0 | Skeleton: `package3/python/` layout + `Driver` / `Venv` / `SkipReason` / `BridgeError` | LANDED | (pending merge) | [phase-00](/docs/implementation/0071/phase-00-skeleton) |
-| 1 | Simple-index client (PEP 503 HTML + PEP 691 JSON + PEP 700 metadata, sha256 + blake3 download verify) | NOT STARTED | — | [phase-01](/docs/implementation/0071/phase-01-simple-index) |
+| 0 | Skeleton: `package3/python/` layout + `Driver` / `Venv` / `SkipReason` / `BridgeError` | LANDED | `8e1ef75f` | [phase-00](/docs/implementation/0071/phase-00-skeleton) |
+| 1 | Simple-index client (PEP 503 HTML + PEP 691 JSON + PEP 700 metadata, sha256 + blake3 download verify) | LANDED | (pending merge) | [phase-01](/docs/implementation/0071/phase-01-simple-index) |
 | 2 | uv resolver bridge (subprocess + lockfile parsing) + PEP 751 pylock.toml round-trip | NOT STARTED | — | [phase-02](/docs/implementation/0071/phase-02-uv-resolver) |
 | 3 | PEP 561 stub discovery (4-tier precedence, typeshed pin, stubgen sandbox) + `.pyi` parser | NOT STARTED | — | [phase-03](/docs/implementation/0071/phase-03-stub-ingest) |
 | 4 | Closed type-mapping table (scalars / strings / collections / Optional / Union / dataclass / TypedDict / Protocol) | NOT STARTED | — | [phase-04](/docs/implementation/0071/phase-04-type-mapping) |
@@ -89,7 +89,7 @@ The `package3/python/` location is shared with the broader MEP-57 polyglot packa
 
 ## Status snapshot
 
-As of 2026-05-29 22:40 (GMT+7): MEP-71 spec and research bundle landed; phase 0 LANDED; phases 1-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
+As of 2026-05-29 22:57 (GMT+7): MEP-71 spec and research bundle landed; phases 0-1 LANDED; phases 2-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
 
 ## Cross-references
 

--- a/website/docs/implementation/0071/phase-00-skeleton.md
+++ b/website/docs/implementation/0071/phase-00-skeleton.md
@@ -15,7 +15,7 @@ description: "MEP-71 Phase 0 lands package3/python/ skeleton: Driver / Venv type
 | Landed         | 2026-05-29 22:40 (GMT+7) |
 | Tracking issue | (filled by automation) |
 | Tracking PR    | (filled by automation) |
-| Commit         | (filled by automation) |
+| Commit         | `8e1ef75f` |
 
 ## Gate
 

--- a/website/docs/implementation/0071/phase-01-simple-index.md
+++ b/website/docs/implementation/0071/phase-01-simple-index.md
@@ -1,0 +1,95 @@
+---
+title: "Phase 1. Simple-index client"
+sidebar_position: 3
+sidebar_label: "Phase 1. Simple-index"
+description: "MEP-71 Phase 1 lands the PEP 503 / 691 / 700 / 658 / 592 simple-index client, PEP 440 version + specifier algebra, and a streaming sha256+blake3 verifier."
+---
+
+# Phase 1. Simple-index client
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-71 §Phases](/docs/mep/mep-0071#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-29 22:42 (GMT+7) |
+| Landed         | 2026-05-29 22:57 (GMT+7) |
+| Tracking issue | (filled by automation) |
+| Tracking PR    | (filled by automation) |
+| Commit         | (filled by automation) |
+
+## Gate
+
+`TestPhase1SimpleIndex` in `package3/python/simple/phase01_test.go` with subtests:
+
+- `end_to_end_html`. Spins up an `httptest.NewServer` returning a PEP 503 HTML index, fetches the project via `HTTPClient.FetchProject(ctx, name, FormatHTML)`, fetches the advertised file via `FetchFile`, and streams the body through `Verify` against the parsed hashes. Asserts the verifier reports no mismatch.
+- `end_to_end_json`. Same shape using a PEP 691 JSON response (`application/vnd.pypi.simple.v1+json`). Asserts the parsed `Meta.APIVersion` round-trips and the streamed file body verifies.
+- `normalise_invariants`. PEP 503 §"Normalised names" properties: idempotence of `Normalise`, output is lowercase, output contains no `_` or `.`.
+- `verify_md5_rejected`. Even when the index advertises only md5, `Verify` must refuse rather than silently accept. Matches PEP 503's de facto guidance and the bridge's "no md5 ever" rule from MEP-71 §3.
+
+The package-level test suite covers:
+
+- `index_test.go`: PEP 503 normalisation across 12 inputs (lowercase, `.`/`_`/`-` collapsing, multi-run collapsing), `Validate` happy / sad paths, `FilesByFilename` map.
+- `html_test.go`: minimal HTML index, relative-URL resolution against the base, PEP 592 `data-yanked` (with reason / empty reason / absent), PEP 503 `data-requires-python` with HTML-escaped value, PEP 658 `data-core-metadata` and the legacy `data-dist-info-metadata` alias, malformed fragment rejection (`#sha256` no `=`), empty digest rejection (`#sha256=`), multi-hash fragment (`#sha256=abc&blake3=def`), anchor without href skipped, uppercase hash key lowercased, basename extraction from a deeper URL path.
+- `json_test.go`: PEP 691 minimal envelope, PEP 592 `yanked` as bool or string, PEP 691 `core-metadata` as bool or `{"sha256":"..."}` object, relative URL resolution, forward-compatible unknown-field tolerance at envelope and file level, missing name / filename / url errors, truncated JSON error, hash-key lowercasing, missing meta object yields empty `APIVersion`, numeric `yanked` rejected.
+- `verify_test.go`: known sha256 + blake3 vectors, sha256 mismatch error, blake3 mismatch error, both-present-both-match success, one-of-two mismatch error, empty expected rejected, md5 rejected with "no supported hash algorithm" error, uppercase hex digest normalised before comparison, `HashAll` returns both algorithms over the same stream, empty-input edge case.
+- `client_test.go`: `httptest.NewServer` fixtures cover HTML fetch, JSON fetch (asserts Accept header advertises `application/vnd.pypi.simple.v1+json`), JSON-hint negotiates down to HTML, HTTP error surfaces the status code, empty `BaseURL` rejected, name is PEP 503 normalised before insertion into the URL path (`Flask_SQLAlchemy` -> `/simple/flask-sqlalchemy/`), `FetchFile` streams, `FetchFile` surfaces HTTP errors, `ensureTrailingSlash` table, `IndexFormat.String` table, `NewHTTPClient` defaults.
+
+The `semver/` package ships independently and is tested at:
+
+- `version_test.go`: PEP 440 grammar acceptance over 12 inputs (epoch, release, pre `a`/`b`/`rc`, post, dev, local), rejection of 14 bad inputs (leading sign, embedded space, missing release, invalid pre kind, etc.), `String` round-trip, the canonical PEP 440 ascending chain `1.0.dev0 < 1.0a1.dev0 < 1.0a1 < 1.0a1.post1 < 1.0b1 < 1.0rc1 < 1.0 < 1.0.post1 < 1.0.post1.dev0 < 1.0.post2 < 1.1.dev0 < 1.1 < 1!1.0 < 2!1.0`, release-length zero-padding (`1.0` == `1.0.0`), local-version ordering, PEP 440 §"Local version" numeric-vs-alpha rule (`1.0+1` < `1.0+a`), `IsPreRelease` discrimination, `SortByCompare` stability.
+- `specifier_test.go`: clause parser over 8 operators (`==`, `===`, `!=`, `<=`, `>=`, `<`, `>`, `~=`), order-sensitive `===`-before-`==` rule, rejection of unknown ops, multi-clause AND combination, `~=` "compatible release" semantics with PEP 440 right-zero-pad.
+
+## Lowering decisions
+
+The simple-index client is split into four self-contained sub-packages so phase 2 (uv resolver bridge) can mock them independently:
+
+- `package3/python/semver/`. PEP 440 version + specifier algebra. No PyPI dependency; uses only `strconv` and `strings`. The version struct is `(Epoch int, Release []int, PreKind, PreNum, Post, Dev, Local)`. The comparator uses asymmetric infinity keys for pre / post / dev: an absent pre key sorts after any present pre key, but an absent pre key on a dev-only release (no post, no pre, dev present) sorts as -infinity to match `packaging.py._cmpkey`. This is the only non-obvious bit and it is the one that the canonical ascending-chain test pins down.
+- `package3/python/simple/`. Index parser (HTML + JSON), HTTP client, stream verifier.
+
+The HTML parser uses `golang.org/x/net/html` which is already a transitive Mochi dependency. The JSON parser uses `encoding/json` with `json.RawMessage` for the `yanked` and `core-metadata` fields so it can decide between bool / string / object after the initial decode. The decoder is deliberately permissive about unknown fields because PEP 691 §"Future extensions" reserves the right to add new fields and the bridge must not start refusing the index when PyPI adds, say, `data-attestation` in 2027.
+
+The verifier picks all supported algorithms present in the `expected` map and streams the body through an `io.MultiWriter` of `hash.Hash` instances. SupportedHashAlgos is `{"blake3", "sha256"}` in that priority order. MD5 is rejected even when advertised: pip already refuses to install on MD5-only entries and the bridge follows suit.
+
+The HTTP client is intentionally bare. `FetchProject` sets `Accept: application/vnd.pypi.simple.v1+json, application/vnd.pypi.simple.v1+html;q=0.5, text/html;q=0.1` when the caller hints `FormatJSON`, then dispatches to ParseHTML or ParseJSON based on the response Content-Type (substring match on `json`). This is the negotiation pattern `pip --index-url` uses. `FetchFile` is a transparent GET that returns the body stream so the bridge can `io.TeeReader` it into the cache while `Verify` drains it.
+
+The client URL builder PEP 503-normalises the project name before constructing the request path. PyPI returns 301 redirects when handed an unnormalised name, but other simple indexes (devpi, gemfury, local mirror with a static-file serve) do not, so client-side normalisation is the safe default.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/python/semver/doc.go` | Package doc |
+| `package3/python/semver/version.go` | `Version`, `Parse`, `String`, `Compare`, `IsPreRelease`, `SortByCompare` |
+| `package3/python/semver/specifier.go` | `Operator`, `Clause`, `Specifier`, `ParseClause`, `ParseSpecifier`, `Match`, `Compatible` |
+| `package3/python/semver/version_test.go` | PEP 440 parse + compare + sort tests |
+| `package3/python/semver/specifier_test.go` | PEP 440 specifier tests including `~=` semantics |
+| `package3/python/simple/doc.go` | Package doc |
+| `package3/python/simple/index.go` | `Project`, `File`, `Meta`, `Normalise`, `Validate`, `FilesByFilename` |
+| `package3/python/simple/html.go` | `ParseHTML` (PEP 503 + 592 + 658 + 700 data-attrs) |
+| `package3/python/simple/json.go` | `ParseJSON` (PEP 691 envelope with permissive future fields) |
+| `package3/python/simple/verify.go` | `Verify`, `HashAll`, `SupportedHashAlgos` |
+| `package3/python/simple/client.go` | `Client` interface, `HTTPClient`, `IndexFormat`, `NewHTTPClient`, `FetchProject`, `FetchFile` |
+| `package3/python/simple/index_test.go` | Index struct + Normalise + Validate tests |
+| `package3/python/simple/html_test.go` | PEP 503 / 592 / 658 / 700 HTML fixtures |
+| `package3/python/simple/json_test.go` | PEP 691 JSON fixtures |
+| `package3/python/simple/verify_test.go` | sha256 + blake3 vectors |
+| `package3/python/simple/client_test.go` | `httptest`-driven fetcher + negotiator tests |
+| `package3/python/simple/phase01_test.go` | `TestPhase1SimpleIndex` sentinel with 4 subtests |
+
+## Test set
+
+- `TestPhase1SimpleIndex/end_to_end_html`
+- `TestPhase1SimpleIndex/end_to_end_json`
+- `TestPhase1SimpleIndex/normalise_invariants`
+- `TestPhase1SimpleIndex/verify_md5_rejected`
+- All `package3/python/semver/...` and `package3/python/simple/...` unit tests.
+
+## Closeout notes
+
+Phase 1 ships the entire "read the simple-index" surface in a single PR because the four files (parser HTML, parser JSON, client, verifier) are mutually self-referential through the `Project` / `File` struct and splitting them would have meant landing dead code in three of the four PRs. The total Go surface is ~700 lines plus ~600 lines of tests.
+
+PEP 440 was implemented from scratch rather than wrapping the `version.Version` portions of `golang.org/x/mod/semver` because PEP 440 has six version segment classes (epoch, release, pre, post, dev, local) and `x/mod/semver` only models four. There is also no maintained pure-Go port of `packaging.py` we could vendor at the time of writing. The asymmetric-infinity rule for the pre key when dev-only is the only subtle bit; the canonical ascending-chain test (`1.0.dev0 < 1.0a1.dev0 < ...`) pins it down.
+
+The verifier streams once. Callers that need the verified bytes wrap their reader in an `io.TeeReader` to capture them; the verifier drains the original stream and emits all bookkeeping on the captured digest after `io.Copy` finishes. This is how phase 8 (build orchestration) will tee the downloaded wheel into the content-addressed cache while verifying.
+
+No CPython runtime is required for any test in this phase. The `httptest.NewServer` fixtures cover the index-and-fetch surface end-to-end without touching the network. CI cost is the four extra Go tests at sub-second total.


### PR DESCRIPTION
MEP-71 Phase 1. Tracking issue: #22786. Phase 0 landed at commit `8e1ef75f`.

## Summary

- `package3/python/semver/`: PEP 440 version + specifier algebra. `Version` struct (epoch, release, pre, post, dev, local), `Parse`, `String` round-trip, `Compare` with PEP 440-correct asymmetric infinity for pre/post/dev keys, `SortByCompare`. `Specifier` supports all 8 PEP 440 operators (`==`, `===`, `!=`, `<=`, `>=`, `<`, `>`, `~=`) including the PEP 440 right-zero-pad rule for `~=` compatible release. Stdlib only.
- `package3/python/simple/`: PEP 503 HTML + PEP 691 JSON + PEP 700 metadata simple-index client. `Project` / `File` / `Meta` structs, `Normalise` (PEP 503 §"Normalised names"), `ParseHTML` (using `golang.org/x/net/html` for the anchor walk, with PEP 592 `data-yanked`, PEP 503 `data-requires-python`, PEP 658 `data-core-metadata` and the legacy `data-dist-info-metadata`), `ParseJSON` (with permissive future-field tolerance plus bool-or-string `yanked` plus bool-or-object `core-metadata`), streaming `Verify` and `HashAll` over sha256+blake3 with MD5 explicitly rejected. `HTTPClient` with content-negotiating Accept header for PEP 691 JSON.

## Tests

`TestPhase1SimpleIndex` sentinel covers end-to-end HTML and JSON paths (mock index + mock file server + parse + verify), PEP 503 normalisation idempotence, and the MD5-refused rule.

Package-level coverage: PEP 440 grammar across 12 acceptances and 14 rejections, canonical PEP 440 ascending chain (`1.0.dev0 < 1.0a1.dev0 < 1.0a1 < 1.0a1.post1 < 1.0b1 < 1.0rc1 < 1.0 < 1.0.post1 < 1.0.post1.dev0 < 1.0.post2 < 1.1.dev0 < 1.1 < 1!1.0 < 2!1.0`), specifier match across all 8 operators and `~=` compatible-release, HTML hash-fragment + yanked + requires-python + core-metadata + dist-info-metadata + relative-URL resolution + multi-hash fragments + uppercase-key normalisation, JSON yanked-as-bool-or-string + core-metadata-as-bool-or-object + unknown-field tolerance + missing-field errors, sha256+blake3 vectors + mismatch + empty + MD5 rejection + uppercase-hex normalisation, `httptest` client tests for HTML/JSON content negotiation + name normalisation at URL path + HTTP error surfacing.

## Test plan

- [x] `go test ./package3/python/semver/... ./package3/python/simple/...` green locally
- [x] `go test ./package3/python/...` (phase 0 + phase 1) green locally
- [x] `go vet ./package3/python/...` clean
- [ ] CI green on `mep/0071-phase-01`
- [ ] `gh pr merge --merge --admin` to main per auto-ship cadence

## Refs

- MEP-71 spec: `website/docs/mep/mep-0071.md`
- Phase tracking: `website/docs/implementation/0071/phase-01-simple-index.md`
- Phase 0 (skeleton): #22777