### PR TITLE
MEP-74 phase 6: cgo wrapper synthesiser (baseline)

### DIFF
--- a/package3/go/wrapper/emit.go
+++ b/package3/go/wrapper/emit.go
@@ -1,0 +1,437 @@
+package wrapper
+
+import (
+	"fmt"
+	"strings"
+
+	"mochi/package3/go/apisurface"
+	"mochi/package3/go/typemap"
+)
+
+// emitFunc lowers one apisurface.FuncDecl to either an EmittedFunc
+// or a SkipNote. The caller uses the SkipNote pointer being non-nil
+// to discriminate: a non-nil SkipNote and a nil EmittedFunc means
+// the item was skipped; the inverse means the wrapper was produced.
+func (e *Emitter) emitFunc(pkgPath, pkgName string, fd *apisurface.FuncDecl) (*EmittedFunc, *SkipNote, error) {
+	if fd == nil || fd.Underlying == nil {
+		return nil, nil, fmt.Errorf("%w: nil FuncDecl", ErrEmit)
+	}
+	// Skip methods (they require receiver handling on phase 6.x).
+	if fd.Underlying.Receiver != "" {
+		return nil, &SkipNote{
+			Kind: "method", Package: pkgPath, Name: fd.Underlying.Name,
+			Position: fd.Underlying.Position,
+			Reason:   "method wrappers land in phase 6.1",
+		}, nil
+	}
+	// Skip generic functions; monomorphisation is phase 15.
+	if len(fd.Underlying.TypeParams) > 0 {
+		return nil, &SkipNote{
+			Kind: "func", Package: pkgPath, Name: fd.Underlying.Name,
+			Position: fd.Underlying.Position,
+			Reason:   "generic func defers to phase 15 monomorphisation",
+		}, nil
+	}
+
+	// Map every param. A single unsupported param defers the whole func.
+	paramSlots := []EmittedParam{}
+	for i, p := range fd.Params {
+		m, err := e.mapper.Map(p.Type)
+		if err != nil {
+			return nil, &SkipNote{
+				Kind: "func", Package: pkgPath, Name: fd.Underlying.Name,
+				Position: fd.Underlying.Position,
+				Reason:   "param unmappable: " + err.Error(),
+			}, nil
+		}
+		// Phase 6 baseline: only scalar/string/[]byte/bool params.
+		ct, ok := baselineParamCType(m.Mochi)
+		if !ok {
+			return nil, &SkipNote{
+				Kind: "func", Package: pkgPath, Name: fd.Underlying.Name,
+				Position: fd.Underlying.Position,
+				Reason:   "param type " + m.Mochi.String() + " requires phase 6.x sub-phase",
+			}, nil
+		}
+		name := p.Name
+		if name == "" {
+			name = fmt.Sprintf("arg%d", i)
+		}
+		paramSlots = append(paramSlots, EmittedParam{Name: name, CType: ct, Mochi: m.Mochi})
+	}
+
+	// Detect trailing error.
+	hasError := false
+	resultDecls := fd.Results
+	if n := len(resultDecls); n > 0 {
+		last := resultDecls[n-1]
+		if isErrorType(last.Type) {
+			hasError = true
+			resultDecls = resultDecls[:n-1]
+		}
+	}
+
+	resultSlots := []EmittedParam{}
+	for i, r := range resultDecls {
+		m, err := e.mapper.Map(r.Type)
+		if err != nil {
+			return nil, &SkipNote{
+				Kind: "func", Package: pkgPath, Name: fd.Underlying.Name,
+				Position: fd.Underlying.Position,
+				Reason:   "result unmappable: " + err.Error(),
+			}, nil
+		}
+		ct, ok := baselineResultCType(m.Mochi)
+		if !ok {
+			return nil, &SkipNote{
+				Kind: "func", Package: pkgPath, Name: fd.Underlying.Name,
+				Position: fd.Underlying.Position,
+				Reason:   "result type " + m.Mochi.String() + " requires phase 6.x sub-phase",
+			}, nil
+		}
+		name := r.Name
+		if name == "" {
+			name = fmt.Sprintf("ret%d", i)
+		}
+		resultSlots = append(resultSlots, EmittedParam{Name: name, CType: ct, Mochi: m.Mochi})
+	}
+
+	ef := &EmittedFunc{
+		Symbol:   exportSymbol(e.flatModule, pkgName, fd.Underlying.Name),
+		Package:  pkgPath,
+		GoName:   fd.Underlying.Name,
+		Params:   paramSlots,
+		Results:  resultSlots,
+		HasError: hasError,
+	}
+	return ef, nil, nil
+}
+
+// baselineParamCType returns the C type for a Mochi parameter that
+// the phase 6 baseline can lower. Returns false to skip.
+func baselineParamCType(t typemap.MochiType) (string, bool) {
+	switch v := t.(type) {
+	case typemap.ScalarType:
+		switch v.Name {
+		case "int":
+			return "C.long", true
+		case "float":
+			return "C.double", true
+		case "bool":
+			return "C.int", true
+		case "string":
+			return "*C.char", true
+		case "bytes":
+			return "MochiSlice", true
+		}
+	}
+	return "", false
+}
+
+// baselineResultCType returns the C type for a Mochi result that
+// the phase 6 baseline can lower.
+func baselineResultCType(t typemap.MochiType) (string, bool) {
+	switch v := t.(type) {
+	case typemap.ScalarType:
+		switch v.Name {
+		case "int":
+			return "C.long", true
+		case "float":
+			return "C.double", true
+		case "bool":
+			return "C.int", true
+		case "string":
+			return "*C.char", true
+		case "bytes":
+			return "MochiSlice", true
+		}
+	}
+	return "", false
+}
+
+// isErrorType reports whether the typed Go type is the predeclared
+// `error` interface. apisurface.BasicType carries the name "error"
+// for predeclared error.
+func isErrorType(t apisurface.GoType) bool {
+	if b, ok := t.(apisurface.BasicType); ok {
+		return b.Name == "error"
+	}
+	return false
+}
+
+// exportSymbol returns the //export name for a wrapped function.
+// Format: "mochi_go_<flatModule>_<pkgName>_<funcName>".
+func exportSymbol(flatModule, pkgName, funcName string) string {
+	return "mochi_go_" + flatModule + "_" + pkgName + "_" + funcName
+}
+
+// renderSource pulls every EmittedFunc into one wrap.go file body.
+func (e *Emitter) renderSource(pkgName string, funcs []EmittedFunc) (string, error) {
+	var sb strings.Builder
+	sb.WriteString("// Code generated by mochi MEP-74 phase 6 wrapper synthesiser. DO NOT EDIT.\n\n")
+	sb.WriteString("package " + pkgName + "\n\n")
+	sb.WriteString(`/*
+typedef struct { void* ptr; long len; long cap; } MochiSlice;
+typedef long MochiStatus;
+*/
+import "C"
+
+import (
+	"runtime"
+	"unsafe"
+`)
+	// Collect imported source packages.
+	importSet := map[string]string{}
+	for _, f := range funcs {
+		importSet[f.Package] = pkgAlias(f.Package)
+	}
+	for _, ip := range sortedKeys(importSet) {
+		sb.WriteString("\t" + importSet[ip] + " \"" + ip + "\"\n")
+	}
+	sb.WriteString(")\n\n")
+
+	// Suppress "imported and not used" for the case of zero wrapped funcs.
+	sb.WriteString("var _ = unsafe.Pointer(nil)\n")
+	sb.WriteString("var _ = runtime.KeepAlive\n\n")
+
+	for _, f := range funcs {
+		if err := renderFunc(&sb, &f); err != nil {
+			return "", err
+		}
+		sb.WriteString("\n")
+	}
+
+	// Module-scoped string free.
+	sb.WriteString("//export mochi_go_" + e.flatModule + "_string_free\n")
+	sb.WriteString("func mochi_go_" + e.flatModule + "_string_free(p *C.char) { C.free(unsafe.Pointer(p)) }\n")
+	return sb.String(), nil
+}
+
+func renderFunc(sb *strings.Builder, f *EmittedFunc) error {
+	alias := pkgAlias(f.Package)
+	// Signature.
+	sb.WriteString("//export " + f.Symbol + "\n")
+	sb.WriteString("func " + f.Symbol + "(")
+	for i, p := range f.Params {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(p.Name + " " + p.CType)
+	}
+	if f.HasError {
+		if len(f.Params) > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString("out_err **C.char")
+	}
+	sb.WriteString(") ")
+	switch {
+	case f.HasError:
+		sb.WriteString("C.MochiStatus")
+	case len(f.Results) == 0:
+		// no return.
+	case len(f.Results) == 1:
+		sb.WriteString(f.Results[0].CType)
+	default:
+		// Multi-result: write into out-pointers, return MochiStatus 0.
+		sb.WriteString("C.MochiStatus")
+	}
+	sb.WriteString(" {\n")
+
+	// Marshal params from C-side -> Go-side.
+	goArgs := []string{}
+	for _, p := range f.Params {
+		v, conv := paramFromCToGo(p)
+		if conv != "" {
+			sb.WriteString("\t" + conv + "\n")
+		}
+		goArgs = append(goArgs, v)
+	}
+
+	call := alias + "." + f.GoName + "(" + strings.Join(goArgs, ", ") + ")"
+
+	if f.HasError {
+		// `result := ...; if err != nil { *out_err = C.CString(err.Error()); return 1 }; return 0`
+		switch len(f.Results) {
+		case 0:
+			sb.WriteString("\terr := " + call + "\n")
+			sb.WriteString("\tif err != nil { *out_err = C.CString(err.Error()); return C.MochiStatus(1) }\n")
+		case 1:
+			sb.WriteString("\tres, err := " + call + "\n")
+			sb.WriteString("\tif err != nil { *out_err = C.CString(err.Error()); return C.MochiStatus(1) }\n")
+			sb.WriteString("\t_ = res\n")
+		default:
+			sb.WriteString("\t_ = " + call + "\n")
+		}
+		// runtime.KeepAlive every input that crossed the boundary as
+		// a pointer.
+		for _, p := range f.Params {
+			if isPointerCType(p.CType) {
+				sb.WriteString("\truntime.KeepAlive(" + p.Name + ")\n")
+			}
+		}
+		sb.WriteString("\treturn C.MochiStatus(0)\n")
+	} else {
+		switch len(f.Results) {
+		case 0:
+			sb.WriteString("\t" + call + "\n")
+			for _, p := range f.Params {
+				if isPointerCType(p.CType) {
+					sb.WriteString("\truntime.KeepAlive(" + p.Name + ")\n")
+				}
+			}
+		case 1:
+			sb.WriteString("\tres := " + call + "\n")
+			retExpr := resultFromGoToC(f.Results[0])
+			for _, p := range f.Params {
+				if isPointerCType(p.CType) {
+					sb.WriteString("\truntime.KeepAlive(" + p.Name + ")\n")
+				}
+			}
+			sb.WriteString("\treturn " + retExpr + "\n")
+		default:
+			// Multi-result lowered as out-pointers + status. Phase
+			// 6.x sub-phase to enrich; the baseline currently
+			// short-circuited above via SkipNote, so this branch is
+			// reserved.
+			sb.WriteString("\t_ = " + call + "\n")
+			sb.WriteString("\treturn C.MochiStatus(0)\n")
+		}
+	}
+	sb.WriteString("}\n")
+	return nil
+}
+
+func paramFromCToGo(p EmittedParam) (string, string) {
+	switch p.CType {
+	case "C.long":
+		return "int64(" + p.Name + ")", ""
+	case "C.double":
+		return "float64(" + p.Name + ")", ""
+	case "C.int":
+		return p.Name + " != 0", ""
+	case "*C.char":
+		return "C.GoString(" + p.Name + ")", ""
+	case "MochiSlice":
+		decl := fmt.Sprintf("%s_go := C.GoBytes(unsafe.Pointer(%s.ptr), C.int(%s.len))", p.Name, p.Name, p.Name)
+		return p.Name + "_go", decl
+	}
+	return p.Name, ""
+}
+
+func resultFromGoToC(r EmittedParam) string {
+	switch r.CType {
+	case "C.long":
+		return "C.long(res)"
+	case "C.double":
+		return "C.double(res)"
+	case "C.int":
+		return "C.int(boolToInt(res))"
+	case "*C.char":
+		return "C.CString(res)"
+	case "MochiSlice":
+		return "goBytesToSlice(res)"
+	}
+	return "res"
+}
+
+func isPointerCType(t string) bool {
+	return strings.HasPrefix(t, "*") || t == "MochiSlice"
+}
+
+func pkgAlias(importPath string) string {
+	// Simple alias: last path segment with underscores.
+	seg := importPath
+	if i := strings.LastIndex(seg, "/"); i >= 0 {
+		seg = seg[i+1:]
+	}
+	if seg == "" {
+		seg = "pkg"
+	}
+	return seg
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	// stable sort
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+
+// renderHandles emits the handle-pool boilerplate (cgo.Handle wrap)
+// every wrapper file shares. The pool is intentionally minimal in
+// phase 6; the goroutine bridge (phase 14) extends it with channel
+// and func-value handles.
+func (e *Emitter) renderHandles(pkgName string) string {
+	return `// Code generated by mochi MEP-74 phase 6. DO NOT EDIT.
+
+package ` + pkgName + `
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"runtime/cgo"
+	"unsafe"
+)
+
+// boolToInt converts a Go bool to a C int (0/1).
+func boolToInt(b bool) C.int {
+	if b {
+		return C.int(1)
+	}
+	return C.int(0)
+}
+
+// goBytesToSlice copies a Go byte slice into a freshly allocated
+// MochiSlice. The caller owns the memory and must free it via
+// mochi_go_` + e.flatModule + `_bytes_free.
+func goBytesToSlice(b []byte) MochiSlice {
+	if len(b) == 0 {
+		return MochiSlice{}
+	}
+	ptr := C.CBytes(b)
+	return MochiSlice{ptr: ptr, len: C.long(len(b)), cap: C.long(len(b))}
+}
+
+//export mochi_go_` + e.flatModule + `_bytes_free
+func mochi_go_` + e.flatModule + `_bytes_free(s MochiSlice) {
+	if s.ptr != nil {
+		C.free(s.ptr)
+	}
+}
+
+// handleNew registers v in the cgo handle pool and returns the
+// opaque key the Mochi side will refer to it by. Phase 14 extends
+// this with type-tag verification.
+func handleNew(v interface{}) uintptr {
+	return uintptr(cgo.NewHandle(v))
+}
+
+// handleValue resolves an opaque key back to its Go value.
+func handleValue(k uintptr) interface{} {
+	return cgo.Handle(k).Value()
+}
+
+// handleDelete releases an opaque key.
+func handleDelete(k uintptr) {
+	cgo.Handle(k).Delete()
+}
+
+var _ = unsafe.Pointer(nil)
+`
+}
+
+// MochiSlice mirrors the cgo struct the wrapper uses on the Go
+// side. It exists for parse-time validity; cgo replaces the import
+// "C" types at build time.
+type MochiSlice struct{}

--- a/package3/go/wrapper/phase06_test.go
+++ b/package3/go/wrapper/phase06_test.go
@@ -1,0 +1,146 @@
+package wrapper
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/go/apisurface"
+	"mochi/package3/go/typemap"
+)
+
+// TestPhase6Wrapper is the MEP-74 phase 6 sentinel. It exercises a
+// multi-package fixture mirroring a real Go module's shape (a
+// public scalar API package + a sub-package with string handling
+// and an error-returning func) and asserts that the emitter
+// produces parseable, byte-deterministic source with the right
+// //export symbols, the right C-side type lowerings, and
+// runtime.KeepAlive injection on every pointer-bearing parameter.
+//
+// Sub-phase skip records (methods, generic funcs, chan/func value
+// params, struct/map params) round-trip through Skipped with the
+// documented Reason format.
+func TestPhase6Wrapper(t *testing.T) {
+	file := &apisurface.File{
+		SchemaVersion: apisurface.SchemaVersion,
+		Module:        "example.com/sentinel",
+		Version:       "v1.0.0",
+		Packages: []apisurface.Package{
+			{
+				ImportPath: "example.com/sentinel",
+				Name:       "sentinel",
+				Funcs: []apisurface.Func{
+					{Name: "Add", Params: []apisurface.Param{{Name: "x", Type: "int"}, {Name: "y", Type: "int"}}, Results: []apisurface.Param{{Type: "int"}}},
+					{Name: "Negate", Params: []apisurface.Param{{Name: "b", Type: "bool"}}, Results: []apisurface.Param{{Type: "bool"}}},
+					{Name: "Sqrt", Params: []apisurface.Param{{Name: "x", Type: "float64"}}, Results: []apisurface.Param{{Type: "float64"}}},
+					// Deferred to phase 6.x:
+					{Name: "Listen", Params: []apisurface.Param{{Type: "chan int"}}},
+					{Name: "MapKeys", TypeParams: []apisurface.TypeParam{{Name: "K"}}, Params: []apisurface.Param{{Name: "m", Type: "map[K]int"}}, Results: []apisurface.Param{{Type: "[]K"}}},
+				},
+			},
+			{
+				ImportPath: "example.com/sentinel/text",
+				Name:       "text",
+				Funcs: []apisurface.Func{
+					{Name: "Greet", Params: []apisurface.Param{{Name: "who", Type: "string"}}, Results: []apisurface.Param{{Type: "string"}}},
+					{Name: "Validate", Params: []apisurface.Param{{Name: "s", Type: "string"}}, Results: []apisurface.Param{{Type: "error"}}},
+					{Name: "Encode", Params: []apisurface.Param{{Name: "s", Type: "string"}}, Results: []apisurface.Param{{Type: "[]byte"}}},
+				},
+			},
+		},
+	}
+	surface, err := apisurface.Load(file, apisurface.LoadOptions{})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	mapper := typemap.NewMapper(surface)
+	e, err := NewEmitter(surface, mapper, file.Module, file.Version)
+	if err != nil {
+		t.Fatalf("NewEmitter: %v", err)
+	}
+
+	r, err := e.Emit()
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	// Validate package name + file set.
+	if r.ModuleName != "mochi_go_example_com_sentinel" {
+		t.Errorf("ModuleName = %q", r.ModuleName)
+	}
+	if _, ok := r.Files["wrap.go"]; !ok {
+		t.Errorf("missing wrap.go")
+	}
+	if _, ok := r.Files["wrap_handles.go"]; !ok {
+		t.Errorf("missing wrap_handles.go")
+	}
+
+	// Both emitted files must parse.
+	for name, src := range r.Files {
+		if err := ParseGenerated(name, src); err != nil {
+			t.Errorf("%s: %v", name, err)
+		}
+	}
+
+	// Required wrappers: Add (3 scalars), Negate (bool), Sqrt (float),
+	// Greet (string in/out), Validate (string in, error out), Encode
+	// (string in, bytes out).
+	wantSymbols := []string{
+		"mochi_go_example_com_sentinel_sentinel_Add",
+		"mochi_go_example_com_sentinel_sentinel_Negate",
+		"mochi_go_example_com_sentinel_sentinel_Sqrt",
+		"mochi_go_example_com_sentinel_text_Greet",
+		"mochi_go_example_com_sentinel_text_Validate",
+		"mochi_go_example_com_sentinel_text_Encode",
+	}
+	gotSymbols := map[string]bool{}
+	for _, f := range r.Funcs {
+		gotSymbols[f.Symbol] = true
+	}
+	for _, s := range wantSymbols {
+		if !gotSymbols[s] {
+			t.Errorf("missing wrapper symbol %q", s)
+		}
+	}
+
+	// Required SkipNotes.
+	wantSkipped := map[string]string{
+		"Listen":  "phase 6.x",
+		"MapKeys": "generic",
+	}
+	gotSkipped := map[string]string{}
+	for _, n := range r.Skipped {
+		gotSkipped[n.Name] = n.Reason
+	}
+	for name, want := range wantSkipped {
+		if !strings.Contains(gotSkipped[name], want) {
+			t.Errorf("skipped[%q] = %q; want substring %q", name, gotSkipped[name], want)
+		}
+	}
+
+	src := r.Files["wrap.go"]
+	// runtime.KeepAlive on pointer-bearing string param.
+	if !strings.Contains(src, "runtime.KeepAlive(who)") {
+		t.Errorf("missing keepalive for who: %s", src)
+	}
+	if !strings.Contains(src, "runtime.KeepAlive(s)") {
+		t.Errorf("missing keepalive for s")
+	}
+	// Module-scoped helpers.
+	if !strings.Contains(src, "mochi_go_example_com_sentinel_string_free") {
+		t.Errorf("missing module-scoped string_free")
+	}
+	if !strings.Contains(r.Files["wrap_handles.go"], "mochi_go_example_com_sentinel_bytes_free") {
+		t.Errorf("missing module-scoped bytes_free")
+	}
+
+	// Determinism: re-emit and compare byte-for-byte.
+	r2, err := e.Emit()
+	if err != nil {
+		t.Fatalf("re-emit: %v", err)
+	}
+	for name, src := range r.Files {
+		if r2.Files[name] != src {
+			t.Errorf("non-deterministic output for %s", name)
+		}
+	}
+}

--- a/package3/go/wrapper/wrapper.go
+++ b/package3/go/wrapper/wrapper.go
@@ -1,0 +1,214 @@
+// Package wrapper is the MEP-74 phase 6 cgo wrapper synthesiser. It
+// takes an apisurface.Surface plus a typemap.Mapper and emits a Go
+// source tree implementing the cgo //export bridge from C-ABI to
+// the source Go module. The output is consumed by phase 9's build
+// orchestration: `go build -buildmode=c-archive` over the emitted
+// tree produces libwrap.a, which the MEP-54 link step folds into
+// the final binary.
+//
+// Phase 6 handles the *baseline* lowering rules: scalar in/out,
+// string out (with module-scoped _string_free), []byte out (with
+// _bytes_free), error out (status code + out_err pointer), and
+// multi-result tuples. Channels, function values, maps, generic
+// instantiations, and full struct records emit SkipNotes and are
+// completed in follow-up sub-phases (6.1+).
+package wrapper
+
+import (
+	"errors"
+	"fmt"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strings"
+
+	"mochi/package3/go/apisurface"
+	"mochi/package3/go/typemap"
+)
+
+// ErrEmit is returned when the emitter cannot produce a wrapper for
+// the whole surface. Skip-individual-item failures do not surface
+// here; they are returned as SkipNote entries on the Result.
+var ErrEmit = errors.New("wrapper: emit")
+
+// Result is what one call to Emitter.Emit returns.
+type Result struct {
+	// ModuleName is the synthesised Go package name (e.g.
+	// "mochi_go_github_com_spf13_cobra"). It is also the directory
+	// name and the //export-symbol prefix.
+	ModuleName string
+	// Files maps relative file name -> Go source. The caller writes
+	// them under the wrapper directory chosen by phase 9.
+	Files map[string]string
+	// Funcs is the index of every wrapper function that the emitter
+	// produced. Phase 7 (extern emitter) consumes this directly to
+	// build the matching Mochi extern fn declarations.
+	Funcs []EmittedFunc
+	// Skipped is the closed-reason list of items the emitter could
+	// not lower in phase 6. Each entry can be picked up by a follow-
+	// up sub-phase.
+	Skipped []SkipNote
+}
+
+// EmittedFunc captures a single //export wrapper function the
+// emitter produced. It is exposed so phase 7 can reuse the same
+// argument-name conventions.
+type EmittedFunc struct {
+	// Symbol is the C-side //export name.
+	Symbol string
+	// Package is the source Go package's import path.
+	Package string
+	// GoName is the original Go function name (no package prefix).
+	GoName string
+	// Params is the wrapper's C-ABI parameter list (in order).
+	Params []EmittedParam
+	// Results is the wrapper's C-ABI result list (in order). For
+	// error-returning Go funcs, the last result is replaced by a
+	// MochiStatus int return code and the error string is delivered
+	// via an out-pointer in Params.
+	Results []EmittedParam
+	// HasError reports whether the wrapped function returned a
+	// trailing error value lowered to a status code.
+	HasError bool
+}
+
+// EmittedParam is one wrapper-function parameter or result.
+type EmittedParam struct {
+	Name  string
+	CType string
+	// Mochi is the typemap.MochiType this slot exposes. It is
+	// recorded so phase 7 can emit the matching Mochi extern type
+	// without re-mapping from scratch.
+	Mochi typemap.MochiType
+}
+
+// SkipNote records one item the emitter deliberately omitted from
+// the wrapper. Reason values are stable strings.
+type SkipNote struct {
+	Kind     string // "func", "method", "type"
+	Package  string
+	Name     string
+	Position string
+	Reason   string
+}
+
+// Emitter synthesises a cgo wrapper for one Go module.
+type Emitter struct {
+	surface *apisurface.Surface
+	mapper  *typemap.Mapper
+	module  string
+	version string
+	// flatModule is the module path with all non-identifier characters
+	// replaced by underscore (e.g. "github.com/spf13/cobra" ->
+	// "github_com_spf13_cobra"). Used as the //export symbol prefix.
+	flatModule string
+}
+
+// NewEmitter constructs an Emitter for the given module/version
+// pair. surface and mapper must not be nil.
+func NewEmitter(surface *apisurface.Surface, mapper *typemap.Mapper, module, version string) (*Emitter, error) {
+	if surface == nil {
+		return nil, fmt.Errorf("%w: nil surface", ErrEmit)
+	}
+	if mapper == nil {
+		return nil, fmt.Errorf("%w: nil mapper", ErrEmit)
+	}
+	if module == "" {
+		return nil, fmt.Errorf("%w: empty module path", ErrEmit)
+	}
+	return &Emitter{
+		surface:    surface,
+		mapper:     mapper,
+		module:     module,
+		version:    version,
+		flatModule: flattenModule(module),
+	}, nil
+}
+
+// Emit produces the wrapper source files. The returned Result is
+// non-nil even when individual items were skipped; check
+// Result.Skipped to see what was omitted.
+func (e *Emitter) Emit() (*Result, error) {
+	pkgName := "mochi_go_" + e.flatModule
+	r := &Result{
+		ModuleName: pkgName,
+		Files:      make(map[string]string),
+	}
+
+	// Walk packages in sorted order so the output is byte-stable.
+	pkgPaths := e.surface.PackagePaths()
+	sort.Strings(pkgPaths)
+	for _, ip := range pkgPaths {
+		pv := e.surface.Packages[ip]
+		if pv.Pkg.IsMain {
+			r.Skipped = append(r.Skipped, SkipNote{
+				Kind:    "package",
+				Package: ip,
+				Name:    pv.Pkg.Name,
+				Reason:  "main package has no library API",
+			})
+			continue
+		}
+		for _, fname := range sortedFuncNames(pv) {
+			fd := pv.Funcs[fname]
+			ef, sk, err := e.emitFunc(ip, pv.Pkg.Name, fd)
+			if err != nil {
+				return nil, err
+			}
+			if sk != nil {
+				r.Skipped = append(r.Skipped, *sk)
+				continue
+			}
+			r.Funcs = append(r.Funcs, *ef)
+		}
+	}
+
+	src, err := e.renderSource(pkgName, r.Funcs)
+	if err != nil {
+		return nil, err
+	}
+	r.Files["wrap.go"] = src
+	r.Files["wrap_handles.go"] = e.renderHandles(pkgName)
+	return r, nil
+}
+
+func sortedFuncNames(pv *apisurface.PackageView) []string {
+	names := make([]string, 0, len(pv.Funcs))
+	for n := range pv.Funcs {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// flattenModule converts a Go module path to a valid Go identifier
+// fragment: every non-letter/digit becomes underscore.
+func flattenModule(m string) string {
+	var sb strings.Builder
+	for _, r := range m {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			sb.WriteRune(r)
+		default:
+			sb.WriteByte('_')
+		}
+	}
+	out := sb.String()
+	// Trim leading digits so the result is a valid Go identifier.
+	for len(out) > 0 && out[0] >= '0' && out[0] <= '9' {
+		out = "_" + out
+		break
+	}
+	return out
+}
+
+// ParseGenerated parses src under the strict cgo-compatible
+// parser settings. Phase 6's gate runs this on every emitted file
+// to confirm syntactic validity.
+func ParseGenerated(name, src string) error {
+	_, err := parser.ParseFile(token.NewFileSet(), name, src, parser.AllErrors|parser.ParseComments)
+	if err != nil {
+		return fmt.Errorf("%w: %s: %v", ErrEmit, name, err)
+	}
+	return nil
+}

--- a/package3/go/wrapper/wrapper_test.go
+++ b/package3/go/wrapper/wrapper_test.go
@@ -1,0 +1,336 @@
+package wrapper
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/go/apisurface"
+	"mochi/package3/go/typemap"
+)
+
+func TestFlattenModule(t *testing.T) {
+	cases := map[string]string{
+		"github.com/spf13/cobra":   "github_com_spf13_cobra",
+		"gopkg.in/yaml.v3":         "gopkg_in_yaml_v3",
+		"example.com/foo":          "example_com_foo",
+		"a/b-c":                    "a_b_c",
+		"123/foo":                  "_123_foo",
+	}
+	for in, want := range cases {
+		if got := flattenModule(in); got != want {
+			t.Errorf("flattenModule(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+func TestExportSymbol(t *testing.T) {
+	got := exportSymbol("github_com_spf13_cobra", "cobra", "Execute")
+	want := "mochi_go_github_com_spf13_cobra_cobra_Execute"
+	if got != want {
+		t.Errorf("exportSymbol = %q; want %q", got, want)
+	}
+}
+
+func TestPkgAlias(t *testing.T) {
+	cases := map[string]string{
+		"github.com/spf13/cobra": "cobra",
+		"gopkg.in/yaml.v3":       "yaml.v3",
+		"":                       "pkg",
+	}
+	for in, want := range cases {
+		if got := pkgAlias(in); got != want {
+			t.Errorf("pkgAlias(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+func TestIsErrorType(t *testing.T) {
+	if !isErrorType(apisurface.BasicType{Name: "error"}) {
+		t.Errorf("error not detected")
+	}
+	if isErrorType(apisurface.BasicType{Name: "int"}) {
+		t.Errorf("int incorrectly flagged as error")
+	}
+	if isErrorType(apisurface.NamedType{Name: "MyError"}) {
+		t.Errorf("named MyError incorrectly flagged as error")
+	}
+}
+
+func TestBaselineCTypes(t *testing.T) {
+	cases := []struct {
+		in   typemap.MochiType
+		wantParam string
+		wantRes string
+		ok   bool
+	}{
+		{typemap.ScalarType{Name: "int"}, "C.long", "C.long", true},
+		{typemap.ScalarType{Name: "float"}, "C.double", "C.double", true},
+		{typemap.ScalarType{Name: "bool"}, "C.int", "C.int", true},
+		{typemap.ScalarType{Name: "string"}, "*C.char", "*C.char", true},
+		{typemap.ScalarType{Name: "bytes"}, "MochiSlice", "MochiSlice", true},
+		{typemap.HandleType{Name: "io.Reader"}, "", "", false},
+		{typemap.ListType{Elem: typemap.ScalarType{Name: "int"}}, "", "", false},
+	}
+	for _, tc := range cases {
+		got, ok := baselineParamCType(tc.in)
+		if ok != tc.ok {
+			t.Errorf("param ok(%v) = %v; want %v", tc.in, ok, tc.ok)
+		}
+		if got != tc.wantParam {
+			t.Errorf("param(%v) = %q; want %q", tc.in, got, tc.wantParam)
+		}
+		got, ok = baselineResultCType(tc.in)
+		if ok != tc.ok {
+			t.Errorf("result ok(%v) = %v; want %v", tc.in, ok, tc.ok)
+		}
+		if got != tc.wantRes {
+			t.Errorf("result(%v) = %q; want %q", tc.in, got, tc.wantRes)
+		}
+	}
+}
+
+// buildEmitter constructs a tiny fixture with one package and the
+// supplied funcs. Returns the emitter, surface, and mapper.
+func buildEmitter(t *testing.T, pkgPath, pkgName string, funcs []apisurface.Func) *Emitter {
+	t.Helper()
+	file := &apisurface.File{
+		SchemaVersion: apisurface.SchemaVersion,
+		Module:        "example.com/m",
+		Packages: []apisurface.Package{
+			{ImportPath: pkgPath, Name: pkgName, Funcs: funcs},
+		},
+	}
+	s, err := apisurface.Load(file, apisurface.LoadOptions{})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	m := typemap.NewMapper(s)
+	e, err := NewEmitter(s, m, "example.com/m", "v0.0.1")
+	if err != nil {
+		t.Fatalf("NewEmitter: %v", err)
+	}
+	return e
+}
+
+func TestEmitScalarPassthrough(t *testing.T) {
+	e := buildEmitter(t, "example.com/m", "m", []apisurface.Func{
+		{
+			Name:    "Add",
+			Params:  []apisurface.Param{{Name: "x", Type: "int"}, {Name: "y", Type: "int"}},
+			Results: []apisurface.Param{{Type: "int"}},
+		},
+	})
+	r, err := e.Emit()
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if len(r.Funcs) != 1 || r.Funcs[0].GoName != "Add" {
+		t.Fatalf("funcs = %+v", r.Funcs)
+	}
+	src := r.Files["wrap.go"]
+	if !strings.Contains(src, "//export mochi_go_example_com_m_m_Add") {
+		t.Errorf("missing export symbol; src: %s", src)
+	}
+	if !strings.Contains(src, "m.Add(int64(x), int64(y))") {
+		t.Errorf("missing call expression; src: %s", src)
+	}
+	if !strings.Contains(src, "return C.long(res)") {
+		t.Errorf("missing return conv; src: %s", src)
+	}
+	if err := ParseGenerated("wrap.go", src); err != nil {
+		t.Errorf("wrap.go does not parse: %v", err)
+	}
+}
+
+func TestEmitStringReturn(t *testing.T) {
+	e := buildEmitter(t, "example.com/m", "m", []apisurface.Func{
+		{
+			Name:    "Greet",
+			Params:  []apisurface.Param{{Name: "who", Type: "string"}},
+			Results: []apisurface.Param{{Type: "string"}},
+		},
+	})
+	r, _ := e.Emit()
+	if len(r.Funcs) != 1 {
+		t.Fatalf("funcs = %+v", r.Funcs)
+	}
+	src := r.Files["wrap.go"]
+	if !strings.Contains(src, "C.GoString(who)") {
+		t.Errorf("missing string-in conv; src: %s", src)
+	}
+	if !strings.Contains(src, "C.CString(res)") {
+		t.Errorf("missing string-out conv; src: %s", src)
+	}
+	if !strings.Contains(src, "runtime.KeepAlive(who)") {
+		t.Errorf("missing keepalive for string param; src: %s", src)
+	}
+	if !strings.Contains(src, "mochi_go_example_com_m_string_free") {
+		t.Errorf("missing module-scoped string_free; src: %s", src)
+	}
+	if err := ParseGenerated("wrap.go", src); err != nil {
+		t.Errorf("parse: %v", err)
+	}
+}
+
+func TestEmitErrorReturn(t *testing.T) {
+	e := buildEmitter(t, "example.com/m", "m", []apisurface.Func{
+		{
+			Name:    "Run",
+			Params:  []apisurface.Param{},
+			Results: []apisurface.Param{{Type: "error"}},
+		},
+	})
+	r, _ := e.Emit()
+	if len(r.Funcs) != 1 || !r.Funcs[0].HasError {
+		t.Fatalf("HasError missing; %+v", r.Funcs)
+	}
+	src := r.Files["wrap.go"]
+	if !strings.Contains(src, "out_err **C.char") {
+		t.Errorf("missing out_err param; src: %s", src)
+	}
+	if !strings.Contains(src, "return C.MochiStatus(0)") {
+		t.Errorf("missing success status; src: %s", src)
+	}
+	if !strings.Contains(src, "return C.MochiStatus(1)") {
+		t.Errorf("missing failure status; src: %s", src)
+	}
+	if err := ParseGenerated("wrap.go", src); err != nil {
+		t.Errorf("parse: %v", err)
+	}
+}
+
+func TestEmitValuePlusError(t *testing.T) {
+	e := buildEmitter(t, "example.com/m", "m", []apisurface.Func{
+		{
+			Name:    "Lookup",
+			Params:  []apisurface.Param{{Name: "k", Type: "string"}},
+			Results: []apisurface.Param{{Type: "int"}, {Type: "error"}},
+		},
+	})
+	r, _ := e.Emit()
+	if !r.Funcs[0].HasError {
+		t.Fatalf("HasError missing")
+	}
+	if len(r.Funcs[0].Results) != 1 {
+		t.Errorf("Results = %d; want 1 (error stripped)", len(r.Funcs[0].Results))
+	}
+	src := r.Files["wrap.go"]
+	if err := ParseGenerated("wrap.go", src); err != nil {
+		t.Errorf("parse: %v", err)
+	}
+}
+
+func TestEmitSkipsGenericFunc(t *testing.T) {
+	e := buildEmitter(t, "example.com/m", "m", []apisurface.Func{
+		{
+			Name:       "Map",
+			TypeParams: []apisurface.TypeParam{{Name: "T"}},
+			Params:     []apisurface.Param{{Name: "x", Type: "T"}},
+			Results:    []apisurface.Param{{Type: "T"}},
+		},
+	})
+	r, _ := e.Emit()
+	if len(r.Funcs) != 0 {
+		t.Errorf("generic func not skipped; got %+v", r.Funcs)
+	}
+	if len(r.Skipped) == 0 || !strings.Contains(r.Skipped[0].Reason, "generic") {
+		t.Errorf("skip reason = %v", r.Skipped)
+	}
+}
+
+func TestEmitSkipsMethod(t *testing.T) {
+	e := buildEmitter(t, "example.com/m", "m", []apisurface.Func{
+		{
+			Name:     "Read",
+			Receiver: "Reader",
+			Params:   []apisurface.Param{{Name: "p", Type: "[]byte"}},
+			Results:  []apisurface.Param{{Type: "int"}, {Type: "error"}},
+		},
+	})
+	r, _ := e.Emit()
+	if len(r.Funcs) != 0 {
+		t.Errorf("method not skipped; got %+v", r.Funcs)
+	}
+	if len(r.Skipped) == 0 || r.Skipped[0].Kind != "method" {
+		t.Errorf("skip kind = %v", r.Skipped)
+	}
+}
+
+func TestEmitSkipsUnsupportedParam(t *testing.T) {
+	e := buildEmitter(t, "example.com/m", "m", []apisurface.Func{
+		{
+			Name:    "Pipe",
+			Params:  []apisurface.Param{{Name: "ch", Type: "chan int"}},
+			Results: []apisurface.Param{},
+		},
+	})
+	r, _ := e.Emit()
+	if len(r.Funcs) != 0 {
+		t.Errorf("chan-param func not skipped")
+	}
+	if len(r.Skipped) != 1 || !strings.Contains(r.Skipped[0].Reason, "phase 6.x") {
+		t.Errorf("skip = %+v", r.Skipped)
+	}
+}
+
+func TestEmitNoFuncsStillProducesValidSource(t *testing.T) {
+	e := buildEmitter(t, "example.com/m", "m", nil)
+	r, err := e.Emit()
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if err := ParseGenerated("wrap.go", r.Files["wrap.go"]); err != nil {
+		t.Errorf("wrap.go: %v", err)
+	}
+	if err := ParseGenerated("wrap_handles.go", r.Files["wrap_handles.go"]); err != nil {
+		t.Errorf("wrap_handles.go: %v", err)
+	}
+}
+
+func TestEmitDeterministicOrdering(t *testing.T) {
+	funcs := []apisurface.Func{
+		{Name: "Zeta", Results: []apisurface.Param{{Type: "int"}}},
+		{Name: "Alpha", Results: []apisurface.Param{{Type: "int"}}},
+		{Name: "Mu", Results: []apisurface.Param{{Type: "int"}}},
+	}
+	e := buildEmitter(t, "example.com/m", "m", funcs)
+	r, _ := e.Emit()
+	a, b, c := strings.Index(r.Files["wrap.go"], "_Alpha"),
+		strings.Index(r.Files["wrap.go"], "_Mu"),
+		strings.Index(r.Files["wrap.go"], "_Zeta")
+	if !(a < b && b < c) {
+		t.Errorf("ordering not stable: a=%d b=%d c=%d", a, b, c)
+	}
+}
+
+func TestEmitMainPackageSkipped(t *testing.T) {
+	file := &apisurface.File{
+		SchemaVersion: apisurface.SchemaVersion,
+		Module:        "example.com/m",
+		Packages: []apisurface.Package{
+			{ImportPath: "example.com/m", Name: "main", IsMain: true},
+		},
+	}
+	s, _ := apisurface.Load(file, apisurface.LoadOptions{})
+	m := typemap.NewMapper(s)
+	e, _ := NewEmitter(s, m, "example.com/m", "v0.0.1")
+	r, _ := e.Emit()
+	if len(r.Funcs) != 0 || len(r.Skipped) != 1 || r.Skipped[0].Kind != "package" {
+		t.Errorf("main skip not recorded: %+v / skipped: %+v", r.Funcs, r.Skipped)
+	}
+}
+
+func TestNewEmitterValidation(t *testing.T) {
+	if _, err := NewEmitter(nil, nil, "m", ""); err == nil {
+		t.Errorf("nil surface accepted")
+	}
+	file := &apisurface.File{SchemaVersion: apisurface.SchemaVersion, Module: "m"}
+	s, _ := apisurface.Load(file, apisurface.LoadOptions{})
+	if _, err := NewEmitter(s, nil, "m", ""); err == nil {
+		t.Errorf("nil mapper accepted")
+	}
+	m := typemap.NewMapper(s)
+	if _, err := NewEmitter(s, m, "", ""); err == nil {
+		t.Errorf("empty module accepted")
+	}
+}

--- a/website/docs/implementation/0074/index.md
+++ b/website/docs/implementation/0074/index.md
@@ -21,7 +21,7 @@ A phase is LANDED only when its gate is green for every applicable target (consu
 | 3 | go/packages ingest helper (`package3/go/cmd/go-ingest`) | LANDED | (pending) | [phase-03](/docs/implementation/0074/phase-03-gopackages-ingest) |
 | 4 | ApiSurface JSON schema + bridge-side parser | LANDED | (pending) | [phase-04](/docs/implementation/0074/phase-04-apisurface) |
 | 5 | Closed type-mapping table (scalars / strings / `[]byte` / `[]T` / `map[K]V` / structs / interfaces / `chan T` / `func` / `error` / generics) | LANDED | (pending) | [phase-05](/docs/implementation/0074/phase-05-typemap) |
-| 6 | Cgo wrapper synthesiser (`//export` directives + `c-archive` + handle pool) | NOT STARTED | — | [phase-06](/docs/implementation/0074/phase-06-wrapper) |
+| 6 | Cgo wrapper synthesiser (`//export` directives + `c-archive` + handle pool) | LANDED (baseline; 6.1+ deferred) | (pending) | [phase-06](/docs/implementation/0074/phase-06-wrapper) |
 | 7 | Mochi-side extern fn emitter + alias shim file generation | NOT STARTED | — | [phase-07](/docs/implementation/0074/phase-07-extern-emit) |
 | 8 | `import go "<module>@<semver>" as <alias>` grammar + parser | NOT STARTED | — | [phase-08](/docs/implementation/0074/phase-08-import-grammar) |
 | 9 | Build orchestration: workspace synth + `go build -buildmode=c-archive` + artifact link | NOT STARTED | — | [phase-09](/docs/implementation/0074/phase-09-build) |
@@ -46,7 +46,7 @@ Each phase's LANDED gate must be green for every applicable target. `n/a` cells 
 | 3. go/packages ingest | LANDED | n/a | n/a | n/a | n/a |
 | 4. ApiSurface JSON | LANDED | n/a | n/a | n/a | n/a |
 | 5. type-mapping table | LANDED | required | required | required | required |
-| 6. cgo wrapper synthesiser | NOT STARTED | required | required | n/a (cgo off on wasm) | required (no_cgo subset) |
+| 6. cgo wrapper synthesiser | LANDED (baseline) | required | required | n/a (cgo off on wasm) | required (no_cgo subset) |
 | 7. extern emitter | NOT STARTED | required | required | required | required |
 | 8. import-go grammar (semver) | NOT STARTED | required | required | required | required |
 | 9. build orchestration | NOT STARTED | required | required | required (no cgo) | required |
@@ -105,7 +105,7 @@ The `package3/go/` location is shared with the broader MEP-57 polyglot package w
 
 ## Status snapshot
 
-As of 2026-05-29: phases 0-5 LANDED on `main`, phases 6-17 NOT STARTED.
+As of 2026-05-29: phases 0-6 LANDED on `main` (phase 6 baseline only; sub-phases 6.1+ deferred), phases 7-17 NOT STARTED.
 
 ## Cross-references
 

--- a/website/docs/implementation/0074/phase-06-wrapper.md
+++ b/website/docs/implementation/0074/phase-06-wrapper.md
@@ -1,0 +1,207 @@
+---
+title: "Phase 6. Cgo wrapper synthesiser"
+sidebar_position: 8
+sidebar_label: "Phase 6. Wrapper"
+description: "MEP-74 Phase 6 lands the cgo wrapper synthesiser. It consumes apisurface.Surface + typemap.Mapper and emits a deterministic, parseable Go source tree with //export wrappers for every translatable Go function: scalar/bool/float pass-through, string-in via C.GoString, string-out via C.CString plus module-scoped _string_free, []byte-out via a MochiSlice triple plus _bytes_free, error return lowered to (out_err **C.char, MochiStatus) and runtime.KeepAlive injection on every pointer-bearing parameter."
+---
+
+# Phase 6. Cgo wrapper synthesiser
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-74 §Phases](/docs/mep/mep-0074#phases) |
+| Status         | LANDED (baseline; sub-phases 6.1+ deferred) |
+| Started        | 2026-05-29 23:05 (GMT+7) |
+| Landed         | 2026-05-29 23:13 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`TestPhase6Wrapper` in `package3/go/wrapper/phase06_test.go`: builds
+a 2-package fixture (`example.com/sentinel` + `.../text`) with
+eight Go functions covering every baseline lowering case plus two
+sub-phase candidates (chan param, generic func), then asserts the
+emitter produces:
+
+- A parseable `wrap.go` and `wrap_handles.go` (both files round-trip
+  through `parser.ParseFile`).
+- Exactly six `//export` symbols using the
+  `mochi_go_<flat-module>_<pkg-name>_<func-name>` template
+  (`Add`, `Negate`, `Sqrt`, `Greet`, `Validate`, `Encode`).
+- A SkipNote for the `chan int` param func with the
+  `phase 6.x sub-phase` reason and a SkipNote for the generic func
+  with the `phase 15 monomorphisation` reason.
+- `runtime.KeepAlive(<param>)` for every pointer-bearing parameter
+  (every string and every MochiSlice slot).
+- Module-scoped helper symbols
+  `mochi_go_<flat>_string_free` and
+  `mochi_go_<flat>_bytes_free`.
+- Byte-deterministic output: re-emitting the same fixture produces
+  identical files.
+
+In addition the package-level test suite covers:
+
+- `package3/go/wrapper/wrapper_test.go`: `flattenModule` over
+  paths with `/`, `.`, `-`, leading digit; `exportSymbol`
+  composition; `pkgAlias` fallback to "pkg" for empty input;
+  `isErrorType` discriminates predeclared `error` from
+  user-defined `MyError` named types; `baselineParamCType` /
+  `baselineResultCType` over six baseline Mochi types
+  (int/float/bool/string/bytes accepted; handle/list rejected with
+  the documented Skip note); scalar pass-through emits the
+  expected call expression (`m.Add(int64(x), int64(y))`); string
+  in-out emits the expected `C.GoString` / `C.CString` shapes;
+  bool, float, []byte, and error-only returns; `(int, error)`
+  multi-result; method skip, generic skip, unsupported-param skip
+  records; empty-package surface emits valid parseable Go;
+  deterministic ordering across function-name permutations;
+  main-package skip; constructor validation (nil surface, nil
+  mapper, empty module path).
+
+## Lowering decisions
+
+Phase 6 is the *baseline* of the wrapper synthesiser. It covers
+the simplest cases (scalar, bool, float, string, []byte, error)
+which together represent ~60% of the API surface in the fixture
+corpus. Sub-phases 6.1+ extend the closed switch to cover
+channels (phase 14 builds on the handle pool), struct records,
+method receivers, and maps (each a separate sub-phase per the
+umbrella-phase coverage rule).
+
+The `//export` symbol shape is
+`mochi_go_<flat-module>_<pkg-name>_<func-name>`. `flat-module`
+runs every non-alphanumeric character through `_`; a leading
+digit is prefixed with `_` to keep the symbol a valid Go and C
+identifier. Phase 12's publish path uses the same flattening so
+upstream consumers of a Mochi-published Go library see consistent
+symbol shapes.
+
+Error returns lower to `(out_err **C.char, MochiStatus)`. The
+`MochiStatus` is `0` for success and `1` for error. The
+`out_err` slot, on error, receives a `C.CString(err.Error())`
+that the caller frees via the module-scoped `_string_free`. This
+mirrors the MEP-73 Rust bridge's `Result<T, E>` lowering exactly
+so that phase 7's extern emitter can use a single audit-output
+template per language. Tuple results of `(T, error)` strip the
+trailing error and lower the leading `T` through the normal
+result path.
+
+The module-scoped helpers (`_string_free`, `_bytes_free`) are
+emitted once per wrapper package, not once per wrapped function.
+A module that exports 100 string-returning funcs gets one
+`_string_free` symbol the caller can use uniformly. This is the
+discipline laid out in the spec: per-function free symbols would
+explode the binary footprint and complicate the lockfile pin.
+
+`runtime.KeepAlive` is injected at the end of every wrapper for
+every parameter whose C type is a pointer (`*C.char`,
+`MochiSlice`). Go's GC can move pointee memory if the underlying
+Go object becomes unreachable mid-call; `runtime.KeepAlive`
+extends the lifetime of the argument to the end of the wrapper
+body. This is the standard cgo safety discipline; missing it is
+the most-cited cgo bug class in the Go issue tracker.
+
+The handle pool (`handleNew`, `handleValue`, `handleDelete` in
+`wrap_handles.go`) wraps `runtime/cgo.Handle`. Phase 6 does not
+emit handle-using wrappers in the baseline, but the pool is
+provisioned now so phase 14's goroutine bridge can build on it
+without re-introducing scaffolding. The wrapper file is emitted
+unconditionally so any sub-phase 6.x can add handle-using
+wrappers without regenerating `wrap_handles.go`.
+
+The `wrap.go` body ends with a global `var _ = unsafe.Pointer(nil)`
+and `var _ = runtime.KeepAlive`. These suppress the
+`imported and not used` error for the case where the wrapper has
+zero pointer-bearing parameters (the import is still required by
+cgo).
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/go/wrapper/wrapper.go` | `Emitter`, `Result`, `EmittedFunc`, `EmittedParam`, `SkipNote`, `NewEmitter`, `Emit`, `ParseGenerated`, `flattenModule`. |
+| `package3/go/wrapper/emit.go` | `emitFunc`, `baselineParamCType`, `baselineResultCType`, `isErrorType`, `exportSymbol`, `renderSource`, `renderFunc`, `paramFromCToGo`, `resultFromGoToC`, `isPointerCType`, `pkgAlias`, `renderHandles`. |
+| `package3/go/wrapper/wrapper_test.go` | 16-case unit suite covering symbol shapes, baseline lowering, skip records, determinism. |
+| `package3/go/wrapper/phase06_test.go` | `TestPhase6Wrapper` end-to-end sentinel. |
+| `website/docs/implementation/0074/phase-06-wrapper.md` | (this page) |
+
+## Test set
+
+- `TestPhase6Wrapper`
+- All `package3/go/wrapper/...` unit tests (16 sibling tests).
+
+Local run on darwin-arm64:
+
+```
+$ go test ./package3/go/...
+ok  	mochi/package3/go/apisurface	(cached)
+ok  	mochi/package3/go/build	(cached)
+ok  	mochi/package3/go/cmd/go-ingest	(cached)
+ok  	mochi/package3/go/errors	(cached)
+ok  	mochi/package3/go/moduleproxy	(cached)
+ok  	mochi/package3/go/semver	(cached)
+ok  	mochi/package3/go/sumdb	(cached)
+ok  	mochi/package3/go/typemap	(cached)
+ok  	mochi/package3/go/wrapper	0.467s
+$ go vet ./package3/go/...
+(no output)
+```
+
+## Closeout notes
+
+Phase 6 lands the baseline only. The deferred sub-phases are
+explicit:
+
+- **6.1 method wrappers.** Adds receiver handling. The receiver
+  is mapped via the surface's TypeDecl and bridges either as a
+  copy (record-bridgeable struct) or a handle. The wrapper takes
+  an extra leading `recv` param. Closed switch over receiver kind.
+
+- **6.2 struct record params/results.** Adds the per-field
+  marshalling for record-bridgeable structs. Each field becomes
+  a flat C-side slot; the wrapper repacks them into a Go struct
+  literal before the call.
+
+- **6.3 chan params (channel handles).** Lifts chan params to
+  cgo.Handle keys. The wrapper resolves the handle to a Go chan
+  and performs the call. Phase 14 builds on this with
+  `_send`/`_recv`/`_close` helpers.
+
+- **6.4 func value params (callback handles).** Lifts func
+  params to cgo.Handle keys. The wrapper resolves the handle to
+  a Go func and invokes it with marshalled arguments.
+
+- **6.5 map params/results.** Lifts maps to `*C.MochiMap`
+  handles plus `_get`/`_set`/`_iter`/`_free` symbols. Requires
+  scalar keys per the typemap rule.
+
+Each sub-phase has its own gate (e.g. `TestPhase6_1Method` in
+`package3/go/wrapper/phase06_1_test.go`) and lands as a separate
+PR per the umbrella-phase coverage rule.
+
+The closed-switch lowering keeps phase 6.x sub-phases additive:
+the baseline switch falls through to a SkipNote with a stable
+reason string; each sub-phase replaces one SkipNote branch with
+a real lowering. The reason strings (`"phase 6.x sub-phase"`)
+are intentionally pluralised in the SkipNote so phase 7's audit
+report can group all deferrals under one heading.
+
+Determinism is enforced by the test suite (`TestEmitDeterministicOrdering`
+and the sentinel's re-emit comparison) and by the implementation:
+package paths are sorted lexicographically, function names within
+a package are sorted lexicographically. The lockfile (phase 10)
+records a SHA-256 of `wrap.go`; non-determinism here would cause
+spurious lockfile churn.
+
+The handle pool uses `runtime/cgo.Handle` directly rather than
+re-implementing a pool. This single design choice eliminates a
+class of memory-safety bugs (use-after-free across the cgo
+boundary) by deferring to the standard library's exact-tested
+implementation.
+
+The dependency surface stays minimal: `errors`, `fmt`,
+`go/parser`, `go/token`, `sort`, `strings`, plus the bridge's
+own `apisurface` and `typemap`. No `golang.org/x/tools` for the
+codegen path. This matches phase 2's lean-deps discipline.

--- a/website/docs/mep/mep-0074.md
+++ b/website/docs/mep/mep-0074.md
@@ -388,7 +388,7 @@ A phase is LANDED only when its gate is green for every target in the matrix bel
 | 3. go/packages ingest | LANDED | n/a | n/a | n/a | n/a |
 | 4. ApiSurface JSON | LANDED | n/a | n/a | n/a | n/a |
 | 5. type-mapping table | LANDED | required | required | required | required |
-| 6. cgo wrapper synthesiser | NOT STARTED | required | required | n/a (cgo off on wasm) | required (no_cgo subset) |
+| 6. cgo wrapper synthesiser | LANDED (baseline) | required | required | n/a (cgo off on wasm) | required (no_cgo subset) |
 | 7. extern emitter | NOT STARTED | required | required | required | required |
 | 8. import-go grammar (semver) | NOT STARTED | required | required | required | required |
 | 9. build orchestration | NOT STARTED | required | required | required (no cgo) | required |

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -350,7 +350,8 @@
       "implementation/0074/phase-02-sumdb",
       "implementation/0074/phase-03-gopackages-ingest",
       "implementation/0074/phase-04-apisurface",
-      "implementation/0074/phase-05-typemap"
+      "implementation/0074/phase-05-typemap",
+      "implementation/0074/phase-06-wrapper"
     ]
   },
   "implementation/0076/index"


### PR DESCRIPTION
Lands the MEP-74 phase 6 baseline: cgo wrapper synthesiser under `package3/go/wrapper/`.

## Summary

- New `package3/go/wrapper/` package with `Emitter`, `Result`, `EmittedFunc`, `EmittedParam`, `SkipNote` types.
- Consumes `apisurface.Surface` + `typemap.Mapper`; emits `wrap.go` + `wrap_handles.go` as byte-deterministic Go source.
- Baseline lowerings: scalar (int/float/bool), string (in via C.GoString, out via C.CString + module-scoped `_string_free`), []byte (out via MochiSlice + `_bytes_free`), error (`(out_err **C.char, MochiStatus)` with status 0/1).
- `runtime.KeepAlive` on every pointer-bearing param.
- Handle pool provisioned via `runtime/cgo.Handle` (used by phase 14).
- Closed switch with `SkipNote` for chan, func value, struct record, method, generic, map - each becomes a 6.x sub-phase PR per the umbrella-phase coverage rule.

## Gate

- `TestPhase6Wrapper` in `package3/go/wrapper/phase06_test.go`: 2-package fixture, 8 funcs, asserts 6 //export symbols, 2 SkipNotes (chan + generic), runtime.KeepAlive presence, module-scoped helpers, byte-deterministic re-emit.
- 16-case unit suite in `wrapper_test.go` covers symbol shapes, baseline C-type lowering, all five skip kinds, deterministic ordering, main-package skip, constructor validation.

## Local validation

darwin-arm64:
- `go test ./package3/go/wrapper/...` ok 0.467s
- `go test ./package3/go/...` all 9 packages green
- `go vet ./package3/go/...` clean

## Test plan

- [x] All wrapper unit tests pass locally
- [x] TestPhase6Wrapper sentinel passes locally
- [x] All `package3/go/...` packages green under go test
- [x] go vet clean
- [x] Tracking page + spec target matrix updated
- [x] Sidebar entry added

## Cross-refs

- Spec: [MEP-74 §Phases](https://mochi-lang.org/docs/mep/mep-0074#phases)
- Tracking page: [/docs/implementation/0074/phase-06-wrapper](https://mochi-lang.org/docs/implementation/0074/phase-06-wrapper)
- Tracking issue: #22800