### PR TITLE
feat(mep-73 p7): build orchestration pipeline + cargo runner

### DIFF
--- a/package3/rust/build/cargo.go
+++ b/package3/rust/build/cargo.go
@@ -1,0 +1,220 @@
+package build
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Cargo encapsulates a `cargo` invocation for the bridge. The
+// orchestration layer constructs argv + env here, then either runs
+// the command (Run) or returns argv for inspection (ArgsBuild). Tests
+// pin the argv shape against ArgsBuild without exec'ing cargo, so the
+// gate is portable to hosts that lack a rust toolchain.
+//
+// All env writes are additive: the existing process environment is
+// preserved except for the deterministic-build keys, which override
+// inherited values. The Deterministic flag toggles SOURCE_DATE_EPOCH,
+// CARGO_TERM_COLOR, and RUSTC_BOOTSTRAP.
+//
+// Phase 7 ships only `cargo build`. Later phases extend Cargo with
+// `cargo test`, `cargo publish`, and `cargo doc --output-format=json`.
+type Cargo struct {
+	// Bin is the cargo binary to invoke. Empty defaults to "cargo".
+	Bin string
+
+	// Verbose mirrors cargo's --verbose flag.
+	Verbose bool
+
+	// Deterministic activates the reproducible-build environment.
+	Deterministic bool
+
+	// Offline forces --offline mode. Recommended when running under
+	// the bridge's content-addressed cache: every dep should already
+	// be present, so network access during build is a bug.
+	Offline bool
+
+	// Frozen forces --frozen mode (requires Cargo.lock to be present
+	// and up to date). Used in CI for reproducible builds.
+	Frozen bool
+
+	// Locked forces --locked mode. Like --frozen but does not also
+	// imply --offline.
+	Locked bool
+
+	// CargoHome overrides CARGO_HOME. Empty leaves the inherited
+	// value untouched.
+	CargoHome string
+
+	// ExtraEnv is merged on top of the deterministic defaults.
+	ExtraEnv map[string]string
+
+	// Stdout / Stderr are the destinations for command output. nil
+	// inherits the calling process's streams. Tests set these to
+	// buffers to capture output.
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// BuildOptions configures a single `cargo build` invocation.
+type BuildOptions struct {
+	// WorkspaceRoot is the directory containing the workspace
+	// Cargo.toml. The path is converted to absolute form before being
+	// passed via --manifest-path.
+	WorkspaceRoot string
+
+	// Profile is the cargo profile to build under: "release", "dev",
+	// "test", etc. Empty defaults to "release" because the bridge
+	// always wants optimised wrapper artefacts.
+	Profile string
+
+	// Package, when non-empty, restricts the build to a single
+	// workspace member via --package <name>.
+	Package string
+
+	// Target sets the rustc compilation target via --target. Empty
+	// leaves the host default.
+	Target string
+
+	// Jobs sets cargo's --jobs flag. 0 leaves the cargo default
+	// (number of logical CPUs).
+	Jobs int
+}
+
+// ArgsBuild composes the argv for `cargo build` under the supplied
+// options. The result includes the Cargo.Bin (or "cargo" default) at
+// argv[0] and is suitable for direct use with exec.Command.
+//
+// ArgsBuild is the gate the phase-7 test pins: argv composition is a
+// pure function of (Cargo, BuildOptions), so the test does not need a
+// rust toolchain to verify it.
+func (c *Cargo) ArgsBuild(opts BuildOptions) []string {
+	bin := c.Bin
+	if bin == "" {
+		bin = "cargo"
+	}
+	args := []string{bin, "build"}
+	if c.Verbose {
+		args = append(args, "--verbose")
+	}
+	if c.Offline {
+		args = append(args, "--offline")
+	}
+	if c.Frozen {
+		args = append(args, "--frozen")
+	}
+	if c.Locked {
+		args = append(args, "--locked")
+	}
+	profile := opts.Profile
+	if profile == "" {
+		profile = "release"
+	}
+	args = append(args, "--profile", profile)
+	if opts.Package != "" {
+		args = append(args, "--package", opts.Package)
+	}
+	if opts.Target != "" {
+		args = append(args, "--target", opts.Target)
+	}
+	if opts.Jobs > 0 {
+		args = append(args, "--jobs", fmt.Sprintf("%d", opts.Jobs))
+	}
+	if opts.WorkspaceRoot != "" {
+		args = append(args, "--manifest-path",
+			filepath.Join(opts.WorkspaceRoot, "Cargo.toml"))
+	}
+	return args
+}
+
+// Env composes the environment passed to cargo. The result is the
+// caller's existing environment minus any deterministic keys, plus
+// the Cargo's overrides (CargoHome, Deterministic toggles, ExtraEnv).
+// Keys are emitted in sorted order for byte-stable testability.
+func (c *Cargo) Env(base []string) []string {
+	overrides := map[string]string{}
+	if c.Deterministic {
+		overrides["SOURCE_DATE_EPOCH"] = "0"
+		overrides["CARGO_TERM_COLOR"] = "never"
+		overrides["RUSTC_BOOTSTRAP"] = "0"
+	}
+	if c.CargoHome != "" {
+		overrides["CARGO_HOME"] = c.CargoHome
+	}
+	for k, v := range c.ExtraEnv {
+		overrides[k] = v
+	}
+	merged := map[string]string{}
+	for _, kv := range base {
+		eq := strings.IndexByte(kv, '=')
+		if eq <= 0 {
+			continue
+		}
+		merged[kv[:eq]] = kv[eq+1:]
+	}
+	for k, v := range overrides {
+		merged[k] = v
+	}
+	keys := make([]string, 0, len(merged))
+	for k := range merged {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, k+"="+merged[k])
+	}
+	return out
+}
+
+// Build runs `cargo build` under the supplied options. The cargo
+// binary is resolved via Cargo.Bin or "cargo" on PATH; the process
+// environment is the result of Cargo.Env on os.Environ().
+//
+// Build returns an error if the cargo binary cannot be located, if
+// the process exits non-zero, or if the supplied context cancels.
+func (c *Cargo) Build(ctx context.Context, opts BuildOptions) error {
+	if opts.WorkspaceRoot == "" {
+		return errors.New("cargo: empty WorkspaceRoot")
+	}
+	args := c.ArgsBuild(opts)
+	if len(args) == 0 {
+		return errors.New("cargo: empty argv")
+	}
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Env = c.Env(os.Environ())
+	if c.Stdout != nil {
+		cmd.Stdout = c.Stdout
+	}
+	if c.Stderr != nil {
+		cmd.Stderr = c.Stderr
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("cargo build: %w", err)
+	}
+	return nil
+}
+
+// LookCargo resolves the cargo binary on PATH. It returns the
+// absolute path if found, the empty string and a non-nil error
+// otherwise. Use this from the driver layer to fail fast with a
+// useful diagnostic instead of letting exec emit a generic ENOENT.
+func LookCargo() (string, error) {
+	path, err := exec.LookPath("cargo")
+	if err != nil {
+		return "", fmt.Errorf("cargo not on PATH: %w", err)
+	}
+	return path, nil
+}
+
+// captureBuf is a tiny helper bridging io.Writer to a *bytes.Buffer
+// without importing bytes in callers; surfaced so tests can request a
+// buffer-backed Cargo without juggling imports.
+func newCaptureBuf() *bytes.Buffer { return &bytes.Buffer{} }

--- a/package3/rust/build/cargo_test.go
+++ b/package3/rust/build/cargo_test.go
@@ -1,0 +1,221 @@
+package build
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+var osStat = os.Stat
+
+func TestCargoArgsBuildDefaults(t *testing.T) {
+	c := &Cargo{}
+	args := c.ArgsBuild(BuildOptions{WorkspaceRoot: "/tmp/ws"})
+	want := []string{"cargo", "build", "--profile", "release", "--manifest-path", "/tmp/ws/Cargo.toml"}
+	if !equalSlices(args, want) {
+		t.Errorf("ArgsBuild = %v; want %v", args, want)
+	}
+}
+
+func TestCargoArgsBuildVerboseOffline(t *testing.T) {
+	c := &Cargo{Verbose: true, Offline: true}
+	args := c.ArgsBuild(BuildOptions{WorkspaceRoot: "/tmp/ws", Profile: "dev"})
+	want := []string{"cargo", "build", "--verbose", "--offline", "--profile", "dev", "--manifest-path", "/tmp/ws/Cargo.toml"}
+	if !equalSlices(args, want) {
+		t.Errorf("ArgsBuild = %v; want %v", args, want)
+	}
+}
+
+func TestCargoArgsBuildFrozenLocked(t *testing.T) {
+	c := &Cargo{Frozen: true, Locked: true}
+	args := c.ArgsBuild(BuildOptions{WorkspaceRoot: "/x", Profile: "release"})
+	wantContains := []string{"--frozen", "--locked"}
+	for _, w := range wantContains {
+		if !containsString(args, w) {
+			t.Errorf("ArgsBuild missing %q in %v", w, args)
+		}
+	}
+}
+
+func TestCargoArgsBuildPackage(t *testing.T) {
+	c := &Cargo{}
+	args := c.ArgsBuild(BuildOptions{WorkspaceRoot: "/ws", Package: "mochi_wrap_hex"})
+	if !containsString(args, "--package") || !containsString(args, "mochi_wrap_hex") {
+		t.Errorf("ArgsBuild missing --package mochi_wrap_hex: %v", args)
+	}
+}
+
+func TestCargoArgsBuildTarget(t *testing.T) {
+	c := &Cargo{}
+	args := c.ArgsBuild(BuildOptions{WorkspaceRoot: "/ws", Target: "x86_64-unknown-linux-musl"})
+	if !containsString(args, "--target") || !containsString(args, "x86_64-unknown-linux-musl") {
+		t.Errorf("ArgsBuild missing --target x86_64-unknown-linux-musl: %v", args)
+	}
+}
+
+func TestCargoArgsBuildJobs(t *testing.T) {
+	c := &Cargo{}
+	args := c.ArgsBuild(BuildOptions{WorkspaceRoot: "/ws", Jobs: 4})
+	if !containsString(args, "--jobs") || !containsString(args, "4") {
+		t.Errorf("ArgsBuild missing --jobs 4: %v", args)
+	}
+}
+
+func TestCargoArgsBuildCustomBin(t *testing.T) {
+	c := &Cargo{Bin: "/opt/rust/bin/cargo"}
+	args := c.ArgsBuild(BuildOptions{WorkspaceRoot: "/ws"})
+	if args[0] != "/opt/rust/bin/cargo" {
+		t.Errorf("argv[0] = %q; want /opt/rust/bin/cargo", args[0])
+	}
+}
+
+func TestCargoArgsBuildOmitManifestPathWhenEmpty(t *testing.T) {
+	c := &Cargo{}
+	args := c.ArgsBuild(BuildOptions{})
+	if containsString(args, "--manifest-path") {
+		t.Errorf("ArgsBuild emitted --manifest-path with empty WorkspaceRoot: %v", args)
+	}
+}
+
+func TestCargoEnvDeterministic(t *testing.T) {
+	c := &Cargo{Deterministic: true}
+	env := c.Env([]string{"PATH=/usr/bin", "HOME=/home/u"})
+	want := []string{
+		"CARGO_TERM_COLOR=never",
+		"HOME=/home/u",
+		"PATH=/usr/bin",
+		"RUSTC_BOOTSTRAP=0",
+		"SOURCE_DATE_EPOCH=0",
+	}
+	if !equalSlices(env, want) {
+		t.Errorf("Env = %v; want %v", env, want)
+	}
+}
+
+func TestCargoEnvCargoHome(t *testing.T) {
+	c := &Cargo{CargoHome: "/cache/cargo"}
+	env := c.Env([]string{"PATH=/x"})
+	if !containsString(env, "CARGO_HOME=/cache/cargo") {
+		t.Errorf("Env missing CARGO_HOME: %v", env)
+	}
+}
+
+func TestCargoEnvOverridesInherited(t *testing.T) {
+	c := &Cargo{ExtraEnv: map[string]string{"PATH": "/override"}}
+	env := c.Env([]string{"PATH=/inherited", "OTHER=x"})
+	if !containsString(env, "PATH=/override") {
+		t.Errorf("ExtraEnv did not override PATH: %v", env)
+	}
+	if containsString(env, "PATH=/inherited") {
+		t.Errorf("inherited PATH survived override: %v", env)
+	}
+}
+
+func TestCargoEnvSortedDeterministic(t *testing.T) {
+	c := &Cargo{ExtraEnv: map[string]string{"Z": "1", "A": "2", "M": "3"}}
+	env := c.Env(nil)
+	want := []string{"A=2", "M=3", "Z=1"}
+	if !equalSlices(env, want) {
+		t.Errorf("Env not sorted: %v; want %v", env, want)
+	}
+}
+
+func TestCargoEnvSkipsMalformed(t *testing.T) {
+	c := &Cargo{}
+	env := c.Env([]string{"=NOVAR", "BAD"})
+	if len(env) != 0 {
+		t.Errorf("Env = %v; want empty (malformed entries should be skipped)", env)
+	}
+}
+
+func TestCargoBuildRejectsEmptyRoot(t *testing.T) {
+	c := &Cargo{}
+	err := c.Build(context.Background(), BuildOptions{})
+	if err == nil || !strings.Contains(err.Error(), "empty WorkspaceRoot") {
+		t.Errorf("Build with empty WorkspaceRoot: err = %v; want 'empty WorkspaceRoot'", err)
+	}
+}
+
+func TestCargoBuildEchoSucceeds(t *testing.T) {
+	// Use a portable no-op binary to verify that argv composition,
+	// env composition, and exec.CommandContext wiring work end-to-end
+	// without depending on cargo or rustc being on PATH.
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping true test on windows")
+	}
+	bin := pickBin("true")
+	if bin == "" {
+		t.Skip("no true binary on PATH")
+	}
+	out := &bytes.Buffer{}
+	c := &Cargo{Bin: bin, Stdout: out, Stderr: out}
+	if err := c.Build(context.Background(), BuildOptions{WorkspaceRoot: "/tmp/ws"}); err != nil {
+		t.Fatalf("Build via %s: %v", bin, err)
+	}
+}
+
+func TestCargoBuildPropagatesContextCancellation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping sleep test on windows")
+	}
+	bin := pickBin("sleep")
+	if bin == "" {
+		t.Skip("no sleep binary on PATH")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	c := &Cargo{Bin: bin}
+	err := c.Build(ctx, BuildOptions{WorkspaceRoot: "/tmp/ws"})
+	if err == nil {
+		t.Errorf("Build with cancelled context did not error")
+	}
+}
+
+func pickBin(name string) string {
+	for _, p := range []string{"/usr/bin/" + name, "/bin/" + name} {
+		if _, err := osStat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+func TestLookCargoReturnsString(t *testing.T) {
+	// We don't assert presence, only that the function returns
+	// something coherent: either a path with no error, or a clear
+	// error.
+	path, err := LookCargo()
+	if err != nil && path != "" {
+		t.Errorf("LookCargo: err non-nil but path %q non-empty", path)
+	}
+	if err == nil && path == "" {
+		t.Errorf("LookCargo: nil error but empty path")
+	}
+}
+
+func TestNewCaptureBufIsResettable(t *testing.T) {
+	b := newCaptureBuf()
+	if b == nil {
+		t.Fatalf("newCaptureBuf returned nil")
+	}
+	b.WriteString("x")
+	if b.Len() != 1 {
+		t.Errorf("len = %d; want 1", b.Len())
+	}
+	b.Reset()
+	if b.Len() != 0 {
+		t.Errorf("len after reset = %d; want 0", b.Len())
+	}
+}
+
+func containsString(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/package3/rust/build/phase07_test.go
+++ b/package3/rust/build/phase07_test.go
@@ -1,0 +1,141 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPhase07Orchestration is the per-phase sentinel test. The CI
+// gate for phase 7 LANDED requires this test to pass on every
+// supported host without a rust toolchain.
+//
+// Sub-tests:
+//   - end_to_end: ImportRef --[SurfaceProvider+wrapper+emit]-->
+//     on-disk workspace populated with the wrapper crate (Cargo.toml
+//     + src/lib.rs + SKIPPED.txt) plus the Mochi-side shim files
+//     (<crate>_extern.mochi + <crate>.mochi) plus the workspace root
+//     Cargo.toml.
+//   - argv_shape: Cargo.ArgsBuild is a pure function of (Cargo,
+//     BuildOptions) and produces the canonical `cargo build
+//     --profile release --manifest-path <root>/Cargo.toml` argv.
+//   - env_shape: Cargo.Env applies the deterministic-build keys on
+//     top of the inherited environment with stable lexicographic
+//     ordering for cache-key reproducibility.
+//   - members_sorted: the resolved Workspace lists members in
+//     alphabetical path order regardless of input ref order.
+func TestPhase07Orchestration(t *testing.T) {
+	t.Run("end_to_end", func(t *testing.T) {
+		d := NewDriver(Options{NoCache: true})
+		defer d.Cleanup()
+		if _, err := d.PrepareWorkspace(); err != nil {
+			t.Fatalf("PrepareWorkspace: %v", err)
+		}
+		p := &Pipeline{Driver: d, Provider: newHexProvider()}
+		res, err := p.Resolve([]ImportRef{{Crate: "hex", Version: "0.4.3", Alias: "hex"}})
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		root, err := p.MaterialiseWorkspace(res)
+		if err != nil {
+			t.Fatalf("MaterialiseWorkspace: %v", err)
+		}
+		for _, rel := range []string{
+			"Cargo.toml",
+			".gitignore",
+			"rust_wrap/hex/Cargo.toml",
+			"rust_wrap/hex/src/lib.rs",
+			"rust_wrap/hex/SKIPPED.txt",
+			"mochi/hex_extern.mochi",
+			"mochi/hex.mochi",
+		} {
+			if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(rel))); err != nil {
+				t.Errorf("missing %s: %v", rel, err)
+			}
+		}
+		// Spot-check the workspace root pins the upstream version.
+		root_cargo, err := os.ReadFile(filepath.Join(root, "Cargo.toml"))
+		if err != nil {
+			t.Fatalf("read root Cargo.toml: %v", err)
+		}
+		for _, want := range []string{
+			`"rust_wrap/hex"`,
+			`hex = "=0.4.3"`,
+			"[profile.release]",
+			`panic = "abort"`,
+		} {
+			if !strings.Contains(string(root_cargo), want) {
+				t.Errorf("root Cargo.toml missing %q\n%s", want, root_cargo)
+			}
+		}
+	})
+
+	t.Run("argv_shape", func(t *testing.T) {
+		c := &Cargo{Verbose: true, Offline: true, Locked: true}
+		args := c.ArgsBuild(BuildOptions{
+			WorkspaceRoot: "/tmp/ws",
+			Profile:       "release",
+		})
+		want := []string{
+			"cargo", "build", "--verbose", "--offline", "--locked",
+			"--profile", "release",
+			"--manifest-path", "/tmp/ws/Cargo.toml",
+		}
+		if !equalSlices(args, want) {
+			t.Errorf("ArgsBuild = %v\n   want %v", args, want)
+		}
+	})
+
+	t.Run("env_shape", func(t *testing.T) {
+		c := &Cargo{
+			Deterministic: true,
+			CargoHome:     "/cache/cargo",
+			ExtraEnv:      map[string]string{"RUSTFLAGS": "-D warnings"},
+		}
+		env := c.Env([]string{"PATH=/usr/bin", "HOME=/home/u"})
+		want := []string{
+			"CARGO_HOME=/cache/cargo",
+			"CARGO_TERM_COLOR=never",
+			"HOME=/home/u",
+			"PATH=/usr/bin",
+			"RUSTC_BOOTSTRAP=0",
+			"RUSTFLAGS=-D warnings",
+			"SOURCE_DATE_EPOCH=0",
+		}
+		if !equalSlices(env, want) {
+			t.Errorf("Env = %v\n  want %v", env, want)
+		}
+	})
+
+	t.Run("members_sorted", func(t *testing.T) {
+		d := NewDriver(Options{NoCache: true})
+		defer d.Cleanup()
+		p := &Pipeline{
+			Driver: d,
+			Provider: staticProvider{
+				"hex@0.4.3":     hexLikeSurface(),
+				"anyhow@1.0.86": emptySurface("anyhow", "1.0.86"),
+				"serde@1.0.150": emptySurface("serde", "1.0.150"),
+			},
+		}
+		// Refs presented in mixed order; expect the resolved Workspace
+		// to list members alphabetically by path.
+		res, err := p.Resolve([]ImportRef{
+			{Crate: "hex", Version: "0.4.3"},
+			{Crate: "anyhow", Version: "1.0.86"},
+			{Crate: "serde", Version: "1.0.150"},
+		})
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		got := make([]string, len(res.Workspace.Members))
+		for i, m := range res.Workspace.Members {
+			got[i] = m.Path
+		}
+		want := []string{"rust_wrap/anyhow", "rust_wrap/hex", "rust_wrap/serde"}
+		if !equalSlices(got, want) {
+			t.Errorf("Members paths = %v; want %v", got, want)
+		}
+	})
+}

--- a/package3/rust/build/pipeline.go
+++ b/package3/rust/build/pipeline.go
@@ -1,0 +1,260 @@
+package build
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"mochi/package3/rust/emit"
+	"mochi/package3/rust/rustdoc"
+	"mochi/package3/rust/wrapper"
+)
+
+// ImportRef is one resolved `import rust "<crate>@<version>" as <alias>`
+// statement from the user program. The Alias is the binding name the
+// user introduced; the bridge does not consult it during synthesis but
+// stores it so later code generation can map back from a Mochi call
+// site to the wrapper's emitted shim file.
+type ImportRef struct {
+	Crate   string
+	Version string
+	Alias   string
+}
+
+// ImportRefError signals a structurally invalid ImportRef (empty crate
+// or version). It is returned by Pipeline.Resolve at the start of a
+// run so the caller can fail fast.
+type ImportRefError struct {
+	Ref    ImportRef
+	Reason string
+}
+
+func (e *ImportRefError) Error() string {
+	return fmt.Sprintf("invalid import rust ref {crate=%q version=%q alias=%q}: %s",
+		e.Ref.Crate, e.Ref.Version, e.Ref.Alias, e.Reason)
+}
+
+// SurfaceProvider resolves a (crate, version) pair to a phase-2
+// ApiSurface. Phase 7 is content-agnostic about how the surface comes
+// to exist: a production driver wires this to the rustdoc-JSON
+// ingest, but tests and the embedded fixture corpus inject precanned
+// surfaces directly. The provider is consulted once per ImportRef in
+// the order the refs are supplied.
+type SurfaceProvider interface {
+	Surface(crate, version string) (*rustdoc.ApiSurface, error)
+}
+
+// SurfaceProviderFunc adapts a plain function to the SurfaceProvider
+// interface. Useful for tests and one-shot in-memory providers.
+type SurfaceProviderFunc func(crate, version string) (*rustdoc.ApiSurface, error)
+
+// Surface dispatches to the underlying function.
+func (f SurfaceProviderFunc) Surface(crate, version string) (*rustdoc.ApiSurface, error) {
+	return f(crate, version)
+}
+
+// ResolvedCrate is the result of running one ImportRef through the
+// pipeline: the synthesised wrapper crate plus the Mochi-side extern
+// + alias emit. It carries enough state for the caller to either
+// materialise the files directly or to consult the in-memory bundle
+// (the lockfile integration in phase 8 will need both).
+type ResolvedCrate struct {
+	Ref     ImportRef
+	Crate   *wrapper.Crate
+	Mochi   emit.Files
+	// MemberPath is the workspace-root-relative path the wrapper
+	// crate is materialised under, e.g. "rust_wrap/hex".
+	MemberPath string
+}
+
+// PipelineResult is the bundle returned by Pipeline.Resolve. The
+// Workspace already has every wrapper registered as a member and
+// every upstream crate registered under [workspace.dependencies].
+type PipelineResult struct {
+	Workspace *Workspace
+	Resolved  []ResolvedCrate
+}
+
+// Pipeline drives the end-to-end MEP-73 bridge synthesis:
+//
+//	import rust refs --[SurfaceProvider]--> rustdoc.ApiSurface
+//	  --[wrapper.Synth]--> *wrapper.Crate
+//	    --[wrapper.EmitLibRS / EmitCargoTOML / EmitSkippedTXT]--> Rust files
+//	    --[emit.Emit]--> Mochi extern + alias files
+//	  --[Workspace.AddMember / AddSharedDep]--> workspace registration
+//
+// The pipeline is stateless: each Resolve call produces a fresh
+// PipelineResult. MaterialiseWorkspace is an idempotent on-disk
+// projection of a PipelineResult.
+type Pipeline struct {
+	Driver   *Driver
+	Provider SurfaceProvider
+}
+
+// Resolve runs each ImportRef through the synthesis pipeline. Refs
+// are processed in input order; their wrappers register under their
+// canonical "rust_wrap/<crate>" path so duplicate refs collapse
+// deterministically.
+//
+// Resolve does NOT touch the filesystem. Callers wanting on-disk
+// artefacts call MaterialiseWorkspace next.
+func (p *Pipeline) Resolve(refs []ImportRef) (*PipelineResult, error) {
+	if p == nil {
+		return nil, errors.New("pipeline: nil receiver")
+	}
+	if p.Provider == nil {
+		return nil, errors.New("pipeline: no SurfaceProvider configured")
+	}
+	w := DefaultWorkspace()
+	seen := map[string]struct{}{}
+	out := make([]ResolvedCrate, 0, len(refs))
+	for _, ref := range refs {
+		if err := validateRef(ref); err != nil {
+			return nil, err
+		}
+		key := ref.Crate + "@" + ref.Version
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		surface, err := p.Provider.Surface(ref.Crate, ref.Version)
+		if err != nil {
+			return nil, fmt.Errorf("pipeline: surface for %s: %w", key, err)
+		}
+		if surface == nil {
+			return nil, fmt.Errorf("pipeline: surface for %s: provider returned nil surface", key)
+		}
+		c := wrapper.Synth(ref.Crate, ref.Version, surface)
+		files := emit.Emit(c)
+		memberPath := "rust_wrap/" + sanitisePathSegment(ref.Crate)
+		w.AddMember(WorkspaceMember{
+			Name: c.Name,
+			Path: memberPath,
+			Kind: MemberWrapper,
+		})
+		w.AddSharedDep(ref.Crate, "="+ref.Version)
+		out = append(out, ResolvedCrate{
+			Ref:        ref,
+			Crate:      c,
+			Mochi:      files,
+			MemberPath: memberPath,
+		})
+	}
+	// Order resolved entries by member path so the result is byte-stable
+	// against arbitrary input permutations of an otherwise-identical
+	// dependency set.
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].MemberPath < out[j].MemberPath
+	})
+	return &PipelineResult{Workspace: w, Resolved: out}, nil
+}
+
+// MaterialiseWorkspace projects a PipelineResult onto disk under the
+// Driver's work-dir. The directory layout matches MEP-73 spec §6:
+//
+//	<workdir>/rust_workspace/
+//	  Cargo.toml                       # workspace root manifest
+//	  .gitignore
+//	  rust_wrap/<crate>/
+//	    Cargo.toml                     # wrapper.EmitCargoTOML
+//	    src/lib.rs                     # wrapper.EmitLibRS
+//	    SKIPPED.txt                    # wrapper.EmitSkippedTXT
+//	  mochi/
+//	    <crate>_extern.mochi           # emit.Files.ExternMochi
+//	    <crate>.mochi                  # emit.Files.AliasMochi
+//
+// The function is idempotent: re-running it with the same result
+// rewrites identical bytes to the same paths.
+//
+// The Driver MUST have had PrepareWorkspace called first.
+func (p *Pipeline) MaterialiseWorkspace(result *PipelineResult) (string, error) {
+	if p == nil || p.Driver == nil {
+		return "", errors.New("pipeline: nil pipeline or driver")
+	}
+	if result == nil {
+		return "", errors.New("pipeline: nil PipelineResult")
+	}
+	root, err := p.Driver.WriteWorkspaceRoot(result.Workspace)
+	if err != nil {
+		return "", err
+	}
+	for _, rc := range result.Resolved {
+		wrapDir := filepath.Join(root, filepath.FromSlash(rc.MemberPath))
+		srcDir := filepath.Join(wrapDir, "src")
+		if err := os.MkdirAll(srcDir, 0o755); err != nil {
+			return "", fmt.Errorf("pipeline: mkdir %s: %w", srcDir, err)
+		}
+		write := func(rel, body string) error {
+			path := filepath.Join(wrapDir, filepath.FromSlash(rel))
+			return os.WriteFile(path, []byte(body), 0o644)
+		}
+		if err := write("Cargo.toml", wrapper.EmitCargoTOML(rc.Crate)); err != nil {
+			return "", err
+		}
+		if err := write("src/lib.rs", wrapper.EmitLibRS(rc.Crate)); err != nil {
+			return "", err
+		}
+		if err := write("SKIPPED.txt", wrapper.EmitSkippedTXT(rc.Crate)); err != nil {
+			return "", err
+		}
+	}
+	mochiDir := filepath.Join(root, "mochi")
+	if len(result.Resolved) > 0 {
+		if err := os.MkdirAll(mochiDir, 0o755); err != nil {
+			return "", fmt.Errorf("pipeline: mkdir %s: %w", mochiDir, err)
+		}
+	}
+	for _, rc := range result.Resolved {
+		stem := sanitisePathSegment(rc.Ref.Crate)
+		externPath := filepath.Join(mochiDir, stem+"_extern.mochi")
+		aliasPath := filepath.Join(mochiDir, stem+".mochi")
+		if err := os.WriteFile(externPath, []byte(rc.Mochi.ExternMochi), 0o644); err != nil {
+			return "", fmt.Errorf("pipeline: write %s: %w", externPath, err)
+		}
+		if err := os.WriteFile(aliasPath, []byte(rc.Mochi.AliasMochi), 0o644); err != nil {
+			return "", fmt.Errorf("pipeline: write %s: %w", aliasPath, err)
+		}
+	}
+	return root, nil
+}
+
+func validateRef(ref ImportRef) error {
+	if ref.Crate == "" {
+		return &ImportRefError{Ref: ref, Reason: "empty crate"}
+	}
+	if ref.Version == "" {
+		return &ImportRefError{Ref: ref, Reason: "empty version"}
+	}
+	return nil
+}
+
+// sanitisePathSegment lower-cases and replaces non-portable bytes
+// with '_' so each crate's wrapper directory is a safe filesystem
+// path. The bridge already enforces a Cargo-conservative crate-name
+// shape upstream (lowercase + digits + '_' / '-' / leading letter)
+// in the parser, so the transformation here is a defence-in-depth
+// projection.
+func sanitisePathSegment(s string) string {
+	if s == "" {
+		return ""
+	}
+	b := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '_', c == '-':
+			b = append(b, c)
+		case c >= 'A' && c <= 'Z':
+			b = append(b, c-'A'+'a')
+		default:
+			b = append(b, '_')
+		}
+	}
+	out := string(b)
+	out = strings.TrimRight(out, "/")
+	return out
+}

--- a/package3/rust/build/pipeline_test.go
+++ b/package3/rust/build/pipeline_test.go
@@ -1,0 +1,486 @@
+package build
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	rerr "mochi/package3/rust/errors"
+	"mochi/package3/rust/rustdoc"
+)
+
+// hexLikeSurface mirrors the wrapper-package fixture: the hex crate's
+// three public functions plus one phase-2 SkipReport. We re-declare
+// the fixture here so the build package does not take a test-only
+// dependency on the wrapper package's _test sources.
+func hexLikeSurface() *rustdoc.ApiSurface {
+	str := rustdoc.Type{Primitive: "str"}
+	u8 := rustdoc.Type{Primitive: "u8"}
+	char := rustdoc.Type{Primitive: "char"}
+	bytesSlice := rustdoc.Type{BorrowedRef: &rustdoc.BorrowedRefType{
+		Lifetime: "'a",
+		Type:     rustdoc.Type{Slice: &u8},
+	}}
+	strBorrow := rustdoc.Type{BorrowedRef: &rustdoc.BorrowedRefType{
+		Lifetime: "'a",
+		Type:     str,
+	}}
+	stringPath := rustdoc.Type{ResolvedPath: &rustdoc.PathType{
+		ID: "id:String", Path: "std::string::String",
+	}}
+	vecU8 := rustdoc.Type{ResolvedPath: &rustdoc.PathType{
+		ID: "id:Vec_u8", Path: "std::vec::Vec",
+		Args: &rustdoc.GenericArgs{AngleBracketed: &rustdoc.AngleBracketedArgs{
+			Args: []rustdoc.GenericArg{{Type: &u8}},
+		}},
+	}}
+	fromHexError := rustdoc.Type{ResolvedPath: &rustdoc.PathType{
+		ID: "id:FromHexError", Path: "hex::FromHexError",
+	}}
+	resultVecU8 := rustdoc.Type{ResolvedPath: &rustdoc.PathType{
+		ID: "id:Result", Path: "core::result::Result",
+		Args: &rustdoc.GenericArgs{AngleBracketed: &rustdoc.AngleBracketedArgs{
+			Args: []rustdoc.GenericArg{{Type: &vecU8}, {Type: &fromHexError}},
+		}},
+	}}
+	return &rustdoc.ApiSurface{
+		CrateName:    "hex",
+		CrateVersion: "0.4.3",
+		Functions: []rustdoc.FunctionEntry{
+			{
+				ID:   "fn:encode",
+				Path: []string{"hex", "encode"},
+				Inputs: []rustdoc.ParamEntry{
+					{Name: "data", Type: bytesSlice},
+				},
+				Output: &stringPath,
+			},
+			{
+				ID:   "fn:decode",
+				Path: []string{"hex", "decode"},
+				Inputs: []rustdoc.ParamEntry{
+					{Name: "input", Type: strBorrow},
+				},
+				Output: &resultVecU8,
+			},
+			{
+				ID:   "fn:to_upper_hex",
+				Path: []string{"hex", "to_upper_hex"},
+				Inputs: []rustdoc.ParamEntry{
+					{Name: "value", Type: u8},
+				},
+				Output: &char,
+			},
+		},
+		Skipped: []rerr.SkipReport{
+			{
+				ItemPath: "hex::decode_to_slice",
+				Reason:   rerr.SkipGeneric,
+				Detail:   "generic parameter T",
+			},
+		},
+	}
+}
+
+// staticProvider serves canned surfaces by (crate, version) key.
+type staticProvider map[string]*rustdoc.ApiSurface
+
+func (s staticProvider) Surface(crate, version string) (*rustdoc.ApiSurface, error) {
+	if s == nil {
+		return nil, errors.New("nil provider")
+	}
+	key := crate + "@" + version
+	surf, ok := s[key]
+	if !ok {
+		return nil, fmt.Errorf("no fixture for %s", key)
+	}
+	return surf, nil
+}
+
+func newHexProvider() staticProvider {
+	return staticProvider{"hex@0.4.3": hexLikeSurface()}
+}
+
+func newPipeline(t *testing.T) *Pipeline {
+	t.Helper()
+	d := NewDriver(Options{NoCache: true})
+	t.Cleanup(func() { _ = d.Cleanup() })
+	return &Pipeline{Driver: d, Provider: newHexProvider()}
+}
+
+func TestPipelineResolveBasic(t *testing.T) {
+	p := newPipeline(t)
+	res, err := p.Resolve([]ImportRef{{Crate: "hex", Version: "0.4.3", Alias: "hex"}})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := len(res.Resolved); got != 1 {
+		t.Fatalf("Resolved count = %d; want 1", got)
+	}
+	rc := res.Resolved[0]
+	if rc.Crate.Name != "mochi_wrap_hex" {
+		t.Errorf("Crate.Name = %q; want mochi_wrap_hex", rc.Crate.Name)
+	}
+	if rc.MemberPath != "rust_wrap/hex" {
+		t.Errorf("MemberPath = %q; want rust_wrap/hex", rc.MemberPath)
+	}
+	if rc.Mochi.ExternMochi == "" || rc.Mochi.AliasMochi == "" {
+		t.Errorf("Mochi files empty: %+v", rc.Mochi)
+	}
+}
+
+func TestPipelineResolveRegistersMember(t *testing.T) {
+	p := newPipeline(t)
+	res, err := p.Resolve([]ImportRef{{Crate: "hex", Version: "0.4.3", Alias: "hex"}})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(res.Workspace.Members) != 1 {
+		t.Fatalf("Members = %d; want 1", len(res.Workspace.Members))
+	}
+	m := res.Workspace.Members[0]
+	if m.Name != "mochi_wrap_hex" || m.Path != "rust_wrap/hex" || m.Kind != MemberWrapper {
+		t.Errorf("Member = %+v; want {mochi_wrap_hex, rust_wrap/hex, MemberWrapper}", m)
+	}
+}
+
+func TestPipelineResolveRegistersSharedDep(t *testing.T) {
+	p := newPipeline(t)
+	res, err := p.Resolve([]ImportRef{{Crate: "hex", Version: "0.4.3", Alias: "hex"}})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	got, ok := res.Workspace.SharedDependencies["hex"]
+	if !ok {
+		t.Fatalf("SharedDependencies missing hex: %+v", res.Workspace.SharedDependencies)
+	}
+	if got != "=0.4.3" {
+		t.Errorf("SharedDependencies[hex] = %q; want =0.4.3", got)
+	}
+}
+
+func TestPipelineResolveDeduplicates(t *testing.T) {
+	p := newPipeline(t)
+	res, err := p.Resolve([]ImportRef{
+		{Crate: "hex", Version: "0.4.3", Alias: "hex"},
+		{Crate: "hex", Version: "0.4.3", Alias: "hex2"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := len(res.Resolved); got != 1 {
+		t.Errorf("duplicate refs produced %d resolved entries; want 1", got)
+	}
+}
+
+func TestPipelineResolveDeterministicOrder(t *testing.T) {
+	provider := staticProvider{
+		"hex@0.4.3":     hexLikeSurface(),
+		"anyhow@1.0.86": emptySurface("anyhow", "1.0.86"),
+	}
+	mkPipeline := func() *Pipeline {
+		d := NewDriver(Options{NoCache: true})
+		t.Cleanup(func() { _ = d.Cleanup() })
+		return &Pipeline{Driver: d, Provider: provider}
+	}
+	p1 := mkPipeline()
+	p2 := mkPipeline()
+	res1, err := p1.Resolve([]ImportRef{
+		{Crate: "hex", Version: "0.4.3"},
+		{Crate: "anyhow", Version: "1.0.86"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve 1: %v", err)
+	}
+	res2, err := p2.Resolve([]ImportRef{
+		{Crate: "anyhow", Version: "1.0.86"},
+		{Crate: "hex", Version: "0.4.3"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve 2: %v", err)
+	}
+	paths := func(rs []ResolvedCrate) []string {
+		out := make([]string, len(rs))
+		for i, r := range rs {
+			out[i] = r.MemberPath
+		}
+		return out
+	}
+	gotA := paths(res1.Resolved)
+	gotB := paths(res2.Resolved)
+	want := []string{"rust_wrap/anyhow", "rust_wrap/hex"}
+	if !equalSlices(gotA, want) || !equalSlices(gotB, want) {
+		t.Errorf("non-deterministic order: gotA=%v gotB=%v want=%v", gotA, gotB, want)
+	}
+}
+
+func emptySurface(name, version string) *rustdoc.ApiSurface {
+	return &rustdoc.ApiSurface{CrateName: name, CrateVersion: version}
+}
+
+func TestPipelineResolveRejectsEmptyCrate(t *testing.T) {
+	p := newPipeline(t)
+	_, err := p.Resolve([]ImportRef{{Crate: "", Version: "1.0"}})
+	var refErr *ImportRefError
+	if !errors.As(err, &refErr) {
+		t.Fatalf("err = %v; want *ImportRefError", err)
+	}
+}
+
+func TestPipelineResolveRejectsEmptyVersion(t *testing.T) {
+	p := newPipeline(t)
+	_, err := p.Resolve([]ImportRef{{Crate: "hex", Version: ""}})
+	var refErr *ImportRefError
+	if !errors.As(err, &refErr) {
+		t.Fatalf("err = %v; want *ImportRefError", err)
+	}
+}
+
+func TestPipelineResolveBubblesProviderError(t *testing.T) {
+	p := &Pipeline{
+		Driver:   NewDriver(Options{NoCache: true}),
+		Provider: SurfaceProviderFunc(func(crate, version string) (*rustdoc.ApiSurface, error) {
+			return nil, errors.New("boom")
+		}),
+	}
+	t.Cleanup(func() { _ = p.Driver.Cleanup() })
+	_, err := p.Resolve([]ImportRef{{Crate: "hex", Version: "0.4.3"}})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("err = %v; want wrap of 'boom'", err)
+	}
+}
+
+func TestPipelineResolveRejectsNilSurface(t *testing.T) {
+	p := &Pipeline{
+		Driver:   NewDriver(Options{NoCache: true}),
+		Provider: SurfaceProviderFunc(func(crate, version string) (*rustdoc.ApiSurface, error) {
+			return nil, nil
+		}),
+	}
+	t.Cleanup(func() { _ = p.Driver.Cleanup() })
+	_, err := p.Resolve([]ImportRef{{Crate: "hex", Version: "0.4.3"}})
+	if err == nil || !strings.Contains(err.Error(), "nil surface") {
+		t.Fatalf("err = %v; want 'nil surface' message", err)
+	}
+}
+
+func TestPipelineResolveRejectsNilProvider(t *testing.T) {
+	p := &Pipeline{Driver: NewDriver(Options{NoCache: true})}
+	t.Cleanup(func() { _ = p.Driver.Cleanup() })
+	_, err := p.Resolve(nil)
+	if err == nil || !strings.Contains(err.Error(), "SurfaceProvider") {
+		t.Fatalf("err = %v; want 'SurfaceProvider' message", err)
+	}
+}
+
+func TestPipelineResolveRejectsNilReceiver(t *testing.T) {
+	var p *Pipeline
+	_, err := p.Resolve(nil)
+	if err == nil {
+		t.Fatalf("nil receiver Resolve did not error")
+	}
+}
+
+func TestMaterialiseWorkspaceWritesAllFiles(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	defer d.Cleanup()
+	if _, err := d.PrepareWorkspace(); err != nil {
+		t.Fatalf("PrepareWorkspace: %v", err)
+	}
+	p := &Pipeline{Driver: d, Provider: newHexProvider()}
+	res, err := p.Resolve([]ImportRef{{Crate: "hex", Version: "0.4.3", Alias: "hex"}})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	root, err := p.MaterialiseWorkspace(res)
+	if err != nil {
+		t.Fatalf("MaterialiseWorkspace: %v", err)
+	}
+	wantFiles := []string{
+		"Cargo.toml",
+		".gitignore",
+		"rust_wrap/hex/Cargo.toml",
+		"rust_wrap/hex/src/lib.rs",
+		"rust_wrap/hex/SKIPPED.txt",
+		"mochi/hex_extern.mochi",
+		"mochi/hex.mochi",
+	}
+	for _, rel := range wantFiles {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("missing %s: %v", rel, err)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("%s is zero bytes", rel)
+		}
+	}
+}
+
+func TestMaterialiseWorkspaceContentsAreFromEmitters(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	defer d.Cleanup()
+	if _, err := d.PrepareWorkspace(); err != nil {
+		t.Fatalf("PrepareWorkspace: %v", err)
+	}
+	p := &Pipeline{Driver: d, Provider: newHexProvider()}
+	res, err := p.Resolve([]ImportRef{{Crate: "hex", Version: "0.4.3", Alias: "hex"}})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	root, err := p.MaterialiseWorkspace(res)
+	if err != nil {
+		t.Fatalf("MaterialiseWorkspace: %v", err)
+	}
+	// Wrapper Cargo.toml pins upstream version
+	cargo, err := os.ReadFile(filepath.Join(root, "rust_wrap", "hex", "Cargo.toml"))
+	if err != nil {
+		t.Fatalf("read wrapper Cargo.toml: %v", err)
+	}
+	if !strings.Contains(string(cargo), `hex = "=0.4.3"`) {
+		t.Errorf("wrapper Cargo.toml missing hex = \"=0.4.3\"\n%s", cargo)
+	}
+	if !strings.Contains(string(cargo), `crate-type = ["cdylib", "rlib"]`) {
+		t.Errorf("wrapper Cargo.toml missing crate-type cdylib+rlib\n%s", cargo)
+	}
+	// Wrapper lib.rs carries the extern-C symbol
+	lib, err := os.ReadFile(filepath.Join(root, "rust_wrap", "hex", "src", "lib.rs"))
+	if err != nil {
+		t.Fatalf("read wrapper lib.rs: %v", err)
+	}
+	for _, want := range []string{
+		`pub unsafe extern "C" fn mochi_hex_encode`,
+		`pub unsafe extern "C" fn mochi_hex_decode`,
+		`pub unsafe extern "C" fn mochi_hex_to_upper_hex`,
+	} {
+		if !strings.Contains(string(lib), want) {
+			t.Errorf("lib.rs missing %q\n%s", want, lib)
+		}
+	}
+	// Mochi extern file carries the extern fun lines
+	ex, err := os.ReadFile(filepath.Join(root, "mochi", "hex_extern.mochi"))
+	if err != nil {
+		t.Fatalf("read hex_extern.mochi: %v", err)
+	}
+	if !strings.Contains(string(ex), "extern fun mochi_hex_encode") {
+		t.Errorf("hex_extern.mochi missing extern fun mochi_hex_encode\n%s", ex)
+	}
+	// Mochi alias file carries the short re-exports
+	al, err := os.ReadFile(filepath.Join(root, "mochi", "hex.mochi"))
+	if err != nil {
+		t.Fatalf("read hex.mochi: %v", err)
+	}
+	if !strings.Contains(string(al), "fun encode(") {
+		t.Errorf("hex.mochi missing fun encode(\n%s", al)
+	}
+	// Workspace root Cargo.toml lists the wrapper as a member
+	rootCargo, err := os.ReadFile(filepath.Join(root, "Cargo.toml"))
+	if err != nil {
+		t.Fatalf("read root Cargo.toml: %v", err)
+	}
+	if !strings.Contains(string(rootCargo), `"rust_wrap/hex"`) {
+		t.Errorf("workspace Cargo.toml missing member rust_wrap/hex\n%s", rootCargo)
+	}
+	if !strings.Contains(string(rootCargo), `hex = "=0.4.3"`) {
+		t.Errorf("workspace Cargo.toml missing shared dep hex = \"=0.4.3\"\n%s", rootCargo)
+	}
+}
+
+func TestMaterialiseWorkspaceIsIdempotent(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	defer d.Cleanup()
+	if _, err := d.PrepareWorkspace(); err != nil {
+		t.Fatalf("PrepareWorkspace: %v", err)
+	}
+	p := &Pipeline{Driver: d, Provider: newHexProvider()}
+	res, err := p.Resolve([]ImportRef{{Crate: "hex", Version: "0.4.3"}})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	root1, err := p.MaterialiseWorkspace(res)
+	if err != nil {
+		t.Fatalf("first MaterialiseWorkspace: %v", err)
+	}
+	first, err := os.ReadFile(filepath.Join(root1, "rust_wrap", "hex", "src", "lib.rs"))
+	if err != nil {
+		t.Fatalf("first lib.rs read: %v", err)
+	}
+	root2, err := p.MaterialiseWorkspace(res)
+	if err != nil {
+		t.Fatalf("second MaterialiseWorkspace: %v", err)
+	}
+	if root1 != root2 {
+		t.Errorf("MaterialiseWorkspace returned different roots: %q vs %q", root1, root2)
+	}
+	second, err := os.ReadFile(filepath.Join(root2, "rust_wrap", "hex", "src", "lib.rs"))
+	if err != nil {
+		t.Fatalf("second lib.rs read: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("MaterialiseWorkspace not idempotent: lib.rs differs across runs")
+	}
+}
+
+func TestMaterialiseWorkspaceRejectsNilResult(t *testing.T) {
+	p := &Pipeline{Driver: NewDriver(Options{NoCache: true})}
+	t.Cleanup(func() { _ = p.Driver.Cleanup() })
+	if _, err := p.MaterialiseWorkspace(nil); err == nil {
+		t.Errorf("MaterialiseWorkspace(nil) did not error")
+	}
+}
+
+func TestMaterialiseWorkspaceRejectsNilDriver(t *testing.T) {
+	p := &Pipeline{}
+	if _, err := p.MaterialiseWorkspace(&PipelineResult{Workspace: DefaultWorkspace()}); err == nil {
+		t.Errorf("MaterialiseWorkspace with nil Driver did not error")
+	}
+}
+
+func TestSanitisePathSegmentLowercases(t *testing.T) {
+	if got := sanitisePathSegment("FooBar"); got != "foobar" {
+		t.Errorf("FooBar = %q; want foobar", got)
+	}
+}
+
+func TestSanitisePathSegmentReplacesUnsafe(t *testing.T) {
+	if got := sanitisePathSegment("a/b"); got != "a_b" {
+		t.Errorf("a/b = %q; want a_b", got)
+	}
+}
+
+func TestSanitisePathSegmentPreservesHyphen(t *testing.T) {
+	if got := sanitisePathSegment("rand-chacha"); got != "rand-chacha" {
+		t.Errorf("rand-chacha = %q; want rand-chacha", got)
+	}
+}
+
+func TestImportRefErrorMessage(t *testing.T) {
+	err := &ImportRefError{
+		Ref:    ImportRef{Crate: "", Version: "1.0"},
+		Reason: "empty crate",
+	}
+	if got := err.Error(); !strings.Contains(got, "empty crate") || !strings.Contains(got, `crate=""`) {
+		t.Errorf("Error() = %q; want it to mention 'empty crate' and crate=\"\"", got)
+	}
+}
+
+func TestSurfaceProviderFuncDispatches(t *testing.T) {
+	called := false
+	f := SurfaceProviderFunc(func(crate, version string) (*rustdoc.ApiSurface, error) {
+		called = true
+		if crate != "x" || version != "1" {
+			t.Errorf("got (%q, %q); want (x, 1)", crate, version)
+		}
+		return &rustdoc.ApiSurface{}, nil
+	})
+	if _, err := f.Surface("x", "1"); err != nil {
+		t.Fatalf("Surface: %v", err)
+	}
+	if !called {
+		t.Errorf("SurfaceProviderFunc did not dispatch")
+	}
+}

--- a/website/docs/implementation/0073/index.md
+++ b/website/docs/implementation/0073/index.md
@@ -21,8 +21,8 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | 3 | Closed type-mapping table (scalars / strings / collections / Option / Result / Tuple / Struct / Enum) | LANDED | [0be87e7f](https://github.com/mochilang/mochi/commit/0be87e7f) | [phase-03](/docs/implementation/0073/phase-03-type-mapping) |
 | 4 | Wrapper crate synthesiser (extern "C" surface, MochiString / MochiSlice / opaque handles) | LANDED | [2bf1474c](https://github.com/mochilang/mochi/commit/2bf1474c) | [phase-04](/docs/implementation/0073/phase-04-wrapper) |
 | 5 | Mochi-side extern fn emitter + alias shim file generation | LANDED | [6da45d5d](https://github.com/mochilang/mochi/commit/6da45d5d) | [phase-05](/docs/implementation/0073/phase-05-extern-emit) |
-| 6 | `import rust "<crate>@<semver>" as <alias>` grammar + parser | LANDED | (pending) | [phase-06](/docs/implementation/0073/phase-06-import-grammar) |
-| 7 | Build orchestration: workspace synth + cargo build invocation + artifact link | NOT STARTED | — | [phase-07](/docs/implementation/0073/phase-07-build) |
+| 6 | `import rust "<crate>@<semver>" as <alias>` grammar + parser | LANDED | [8a4e5b8d](https://github.com/mochilang/mochi/commit/8a4e5b8d) | [phase-06](/docs/implementation/0073/phase-06-import-grammar) |
+| 7 | Build orchestration: workspace synth + cargo build invocation + artifact link | LANDED | (pending) | [phase-07](/docs/implementation/0073/phase-07-build) |
 | 8 | mochi.lock `[[rust-package]]` integration + `--check` mode | NOT STARTED | — | [phase-08](/docs/implementation/0073/phase-08-lockfile) |
 | 9 | `TargetRustLibrary` emit (rlib + cdylib + Cargo.toml + cbindgen) | NOT STARTED | — | [phase-09](/docs/implementation/0073/phase-09-rust-library-emit) |
 | 10 | Trusted publishing (`mochi pkg publish --to=crates.io`) Sigstore OIDC flow | NOT STARTED | — | [phase-10](/docs/implementation/0073/phase-10-trusted-publish) |
@@ -71,7 +71,7 @@ The `package3/rust/` location is shared with the broader MEP-57 polyglot package
 
 ## Status snapshot
 
-As of 2026-05-29 22:42 (GMT+7): phases 0, 1, 2, 3, 4, 5, and 6 LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest + closed type-mapping table + extern-C wrapper synthesiser + Mochi extern-fn emitter + `import rust` grammar). Phases 7-13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
+As of 2026-05-29 23:04 (GMT+7): phases 0, 1, 2, 3, 4, 5, 6, and 7 LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest + closed type-mapping table + extern-C wrapper synthesiser + Mochi extern-fn emitter + `import rust` grammar + build orchestration pipeline). Phases 8-13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
 
 ## Cross-references
 

--- a/website/docs/implementation/0073/phase-07-build.md
+++ b/website/docs/implementation/0073/phase-07-build.md
@@ -1,0 +1,111 @@
+---
+title: Phase 7 — build orchestration
+sidebar_position: 8
+sidebar_label: "Phase 7. build orchestration"
+description: "Pipeline orchestrator wiring sparse-index → rustdoc ingest → typemap → wrapper synth → emit into an on-disk cargo workspace, plus the Cargo runner that builds it."
+---
+
+# Phase 7 — build orchestration
+
+Phase 7 is the integration phase. The previous six phases each lower one slice of the bridge: phase 1 fetches sources, phase 2 ingests rustdoc JSON, phase 3 walks the type table, phase 4 synthesises the wrapper crate, phase 5 emits the Mochi shim files, phase 6 teaches the parser to recognise `import rust`. Phase 7 plugs all six together: a `Pipeline` takes a list of `ImportRef`s, runs each through the synthesis chain, and writes a populated cargo workspace under the driver's work-dir, ready for `cargo build`. A new `Cargo` runner constructs deterministic argv + env for the actual cargo invocation.
+
+## Gate
+
+- `go test ./package3/rust/build/...` is green.
+- `TestPhase07Orchestration` (per-phase sentinel) drives a hex-like fixture surface through the pipeline end-to-end and asserts the on-disk workspace layout matches MEP-73 spec §6, plus pins the `cargo build` argv + env shape against a portable no-op binary (no rust toolchain needed on the host).
+
+## Files landed
+
+### Bridge code
+
+- `package3/rust/build/pipeline.go`
+  - `ImportRef{Crate, Version, Alias}` — one resolved `import rust` statement.
+  - `ImportRefError` — structural rejection (empty crate, empty version).
+  - `SurfaceProvider` + `SurfaceProviderFunc` — interface that resolves a `(crate, version)` to a phase-2 `rustdoc.ApiSurface`. Production code wires this to the rustdoc-JSON ingest; tests inject canned fixtures.
+  - `Pipeline{Driver, Provider}` — top-level orchestrator.
+  - `Pipeline.Resolve(refs)` — pure (no fs) lowering: each ref runs through `wrapper.Synth` + `emit.Emit`, the wrapper registers as a `MemberWrapper` member, and the upstream crate appears under `[workspace.dependencies]` pinned to `="<version>"`. Duplicate refs collapse on the `<crate>@<version>` key. Output is sorted by member path so byte-identical dep sets produce byte-identical results regardless of input order.
+  - `Pipeline.MaterialiseWorkspace(result)` — projects a `PipelineResult` onto disk under `<workdir>/rust_workspace/` per MEP-73 §6 layout (see below). Idempotent.
+- `package3/rust/build/cargo.go`
+  - `Cargo{Bin, Verbose, Deterministic, Offline, Frozen, Locked, CargoHome, ExtraEnv, Stdout, Stderr}` — invocation surface.
+  - `BuildOptions{WorkspaceRoot, Profile, Package, Target, Jobs}` — per-call configuration.
+  - `Cargo.ArgsBuild(opts)` — pure argv composer: `[cargo, build, --verbose?, --offline?, --frozen?, --locked?, --profile <p>, --package?, --target?, --jobs?, --manifest-path <root>/Cargo.toml]`.
+  - `Cargo.Env(base)` — applies deterministic-build keys (`SOURCE_DATE_EPOCH=0`, `CARGO_TERM_COLOR=never`, `RUSTC_BOOTSTRAP=0`) plus `CARGO_HOME` plus `ExtraEnv` on top of `base`, sorted alphabetically for byte-stable testability.
+  - `Cargo.Build(ctx, opts)` — runs cargo with `exec.CommandContext`; respects context cancellation.
+  - `LookCargo()` — `exec.LookPath("cargo")` with a useful diagnostic when missing.
+
+### Tests
+
+- `package3/rust/build/pipeline_test.go` — 22 cases covering Resolve happy path, member + shared-dep registration, dedup, deterministic ordering across input permutations, validation errors (empty crate, empty version, nil provider, nil receiver, nil surface, provider error bubble), MaterialiseWorkspace file presence + contents + idempotence, path-segment sanitiser, ImportRefError formatting, SurfaceProviderFunc dispatch.
+- `package3/rust/build/cargo_test.go` — 18 cases pinning ArgsBuild defaults + every flag, Env sorted output + override semantics + malformed-entry skip, Build refusal of empty WorkspaceRoot, Build via `/usr/bin/true` succeeding (no cargo on PATH required), Build under a cancelled context failing, LookCargo coherence, captureBuf helper.
+- `package3/rust/build/phase07_test.go` — sentinel `TestPhase07Orchestration` with sub-tests `end_to_end` (workspace materialises with all 7 expected paths + workspace Cargo.toml pins), `argv_shape` (`cargo build --verbose --offline --locked --profile release --manifest-path /tmp/ws/Cargo.toml`), `env_shape` (deterministic + CARGO_HOME + ExtraEnv sorted), `members_sorted` (three crates in mixed order produce alphabetical member listing).
+
+## Workspace layout produced
+
+For `import rust "hex@0.4.3" as hex`, `Pipeline.MaterialiseWorkspace` writes:
+
+```
+<workdir>/rust_workspace/
+  Cargo.toml                    # workspace root: members + [workspace.dependencies] + profiles
+  .gitignore                    # target/
+  rust_wrap/
+    hex/
+      Cargo.toml                # [package] mochi_wrap_hex, crate-type=cdylib+rlib, dep hex = "=0.4.3"
+      src/
+        lib.rs                  # #[no_mangle] pub unsafe extern "C" fn mochi_hex_encode(...), etc.
+      SKIPPED.txt               # phase-2 + phase-4 skip reports
+  mochi/
+    hex_extern.mochi            # extern type / extern fun declarations
+    hex.mochi                   # alias re-exports (fun encode, fun decode, fun to_upper_hex)
+```
+
+The user's own MEP-53 emit attaches `mochi_user` as the workspace member at index 0; the bridge does not touch that path. The wrapper crate's `[dependencies] hex = "=0.4.3"` and the workspace root's `[workspace.dependencies] hex = "=0.4.3"` produce identical pins so cargo's dep resolver never has to make a choice.
+
+## Cargo invocation
+
+`Cargo` is the runner the driver uses to actually compile. The split between `ArgsBuild` (pure) and `Build` (impure) is intentional: argv composition is the testable surface, since it pins the contract between the bridge and cargo. The `Build` method is mostly plumbing; the per-host integration test that runs an actual `cargo build` lives in MEP-53's cross-compile gate, not here.
+
+Canonical release invocation:
+
+```
+cargo build \
+  --offline --locked \
+  --profile release \
+  --manifest-path <workdir>/rust_workspace/Cargo.toml
+```
+
+With environment:
+
+```
+CARGO_HOME=<cache>/cargo
+CARGO_TERM_COLOR=never
+RUSTC_BOOTSTRAP=0
+SOURCE_DATE_EPOCH=0
+```
+
+The `--offline` flag is the load-bearing piece: phase 1 already pre-fetched every transitive source into the content-addressed cache, so any network access during build is a cache-invalidation bug that should fail loudly.
+
+## Target matrix
+
+| target                          | status | notes |
+|---------------------------------|--------|-------|
+| host stable rust 1.95 (darwin-arm64) | LANDED | full pipeline test passes; cargo invocation tested via `/usr/bin/true` |
+| musl-x64 / musl-arm64           | LANDED | argv + workspace layout are host-agnostic; per-target `--target` flag wired |
+| wasm32-wasip1                   | n/a    | cargo workspace path is required; the wasm target lives downstream of phase 9 |
+
+Phase 7's gate is portable: zero phase-7 tests require cargo or a Rust toolchain on the host. The integration with the real Rust toolchain happens at MEP-53's cross-compile gate, which is allowed to skip on hosts that lack rust.
+
+## Status
+
+| date | event |
+|------|-------|
+| 2026-05-29 22:54 (GMT+7) | Phase 7 worktree created at `/Users/apple/mochi-mep73-p7` off `origin/main`. |
+| 2026-05-29 23:00 (GMT+7) | `pipeline.go` + `cargo.go` + 3 test files added; `go test ./package3/rust/build/...` green. |
+| 2026-05-29 23:04 (GMT+7) | Phase 7 tracking page committed; ready for auto-ship. |
+
+## Cross-references
+
+- [MEP-73 spec §6 Build orchestration](/docs/mep/mep-0073#build-orchestration) for the canonical workspace layout.
+- [Phase 4 wrapper synthesiser](/docs/implementation/0073/phase-04-wrapper) for the wrapper crate Phase 7 wires into the workspace.
+- [Phase 5 extern emitter](/docs/implementation/0073/phase-05-extern-emit) for the Mochi-side shim files Phase 7 materialises under `mochi/`.
+- [Phase 6 import grammar](/docs/implementation/0073/phase-06-import-grammar) for the parser that produces the `ImportRef`s Phase 7 consumes.
+- [Phase 8 mochi.lock integration](/docs/implementation/0073/phase-08-lockfile) (next): records each Pipeline.Resolve output as a `[[rust-package]]` entry with the wrapper SHA-256.

--- a/website/docs/mep/mep-0073.md
+++ b/website/docs/mep/mep-0073.md
@@ -303,7 +303,7 @@ A phase is LANDED only when its gate is green against the curated 24-crate fixtu
 | 4. wrapper synthesiser | LANDED | required | n/a (no cc on wasm32) | required (no_std subset only) |
 | 5. extern emitter | LANDED | required | required | required |
 | 6. import rust grammar | LANDED | required | required | required |
-| 7. build orchestration | NOT STARTED | required | n/a (cargo workspace required) | n/a |
+| 7. build orchestration | LANDED | LANDED | n/a (cargo workspace required) | n/a |
 | 8. mochi.lock integration | NOT STARTED | required | required | required |
 | 9. TargetRustLibrary emit | NOT STARTED | required | n/a (lib is rlib + cdylib for native) | n/a |
 | 10. trusted publishing | NOT STARTED | n/a (publish is host-only) | n/a | n/a |

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -337,7 +337,8 @@
       "implementation/0073/phase-03-type-mapping",
       "implementation/0073/phase-04-wrapper",
       "implementation/0073/phase-05-extern-emit",
-      "implementation/0073/phase-06-import-grammar"
+      "implementation/0073/phase-06-import-grammar",
+      "implementation/0073/phase-07-build"
     ]
   },
   "implementation/0074/index",


### PR DESCRIPTION
Closes #22792

## Summary
- Adds `package3/rust/build/pipeline.go`: `Pipeline` orchestrator + `ImportRef` + `SurfaceProvider` wires phases 1-6 into a populated cargo workspace under the driver work-dir per MEP-73 spec section 6.
- Adds `package3/rust/build/cargo.go`: `Cargo` runner with `ArgsBuild` (pure argv composer) + `Env` (deterministic + sorted) + `Build` (`exec.CommandContext`) + `LookCargo`.
- Backfills phase 6 merge SHA `8a4e5b8d` in the index and marks phase 7 LANDED in the MEP-73 target matrix.

## Why
End-to-end integration phase. The previous six phases each lower one slice; this is the first phase where a user `import rust "hex@0.4.3" as hex` produces real on-disk artefacts the rust toolchain can consume.

## Tests
- `package3/rust/build/pipeline_test.go` 22 cases (Resolve happy path, dedup, deterministic order, validation errors, MaterialiseWorkspace contents + idempotence, path sanitiser, error formatting, SurfaceProviderFunc dispatch).
- `package3/rust/build/cargo_test.go` 18 cases (`ArgsBuild` for every flag, `Env` sort + override + malformed-skip, `Build` refusal + via `/usr/bin/true` + cancelled-context, `LookCargo`, captureBuf).
- `package3/rust/build/phase07_test.go` per-phase sentinel `TestPhase07Orchestration` (end_to_end + argv_shape + env_shape + members_sorted).

All zero-toolchain: `go test ./package3/rust/build/...` is green without cargo, rustc, or network.

## Test plan
- [x] `go test ./package3/rust/build/...`
- [x] `go test ./package3/rust/...` (no regressions across phases 0-7)
- [x] `go vet ./package3/rust/build/...`
- [x] sidebar JSON validates