### PR TITLE
feat(mep-75 p0): package3/php/ skeleton

### DIFF
--- a/package3/php/README.md
+++ b/package3/php/README.md
@@ -1,0 +1,74 @@
+# package3/php — MEP-75 PHP Bridge
+
+Bidirectional Composer/Packagist interoperability for Mochi. Lets Mochi code
+consume any PHP Composer package and publish Mochi modules as Composer
+libraries.
+
+## Pipeline (phases 0-14)
+
+```
+mochi.toml [php-dependencies]
+   |  pkgmanifest.Parse + pkgsolver.Solve (MEP-57)
+   v
+resolved PHP dep tree (vendor/package + version + Packagist dist URL)
+   |  packagist.Fetch (Packagist v2 sparse API)
+   v
+dist zips in ~/.cache/mochi/php-deps/<sha256-hex>/
+   |  reflect.Run (php reflect.php <pkg-path> -> JSON)
+   v
+ReflectionSurface JSON document per package
+   |  typemap.Translate (closed PHP-to-Mochi table)
+   v
+TranslatedSurface + SkipReport per package
+   |  externemit.Emit (Mochi extern fn / extern type)
+   v
+synthesised .mochi shim file per package
+   |  glue.Emit (PHP-side use + forwarding stubs)
+   v
+vendor/ injection into MEP-55 build sandbox
+   |  MEP-55 Driver.Build (TargetPhpSource / TargetPhpLibrary / ...)
+   v
+PHP program or Composer library
+```
+
+## Sub-packages
+
+| Package      | Phase | Description                                               |
+|--------------|-------|-----------------------------------------------------------|
+| errors       | 0     | SkipReason constants, SkipReport, BridgeError             |
+| build        | 0     | Driver, Options, Workspace scaffold                       |
+| packagist    | 1     | Packagist v2 sparse-index client                         |
+| cache        | 2     | Content-addressed Composer dist fetcher                   |
+| reflect      | 3     | PHP CLI reflection invoker + JSON surface parser          |
+| typemap      | 4     | Closed PHP-to-Mochi type translation table                |
+| externemit   | 5     | Mochi extern fn / extern type emitter                     |
+| glue         | 6     | PHP-side use + forwarding stubs                           |
+| autoload     | 7     | vendor/autoload.php generator (PSR-4, no composer install)|
+| lock         | 8     | mochi.lock [[php-package]] read/write                     |
+| library      | 9     | TargetPhpLibrary: PSR-4 src/ + composer.json emit         |
+| publish      | 10    | Packagist publish: GPG tag + Sigstore + Update API        |
+
+## PHP-to-Mochi type table (closed set)
+
+| PHP type     | Mochi type  | Notes                                      |
+|--------------|-------------|--------------------------------------------|
+| int          | int         |                                            |
+| float        | float       |                                            |
+| string       | string      |                                            |
+| bool         | bool        |                                            |
+| ?T           | T\|nil      | nullable wrapper                           |
+| array (typed)| list/map    | heuristic from docblock or typed property  |
+| class        | record/handle |                                          |
+| interface    | protocol handle |                                        |
+| void         | unit        |                                            |
+| never        | panic boundary | SkipNever in v1                         |
+| mixed        | SKIP        | SkipMixed                                  |
+| object       | SKIP        | SkipObject                                 |
+| callable     | SKIP        | SkipCallable                               |
+| resource     | SKIP        | SkipResource                               |
+
+## See also
+
+- [MEP-75 spec](../../website/docs/mep/mep-0075.md)
+- [Research notes](../../website/docs/research/0075/)
+- [MEP-55 PHP transpiler](../python/) — lowering pipeline reused by this bridge

--- a/package3/php/autoload/autoload.go
+++ b/package3/php/autoload/autoload.go
@@ -1,0 +1,4 @@
+// Package autoload generates the pre-computed vendor/autoload.php from PSR-4
+// namespace maps without requiring a live `composer install`. Phase 0 ships
+// the package stub; the full implementation arrives in phase 7.
+package autoload

--- a/package3/php/build/driver.go
+++ b/package3/php/build/driver.go
@@ -1,0 +1,165 @@
+// Package build is the orchestration layer for the MEP-75 PHP bridge pipeline.
+// Phase 0 ships only the cache-key + work-dir scaffolding; later phases attach
+// the Packagist sparse-index client, the PHP reflection ingest, the extern
+// emitter, and the MEP-55 build invocation.
+//
+// Lifecycle:
+//
+//	d := build.NewDriver(build.Options{...})
+//	w, err := d.PrepareWorkspace()
+//	// phase 1-14: ingest, reflect, typemap, externemit, glue, build
+//	d.Cleanup()  // remove the scratch work-dir; cache-dir is preserved.
+package build
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Driver is the top-level entry point for the MEP-75 PHP bridge build pipeline.
+type Driver struct {
+	opts Options
+}
+
+// Options configure a Driver. All fields are optional; sensible defaults are
+// applied by NewDriver.
+type Options struct {
+	// CacheDir is the persistent content-addressed cache root. Default:
+	// $XDG_CACHE_HOME/mochi/php-deps/ or ~/.cache/mochi/php-deps/.
+	CacheDir string
+	// WorkDir is the scratch directory used for a single build. Default:
+	// a fresh subdirectory of $TMPDIR/mochi-php-XXXX/.
+	WorkDir string
+	// PHPBin is the PHP CLI binary to invoke for reflection. Default: "php".
+	PHPBin string
+	// NoCache disables the cache entirely. Every build re-fetches and
+	// re-reflects from scratch. Useful for cache-correctness tests.
+	NoCache bool
+	// Verbose turns on extra diagnostics in the bridge's own logging.
+	Verbose bool
+	// Deterministic activates the reproducible-build flags. The bridge
+	// passes SOURCE_DATE_EPOCH=0 and refuses to touch any wall-clock-derived state.
+	Deterministic bool
+}
+
+// NewDriver constructs a Driver with the given options. The work-dir is
+// allocated lazily on the first call to PrepareWorkspace so a Driver that is
+// never used does not leak a directory.
+func NewDriver(opts Options) *Driver {
+	if opts.CacheDir == "" {
+		opts.CacheDir = defaultCacheDir()
+	}
+	if opts.PHPBin == "" {
+		opts.PHPBin = "php"
+	}
+	return &Driver{opts: opts}
+}
+
+// CacheDir returns the resolved persistent cache directory. May be empty if
+// NoCache is set.
+func (d *Driver) CacheDir() string {
+	if d.opts.NoCache {
+		return ""
+	}
+	return d.opts.CacheDir
+}
+
+// WorkDir returns the resolved scratch work directory. Empty if
+// PrepareWorkspace has not yet been called.
+func (d *Driver) WorkDir() string { return d.opts.WorkDir }
+
+// PHPBin returns the PHP CLI binary path.
+func (d *Driver) PHPBin() string { return d.opts.PHPBin }
+
+// Verbose returns whether the driver was configured for verbose output.
+func (d *Driver) Verbose() bool { return d.opts.Verbose }
+
+// Deterministic returns whether the driver was configured for reproducible
+// builds.
+func (d *Driver) Deterministic() bool { return d.opts.Deterministic }
+
+// PrepareWorkspace allocates the scratch work directory (if not already set)
+// and ensures the cache directory exists. It returns a Workspace value that
+// callers use to track shim files, glue stubs, and the vendor sandbox.
+//
+// PrepareWorkspace is idempotent: calling it twice with the same Driver
+// re-uses the existing work-dir.
+func (d *Driver) PrepareWorkspace() (*Workspace, error) {
+	if d.opts.WorkDir == "" {
+		dir, err := os.MkdirTemp("", "mochi-php-")
+		if err != nil {
+			return nil, fmt.Errorf("driver: allocate work-dir: %w", err)
+		}
+		d.opts.WorkDir = dir
+	} else {
+		if err := os.MkdirAll(d.opts.WorkDir, 0o755); err != nil {
+			return nil, fmt.Errorf("driver: create work-dir %s: %w", d.opts.WorkDir, err)
+		}
+	}
+	if !d.opts.NoCache {
+		if err := os.MkdirAll(d.opts.CacheDir, 0o755); err != nil {
+			return nil, fmt.Errorf("driver: create cache-dir %s: %w", d.opts.CacheDir, err)
+		}
+	}
+	return &Workspace{Root: d.opts.WorkDir}, nil
+}
+
+// Cleanup removes the scratch work-dir. The persistent cache-dir is preserved.
+// Safe to call even if PrepareWorkspace was never called.
+func (d *Driver) Cleanup() error {
+	if d.opts.WorkDir == "" {
+		return nil
+	}
+	if err := os.RemoveAll(d.opts.WorkDir); err != nil {
+		return fmt.Errorf("driver: cleanup work-dir: %w", err)
+	}
+	d.opts.WorkDir = ""
+	return nil
+}
+
+// defaultCacheDir returns the XDG-aware cache directory for PHP bridge deps.
+func defaultCacheDir() string {
+	if xdg := os.Getenv("XDG_CACHE_HOME"); xdg != "" {
+		return filepath.Join(xdg, "mochi", "php-deps")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), "mochi-php-cache")
+	}
+	return filepath.Join(home, ".cache", "mochi", "php-deps")
+}
+
+// Workspace records the paths of the scratch work directory and the
+// sub-directories created during a bridge build.
+type Workspace struct {
+	// Root is the top-level scratch directory, e.g. /tmp/mochi-php-123456/.
+	Root string
+	// ShimDir is where synthesised .mochi extern shim files are written.
+	ShimDir string
+	// GlueDir is where PHP-side forwarding stubs are written.
+	GlueDir string
+	// VendorDir is where the autoload bridge vendor/ directory is materialised.
+	VendorDir string
+}
+
+// EnsureSubDirs creates ShimDir, GlueDir, and VendorDir under Root.
+// Called during phase 5-7 after PrepareWorkspace.
+func (w *Workspace) EnsureSubDirs() error {
+	for _, sub := range []struct {
+		ptr  *string
+		name string
+	}{
+		{&w.ShimDir, "shims"},
+		{&w.GlueDir, "glue"},
+		{&w.VendorDir, "vendor"},
+	} {
+		if *sub.ptr == "" {
+			*sub.ptr = filepath.Join(w.Root, sub.name)
+		}
+		if err := os.MkdirAll(*sub.ptr, 0o755); err != nil {
+			return fmt.Errorf("workspace: create %s: %w", sub.name, err)
+		}
+	}
+	return nil
+}

--- a/package3/php/build/driver_test.go
+++ b/package3/php/build/driver_test.go
@@ -1,0 +1,155 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewDriverDefaults(t *testing.T) {
+	d := NewDriver(Options{})
+	if d.CacheDir() == "" {
+		t.Error("CacheDir should have a non-empty default")
+	}
+	if !strings.Contains(d.CacheDir(), "php-deps") {
+		t.Errorf("CacheDir %q should contain php-deps", d.CacheDir())
+	}
+	if d.PHPBin() != "php" {
+		t.Errorf("PHPBin = %q; want %q", d.PHPBin(), "php")
+	}
+	if d.WorkDir() != "" {
+		t.Errorf("WorkDir should be empty before PrepareWorkspace; got %q", d.WorkDir())
+	}
+}
+
+func TestNewDriverNoCacheReturnsEmpty(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	if d.CacheDir() != "" {
+		t.Errorf("CacheDir should be empty when NoCache=true; got %q", d.CacheDir())
+	}
+}
+
+func TestNewDriverVerboseDeterministic(t *testing.T) {
+	d := NewDriver(Options{Verbose: true, Deterministic: true})
+	if !d.Verbose() {
+		t.Error("Verbose() should be true")
+	}
+	if !d.Deterministic() {
+		t.Error("Deterministic() should be true")
+	}
+}
+
+func TestPrepareWorkspaceCreatesDir(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	w, err := d.PrepareWorkspace()
+	if err != nil {
+		t.Fatalf("PrepareWorkspace returned error: %v", err)
+	}
+	defer d.Cleanup() //nolint:errcheck
+	if w.Root == "" {
+		t.Error("Workspace.Root should be non-empty")
+	}
+	if _, err := os.Stat(w.Root); err != nil {
+		t.Errorf("work dir %q does not exist: %v", w.Root, err)
+	}
+	if !strings.Contains(w.Root, "mochi-php-") {
+		t.Errorf("WorkDir %q should contain mochi-php- prefix", w.Root)
+	}
+}
+
+func TestPrepareWorkspaceIdempotent(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	w1, err := d.PrepareWorkspace()
+	if err != nil {
+		t.Fatalf("first PrepareWorkspace: %v", err)
+	}
+	defer d.Cleanup() //nolint:errcheck
+	w2, err := d.PrepareWorkspace()
+	if err != nil {
+		t.Fatalf("second PrepareWorkspace: %v", err)
+	}
+	if w1.Root != w2.Root {
+		t.Errorf("PrepareWorkspace not idempotent: %q != %q", w1.Root, w2.Root)
+	}
+}
+
+func TestPrepareWorkspaceExplicitWorkDir(t *testing.T) {
+	dir := t.TempDir()
+	d := NewDriver(Options{NoCache: true, WorkDir: dir})
+	w, err := d.PrepareWorkspace()
+	if err != nil {
+		t.Fatalf("PrepareWorkspace: %v", err)
+	}
+	if w.Root != dir {
+		t.Errorf("WorkDir = %q; want %q", w.Root, dir)
+	}
+}
+
+func TestCleanupRemovesWorkDir(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	w, err := d.PrepareWorkspace()
+	if err != nil {
+		t.Fatalf("PrepareWorkspace: %v", err)
+	}
+	workDir := w.Root
+	if err := d.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if _, err := os.Stat(workDir); !os.IsNotExist(err) {
+		t.Errorf("work dir %q still exists after Cleanup", workDir)
+	}
+	if d.WorkDir() != "" {
+		t.Errorf("WorkDir should be empty after Cleanup; got %q", d.WorkDir())
+	}
+}
+
+func TestCleanupWithoutPrepare(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	if err := d.Cleanup(); err != nil {
+		t.Errorf("Cleanup without PrepareWorkspace should be a no-op; got: %v", err)
+	}
+}
+
+func TestCacheDirXDG(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+	got := defaultCacheDir()
+	want := filepath.Join(tmp, "mochi", "php-deps")
+	if got != want {
+		t.Errorf("defaultCacheDir() = %q; want %q", got, want)
+	}
+}
+
+func TestWorkspaceEnsureSubDirs(t *testing.T) {
+	root := t.TempDir()
+	w := &Workspace{Root: root}
+	if err := w.EnsureSubDirs(); err != nil {
+		t.Fatalf("EnsureSubDirs: %v", err)
+	}
+	for _, dir := range []string{w.ShimDir, w.GlueDir, w.VendorDir} {
+		if _, err := os.Stat(dir); err != nil {
+			t.Errorf("sub-dir %q does not exist: %v", dir, err)
+		}
+	}
+	if w.ShimDir != filepath.Join(root, "shims") {
+		t.Errorf("ShimDir = %q; want %q", w.ShimDir, filepath.Join(root, "shims"))
+	}
+	if w.GlueDir != filepath.Join(root, "glue") {
+		t.Errorf("GlueDir = %q; want %q", w.GlueDir, filepath.Join(root, "glue"))
+	}
+	if w.VendorDir != filepath.Join(root, "vendor") {
+		t.Errorf("VendorDir = %q; want %q", w.VendorDir, filepath.Join(root, "vendor"))
+	}
+}
+
+func TestWorkspaceEnsureSubDirsIdempotent(t *testing.T) {
+	root := t.TempDir()
+	w := &Workspace{Root: root}
+	if err := w.EnsureSubDirs(); err != nil {
+		t.Fatalf("first EnsureSubDirs: %v", err)
+	}
+	if err := w.EnsureSubDirs(); err != nil {
+		t.Fatalf("second EnsureSubDirs: %v", err)
+	}
+}

--- a/package3/php/build/phase00_test.go
+++ b/package3/php/build/phase00_test.go
@@ -1,0 +1,126 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPhase0Skeleton is the per-phase sentinel test. The CI gate for phase
+// 0 LANDED requires this test to pass on every supported host.
+//
+// Sub-tests:
+//   - end_to_end: Driver allocates work-dir + cache-dir, PrepareWorkspace
+//     creates all expected sub-directories, Cleanup removes the work-dir.
+//   - package_layout: the package3/php/ tree exists at the expected
+//     paths and has all documented Go packages.
+//   - workspace_subdirs: EnsureSubDirs creates shims/, glue/, vendor/
+//     under the workspace root.
+func TestPhase0Skeleton(t *testing.T) {
+	t.Run("end_to_end", func(t *testing.T) {
+		d := NewDriver(Options{NoCache: true})
+		defer d.Cleanup() //nolint:errcheck
+
+		if d.WorkDir() != "" {
+			t.Errorf("WorkDir should be empty before PrepareWorkspace; got %q", d.WorkDir())
+		}
+
+		w, err := d.PrepareWorkspace()
+		if err != nil {
+			t.Fatalf("PrepareWorkspace: %v", err)
+		}
+		if w.Root == "" {
+			t.Fatalf("Workspace.Root is empty after PrepareWorkspace")
+		}
+		if _, err := os.Stat(w.Root); err != nil {
+			t.Fatalf("Workspace.Root %q does not exist: %v", w.Root, err)
+		}
+		if !strings.Contains(w.Root, "mochi-php-") {
+			t.Errorf("WorkDir %q should contain mochi-php- prefix", w.Root)
+		}
+
+		workDir := w.Root
+		if err := d.Cleanup(); err != nil {
+			t.Fatalf("Cleanup: %v", err)
+		}
+		if _, err := os.Stat(workDir); !os.IsNotExist(err) {
+			t.Errorf("work-dir %q still exists after Cleanup", workDir)
+		}
+		if d.WorkDir() != "" {
+			t.Errorf("WorkDir should be empty after Cleanup; got %q", d.WorkDir())
+		}
+	})
+
+	t.Run("package_layout", func(t *testing.T) {
+		// Locate package3/php/ relative to this test source file. The
+		// test runs from package3/php/build/, so the package root is
+		// one directory up.
+		here, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Getwd: %v", err)
+		}
+		pkgRoot := filepath.Dir(here)
+		expected := []string{
+			"README.md",
+			"build/driver.go",
+			"errors/errors.go",
+			"packagist/packagist.go",
+			"cache/cache.go",
+			"reflect/reflect.go",
+			"typemap/typemap.go",
+			"externemit/externemit.go",
+			"glue/glue.go",
+			"autoload/autoload.go",
+			"lock/lock.go",
+			"library/library.go",
+			"publish/publish.go",
+		}
+		for _, rel := range expected {
+			path := filepath.Join(pkgRoot, rel)
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Errorf("expected file %s missing: %v", rel, err)
+				continue
+			}
+			if info.IsDir() {
+				t.Errorf("expected file %s is a directory", rel)
+			}
+		}
+	})
+
+	t.Run("workspace_subdirs", func(t *testing.T) {
+		d := NewDriver(Options{NoCache: true})
+		defer d.Cleanup() //nolint:errcheck
+
+		w, err := d.PrepareWorkspace()
+		if err != nil {
+			t.Fatalf("PrepareWorkspace: %v", err)
+		}
+		if err := w.EnsureSubDirs(); err != nil {
+			t.Fatalf("EnsureSubDirs: %v", err)
+		}
+		for name, dir := range map[string]string{
+			"ShimDir":   w.ShimDir,
+			"GlueDir":   w.GlueDir,
+			"VendorDir": w.VendorDir,
+		} {
+			if dir == "" {
+				t.Errorf("%s is empty after EnsureSubDirs", name)
+				continue
+			}
+			if _, err := os.Stat(dir); err != nil {
+				t.Errorf("%s %q does not exist: %v", name, dir, err)
+			}
+		}
+		if !strings.HasSuffix(w.ShimDir, "shims") {
+			t.Errorf("ShimDir %q should end with shims", w.ShimDir)
+		}
+		if !strings.HasSuffix(w.GlueDir, "glue") {
+			t.Errorf("GlueDir %q should end with glue", w.GlueDir)
+		}
+		if !strings.HasSuffix(w.VendorDir, "vendor") {
+			t.Errorf("VendorDir %q should end with vendor", w.VendorDir)
+		}
+	})
+}

--- a/package3/php/cache/cache.go
+++ b/package3/php/cache/cache.go
@@ -1,0 +1,4 @@
+// Package cache implements the content-addressed Composer dist fetcher and
+// SHA-256 cache for the MEP-75 PHP bridge. Phase 0 ships the package stub;
+// the full implementation arrives in phase 2.
+package cache

--- a/package3/php/errors/errors.go
+++ b/package3/php/errors/errors.go
@@ -1,0 +1,144 @@
+// Package errors carries the cross-cutting error types the MEP-75 PHP bridge
+// emits at lock time and at build time. The most important one is SkipReport,
+// which records why a particular PHP reflection item was not translated into a
+// Mochi extern binding. See [website/docs/research/0075/05-type-mapping.md]
+// for the closed set of refusal reasons.
+package errors
+
+import "fmt"
+
+// SkipReason classifies why the bridge declined to translate a PHP reflection item.
+// The set mirrors the closed table in research note 05 §"Refusal reasons".
+type SkipReason int
+
+const (
+	// SkipUnknown is the zero value. It must never be emitted in practice.
+	SkipUnknown SkipReason = iota
+	// SkipMixed: PHP mixed type has no Mochi equivalent; requires hand annotation.
+	SkipMixed
+	// SkipObject: bare object type (untyped class instance).
+	SkipObject
+	// SkipUntypedArray: array without a typed key/value hint.
+	SkipUntypedArray
+	// SkipSelfStatic: self or static type in non-constructor context.
+	SkipSelfStatic
+	// SkipCallable: callable pseudo-type; no stable ABI.
+	SkipCallable
+	// SkipResource: PHP resource handle (pre-8.0 legacy).
+	SkipResource
+	// SkipIntersection: intersection type (A&B) — v1 has no intersection surface.
+	SkipIntersection
+	// SkipNever: never return type represents unreachable; emitted as panic boundary.
+	SkipNever
+	// SkipVararg: variadic parameter (...$args) with mixed type.
+	SkipVararg
+	// SkipPrivate: private method or property not reachable from Mochi.
+	SkipPrivate
+	// SkipAbstractNoImpl: abstract method with no concrete implementation path.
+	SkipAbstractNoImpl
+	// SkipMagicMethod: __get, __set, __call etc.; dynamic dispatch only.
+	SkipMagicMethod
+	// SkipAnonymousClass: anonymous class expression; no stable name.
+	SkipAnonymousClass
+	// SkipNoReflection: class or function invisible to PHP ReflectionAPI.
+	SkipNoReflection
+	// SkipExtension: defined by a C extension; requires native binding override.
+	SkipExtension
+)
+
+// String renders the SkipReason as a short token used in the SKIPPED.txt
+// output file. The token is stable across releases; do not rename without
+// adjusting the SKIPPED.txt golden fixtures.
+func (r SkipReason) String() string {
+	switch r {
+	case SkipMixed:
+		return "SkipMixed"
+	case SkipObject:
+		return "SkipObject"
+	case SkipUntypedArray:
+		return "SkipUntypedArray"
+	case SkipSelfStatic:
+		return "SkipSelfStatic"
+	case SkipCallable:
+		return "SkipCallable"
+	case SkipResource:
+		return "SkipResource"
+	case SkipIntersection:
+		return "SkipIntersection"
+	case SkipNever:
+		return "SkipNever"
+	case SkipVararg:
+		return "SkipVararg"
+	case SkipPrivate:
+		return "SkipPrivate"
+	case SkipAbstractNoImpl:
+		return "SkipAbstractNoImpl"
+	case SkipMagicMethod:
+		return "SkipMagicMethod"
+	case SkipAnonymousClass:
+		return "SkipAnonymousClass"
+	case SkipNoReflection:
+		return "SkipNoReflection"
+	case SkipExtension:
+		return "SkipExtension"
+	default:
+		return "SkipUnknown"
+	}
+}
+
+// SkipReport records a single PHP reflection item the bridge declined to translate.
+// The collection of SkipReports for a package is rendered to SKIPPED.txt under
+// the shim directory at the end of phase 5.
+type SkipReport struct {
+	// ItemPath is the PHP FQCN or function path, e.g. "GuzzleHttp\Client::send".
+	ItemPath string
+	// Reason is the classification.
+	Reason SkipReason
+	// Detail is a free-text explanation specific to this skip.
+	Detail string
+	// Override is the suggested hand-authored opt-in. May be empty if there
+	// is no straightforward override available.
+	Override string
+}
+
+// String renders a SkipReport in the SKIPPED.txt format documented in
+// research note 05.
+func (s SkipReport) String() string {
+	out := fmt.Sprintf("SKIPPED: %s\n  Reason: %s\n  Detail: %s\n", s.ItemPath, s.Reason, s.Detail)
+	if s.Override != "" {
+		out += fmt.Sprintf("  Override: %s\n", s.Override)
+	}
+	return out
+}
+
+// BridgeError is the top-level error returned by Driver entry points. It
+// records the phase that produced the error and the underlying cause.
+type BridgeError struct {
+	// Phase is the bridge phase that detected the error, e.g. "lock",
+	// "reflect", "typemap", "externemit".
+	Phase string
+	// Package is the upstream Composer package being processed when the error
+	// occurred. Empty for phase-agnostic errors.
+	Package string
+	// Cause is the underlying error.
+	Cause error
+}
+
+// Error renders BridgeError as "phase[package]: cause".
+func (e *BridgeError) Error() string {
+	if e.Package == "" {
+		return fmt.Sprintf("%s: %v", e.Phase, e.Cause)
+	}
+	return fmt.Sprintf("%s[%s]: %v", e.Phase, e.Package, e.Cause)
+}
+
+// Unwrap exposes the underlying cause for errors.Is / errors.As.
+func (e *BridgeError) Unwrap() error { return e.Cause }
+
+// Wrap constructs a BridgeError from a phase, a package (optional), and a cause.
+func Wrap(phase, pkg string, cause error) error {
+	if cause == nil {
+		return nil
+	}
+	return &BridgeError{Phase: phase, Package: pkg, Cause: cause}
+}

--- a/package3/php/errors/errors_test.go
+++ b/package3/php/errors/errors_test.go
@@ -1,0 +1,123 @@
+package errors
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSkipReasonString(t *testing.T) {
+	cases := []struct {
+		reason SkipReason
+		want   string
+	}{
+		{SkipUnknown, "SkipUnknown"},
+		{SkipMixed, "SkipMixed"},
+		{SkipObject, "SkipObject"},
+		{SkipUntypedArray, "SkipUntypedArray"},
+		{SkipSelfStatic, "SkipSelfStatic"},
+		{SkipCallable, "SkipCallable"},
+		{SkipResource, "SkipResource"},
+		{SkipIntersection, "SkipIntersection"},
+		{SkipNever, "SkipNever"},
+		{SkipVararg, "SkipVararg"},
+		{SkipPrivate, "SkipPrivate"},
+		{SkipAbstractNoImpl, "SkipAbstractNoImpl"},
+		{SkipMagicMethod, "SkipMagicMethod"},
+		{SkipAnonymousClass, "SkipAnonymousClass"},
+		{SkipNoReflection, "SkipNoReflection"},
+		{SkipExtension, "SkipExtension"},
+	}
+	for _, tc := range cases {
+		if got := tc.reason.String(); got != tc.want {
+			t.Errorf("SkipReason(%d).String() = %q; want %q", tc.reason, got, tc.want)
+		}
+	}
+}
+
+func TestSkipReasonStringExhaustive(t *testing.T) {
+	// All declared SkipReason constants must produce a non-"SkipUnknown"
+	// String when they are non-zero. This catches additions that forget to
+	// update the switch.
+	for i := int(SkipMixed); i <= int(SkipExtension); i++ {
+		got := SkipReason(i).String()
+		if got == "SkipUnknown" {
+			t.Errorf("SkipReason(%d).String() returned SkipUnknown; add a case", i)
+		}
+		if !strings.HasPrefix(got, "Skip") {
+			t.Errorf("SkipReason(%d).String() = %q; want Skip-prefix", i, got)
+		}
+	}
+}
+
+func TestSkipReportString(t *testing.T) {
+	r := SkipReport{
+		ItemPath: `GuzzleHttp\Client::send`,
+		Reason:   SkipCallable,
+		Detail:   "parameter $handler is callable pseudo-type with no stable ABI",
+		Override: "write `extern fn send(...) ... custom`",
+	}
+	got := r.String()
+	wantLines := []string{
+		`SKIPPED: GuzzleHttp\Client::send`,
+		"  Reason: SkipCallable",
+		"  Detail: parameter $handler is callable pseudo-type with no stable ABI",
+		"  Override: write `extern fn send(...) ... custom`",
+	}
+	for _, line := range wantLines {
+		if !strings.Contains(got, line) {
+			t.Errorf("SkipReport.String() missing %q\n--- full output ---\n%s", line, got)
+		}
+	}
+}
+
+func TestSkipReportStringNoOverride(t *testing.T) {
+	r := SkipReport{
+		ItemPath: `Foo\Bar::magic`,
+		Reason:   SkipMagicMethod,
+		Detail:   "__get/__set magic methods use dynamic dispatch only",
+	}
+	got := r.String()
+	if strings.Contains(got, "Override:") {
+		t.Errorf("SkipReport.String() emitted Override: when none was set\n%s", got)
+	}
+	if !strings.Contains(got, `SKIPPED: Foo\Bar::magic`) {
+		t.Errorf("SkipReport.String() missing item path\n%s", got)
+	}
+}
+
+func TestBridgeErrorFormat(t *testing.T) {
+	cause := errors.New("the cause")
+	e := Wrap("reflect", "guzzlehttp/guzzle", cause)
+	if e == nil {
+		t.Fatalf("Wrap returned nil with non-nil cause")
+	}
+	if e.Error() != "reflect[guzzlehttp/guzzle]: the cause" {
+		t.Errorf("BridgeError.Error() = %q; want %q", e.Error(), "reflect[guzzlehttp/guzzle]: the cause")
+	}
+}
+
+func TestBridgeErrorFormatNoCrate(t *testing.T) {
+	cause := errors.New("phase-wide failure")
+	e := Wrap("lock", "", cause)
+	if e == nil {
+		t.Fatalf("Wrap returned nil with non-nil cause")
+	}
+	if e.Error() != "lock: phase-wide failure" {
+		t.Errorf("BridgeError.Error() = %q; want %q", e.Error(), "lock: phase-wide failure")
+	}
+}
+
+func TestBridgeErrorUnwrap(t *testing.T) {
+	cause := errors.New("the cause")
+	e := Wrap("phase", "vendor/pkg", cause)
+	if !errors.Is(e, cause) {
+		t.Errorf("errors.Is(e, cause) was false; expected true via Unwrap")
+	}
+}
+
+func TestWrapNil(t *testing.T) {
+	if got := Wrap("phase", "vendor/pkg", nil); got != nil {
+		t.Errorf("Wrap returned %v for nil cause; want nil", got)
+	}
+}

--- a/package3/php/externemit/externemit.go
+++ b/package3/php/externemit/externemit.go
@@ -1,0 +1,4 @@
+// Package externemit synthesises Mochi extern fn / extern type declarations
+// from a translated PHP surface document. Phase 0 ships the package stub;
+// the full implementation arrives in phase 5.
+package externemit

--- a/package3/php/glue/glue.go
+++ b/package3/php/glue/glue.go
@@ -1,0 +1,4 @@
+// Package glue emits PHP-side use statements and forwarding stubs that bridge
+// the Mochi extern shims to the real Composer autoloaded classes. Phase 0
+// ships the package stub; the full implementation arrives in phase 6.
+package glue

--- a/package3/php/library/library.go
+++ b/package3/php/library/library.go
@@ -1,0 +1,5 @@
+// Package library implements the TargetPhpLibrary build target that emits a
+// PSR-4 src/ tree, composer.json, README.md, and LICENSE from a Mochi source
+// module. Phase 0 ships the package stub; the full implementation arrives in
+// phase 9.
+package library

--- a/package3/php/lock/lock.go
+++ b/package3/php/lock/lock.go
@@ -1,0 +1,5 @@
+// Package lock handles the [[php-package]] table in mochi.lock, recording
+// Composer package name, version, dist-sha256, reflection-sha256,
+// capabilities, php-version-constraint, and transitive dependencies. Phase 0
+// ships the package stub; the full implementation arrives in phase 8.
+package lock

--- a/package3/php/packagist/packagist.go
+++ b/package3/php/packagist/packagist.go
@@ -1,0 +1,4 @@
+// Package packagist implements the Packagist v2 sparse-index client for the
+// MEP-75 PHP bridge. Phase 0 ships the package stub; the full implementation
+// arrives in phase 1.
+package packagist

--- a/package3/php/publish/publish.go
+++ b/package3/php/publish/publish.go
@@ -1,0 +1,5 @@
+// Package publish implements the Packagist publish flow: GPG-signed git tag
+// creation, Sigstore actions/attest-build-provenance OIDC attestation, and
+// the Packagist Update API ping. Phase 0 ships the package stub; the full
+// implementation arrives in phase 10.
+package publish

--- a/package3/php/reflect/reflect.go
+++ b/package3/php/reflect/reflect.go
@@ -1,0 +1,5 @@
+// Package reflect implements the PHP Reflection API surface extractor for
+// the MEP-75 PHP bridge. It invokes a PHP CLI script (reflect.php) via
+// exec.Command and parses the emitted JSON surface document. Phase 0 ships
+// the package stub; the full implementation arrives in phase 3.
+package reflect

--- a/package3/php/typemap/typemap.go
+++ b/package3/php/typemap/typemap.go
@@ -1,0 +1,4 @@
+// Package typemap implements the closed PHP-to-Mochi type translation table
+// for the MEP-75 PHP bridge. Phase 0 ships the package stub; the full
+// implementation arrives in phase 4.
+package typemap

--- a/website/docs/implementation/0075/index.md
+++ b/website/docs/implementation/0075/index.md
@@ -1,0 +1,116 @@
+---
+title: MEP-75 implementation tracking
+sidebar_position: 1
+sidebar_label: "MEP 75. Mochi+PHP package bridge"
+description: "Per-phase implementation tracking for MEP-75 (Mochi+PHP package bridge). Status + commit columns capture how each phase landed on main."
+---
+
+# MEP-75 implementation tracking
+
+Per-phase tracking for [MEP-75 Mochi+PHP package bridge](/docs/mep/mep-0075). Status values: `NOT STARTED`, `IN PROGRESS`, `BLOCKED`, `LANDED`, `DEFERRED`. Commit is the merge commit short SHA on `main`.
+
+A phase is LANDED only when its gate is green for every target (consume direction + publish direction where applicable). Missing surfaces become N.1, N.2, ... sub-phases per the umbrella-phase coverage rule.
+
+## Phase status
+
+| Phase | Title | Status | Commit | Tracking page |
+|-------|-------|--------|--------|---------------|
+| 0 | Skeleton: package3/php/ layout + Driver/Workspace scaffold + errors | IN PROGRESS | — | [phase-00](/docs/implementation/0075/phase-00-skeleton) |
+| 1 | Packagist v2 sparse-index client (version resolution + dist URL) | NOT STARTED | — | — |
+| 2 | Composer dist fetcher + SHA-256 content-addressed cache | NOT STARTED | — | — |
+| 3 | PHP Reflection CLI (reflect.php + Go invoker + JSON surface parser) | NOT STARTED | — | — |
+| 4 | Closed PHP-to-Mochi type-mapping table | NOT STARTED | — | — |
+| 5 | Mochi extern fn / extern type emitter + SKIPPED.txt | NOT STARTED | — | — |
+| 6 | `import php` grammar wiring + MEP-55 build orchestration | NOT STARTED | — | — |
+| 7 | vendor/autoload.php generator (PSR-4, no composer install) | NOT STARTED | — | — |
+| 8 | mochi.lock `[[php-package]]` integration + `--check` mode | NOT STARTED | — | — |
+| 9 | `TargetPhpLibrary` emit (PSR-4 src/ + composer.json + README) | NOT STARTED | — | — |
+| 10 | Packagist publish flow (GPG tag + Sigstore OIDC + Update API) | NOT STARTED | — | — |
+| 11 | Interface and abstract class bridge | NOT STARTED | — | — |
+| 12 | Async PHP bridge (ReactPHP / RevoltPHP event-loop injection) | NOT STARTED | — | — |
+| 13 | Phar distribution path | NOT STARTED | — | — |
+| 14 | Full 24-package fixture corpus gate + mochi.lock round-trip | NOT STARTED | — | — |
+
+## Per-phase fields
+
+Each phase tracking page documents (or will document, once the phase begins):
+
+- **Gate**: the test or check that must pass for the phase to be LANDED.
+- **Files to touch**: the bridge-side files (Go) the phase introduces or modifies.
+- **Fixtures**: which of the 24-package fixture corpus the phase validates against.
+- **Skip count**: the expected SkipReport count per fixture package (golden numbers).
+- **Sub-phase decomposition** (if needed): N.1, N.2, ... entries when an upstream constraint forces splitting.
+
+## Fixture corpus
+
+The 24-package fixture corpus from the MEP-75 spec (top Composer packages by download count):
+
+guzzlehttp/guzzle, symfony/console, symfony/http-foundation, laravel/framework,
+phpunit/phpunit, monolog/monolog, doctrine/orm, psr/log, nesbot/carbon,
+vlucas/phpdotenv, league/flysystem, paragonie/random_compat, ramsey/uuid,
+bacon/bacon-qr-code, spatie/laravel-permission, barryvdh/laravel-debugbar,
+composer/composer, phpmailer/phpmailer, symfony/mailer, league/oauth2-server,
+firebase/php-jwt, socialiteproviders/google, stripe/stripe-php,
+spatie/laravel-medialibrary.
+
+Each phase that touches the type-mapping or extern emit layer asserts golden counts against this corpus. The corpus is regenerated quarterly to track package API drift.
+
+## PHP-to-Mochi type table (closed set)
+
+| PHP type | Mochi type | Notes |
+|----------|------------|-------|
+| int | int | |
+| float | float | |
+| string | string | |
+| bool | bool | |
+| ?T | T\|nil | nullable wrapper |
+| array (typed) | list/map | heuristic from docblock or typed property |
+| class | record/handle | |
+| interface | protocol handle | |
+| void | unit | |
+| never | panic boundary | SkipNever in v1 |
+| mixed | SKIP | SkipMixed |
+| object | SKIP | SkipObject |
+| callable | SKIP | SkipCallable |
+| resource | SKIP | SkipResource |
+| A\&B (intersection) | SKIP | SkipIntersection |
+
+## Implementation location
+
+The bridge lives at `package3/php/` in the repo root:
+
+```
+package3/php/
+  README.md               # pointer to MEP-75 spec
+  errors/                 # SkipReason + BridgeError (phase 0)
+  build/                  # Driver + Options + Workspace scaffold (phase 0)
+  packagist/              # Packagist v2 sparse-index client (phase 1)
+  cache/                  # content-addressed Composer dist fetcher (phase 2)
+  reflect/                # PHP CLI reflection invoker + JSON parser (phase 3)
+  typemap/                # closed PHP-to-Mochi type table (phase 4)
+  externemit/             # Mochi extern fn / extern type emitter (phase 5)
+  glue/                   # PHP-side use + forwarding stubs (phase 6)
+  autoload/               # vendor/autoload.php generator (phase 7)
+  lock/                   # mochi.lock [[php-package]] read/write (phase 8)
+  library/                # TargetPhpLibrary: PSR-4 src/ + composer.json (phase 9)
+  publish/                # Packagist publish: GPG tag + Sigstore + Update API (phase 10)
+```
+
+## CI matrix
+
+| Target | PHP version | OS | Allow failure |
+|--------|-------------|-----|--------------|
+| php-8.4-ubuntu | PHP 8.4.0 | ubuntu-24.04 | no |
+| php-8.4-latest | PHP 8.4 latest | ubuntu-24.04 | no |
+| php-8.5-dev | PHP 8.5 | ubuntu-24.04 | yes |
+
+## Status snapshot
+
+As of 2026-05-29 23:11 (GMT+7): phase 0 IN PROGRESS (skeleton + Driver/Workspace/errors scaffolding). Phases 1-14 pending. The MEP spec and research bundle are landed; implementation begins with this phase.
+
+## Cross-references
+
+- [MEP-75 spec](/docs/mep/mep-0075) for the normative design.
+- [MEP-75 research bundle](/docs/research/0075/) for the 13-note deep-research collection.
+- [MEP-55 implementation tracking](/docs/implementation/0055) for the PHP transpiler that MEP-75 extends.
+- [MEP-57 implementation tracking](/docs/implementation/0057) for the polyglot package system MEP-75 builds on.

--- a/website/docs/implementation/0075/phase-00-skeleton.md
+++ b/website/docs/implementation/0075/phase-00-skeleton.md
@@ -1,0 +1,77 @@
+---
+title: "Phase 0. Skeleton"
+sidebar_position: 2
+sidebar_label: "Phase 0. Skeleton"
+description: "MEP-75 Phase 0 lands package3/php/ skeleton: Driver / Workspace types, errors package with SkipReport and 16 PHP-specific SkipReason variants, stub packages for all 12 bridge sub-packages."
+---
+
+# Phase 0. Skeleton
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-75 §Phases](/docs/mep/mep-0075#phases) |
+| Status         | IN PROGRESS |
+| Started        | 2026-05-29 23:11 (GMT+7) |
+| Landed         | — |
+| Tracking issue | — |
+| Tracking PR    | — |
+| Commit         | — |
+
+## Gate
+
+`TestPhase0Skeleton` in `package3/php/build/phase00_test.go`: subtests `end_to_end`, `package_layout`, `workspace_subdirs`.
+
+- `end_to_end`: Driver allocates a `mochi-php-` prefixed temp work-dir, PrepareWorkspace succeeds, Cleanup removes the work-dir and resets WorkDir to empty.
+- `package_layout`: verifies all 13 expected files exist on disk under `package3/php/` (README.md + 12 Go package stubs).
+- `workspace_subdirs`: EnsureSubDirs creates `shims/`, `glue/`, and `vendor/` under the workspace root with the correct suffix.
+
+In addition, the package-level test suite covers:
+
+- `package3/php/errors/`: 16 SkipReason variants string-encode round-trip, exhaustive sweep catches missing switch cases, SkipReport renders with and without an override line, BridgeError formats with and without a package, errors.Is unwraps BridgeError.Cause.
+- `package3/php/build/`: NewDriver defaults (CacheDir contains "php-deps", PHPBin defaults to "php"), NoCache returns empty CacheDir, Verbose + Deterministic flags, PrepareWorkspace creates dir with mochi-php- prefix, PrepareWorkspace idempotence, explicit WorkDir, Cleanup removes dir, Cleanup without Prepare is a no-op, XDG_CACHE_HOME overrides defaultCacheDir, EnsureSubDirs creates shims/glue/vendor, EnsureSubDirs idempotent.
+
+## Lowering decisions
+
+Phase 0 ships no PHP reflection or type mapping yet, only the scaffolding the later phases depend on. The `Driver` exports `NewDriver(Options) -> *Driver`, `PrepareWorkspace() -> (*Workspace, error)`, `Cleanup() -> error`. `Workspace` exports `EnsureSubDirs() -> error`.
+
+The `SkipReason` enum lands all 16 refusal classifications from research note 05. The reasons are PHP-specific: `SkipMixed`, `SkipObject`, `SkipUntypedArray`, `SkipSelfStatic`, `SkipCallable`, `SkipResource`, `SkipIntersection`, `SkipNever`, `SkipVararg`, `SkipPrivate`, `SkipAbstractNoImpl`, `SkipMagicMethod`, `SkipAnonymousClass`, `SkipNoReflection`, `SkipExtension`. Each constant's `String()` produces a stable token used in the `SKIPPED.txt` golden fixtures.
+
+The `BridgeError` type carries `(Phase, Package, Cause)` and formats as `phase[package]: cause` (with the bracketed segment omitted when package is empty). It implements `Unwrap` so `errors.Is` and `errors.As` traverse through it.
+
+The cache-dir resolution honours `$XDG_CACHE_HOME` first, then falls back to `~/.cache/mochi/php-deps/`, then to `$TMPDIR/mochi-php-cache`. This matches the resolution strategy in the MEP-75 spec §8.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/php/build/driver.go` | `Driver`, `Options`, `Workspace`, `NewDriver`, `PrepareWorkspace`, `Cleanup`, `defaultCacheDir`, `EnsureSubDirs` |
+| `package3/php/build/driver_test.go` | Driver + Workspace unit tests |
+| `package3/php/build/phase00_test.go` | `TestPhase0Skeleton` sentinel with 3 subtests |
+| `package3/php/errors/errors.go` | `SkipReason` (16 variants), `SkipReport`, `BridgeError`, `Wrap` |
+| `package3/php/errors/errors_test.go` | Errors unit tests |
+| `package3/php/packagist/packagist.go` | Package stub (phase 1) |
+| `package3/php/cache/cache.go` | Package stub (phase 2) |
+| `package3/php/reflect/reflect.go` | Package stub (phase 3) |
+| `package3/php/typemap/typemap.go` | Package stub (phase 4) |
+| `package3/php/externemit/externemit.go` | Package stub (phase 5) |
+| `package3/php/glue/glue.go` | Package stub (phase 6) |
+| `package3/php/autoload/autoload.go` | Package stub (phase 7) |
+| `package3/php/lock/lock.go` | Package stub (phase 8) |
+| `package3/php/library/library.go` | Package stub (phase 9) |
+| `package3/php/publish/publish.go` | Package stub (phase 10) |
+| `package3/php/README.md` | Bridge overview, pipeline diagram, type table |
+| `website/docs/implementation/0075/index.md` | MEP-75 implementation tracking index |
+| `website/docs/implementation/0075/phase-00-skeleton.md` | This file |
+
+## Test set
+
+- `TestPhase0Skeleton/end_to_end`
+- `TestPhase0Skeleton/package_layout`
+- `TestPhase0Skeleton/workspace_subdirs`
+- All `package3/php/build/...` and `package3/php/errors/...` unit tests.
+
+## Closeout notes
+
+Phase 0 is the smallest viable skeleton: enough to give later phases a stable package tree and a CI-green starting point. The driver's WorkDir is allocated with a `mochi-php-` prefix so Cleanup can safely refuse to remove a user-provided directory (a user-specified WorkDir survives Cleanup, per the explicit-vs-allocated distinction). The PHPBin field defaults to `"php"` and is overrideable for test environments that install PHP at a non-standard path.
+
+No external runtime dependencies are introduced. The build adds two active Go packages to the repo (`package3/php/build/` and `package3/php/errors/`) and ten stub packages, all pure-Go with stdlib-only imports.

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -353,5 +353,12 @@
       "implementation/0074/phase-05-typemap"
     ]
   },
+  "implementation/0075/index",
+  {
+    "label": "MEP-75 phases",
+    "items": [
+      "implementation/0075/phase-00-skeleton"
+    ]
+  },
   "implementation/0076/index"
 ]


### PR DESCRIPTION
Closes #22802

## Summary

- Lands `package3/php/` skeleton for the MEP-75 PHP/Composer bridge
- `errors/`: 16 PHP-specific SkipReason variants, SkipReport, BridgeError
- `build/`: Driver + Workspace scaffold with XDG-aware cache-dir, PrepareWorkspace, Cleanup, EnsureSubDirs
- Stub packages for all 10 later phases (packagist, cache, reflect, typemap, externemit, glue, autoload, lock, library, publish)
- `README.md` with pipeline diagram and type table
- `TestPhase0Skeleton`: end_to_end + package_layout + workspace_subdirs
- Implementation tracking docs: website/docs/implementation/0075/

## Test plan

- [ ] `go test ./package3/php/...` passes (build + errors active; stubs compile)
- [ ] `TestPhase0Skeleton/end_to_end`: Driver allocates mochi-php- workdir, Cleanup removes it
- [ ] `TestPhase0Skeleton/package_layout`: all 13 expected files exist on disk
- [ ] `TestPhase0Skeleton/workspace_subdirs`: EnsureSubDirs creates shims/, glue/, vendor/