### PR TITLE
feat(mep-71 p3): PEP 561 stub discovery + typeshed pin + stubgen + .pyi reader

### DIFF
--- a/package3/python/stubs/discovery.go
+++ b/package3/python/stubs/discovery.go
@@ -1,0 +1,202 @@
+package stubs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Tier is the PEP 561 stub source tier.
+type Tier int
+
+const (
+	TierUnknown Tier = iota
+	// TierInline: package ships py.typed marker + bundled .pyi or annotated .py.
+	TierInline
+	// TierSiblingStubs: separate `<name>-stubs` distribution.
+	TierSiblingStubs
+	// TierTypeshed: centralised typeshed lookup.
+	TierTypeshed
+	// TierStubgen: fallback generated from .py source.
+	TierStubgen
+)
+
+// String renders the tier token.
+func (t Tier) String() string {
+	switch t {
+	case TierInline:
+		return "inline"
+	case TierSiblingStubs:
+		return "sibling-stubs"
+	case TierTypeshed:
+		return "typeshed"
+	case TierStubgen:
+		return "stubgen"
+	default:
+		return "unknown"
+	}
+}
+
+// StubSource is the discovered set of stub files for a package, plus the tier
+// that produced them.
+type StubSource struct {
+	// Package is the PEP 503 normalised name.
+	Package string
+	// Tier indicates which PEP 561 source the stubs came from.
+	Tier Tier
+	// RootDir is the directory at which the package's stubs are rooted. For
+	// inline stubs this is the package itself; for sibling stubs it is the
+	// `<name>-stubs` directory; for typeshed it is the corresponding subtree
+	// of the pinned typeshed checkout; for stubgen it is the cache directory
+	// where stubgen wrote its output.
+	RootDir string
+	// Files is the relative paths of every .pyi (and .py with explicit
+	// annotations under TierInline) under RootDir, sorted alphabetically.
+	Files []string
+	// Partial is true when the source carries no guarantee of completeness
+	// (PEP 561 `py.typed` files contain the literal token "partial" or this
+	// is a stubgen fallback). Phase 4 refuses to emit wrappers for partial
+	// sources unless --allow-partial is set on the build.
+	Partial bool
+}
+
+// Discovery resolves a package name into a StubSource by walking the four
+// PEP 561 tiers in priority order.
+type Discovery struct {
+	// SitePackages is the venv `site-packages` directory containing the
+	// installed package and any sibling stub distributions.
+	SitePackages string
+	// Typeshed is the optional pinned typeshed repository.
+	Typeshed *Typeshed
+	// Stubgen is the optional stubgen fallback runner.
+	Stubgen Stubgen
+	// AllowStubgen, when true, lets Resolve drop to the stubgen tier instead
+	// of returning a not-found error.
+	AllowStubgen bool
+}
+
+// Resolve runs the 4-tier lookup for `name` and returns the highest-tier hit.
+// Returns (nil, err) when no source is available and stubgen is disabled.
+// The returned StubSource's RootDir / Files are populated.
+func (d *Discovery) Resolve(name string) (*StubSource, error) {
+	if name == "" {
+		return nil, fmt.Errorf("stubs: empty package name")
+	}
+	moduleName := strings.ReplaceAll(name, "-", "_")
+
+	// Tier 1: inline (py.typed in the package).
+	if d.SitePackages != "" {
+		pkgDir := filepath.Join(d.SitePackages, moduleName)
+		if info, err := os.Stat(filepath.Join(pkgDir, "py.typed")); err == nil && !info.IsDir() {
+			files, _ := walkStubFiles(pkgDir)
+			partial, _ := readPartialMarker(filepath.Join(pkgDir, "py.typed"))
+			return &StubSource{
+				Package: name,
+				Tier:    TierInline,
+				RootDir: pkgDir,
+				Files:   files,
+				Partial: partial,
+			}, nil
+		}
+	}
+
+	// Tier 2: sibling `<name>-stubs` distribution.
+	if d.SitePackages != "" {
+		stubDir := filepath.Join(d.SitePackages, moduleName+"-stubs")
+		if info, err := os.Stat(stubDir); err == nil && info.IsDir() {
+			files, _ := walkStubFiles(stubDir)
+			return &StubSource{
+				Package: name,
+				Tier:    TierSiblingStubs,
+				RootDir: stubDir,
+				Files:   files,
+				Partial: false,
+			}, nil
+		}
+	}
+
+	// Tier 3: typeshed.
+	if d.Typeshed != nil {
+		if src, ok := d.Typeshed.Lookup(name); ok {
+			return src, nil
+		}
+	}
+
+	// Tier 4: stubgen fallback.
+	if d.AllowStubgen && d.Stubgen != nil {
+		src, err := d.Stubgen.Generate(name, moduleName, d.SitePackages)
+		if err != nil {
+			return nil, fmt.Errorf("stubs: stubgen fallback for %q: %w", name, err)
+		}
+		return src, nil
+	}
+
+	return nil, fmt.Errorf("stubs: no PEP 561 stubs found for package %q (tiers: inline / sibling-stubs / typeshed / stubgen)", name)
+}
+
+// walkStubFiles returns the relative paths of every .pyi file under root,
+// sorted alphabetically. .py files are included only when no .pyi shadows them.
+func walkStubFiles(root string) ([]string, error) {
+	var files []string
+	seen := map[string]bool{}
+	err := filepath.WalkDir(root, func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		ext := filepath.Ext(path)
+		if ext != ".pyi" && ext != ".py" {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if ext == ".pyi" {
+			files = append(files, rel)
+			noExt := strings.TrimSuffix(rel, ".pyi")
+			seen[noExt] = true
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	// Pass 2: include .py whose .pyi twin is absent.
+	err = filepath.WalkDir(root, func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if filepath.Ext(path) != ".py" {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		noExt := strings.TrimSuffix(rel, ".py")
+		if seen[noExt] {
+			return nil
+		}
+		files = append(files, rel)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+// readPartialMarker reads a PEP 561 `py.typed` file. PEP 561 §"Stub-Only
+// Packages" allows the contents to be either empty (full type information) or
+// the literal token "partial" (incomplete stubs). Any other content is
+// tolerated but treated as full.
+func readPartialMarker(path string) (bool, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(body)) == "partial", nil
+}

--- a/package3/python/stubs/discovery_test.go
+++ b/package3/python/stubs/discovery_test.go
@@ -1,0 +1,354 @@
+package stubs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTierString(t *testing.T) {
+	cases := []struct {
+		tier Tier
+		want string
+	}{
+		{TierInline, "inline"},
+		{TierSiblingStubs, "sibling-stubs"},
+		{TierTypeshed, "typeshed"},
+		{TierStubgen, "stubgen"},
+		{TierUnknown, "unknown"},
+		{Tier(99), "unknown"},
+	}
+	for _, c := range cases {
+		if got := c.tier.String(); got != c.want {
+			t.Errorf("Tier(%d).String() = %q, want %q", c.tier, got, c.want)
+		}
+	}
+}
+
+func TestResolveEmptyName(t *testing.T) {
+	d := &Discovery{}
+	if _, err := d.Resolve(""); err == nil {
+		t.Fatal("expected error for empty name")
+	}
+}
+
+func TestResolveInlineFull(t *testing.T) {
+	dir := t.TempDir()
+	pkg := filepath.Join(dir, "mypkg")
+	if err := os.MkdirAll(pkg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkg, "py.typed"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkg, "__init__.pyi"), []byte("X: int\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d := &Discovery{SitePackages: dir}
+	src, err := d.Resolve("mypkg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src.Tier != TierInline {
+		t.Errorf("Tier = %v, want TierInline", src.Tier)
+	}
+	if src.Partial {
+		t.Error("Partial should be false for empty py.typed")
+	}
+	if len(src.Files) == 0 {
+		t.Error("expected at least one file")
+	}
+}
+
+func TestResolveInlinePartial(t *testing.T) {
+	dir := t.TempDir()
+	pkg := filepath.Join(dir, "mypkg")
+	if err := os.MkdirAll(pkg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkg, "py.typed"), []byte("partial\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkg, "__init__.pyi"), []byte("X: int\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d := &Discovery{SitePackages: dir}
+	src, err := d.Resolve("mypkg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !src.Partial {
+		t.Error("Partial should be true for partial py.typed")
+	}
+}
+
+func TestResolveSiblingStubs(t *testing.T) {
+	dir := t.TempDir()
+	stubs := filepath.Join(dir, "mypkg-stubs")
+	if err := os.MkdirAll(stubs, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stubs, "__init__.pyi"), []byte("def f() -> int: ...\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d := &Discovery{SitePackages: dir}
+	src, err := d.Resolve("mypkg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src.Tier != TierSiblingStubs {
+		t.Errorf("Tier = %v, want TierSiblingStubs", src.Tier)
+	}
+	if src.Partial {
+		t.Error("sibling stubs should not be marked partial")
+	}
+}
+
+func TestResolveInlineBeatsSibling(t *testing.T) {
+	dir := t.TempDir()
+	pkg := filepath.Join(dir, "mypkg")
+	sib := filepath.Join(dir, "mypkg-stubs")
+	for _, d := range []string{pkg, sib} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(pkg, "py.typed"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkg, "__init__.pyi"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sib, "__init__.pyi"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d := &Discovery{SitePackages: dir}
+	src, err := d.Resolve("mypkg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src.Tier != TierInline {
+		t.Errorf("Tier = %v, want TierInline (inline must beat sibling)", src.Tier)
+	}
+}
+
+func TestResolveSiblingBeatsTypeshed(t *testing.T) {
+	dir := t.TempDir()
+	tsRoot := t.TempDir()
+	// sibling stubs
+	sib := filepath.Join(dir, "mypkg-stubs")
+	if err := os.MkdirAll(sib, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sib, "__init__.pyi"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// typeshed third-party entry
+	tsPkg := filepath.Join(tsRoot, "stubs", "mypkg", "mypkg")
+	if err := os.MkdirAll(tsPkg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tsRoot, "stdlib"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tsPkg, "__init__.pyi"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ts, err := NewTypeshed(tsRoot, "deadbeef")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := &Discovery{SitePackages: dir, Typeshed: ts}
+	src, err := d.Resolve("mypkg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src.Tier != TierSiblingStubs {
+		t.Errorf("Tier = %v, want TierSiblingStubs", src.Tier)
+	}
+}
+
+func TestResolveTypeshedBeatsStubgen(t *testing.T) {
+	dir := t.TempDir()
+	tsRoot := t.TempDir()
+	cacheDir := t.TempDir()
+	tsPkg := filepath.Join(tsRoot, "stdlib", "mypkg")
+	if err := os.MkdirAll(tsPkg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tsPkg, "__init__.pyi"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ts, err := NewTypeshed(tsRoot, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := &Discovery{
+		SitePackages: dir,
+		Typeshed:     ts,
+		Stubgen:      &FakeStubgen{CacheDir: cacheDir, Body: []byte("def f(): ...\n")},
+		AllowStubgen: true,
+	}
+	src, err := d.Resolve("mypkg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src.Tier != TierTypeshed {
+		t.Errorf("Tier = %v, want TierTypeshed", src.Tier)
+	}
+}
+
+func TestResolveStubgenFallback(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := t.TempDir()
+	d := &Discovery{
+		SitePackages: dir,
+		Stubgen:      &FakeStubgen{CacheDir: cacheDir, Body: []byte("def f(): ...\n")},
+		AllowStubgen: true,
+	}
+	src, err := d.Resolve("mypkg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src.Tier != TierStubgen {
+		t.Errorf("Tier = %v, want TierStubgen", src.Tier)
+	}
+	if !src.Partial {
+		t.Error("stubgen output must be marked Partial")
+	}
+}
+
+func TestResolveStubgenDisabled(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := t.TempDir()
+	d := &Discovery{
+		SitePackages: dir,
+		Stubgen:      &FakeStubgen{CacheDir: cacheDir, Body: []byte("x")},
+		AllowStubgen: false,
+	}
+	if _, err := d.Resolve("mypkg"); err == nil {
+		t.Fatal("expected not-found error when AllowStubgen is false")
+	}
+}
+
+func TestResolveNotFound(t *testing.T) {
+	d := &Discovery{SitePackages: t.TempDir()}
+	if _, err := d.Resolve("mypkg"); err == nil {
+		t.Fatal("expected not-found error")
+	}
+}
+
+func TestResolveHyphenatedNameMapsToUnderscore(t *testing.T) {
+	dir := t.TempDir()
+	// PEP 503 name `flask-sqlalchemy` maps to module `flask_sqlalchemy`.
+	pkg := filepath.Join(dir, "flask_sqlalchemy")
+	if err := os.MkdirAll(pkg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkg, "py.typed"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d := &Discovery{SitePackages: dir}
+	src, err := d.Resolve("flask-sqlalchemy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src.Tier != TierInline {
+		t.Errorf("Tier = %v", src.Tier)
+	}
+}
+
+func TestWalkStubFilesSorted(t *testing.T) {
+	dir := t.TempDir()
+	for _, f := range []string{"z.pyi", "a.pyi", "sub/m.pyi"} {
+		full := filepath.Join(dir, f)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := walkStubFiles(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"a.pyi", filepath.Join("sub", "m.pyi"), "z.pyi"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, g := range got {
+		if g != want[i] {
+			t.Errorf("file[%d] = %q, want %q", i, g, want[i])
+		}
+	}
+}
+
+func TestWalkStubFilesPyFallback(t *testing.T) {
+	dir := t.TempDir()
+	// shadowed.py is shadowed by shadowed.pyi
+	if err := os.WriteFile(filepath.Join(dir, "shadowed.py"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "shadowed.pyi"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// onlypy.py has no .pyi twin so it should appear.
+	if err := os.WriteFile(filepath.Join(dir, "onlypy.py"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := walkStubFiles(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hasPyi := false
+	hasOnlyPy := false
+	hasShadowedPy := false
+	for _, g := range got {
+		switch g {
+		case "shadowed.pyi":
+			hasPyi = true
+		case "onlypy.py":
+			hasOnlyPy = true
+		case "shadowed.py":
+			hasShadowedPy = true
+		}
+	}
+	if !hasPyi {
+		t.Error("shadowed.pyi missing")
+	}
+	if !hasOnlyPy {
+		t.Error("onlypy.py missing")
+	}
+	if hasShadowedPy {
+		t.Error("shadowed.py should be shadowed by .pyi twin")
+	}
+}
+
+func TestReadPartialMarker(t *testing.T) {
+	dir := t.TempDir()
+	cases := []struct {
+		body string
+		want bool
+	}{
+		{"", false},
+		{"partial", true},
+		{"partial\n", true},
+		{"  partial  ", true},
+		{"full", false},
+		{"PARTIAL", false},
+	}
+	for i, c := range cases {
+		p := filepath.Join(dir, "f.txt")
+		if err := os.WriteFile(p, []byte(c.body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		got, err := readPartialMarker(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != c.want {
+			t.Errorf("case %d body=%q: got %v, want %v", i, c.body, got, c.want)
+		}
+	}
+}

--- a/package3/python/stubs/doc.go
+++ b/package3/python/stubs/doc.go
@@ -1,0 +1,29 @@
+// Package stubs implements MEP-71 Phase 3: PEP 561 stub discovery, typeshed
+// pinning, the stubgen subprocess wrapper, and a focused `.pyi` parser.
+//
+// PEP 561 §"Stub-Only Packages" defines four sources of stubs for a Python
+// package, in priority order:
+//
+//  1. Inline stubs. The package itself ships a `py.typed` marker file at the
+//     package root and bundles `.pyi` files (or types in `.py`).
+//  2. Sibling stubs. A separate distribution `<name>-stubs` (PEP 561 §"Stub-
+//     only packages") ships under `<name>-stubs/` and is consulted ahead of
+//     typeshed.
+//  3. Typeshed. The community-maintained centralised stub repository at
+//     https://github.com/python/typeshed. The bridge pins to a specific
+//     typeshed commit so type metadata is reproducible across builds.
+//  4. Stubgen fallback. When no other source is available the bridge invokes
+//     `python -m mypy.stubgen` in a sandboxed venv to synthesise stubs from
+//     the .py source. The output is marked as `partial = true` so the type
+//     mapper (phase 4) refuses to emit wrappers for symbols without explicit
+//     annotations.
+//
+// The Discovery type runs the 4-tier search and returns a StubSource carrying
+// the file paths and the tier that produced them. Downstream phases (4-6) read
+// the .pyi contents via the package's `Reader`.
+//
+// The .pyi reader is intentionally not a complete Python parser. It extracts
+// the surface phase 4 needs (top-level classes, functions, type aliases,
+// constants, imports) and treats type expressions as opaque strings. Phase 4
+// parses those strings against the closed type-mapping table.
+package stubs

--- a/package3/python/stubs/phase03_test.go
+++ b/package3/python/stubs/phase03_test.go
@@ -1,0 +1,151 @@
+package stubs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPhase3StubIngest is the umbrella sentinel for MEP-71 Phase 3. It exercises
+// the 4-tier discovery in cooperation with the .pyi reader, so the closeout
+// gate can run a single `go test -run TestPhase3StubIngest`.
+func TestPhase3StubIngest(t *testing.T) {
+	t.Run("inline_tier_wins", func(t *testing.T) {
+		dir := t.TempDir()
+		pkg := filepath.Join(dir, "pkg")
+		sib := filepath.Join(dir, "pkg-stubs")
+		for _, d := range []string{pkg, sib} {
+			if err := os.MkdirAll(d, 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(pkg, "py.typed"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkg, "__init__.pyi"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(sib, "__init__.pyi"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		d := &Discovery{SitePackages: dir}
+		src, err := d.Resolve("pkg")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if src.Tier != TierInline {
+			t.Errorf("Tier = %v, want TierInline", src.Tier)
+		}
+	})
+
+	t.Run("sibling_stubs_tier", func(t *testing.T) {
+		dir := t.TempDir()
+		sib := filepath.Join(dir, "pkg-stubs")
+		if err := os.MkdirAll(sib, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(sib, "__init__.pyi"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		d := &Discovery{SitePackages: dir}
+		src, err := d.Resolve("pkg")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if src.Tier != TierSiblingStubs {
+			t.Errorf("Tier = %v, want TierSiblingStubs", src.Tier)
+		}
+	})
+
+	t.Run("typeshed_tier", func(t *testing.T) {
+		dir := t.TempDir()
+		tsRoot := t.TempDir()
+		stdlibPkg := filepath.Join(tsRoot, "stdlib", "pkg")
+		if err := os.MkdirAll(stdlibPkg, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(stdlibPkg, "__init__.pyi"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		ts, err := NewTypeshed(tsRoot, "deadbeef")
+		if err != nil {
+			t.Fatal(err)
+		}
+		d := &Discovery{SitePackages: dir, Typeshed: ts}
+		src, err := d.Resolve("pkg")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if src.Tier != TierTypeshed {
+			t.Errorf("Tier = %v, want TierTypeshed", src.Tier)
+		}
+	})
+
+	t.Run("stubgen_fallback", func(t *testing.T) {
+		dir := t.TempDir()
+		cacheDir := t.TempDir()
+		d := &Discovery{
+			SitePackages: dir,
+			Stubgen:      &FakeStubgen{CacheDir: cacheDir, Body: []byte("def f() -> int: ...\n")},
+			AllowStubgen: true,
+		}
+		src, err := d.Resolve("pkg")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if src.Tier != TierStubgen {
+			t.Errorf("Tier = %v, want TierStubgen", src.Tier)
+		}
+		if !src.Partial {
+			t.Error("stubgen output must be marked Partial")
+		}
+		// Round-trip the body through ParsePYI to confirm the end-to-end ingest works.
+		body, err := os.ReadFile(filepath.Join(src.RootDir, "pkg.pyi"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		m, err := ParsePYI(string(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(m.Functions) != 1 || m.Functions[0].Name != "f" || m.Functions[0].ReturnType != "int" {
+			t.Errorf("parsed surface = %+v", m)
+		}
+	})
+
+	t.Run("pyi_round_trip", func(t *testing.T) {
+		src := `from typing import List, Optional
+
+def echo(x: int) -> int: ...
+
+class Greeter:
+    name: str
+    def hello(self, who: Optional[str] = None) -> str: ...
+
+Vector = List[float]
+MAX: int = 100
+`
+		m, err := ParsePYI(src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(m.Imports) != 1 || m.Imports[0].Module != "typing" {
+			t.Errorf("imports = %+v", m.Imports)
+		}
+		if len(m.Functions) != 1 || m.Functions[0].Name != "echo" {
+			t.Errorf("funcs = %+v", m.Functions)
+		}
+		if len(m.Classes) != 1 || m.Classes[0].Name != "Greeter" {
+			t.Errorf("classes = %+v", m.Classes)
+		}
+		if len(m.Classes[0].Methods) != 1 || m.Classes[0].Methods[0].ReturnType != "str" {
+			t.Errorf("Greeter methods = %+v", m.Classes[0].Methods)
+		}
+		if len(m.Aliases) != 1 || m.Aliases[0].Name != "Vector" {
+			t.Errorf("aliases = %+v", m.Aliases)
+		}
+		if len(m.Constants) != 1 || m.Constants[0].Name != "MAX" || m.Constants[0].Default != "100" {
+			t.Errorf("constants = %+v", m.Constants)
+		}
+	})
+}

--- a/package3/python/stubs/pyi.go
+++ b/package3/python/stubs/pyi.go
@@ -1,0 +1,724 @@
+package stubs
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// ModuleSurface is the structured view of a .pyi file that phase 4 (type
+// mapping) and phase 5 (wrapper synthesiser) read.
+type ModuleSurface struct {
+	// Imports is every top-level `import X` and `from X import Y` parsed
+	// from the module.
+	Imports []ImportDecl
+	// Classes is every top-level `class X(...)` declaration.
+	Classes []ClassDecl
+	// Functions is every top-level `def X(...) -> T:` declaration. Methods
+	// are stored inside the owning ClassDecl.Methods.
+	Functions []FuncDecl
+	// Aliases is every top-level `Name = Expr` where Expr is treated as a
+	// type expression (Phase 4 may reclassify into TypeVar / value).
+	Aliases []AliasDecl
+	// Constants is every top-level `Name: Type` declaration with no body or
+	// with a value body. The value is preserved as a raw string.
+	Constants []ConstantDecl
+}
+
+// ImportDecl is `import X` or `from X import (Y, Z as W)`.
+type ImportDecl struct {
+	// Module is the source module ("typing" in `from typing import Any`).
+	// Empty for `import X` (in that case Names has one entry holding X).
+	Module string
+	// Names is the imported names, possibly with aliases.
+	Names []ImportedName
+}
+
+// ImportedName is `Y` or `Y as W` in an import list.
+type ImportedName struct {
+	Name  string
+	Alias string
+}
+
+// ClassDecl is `class Name(Bases): <body>`.
+type ClassDecl struct {
+	Name      string
+	Bases     []string // raw base expressions, e.g. "Protocol", "TypedDict", "Generic[T]".
+	Methods   []FuncDecl
+	Fields    []FieldDecl
+	IsTypedDict bool
+	IsProtocol  bool
+	IsDataclass bool
+	Decorators  []string
+}
+
+// FuncDecl is `def Name(Params) -> Return:`.
+type FuncDecl struct {
+	Name       string
+	Params     []ParamDecl
+	ReturnType string // raw expression, empty when omitted
+	Decorators []string
+	IsAsync    bool
+}
+
+// ParamDecl is one parameter in a FuncDecl. Kind tracks the four PEP 3102 /
+// PEP 570 categories.
+type ParamDecl struct {
+	Name      string
+	Type      string // raw expression, empty when no annotation
+	Default   string // raw default expression, empty when no default
+	Kind      ParamKind
+}
+
+// ParamKind is the parameter category.
+type ParamKind int
+
+const (
+	ParamPositional ParamKind = iota // `x` (positional or keyword)
+	ParamPositionalOnly                // before `/`
+	ParamKeywordOnly                   // after `*` separator
+	ParamVarArgs                       // `*args`
+	ParamKwArgs                        // `**kwargs`
+)
+
+// FieldDecl is `name: Type` or `name: Type = default` inside a class body.
+type FieldDecl struct {
+	Name    string
+	Type    string
+	Default string
+}
+
+// AliasDecl is `Name = Expr` at module scope.
+type AliasDecl struct {
+	Name string
+	Expr string
+}
+
+// ConstantDecl is `Name: Type` or `Name: Type = value` at module scope.
+type ConstantDecl struct {
+	Name    string
+	Type    string
+	Default string
+}
+
+// ParsePYI reads the surface from a .pyi document. The parser is intentionally
+// scoped to the constructs phase 4 + 5 consume; anything else is silently
+// skipped with no error so we degrade gracefully on exotic stubs.
+func ParsePYI(src string) (*ModuleSurface, error) {
+	lines, err := logicalLines(src)
+	if err != nil {
+		return nil, err
+	}
+	m := &ModuleSurface{}
+	pendingDecorators := []string(nil)
+	for i := 0; i < len(lines); i++ {
+		l := lines[i]
+		if l.indent != 0 {
+			continue // body content; handled by class parser
+		}
+		text := strings.TrimSpace(l.text)
+		switch {
+		case text == "" || strings.HasPrefix(text, "#"):
+			continue
+		case strings.HasPrefix(text, "@"):
+			pendingDecorators = append(pendingDecorators, strings.TrimSpace(text[1:]))
+		case strings.HasPrefix(text, "import "):
+			imp := parseImport(text)
+			m.Imports = append(m.Imports, imp)
+			pendingDecorators = nil
+		case strings.HasPrefix(text, "from "):
+			imp, err := parseFromImport(text)
+			if err != nil {
+				return nil, fmt.Errorf("pyi: line %d: %w", l.line, err)
+			}
+			m.Imports = append(m.Imports, imp)
+			pendingDecorators = nil
+		case strings.HasPrefix(text, "class "):
+			cd, consumed, err := parseClass(lines, i, pendingDecorators)
+			if err != nil {
+				return nil, fmt.Errorf("pyi: line %d: %w", l.line, err)
+			}
+			m.Classes = append(m.Classes, cd)
+			i += consumed
+			pendingDecorators = nil
+		case strings.HasPrefix(text, "def ") || strings.HasPrefix(text, "async def "):
+			fd, err := parseFunction(text, pendingDecorators)
+			if err != nil {
+				return nil, fmt.Errorf("pyi: line %d: %w", l.line, err)
+			}
+			m.Functions = append(m.Functions, fd)
+			pendingDecorators = nil
+		default:
+			// Module-level `Name: Type [= value]` or `Name = value` (alias).
+			if name, typ, def, ok := splitAnnotation(text); ok {
+				m.Constants = append(m.Constants, ConstantDecl{Name: name, Type: typ, Default: def})
+				pendingDecorators = nil
+				continue
+			}
+			if name, expr, ok := splitAlias(text); ok {
+				m.Aliases = append(m.Aliases, AliasDecl{Name: name, Expr: expr})
+				pendingDecorators = nil
+				continue
+			}
+			// Unknown: silently skip per the doc.
+			pendingDecorators = nil
+		}
+	}
+	return m, nil
+}
+
+type pyiLine struct {
+	indent int
+	text   string
+	line   int // 1-based source line for the start of the logical line
+}
+
+// logicalLines collapses Python's physical lines into logical lines, joining
+// backslash continuations and parenthesised continuations.
+func logicalLines(src string) ([]pyiLine, error) {
+	var out []pyiLine
+	physical := strings.Split(src, "\n")
+	var buf strings.Builder
+	var startLine int
+	startIndent := -1
+	depth := 0
+	flush := func() {
+		t := buf.String()
+		buf.Reset()
+		if strings.TrimSpace(t) == "" {
+			startIndent = -1
+			return
+		}
+		out = append(out, pyiLine{indent: startIndent, text: t, line: startLine})
+		startIndent = -1
+	}
+	for i, raw := range physical {
+		line := i + 1
+		// Drop the BOM on the very first physical line.
+		if i == 0 {
+			raw = strings.TrimPrefix(raw, "\ufeff")
+		}
+		// Compute indent for the start of a new logical line.
+		if startIndent == -1 {
+			indent := 0
+			for j := 0; j < len(raw); j++ {
+				if raw[j] == ' ' {
+					indent++
+				} else if raw[j] == '\t' {
+					indent += 8 - (indent % 8)
+				} else {
+					break
+				}
+			}
+			startIndent = indent
+			startLine = line
+		}
+		// Strip comments outside of strings.
+		stripped := stripPyComment(raw)
+		// Track bracket depth.
+		depth += bracketDelta(stripped)
+		if depth < 0 {
+			return nil, fmt.Errorf("pyi: line %d: unbalanced brackets", line)
+		}
+		// Backslash continuation.
+		trimRight := strings.TrimRight(stripped, " \t")
+		cont := strings.HasSuffix(trimRight, "\\")
+		if cont {
+			trimRight = strings.TrimSuffix(trimRight, "\\")
+		}
+		buf.WriteString(trimRight)
+		buf.WriteByte(' ')
+		if cont || depth > 0 {
+			continue
+		}
+		flush()
+	}
+	if buf.Len() > 0 {
+		flush()
+	}
+	return out, nil
+}
+
+// stripPyComment removes `#`-comments outside of single / double / triple
+// quoted strings. .pyi files routinely contain string literals (e.g. in
+// `Literal["a", "b"]` and default values) so we cannot naively split on `#`.
+func stripPyComment(s string) string {
+	out := make([]byte, 0, len(s))
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		if c == '#' {
+			return string(out)
+		}
+		if c == '"' || c == '\'' {
+			// Detect triple quote.
+			triple := i+2 < len(s) && s[i+1] == c && s[i+2] == c
+			out = append(out, c)
+			i++
+			if triple {
+				out = append(out, c, c)
+				i += 2
+				for i < len(s) {
+					if i+2 < len(s) && s[i] == c && s[i+1] == c && s[i+2] == c {
+						out = append(out, c, c, c)
+						i += 3
+						break
+					}
+					out = append(out, s[i])
+					i++
+				}
+				continue
+			}
+			for i < len(s) {
+				if s[i] == '\\' && i+1 < len(s) {
+					out = append(out, s[i], s[i+1])
+					i += 2
+					continue
+				}
+				if s[i] == c {
+					out = append(out, s[i])
+					i++
+					break
+				}
+				out = append(out, s[i])
+				i++
+			}
+			continue
+		}
+		out = append(out, c)
+		i++
+	}
+	return string(out)
+}
+
+// bracketDelta returns the net change in open bracket depth contributed by s,
+// ignoring brackets inside strings. Strings are skipped because stripPyComment
+// preserves them and we need to count brackets again here.
+func bracketDelta(s string) int {
+	d := 0
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		if c == '"' || c == '\'' {
+			triple := i+2 < len(s) && s[i+1] == c && s[i+2] == c
+			i++
+			if triple {
+				i += 2
+				for i < len(s) {
+					if i+2 < len(s) && s[i] == c && s[i+1] == c && s[i+2] == c {
+						i += 3
+						break
+					}
+					i++
+				}
+				continue
+			}
+			for i < len(s) {
+				if s[i] == '\\' && i+1 < len(s) {
+					i += 2
+					continue
+				}
+				if s[i] == c {
+					i++
+					break
+				}
+				i++
+			}
+			continue
+		}
+		switch c {
+		case '(', '[', '{':
+			d++
+		case ')', ']', '}':
+			d--
+		}
+		i++
+	}
+	return d
+}
+
+func parseImport(text string) ImportDecl {
+	rest := strings.TrimPrefix(text, "import ")
+	rest = strings.TrimSpace(rest)
+	names := splitTopLevel(rest, ',')
+	var out []ImportedName
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if idx := strings.Index(n, " as "); idx >= 0 {
+			out = append(out, ImportedName{Name: strings.TrimSpace(n[:idx]), Alias: strings.TrimSpace(n[idx+4:])})
+		} else {
+			out = append(out, ImportedName{Name: n})
+		}
+	}
+	return ImportDecl{Names: out}
+}
+
+func parseFromImport(text string) (ImportDecl, error) {
+	rest := strings.TrimPrefix(text, "from ")
+	idx := strings.Index(rest, " import ")
+	if idx < 0 {
+		return ImportDecl{}, fmt.Errorf("malformed from-import: %q", text)
+	}
+	module := strings.TrimSpace(rest[:idx])
+	names := strings.TrimSpace(rest[idx+8:])
+	names = strings.TrimPrefix(names, "(")
+	names = strings.TrimSuffix(names, ")")
+	parts := splitTopLevel(names, ',')
+	var out []ImportedName
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if alias := strings.Index(p, " as "); alias >= 0 {
+			out = append(out, ImportedName{Name: strings.TrimSpace(p[:alias]), Alias: strings.TrimSpace(p[alias+4:])})
+		} else {
+			out = append(out, ImportedName{Name: p})
+		}
+	}
+	return ImportDecl{Module: module, Names: out}, nil
+}
+
+func parseClass(lines []pyiLine, start int, decorators []string) (ClassDecl, int, error) {
+	header := strings.TrimSpace(lines[start].text)
+	// strip leading "class "
+	rest := strings.TrimPrefix(header, "class ")
+	var name, basesRaw string
+	colon := strings.LastIndex(rest, ":")
+	if colon < 0 {
+		return ClassDecl{}, 0, fmt.Errorf("class header missing ':' : %q", header)
+	}
+	left := strings.TrimSpace(rest[:colon])
+	if paren := strings.Index(left, "("); paren >= 0 {
+		name = strings.TrimSpace(left[:paren])
+		close := strings.LastIndex(left, ")")
+		if close < paren {
+			return ClassDecl{}, 0, fmt.Errorf("class header missing ')' : %q", header)
+		}
+		basesRaw = strings.TrimSpace(left[paren+1 : close])
+	} else {
+		name = left
+	}
+	cd := ClassDecl{Name: name, Decorators: append([]string(nil), decorators...)}
+	for _, b := range splitTopLevel(basesRaw, ',') {
+		b = strings.TrimSpace(b)
+		if b == "" {
+			continue
+		}
+		cd.Bases = append(cd.Bases, b)
+		if b == "Protocol" || strings.HasPrefix(b, "Protocol[") {
+			cd.IsProtocol = true
+		}
+		if b == "TypedDict" || strings.HasPrefix(b, "TypedDict[") || strings.Contains(b, "TypedDict,") {
+			cd.IsTypedDict = true
+		}
+	}
+	for _, d := range cd.Decorators {
+		if d == "dataclass" || strings.HasPrefix(d, "dataclass(") || strings.HasSuffix(d, ".dataclass") {
+			cd.IsDataclass = true
+		}
+	}
+	// Walk the body: every subsequent line with indent > 0 belongs to the class.
+	consumed := 0
+	pendingDecorators := []string(nil)
+	for j := start + 1; j < len(lines); j++ {
+		body := lines[j]
+		if body.indent == 0 {
+			break
+		}
+		consumed++
+		bt := strings.TrimSpace(body.text)
+		switch {
+		case bt == "" || bt == "..." || bt == "pass":
+			continue
+		case strings.HasPrefix(bt, "@"):
+			pendingDecorators = append(pendingDecorators, strings.TrimSpace(bt[1:]))
+		case strings.HasPrefix(bt, "def ") || strings.HasPrefix(bt, "async def "):
+			fd, err := parseFunction(bt, pendingDecorators)
+			if err != nil {
+				return cd, 0, err
+			}
+			cd.Methods = append(cd.Methods, fd)
+			pendingDecorators = nil
+		default:
+			if name, typ, def, ok := splitAnnotation(bt); ok {
+				cd.Fields = append(cd.Fields, FieldDecl{Name: name, Type: typ, Default: def})
+			}
+			pendingDecorators = nil
+		}
+	}
+	return cd, consumed, nil
+}
+
+func parseFunction(text string, decorators []string) (FuncDecl, error) {
+	fd := FuncDecl{Decorators: append([]string(nil), decorators...)}
+	rest := text
+	if strings.HasPrefix(rest, "async def ") {
+		fd.IsAsync = true
+		rest = strings.TrimPrefix(rest, "async def ")
+	} else {
+		rest = strings.TrimPrefix(rest, "def ")
+	}
+	openParen := strings.Index(rest, "(")
+	if openParen < 0 {
+		return fd, fmt.Errorf("function missing '(' : %q", text)
+	}
+	fd.Name = strings.TrimSpace(rest[:openParen])
+	closeParen := matchingClose(rest, openParen, '(', ')')
+	if closeParen < 0 {
+		return fd, fmt.Errorf("function missing ')' : %q", text)
+	}
+	paramsRaw := rest[openParen+1 : closeParen]
+	// After ')', look for `-> Return:` (or just `:` if no return annotation).
+	tail := strings.TrimSpace(rest[closeParen+1:])
+	if strings.HasPrefix(tail, "->") {
+		tail = strings.TrimSpace(tail[2:])
+		if colon := strings.LastIndex(tail, ":"); colon >= 0 {
+			fd.ReturnType = strings.TrimSpace(tail[:colon])
+		} else {
+			fd.ReturnType = tail
+		}
+	}
+	fd.Params = parseParams(paramsRaw)
+	return fd, nil
+}
+
+func parseParams(raw string) []ParamDecl {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := splitTopLevel(raw, ',')
+	var out []ParamDecl
+	keywordOnly := false
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if p == "/" {
+			// Convert all preceding to positional-only.
+			for i := range out {
+				if out[i].Kind == ParamPositional {
+					out[i].Kind = ParamPositionalOnly
+				}
+			}
+			continue
+		}
+		if p == "*" {
+			keywordOnly = true
+			continue
+		}
+		pd := ParamDecl{Kind: ParamPositional}
+		if keywordOnly {
+			pd.Kind = ParamKeywordOnly
+		}
+		if strings.HasPrefix(p, "**") {
+			pd.Kind = ParamKwArgs
+			p = strings.TrimPrefix(p, "**")
+			keywordOnly = true
+		} else if strings.HasPrefix(p, "*") {
+			pd.Kind = ParamVarArgs
+			p = strings.TrimPrefix(p, "*")
+			keywordOnly = true
+		}
+		// Split name : type = default.
+		if eq := findTopLevelEq(p); eq >= 0 {
+			pd.Default = strings.TrimSpace(p[eq+1:])
+			p = strings.TrimSpace(p[:eq])
+		}
+		if colon := strings.Index(p, ":"); colon >= 0 {
+			pd.Name = strings.TrimSpace(p[:colon])
+			pd.Type = strings.TrimSpace(p[colon+1:])
+		} else {
+			pd.Name = strings.TrimSpace(p)
+		}
+		out = append(out, pd)
+	}
+	return out
+}
+
+func splitAnnotation(text string) (name, typ, def string, ok bool) {
+	// `Name: Type` or `Name: Type = value`. Reject if there's no colon at
+	// the top level or no `=`-but-no-colon-but-looks-like-identifier.
+	colon := findTopLevelColon(text)
+	if colon < 0 {
+		return "", "", "", false
+	}
+	name = strings.TrimSpace(text[:colon])
+	if !isPlainIdent(name) {
+		return "", "", "", false
+	}
+	rest := text[colon+1:]
+	if eq := findTopLevelEq(rest); eq >= 0 {
+		typ = strings.TrimSpace(rest[:eq])
+		def = strings.TrimSpace(rest[eq+1:])
+		return name, typ, def, true
+	}
+	return name, strings.TrimSpace(rest), "", true
+}
+
+func splitAlias(text string) (name, expr string, ok bool) {
+	// `Name = Expr` where Name is a plain identifier.
+	eq := findTopLevelEq(text)
+	if eq < 0 {
+		return "", "", false
+	}
+	name = strings.TrimSpace(text[:eq])
+	if !isPlainIdent(name) {
+		return "", "", false
+	}
+	expr = strings.TrimSpace(text[eq+1:])
+	return name, expr, true
+}
+
+func isPlainIdent(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if i == 0 && !(unicode.IsLetter(r) || r == '_') {
+			return false
+		}
+		if !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+func findTopLevelColon(s string) int {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case ':':
+			if depth == 0 {
+				return i
+			}
+		case '"', '\'':
+			// Skip string content.
+			q := c
+			j := i + 1
+			for j < len(s) && s[j] != q {
+				if s[j] == '\\' && j+1 < len(s) {
+					j += 2
+					continue
+				}
+				j++
+			}
+			i = j
+		}
+	}
+	return -1
+}
+
+func findTopLevelEq(s string) int {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case '=':
+			if depth == 0 {
+				// Reject `==`, `>=`, `<=`, `!=`.
+				if i+1 < len(s) && s[i+1] == '=' {
+					i++
+					continue
+				}
+				if i > 0 && (s[i-1] == '>' || s[i-1] == '<' || s[i-1] == '!' || s[i-1] == '=') {
+					continue
+				}
+				return i
+			}
+		case '"', '\'':
+			q := c
+			j := i + 1
+			for j < len(s) && s[j] != q {
+				if s[j] == '\\' && j+1 < len(s) {
+					j += 2
+					continue
+				}
+				j++
+			}
+			i = j
+		}
+	}
+	return -1
+}
+
+// splitTopLevel splits s on `sep` ignoring separators inside brackets / quotes.
+func splitTopLevel(s string, sep byte) []string {
+	var out []string
+	depth := 0
+	start := 0
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		switch c {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case '"', '\'':
+			q := c
+			j := i + 1
+			for j < len(s) && s[j] != q {
+				if s[j] == '\\' && j+1 < len(s) {
+					j += 2
+					continue
+				}
+				j++
+			}
+			i = j
+		case sep:
+			if depth == 0 {
+				out = append(out, s[start:i])
+				start = i + 1
+			}
+		}
+		i++
+	}
+	if start <= len(s) {
+		out = append(out, s[start:])
+	}
+	return out
+}
+
+// matchingClose returns the index of the closing bracket matching the opener
+// at `open` (which is open / close pair).
+func matchingClose(s string, openIdx int, openCh, closeCh byte) int {
+	depth := 0
+	for i := openIdx; i < len(s); i++ {
+		c := s[i]
+		if c == '"' || c == '\'' {
+			q := c
+			j := i + 1
+			for j < len(s) && s[j] != q {
+				if s[j] == '\\' && j+1 < len(s) {
+					j += 2
+					continue
+				}
+				j++
+			}
+			i = j
+			continue
+		}
+		switch c {
+		case openCh:
+			depth++
+		case closeCh:
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}

--- a/package3/python/stubs/pyi_test.go
+++ b/package3/python/stubs/pyi_test.go
@@ -1,0 +1,537 @@
+package stubs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParsePYIEmpty(t *testing.T) {
+	m, err := ParsePYI("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m == nil {
+		t.Fatal("nil module")
+	}
+	if len(m.Imports)+len(m.Classes)+len(m.Functions)+len(m.Aliases)+len(m.Constants) != 0 {
+		t.Errorf("expected empty surface, got %+v", m)
+	}
+}
+
+func TestParsePYIImports(t *testing.T) {
+	src := `import os
+import sys as system
+from typing import Any, List, Optional
+from collections.abc import Iterable as It
+`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Imports) != 4 {
+		t.Fatalf("len(Imports) = %d, want 4: %+v", len(m.Imports), m.Imports)
+	}
+	if m.Imports[0].Module != "" || m.Imports[0].Names[0].Name != "os" {
+		t.Errorf("import os: %+v", m.Imports[0])
+	}
+	if m.Imports[1].Names[0].Alias != "system" {
+		t.Errorf("alias not parsed: %+v", m.Imports[1])
+	}
+	if m.Imports[2].Module != "typing" {
+		t.Errorf("from-module = %q", m.Imports[2].Module)
+	}
+	if len(m.Imports[2].Names) != 3 {
+		t.Errorf("names = %+v", m.Imports[2].Names)
+	}
+	if m.Imports[3].Names[0].Name != "Iterable" || m.Imports[3].Names[0].Alias != "It" {
+		t.Errorf("aliased from-import: %+v", m.Imports[3])
+	}
+}
+
+func TestParsePYIFromImportParenthesised(t *testing.T) {
+	src := `from typing import (
+    Any,
+    List,
+    Optional,
+)
+`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Imports) != 1 {
+		t.Fatalf("imports = %+v", m.Imports)
+	}
+	got := m.Imports[0]
+	if got.Module != "typing" {
+		t.Errorf("module = %q", got.Module)
+	}
+	if len(got.Names) != 3 {
+		t.Errorf("names = %+v", got.Names)
+	}
+	wantNames := []string{"Any", "List", "Optional"}
+	for i, n := range got.Names {
+		if n.Name != wantNames[i] {
+			t.Errorf("name[%d] = %q, want %q", i, n.Name, wantNames[i])
+		}
+	}
+}
+
+func TestParsePYIClassesBasic(t *testing.T) {
+	src := `class Foo:
+    x: int
+    y: str = "hi"
+    def m(self) -> int: ...
+
+class Bar(Foo):
+    ...
+`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Classes) != 2 {
+		t.Fatalf("classes = %+v", m.Classes)
+	}
+	foo := m.Classes[0]
+	if foo.Name != "Foo" {
+		t.Errorf("Name = %q", foo.Name)
+	}
+	if len(foo.Fields) != 2 {
+		t.Errorf("Fields = %+v", foo.Fields)
+	}
+	if foo.Fields[0].Name != "x" || foo.Fields[0].Type != "int" {
+		t.Errorf("field 0: %+v", foo.Fields[0])
+	}
+	if foo.Fields[1].Default != `"hi"` {
+		t.Errorf("field 1 default = %q", foo.Fields[1].Default)
+	}
+	if len(foo.Methods) != 1 || foo.Methods[0].Name != "m" {
+		t.Errorf("Methods = %+v", foo.Methods)
+	}
+	bar := m.Classes[1]
+	if len(bar.Bases) != 1 || bar.Bases[0] != "Foo" {
+		t.Errorf("Bar bases = %+v", bar.Bases)
+	}
+}
+
+func TestParsePYIProtocolAndTypedDict(t *testing.T) {
+	src := `class P(Protocol):
+    def f(self) -> int: ...
+
+class T(TypedDict):
+    x: int
+
+class TG(TypedDict, total=False):
+    y: str
+`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.Classes[0].IsProtocol {
+		t.Error("class P should be Protocol")
+	}
+	if !m.Classes[1].IsTypedDict {
+		t.Error("class T should be TypedDict")
+	}
+	if !m.Classes[2].IsTypedDict {
+		t.Error("class TG should be TypedDict (with total=False)")
+	}
+}
+
+func TestParsePYIDataclassDecorator(t *testing.T) {
+	src := `@dataclass
+class D:
+    x: int
+
+@dataclasses.dataclass
+class E:
+    y: int
+`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.Classes[0].IsDataclass {
+		t.Error("D should be dataclass")
+	}
+	if !m.Classes[1].IsDataclass {
+		t.Error("E should be dataclass (dataclasses.dataclass)")
+	}
+}
+
+func TestParsePYIFunctions(t *testing.T) {
+	src := `def simple() -> None: ...
+async def fetch(url: str) -> bytes: ...
+def add(a: int, b: int = 0) -> int: ...
+`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Functions) != 3 {
+		t.Fatalf("funcs = %+v", m.Functions)
+	}
+	if m.Functions[0].ReturnType != "None" {
+		t.Errorf("simple return = %q", m.Functions[0].ReturnType)
+	}
+	if !m.Functions[1].IsAsync {
+		t.Error("fetch should be async")
+	}
+	if m.Functions[1].ReturnType != "bytes" {
+		t.Errorf("fetch return = %q", m.Functions[1].ReturnType)
+	}
+	add := m.Functions[2]
+	if len(add.Params) != 2 {
+		t.Fatalf("add params = %+v", add.Params)
+	}
+	if add.Params[1].Default != "0" {
+		t.Errorf("default = %q", add.Params[1].Default)
+	}
+}
+
+func TestParsePYIPositionalOnly(t *testing.T) {
+	src := `def f(a: int, b: int, /, c: int) -> int: ...`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := m.Functions[0]
+	if len(f.Params) != 3 {
+		t.Fatalf("params = %+v", f.Params)
+	}
+	if f.Params[0].Kind != ParamPositionalOnly {
+		t.Errorf("a kind = %v", f.Params[0].Kind)
+	}
+	if f.Params[1].Kind != ParamPositionalOnly {
+		t.Errorf("b kind = %v", f.Params[1].Kind)
+	}
+	if f.Params[2].Kind != ParamPositional {
+		t.Errorf("c kind = %v", f.Params[2].Kind)
+	}
+}
+
+func TestParsePYIKeywordOnly(t *testing.T) {
+	src := `def f(a: int, *, b: int, c: int = 1) -> int: ...`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := m.Functions[0]
+	if len(f.Params) != 3 {
+		t.Fatalf("params = %+v", f.Params)
+	}
+	if f.Params[0].Kind != ParamPositional {
+		t.Errorf("a kind = %v", f.Params[0].Kind)
+	}
+	if f.Params[1].Kind != ParamKeywordOnly {
+		t.Errorf("b kind = %v", f.Params[1].Kind)
+	}
+	if f.Params[2].Kind != ParamKeywordOnly {
+		t.Errorf("c kind = %v", f.Params[2].Kind)
+	}
+}
+
+func TestParsePYIVarArgs(t *testing.T) {
+	src := `def f(*args: int, **kwargs: str) -> None: ...`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := m.Functions[0]
+	if len(f.Params) != 2 {
+		t.Fatalf("params = %+v", f.Params)
+	}
+	if f.Params[0].Kind != ParamVarArgs || f.Params[0].Name != "args" {
+		t.Errorf("args: %+v", f.Params[0])
+	}
+	if f.Params[1].Kind != ParamKwArgs || f.Params[1].Name != "kwargs" {
+		t.Errorf("kwargs: %+v", f.Params[1])
+	}
+}
+
+func TestParsePYIMethodDecorators(t *testing.T) {
+	src := `class C:
+    @property
+    def x(self) -> int: ...
+    @staticmethod
+    def y() -> int: ...
+    @overload
+    def z(self, a: int) -> int: ...
+    @overload
+    def z(self, a: str) -> str: ...
+`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := m.Classes[0]
+	if len(c.Methods) != 4 {
+		t.Fatalf("methods = %+v", c.Methods)
+	}
+	if c.Methods[0].Decorators[0] != "property" {
+		t.Errorf("property decorator missing: %+v", c.Methods[0])
+	}
+	if c.Methods[1].Decorators[0] != "staticmethod" {
+		t.Errorf("staticmethod decorator missing: %+v", c.Methods[1])
+	}
+}
+
+func TestParsePYIAliases(t *testing.T) {
+	src := `Vector = List[float]
+T = TypeVar('T')
+StringMap = dict[str, str]
+`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Aliases) != 3 {
+		t.Fatalf("aliases = %+v", m.Aliases)
+	}
+	if m.Aliases[0].Name != "Vector" || m.Aliases[0].Expr != "List[float]" {
+		t.Errorf("Vector: %+v", m.Aliases[0])
+	}
+	if m.Aliases[1].Expr != "TypeVar('T')" {
+		t.Errorf("T expr = %q", m.Aliases[1].Expr)
+	}
+}
+
+func TestParsePYIConstants(t *testing.T) {
+	src := `MAX_LEN: int
+NAME: str = "hello"
+PAIR: tuple[int, str] = (1, "x")
+`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Constants) != 3 {
+		t.Fatalf("constants = %+v", m.Constants)
+	}
+	if m.Constants[0].Name != "MAX_LEN" || m.Constants[0].Type != "int" || m.Constants[0].Default != "" {
+		t.Errorf("MAX_LEN: %+v", m.Constants[0])
+	}
+	if m.Constants[1].Default != `"hello"` {
+		t.Errorf("NAME default = %q", m.Constants[1].Default)
+	}
+	if m.Constants[2].Type != "tuple[int, str]" {
+		t.Errorf("PAIR type = %q", m.Constants[2].Type)
+	}
+}
+
+func TestParsePYICommentStripping(t *testing.T) {
+	src := `# top comment
+def f() -> int: ...  # trailing
+X: int = 0  # value comment
+Y: str = "hash # inside"  # not a comment
+`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Functions) != 1 || m.Functions[0].Name != "f" {
+		t.Errorf("funcs = %+v", m.Functions)
+	}
+	if len(m.Constants) != 2 {
+		t.Fatalf("constants = %+v", m.Constants)
+	}
+	if !strings.Contains(m.Constants[1].Default, `"hash # inside"`) {
+		t.Errorf("Y default = %q (should preserve # inside string)", m.Constants[1].Default)
+	}
+}
+
+func TestParsePYIBackslashContinuation(t *testing.T) {
+	src := `X: int = \
+    42
+`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Constants) != 1 || m.Constants[0].Default != "42" {
+		t.Errorf("constants = %+v", m.Constants)
+	}
+}
+
+func TestParsePYIParenContinuation(t *testing.T) {
+	src := `def f(
+    a: int,
+    b: int,
+) -> int: ...
+`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Functions) != 1 || len(m.Functions[0].Params) != 2 {
+		t.Errorf("funcs = %+v", m.Functions)
+	}
+}
+
+func TestParsePYIUnbalancedBrackets(t *testing.T) {
+	src := `def f()) -> int: ...`
+	if _, err := ParsePYI(src); err == nil {
+		t.Fatal("expected error for unbalanced brackets")
+	}
+}
+
+func TestParsePYIBOM(t *testing.T) {
+	src := "\ufeffimport os\n"
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Imports) != 1 || m.Imports[0].Names[0].Name != "os" {
+		t.Errorf("imports = %+v", m.Imports)
+	}
+}
+
+func TestParsePYIRejectsEqEqInAlias(t *testing.T) {
+	src := `X = 1 == 2`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Aliases) != 1 {
+		t.Fatalf("aliases = %+v", m.Aliases)
+	}
+	if m.Aliases[0].Expr != "1 == 2" {
+		t.Errorf("expr = %q (should not split on ==)", m.Aliases[0].Expr)
+	}
+}
+
+func TestParsePYIIgnoresUnknownTopLevel(t *testing.T) {
+	// Unknown constructs should be silently skipped per doc.
+	src := `pass
+...
+def known() -> int: ...
+`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Functions) != 1 {
+		t.Errorf("funcs = %+v", m.Functions)
+	}
+}
+
+func TestParsePYIIsPlainIdent(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"x", true},
+		{"X", true},
+		{"_x", true},
+		{"x1", true},
+		{"x_y", true},
+		{"", false},
+		{"1x", false},
+		{"x.y", false},
+		{"x[y]", false},
+		{"x, y", false},
+	}
+	for _, c := range cases {
+		if got := isPlainIdent(c.in); got != c.want {
+			t.Errorf("isPlainIdent(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParsePYIFindTopLevelColon(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"X: int", 1},
+		{"X[Y]: int", 4},
+		{`X: "str:thing"`, 1},
+		{"no colon", -1},
+		{"X[a:b]", -1},
+		{"X{a:b}: int", 6},
+	}
+	for _, c := range cases {
+		if got := findTopLevelColon(c.in); got != c.want {
+			t.Errorf("findTopLevelColon(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParsePYIFindTopLevelEq(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"X = 1", 2},
+		{"X == 1", -1},
+		{"X >= 1", -1},
+		{"X[a=b]", -1},
+		{"X = (a == b)", 2},
+	}
+	for _, c := range cases {
+		if got := findTopLevelEq(c.in); got != c.want {
+			t.Errorf("findTopLevelEq(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParsePYISplitTopLevel(t *testing.T) {
+	got := splitTopLevel("a, b, c", ',')
+	if len(got) != 3 {
+		t.Errorf("simple split: %v", got)
+	}
+	got = splitTopLevel("a, List[b, c], d", ',')
+	if len(got) != 3 {
+		t.Errorf("bracketed split: %v", got)
+	}
+	got = splitTopLevel(`a, "b, c", d`, ',')
+	if len(got) != 3 {
+		t.Errorf("quoted split: %v", got)
+	}
+}
+
+func TestParsePYIDataclassRoundTrip(t *testing.T) {
+	src := `from dataclasses import dataclass
+
+@dataclass
+class Point:
+    x: int
+    y: int = 0
+
+    def shift(self, dx: int, dy: int = 0) -> "Point": ...
+`
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Imports) != 1 {
+		t.Errorf("imports = %+v", m.Imports)
+	}
+	if len(m.Classes) != 1 {
+		t.Fatalf("classes = %+v", m.Classes)
+	}
+	p := m.Classes[0]
+	if !p.IsDataclass {
+		t.Error("Point should be dataclass")
+	}
+	if len(p.Fields) != 2 {
+		t.Errorf("fields = %+v", p.Fields)
+	}
+	if len(p.Methods) != 1 || p.Methods[0].ReturnType != `"Point"` {
+		t.Errorf("method return = %q", p.Methods[0].ReturnType)
+	}
+}
+
+func TestParsePYITabsAreIndent(t *testing.T) {
+	src := "class C:\n\tx: int\n\tdef m(self) -> int: ...\n"
+	m, err := ParsePYI(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := m.Classes[0]
+	if len(c.Fields) != 1 || len(c.Methods) != 1 {
+		t.Errorf("class C: %+v", c)
+	}
+}

--- a/package3/python/stubs/stubgen.go
+++ b/package3/python/stubs/stubgen.go
@@ -1,0 +1,123 @@
+package stubs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Stubgen is the abstract surface for the tier-4 stubgen fallback. The default
+// implementation shells out to `python -m mypy.stubgen`. Tests substitute a
+// fake that writes pre-baked .pyi bytes into a temp directory.
+type Stubgen interface {
+	// Generate runs stubgen for `name` (PEP 503 distribution name) /
+	// `module` (Python import name) under sitePackages and returns a
+	// StubSource pointing at the generated output. The output is always
+	// marked Partial = true.
+	Generate(name, module, sitePackages string) (*StubSource, error)
+}
+
+// ExecStubgen shells out to a Python interpreter that has mypy installed.
+type ExecStubgen struct {
+	// Python is the interpreter to invoke. Empty means "python3 on PATH".
+	Python string
+	// CacheDir is the directory under which per-package output trees are
+	// written. The bridge typically points this at the venv's stubgen-out
+	// directory so phase 8's content-addressed cache can recover.
+	CacheDir string
+	// Timeout caps each stubgen invocation. Zero uses 60 seconds.
+	Timeout time.Duration
+}
+
+// NewExecStubgen returns an ExecStubgen with sensible defaults.
+func NewExecStubgen(cacheDir string) *ExecStubgen {
+	return &ExecStubgen{
+		Python:   "",
+		CacheDir: cacheDir,
+		Timeout:  60 * time.Second,
+	}
+}
+
+// Generate implements Stubgen.
+func (s *ExecStubgen) Generate(name, module, sitePackages string) (*StubSource, error) {
+	if s.CacheDir == "" {
+		return nil, fmt.Errorf("stubgen: CacheDir is empty")
+	}
+	out := filepath.Join(s.CacheDir, name)
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		return nil, fmt.Errorf("stubgen: mkdir %q: %w", out, err)
+	}
+	bin := s.Python
+	if bin == "" {
+		path, err := exec.LookPath("python3")
+		if err != nil {
+			return nil, fmt.Errorf("stubgen: python3 not on PATH: %w", err)
+		}
+		bin = path
+	}
+	timeout := s.Timeout
+	if timeout == 0 {
+		timeout = 60 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	args := []string{
+		"-m", "mypy.stubgen",
+		"--package", module,
+		"--output", out,
+		"--quiet",
+	}
+	cmd := exec.CommandContext(ctx, bin, args...)
+	// Run inside the venv site-packages so stubgen can find the package.
+	if sitePackages != "" {
+		cmd.Env = append(os.Environ(), "PYTHONPATH="+sitePackages)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("stubgen: %s %s: %w (stderr: %s)", bin, strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	files, _ := walkStubFiles(out)
+	return &StubSource{
+		Package: name,
+		Tier:    TierStubgen,
+		RootDir: out,
+		Files:   files,
+		Partial: true,
+	}, nil
+}
+
+// FakeStubgen is a test double that "generates" stubs by writing a fixed
+// per-module .pyi body to disk. The body is set once at construction.
+type FakeStubgen struct {
+	CacheDir string
+	Body     []byte
+}
+
+// Generate implements Stubgen.
+func (f *FakeStubgen) Generate(name, module, sitePackages string) (*StubSource, error) {
+	if f.CacheDir == "" {
+		return nil, fmt.Errorf("FakeStubgen: empty CacheDir")
+	}
+	out := filepath.Join(f.CacheDir, name)
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(out, module+".pyi")
+	if err := os.WriteFile(path, f.Body, 0o644); err != nil {
+		return nil, err
+	}
+	return &StubSource{
+		Package: name,
+		Tier:    TierStubgen,
+		RootDir: out,
+		Files:   []string{module + ".pyi"},
+		Partial: true,
+	}, nil
+}

--- a/package3/python/stubs/stubgen_test.go
+++ b/package3/python/stubs/stubgen_test.go
@@ -1,0 +1,100 @@
+package stubs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFakeStubgenGenerate(t *testing.T) {
+	cacheDir := t.TempDir()
+	f := &FakeStubgen{CacheDir: cacheDir, Body: []byte("def f() -> int: ...\n")}
+	src, err := f.Generate("mypkg", "mypkg", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src.Tier != TierStubgen {
+		t.Errorf("Tier = %v, want TierStubgen", src.Tier)
+	}
+	if !src.Partial {
+		t.Error("FakeStubgen must produce Partial = true")
+	}
+	if src.Package != "mypkg" {
+		t.Errorf("Package = %q, want mypkg", src.Package)
+	}
+	wantPath := filepath.Join(cacheDir, "mypkg", "mypkg.pyi")
+	body, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "def f() -> int: ...\n" {
+		t.Errorf("body = %q", body)
+	}
+	if len(src.Files) != 1 || src.Files[0] != "mypkg.pyi" {
+		t.Errorf("Files = %v", src.Files)
+	}
+}
+
+func TestFakeStubgenEmptyCacheDir(t *testing.T) {
+	f := &FakeStubgen{}
+	if _, err := f.Generate("mypkg", "mypkg", ""); err == nil {
+		t.Fatal("expected error on empty CacheDir")
+	}
+}
+
+func TestFakeStubgenModuleAlias(t *testing.T) {
+	cacheDir := t.TempDir()
+	f := &FakeStubgen{CacheDir: cacheDir, Body: []byte("x: int\n")}
+	// PEP 503 distribution name vs Python module name.
+	src, err := f.Generate("Flask-SQLAlchemy", "flask_sqlalchemy", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(cacheDir, "Flask-SQLAlchemy", "flask_sqlalchemy.pyi")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("expected %q to exist: %v", want, err)
+	}
+	if src.Files[0] != "flask_sqlalchemy.pyi" {
+		t.Errorf("Files[0] = %q", src.Files[0])
+	}
+}
+
+func TestNewExecStubgenDefaults(t *testing.T) {
+	s := NewExecStubgen("/tmp/cache")
+	if s.CacheDir != "/tmp/cache" {
+		t.Errorf("CacheDir = %q", s.CacheDir)
+	}
+	if s.Timeout != 60*time.Second {
+		t.Errorf("Timeout = %v, want 60s", s.Timeout)
+	}
+	if s.Python != "" {
+		t.Errorf("Python = %q, want empty (PATH lookup)", s.Python)
+	}
+}
+
+func TestExecStubgenEmptyCacheDir(t *testing.T) {
+	s := &ExecStubgen{}
+	if _, err := s.Generate("mypkg", "mypkg", ""); err == nil {
+		t.Fatal("expected error on empty CacheDir")
+	}
+}
+
+func TestExecStubgenMissingPython(t *testing.T) {
+	// Set Python to a path that definitely doesn't exist and verify the error
+	// path that runs the subprocess returns a wrapped error.
+	cacheDir := t.TempDir()
+	s := &ExecStubgen{
+		Python:   "/nonexistent/python",
+		CacheDir: cacheDir,
+		Timeout:  2 * time.Second,
+	}
+	_, err := s.Generate("mypkg", "mypkg", "")
+	if err == nil {
+		t.Fatal("expected error from missing interpreter")
+	}
+	if !strings.Contains(err.Error(), "stubgen") {
+		t.Errorf("error should mention stubgen: %v", err)
+	}
+}

--- a/package3/python/stubs/typeshed.go
+++ b/package3/python/stubs/typeshed.go
@@ -1,0 +1,118 @@
+package stubs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Typeshed is a pinned local checkout of github.com/python/typeshed used as
+// the tier-3 stub source. The bridge does not fetch typeshed itself; the
+// workspace orchestrator (phase 8) ensures a checkout exists at the pinned
+// commit before discovery runs.
+type Typeshed struct {
+	// Root is the local typeshed checkout directory.
+	Root string
+	// Commit is the pinned commit SHA. It is recorded in the lockfile but
+	// otherwise unused at lookup time; the bridge trusts the Root to be at
+	// that commit.
+	Commit string
+}
+
+// NewTypeshed wraps a local checkout. Root must exist and contain `stdlib/` or
+// `stubs/` subdirectories (the typeshed layout).
+func NewTypeshed(root, commit string) (*Typeshed, error) {
+	if root == "" {
+		return nil, fmt.Errorf("typeshed: empty root")
+	}
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("typeshed: stat %q: %w", root, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("typeshed: %q is not a directory", root)
+	}
+	// Soft check: at least one of the two canonical subtrees should exist.
+	hasStdlib := dirExists(filepath.Join(root, "stdlib"))
+	hasStubs := dirExists(filepath.Join(root, "stubs"))
+	if !hasStdlib && !hasStubs {
+		return nil, fmt.Errorf("typeshed: %q does not look like a typeshed checkout (no stdlib/ or stubs/)", root)
+	}
+	return &Typeshed{Root: root, Commit: commit}, nil
+}
+
+// Lookup searches typeshed for `name` (PEP 503 normalised) and returns a
+// StubSource on hit. Returns (nil, false) when not found.
+//
+// Search order within typeshed:
+//   1. stubs/<name>/<module>/ for third-party stubs.
+//   2. stdlib/<module>/ for stdlib modules where name == module.
+func (ts *Typeshed) Lookup(name string) (*StubSource, bool) {
+	module := moduleFromName(name)
+	// Third-party: `stubs/<name>/<module>` with a top-level METADATA.toml.
+	thirdParty := filepath.Join(ts.Root, "stubs", name, module)
+	if dirExists(thirdParty) {
+		files, _ := walkStubFiles(thirdParty)
+		return &StubSource{
+			Package: name,
+			Tier:    TierTypeshed,
+			RootDir: thirdParty,
+			Files:   files,
+		}, true
+	}
+	// Some typeshed entries place the stubs at `stubs/<name>` directly.
+	thirdParty2 := filepath.Join(ts.Root, "stubs", name)
+	if dirExists(thirdParty2) {
+		files, _ := walkStubFiles(thirdParty2)
+		return &StubSource{
+			Package: name,
+			Tier:    TierTypeshed,
+			RootDir: thirdParty2,
+			Files:   files,
+		}, true
+	}
+	// Stdlib: `stdlib/<module>.pyi` or `stdlib/<module>/`.
+	stdlibDir := filepath.Join(ts.Root, "stdlib", module)
+	if dirExists(stdlibDir) {
+		files, _ := walkStubFiles(stdlibDir)
+		return &StubSource{
+			Package: name,
+			Tier:    TierTypeshed,
+			RootDir: stdlibDir,
+			Files:   files,
+		}, true
+	}
+	stdlibFile := filepath.Join(ts.Root, "stdlib", module+".pyi")
+	if _, err := os.Stat(stdlibFile); err == nil {
+		return &StubSource{
+			Package: name,
+			Tier:    TierTypeshed,
+			RootDir: filepath.Join(ts.Root, "stdlib"),
+			Files:   []string{module + ".pyi"},
+		}, true
+	}
+	return nil, false
+}
+
+// moduleFromName converts a PEP 503 distribution name into the most likely
+// import module name. `Flask-SQLAlchemy` -> `flask_sqlalchemy`.
+func moduleFromName(name string) string {
+	out := make([]byte, len(name))
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case c >= 'A' && c <= 'Z':
+			out[i] = c + ('a' - 'A')
+		case c == '-':
+			out[i] = '_'
+		default:
+			out[i] = c
+		}
+	}
+	return string(out)
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/package3/python/stubs/typeshed_test.go
+++ b/package3/python/stubs/typeshed_test.go
@@ -1,0 +1,191 @@
+package stubs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewTypeshedRejectsEmptyRoot(t *testing.T) {
+	if _, err := NewTypeshed("", ""); err == nil {
+		t.Fatal("expected error for empty root")
+	}
+}
+
+func TestNewTypeshedRejectsMissingRoot(t *testing.T) {
+	if _, err := NewTypeshed(filepath.Join(t.TempDir(), "nope"), ""); err == nil {
+		t.Fatal("expected error for missing root")
+	}
+}
+
+func TestNewTypeshedRejectsRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "afile")
+	if err := os.WriteFile(p, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewTypeshed(p, ""); err == nil {
+		t.Fatal("expected error: root is not a directory")
+	}
+}
+
+func TestNewTypeshedRejectsNonTypeshedDir(t *testing.T) {
+	dir := t.TempDir() // empty
+	if _, err := NewTypeshed(dir, ""); err == nil {
+		t.Fatal("expected error: missing stdlib/ or stubs/")
+	}
+}
+
+func TestNewTypeshedAcceptsStdlibOnly(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "stdlib"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ts, err := NewTypeshed(dir, "abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ts.Commit != "abc123" {
+		t.Errorf("Commit = %q, want abc123", ts.Commit)
+	}
+}
+
+func TestNewTypeshedAcceptsStubsOnly(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "stubs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewTypeshed(dir, ""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLookupStdlibDir(t *testing.T) {
+	dir := t.TempDir()
+	pkgDir := filepath.Join(dir, "stdlib", "json")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "__init__.pyi"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ts, _ := NewTypeshed(dir, "")
+	src, ok := ts.Lookup("json")
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	if src.Tier != TierTypeshed {
+		t.Errorf("Tier = %v, want TierTypeshed", src.Tier)
+	}
+	if src.RootDir != pkgDir {
+		t.Errorf("RootDir = %q, want %q", src.RootDir, pkgDir)
+	}
+}
+
+func TestLookupStdlibFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "stdlib"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "stdlib", "os.pyi"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ts, _ := NewTypeshed(dir, "")
+	src, ok := ts.Lookup("os")
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	if src.Tier != TierTypeshed {
+		t.Errorf("Tier = %v, want TierTypeshed", src.Tier)
+	}
+	if len(src.Files) != 1 || src.Files[0] != "os.pyi" {
+		t.Errorf("Files = %v, want [os.pyi]", src.Files)
+	}
+}
+
+func TestLookupThirdPartyNested(t *testing.T) {
+	dir := t.TempDir()
+	tsPkg := filepath.Join(dir, "stubs", "requests", "requests")
+	if err := os.MkdirAll(tsPkg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tsPkg, "__init__.pyi"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "stdlib"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ts, _ := NewTypeshed(dir, "")
+	src, ok := ts.Lookup("requests")
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	if src.RootDir != tsPkg {
+		t.Errorf("RootDir = %q, want %q", src.RootDir, tsPkg)
+	}
+}
+
+func TestLookupThirdPartyFlat(t *testing.T) {
+	dir := t.TempDir()
+	tsPkg := filepath.Join(dir, "stubs", "toml")
+	if err := os.MkdirAll(tsPkg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tsPkg, "__init__.pyi"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ts, _ := NewTypeshed(dir, "")
+	src, ok := ts.Lookup("toml")
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	if src.RootDir != tsPkg {
+		t.Errorf("RootDir = %q, want %q", src.RootDir, tsPkg)
+	}
+}
+
+func TestLookupMiss(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "stdlib"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ts, _ := NewTypeshed(dir, "")
+	if _, ok := ts.Lookup("nope"); ok {
+		t.Fatal("expected miss")
+	}
+}
+
+func TestModuleFromName(t *testing.T) {
+	cases := []struct {
+		name, want string
+	}{
+		{"requests", "requests"},
+		{"Flask", "flask"},
+		{"Flask-SQLAlchemy", "flask_sqlalchemy"},
+		{"PyYAML", "pyyaml"},
+		{"numpy", "numpy"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := moduleFromName(c.name); got != c.want {
+			t.Errorf("moduleFromName(%q) = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestDirExists(t *testing.T) {
+	dir := t.TempDir()
+	if !dirExists(dir) {
+		t.Error("temp dir should exist")
+	}
+	if dirExists(filepath.Join(dir, "nope")) {
+		t.Error("missing dir should not exist")
+	}
+	p := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(p, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if dirExists(p) {
+		t.Error("regular file should not register as dir")
+	}
+}

--- a/website/docs/implementation/0071/index.md
+++ b/website/docs/implementation/0071/index.md
@@ -17,8 +17,8 @@ A phase is LANDED only when its gate is green for every target (consume directio
 |-------|-------|--------|--------|---------------|
 | 0 | Skeleton: `package3/python/` layout + `Driver` / `Venv` / `SkipReason` / `BridgeError` | LANDED | `8e1ef75f` | [phase-00](/docs/implementation/0071/phase-00-skeleton) |
 | 1 | Simple-index client (PEP 503 HTML + PEP 691 JSON + PEP 700 metadata, sha256 + blake3 download verify) | LANDED | `3dfc4490` | [phase-01](/docs/implementation/0071/phase-01-simple-index) |
-| 2 | uv resolver bridge (subprocess + lockfile parsing) + PEP 751 pylock.toml round-trip | LANDED | (pending merge) | [phase-02](/docs/implementation/0071/phase-02-uv-resolver) |
-| 3 | PEP 561 stub discovery (4-tier precedence, typeshed pin, stubgen sandbox) + `.pyi` parser | NOT STARTED | — | [phase-03](/docs/implementation/0071/phase-03-stub-ingest) |
+| 2 | uv resolver bridge (subprocess + lockfile parsing) + PEP 751 pylock.toml round-trip | LANDED | `a38cb023` | [phase-02](/docs/implementation/0071/phase-02-uv-resolver) |
+| 3 | PEP 561 stub discovery (4-tier precedence, typeshed pin, stubgen sandbox) + `.pyi` parser | LANDED | (pending merge) | [phase-03](/docs/implementation/0071/phase-03-stub-ingest) |
 | 4 | Closed type-mapping table (scalars / strings / collections / Optional / Union / dataclass / TypedDict / Protocol) | NOT STARTED | — | [phase-04](/docs/implementation/0071/phase-04-type-mapping) |
 | 5 | Wrapper module synthesiser (CPython extension `.so` + `_mochi_wrap.py` + `.pyi`) | NOT STARTED | — | [phase-05](/docs/implementation/0071/phase-05-wrapper) |
 | 6 | Mochi-side extern fn emitter + alias shim file generation + sidecar (`*_externs.py`) loader | NOT STARTED | — | [phase-06](/docs/implementation/0071/phase-06-extern-emit) |
@@ -90,7 +90,7 @@ The `package3/python/` location is shared with the broader MEP-57 polyglot packa
 
 ## Status snapshot
 
-As of 2026-05-29 23:09 (GMT+7): MEP-71 spec and research bundle landed; phases 0-2 LANDED; phases 3-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
+As of 2026-05-29 23:22 (GMT+7): MEP-71 spec and research bundle landed; phases 0-3 LANDED; phases 4-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
 
 ## Cross-references
 

--- a/website/docs/implementation/0071/phase-02-uv-resolver.md
+++ b/website/docs/implementation/0071/phase-02-uv-resolver.md
@@ -15,7 +15,7 @@ description: "MEP-71 Phase 2 lands the uv subprocess wrapper, a minimal TOML rea
 | Landed         | 2026-05-29 23:09 (GMT+7) |
 | Tracking issue | (filled by automation) |
 | Tracking PR    | (filled by automation) |
-| Commit         | (filled by automation) |
+| Commit         | `a38cb023` |
 
 ## Gate
 

--- a/website/docs/implementation/0071/phase-03-stub-ingest.md
+++ b/website/docs/implementation/0071/phase-03-stub-ingest.md
@@ -1,0 +1,85 @@
+---
+title: "Phase 3. PEP 561 stub ingest"
+sidebar_position: 5
+sidebar_label: "Phase 3. stub ingest"
+description: "MEP-71 Phase 3 lands the 4-tier PEP 561 stub discovery (inline / sibling-stubs / typeshed / stubgen), the typeshed pin, and a focused .pyi reader."
+---
+
+# Phase 3. PEP 561 stub ingest
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-71 §Phases](/docs/mep/mep-0071#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-29 23:12 (GMT+7) |
+| Landed         | 2026-05-29 23:22 (GMT+7) |
+| Tracking issue | (filled by automation) |
+| Tracking PR    | (filled by automation) |
+| Commit         | (filled by automation) |
+
+## Gate
+
+`TestPhase3StubIngest` in `package3/python/stubs/phase03_test.go` with subtests:
+
+- `inline_tier_wins`. Constructs a fake site-packages with both a `py.typed`-marked package and a parallel `<name>-stubs` directory. Resolves to TierInline, confirming the PEP 561 priority order is honoured.
+- `sibling_stubs_tier`. Constructs a site-packages with only `<name>-stubs`. Resolves to TierSiblingStubs.
+- `typeshed_tier`. Constructs a fake typeshed checkout under `stdlib/pkg/__init__.pyi`. Resolves to TierTypeshed.
+- `stubgen_fallback`. Drops to the stubgen tier via a `FakeStubgen` that writes a fixed body to disk. Asserts `Partial = true` and round-trips the generated `.pyi` through `ParsePYI` to confirm the end-to-end pipeline produces a parseable `ModuleSurface`.
+- `pyi_round_trip`. Parses a representative `.pyi` exercising imports / functions / classes (with method + field) / aliases / constants, and asserts the structured surface matches.
+
+The package-level coverage:
+
+- `package3/python/stubs/discovery_test.go`. Tier string rendering (6 cases including the unknown / out-of-range sentinel), empty-name rejection, inline-full vs inline-partial via `py.typed` body sniff, sibling stubs discovery, inline-beats-sibling, sibling-beats-typeshed, typeshed-beats-stubgen, stubgen fallback path, stubgen-disabled rejection, plain not-found error, hyphenated PEP 503 name mapping to underscore module name, walkStubFiles sort order across nested directories, `.py` fallback only when no `.pyi` twin exists, `readPartialMarker` over 6 body shapes including whitespace tolerance.
+- `package3/python/stubs/typeshed_test.go`. `NewTypeshed` rejects empty root, missing path, regular file, and non-typeshed directory; accepts stdlib-only and stubs-only checkouts; `Lookup` covers stdlib directory, stdlib `.pyi` file, third-party nested `stubs/<name>/<module>`, third-party flat `stubs/<name>`, and miss; `moduleFromName` over 6 PEP 503 names (uppercase, hyphen-to-underscore, empty); `dirExists` over directory / missing / regular-file.
+- `package3/python/stubs/stubgen_test.go`. `FakeStubgen.Generate` writes the right body to the right path and produces a `StubSource` with `Tier = TierStubgen`, `Partial = true`; `FakeStubgen` rejects empty `CacheDir`; module-vs-name aliasing (e.g. `Flask-SQLAlchemy` -> `flask_sqlalchemy.pyi`); `NewExecStubgen` defaults (Python lookup deferred, 60s timeout); `ExecStubgen` rejects empty `CacheDir` and surfaces a wrapped error when the interpreter does not exist.
+- `package3/python/stubs/pyi_test.go`. Empty body, `import X` / `import X as Y` / `from X import Y, Z as W` / parenthesised multi-line from-imports, classes with field + method + base, Protocol / TypedDict / TypedDict-with-options, `@dataclass` and `@dataclasses.dataclass`, sync + async functions, default values, positional-only (`/`), keyword-only (`*`), `*args` / `**kwargs` kind tracking, method decorators (`@property` / `@staticmethod` / `@overload`), type aliases, `TypeVar('T')`, scalar constants, constants with default values, comment stripping (top-level / trailing / value-side / `#` inside a string), backslash continuation, parenthesised continuation, unbalanced bracket rejection, BOM tolerance, `==` is not split as `=` in aliases, unknown top-level constructs silently skipped, plain-identifier sniffing (10 cases), top-level colon finder (6 cases including bracket / string content), top-level eq finder (5 cases rejecting `==`, `>=` and friends), top-level splitter respecting brackets + strings, dataclass round-trip covering imports + decorated class + method with forward-reference return type, tabs as indent.
+
+## Lowering decisions
+
+Phase 3 owns four sub-systems:
+
+- `package3/python/stubs/discovery.go`. `Discovery{SitePackages, Typeshed, Stubgen, AllowStubgen}` runs the 4-tier search. The PEP 503 distribution name is normalised to the import module name via `name -> strings.ReplaceAll(name, "-", "_")` (a stricter normalisation is reserved for phase 4 once the type mapper sees the surface). `StubSource{Package, Tier, RootDir, Files, Partial}` is the cross-tier handoff. `walkStubFiles` returns sorted relative paths under the root, preferring `.pyi` and only including `.py` when no `.pyi` twin shadows it. `readPartialMarker` sniffs PEP 561 `py.typed` for the literal token "partial" (other bodies are tolerated and treated as full).
+- `package3/python/stubs/typeshed.go`. `Typeshed{Root, Commit}` wraps a pinned local checkout. `NewTypeshed` validates the canonical layout (at least one of `stdlib/` or `stubs/`). `Lookup` searches stubs/<name>/<module>/ first (the typeshed convention), falls back to stubs/<name>/ (for entries where the stub directory matches the PEP 503 name exactly), then stdlib/<module>/, then stdlib/<module>.pyi. The pin commit is recorded but not enforced at lookup time; the workspace orchestrator (phase 8) ensures the checkout is at the pinned commit before discovery runs.
+- `package3/python/stubs/stubgen.go`. `Stubgen` is an interface so tests can substitute. `ExecStubgen` shells out to `<python> -m mypy.stubgen --package <module> --output <cache>/<name> --quiet` with a 60-second default timeout. `FakeStubgen` writes a fixed body to `<cache>/<name>/<module>.pyi`; both implementations stamp `Partial = true` on every output so phase 4 will refuse to emit wrappers for synthesised surfaces unless the build sets `--allow-partial`.
+- `package3/python/stubs/pyi.go`. The `.pyi` parser is intentionally not a full Python parser. `ParsePYI` walks logical lines (joining backslash and parenthesised continuations), strips comments outside of strings (including triple-quoted), tracks bracket depth and rejects mismatched brackets, and dispatches on the leading token. It extracts the surface phase 4 + 5 consume: imports (`ImportDecl` / `ImportedName`), classes (`ClassDecl` with `IsProtocol` / `IsTypedDict` / `IsDataclass` and inline `Methods` + `Fields`), functions (`FuncDecl` with `IsAsync`, decorators, params, return type), parameters (`ParamDecl` with PEP 570 / PEP 3102 `ParamKind` tracking `/` and `*` separators plus `*args` / `**kwargs`), aliases (`Name = Expr`), constants (`Name: Type [= value]`). Type expressions are stored as raw strings; phase 4 will parse them against the closed type-mapping table.
+
+The 4-tier order matches PEP 561 §"Stub-Only Packages":
+
+1. Inline stubs ship with the package and announce themselves via `py.typed`. If the file contents are the literal token "partial", the source is tagged `Partial = true` and phase 4 will refuse to wrap symbols without explicit annotations.
+2. Sibling stubs distributed as `<name>-stubs` (PEP 561 §"Stub-only packages") take precedence over typeshed because they are tied to a specific package version.
+3. Typeshed is a centralised, community-maintained source. The bridge pins a commit so type information is reproducible across machines.
+4. Stubgen is the last-resort synthesiser. The bridge does not run mypy stubgen at discovery time without `AllowStubgen = true`; phase 8 sets that flag based on the build's policy.
+
+The deliberate "structural .pyi parser" decision is documented at the top of `package3/python/stubs/doc.go`. We avoid pulling in a full Python parser (and there is no Go-native CPython AST library that we trust in-tree). The reader is ~720 lines and handles the constructs phase 4 + 5 actually use; anything else is silently skipped so we degrade gracefully on exotic stubs (TypeVar tuples, ParamSpec, decorated module-level assignments) rather than blowing up the build.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/python/stubs/doc.go` | Package doc (4-tier discovery + scope of the .pyi reader) |
+| `package3/python/stubs/discovery.go` | `Tier`, `StubSource`, `Discovery`, `walkStubFiles`, `readPartialMarker` |
+| `package3/python/stubs/typeshed.go` | `Typeshed`, `NewTypeshed`, `Lookup`, `moduleFromName`, `dirExists` |
+| `package3/python/stubs/stubgen.go` | `Stubgen` interface, `ExecStubgen`, `FakeStubgen` |
+| `package3/python/stubs/pyi.go` | `ModuleSurface`, `ParsePYI`, logical-line + comment-strip + bracket-track helpers |
+| `package3/python/stubs/discovery_test.go` | Discovery + tier-priority + walk + partial-marker tests |
+| `package3/python/stubs/typeshed_test.go` | Typeshed constructor + lookup matrix + name-normalisation tests |
+| `package3/python/stubs/stubgen_test.go` | FakeStubgen + ExecStubgen tests (no Python required) |
+| `package3/python/stubs/pyi_test.go` | `.pyi` parser tests (imports / classes / funcs / aliases / constants + helper coverage) |
+| `package3/python/stubs/phase03_test.go` | `TestPhase3StubIngest` sentinel with 5 subtests |
+
+## Test set
+
+- `TestPhase3StubIngest/inline_tier_wins`
+- `TestPhase3StubIngest/sibling_stubs_tier`
+- `TestPhase3StubIngest/typeshed_tier`
+- `TestPhase3StubIngest/stubgen_fallback`
+- `TestPhase3StubIngest/pyi_round_trip`
+- All `package3/python/stubs/...` unit tests.
+
+## Closeout notes
+
+Phase 3 deliberately does not implement type mapping. The `.pyi` reader hands phase 4 a `ModuleSurface` carrying raw type-expression strings; phase 4 owns the closed table that decides what becomes `int` vs `int64` vs `BigInt`, what Optional[T] becomes vs `T | None`, and where Protocol classes lower into Mochi interfaces. Keeping the structural reader simple means we can grow the type table without churning the parser.
+
+The `Partial` flag is the load-bearing handoff to phase 4. Stubgen output is partial by definition; PEP 561 `partial` py.typed is partial by author intent. Phase 4's wrapper emitter respects this flag and refuses to wrap symbols without explicit annotations when `Partial == true` and the build did not opt into `--allow-partial`. This is the deterministic safety net that prevents the bridge from inventing types when the upstream package has not committed to them.
+
+No CPython runtime, no mypy install, and no typeshed checkout is required for any test in this phase. `FakeStubgen` substitutes for the subprocess; `t.TempDir()` constructs site-packages and typeshed layouts in memory.


### PR DESCRIPTION
Phase 3 of the MEP-71 Mochi+Python package bridge.

Closes #22806.

## Summary

- 4-tier PEP 561 discovery in \`package3/python/stubs/discovery.go\`: inline (py.typed) -> sibling \`<name>-stubs\` -> typeshed pin -> stubgen fallback.
- Typeshed pin in \`package3/python/stubs/typeshed.go\`: validated local checkout with commit recording, third-party + stdlib lookup matrix, PEP 503 name -> module conversion.
- Stubgen in \`package3/python/stubs/stubgen.go\`: \`ExecStubgen\` (shells out to \`python -m mypy.stubgen\`) plus \`FakeStubgen\` test double.
- \`.pyi\` reader in \`package3/python/stubs/pyi.go\`: structural parser producing \`ModuleSurface\` (imports / classes / functions / aliases / constants) with logical-line joining, comment stripping outside of strings, bracket-depth tracking, PEP 570 / PEP 3102 param-kind tracking.

The reader is intentionally scoped to the constructs phases 4 + 5 consume. Type expressions are stored as raw strings; phase 4's closed type table will parse them.

## Test plan

- [x] \`go test ./package3/python/stubs/...\` (60+ tests across the four units)
- [x] \`go test ./package3/python/...\` (cross-package check)
- [x] \`TestPhase3StubIngest\` sentinel with 5 subtests
- [x] No CPython runtime, no network access, no typeshed checkout required

## Cross-references

- [MEP-71 spec](https://github.com/mochilang/mochi/blob/main/website/docs/mep/mep-0071.md)
- [Phase 3 tracking page](https://github.com/mochilang/mochi/blob/main/website/docs/implementation/0071/phase-03-stub-ingest.md)