### PR TITLE
MEP-74 phase 5: closed Go-to-Mochi type-mapping table

### DIFF
--- a/package3/go/typemap/mapper.go
+++ b/package3/go/typemap/mapper.go
@@ -1,0 +1,345 @@
+package typemap
+
+import (
+	"errors"
+	"fmt"
+
+	"mochi/package3/go/apisurface"
+)
+
+// ErrUnmappable is returned when a Go type has no Mochi mapping.
+// Phase 6 treats this as a skipReason and adds a SkipNote to the
+// generated wrapper output rather than failing the whole module.
+var ErrUnmappable = errors.New("typemap: unmappable Go type")
+
+// Mapper turns apisurface.GoType expressions into Mochi types +
+// transfer directives. The mapper is stateful only in the lookup
+// cache: identical type expressions return the same Mapping.
+type Mapper struct {
+	surface *apisurface.Surface
+	cache   map[string]*Mapping
+}
+
+// NewMapper constructs a Mapper bound to surface. The surface is
+// consulted for cross-reference resolution (e.g. mapping a named
+// type to its underlying struct fields). A nil surface means
+// cross-references are ignored; named types map to handles.
+func NewMapper(surface *apisurface.Surface) *Mapper {
+	return &Mapper{surface: surface, cache: make(map[string]*Mapping)}
+}
+
+// Map maps t to a Mochi type. Returns ErrUnmappable wrapped with
+// the offending shape on failure.
+func (m *Mapper) Map(t apisurface.GoType) (*Mapping, error) {
+	key := ""
+	if t != nil {
+		key = t.String()
+		if cached, ok := m.cache[key]; ok {
+			return cached, nil
+		}
+	}
+	out, err := m.mapType(t)
+	if err == nil && t != nil {
+		m.cache[key] = out
+	}
+	return out, err
+}
+
+func (m *Mapper) mapType(t apisurface.GoType) (*Mapping, error) {
+	switch v := t.(type) {
+	case nil:
+		return nil, fmt.Errorf("%w: nil type", ErrUnmappable)
+	case apisurface.BasicType:
+		return mapBasic(v)
+	case apisurface.PointerType:
+		return m.mapPointer(v)
+	case apisurface.SliceType:
+		return m.mapSlice(v)
+	case apisurface.ArrayType:
+		return m.mapArray(v)
+	case apisurface.MapType:
+		return m.mapMochiMap(v)
+	case apisurface.ChanType:
+		return mapChan(v)
+	case apisurface.FuncType:
+		return m.mapFunc(v)
+	case apisurface.EllipsisType:
+		return m.mapEllipsis(v)
+	case apisurface.InterfaceType:
+		return mapInterface(v)
+	case apisurface.StructType:
+		return mapStruct(v)
+	case apisurface.NamedType:
+		return m.mapNamed(v)
+	default:
+		return nil, fmt.Errorf("%w: %T", ErrUnmappable, t)
+	}
+}
+
+// scalarMap defines the Go-basic-to-Mochi-scalar mapping. Every
+// concrete Go basic type appears here; "any" and "comparable" map
+// to AnyType (with a Note marking the unboxing requirement).
+var scalarMap = map[string]ScalarType{
+	"bool":    {Name: "bool"},
+	"string":  {Name: "string"},
+	"int":     {Name: "int"},
+	"int8":    {Name: "int"},
+	"int16":   {Name: "int"},
+	"int32":   {Name: "int"},
+	"int64":   {Name: "int"},
+	"uint":    {Name: "int"},
+	"uint8":   {Name: "int"},
+	"uint16":  {Name: "int"},
+	"uint32":  {Name: "int"},
+	"uint64":  {Name: "int"},
+	"uintptr": {Name: "int"},
+	"byte":    {Name: "int"},
+	"rune":    {Name: "int"},
+	"float32": {Name: "float"},
+	"float64": {Name: "float"},
+	"error":   {Name: "error"},
+}
+
+func mapBasic(b apisurface.BasicType) (*Mapping, error) {
+	if s, ok := scalarMap[b.Name]; ok {
+		notes := []string(nil)
+		if b.Name != s.Name && s.Name != "int" && s.Name != "float" {
+			// Currently never reached; left for future expansion.
+		}
+		if isWideningSourced(b.Name) {
+			notes = append(notes, "Go "+b.Name+" widens to Mochi int")
+		}
+		return &Mapping{Mochi: s, Direction: Copy, Notes: notes}, nil
+	}
+	if b.Name == "any" || b.Name == "comparable" {
+		return &Mapping{Mochi: AnyType{}, Direction: Handle, Notes: []string{"Go " + b.Name + " maps to Mochi any via handle"}}, nil
+	}
+	return nil, fmt.Errorf("%w: basic %s", ErrUnmappable, b.Name)
+}
+
+func isWideningSourced(name string) bool {
+	switch name {
+	case "int8", "int16", "int32", "uint", "uint8", "uint16", "uint32", "byte", "rune", "uintptr":
+		return true
+	}
+	return false
+}
+
+func (m *Mapper) mapPointer(p apisurface.PointerType) (*Mapping, error) {
+	inner, err := m.Map(p.Elem)
+	if err != nil {
+		return nil, fmt.Errorf("%w: pointer elem: %v", ErrUnmappable, err)
+	}
+	// Pointer-to-scalar / list / map / record -> option<T>, Copy.
+	// Pointer-to-handle -> Handle (no double-wrapping).
+	switch inner.Mochi.(type) {
+	case HandleType:
+		return inner, nil
+	}
+	return &Mapping{Mochi: OptionType{Elem: inner.Mochi}, Direction: inner.Direction, Notes: append([]string{"Go pointer maps to Mochi option"}, inner.Notes...)}, nil
+}
+
+func (m *Mapper) mapSlice(s apisurface.SliceType) (*Mapping, error) {
+	if b, ok := s.Elem.(apisurface.BasicType); ok && b.Name == "byte" {
+		return &Mapping{Mochi: ScalarType{Name: "bytes"}, Direction: Copy, Notes: []string{"[]byte maps to Mochi bytes"}}, nil
+	}
+	inner, err := m.Map(s.Elem)
+	if err != nil {
+		return nil, fmt.Errorf("%w: slice elem: %v", ErrUnmappable, err)
+	}
+	dir := inner.Direction
+	if dir == View {
+		dir = Copy // a list view of element views needs flattening; for now copy.
+	}
+	return &Mapping{Mochi: ListType{Elem: inner.Mochi}, Direction: dir}, nil
+}
+
+func (m *Mapper) mapArray(a apisurface.ArrayType) (*Mapping, error) {
+	// Arrays are length-locked and bridged as fixed-length lists.
+	inner, err := m.Map(a.Elem)
+	if err != nil {
+		return nil, fmt.Errorf("%w: array elem: %v", ErrUnmappable, err)
+	}
+	return &Mapping{Mochi: ListType{Elem: inner.Mochi}, Direction: Copy, Notes: []string{fmt.Sprintf("Go [%d] array maps to Mochi list (length erased)", a.Len)}}, nil
+}
+
+func (m *Mapper) mapMochiMap(mp apisurface.MapType) (*Mapping, error) {
+	k, err := m.Map(mp.Key)
+	if err != nil {
+		return nil, fmt.Errorf("%w: map key: %v", ErrUnmappable, err)
+	}
+	if _, ok := k.Mochi.(ScalarType); !ok {
+		return nil, fmt.Errorf("%w: map key is not a scalar: %s", ErrUnmappable, k.Mochi)
+	}
+	v, err := m.Map(mp.Value)
+	if err != nil {
+		return nil, fmt.Errorf("%w: map value: %v", ErrUnmappable, err)
+	}
+	return &Mapping{Mochi: MochiMap{Key: k.Mochi, Value: v.Mochi}, Direction: Copy}, nil
+}
+
+func mapChan(c apisurface.ChanType) (*Mapping, error) {
+	name := "chan<" + c.Elem.String() + ">"
+	notes := []string{"channels are bridged via the cgo handle pool (phase 14)"}
+	return &Mapping{Mochi: HandleType{Name: name}, Direction: Handle, Notes: notes}, nil
+}
+
+func (m *Mapper) mapFunc(f apisurface.FuncType) (*Mapping, error) {
+	var params []MochiType
+	for i, p := range f.Params {
+		// Strip ellipsis: callers see a regular list of T.
+		if e, ok := p.(apisurface.EllipsisType); ok && i == len(f.Params)-1 {
+			inner, err := m.Map(e.Elem)
+			if err != nil {
+				return nil, fmt.Errorf("%w: variadic param: %v", ErrUnmappable, err)
+			}
+			params = append(params, ListType{Elem: inner.Mochi})
+			continue
+		}
+		mp, err := m.Map(p)
+		if err != nil {
+			return nil, fmt.Errorf("%w: func param: %v", ErrUnmappable, err)
+		}
+		params = append(params, mp.Mochi)
+	}
+	var results []MochiType
+	for _, r := range f.Results {
+		mp, err := m.Map(r)
+		if err != nil {
+			return nil, fmt.Errorf("%w: func result: %v", ErrUnmappable, err)
+		}
+		results = append(results, mp.Mochi)
+	}
+	return &Mapping{Mochi: FuncType{Params: params, Results: results}, Direction: Handle, Notes: []string{"func values bridge via the cgo handle pool"}}, nil
+}
+
+func (m *Mapper) mapEllipsis(e apisurface.EllipsisType) (*Mapping, error) {
+	// At top level (not inside a func sig), an ellipsis collapses to
+	// list<T>.
+	inner, err := m.Map(e.Elem)
+	if err != nil {
+		return nil, err
+	}
+	return &Mapping{Mochi: ListType{Elem: inner.Mochi}, Direction: inner.Direction}, nil
+}
+
+func mapInterface(i apisurface.InterfaceType) (*Mapping, error) {
+	// Empty interface{} maps to any; everything else is a handle.
+	src := i.Source
+	if src == "interface{}" || src == "interface {}" {
+		return &Mapping{Mochi: AnyType{}, Direction: Handle, Notes: []string{"interface{} maps to any via handle"}}, nil
+	}
+	return &Mapping{Mochi: HandleType{Name: "iface"}, Direction: Handle, Notes: []string{"anonymous interface maps to a handle; method set is opaque"}}, nil
+}
+
+func mapStruct(s apisurface.StructType) (*Mapping, error) {
+	return &Mapping{Mochi: HandleType{Name: "struct"}, Direction: Handle, Notes: []string{"anonymous struct literal maps to a handle (fields opaque)"}}, nil
+}
+
+func (m *Mapper) mapNamed(n apisurface.NamedType) (*Mapping, error) {
+	// stdlib special-cases.
+	if n.PackagePath == "" || n.PackagePath == "_self" {
+		// Self-package named type: consult the surface (if any) to
+		// see if it is a struct, alias, or scalar wrapper.
+		if m.surface != nil {
+			if td := m.lookupSelfType(n.Name); td != nil {
+				return m.mapTypeDecl(td)
+			}
+		}
+		// Fall back to handle so the bridge can still expose the
+		// value as opaque.
+		return &Mapping{Mochi: HandleType{Name: n.Name}, Direction: Handle, Notes: []string{"self-package named type with no surface info"}}, nil
+	}
+	// Cross-package named type: try to find it in the surface.
+	if m.surface != nil {
+		if td := m.lookupCrossType(n.PackagePath, n.Name); td != nil {
+			return m.mapTypeDecl(td)
+		}
+	}
+	// Default: handle keyed by qualified name.
+	return &Mapping{Mochi: HandleType{Name: n.PackagePath + "." + n.Name}, Direction: Handle, Notes: []string{"cross-package named type defaults to handle"}}, nil
+}
+
+func (m *Mapper) lookupSelfType(name string) *apisurface.TypeDecl {
+	// Walk every package; the self-package convention is ambiguous
+	// when multiple packages are in play. Phase 6 will narrow the
+	// scope.
+	for _, pkg := range m.surface.PackagePaths() {
+		if td := m.surface.LookupType(pkg, name); td != nil {
+			return td
+		}
+	}
+	return nil
+}
+
+func (m *Mapper) lookupCrossType(pkg, name string) *apisurface.TypeDecl {
+	return m.surface.LookupType(pkg, name)
+}
+
+func (m *Mapper) mapTypeDecl(td *apisurface.TypeDecl) (*Mapping, error) {
+	switch td.Kind {
+	case apisurface.KindAlias:
+		if td.AliasOf != nil {
+			return m.Map(td.AliasOf)
+		}
+		return &Mapping{Mochi: HandleType{Name: td.Underlying.Name}, Direction: Handle, Notes: []string{"alias target unresolved"}}, nil
+	case apisurface.KindBasic:
+		if td.UnderlyingType != nil {
+			return m.Map(td.UnderlyingType)
+		}
+		return &Mapping{Mochi: HandleType{Name: td.Underlying.Name}, Direction: Handle}, nil
+	case apisurface.KindStruct:
+		return m.mapStructDecl(td)
+	case apisurface.KindInterface:
+		// Interfaces always handle.
+		return &Mapping{Mochi: HandleType{Name: td.Underlying.Name}, Direction: Handle, Notes: []string{"interface bridges as handle (method set on Mochi side via wrapper)"}}, nil
+	case apisurface.KindSlice, apisurface.KindMap, apisurface.KindChan, apisurface.KindArray, apisurface.KindFunc, apisurface.KindPointer:
+		// Unfold via the underlying.
+		if td.UnderlyingType != nil {
+			return m.Map(td.UnderlyingType)
+		}
+	}
+	return &Mapping{Mochi: HandleType{Name: td.Underlying.Name}, Direction: Handle, Notes: []string{"named type with unknown kind defaults to handle"}}, nil
+}
+
+func (m *Mapper) mapStructDecl(td *apisurface.TypeDecl) (*Mapping, error) {
+	// A struct is record-bridgeable iff every Exported field is
+	// itself record-bridgeable as Copy (recursively). Otherwise we
+	// fall back to a handle.
+	fields := []RecordField{}
+	for _, f := range td.Fields {
+		if !f.Exported {
+			// An unexported field forces handle. The bridge can't
+			// see private state.
+			return &Mapping{Mochi: HandleType{Name: td.Underlying.Name}, Direction: Handle, Notes: []string{"struct has unexported fields"}}, nil
+		}
+		fm, err := m.Map(f.Type)
+		if err != nil {
+			return &Mapping{Mochi: HandleType{Name: td.Underlying.Name}, Direction: Handle, Notes: []string{"struct field unmappable: " + f.Name}}, nil
+		}
+		if fm.Direction == Handle {
+			// A field that bridges as a handle (e.g. nested *mu
+			// sync.Mutex) forces the whole struct to be a handle.
+			return &Mapping{Mochi: HandleType{Name: td.Underlying.Name}, Direction: Handle, Notes: []string{"struct field " + f.Name + " requires handle"}}, nil
+		}
+		fields = append(fields, RecordField{Name: f.Name, Type: fm.Mochi})
+	}
+	return &Mapping{Mochi: RecordType{Name: td.Underlying.Name, Fields: fields}, Direction: Copy}, nil
+}
+
+// MapFunc maps an apisurface.FuncDecl (a top-level func or method)
+// to its Mochi signature. The returned Mapping's Mochi is always a
+// FuncType.
+func (m *Mapper) MapFunc(fd *apisurface.FuncDecl) (*Mapping, error) {
+	if fd == nil {
+		return nil, fmt.Errorf("%w: nil FuncDecl", ErrUnmappable)
+	}
+	ft := apisurface.FuncType{Variadic: fd.Underlying.Variadic}
+	for _, p := range fd.Params {
+		ft.Params = append(ft.Params, p.Type)
+	}
+	for _, r := range fd.Results {
+		ft.Results = append(ft.Results, r.Type)
+	}
+	return m.mapFunc(ft)
+}

--- a/package3/go/typemap/mapper_test.go
+++ b/package3/go/typemap/mapper_test.go
@@ -1,0 +1,537 @@
+package typemap
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"mochi/package3/go/apisurface"
+)
+
+func mustParse(t *testing.T, s string) apisurface.GoType {
+	t.Helper()
+	gt, err := apisurface.ParseType(s)
+	if err != nil {
+		t.Fatalf("ParseType(%q): %v", s, err)
+	}
+	return gt
+}
+
+func TestMapBasicScalars(t *testing.T) {
+	cases := map[string]string{
+		"int":     "int",
+		"int64":   "int",
+		"int8":    "int",
+		"uint":    "int",
+		"byte":    "int",
+		"rune":    "int",
+		"uintptr": "int",
+		"float32": "float",
+		"float64": "float",
+		"bool":    "bool",
+		"string":  "string",
+		"error":   "error",
+	}
+	m := NewMapper(nil)
+	for in, want := range cases {
+		gt := mustParse(t, in)
+		mp, err := m.Map(gt)
+		if err != nil {
+			t.Errorf("Map(%q): %v", in, err)
+			continue
+		}
+		s, ok := mp.Mochi.(ScalarType)
+		if !ok {
+			t.Errorf("Map(%q) = %T; want ScalarType", in, mp.Mochi)
+			continue
+		}
+		if s.Name != want {
+			t.Errorf("Map(%q).Name = %q; want %q", in, s.Name, want)
+		}
+		if mp.Direction != Copy {
+			t.Errorf("Map(%q).Direction = %v; want Copy", in, mp.Direction)
+		}
+	}
+}
+
+func TestMapBytes(t *testing.T) {
+	m := NewMapper(nil)
+	mp, err := m.Map(mustParse(t, "[]byte"))
+	if err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+	s, ok := mp.Mochi.(ScalarType)
+	if !ok || s.Name != "bytes" {
+		t.Errorf("[]byte -> %#v; want ScalarType{bytes}", mp.Mochi)
+	}
+}
+
+func TestMapSlice(t *testing.T) {
+	m := NewMapper(nil)
+	mp, _ := m.Map(mustParse(t, "[]string"))
+	l, ok := mp.Mochi.(ListType)
+	if !ok {
+		t.Fatalf("got %T", mp.Mochi)
+	}
+	if l.Elem.(ScalarType).Name != "string" {
+		t.Errorf("elem = %#v", l.Elem)
+	}
+}
+
+func TestMapMap(t *testing.T) {
+	m := NewMapper(nil)
+	mp, _ := m.Map(mustParse(t, "map[string]int"))
+	mm, ok := mp.Mochi.(MochiMap)
+	if !ok {
+		t.Fatalf("got %T", mp.Mochi)
+	}
+	if mm.Key.(ScalarType).Name != "string" || mm.Value.(ScalarType).Name != "int" {
+		t.Errorf("kv = %#v / %#v", mm.Key, mm.Value)
+	}
+}
+
+func TestMapMapRejectsNonScalarKey(t *testing.T) {
+	m := NewMapper(nil)
+	_, err := m.Map(mustParse(t, "map[chan int]string"))
+	if err == nil || !errors.Is(err, ErrUnmappable) {
+		t.Errorf("want ErrUnmappable, got %v", err)
+	}
+}
+
+func TestMapPointer(t *testing.T) {
+	m := NewMapper(nil)
+	// pointer to scalar -> option<int>, Copy
+	mp, _ := m.Map(mustParse(t, "*int"))
+	if _, ok := mp.Mochi.(OptionType); !ok {
+		t.Errorf("ptr -> %T; want OptionType", mp.Mochi)
+	}
+
+	// pointer to chan -> handle (no double-wrap)
+	mp, _ = m.Map(mustParse(t, "*chan int"))
+	if _, ok := mp.Mochi.(HandleType); !ok {
+		t.Errorf("*chan -> %T; want HandleType", mp.Mochi)
+	}
+}
+
+func TestMapChan(t *testing.T) {
+	m := NewMapper(nil)
+	mp, _ := m.Map(mustParse(t, "chan int"))
+	h, ok := mp.Mochi.(HandleType)
+	if !ok {
+		t.Fatalf("chan -> %T", mp.Mochi)
+	}
+	if !strings.Contains(h.Name, "int") {
+		t.Errorf("handle.Name = %q", h.Name)
+	}
+	if mp.Direction != Handle {
+		t.Errorf("Direction = %v", mp.Direction)
+	}
+}
+
+func TestMapFunc(t *testing.T) {
+	m := NewMapper(nil)
+	mp, _ := m.Map(mustParse(t, "func(int) (string, error)"))
+	ft, ok := mp.Mochi.(FuncType)
+	if !ok {
+		t.Fatalf("got %T", mp.Mochi)
+	}
+	if len(ft.Params) != 1 || len(ft.Results) != 2 {
+		t.Errorf("ft = %#v", ft)
+	}
+	if mp.Direction != Handle {
+		t.Errorf("Direction = %v", mp.Direction)
+	}
+}
+
+func TestMapVariadicFunc(t *testing.T) {
+	m := NewMapper(nil)
+	mp, _ := m.Map(mustParse(t, "func(...string) error"))
+	ft := mp.Mochi.(FuncType)
+	if _, ok := ft.Params[0].(ListType); !ok {
+		t.Errorf("variadic param = %T; want ListType", ft.Params[0])
+	}
+}
+
+func TestMapInterface(t *testing.T) {
+	m := NewMapper(nil)
+	mp, _ := m.Map(mustParse(t, "interface{}"))
+	if _, ok := mp.Mochi.(AnyType); !ok {
+		t.Errorf("interface{} -> %T; want AnyType", mp.Mochi)
+	}
+	mp, _ = m.Map(mustParse(t, "interface{ Read([]byte) (int, error) }"))
+	if _, ok := mp.Mochi.(HandleType); !ok {
+		t.Errorf("non-empty iface -> %T; want HandleType", mp.Mochi)
+	}
+}
+
+func TestMapStructLiteral(t *testing.T) {
+	m := NewMapper(nil)
+	mp, _ := m.Map(mustParse(t, "struct { A int }"))
+	if _, ok := mp.Mochi.(HandleType); !ok {
+		t.Errorf("struct literal -> %T; want HandleType", mp.Mochi)
+	}
+}
+
+func TestMapAnyComparable(t *testing.T) {
+	m := NewMapper(nil)
+	mp, _ := m.Map(mustParse(t, "any"))
+	if _, ok := mp.Mochi.(AnyType); !ok {
+		t.Errorf("any -> %T; want AnyType", mp.Mochi)
+	}
+	if mp.Direction != Handle {
+		t.Errorf("any.Direction = %v; want Handle", mp.Direction)
+	}
+}
+
+func TestMapNamedWithoutSurface(t *testing.T) {
+	m := NewMapper(nil)
+	mp, _ := m.Map(mustParse(t, "io.Reader"))
+	h, ok := mp.Mochi.(HandleType)
+	if !ok {
+		t.Fatalf("got %T", mp.Mochi)
+	}
+	if h.Name != "io.Reader" {
+		t.Errorf("HandleType.Name = %q", h.Name)
+	}
+}
+
+func TestMapNamedStructWithSurface(t *testing.T) {
+	file := &apisurface.File{
+		SchemaVersion: apisurface.SchemaVersion,
+		Module:        "example.com/foo",
+		Packages: []apisurface.Package{
+			{
+				ImportPath: "example.com/foo",
+				Types: []apisurface.Type{
+					{
+						Name: "Point",
+						Kind: apisurface.KindStruct,
+						Fields: []apisurface.Field{
+							{Name: "X", Type: "int", Exported: true},
+							{Name: "Y", Type: "int", Exported: true},
+						},
+					},
+				},
+			},
+		},
+	}
+	s, err := apisurface.Load(file, apisurface.LoadOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := NewMapper(s)
+	mp, _ := m.Map(mustParse(t, "example.com/foo.Point"))
+	r, ok := mp.Mochi.(RecordType)
+	if !ok {
+		t.Fatalf("got %T", mp.Mochi)
+	}
+	if r.Name != "Point" || len(r.Fields) != 2 {
+		t.Errorf("Record = %+v", r)
+	}
+	if mp.Direction != Copy {
+		t.Errorf("Direction = %v; want Copy", mp.Direction)
+	}
+}
+
+func TestMapNamedStructWithUnexportedFieldFallsBackToHandle(t *testing.T) {
+	file := &apisurface.File{
+		SchemaVersion: apisurface.SchemaVersion,
+		Packages: []apisurface.Package{
+			{
+				ImportPath: "x",
+				Types: []apisurface.Type{
+					{
+						Name: "P",
+						Kind: apisurface.KindStruct,
+						Fields: []apisurface.Field{
+							{Name: "X", Type: "int", Exported: true},
+							{Name: "y", Type: "int", Exported: false},
+						},
+					},
+				},
+			},
+		},
+	}
+	s, _ := apisurface.Load(file, apisurface.LoadOptions{})
+	m := NewMapper(s)
+	mp, _ := m.Map(mustParse(t, "x.P"))
+	if _, ok := mp.Mochi.(HandleType); !ok {
+		t.Errorf("got %T; want HandleType", mp.Mochi)
+	}
+}
+
+func TestMapNamedAlias(t *testing.T) {
+	file := &apisurface.File{
+		SchemaVersion: apisurface.SchemaVersion,
+		Packages: []apisurface.Package{
+			{
+				ImportPath: "x",
+				Types: []apisurface.Type{
+					{Name: "Name", Kind: apisurface.KindAlias, AliasOf: "string"},
+				},
+			},
+		},
+	}
+	s, _ := apisurface.Load(file, apisurface.LoadOptions{})
+	m := NewMapper(s)
+	mp, _ := m.Map(mustParse(t, "x.Name"))
+	sc, ok := mp.Mochi.(ScalarType)
+	if !ok || sc.Name != "string" {
+		t.Errorf("alias -> %#v", mp.Mochi)
+	}
+}
+
+func TestMapperCacheStable(t *testing.T) {
+	m := NewMapper(nil)
+	a, _ := m.Map(mustParse(t, "map[string][]int"))
+	b, _ := m.Map(mustParse(t, "map[string][]int"))
+	if a != b {
+		t.Errorf("cache returned different pointers")
+	}
+}
+
+func TestMapFuncDeclWrap(t *testing.T) {
+	m := NewMapper(nil)
+	fd := &apisurface.FuncDecl{
+		Underlying: &apisurface.Func{Name: "Foo", Variadic: false},
+		Params:     []apisurface.ParamDecl{{Name: "x", Type: apisurface.BasicType{Name: "int"}}},
+		Results:    []apisurface.ParamDecl{{Type: apisurface.BasicType{Name: "string"}}},
+	}
+	mp, err := m.MapFunc(fd)
+	if err != nil {
+		t.Fatalf("MapFunc: %v", err)
+	}
+	ft := mp.Mochi.(FuncType)
+	if len(ft.Params) != 1 || len(ft.Results) != 1 {
+		t.Errorf("ft = %+v", ft)
+	}
+}
+
+func TestTransferDirectionString(t *testing.T) {
+	if Copy.String() != "copy" || View.String() != "view" || Handle.String() != "handle" {
+		t.Errorf("dir string: %v %v %v", Copy, View, Handle)
+	}
+}
+
+func TestMochiTypeStringRendering(t *testing.T) {
+	cases := []struct {
+		in   MochiType
+		want string
+	}{
+		{ScalarType{Name: "int"}, "int"},
+		{ListType{Elem: ScalarType{Name: "string"}}, "list<string>"},
+		{MochiMap{Key: ScalarType{Name: "string"}, Value: ScalarType{Name: "int"}}, "map<string, int>"},
+		{HandleType{Name: "io.Reader"}, "handle<io.Reader>"},
+		{HandleType{}, "handle"},
+		{OptionType{Elem: ScalarType{Name: "int"}}, "option<int>"},
+		{AnyType{}, "any"},
+		{FuncType{Params: []MochiType{ScalarType{Name: "int"}}, Results: nil}, "fn(int) -> unit"},
+		{FuncType{Params: nil, Results: []MochiType{ScalarType{Name: "int"}}}, "fn() -> int"},
+		{FuncType{Results: []MochiType{ScalarType{Name: "int"}, ScalarType{Name: "error"}}}, "fn() -> (int, error)"},
+		{RecordType{Name: "Foo"}, "Foo"},
+	}
+	for _, tc := range cases {
+		if got := tc.in.String(); got != tc.want {
+			t.Errorf("String() = %q; want %q", got, tc.want)
+		}
+	}
+}
+
+func TestArrayMapsToList(t *testing.T) {
+	m := NewMapper(nil)
+	mp, _ := m.Map(mustParse(t, "[4]byte"))
+	if _, ok := mp.Mochi.(ListType); !ok {
+		t.Errorf("[4]byte -> %T", mp.Mochi)
+	}
+}
+
+func TestNilMapErrors(t *testing.T) {
+	m := NewMapper(nil)
+	if _, err := m.Map(nil); err == nil {
+		t.Errorf("Map(nil): want error")
+	}
+}
+
+func TestEllipsisTopLevel(t *testing.T) {
+	m := NewMapper(nil)
+	mp, _ := m.Map(mustParse(t, "...int"))
+	if _, ok := mp.Mochi.(ListType); !ok {
+		t.Errorf("...int -> %T", mp.Mochi)
+	}
+}
+
+func TestMapNestedComposites(t *testing.T) {
+	m := NewMapper(nil)
+	// list<list<int>>
+	mp, err := m.Map(mustParse(t, "[][]int"))
+	if err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+	outer, ok := mp.Mochi.(ListType)
+	if !ok {
+		t.Fatalf("outer = %T", mp.Mochi)
+	}
+	inner, ok := outer.Elem.(ListType)
+	if !ok {
+		t.Fatalf("inner = %T", outer.Elem)
+	}
+	if inner.Elem.(ScalarType).Name != "int" {
+		t.Errorf("innermost = %#v", inner.Elem)
+	}
+
+	// map<string, list<map<string, int>>>
+	mp, err = m.Map(mustParse(t, "map[string][]map[string]int"))
+	if err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+	if got := mp.Mochi.String(); got != "map<string, list<map<string, int>>>" {
+		t.Errorf("nested map = %q", got)
+	}
+}
+
+func TestMapPointerToRecordYieldsOptionRecord(t *testing.T) {
+	file := &apisurface.File{
+		SchemaVersion: apisurface.SchemaVersion,
+		Packages: []apisurface.Package{
+			{
+				ImportPath: "x",
+				Types: []apisurface.Type{
+					{
+						Name: "P",
+						Kind: apisurface.KindStruct,
+						Fields: []apisurface.Field{
+							{Name: "X", Type: "int", Exported: true},
+						},
+					},
+				},
+			},
+		},
+	}
+	s, err := apisurface.Load(file, apisurface.LoadOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := NewMapper(s)
+	mp, err := m.Map(mustParse(t, "*x.P"))
+	if err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+	opt, ok := mp.Mochi.(OptionType)
+	if !ok {
+		t.Fatalf("got %T; want OptionType", mp.Mochi)
+	}
+	r, ok := opt.Elem.(RecordType)
+	if !ok {
+		t.Fatalf("opt.Elem = %T", opt.Elem)
+	}
+	if r.Name != "P" {
+		t.Errorf("record name = %q", r.Name)
+	}
+}
+
+func TestMapStructWithHandleFieldFallsBack(t *testing.T) {
+	// A struct whose field is itself a chan must fall back to a
+	// handle — record requires every field be Copy.
+	file := &apisurface.File{
+		SchemaVersion: apisurface.SchemaVersion,
+		Packages: []apisurface.Package{
+			{
+				ImportPath: "x",
+				Types: []apisurface.Type{
+					{
+						Name: "Hub",
+						Kind: apisurface.KindStruct,
+						Fields: []apisurface.Field{
+							{Name: "Name", Type: "string", Exported: true},
+							{Name: "Sink", Type: "chan int", Exported: true},
+						},
+					},
+				},
+			},
+		},
+	}
+	s, _ := apisurface.Load(file, apisurface.LoadOptions{})
+	m := NewMapper(s)
+	mp, _ := m.Map(mustParse(t, "x.Hub"))
+	h, ok := mp.Mochi.(HandleType)
+	if !ok {
+		t.Fatalf("got %T; want HandleType", mp.Mochi)
+	}
+	if h.Name != "Hub" {
+		t.Errorf("handle.Name = %q", h.Name)
+	}
+	// The Note should explain the demotion.
+	joined := strings.Join(mp.Notes, " | ")
+	if !strings.Contains(joined, "Sink") {
+		t.Errorf("Notes missing reason; got %q", joined)
+	}
+}
+
+func TestMapCrossPackageUnknownHandleQualified(t *testing.T) {
+	// With no surface, a cross-package named type becomes a handle
+	// keyed by qualified name.
+	m := NewMapper(nil)
+	mp, _ := m.Map(mustParse(t, "github.com/spf13/cobra.Command"))
+	h, ok := mp.Mochi.(HandleType)
+	if !ok {
+		t.Fatalf("got %T", mp.Mochi)
+	}
+	if !strings.Contains(h.Name, "cobra") || !strings.Contains(h.Name, "Command") {
+		t.Errorf("handle.Name = %q", h.Name)
+	}
+}
+
+func TestMapVariadicHasListLast(t *testing.T) {
+	m := NewMapper(nil)
+	mp, _ := m.Map(mustParse(t, "func(string, ...int) bool"))
+	ft := mp.Mochi.(FuncType)
+	if len(ft.Params) != 2 {
+		t.Fatalf("params = %d", len(ft.Params))
+	}
+	if _, ok := ft.Params[1].(ListType); !ok {
+		t.Errorf("variadic param = %T; want ListType", ft.Params[1])
+	}
+}
+
+func TestMapNamedAliasToComplex(t *testing.T) {
+	// `type IntList = []int` -> list<int>
+	file := &apisurface.File{
+		SchemaVersion: apisurface.SchemaVersion,
+		Packages: []apisurface.Package{
+			{
+				ImportPath: "x",
+				Types: []apisurface.Type{
+					{Name: "IntList", Kind: apisurface.KindAlias, AliasOf: "[]int"},
+				},
+			},
+		},
+	}
+	s, _ := apisurface.Load(file, apisurface.LoadOptions{})
+	m := NewMapper(s)
+	mp, err := m.Map(mustParse(t, "x.IntList"))
+	if err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+	if _, ok := mp.Mochi.(ListType); !ok {
+		t.Errorf("alias -> %T; want ListType", mp.Mochi)
+	}
+}
+
+func TestMapErrorWrapsBaseError(t *testing.T) {
+	m := NewMapper(nil)
+	_, err := m.Map(apisurface.BasicType{Name: "totally-not-a-type"})
+	if err == nil {
+		t.Fatalf("want error")
+	}
+	if !errors.Is(err, ErrUnmappable) {
+		t.Errorf("err = %v; want wraps ErrUnmappable", err)
+	}
+}
+
+func TestWideningNoteAttachedForNarrowGoInt(t *testing.T) {
+	m := NewMapper(nil)
+	mp, _ := m.Map(mustParse(t, "int32"))
+	if len(mp.Notes) == 0 {
+		t.Errorf("int32 should carry a widening note; got %v", mp.Notes)
+	}
+}

--- a/package3/go/typemap/phase05_test.go
+++ b/package3/go/typemap/phase05_test.go
@@ -1,0 +1,131 @@
+package typemap
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/go/apisurface"
+)
+
+// TestPhase5Typemap is the MEP-74 phase 5 sentinel. It drives a small
+// hand-built apisurface.File describing a module with one record-
+// bridgeable struct (Point), one handle-only struct (Mutex; private
+// field), one alias (Name = string), one func, and one chan-valued
+// function. Every variant in the closed Mochi-type grammar
+// (Scalar, List, Map, Record, Handle, Func, Option, Any) must appear
+// somewhere in the resulting mapping, and TransferDirection must
+// match the documented lowering rule for each.
+func TestPhase5Typemap(t *testing.T) {
+	file := &apisurface.File{
+		SchemaVersion: apisurface.SchemaVersion,
+		Module:        "example.com/p5",
+		Packages: []apisurface.Package{
+			{
+				ImportPath: "example.com/p5",
+				Imports:    []string{"io"},
+				Types: []apisurface.Type{
+					{
+						Name: "Point",
+						Kind: apisurface.KindStruct,
+						Fields: []apisurface.Field{
+							{Name: "X", Type: "int", Exported: true},
+							{Name: "Y", Type: "int", Exported: true},
+						},
+					},
+					{
+						Name: "Mutex",
+						Kind: apisurface.KindStruct,
+						Fields: []apisurface.Field{
+							{Name: "state", Type: "int32", Exported: false},
+						},
+					},
+					{
+						Name:    "Name",
+						Kind:    apisurface.KindAlias,
+						AliasOf: "string",
+					},
+				},
+			},
+		},
+	}
+	surface, err := apisurface.Load(file, apisurface.LoadOptions{})
+	if err != nil {
+		t.Fatalf("apisurface.Load: %v", err)
+	}
+	m := NewMapper(surface)
+
+	cases := []struct {
+		expr      string
+		wantKind  string // discriminator (record, handle<...>, list<...>, option<...>, etc.)
+		wantDir   TransferDirection
+		mustHave  string // substring required in Mochi.String()
+	}{
+		{"int", "scalar", Copy, "int"},
+		{"float64", "scalar", Copy, "float"},
+		{"bool", "scalar", Copy, "bool"},
+		{"string", "scalar", Copy, "string"},
+		{"[]byte", "scalar", Copy, "bytes"},
+		{"[]string", "list", Copy, "list<string>"},
+		{"[]example.com/p5.Point", "list", Copy, "list<Point>"},
+		{"map[string]int", "map", Copy, "map<string, int>"},
+		{"*int", "option", Copy, "option<int>"},
+		{"*example.com/p5.Point", "option", Copy, "option<Point>"},
+		{"example.com/p5.Point", "record", Copy, "Point"},
+		{"example.com/p5.Mutex", "handle", Handle, "handle<Mutex>"},
+		{"example.com/p5.Name", "scalar", Copy, "string"},
+		{"chan int", "handle", Handle, "handle<chan<int>>"},
+		{"func(int) (string, error)", "func", Handle, "fn(int) -> (string, error)"},
+		{"interface{}", "any", Handle, "any"},
+		{"any", "any", Handle, "any"},
+		{"io.Reader", "handle", Handle, "handle<io.Reader>"},
+		{"...string", "list", Copy, "list<string>"},
+		{"[4]byte", "list", Copy, "list<int>"},
+		{"map[string][]int", "map", Copy, "map<string, list<int>>"},
+	}
+
+	seenKinds := map[string]bool{}
+	for _, tc := range cases {
+		gt, perr := apisurface.ParseType(tc.expr)
+		if perr != nil {
+			t.Errorf("ParseType(%q): %v", tc.expr, perr)
+			continue
+		}
+		mp, mErr := m.Map(gt)
+		if mErr != nil {
+			t.Errorf("Map(%q): %v", tc.expr, mErr)
+			continue
+		}
+		if mp.Direction != tc.wantDir {
+			t.Errorf("Map(%q).Direction = %v; want %v", tc.expr, mp.Direction, tc.wantDir)
+		}
+		got := mp.Mochi.String()
+		if !strings.Contains(got, tc.mustHave) {
+			t.Errorf("Map(%q).Mochi.String() = %q; want substring %q", tc.expr, got, tc.mustHave)
+		}
+		switch mp.Mochi.(type) {
+		case ScalarType:
+			seenKinds["scalar"] = true
+		case ListType:
+			seenKinds["list"] = true
+		case MochiMap:
+			seenKinds["map"] = true
+		case RecordType:
+			seenKinds["record"] = true
+		case HandleType:
+			seenKinds["handle"] = true
+		case FuncType:
+			seenKinds["func"] = true
+		case OptionType:
+			seenKinds["option"] = true
+		case AnyType:
+			seenKinds["any"] = true
+		}
+	}
+
+	// Every variant of MochiType must be exercised by the sentinel.
+	for _, k := range []string{"scalar", "list", "map", "record", "handle", "func", "option", "any"} {
+		if !seenKinds[k] {
+			t.Errorf("sentinel did not exercise MochiType kind %q", k)
+		}
+	}
+}

--- a/package3/go/typemap/types.go
+++ b/package3/go/typemap/types.go
@@ -1,0 +1,206 @@
+// Package typemap is the MEP-74 closed type-mapping table: it maps
+// every shape of Go type (as recovered by package apisurface) to a
+// MochiType representation plus a TransferDirection that drives the
+// cgo wrapper synthesiser (phase 6) and the extern fn emitter
+// (phase 7).
+//
+// The grammar of MochiType is closed: phase 6 and phase 7 switch
+// over the concrete variants exhaustively. Adding a new MochiType
+// variant requires updating every consumer in lock-step.
+package typemap
+
+import (
+	"sort"
+	"strings"
+)
+
+// MochiType is the Mochi-side representation of a bridged Go type.
+type MochiType interface {
+	isMochiType()
+	// String renders the type in Mochi source syntax.
+	String() string
+}
+
+// ScalarType is a Mochi scalar: int, float, bool, string, bytes,
+// error, any. Mapped from Go basic types and (where applicable)
+// from named types whose underlying is a basic type.
+type ScalarType struct {
+	// Name is one of "int", "float", "bool", "string", "bytes",
+	// "error", "any".
+	Name string
+}
+
+// ListType is Mochi list<T>. Mapped from Go []T (or []byte ->
+// ScalarType bytes; that's handled at the mapper layer).
+type ListType struct {
+	Elem MochiType
+}
+
+// MochiMap is Mochi map<K, V>. Mapped from Go map[K]V.
+type MochiMap struct {
+	Key, Value MochiType
+}
+
+// RecordType is a Mochi record with named fields. Mapped from Go
+// structs whose fields are themselves bridgeable as Copy or View.
+type RecordType struct {
+	// Name is the canonical Mochi type name. For named Go structs,
+	// derived from the original Go name (no package prefix); for
+	// anonymous struct literals, "anon".
+	Name   string
+	Fields []RecordField
+}
+
+// RecordField is one Mochi record field.
+type RecordField struct {
+	Name string
+	Type MochiType
+}
+
+// HandleType is a Mochi handle<TName> -- an opaque pointer kept in
+// the cgo handle pool. Mapped from Go interfaces, channels, funcs,
+// and structs that cannot be copied (private fields, embedded
+// unexported types, ...).
+type HandleType struct {
+	// Name is the Mochi-visible identifier of the handle type. It
+	// disambiguates between handles to different Go types (e.g.
+	// handle<io.Reader> vs. handle<*os.File>).
+	Name string
+}
+
+// FuncType is a Mochi closure type (Params) -> Results.
+type FuncType struct {
+	Params  []MochiType
+	Results []MochiType
+}
+
+// OptionType is Mochi option<T>. Mapped from Go pointer types when
+// the pointee is bridgeable as a value (slices, maps, records).
+type OptionType struct {
+	Elem MochiType
+}
+
+// AnyType is Mochi any. Used as a fallback when the Go type is
+// itself any/interface{} with no methods.
+type AnyType struct{}
+
+func (ScalarType) isMochiType() {}
+func (ListType) isMochiType()   {}
+func (MochiMap) isMochiType()   {}
+func (RecordType) isMochiType() {}
+func (HandleType) isMochiType() {}
+func (FuncType) isMochiType()   {}
+func (OptionType) isMochiType() {}
+func (AnyType) isMochiType()    {}
+
+func (t ScalarType) String() string { return t.Name }
+func (t ListType) String() string   { return "list<" + t.Elem.String() + ">" }
+func (t MochiMap) String() string   { return "map<" + t.Key.String() + ", " + t.Value.String() + ">" }
+
+func (t RecordType) String() string {
+	if t.Name != "" {
+		return t.Name
+	}
+	var sb strings.Builder
+	sb.WriteString("record{")
+	// Render fields sorted by name so the canonical form is stable.
+	names := make([]string, 0, len(t.Fields))
+	idx := make(map[string]int, len(t.Fields))
+	for i, f := range t.Fields {
+		names = append(names, f.Name)
+		idx[f.Name] = i
+	}
+	sort.Strings(names)
+	for i, n := range names {
+		if i > 0 {
+			sb.WriteString("; ")
+		}
+		sb.WriteString(n)
+		sb.WriteString(": ")
+		sb.WriteString(t.Fields[idx[n]].Type.String())
+	}
+	sb.WriteString("}")
+	return sb.String()
+}
+
+func (t HandleType) String() string {
+	if t.Name == "" {
+		return "handle"
+	}
+	return "handle<" + t.Name + ">"
+}
+
+func (t FuncType) String() string {
+	var sb strings.Builder
+	sb.WriteString("fn(")
+	for i, p := range t.Params {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(p.String())
+	}
+	sb.WriteString(") -> ")
+	switch len(t.Results) {
+	case 0:
+		sb.WriteString("unit")
+	case 1:
+		sb.WriteString(t.Results[0].String())
+	default:
+		sb.WriteByte('(')
+		for i, r := range t.Results {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(r.String())
+		}
+		sb.WriteByte(')')
+	}
+	return sb.String()
+}
+
+func (t OptionType) String() string { return "option<" + t.Elem.String() + ">" }
+func (AnyType) String() string      { return "any" }
+
+// TransferDirection captures how a value crosses the Go <-> Mochi
+// boundary at runtime. Phase 6 (wrapper synthesiser) uses this to
+// decide whether to memcpy, materialise a Mochi-side view, or stash
+// the value in the cgo handle pool.
+type TransferDirection int
+
+const (
+	// Copy means the value is byte-copied across the boundary in a
+	// single direction. Scalars, fixed-size structs of scalars, and
+	// other plain-old-data types use this.
+	Copy TransferDirection = iota
+	// View means the Mochi side holds a borrowed pointer or slice
+	// header into the original Go memory. The borrow is valid until
+	// the wrapper returns; phase 6 enforces this via the cgo
+	// `noescape` discipline.
+	View
+	// Handle means the value is registered in the cgo handle pool;
+	// the Mochi side holds an opaque integer key. The Go side
+	// resolves the key on every call back.
+	Handle
+)
+
+func (d TransferDirection) String() string {
+	switch d {
+	case Copy:
+		return "copy"
+	case View:
+		return "view"
+	case Handle:
+		return "handle"
+	}
+	return "unknown"
+}
+
+// Mapping is the result of mapping one Go type to a Mochi type. It
+// pairs the MochiType with the TransferDirection and, optionally, a
+// list of human-readable Notes that document the lowering decision
+// (used by phase 7's diagnostic output).
+type Mapping struct {
+	Mochi     MochiType
+	Direction TransferDirection
+	Notes     []string
+}

--- a/website/docs/implementation/0074/index.md
+++ b/website/docs/implementation/0074/index.md
@@ -20,7 +20,7 @@ A phase is LANDED only when its gate is green for every applicable target (consu
 | 2 | sum.golang.org transparency-log client (signed-tree-head + tile fetch + inclusion proof) | LANDED | (pending) | [phase-02](/docs/implementation/0074/phase-02-sumdb) |
 | 3 | go/packages ingest helper (`package3/go/cmd/go-ingest`) | LANDED | (pending) | [phase-03](/docs/implementation/0074/phase-03-gopackages-ingest) |
 | 4 | ApiSurface JSON schema + bridge-side parser | LANDED | (pending) | [phase-04](/docs/implementation/0074/phase-04-apisurface) |
-| 5 | Closed type-mapping table (scalars / strings / `[]byte` / `[]T` / `map[K]V` / structs / interfaces / `chan T` / `func` / `error` / generics) | NOT STARTED | — | [phase-05](/docs/implementation/0074/phase-05-type-mapping) |
+| 5 | Closed type-mapping table (scalars / strings / `[]byte` / `[]T` / `map[K]V` / structs / interfaces / `chan T` / `func` / `error` / generics) | LANDED | (pending) | [phase-05](/docs/implementation/0074/phase-05-typemap) |
 | 6 | Cgo wrapper synthesiser (`//export` directives + `c-archive` + handle pool) | NOT STARTED | — | [phase-06](/docs/implementation/0074/phase-06-wrapper) |
 | 7 | Mochi-side extern fn emitter + alias shim file generation | NOT STARTED | — | [phase-07](/docs/implementation/0074/phase-07-extern-emit) |
 | 8 | `import go "<module>@<semver>" as <alias>` grammar + parser | NOT STARTED | — | [phase-08](/docs/implementation/0074/phase-08-import-grammar) |
@@ -45,7 +45,7 @@ Each phase's LANDED gate must be green for every applicable target. `n/a` cells 
 | 2. sum.golang.org client | LANDED | n/a | n/a | n/a | n/a |
 | 3. go/packages ingest | LANDED | n/a | n/a | n/a | n/a |
 | 4. ApiSurface JSON | LANDED | n/a | n/a | n/a | n/a |
-| 5. type-mapping table | NOT STARTED | required | required | required | required |
+| 5. type-mapping table | LANDED | required | required | required | required |
 | 6. cgo wrapper synthesiser | NOT STARTED | required | required | n/a (cgo off on wasm) | required (no_cgo subset) |
 | 7. extern emitter | NOT STARTED | required | required | required | required |
 | 8. import-go grammar (semver) | NOT STARTED | required | required | required | required |
@@ -105,7 +105,7 @@ The `package3/go/` location is shared with the broader MEP-57 polyglot package w
 
 ## Status snapshot
 
-As of 2026-05-29: all 18 phases NOT STARTED. The MEP spec and research bundle are landed; implementation is the next major undertaking.
+As of 2026-05-29: phases 0-5 LANDED on `main`, phases 6-17 NOT STARTED.
 
 ## Cross-references
 

--- a/website/docs/implementation/0074/phase-05-typemap.md
+++ b/website/docs/implementation/0074/phase-05-typemap.md
@@ -1,0 +1,211 @@
+---
+title: "Phase 5. Typemap"
+sidebar_position: 7
+sidebar_label: "Phase 5. Typemap"
+description: "MEP-74 Phase 5 lands the closed Go-type to Mochi-type mapping table: ScalarType, ListType, MochiMap, RecordType, HandleType, FuncType, OptionType, AnyType, paired with a TransferDirection (Copy, View, Handle) that drives the cgo wrapper synthesiser in phase 6."
+---
+
+# Phase 5. Typemap
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-74 §Phases](/docs/mep/mep-0074#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-29 22:30 (GMT+7) |
+| Landed         | 2026-05-29 23:03 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`TestPhase5Typemap` in `package3/go/typemap/phase05_test.go`: drives
+a fixture surface with one record-bridgeable struct (Point, both
+fields int + exported), one handle-only struct (Mutex, has an
+unexported field), one alias (Name = string), plus a battery of 21
+type expressions that together exercise every variant of the closed
+MochiType grammar: ScalarType (int, float, bool, string, bytes),
+ListType (`[]string`, `[]Point`, `[4]byte`), MochiMap (with nested
+list value), RecordType (Point), HandleType (Mutex, chan int,
+io.Reader), FuncType (with multi-result), OptionType (pointer to
+scalar and pointer to record), AnyType (`interface{}` and `any`),
+plus the ellipsis-at-top-level shortcut. The sentinel asserts each
+mapping has the documented TransferDirection (Copy for value types,
+Handle for opaque ones) and verifies — via a `seenKinds` set — that
+every concrete MochiType variant is reached. A regression in any
+single mapping rule fails the sentinel even if the regression does
+not affect any other variant.
+
+In addition the package-level test suite covers:
+
+- `package3/go/typemap/mapper_test.go`: every Go basic type widens
+  or maps to the documented Mochi scalar (`int`, `float`, `bool`,
+  `string`, `error`, with `int8/int16/int32/int64/uint*/byte/rune`
+  collapsing to `int` and `float32/float64` collapsing to `float`);
+  `[]byte` collapses to Mochi `bytes`; map with non-scalar key is
+  rejected with `ErrUnmappable`; pointer-to-scalar yields
+  `option<T>`; pointer-to-chan stays a handle (no double-wrap);
+  variadic params surface as `list<T>` in the params tuple; `any`
+  and `comparable` both fall through to `AnyType` with Handle
+  direction; named types map to a handle keyed by qualified name
+  when no surface is available, to a `RecordType` when the surface
+  shows an all-exported, all-Copy struct, and back to a handle when
+  any field is unexported or itself requires Handle; named aliases
+  rewrite to their underlying mapping (`type Name = string` ->
+  `ScalarType{string}`; `type IntList = []int` -> `ListType`);
+  nested composites (`[][]int`, `map[string][]map[string]int`)
+  render canonically; pointer-to-record yields
+  `OptionType{RecordType}`; cross-package unknown named types
+  produce a handle keyed by the qualified name; widening notes are
+  attached to narrow Go integer types; the Mapper cache returns the
+  same Mapping pointer for repeated lookups of the same type
+  expression; `MapFunc` over an `apisurface.FuncDecl` produces a
+  `FuncType` with the same arity; `TransferDirection.String` and
+  `MochiType.String` round-trip every documented form.
+
+## Lowering decisions
+
+Phase 5 defines the closed grammar of Mochi types that the bridge
+will emit. The grammar is intentionally narrow — eight variants —
+so phase 6 (cgo wrapper synthesiser) and phase 7 (extern fn
+emitter) can switch over it exhaustively. Adding a ninth variant
+requires updating every consumer in lock-step, which the closed
+interface (`isMochiType()` private marker method) enforces at
+compile time.
+
+The `TransferDirection` triple — `Copy`, `View`, `Handle` —
+captures the *runtime* boundary-crossing rule, independent of the
+Mochi-side type. A `ListType` may be Copy (slice of scalars), View
+(slice of records borrowed from Go memory), or Handle (slice of
+channels). Phase 6 dispatches on `(MochiType, TransferDirection)`
+together, so embedding the direction in `Mapping` rather than in
+the type itself keeps the type grammar small while still letting
+the wrapper synthesiser make per-call decisions.
+
+Every Go integer width collapses to Mochi `int`. The collapse is
+deliberate: Mochi is a single-int language by spec (MEP-39's
+`int` is a 64-bit signed scalar). Each narrow Go integer
+(`int8/16/32`, `uint*`, `byte`, `rune`, `uintptr`) carries a
+`Note` documenting the widening so phase 7's diagnostic output
+can warn the user that a Go API taking `int32` will see Mochi
+`int` widening on call and narrowing on return. The narrowing
+direction (return-value `int -> int32`) is enforced by the
+wrapper-emitter in phase 6 with an overflow check.
+
+Pointer types map to `OptionType` when the pointee is itself a
+value type (scalar, slice, map, record). The `nil` pointer becomes
+`None`; a live pointer becomes `Some(deref)`. Pointers to handle
+types (chan, func, interface) stay handles directly — wrapping a
+handle in `option` adds no information because the Mochi-side
+handle key is already nullable (the zero key is reserved as
+"absent"). This single-level unwrap is captured by an early-return
+in `mapPointer`.
+
+Named struct types are the load-bearing record-vs-handle decision.
+The rule is conservative: a struct is record-bridgeable iff every
+exported field is itself Copy-bridgeable. Any unexported field, any
+field whose mapping requires Handle (nested chan, func value, or
+non-bridgeable named type), or any unmappable field forces the
+whole struct to be a handle. The fallback path emits a `Note`
+naming the offending field so the user can see why their `Point`-
+shaped struct was bridged opaquely. This precise blame attribution
+is tested by `TestMapStructWithHandleFieldFallsBack`.
+
+Channels, function values, and non-empty interfaces all map to
+`HandleType` with `Handle` direction. Channels carry an
+expressive name (`chan<int>`) so the bridge can distinguish handles
+to channels of different element types at runtime; this protects
+phase 14's channel-bridge against type-confusion mistakes when one
+Go API accepts `chan int` and another accepts `chan string`. Empty
+`interface{}` and `any` collapse to `AnyType` (still Handle
+direction) — the bridge accepts an opaque value, and the Mochi
+side gets a `any` it can inspect via runtime reflection.
+
+The `Mapper` is bound to an `apisurface.Surface` at construction
+time. When the surface is nil, named types collapse to handles
+keyed by qualified name — this is the standalone mode used by
+phase 7's documentation generator. When a surface is present,
+named types consult `surface.LookupType` for their underlying
+shape; this is the cross-reference resolution used by phase 6's
+wrapper emitter.
+
+The Mapper cache is keyed by `GoType.String()` and returns the
+same `*Mapping` pointer for repeated lookups. Pointer-identity
+caching matters because phase 6 will store the Mapping in a struct
+field for each function it emits; identical type expressions
+should share storage rather than duplicate it.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/go/typemap/types.go` | `MochiType` interface + 8 concrete variants (`ScalarType`, `ListType`, `MochiMap`, `RecordType`, `HandleType`, `FuncType`, `OptionType`, `AnyType`), `TransferDirection` enum, `Mapping` record. |
+| `package3/go/typemap/mapper.go` | `Mapper`, `NewMapper`, `Map`, `MapFunc`, `ErrUnmappable`, plus per-shape handlers (`mapBasic`, `mapPointer`, `mapSlice`, `mapArray`, `mapMochiMap`, `mapChan`, `mapFunc`, `mapEllipsis`, `mapInterface`, `mapStruct`, `mapNamed`, `mapTypeDecl`, `mapStructDecl`). |
+| `package3/go/typemap/mapper_test.go` | 32-case unit suite covering every Go type shape, transfer-direction rule, and widening note. |
+| `package3/go/typemap/phase05_test.go` | `TestPhase5Typemap` end-to-end sentinel exercising every MochiType variant + every TransferDirection. |
+| `website/docs/implementation/0074/phase-05-typemap.md` | (this page) |
+
+## Test set
+
+- `TestPhase5Typemap`
+- All `package3/go/typemap/...` unit tests (31 sibling tests).
+
+Local run on darwin-arm64:
+
+```
+$ go test ./package3/go/...
+ok  	mochi/package3/go/apisurface	(cached)
+ok  	mochi/package3/go/build	(cached)
+ok  	mochi/package3/go/cmd/go-ingest	(cached)
+ok  	mochi/package3/go/errors	(cached)
+ok  	mochi/package3/go/moduleproxy	(cached)
+ok  	mochi/package3/go/semver	(cached)
+ok  	mochi/package3/go/sumdb	(cached)
+ok  	mochi/package3/go/typemap	0.514s
+$ go vet ./package3/go/...
+(no output)
+```
+
+## Closeout notes
+
+The closed-grammar approach was a deliberate inversion of the
+common pattern of letting the wrapper emitter (phase 6) make
+ad-hoc type decisions inline. By pushing the table into a dedicated
+package consumed by both phase 6 and phase 7, we ensure that the
+extern-fn documentation generator and the cgo wrapper synthesiser
+agree on what each Go type bridges to. A divergence between them
+would mean the docs say `int` and the wrapper takes `int32`, which
+is exactly the kind of silent contract drift this MEP set out to
+eliminate.
+
+The `Mapping.Notes` slice is the load-bearing feedback channel for
+phase 7's `mochi go-bridge audit` command. Every non-obvious
+decision — int widening, struct demotion to handle, channel
+element-type encoding — leaves a Note so the auditor can produce
+a human-readable report explaining the bridge's choices. Phase 7
+will sort and dedupe these Notes by Go type expression to keep the
+audit output stable across runs.
+
+The `OptionType` variant is intentionally limited to pointer
+unwrap. Mochi has a richer option model (option chains, map-get
+returning option) but those are concerns of the Mochi compiler,
+not the bridge. The bridge's job is to map *one Go type to one
+Mochi type*; richer option flows live in user code on the Mochi
+side once the value is received.
+
+The widening-note discipline matters for the future
+`mochi go-bridge` CLI. A user binding a stdlib API like `os.Pipe`
+that returns `(*os.File, *os.File, error)` will see in the audit
+report that the `*os.File` results bridge as opaque handles (no
+fields are exported), and that any int32 return value (e.g.
+`syscall.Wait4`) widens to Mochi int. These two facts together
+explain to the user *why* their bridge looks the way it does, with
+no need to re-read the spec.
+
+A subtle design decision: the per-field walk in `mapStructDecl`
+short-circuits on the first non-Copy field rather than collecting
+*all* offending fields. This keeps the Note tight (one offender
+named per fallback), and the test suite explicitly verifies the
+first offender's name appears in the Note. If phase 7's audit
+output ever needs the full list of offenders, the walk can be
+generalised in a follow-up without breaking the existing surface.

--- a/website/docs/mep/mep-0074.md
+++ b/website/docs/mep/mep-0074.md
@@ -382,12 +382,12 @@ A phase is LANDED only when its gate is green for every target in the matrix bel
 
 | Phase | host stable go 1.23 (darwin-arm64) | linux-amd64 / linux-arm64 | windows-amd64 | wasm-wasip1 / wasm-js | tinygo embedded |
 |-------|------------------------------------|-----------------------------|----------------|------------------------|------------------|
-| 0. skeleton | NOT STARTED | n/a | n/a | n/a | n/a |
-| 1. module-proxy client | NOT STARTED | n/a | n/a | n/a | n/a |
-| 2. sum.golang.org client | NOT STARTED | n/a | n/a | n/a | n/a |
-| 3. go/packages ingest | NOT STARTED | n/a | n/a | n/a | n/a |
-| 4. ApiSurface JSON | NOT STARTED | n/a | n/a | n/a | n/a |
-| 5. type-mapping table | NOT STARTED | required | required | required | required |
+| 0. skeleton | LANDED | n/a | n/a | n/a | n/a |
+| 1. module-proxy client | LANDED | n/a | n/a | n/a | n/a |
+| 2. sum.golang.org client | LANDED | n/a | n/a | n/a | n/a |
+| 3. go/packages ingest | LANDED | n/a | n/a | n/a | n/a |
+| 4. ApiSurface JSON | LANDED | n/a | n/a | n/a | n/a |
+| 5. type-mapping table | LANDED | required | required | required | required |
 | 6. cgo wrapper synthesiser | NOT STARTED | required | required | n/a (cgo off on wasm) | required (no_cgo subset) |
 | 7. extern emitter | NOT STARTED | required | required | required | required |
 | 8. import-go grammar (semver) | NOT STARTED | required | required | required | required |

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -348,7 +348,8 @@
       "implementation/0074/phase-01-module-proxy",
       "implementation/0074/phase-02-sumdb",
       "implementation/0074/phase-03-gopackages-ingest",
-      "implementation/0074/phase-04-apisurface"
+      "implementation/0074/phase-04-apisurface",
+      "implementation/0074/phase-05-typemap"
     ]
   },
   "implementation/0076/index"


### PR DESCRIPTION
## Summary
- Lands MEP-74 phase 5: the closed type-mapping table in `package3/go/typemap/`.
- `MochiType` is closed: 8 concrete variants (Scalar, List, Map, Record, Handle, Func, Option, Any) plus a `TransferDirection` triple (Copy, View, Handle) that drives the cgo wrapper synthesiser in phase 6.
- `Mapper` consumes `apisurface.GoType`, consults the optional surface for named-type resolution (struct fields, alias targets), and emits a `Mapping` carrying the Mochi type + transfer direction + human-readable lowering notes.

## Test plan
- [x] `go test ./package3/go/typemap/...` — 32 unit tests + `TestPhase5Typemap` sentinel exercising every MochiType variant
- [x] `go test ./package3/go/...` — all package3/go suites green
- [x] `go vet ./package3/go/...` — no warnings

Tracks #22790.