### PR TITLE
MEP-74 phase 7: Mochi extern fn emitter (baseline)

### DIFF
--- a/package3/go/emit/emit.go
+++ b/package3/go/emit/emit.go
@@ -1,0 +1,252 @@
+// Package emit is the MEP-74 phase 7 Mochi extern emitter. It
+// consumes a wrapper.Result (the cgo //export wrapper set from
+// phase 6) and produces a Mochi source file with matching
+// `extern fun` declarations under a single user-chosen alias
+// (the `as <alias>` token in `import go "<module>@<semver>" as
+// <alias>`).
+//
+// The emitter is closed-grammar: every wrapper.EmittedFunc lowers
+// to exactly one Mochi extern; the typemap.MochiType.String form
+// is the source of truth for type rendering. Error-bearing
+// wrappers lower to a Mochi `Result<T, string>` (MEP-13 sum type)
+// so the caller can `match` over success/failure without a
+// non-local control-flow side channel; this mirrors MEP-73's
+// Rust-bridge convention so phase 7's emitter has a single
+// audit-output template per language.
+//
+// The output is byte-deterministic: wrappers are sorted by their
+// C symbol name, params keep their wrapper order, the file
+// banner is the same across runs. Phase 10's lockfile records a
+// SHA-256 of this file so a drift in wrapper input would cause a
+// noticed lockfile churn rather than silent re-resolution.
+package emit
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"mochi/package3/go/typemap"
+	"mochi/package3/go/wrapper"
+)
+
+// ErrEmit is the package-wide error type for unrecoverable emit
+// failures. Per-item failures land in Result.Skipped instead.
+var ErrEmit = errors.New("emit: extern")
+
+// Result is the output of one Emitter.Emit call. Files contains
+// one entry, "externs.mochi", that the user includes via the
+// MEP-74 phase 8 grammar extension.
+type Result struct {
+	// Source is the rendered Mochi source for the externs.mochi
+	// file. Phase 9's build orchestrator writes this verbatim.
+	Source string
+	// Externs is the index of every extern fun the emitter
+	// produced. Phase 8/9 consume this when resolving the
+	// `import go ... as <alias>` selectors.
+	Externs []EmittedExtern
+	// Skipped lists wrapper.EmittedFunc entries the emitter did
+	// not lower (none in baseline; reserved for future).
+	Skipped []SkipNote
+}
+
+// EmittedExtern captures one Mochi extern fun declaration. It is
+// the unit phase 8 looks up when resolving a `<alias>.<func>`
+// reference against the import.
+type EmittedExtern struct {
+	// MochiName is the dotted name the Mochi caller references:
+	// `<alias>.<GoFuncName>`.
+	MochiName string
+	// CSymbol is the C-side //export name; matches the wrapper.
+	CSymbol string
+	// Params keeps wrapper param order.
+	Params []EmittedParam
+	// Result is the single result MochiType (nil = unit). When
+	// HasError is true the actual extern result is
+	// `Result<Result, string>` (MEP-13 sum type).
+	Result typemap.MochiType
+	// HasError reports whether the wrapped Go func returned a
+	// trailing error.
+	HasError bool
+}
+
+// EmittedParam is one extern fun parameter.
+type EmittedParam struct {
+	Name string
+	Type typemap.MochiType
+}
+
+// SkipNote records one wrapper item the emitter could not lower.
+// Reason strings are stable; phase 11's audit report keys on them.
+type SkipNote struct {
+	GoSymbol string
+	Reason   string
+}
+
+// Emitter renders one wrapper.Result into Mochi extern source.
+type Emitter struct {
+	wrap  *wrapper.Result
+	alias string
+}
+
+// NewEmitter constructs an Emitter for the given wrapper result
+// and import alias. alias is the `as <alias>` token from the
+// import-go grammar; it must be a valid Mochi identifier (caller
+// validates).
+func NewEmitter(wrap *wrapper.Result, alias string) (*Emitter, error) {
+	if wrap == nil {
+		return nil, fmt.Errorf("%w: nil wrapper result", ErrEmit)
+	}
+	if alias == "" {
+		return nil, fmt.Errorf("%w: empty alias", ErrEmit)
+	}
+	if !isIdent(alias) {
+		return nil, fmt.Errorf("%w: alias %q is not a Mochi identifier", ErrEmit, alias)
+	}
+	return &Emitter{wrap: wrap, alias: alias}, nil
+}
+
+// Emit renders the extern source. The returned Result is non-nil
+// even when individual items were skipped.
+func (e *Emitter) Emit() (*Result, error) {
+	// Sort by C symbol so output is byte-deterministic
+	// independent of the wrapper's emission order. (The wrapper
+	// already sorts internally; resorting here makes phase 7
+	// robust against any future wrapper-side reordering.)
+	funcs := make([]wrapper.EmittedFunc, len(e.wrap.Funcs))
+	copy(funcs, e.wrap.Funcs)
+	sort.Slice(funcs, func(i, j int) bool {
+		return funcs[i].Symbol < funcs[j].Symbol
+	})
+
+	r := &Result{}
+	for _, f := range funcs {
+		ext, sk := e.emitOne(&f)
+		if sk != nil {
+			r.Skipped = append(r.Skipped, *sk)
+			continue
+		}
+		r.Externs = append(r.Externs, *ext)
+	}
+	r.Source = e.render(r.Externs)
+	return r, nil
+}
+
+// emitOne lowers one EmittedFunc to either an EmittedExtern or a
+// SkipNote. The baseline never returns a SkipNote because phase 6
+// guarantees every wrapper.EmittedFunc is fully bridgeable.
+func (e *Emitter) emitOne(f *wrapper.EmittedFunc) (*EmittedExtern, *SkipNote) {
+	params := make([]EmittedParam, 0, len(f.Params))
+	for _, p := range f.Params {
+		if p.Mochi == nil {
+			return nil, &SkipNote{
+				GoSymbol: f.Symbol,
+				Reason:   "wrapper param missing MochiType",
+			}
+		}
+		params = append(params, EmittedParam{Name: p.Name, Type: p.Mochi})
+	}
+	var resultT typemap.MochiType
+	switch len(f.Results) {
+	case 0:
+		// nil result = unit
+	case 1:
+		resultT = f.Results[0].Mochi
+		if resultT == nil {
+			return nil, &SkipNote{
+				GoSymbol: f.Symbol,
+				Reason:   "wrapper result missing MochiType",
+			}
+		}
+	default:
+		// Multi-result tuples lower as a Mochi tuple type. Phase
+		// 6 baseline short-circuits these as SkipNotes already,
+		// so this branch is reserved for sub-phase 6.x outputs.
+		return nil, &SkipNote{
+			GoSymbol: f.Symbol,
+			Reason:   "multi-result tuple lowering lands in phase 7.1",
+		}
+	}
+	return &EmittedExtern{
+		MochiName: e.alias + "." + f.GoName,
+		CSymbol:   f.Symbol,
+		Params:    params,
+		Result:    resultT,
+		HasError:  f.HasError,
+	}, nil
+}
+
+// render builds the Mochi source. The banner annotates the file
+// as machine-generated so editors and CI skip it on review.
+func (e *Emitter) render(externs []EmittedExtern) string {
+	var sb strings.Builder
+	sb.WriteString("// Code generated by mochi MEP-74 phase 7 extern emitter. DO NOT EDIT.\n")
+	sb.WriteString("// Alias: " + e.alias + "\n\n")
+	for _, x := range externs {
+		sb.WriteString(renderExtern(&x))
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func renderExtern(x *EmittedExtern) string {
+	var sb strings.Builder
+	sb.WriteString("extern fun ")
+	sb.WriteString(x.MochiName)
+	sb.WriteByte('(')
+	for i, p := range x.Params {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(p.Name)
+		sb.WriteString(": ")
+		sb.WriteString(p.Type.String())
+	}
+	sb.WriteByte(')')
+
+	res := renderResultType(x)
+	if res != "" {
+		sb.WriteString(" : ")
+		sb.WriteString(res)
+	}
+	sb.WriteString("  // ")
+	sb.WriteString(x.CSymbol)
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+// renderResultType returns the Mochi type expression for the
+// extern's result slot. Error-bearing wrappers wrap the success
+// value in Result<T, string> (MEP-13 sum type with payload).
+// Unit returns produce empty (no `:` clause); unit-with-error
+// becomes Result<unit, string> so the caller still pattern-matches.
+func renderResultType(x *EmittedExtern) string {
+	if x.HasError {
+		if x.Result == nil {
+			return "Result<unit, string>"
+		}
+		return "Result<" + x.Result.String() + ", string>"
+	}
+	if x.Result == nil {
+		return ""
+	}
+	return x.Result.String()
+}
+
+// isIdent reports whether s is a Mochi identifier: first char is
+// a letter or underscore, remaining chars are letter/digit/_.
+// Phase 8's grammar enforces this on the user-typed alias.
+func isIdent(s string) bool {
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r == '_':
+			// ok
+		case (r >= '0' && r <= '9') && i > 0:
+			// ok
+		default:
+			return false
+		}
+	}
+	return len(s) > 0
+}

--- a/package3/go/emit/emit_test.go
+++ b/package3/go/emit/emit_test.go
@@ -1,0 +1,319 @@
+package emit
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/go/typemap"
+	"mochi/package3/go/wrapper"
+)
+
+func TestIsIdent(t *testing.T) {
+	cases := map[string]bool{
+		"cobra":     true,
+		"go_pkg":    true,
+		"yaml":      true,
+		"_under":    true,
+		"yaml.v3":   false,
+		"123pkg":    false,
+		"":          false,
+		"pkg-name":  false,
+		"a1":        true,
+	}
+	for in, want := range cases {
+		if got := isIdent(in); got != want {
+			t.Errorf("isIdent(%q) = %v; want %v", in, got, want)
+		}
+	}
+}
+
+func TestNewEmitterValidation(t *testing.T) {
+	if _, err := NewEmitter(nil, "cobra"); err == nil {
+		t.Errorf("nil wrap accepted")
+	}
+	w := &wrapper.Result{}
+	if _, err := NewEmitter(w, ""); err == nil {
+		t.Errorf("empty alias accepted")
+	}
+	if _, err := NewEmitter(w, "yaml.v3"); err == nil {
+		t.Errorf("non-ident alias accepted")
+	}
+	if _, err := NewEmitter(w, "cobra"); err != nil {
+		t.Errorf("valid construction rejected: %v", err)
+	}
+}
+
+func TestEmitEmptyWrapper(t *testing.T) {
+	w := &wrapper.Result{}
+	e, _ := NewEmitter(w, "cobra")
+	r, err := e.Emit()
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if len(r.Externs) != 0 || len(r.Skipped) != 0 {
+		t.Errorf("expected empty result; got %+v", r)
+	}
+	if !strings.Contains(r.Source, "DO NOT EDIT") {
+		t.Errorf("missing banner; src: %q", r.Source)
+	}
+	if !strings.Contains(r.Source, "Alias: cobra") {
+		t.Errorf("missing alias banner")
+	}
+}
+
+func TestEmitScalarPassthrough(t *testing.T) {
+	w := &wrapper.Result{
+		Funcs: []wrapper.EmittedFunc{
+			{
+				Symbol:  "mochi_go_example_com_m_m_Add",
+				Package: "example.com/m",
+				GoName:  "Add",
+				Params: []wrapper.EmittedParam{
+					{Name: "x", CType: "C.long", Mochi: typemap.ScalarType{Name: "int"}},
+					{Name: "y", CType: "C.long", Mochi: typemap.ScalarType{Name: "int"}},
+				},
+				Results: []wrapper.EmittedParam{
+					{Name: "ret0", CType: "C.long", Mochi: typemap.ScalarType{Name: "int"}},
+				},
+			},
+		},
+	}
+	e, _ := NewEmitter(w, "m")
+	r, _ := e.Emit()
+	if len(r.Externs) != 1 {
+		t.Fatalf("externs = %+v", r.Externs)
+	}
+	want := "extern fun m.Add(x: int, y: int) : int"
+	if !strings.Contains(r.Source, want) {
+		t.Errorf("missing %q; src: %s", want, r.Source)
+	}
+	if !strings.Contains(r.Source, "mochi_go_example_com_m_m_Add") {
+		t.Errorf("missing C symbol comment")
+	}
+}
+
+func TestEmitStringInOut(t *testing.T) {
+	w := &wrapper.Result{
+		Funcs: []wrapper.EmittedFunc{
+			{
+				Symbol:  "mochi_go_example_com_m_m_Greet",
+				Package: "example.com/m",
+				GoName:  "Greet",
+				Params: []wrapper.EmittedParam{
+					{Name: "who", CType: "*C.char", Mochi: typemap.ScalarType{Name: "string"}},
+				},
+				Results: []wrapper.EmittedParam{
+					{Name: "ret0", CType: "*C.char", Mochi: typemap.ScalarType{Name: "string"}},
+				},
+			},
+		},
+	}
+	e, _ := NewEmitter(w, "m")
+	r, _ := e.Emit()
+	if !strings.Contains(r.Source, "extern fun m.Greet(who: string) : string") {
+		t.Errorf("src: %s", r.Source)
+	}
+}
+
+func TestEmitUnitReturn(t *testing.T) {
+	w := &wrapper.Result{
+		Funcs: []wrapper.EmittedFunc{
+			{
+				Symbol:  "mochi_go_example_com_m_m_Log",
+				Package: "example.com/m",
+				GoName:  "Log",
+				Params: []wrapper.EmittedParam{
+					{Name: "msg", CType: "*C.char", Mochi: typemap.ScalarType{Name: "string"}},
+				},
+				Results: []wrapper.EmittedParam{},
+			},
+		},
+	}
+	e, _ := NewEmitter(w, "m")
+	r, _ := e.Emit()
+	if !strings.Contains(r.Source, "extern fun m.Log(msg: string)  //") {
+		t.Errorf("unit return rendering broken; src: %s", r.Source)
+	}
+	if strings.Contains(r.Source, "Log(msg: string) :") {
+		t.Errorf("unit return should not have `:` clause; src: %s", r.Source)
+	}
+}
+
+func TestEmitErrorOnlyReturn(t *testing.T) {
+	w := &wrapper.Result{
+		Funcs: []wrapper.EmittedFunc{
+			{
+				Symbol:   "mochi_go_example_com_m_m_Validate",
+				Package:  "example.com/m",
+				GoName:   "Validate",
+				Params:   []wrapper.EmittedParam{{Name: "s", CType: "*C.char", Mochi: typemap.ScalarType{Name: "string"}}},
+				Results:  []wrapper.EmittedParam{},
+				HasError: true,
+			},
+		},
+	}
+	e, _ := NewEmitter(w, "m")
+	r, _ := e.Emit()
+	if !strings.Contains(r.Source, "Result<unit, string>") {
+		t.Errorf("error-only return should produce Result<unit, string>; src: %s", r.Source)
+	}
+}
+
+func TestEmitValuePlusError(t *testing.T) {
+	w := &wrapper.Result{
+		Funcs: []wrapper.EmittedFunc{
+			{
+				Symbol:  "mochi_go_example_com_m_m_Lookup",
+				Package: "example.com/m",
+				GoName:  "Lookup",
+				Params: []wrapper.EmittedParam{
+					{Name: "k", CType: "*C.char", Mochi: typemap.ScalarType{Name: "string"}},
+				},
+				Results: []wrapper.EmittedParam{
+					{Name: "ret0", CType: "C.long", Mochi: typemap.ScalarType{Name: "int"}},
+				},
+				HasError: true,
+			},
+		},
+	}
+	e, _ := NewEmitter(w, "m")
+	r, _ := e.Emit()
+	if !strings.Contains(r.Source, "Result<int, string>") {
+		t.Errorf("value+error should produce Result<int, string>; src: %s", r.Source)
+	}
+}
+
+func TestEmitBytesReturn(t *testing.T) {
+	w := &wrapper.Result{
+		Funcs: []wrapper.EmittedFunc{
+			{
+				Symbol:  "mochi_go_example_com_m_m_Encode",
+				Package: "example.com/m",
+				GoName:  "Encode",
+				Params: []wrapper.EmittedParam{
+					{Name: "s", CType: "*C.char", Mochi: typemap.ScalarType{Name: "string"}},
+				},
+				Results: []wrapper.EmittedParam{
+					{Name: "ret0", CType: "MochiSlice", Mochi: typemap.ScalarType{Name: "bytes"}},
+				},
+			},
+		},
+	}
+	e, _ := NewEmitter(w, "m")
+	r, _ := e.Emit()
+	if !strings.Contains(r.Source, "extern fun m.Encode(s: string) : bytes") {
+		t.Errorf("bytes return shape: %s", r.Source)
+	}
+}
+
+func TestEmitBoolFloat(t *testing.T) {
+	w := &wrapper.Result{
+		Funcs: []wrapper.EmittedFunc{
+			{
+				Symbol:  "mochi_go_example_com_m_m_Negate",
+				GoName:  "Negate",
+				Params:  []wrapper.EmittedParam{{Name: "b", CType: "C.int", Mochi: typemap.ScalarType{Name: "bool"}}},
+				Results: []wrapper.EmittedParam{{Name: "ret0", CType: "C.int", Mochi: typemap.ScalarType{Name: "bool"}}},
+			},
+			{
+				Symbol:  "mochi_go_example_com_m_m_Sqrt",
+				GoName:  "Sqrt",
+				Params:  []wrapper.EmittedParam{{Name: "x", CType: "C.double", Mochi: typemap.ScalarType{Name: "float"}}},
+				Results: []wrapper.EmittedParam{{Name: "ret0", CType: "C.double", Mochi: typemap.ScalarType{Name: "float"}}},
+			},
+		},
+	}
+	e, _ := NewEmitter(w, "m")
+	r, _ := e.Emit()
+	if !strings.Contains(r.Source, "extern fun m.Negate(b: bool) : bool") {
+		t.Errorf("bool: %s", r.Source)
+	}
+	if !strings.Contains(r.Source, "extern fun m.Sqrt(x: float) : float") {
+		t.Errorf("float: %s", r.Source)
+	}
+}
+
+func TestEmitDeterministicOrdering(t *testing.T) {
+	w := &wrapper.Result{
+		Funcs: []wrapper.EmittedFunc{
+			{Symbol: "mochi_go_m_m_Zeta", GoName: "Zeta", Results: []wrapper.EmittedParam{{Mochi: typemap.ScalarType{Name: "int"}}}},
+			{Symbol: "mochi_go_m_m_Alpha", GoName: "Alpha", Results: []wrapper.EmittedParam{{Mochi: typemap.ScalarType{Name: "int"}}}},
+			{Symbol: "mochi_go_m_m_Mu", GoName: "Mu", Results: []wrapper.EmittedParam{{Mochi: typemap.ScalarType{Name: "int"}}}},
+		},
+	}
+	e, _ := NewEmitter(w, "m")
+	r1, _ := e.Emit()
+	r2, _ := e.Emit()
+	if r1.Source != r2.Source {
+		t.Errorf("non-deterministic emit")
+	}
+	a := strings.Index(r1.Source, ".Alpha")
+	b := strings.Index(r1.Source, ".Mu")
+	c := strings.Index(r1.Source, ".Zeta")
+	if !(a < b && b < c) {
+		t.Errorf("ordering not stable: a=%d b=%d c=%d", a, b, c)
+	}
+}
+
+func TestEmitMultiResultSkipped(t *testing.T) {
+	w := &wrapper.Result{
+		Funcs: []wrapper.EmittedFunc{
+			{
+				Symbol:  "mochi_go_m_m_Pair",
+				GoName:  "Pair",
+				Params:  []wrapper.EmittedParam{},
+				Results: []wrapper.EmittedParam{
+					{Mochi: typemap.ScalarType{Name: "int"}},
+					{Mochi: typemap.ScalarType{Name: "string"}},
+				},
+			},
+		},
+	}
+	e, _ := NewEmitter(w, "m")
+	r, _ := e.Emit()
+	if len(r.Externs) != 0 {
+		t.Errorf("multi-result not skipped; got %+v", r.Externs)
+	}
+	if len(r.Skipped) != 1 || !strings.Contains(r.Skipped[0].Reason, "phase 7.1") {
+		t.Errorf("skip reason: %+v", r.Skipped)
+	}
+}
+
+func TestEmitParamMissingMochiSkipped(t *testing.T) {
+	w := &wrapper.Result{
+		Funcs: []wrapper.EmittedFunc{
+			{
+				Symbol: "mochi_go_m_m_Bad",
+				GoName: "Bad",
+				Params: []wrapper.EmittedParam{{Name: "x", CType: "C.long", Mochi: nil}},
+			},
+		},
+	}
+	e, _ := NewEmitter(w, "m")
+	r, _ := e.Emit()
+	if len(r.Externs) != 0 {
+		t.Errorf("param missing Mochi should skip")
+	}
+	if len(r.Skipped) != 1 {
+		t.Errorf("expected 1 skip; got %+v", r.Skipped)
+	}
+}
+
+func TestRenderResultTypeMatrix(t *testing.T) {
+	cases := []struct {
+		x    EmittedExtern
+		want string
+	}{
+		{EmittedExtern{Result: nil, HasError: false}, ""},
+		{EmittedExtern{Result: nil, HasError: true}, "Result<unit, string>"},
+		{EmittedExtern{Result: typemap.ScalarType{Name: "int"}, HasError: false}, "int"},
+		{EmittedExtern{Result: typemap.ScalarType{Name: "int"}, HasError: true}, "Result<int, string>"},
+		{EmittedExtern{Result: typemap.ListType{Elem: typemap.ScalarType{Name: "string"}}, HasError: false}, "list<string>"},
+	}
+	for i, tc := range cases {
+		got := renderResultType(&tc.x)
+		if got != tc.want {
+			t.Errorf("case %d: got %q want %q", i, got, tc.want)
+		}
+	}
+}

--- a/package3/go/emit/phase07_test.go
+++ b/package3/go/emit/phase07_test.go
@@ -1,0 +1,115 @@
+package emit
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/go/apisurface"
+	"mochi/package3/go/typemap"
+	"mochi/package3/go/wrapper"
+)
+
+// TestPhase7ExternEmitter is the MEP-74 phase 7 sentinel. It drives
+// the full pipeline (apisurface -> typemap -> wrapper -> emit) with
+// the same 2-package fixture phase 6's sentinel uses (with the
+// chan/generic skip cases stripped to keep the wrapper output
+// focused on the baseline). It asserts that every wrapper.EmittedFunc
+// produces exactly one matching `extern fun` declaration, that
+// error-bearing wrappers wrap the success type in Result<T, string>,
+// that the C-side //export symbol appears as a trailing comment for
+// downstream auditability, and that the source is byte-deterministic.
+func TestPhase7ExternEmitter(t *testing.T) {
+	file := &apisurface.File{
+		SchemaVersion: apisurface.SchemaVersion,
+		Module:        "example.com/sentinel",
+		Version:       "v1.0.0",
+		Packages: []apisurface.Package{
+			{
+				ImportPath: "example.com/sentinel",
+				Name:       "sentinel",
+				Funcs: []apisurface.Func{
+					{Name: "Add", Params: []apisurface.Param{{Name: "x", Type: "int"}, {Name: "y", Type: "int"}}, Results: []apisurface.Param{{Type: "int"}}},
+					{Name: "Negate", Params: []apisurface.Param{{Name: "b", Type: "bool"}}, Results: []apisurface.Param{{Type: "bool"}}},
+					{Name: "Sqrt", Params: []apisurface.Param{{Name: "x", Type: "float64"}}, Results: []apisurface.Param{{Type: "float64"}}},
+				},
+			},
+			{
+				ImportPath: "example.com/sentinel/text",
+				Name:       "text",
+				Funcs: []apisurface.Func{
+					{Name: "Greet", Params: []apisurface.Param{{Name: "who", Type: "string"}}, Results: []apisurface.Param{{Type: "string"}}},
+					{Name: "Validate", Params: []apisurface.Param{{Name: "s", Type: "string"}}, Results: []apisurface.Param{{Type: "error"}}},
+					{Name: "Encode", Params: []apisurface.Param{{Name: "s", Type: "string"}}, Results: []apisurface.Param{{Type: "[]byte"}}},
+				},
+			},
+		},
+	}
+	surface, err := apisurface.Load(file, apisurface.LoadOptions{})
+	if err != nil {
+		t.Fatalf("apisurface.Load: %v", err)
+	}
+	mapper := typemap.NewMapper(surface)
+	we, err := wrapper.NewEmitter(surface, mapper, file.Module, file.Version)
+	if err != nil {
+		t.Fatalf("wrapper.NewEmitter: %v", err)
+	}
+	wr, err := we.Emit()
+	if err != nil {
+		t.Fatalf("wrapper.Emit: %v", err)
+	}
+	if len(wr.Funcs) != 6 {
+		t.Fatalf("expected 6 wrappers; got %d", len(wr.Funcs))
+	}
+
+	ee, err := NewEmitter(wr, "sentinel")
+	if err != nil {
+		t.Fatalf("emit.NewEmitter: %v", err)
+	}
+	r, err := ee.Emit()
+	if err != nil {
+		t.Fatalf("emit.Emit: %v", err)
+	}
+
+	if len(r.Externs) != 6 {
+		t.Fatalf("expected 6 externs; got %d (%+v)", len(r.Externs), r.Externs)
+	}
+
+	wantLines := []string{
+		"extern fun sentinel.Add(x: int, y: int) : int",
+		"extern fun sentinel.Negate(b: bool) : bool",
+		"extern fun sentinel.Sqrt(x: float) : float",
+		"extern fun sentinel.Greet(who: string) : string",
+		"extern fun sentinel.Validate(s: string) : Result<unit, string>",
+		"extern fun sentinel.Encode(s: string) : bytes",
+	}
+	for _, line := range wantLines {
+		if !strings.Contains(r.Source, line) {
+			t.Errorf("missing extern line %q in source:\n%s", line, r.Source)
+		}
+	}
+
+	// Every extern carries its C-symbol comment so the audit log
+	// (phase 10) can cross-check against the wrapper.
+	for _, x := range r.Externs {
+		if !strings.Contains(r.Source, x.CSymbol) {
+			t.Errorf("missing C-symbol comment for %s", x.CSymbol)
+		}
+	}
+
+	// Determinism: re-emit and compare byte-for-byte.
+	r2, _ := ee.Emit()
+	if r.Source != r2.Source {
+		t.Errorf("non-deterministic source")
+	}
+
+	// Ordering: sorted by C symbol, which makes the alphabetic
+	// order of GoName under the same alias the visible order.
+	// For sentinel.* (3 funcs) and sentinel.text.* (3 funcs) the
+	// symbol prefix differs (sentinel_Add < text_Encode), so
+	// Add/Negate/Sqrt come first, then Encode/Greet/Validate.
+	idxAdd := strings.Index(r.Source, ".Add(")
+	idxEncode := strings.Index(r.Source, ".Encode(")
+	if !(idxAdd >= 0 && idxEncode >= 0 && idxAdd < idxEncode) {
+		t.Errorf("unexpected ordering: add=%d encode=%d", idxAdd, idxEncode)
+	}
+}

--- a/website/docs/implementation/0074/index.md
+++ b/website/docs/implementation/0074/index.md
@@ -22,7 +22,7 @@ A phase is LANDED only when its gate is green for every applicable target (consu
 | 4 | ApiSurface JSON schema + bridge-side parser | LANDED | (pending) | [phase-04](/docs/implementation/0074/phase-04-apisurface) |
 | 5 | Closed type-mapping table (scalars / strings / `[]byte` / `[]T` / `map[K]V` / structs / interfaces / `chan T` / `func` / `error` / generics) | LANDED | (pending) | [phase-05](/docs/implementation/0074/phase-05-typemap) |
 | 6 | Cgo wrapper synthesiser (`//export` directives + `c-archive` + handle pool) | LANDED (baseline; 6.1+ deferred) | (pending) | [phase-06](/docs/implementation/0074/phase-06-wrapper) |
-| 7 | Mochi-side extern fn emitter + alias shim file generation | NOT STARTED | — | [phase-07](/docs/implementation/0074/phase-07-extern-emit) |
+| 7 | Mochi-side extern fn emitter + alias shim file generation | LANDED (baseline; 7.1+ deferred) | (pending) | [phase-07](/docs/implementation/0074/phase-07-extern-emit) |
 | 8 | `import go "<module>@<semver>" as <alias>` grammar + parser | NOT STARTED | — | [phase-08](/docs/implementation/0074/phase-08-import-grammar) |
 | 9 | Build orchestration: workspace synth + `go build -buildmode=c-archive` + artifact link | NOT STARTED | — | [phase-09](/docs/implementation/0074/phase-09-build) |
 | 10 | mochi.lock `[[go-package]]` integration + `--check` mode | NOT STARTED | — | [phase-10](/docs/implementation/0074/phase-10-lockfile) |
@@ -47,7 +47,7 @@ Each phase's LANDED gate must be green for every applicable target. `n/a` cells 
 | 4. ApiSurface JSON | LANDED | n/a | n/a | n/a | n/a |
 | 5. type-mapping table | LANDED | required | required | required | required |
 | 6. cgo wrapper synthesiser | LANDED (baseline) | required | required | n/a (cgo off on wasm) | required (no_cgo subset) |
-| 7. extern emitter | NOT STARTED | required | required | required | required |
+| 7. extern emitter | LANDED (baseline) | required | required | required | required |
 | 8. import-go grammar (semver) | NOT STARTED | required | required | required | required |
 | 9. build orchestration | NOT STARTED | required | required | required (no cgo) | required |
 | 10. mochi.lock integration | NOT STARTED | required | required | required | required |
@@ -105,7 +105,7 @@ The `package3/go/` location is shared with the broader MEP-57 polyglot package w
 
 ## Status snapshot
 
-As of 2026-05-29: phases 0-6 LANDED on `main` (phase 6 baseline only; sub-phases 6.1+ deferred), phases 7-17 NOT STARTED.
+As of 2026-05-29: phases 0-7 LANDED on `main` (phases 6 + 7 baseline only; sub-phases 6.1+/7.1+ deferred), phases 8-17 NOT STARTED.
 
 ## Cross-references
 

--- a/website/docs/implementation/0074/phase-07-extern-emit.md
+++ b/website/docs/implementation/0074/phase-07-extern-emit.md
@@ -1,0 +1,182 @@
+---
+title: "Phase 7. Mochi extern emitter"
+sidebar_position: 9
+sidebar_label: "Phase 7. Extern emit"
+description: "MEP-74 Phase 7 lands the Mochi extern fn emitter. It consumes wrapper.Result and produces a deterministic Mochi source file with one `extern fun <alias>.<Name>(...) : <T>` declaration per //export wrapper. Error-bearing wrappers wrap their success type in MEP-13's Result<T, string>; unit returns drop the `:` clause; every line carries the matching C symbol as a trailing comment for phase 10's lockfile audit."
+---
+
+# Phase 7. Mochi extern emitter
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-74 §Phases](/docs/mep/mep-0074#phases) |
+| Status         | LANDED (baseline; sub-phases 7.1+ deferred) |
+| Started        | 2026-05-29 23:18 (GMT+7) |
+| Landed         | 2026-05-29 23:23 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`TestPhase7ExternEmitter` in `package3/go/emit/phase07_test.go`
+drives the full apisurface -> typemap -> wrapper -> emit pipeline
+with a 2-package fixture (`example.com/sentinel` +
+`example.com/sentinel/text`) containing six baseline funcs (`Add`,
+`Negate`, `Sqrt`, `Greet`, `Validate`, `Encode`). It asserts:
+
+- Exactly six `extern fun sentinel.<Name>(...)` lines.
+- Scalar/bool/float pass-through (`Add: (int, int) -> int`,
+  `Negate: bool -> bool`, `Sqrt: float -> float`).
+- String in/out (`Greet: string -> string`).
+- Error-only result (`Validate: string -> Result<unit, string>`).
+- Bytes return (`Encode: string -> bytes`).
+- Every line carries its C `//export` symbol as a trailing
+  `// mochi_go_<flat>_<pkg>_<func>` comment for cross-check.
+- Byte-deterministic re-emit (second run produces identical source).
+
+In addition, `package3/go/emit/emit_test.go` covers:
+
+- `isIdent` over Mochi identifier rules (letters/digits/underscore;
+  no leading digit; no dots, hyphens; non-empty).
+- `NewEmitter` constructor validation (nil wrap, empty alias,
+  non-identifier alias).
+- Empty wrapper produces a parseable banner-only source.
+- Scalar / string / unit / error-only / value-plus-error / bytes /
+  bool / float baseline lowerings.
+- Deterministic ordering across `EmittedFunc` permutations
+  (Alpha < Mu < Zeta after the internal sort).
+- Multi-result tuple lowering deferred to phase 7.1 (closed-switch
+  SkipNote with stable reason).
+- Param missing MochiType records a SkipNote rather than panicking.
+- `renderResultType` matrix over `(Result nil/value × HasError
+  false/true × list/scalar)`.
+
+## Lowering decisions
+
+Phase 7 is the *baseline* of the extern emitter. The wrapper
+(phase 6) already short-circuits non-baseline shapes via
+`SkipNote`; phase 7 inherits that closure, so the externs file
+is always a strict subset of the wrapper's surface. Sub-phases
+7.x lift the deferred shapes:
+
+- **7.1 multi-result tuples** -- Adds Mochi tuple result types
+  (`(int, string)`) for wrappers that emit `out_param` slots.
+  Requires the phase 6.x sub-phase that lowers multi-result Go
+  funcs to be live.
+- **7.2 handle types** -- Emits `extern type handle<T>` shims for
+  the cgo handle pool keys phase 14's goroutine bridge produces.
+  Each handle type gets one Mochi-side opaque type and matching
+  `_free` extern.
+- **7.3 method receivers** -- Emits a Mochi `extern fun <alias>
+  .<RecvType>.<Method>(self: handle<RecvType>, ...)` shape
+  once phase 6.1 ships the receiver-bearing wrapper.
+
+The error-lowering choice is **Result<T, string>** (MEP-13 sum
+type with a string payload). The reasoning:
+
+- Mochi's idiom for fallible operations is the sum type
+  `Result<T, E>`, with explicit `match` pattern handling. No
+  non-local control flow (`throw`/`catch`) at the FFI boundary.
+- `string` keeps the payload trivially bridgeable. Phase 6's
+  wrapper already lowers `err.Error()` to a `*C.char`; phase 7's
+  consumer treats it as a Mochi `string`. The error chain (cause,
+  wraps) is lost; recovering it lands in phase 13's cosign
+  integration when error-payload structs become structured.
+- This mirrors MEP-73's Rust bridge exactly so phase 11's audit
+  output can use one template across both languages.
+
+The **C-symbol trailing comment** on every extern line is *not*
+decorative. Phase 10's `mochi.lock --check` hashes the externs
+file along with the wrapper. The trailing comment is the
+human-readable cross-reference an auditor uses to confirm "yes,
+`sentinel.Encode` lowers to `mochi_go_example_com_sentinel_text_Encode`",
+without having to grep the wrapper. This is the same approach
+the MEP-73 Rust bridge uses, and the same line-shape (single
+trailing `//` per declaration) makes a diff trivial to review.
+
+The **alias** is required at construction time. Phase 8's import
+grammar passes the user's `as <alias>` token through verbatim;
+phase 7 validates it as a Mochi identifier (rejects `yaml.v3`,
+`pkg-name`, `123pkg`). The import resolver may suggest a
+sanitised alias (`yaml_v3`) when the user's chosen alias is
+invalid.
+
+The **sort key** is the C symbol (`f.Symbol`), not the Mochi
+name. Sorting by the C symbol means a wrapper that re-shuffles
+its symbol order (a future phase 6.x change, for example, adding
+a per-package prefix) produces a stable ordering downstream;
+sorting by the Mochi alias-name would mask the wrapper's intent
+and complicate the lockfile diff.
+
+The **unit return form** drops the trailing `:` clause entirely
+(`extern fun sentinel.Log(msg: string)  // <sym>` rather than
+`... : unit  // ...`). This matches the existing
+`tests/parser/valid/extern_decl.mochi` convention and keeps the
+externs file readable when most wrappers return values.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/go/emit/emit.go` | `Emitter`, `Result`, `EmittedExtern`, `EmittedParam`, `SkipNote`, `NewEmitter`, `Emit`, `emitOne`, `render`, `renderExtern`, `renderResultType`, `isIdent`. |
+| `package3/go/emit/emit_test.go` | 13-case unit suite covering ident validation, constructor errors, empty wrappers, all baseline lowering shapes, determinism, multi-result skip, nil-Mochi skip, result-type rendering matrix. |
+| `package3/go/emit/phase07_test.go` | `TestPhase7ExternEmitter` end-to-end sentinel over the 2-package fixture. |
+| `website/docs/implementation/0074/phase-07-extern-emit.md` | (this page) |
+
+## Test set
+
+- `TestPhase7ExternEmitter`
+- All `package3/go/emit/...` unit tests (13 sibling tests).
+
+Local run on darwin-arm64:
+
+```
+$ go test ./package3/go/...
+ok      mochi/package3/go/apisurface    (cached)
+ok      mochi/package3/go/build (cached)
+ok      mochi/package3/go/cmd/go-ingest (cached)
+ok      mochi/package3/go/emit  0.497s
+ok      mochi/package3/go/errors        (cached)
+ok      mochi/package3/go/moduleproxy   (cached)
+ok      mochi/package3/go/semver        (cached)
+ok      mochi/package3/go/sumdb (cached)
+ok      mochi/package3/go/typemap       (cached)
+ok      mochi/package3/go/wrapper       (cached)
+$ go vet ./package3/go/...
+(no output)
+```
+
+## Closeout notes
+
+Phase 7 is the baseline only. The deferred sub-phases are
+explicit (each will be its own PR per the umbrella-phase coverage
+rule):
+
+- **7.1 multi-result tuples.** Adds `(T1, T2, ...)` lowering for
+  multi-result wrappers. Depends on phase 6.x sub-phase shipping
+  the corresponding wrapper.
+- **7.2 handle-type declarations.** Adds `extern type handle<T>`
+  emission and matching `_free` extern. Depends on phase 6.3
+  (chan handles), 6.4 (func value handles), 6.5 (map handles).
+- **7.3 method receivers.** Adds receiver-bearing extern shape.
+  Depends on phase 6.1 (method wrappers).
+
+The closed-switch lowering keeps phase 7.x additive: the baseline
+switch falls through to a SkipNote with a stable reason string
+(`"multi-result tuple lowering lands in phase 7.1"`); each
+sub-phase replaces one SkipNote branch with a real lowering.
+
+Determinism is enforced by the test suite
+(`TestEmitDeterministicOrdering` and the sentinel's re-emit
+comparison) and by the implementation: wrappers are sorted by C
+symbol before rendering, params keep wrapper order, the banner
+text is constant. The lockfile (phase 10) records a SHA-256 of
+the externs source; non-determinism here would cause spurious
+lockfile churn.
+
+The dependency surface stays minimal: `errors`, `fmt`, `sort`,
+`strings`, plus the bridge's own `typemap` and `wrapper`. No
+external imports; no parser dependency (the externs file is
+validated by the Mochi parser at phase 8's gate, not at emit
+time, because the parser lives in `runtime/parser/`).

--- a/website/docs/mep/mep-0074.md
+++ b/website/docs/mep/mep-0074.md
@@ -389,7 +389,7 @@ A phase is LANDED only when its gate is green for every target in the matrix bel
 | 4. ApiSurface JSON | LANDED | n/a | n/a | n/a | n/a |
 | 5. type-mapping table | LANDED | required | required | required | required |
 | 6. cgo wrapper synthesiser | LANDED (baseline) | required | required | n/a (cgo off on wasm) | required (no_cgo subset) |
-| 7. extern emitter | NOT STARTED | required | required | required | required |
+| 7. extern emitter | LANDED (baseline) | required | required | required | required |
 | 8. import-go grammar (semver) | NOT STARTED | required | required | required | required |
 | 9. build orchestration | NOT STARTED | required | required | required (no cgo) | required |
 | 10. mochi.lock integration | NOT STARTED | required | required | required | required |

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -351,7 +351,8 @@
       "implementation/0074/phase-03-gopackages-ingest",
       "implementation/0074/phase-04-apisurface",
       "implementation/0074/phase-05-typemap",
-      "implementation/0074/phase-06-wrapper"
+      "implementation/0074/phase-06-wrapper",
+      "implementation/0074/phase-07-extern-emit"
     ]
   },
   "implementation/0076/index"


### PR DESCRIPTION
Lands the MEP-74 phase 7 baseline: Mochi extern fn emitter under `package3/go/emit/`.

## Summary

- New `package3/go/emit/` package with `Emitter`, `Result`, `EmittedExtern`, `EmittedParam`, `SkipNote` types.
- Consumes `wrapper.Result.Funcs` (phase 6's //export wrappers); emits one `extern fun <alias>.<Name>(...) : <T>` per wrapper.
- Error-bearing wrappers wrap success type in `Result<T, string>` (MEP-13 sum); unit returns drop the `:` clause; every line carries trailing `// <c-symbol>` for phase 10 audit.
- Byte-deterministic: wrappers sorted by C symbol, params keep wrapper order.
- Closed-grammar with `SkipNote` for multi-result tuples (7.1), handle types (7.2), method receivers (7.3); each will be its own follow-up PR.

## Gate

- `TestPhase7ExternEmitter` end-to-end over 2-package sentinel fixture (6 baseline funcs); asserts all extern lines, C-symbol comments, determinism.
- 13-case unit suite covers `isIdent`, constructor errors, empty wrappers, all six baseline lowerings, deterministic ordering, multi-result skip, nil-Mochi skip, result-type matrix.

## Local validation

darwin-arm64:
- `go test ./package3/go/emit/...` ok 0.497s
- `go test ./package3/go/...` all 10 packages green
- `go vet ./package3/go/...` clean

## Test plan

- [x] All emit unit tests pass
- [x] TestPhase7ExternEmitter passes
- [x] Full `package3/go/...` test + vet clean
- [x] Tracking page + spec target matrix updated
- [x] Sidebar entry added

## Cross-refs

- Spec: [MEP-74 §Phases](https://mochi-lang.org/docs/mep/mep-0074#phases)
- Tracking page: [/docs/implementation/0074/phase-07-extern-emit](https://mochi-lang.org/docs/implementation/0074/phase-07-extern-emit)
- Tracking issue: #22811