### PR TITLE
mep-73: phase 8 mochi.lock [[rust-package]] integration

### DIFF
--- a/package3/rust/lockfile/drift.go
+++ b/package3/rust/lockfile/drift.go
@@ -1,0 +1,266 @@
+package lockfile
+
+import (
+	"fmt"
+	"sort"
+)
+
+// DriftKind classifies what changed between a recorded lockfile
+// entry (what mochi.lock said) and a freshly computed entry (what
+// the bridge would write if it locked again right now). Each kind
+// is a hard error at `mochi pkg lock --check` time per MEP-73 §6.
+type DriftKind int
+
+const (
+	// DriftUnknown is the zero value; never returned by Check.
+	DriftUnknown DriftKind = iota
+	// DriftAdded means the fresh set contains a [[rust-package]]
+	// the lockfile did not. Caller may treat this as "expected" on
+	// `mochi pkg lock` (it's the result of a new dep) but as a
+	// hard error on `mochi pkg lock --check`.
+	DriftAdded
+	// DriftRemoved means the lockfile contains a [[rust-package]]
+	// the fresh set does not. Mirror of DriftAdded.
+	DriftRemoved
+	// DriftVersion means the resolved version moved.
+	DriftVersion
+	// DriftSource means the source kind / registry / url moved.
+	DriftSource
+	// DriftCrateBlake3 means the .crate tarball's BLAKE3 digest
+	// changed (so the upstream tarball is no longer
+	// byte-identical to what we locked).
+	DriftCrateBlake3
+	// DriftCrateSHA256 means the .crate SHA-256 changed.
+	DriftCrateSHA256
+	// DriftRustdocTypesVersion means the rustdoc-types schema
+	// the bridge ingests now differs from the schema at lock time.
+	DriftRustdocTypesVersion
+	// DriftRustdocSHA256 means the rustdoc JSON the bridge would
+	// ingest is no longer byte-identical to what we locked.
+	DriftRustdocSHA256
+	// DriftWrapperSHA256 means the wrapper crate src/lib.rs the
+	// bridge would emit is no longer byte-identical.
+	DriftWrapperSHA256
+	// DriftCapabilityAdded means the fresh set declares a
+	// capability the lockfile did not. Per MEP-57's monotonicity
+	// rule, this is a hard error pending re-acknowledgement.
+	DriftCapabilityAdded
+	// DriftCapabilityRemoved means the fresh set drops a
+	// capability the lockfile had. Not a hard error semantically,
+	// but reported so a downstream check can decide policy.
+	DriftCapabilityRemoved
+	// DriftFeatures means the feature set changed.
+	DriftFeatures
+	// DriftDependencies means the transitive dep set changed.
+	DriftDependencies
+)
+
+// String renders a DriftKind as a short token.
+func (k DriftKind) String() string {
+	switch k {
+	case DriftAdded:
+		return "added"
+	case DriftRemoved:
+		return "removed"
+	case DriftVersion:
+		return "version"
+	case DriftSource:
+		return "source"
+	case DriftCrateBlake3:
+		return "crate-blake3"
+	case DriftCrateSHA256:
+		return "crate-sha256"
+	case DriftRustdocTypesVersion:
+		return "rustdoc-types-version"
+	case DriftRustdocSHA256:
+		return "rustdoc-sha256"
+	case DriftWrapperSHA256:
+		return "wrapper-sha256"
+	case DriftCapabilityAdded:
+		return "capability-added"
+	case DriftCapabilityRemoved:
+		return "capability-removed"
+	case DriftFeatures:
+		return "features"
+	case DriftDependencies:
+		return "dependencies"
+	default:
+		return "unknown"
+	}
+}
+
+// Drift is one observed difference between a `want` (lockfile) and
+// `have` (freshly computed) entry. Crate is the [[rust-package]]
+// name the drift applies to; for DriftAdded / DriftRemoved one of
+// Want / Have is nil. Detail is a human-readable rendering of the
+// difference suitable for inclusion in a `--check` diagnostic.
+type Drift struct {
+	Crate  string
+	Kind   DriftKind
+	Want   string
+	Have   string
+	Detail string
+}
+
+// String formats a Drift the way `mochi pkg lock --check` reports
+// it, e.g. `hex: wrapper-sha256 drift: want abc... have def...`.
+func (d Drift) String() string {
+	switch d.Kind {
+	case DriftAdded:
+		return fmt.Sprintf("%s: package added (not in lockfile)", d.Crate)
+	case DriftRemoved:
+		return fmt.Sprintf("%s: package removed (in lockfile, not in fresh resolve)", d.Crate)
+	default:
+		if d.Detail != "" {
+			return fmt.Sprintf("%s: %s drift: %s", d.Crate, d.Kind, d.Detail)
+		}
+		return fmt.Sprintf("%s: %s drift: want %s have %s", d.Crate, d.Kind, d.Want, d.Have)
+	}
+}
+
+// Check compares a `want` set (the recorded lockfile entries) to a
+// `have` set (the freshly resolved entries) and returns every
+// observed Drift. The result is sorted by crate name then drift
+// kind for stable diagnostic output.
+//
+// A clean check (no drifts) returns nil.
+func Check(want, have []RustPackage) []Drift {
+	wantByName := indexByName(want)
+	haveByName := indexByName(have)
+	var drifts []Drift
+	for name, w := range wantByName {
+		h, ok := haveByName[name]
+		if !ok {
+			drifts = append(drifts, Drift{Crate: name, Kind: DriftRemoved})
+			continue
+		}
+		drifts = append(drifts, diffPair(name, w, h)...)
+	}
+	for name := range haveByName {
+		if _, ok := wantByName[name]; !ok {
+			drifts = append(drifts, Drift{Crate: name, Kind: DriftAdded})
+		}
+	}
+	sort.Slice(drifts, func(i, j int) bool {
+		if drifts[i].Crate != drifts[j].Crate {
+			return drifts[i].Crate < drifts[j].Crate
+		}
+		return drifts[i].Kind < drifts[j].Kind
+	})
+	return drifts
+}
+
+func indexByName(ps []RustPackage) map[string]RustPackage {
+	out := make(map[string]RustPackage, len(ps))
+	for _, p := range ps {
+		out[p.Name] = p
+	}
+	return out
+}
+
+func diffPair(name string, w, h RustPackage) []Drift {
+	var out []Drift
+	add := func(k DriftKind, want, have, detail string) {
+		out = append(out, Drift{Crate: name, Kind: k, Want: want, Have: have, Detail: detail})
+	}
+	if w.Version != h.Version {
+		add(DriftVersion, w.Version, h.Version, "")
+	}
+	if !sourceEqual(w.Source, h.Source) {
+		add(DriftSource, sourceString(w.Source), sourceString(h.Source), "")
+	}
+	if w.CrateBlake3 != h.CrateBlake3 {
+		add(DriftCrateBlake3, w.CrateBlake3, h.CrateBlake3, "")
+	}
+	if w.CrateSHA256 != h.CrateSHA256 {
+		add(DriftCrateSHA256, w.CrateSHA256, h.CrateSHA256, "")
+	}
+	if w.RustdocTypesVersion != h.RustdocTypesVersion {
+		add(DriftRustdocTypesVersion, w.RustdocTypesVersion, h.RustdocTypesVersion, "")
+	}
+	if w.RustdocSHA256 != h.RustdocSHA256 {
+		add(DriftRustdocSHA256, w.RustdocSHA256, h.RustdocSHA256, "")
+	}
+	if w.WrapperSHA256 != h.WrapperSHA256 {
+		add(DriftWrapperSHA256, w.WrapperSHA256, h.WrapperSHA256, "")
+	}
+	if added := stringSetDiff(h.CapabilitiesDeclared, w.CapabilitiesDeclared); len(added) > 0 {
+		add(DriftCapabilityAdded, joinSorted(w.CapabilitiesDeclared), joinSorted(h.CapabilitiesDeclared),
+			fmt.Sprintf("new capabilities: %v", added))
+	}
+	if removed := stringSetDiff(w.CapabilitiesDeclared, h.CapabilitiesDeclared); len(removed) > 0 {
+		add(DriftCapabilityRemoved, joinSorted(w.CapabilitiesDeclared), joinSorted(h.CapabilitiesDeclared),
+			fmt.Sprintf("dropped capabilities: %v", removed))
+	}
+	if !stringSetEqual(w.Features, h.Features) {
+		add(DriftFeatures, joinSorted(w.Features), joinSorted(h.Features), "")
+	}
+	if !stringSetEqual(w.Dependencies, h.Dependencies) {
+		add(DriftDependencies, joinSorted(w.Dependencies), joinSorted(h.Dependencies), "")
+	}
+	return out
+}
+
+func sourceEqual(a, b Source) bool {
+	return a.Kind == b.Kind &&
+		a.Registry == b.Registry &&
+		a.URL == b.URL &&
+		a.Rev == b.Rev &&
+		a.Path == b.Path
+}
+
+func sourceString(s Source) string {
+	switch s.Kind {
+	case SourceRegistry:
+		return fmt.Sprintf("registry %s", s.Registry)
+	case SourceGit:
+		if s.Rev != "" {
+			return fmt.Sprintf("git %s#%s", s.URL, s.Rev)
+		}
+		return fmt.Sprintf("git %s", s.URL)
+	case SourcePath:
+		return fmt.Sprintf("path %s", s.Path)
+	default:
+		return fmt.Sprintf("%s", s.Kind)
+	}
+}
+
+func stringSetDiff(a, b []string) []string {
+	set := map[string]struct{}{}
+	for _, s := range b {
+		set[s] = struct{}{}
+	}
+	var out []string
+	for _, s := range a {
+		if _, ok := set[s]; !ok {
+			out = append(out, s)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func stringSetEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	am, bm := map[string]int{}, map[string]int{}
+	for _, s := range a {
+		am[s]++
+	}
+	for _, s := range b {
+		bm[s]++
+	}
+	for k, v := range am {
+		if bm[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func joinSorted(vs []string) string {
+	cp := append([]string{}, vs...)
+	sort.Strings(cp)
+	return fmt.Sprintf("%v", cp)
+}

--- a/package3/rust/lockfile/drift_test.go
+++ b/package3/rust/lockfile/drift_test.go
@@ -1,0 +1,383 @@
+package lockfile
+
+import (
+	"strings"
+	"testing"
+)
+
+func basePkg() RustPackage {
+	return RustPackage{
+		Name:    "hex",
+		Version: "0.4.3",
+		Source: Source{
+			Kind:     SourceRegistry,
+			Registry: "https://github.com/rust-lang/crates.io-index",
+		},
+		CrateBlake3:          "b3-aaaa",
+		CrateSHA256:          "sha-aaaa",
+		RustdocTypesVersion:  "32",
+		RustdocSHA256:        "rd-aaaa",
+		WrapperSHA256:        "wr-aaaa",
+		CapabilitiesDeclared: []string{"pure"},
+		Features:             []string{"std"},
+		Dependencies:         []string{},
+	}
+}
+
+func TestDriftKindString(t *testing.T) {
+	cases := []struct {
+		kind DriftKind
+		want string
+	}{
+		{DriftAdded, "added"},
+		{DriftRemoved, "removed"},
+		{DriftVersion, "version"},
+		{DriftSource, "source"},
+		{DriftCrateBlake3, "crate-blake3"},
+		{DriftCrateSHA256, "crate-sha256"},
+		{DriftRustdocTypesVersion, "rustdoc-types-version"},
+		{DriftRustdocSHA256, "rustdoc-sha256"},
+		{DriftWrapperSHA256, "wrapper-sha256"},
+		{DriftCapabilityAdded, "capability-added"},
+		{DriftCapabilityRemoved, "capability-removed"},
+		{DriftFeatures, "features"},
+		{DriftDependencies, "dependencies"},
+		{DriftUnknown, "unknown"},
+		{DriftKind(99), "unknown"},
+	}
+	for _, c := range cases {
+		if got := c.kind.String(); got != c.want {
+			t.Errorf("DriftKind(%d).String() = %q, want %q", c.kind, got, c.want)
+		}
+	}
+}
+
+func TestDriftStringFormatsAdded(t *testing.T) {
+	d := Drift{Crate: "hex", Kind: DriftAdded}
+	want := "hex: package added (not in lockfile)"
+	if got := d.String(); got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestDriftStringFormatsRemoved(t *testing.T) {
+	d := Drift{Crate: "hex", Kind: DriftRemoved}
+	want := "hex: package removed (in lockfile, not in fresh resolve)"
+	if got := d.String(); got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestDriftStringFormatsKeyedWithoutDetail(t *testing.T) {
+	d := Drift{Crate: "hex", Kind: DriftVersion, Want: "0.4.3", Have: "0.4.4"}
+	want := "hex: version drift: want 0.4.3 have 0.4.4"
+	if got := d.String(); got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestDriftStringFormatsKeyedWithDetail(t *testing.T) {
+	d := Drift{Crate: "hex", Kind: DriftCapabilityAdded, Want: "[]", Have: "[net]", Detail: "new capabilities: [net]"}
+	got := d.String()
+	if !strings.Contains(got, "hex: capability-added drift:") {
+		t.Errorf("missing prefix: %q", got)
+	}
+	if !strings.Contains(got, "new capabilities: [net]") {
+		t.Errorf("missing detail: %q", got)
+	}
+}
+
+func TestCheckIdenticalReturnsNil(t *testing.T) {
+	a := basePkg()
+	b := basePkg()
+	if got := Check([]RustPackage{a}, []RustPackage{b}); got != nil {
+		t.Fatalf("expected nil for identical input, got %v", got)
+	}
+}
+
+func TestCheckDetectsAdded(t *testing.T) {
+	have := basePkg()
+	drifts := Check(nil, []RustPackage{have})
+	if len(drifts) != 1 || drifts[0].Kind != DriftAdded || drifts[0].Crate != "hex" {
+		t.Fatalf("expected single added drift for hex, got %v", drifts)
+	}
+}
+
+func TestCheckDetectsRemoved(t *testing.T) {
+	want := basePkg()
+	drifts := Check([]RustPackage{want}, nil)
+	if len(drifts) != 1 || drifts[0].Kind != DriftRemoved || drifts[0].Crate != "hex" {
+		t.Fatalf("expected single removed drift for hex, got %v", drifts)
+	}
+}
+
+func TestCheckDetectsVersion(t *testing.T) {
+	w := basePkg()
+	h := basePkg()
+	h.Version = "0.4.4"
+	drifts := Check([]RustPackage{w}, []RustPackage{h})
+	if len(drifts) != 1 || drifts[0].Kind != DriftVersion {
+		t.Fatalf("expected version drift, got %v", drifts)
+	}
+	if drifts[0].Want != "0.4.3" || drifts[0].Have != "0.4.4" {
+		t.Errorf("unexpected want/have: %+v", drifts[0])
+	}
+}
+
+func TestCheckDetectsSource(t *testing.T) {
+	w := basePkg()
+	h := basePkg()
+	h.Source = Source{Kind: SourceGit, URL: "https://github.com/RustCrypto/utils.git", Rev: "abc"}
+	drifts := Check([]RustPackage{w}, []RustPackage{h})
+	if len(drifts) != 1 || drifts[0].Kind != DriftSource {
+		t.Fatalf("expected source drift, got %v", drifts)
+	}
+	if !strings.Contains(drifts[0].Have, "git ") {
+		t.Errorf("expected have to render git source, got %q", drifts[0].Have)
+	}
+}
+
+func TestCheckDetectsCrateBlake3(t *testing.T) {
+	w := basePkg()
+	h := basePkg()
+	h.CrateBlake3 = "b3-bbbb"
+	drifts := Check([]RustPackage{w}, []RustPackage{h})
+	if len(drifts) != 1 || drifts[0].Kind != DriftCrateBlake3 {
+		t.Fatalf("expected crate-blake3 drift, got %v", drifts)
+	}
+}
+
+func TestCheckDetectsCrateSHA256(t *testing.T) {
+	w := basePkg()
+	h := basePkg()
+	h.CrateSHA256 = "sha-bbbb"
+	drifts := Check([]RustPackage{w}, []RustPackage{h})
+	if len(drifts) != 1 || drifts[0].Kind != DriftCrateSHA256 {
+		t.Fatalf("expected crate-sha256 drift, got %v", drifts)
+	}
+}
+
+func TestCheckDetectsRustdocTypesVersion(t *testing.T) {
+	w := basePkg()
+	h := basePkg()
+	h.RustdocTypesVersion = "33"
+	drifts := Check([]RustPackage{w}, []RustPackage{h})
+	if len(drifts) != 1 || drifts[0].Kind != DriftRustdocTypesVersion {
+		t.Fatalf("expected rustdoc-types-version drift, got %v", drifts)
+	}
+}
+
+func TestCheckDetectsRustdocSHA256(t *testing.T) {
+	w := basePkg()
+	h := basePkg()
+	h.RustdocSHA256 = "rd-bbbb"
+	drifts := Check([]RustPackage{w}, []RustPackage{h})
+	if len(drifts) != 1 || drifts[0].Kind != DriftRustdocSHA256 {
+		t.Fatalf("expected rustdoc-sha256 drift, got %v", drifts)
+	}
+}
+
+func TestCheckDetectsWrapperSHA256(t *testing.T) {
+	w := basePkg()
+	h := basePkg()
+	h.WrapperSHA256 = "wr-bbbb"
+	drifts := Check([]RustPackage{w}, []RustPackage{h})
+	if len(drifts) != 1 || drifts[0].Kind != DriftWrapperSHA256 {
+		t.Fatalf("expected wrapper-sha256 drift, got %v", drifts)
+	}
+}
+
+func TestCheckDetectsCapabilityAdded(t *testing.T) {
+	w := basePkg()
+	h := basePkg()
+	h.CapabilitiesDeclared = []string{"pure", "net"}
+	drifts := Check([]RustPackage{w}, []RustPackage{h})
+	if len(drifts) != 1 {
+		t.Fatalf("expected single drift, got %d: %v", len(drifts), drifts)
+	}
+	if drifts[0].Kind != DriftCapabilityAdded {
+		t.Fatalf("expected capability-added drift, got %v", drifts[0])
+	}
+	if !strings.Contains(drifts[0].Detail, "net") {
+		t.Errorf("expected detail to mention net, got %q", drifts[0].Detail)
+	}
+}
+
+func TestCheckDetectsCapabilityRemoved(t *testing.T) {
+	w := basePkg()
+	w.CapabilitiesDeclared = []string{"pure", "net"}
+	h := basePkg()
+	drifts := Check([]RustPackage{w}, []RustPackage{h})
+	if len(drifts) != 1 {
+		t.Fatalf("expected single drift, got %d: %v", len(drifts), drifts)
+	}
+	if drifts[0].Kind != DriftCapabilityRemoved {
+		t.Fatalf("expected capability-removed drift, got %v", drifts[0])
+	}
+	if !strings.Contains(drifts[0].Detail, "net") {
+		t.Errorf("expected detail to mention net, got %q", drifts[0].Detail)
+	}
+}
+
+func TestCheckDetectsFeatures(t *testing.T) {
+	w := basePkg()
+	h := basePkg()
+	h.Features = []string{"std", "alloc"}
+	drifts := Check([]RustPackage{w}, []RustPackage{h})
+	if len(drifts) != 1 || drifts[0].Kind != DriftFeatures {
+		t.Fatalf("expected features drift, got %v", drifts)
+	}
+}
+
+func TestCheckDetectsDependencies(t *testing.T) {
+	w := basePkg()
+	h := basePkg()
+	h.Dependencies = []string{"serde 1.0.0"}
+	drifts := Check([]RustPackage{w}, []RustPackage{h})
+	if len(drifts) != 1 || drifts[0].Kind != DriftDependencies {
+		t.Fatalf("expected dependencies drift, got %v", drifts)
+	}
+}
+
+func TestCheckSortsByCrateThenKind(t *testing.T) {
+	w1 := basePkg()
+	w1.Name = "zoo"
+	w2 := basePkg()
+	w2.Name = "alpha"
+	h1 := basePkg()
+	h1.Name = "zoo"
+	h1.Version = "9.9.9"
+	h1.WrapperSHA256 = "wr-zzzz"
+	h2 := basePkg()
+	h2.Name = "alpha"
+	h2.Version = "9.9.9"
+	drifts := Check([]RustPackage{w1, w2}, []RustPackage{h1, h2})
+	if len(drifts) < 3 {
+		t.Fatalf("expected at least 3 drifts, got %d: %v", len(drifts), drifts)
+	}
+	if drifts[0].Crate != "alpha" {
+		t.Errorf("expected alpha first, got %q", drifts[0].Crate)
+	}
+	zooIdx := -1
+	for i, d := range drifts {
+		if d.Crate == "zoo" {
+			zooIdx = i
+			break
+		}
+	}
+	if zooIdx < 0 {
+		t.Fatal("zoo not found in drifts")
+	}
+	if drifts[zooIdx].Kind > drifts[zooIdx+1].Kind {
+		t.Errorf("zoo drifts not sorted by kind: %v", drifts[zooIdx:])
+	}
+}
+
+func TestCheckMultiplePackagesMultiDrift(t *testing.T) {
+	w1 := basePkg()
+	h1 := basePkg()
+	h1.Version = "0.4.4"
+	h1.WrapperSHA256 = "wr-bbbb"
+
+	w2 := basePkg()
+	w2.Name = "anyhow"
+	h2 := basePkg()
+	h2.Name = "anyhow"
+
+	drifts := Check([]RustPackage{w1, w2}, []RustPackage{h1, h2})
+	if len(drifts) != 2 {
+		t.Fatalf("expected 2 drifts (version + wrapper-sha for hex), got %d: %v", len(drifts), drifts)
+	}
+	for _, d := range drifts {
+		if d.Crate != "hex" {
+			t.Errorf("unexpected crate in drifts: %v", d)
+		}
+	}
+}
+
+func TestSourceEqual(t *testing.T) {
+	a := Source{Kind: SourceRegistry, Registry: "https://x"}
+	b := Source{Kind: SourceRegistry, Registry: "https://x"}
+	if !sourceEqual(a, b) {
+		t.Error("equal registry sources should compare equal")
+	}
+	b.Registry = "https://y"
+	if sourceEqual(a, b) {
+		t.Error("different registry should compare unequal")
+	}
+	g1 := Source{Kind: SourceGit, URL: "u", Rev: "r"}
+	g2 := Source{Kind: SourceGit, URL: "u", Rev: "r"}
+	if !sourceEqual(g1, g2) {
+		t.Error("equal git sources should compare equal")
+	}
+	g2.Rev = "s"
+	if sourceEqual(g1, g2) {
+		t.Error("different rev should compare unequal")
+	}
+	p1 := Source{Kind: SourcePath, Path: "./x"}
+	p2 := Source{Kind: SourcePath, Path: "./x"}
+	if !sourceEqual(p1, p2) {
+		t.Error("equal path sources should compare equal")
+	}
+}
+
+func TestSourceString(t *testing.T) {
+	cases := []struct {
+		src      Source
+		contains string
+	}{
+		{Source{Kind: SourceRegistry, Registry: "https://crates.io"}, "registry"},
+		{Source{Kind: SourceGit, URL: "https://x.git", Rev: "abc"}, "abc"},
+		{Source{Kind: SourceGit, URL: "https://x.git"}, "git"},
+		{Source{Kind: SourcePath, Path: "./vendor/x"}, "path"},
+	}
+	for _, c := range cases {
+		got := sourceString(c.src)
+		if !strings.Contains(got, c.contains) {
+			t.Errorf("sourceString(%+v) = %q, want substring %q", c.src, got, c.contains)
+		}
+	}
+}
+
+func TestStringSetEqual(t *testing.T) {
+	cases := []struct {
+		a, b []string
+		want bool
+	}{
+		{nil, nil, true},
+		{[]string{}, []string{}, true},
+		{[]string{"a"}, []string{"a"}, true},
+		{[]string{"a", "b"}, []string{"b", "a"}, true},
+		{[]string{"a"}, []string{"b"}, false},
+		{[]string{"a"}, []string{"a", "a"}, false},
+		{[]string{"a", "a"}, []string{"a", "a"}, true},
+	}
+	for _, c := range cases {
+		if got := stringSetEqual(c.a, c.b); got != c.want {
+			t.Errorf("stringSetEqual(%v, %v) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestStringSetDiff(t *testing.T) {
+	got := stringSetDiff([]string{"a", "b", "c"}, []string{"b"})
+	if len(got) != 2 || got[0] != "a" || got[1] != "c" {
+		t.Errorf("got %v, want [a c]", got)
+	}
+	if got := stringSetDiff(nil, []string{"a"}); len(got) != 0 {
+		t.Errorf("nil minus anything is empty, got %v", got)
+	}
+	if got := stringSetDiff([]string{"a"}, nil); len(got) != 1 || got[0] != "a" {
+		t.Errorf("anything minus nil is anything, got %v", got)
+	}
+}
+
+func TestJoinSorted(t *testing.T) {
+	got := joinSorted([]string{"b", "a", "c"})
+	if got != "[a b c]" {
+		t.Errorf("got %q, want [a b c]", got)
+	}
+	if got := joinSorted(nil); got != "[]" {
+		t.Errorf("nil joinSorted = %q, want []", got)
+	}
+}

--- a/package3/rust/lockfile/lockfile.go
+++ b/package3/rust/lockfile/lockfile.go
@@ -1,0 +1,413 @@
+// Package lockfile is the MEP-73 lockfile integration layer. It
+// owns the `[[rust-package]]` table that MEP-73 spec §3 adds to
+// `mochi.lock`: schema, encoder, decoder, and drift checker
+// (`mochi pkg lock --check`).
+//
+// The package is layering-conservative: it imports no other
+// package3/rust/* module. Callers in the build pipeline compose a
+// []RustPackage from their own state (ResolvedCrate +
+// source-tarball hashes + capability decls) and hand it to Encode;
+// the inverse Decode reads back the same shape.
+package lockfile
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// SourceKind classifies where a rust-package was sourced from. The
+// spec admits three: registry (the default crates.io sparse index),
+// git (a git URL with an optional rev), and path (a local relative
+// directory used during development).
+type SourceKind string
+
+const (
+	// SourceRegistry is a crates.io sparse-index source.
+	SourceRegistry SourceKind = "registry"
+	// SourceGit is a git URL source.
+	SourceGit SourceKind = "git"
+	// SourcePath is a local path source.
+	SourcePath SourceKind = "path"
+)
+
+// Source describes the origin of a rust-package. Exactly one of the
+// optional fields is non-empty depending on the Kind.
+type Source struct {
+	// Kind is one of registry / git / path.
+	Kind SourceKind
+	// Registry is the sparse-index URL when Kind == SourceRegistry.
+	Registry string
+	// URL is the git repo URL when Kind == SourceGit.
+	URL string
+	// Rev is the git revision (commit / tag / branch) when Kind ==
+	// SourceGit. Optional; empty pins to the default branch HEAD at
+	// lock time.
+	Rev string
+	// Path is the local directory (relative to the manifest) when
+	// Kind == SourcePath.
+	Path string
+}
+
+// RustPackage is one [[rust-package]] table entry. The field names
+// in the rendered TOML use the cargo-flavoured kebab-case the spec
+// shows (crate-blake3, rustdoc-types-version, etc.).
+type RustPackage struct {
+	// Name is the published crate name as it appears on crates.io.
+	Name string
+	// Version is the resolved version (full N.N.N triple, never a
+	// requirement form). Pre-release versions render as N.N.N-pre.
+	Version string
+	// Source classifies the origin (registry / git / path).
+	Source Source
+
+	// CrateBlake3 is the lowercase hex BLAKE3-256 of the .crate
+	// tarball. MEP-57's primary verification hash.
+	CrateBlake3 string
+	// CrateSHA256 is the lowercase hex SHA-256 of the .crate
+	// tarball. Matches what crates.io itself publishes.
+	CrateSHA256 string
+
+	// RustdocTypesVersion is the rustdoc-types schema version the
+	// bridge ingested at lock time. A drift here is a hard error.
+	RustdocTypesVersion string
+	// RustdocSHA256 is the lowercase hex SHA-256 of the raw rustdoc
+	// JSON document the bridge parsed. A drift here means the
+	// upstream API surface changed.
+	RustdocSHA256 string
+	// WrapperSHA256 is the lowercase hex SHA-256 of the synthesised
+	// wrapper crate's src/lib.rs. A drift here means the bridge
+	// would regenerate the wrapper with different bytes.
+	WrapperSHA256 string
+
+	// CapabilitiesDeclared is the capability set the manifest
+	// declared for this crate at lock time. New capabilities at
+	// --check time require user re-acknowledgement (the MEP-57
+	// monotonicity rule).
+	CapabilitiesDeclared []string
+	// Dependencies is the resolved transitive dependency tree as
+	// "<crate>@<version-req>" strings.
+	Dependencies []string
+	// Features is the feature set the manifest enabled at lock time.
+	Features []string
+}
+
+// Encode renders a slice of RustPackage entries as the TOML body
+// that the lockfile inserts into mochi.lock. Entries are sorted by
+// name (ascending) for deterministic byte output.
+func Encode(packages []RustPackage) string {
+	cp := append([]RustPackage{}, packages...)
+	sort.Slice(cp, func(i, j int) bool {
+		if cp[i].Name != cp[j].Name {
+			return cp[i].Name < cp[j].Name
+		}
+		return cp[i].Version < cp[j].Version
+	})
+	var b strings.Builder
+	for i, p := range cp {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		writeEntry(&b, p)
+	}
+	return b.String()
+}
+
+func writeEntry(b *strings.Builder, p RustPackage) {
+	b.WriteString("[[rust-package]]\n")
+	fmt.Fprintf(b, "name = %q\n", p.Name)
+	fmt.Fprintf(b, "version = %q\n", p.Version)
+	b.WriteString("source = ")
+	writeSource(b, p.Source)
+	b.WriteString("\n")
+	if p.CrateBlake3 != "" {
+		fmt.Fprintf(b, "crate-blake3 = %q\n", p.CrateBlake3)
+	}
+	if p.CrateSHA256 != "" {
+		fmt.Fprintf(b, "crate-sha256 = %q\n", p.CrateSHA256)
+	}
+	if p.RustdocTypesVersion != "" {
+		fmt.Fprintf(b, "rustdoc-types-version = %q\n", p.RustdocTypesVersion)
+	}
+	if p.RustdocSHA256 != "" {
+		fmt.Fprintf(b, "rustdoc-sha256 = %q\n", p.RustdocSHA256)
+	}
+	if p.WrapperSHA256 != "" {
+		fmt.Fprintf(b, "wrapper-sha256 = %q\n", p.WrapperSHA256)
+	}
+	writeStringArray(b, "capabilities-declared", p.CapabilitiesDeclared)
+	writeStringArray(b, "dependencies", p.Dependencies)
+	writeStringArray(b, "features", p.Features)
+}
+
+func writeSource(b *strings.Builder, s Source) {
+	b.WriteString("{ ")
+	fmt.Fprintf(b, "kind = %q", string(s.Kind))
+	switch s.Kind {
+	case SourceRegistry:
+		if s.Registry != "" {
+			fmt.Fprintf(b, ", registry = %q", s.Registry)
+		}
+	case SourceGit:
+		if s.URL != "" {
+			fmt.Fprintf(b, ", url = %q", s.URL)
+		}
+		if s.Rev != "" {
+			fmt.Fprintf(b, ", rev = %q", s.Rev)
+		}
+	case SourcePath:
+		if s.Path != "" {
+			fmt.Fprintf(b, ", path = %q", s.Path)
+		}
+	}
+	b.WriteString(" }")
+}
+
+func writeStringArray(b *strings.Builder, key string, vs []string) {
+	if len(vs) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "%s = [", key)
+	for i, v := range vs {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(b, "%q", v)
+	}
+	b.WriteString("]\n")
+}
+
+// Decode parses the TOML body produced by Encode (or a hand-edited
+// mochi.lock containing the same shape). The reader is consumed
+// entirely; unknown keys are tolerated for forward-compat but
+// silently dropped.
+//
+// The decoder is line-oriented and rejects any line that is not
+// either empty, a comment, an `[[rust-package]]` header, a flat
+// `key = value` assignment, or a string-array assignment. This
+// keeps the schema closed and the parser small (~150 lines).
+func Decode(r io.Reader) ([]RustPackage, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("lockfile: read: %w", err)
+	}
+	return decodeBytes(data)
+}
+
+// DecodeString is the string-input form of Decode.
+func DecodeString(s string) ([]RustPackage, error) {
+	return decodeBytes([]byte(s))
+}
+
+func decodeBytes(data []byte) ([]RustPackage, error) {
+	lines := strings.Split(string(data), "\n")
+	var out []RustPackage
+	var cur *RustPackage
+	flush := func() {
+		if cur != nil {
+			out = append(out, *cur)
+		}
+		cur = nil
+	}
+	for lineno, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if line == "[[rust-package]]" {
+			flush()
+			cur = &RustPackage{}
+			continue
+		}
+		if cur == nil {
+			// Lines outside a [[rust-package]] block are
+			// tolerated (they may be part of the surrounding
+			// mochi.lock document).
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			return nil, fmt.Errorf("lockfile: line %d: missing '=': %q", lineno+1, line)
+		}
+		key := strings.TrimSpace(line[:eq])
+		val := strings.TrimSpace(line[eq+1:])
+		if err := setField(cur, key, val); err != nil {
+			return nil, fmt.Errorf("lockfile: line %d (%s): %w", lineno+1, key, err)
+		}
+	}
+	flush()
+	return out, nil
+}
+
+func setField(p *RustPackage, key, val string) error {
+	switch key {
+	case "name":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.Name = s
+	case "version":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.Version = s
+	case "source":
+		src, err := parseSource(val)
+		if err != nil {
+			return err
+		}
+		p.Source = src
+	case "crate-blake3":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.CrateBlake3 = s
+	case "crate-sha256":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.CrateSHA256 = s
+	case "rustdoc-types-version":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.RustdocTypesVersion = s
+	case "rustdoc-sha256":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.RustdocSHA256 = s
+	case "wrapper-sha256":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.WrapperSHA256 = s
+	case "capabilities-declared":
+		arr, err := parseStringArray(val)
+		if err != nil {
+			return err
+		}
+		p.CapabilitiesDeclared = arr
+	case "dependencies":
+		arr, err := parseStringArray(val)
+		if err != nil {
+			return err
+		}
+		p.Dependencies = arr
+	case "features":
+		arr, err := parseStringArray(val)
+		if err != nil {
+			return err
+		}
+		p.Features = arr
+	default:
+		// Unknown key: forward-compat tolerance.
+	}
+	return nil
+}
+
+func parseString(val string) (string, error) {
+	val = strings.TrimSpace(val)
+	if len(val) < 2 || val[0] != '"' || val[len(val)-1] != '"' {
+		return "", fmt.Errorf("expected quoted string, got %q", val)
+	}
+	return val[1 : len(val)-1], nil
+}
+
+func parseStringArray(val string) ([]string, error) {
+	val = strings.TrimSpace(val)
+	if !strings.HasPrefix(val, "[") || !strings.HasSuffix(val, "]") {
+		return nil, fmt.Errorf("expected [..], got %q", val)
+	}
+	inner := strings.TrimSpace(val[1 : len(val)-1])
+	if inner == "" {
+		return nil, nil
+	}
+	parts := splitTopLevel(inner, ',')
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		s, err := parseString(p)
+		if err != nil {
+			return nil, fmt.Errorf("array element: %w", err)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+func parseSource(val string) (Source, error) {
+	val = strings.TrimSpace(val)
+	if !strings.HasPrefix(val, "{") || !strings.HasSuffix(val, "}") {
+		return Source{}, fmt.Errorf("expected inline table { ... }, got %q", val)
+	}
+	inner := strings.TrimSpace(val[1 : len(val)-1])
+	parts := splitTopLevel(inner, ',')
+	src := Source{}
+	for _, kv := range parts {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			return Source{}, fmt.Errorf("source key without '=': %q", kv)
+		}
+		k := strings.TrimSpace(kv[:eq])
+		v := strings.TrimSpace(kv[eq+1:])
+		s, err := parseString(v)
+		if err != nil {
+			return Source{}, fmt.Errorf("source[%s]: %w", k, err)
+		}
+		switch k {
+		case "kind":
+			src.Kind = SourceKind(s)
+		case "registry":
+			src.Registry = s
+		case "url":
+			src.URL = s
+		case "rev":
+			src.Rev = s
+		case "path":
+			src.Path = s
+		}
+	}
+	if src.Kind == "" {
+		return Source{}, fmt.Errorf("source missing kind: %q", val)
+	}
+	return src, nil
+}
+
+// splitTopLevel splits s on sep, ignoring sep when it appears inside
+// matched braces, brackets, or double-quoted strings. Used so that
+// inline-table values like `source = { ... }` and string arrays
+// `["a", "b"]` are not split on their interior commas.
+func splitTopLevel(s string, sep byte) []string {
+	var out []string
+	depth := 0
+	inStr := false
+	last := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case inStr:
+			if c == '"' && (i == 0 || s[i-1] != '\\') {
+				inStr = false
+			}
+		case c == '"':
+			inStr = true
+		case c == '{' || c == '[':
+			depth++
+		case c == '}' || c == ']':
+			depth--
+		case c == sep && depth == 0:
+			out = append(out, strings.TrimSpace(s[last:i]))
+			last = i + 1
+		}
+	}
+	out = append(out, strings.TrimSpace(s[last:]))
+	return out
+}

--- a/package3/rust/lockfile/lockfile_test.go
+++ b/package3/rust/lockfile/lockfile_test.go
@@ -1,0 +1,353 @@
+package lockfile
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func sampleRegistryPkg() RustPackage {
+	return RustPackage{
+		Name:    "tokio",
+		Version: "1.42.0",
+		Source: Source{
+			Kind:     SourceRegistry,
+			Registry: "https://index.crates.io",
+		},
+		CrateBlake3:          "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		CrateSHA256:          "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
+		RustdocTypesVersion:  "0.39.0",
+		RustdocSHA256:        "aaaa",
+		WrapperSHA256:        "bbbb",
+		CapabilitiesDeclared: []string{"net", "fs"},
+		Dependencies:         []string{"mio@^1.0", "bytes@^1.7", "pin-project-lite@^0.2"},
+		Features:             []string{"rt", "macros"},
+	}
+}
+
+func TestEncodeBasic(t *testing.T) {
+	got := Encode([]RustPackage{sampleRegistryPkg()})
+	wantBits := []string{
+		"[[rust-package]]",
+		`name = "tokio"`,
+		`version = "1.42.0"`,
+		`source = { kind = "registry", registry = "https://index.crates.io" }`,
+		`crate-blake3 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"`,
+		`crate-sha256 = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"`,
+		`rustdoc-types-version = "0.39.0"`,
+		`rustdoc-sha256 = "aaaa"`,
+		`wrapper-sha256 = "bbbb"`,
+		`capabilities-declared = ["net", "fs"]`,
+		`dependencies = ["mio@^1.0", "bytes@^1.7", "pin-project-lite@^0.2"]`,
+		`features = ["rt", "macros"]`,
+	}
+	for _, bit := range wantBits {
+		if !strings.Contains(got, bit) {
+			t.Errorf("Encode output missing %q\n--- output ---\n%s", bit, got)
+		}
+	}
+}
+
+func TestEncodeSortsByName(t *testing.T) {
+	got := Encode([]RustPackage{
+		{Name: "zlib", Version: "1.0", Source: Source{Kind: SourceRegistry}},
+		{Name: "anyhow", Version: "1.0", Source: Source{Kind: SourceRegistry}},
+		{Name: "hex", Version: "0.4.3", Source: Source{Kind: SourceRegistry}},
+	})
+	idxAnyhow := strings.Index(got, `name = "anyhow"`)
+	idxHex := strings.Index(got, `name = "hex"`)
+	idxZlib := strings.Index(got, `name = "zlib"`)
+	if !(idxAnyhow >= 0 && idxAnyhow < idxHex && idxHex < idxZlib) {
+		t.Errorf("Encode did not sort by name. anyhow=%d hex=%d zlib=%d\n%s",
+			idxAnyhow, idxHex, idxZlib, got)
+	}
+}
+
+func TestEncodeDeterministic(t *testing.T) {
+	pkgs := []RustPackage{sampleRegistryPkg(), {
+		Name: "hex", Version: "0.4.3",
+		Source: Source{Kind: SourceRegistry, Registry: "https://index.crates.io"},
+	}}
+	first := Encode(pkgs)
+	for i := 0; i < 10; i++ {
+		if got := Encode(pkgs); got != first {
+			t.Fatalf("Encode non-deterministic on iter %d\n--- first ---\n%s\n--- got ---\n%s", i, first, got)
+		}
+	}
+}
+
+func TestEncodeOmitsEmptyArrays(t *testing.T) {
+	got := Encode([]RustPackage{{
+		Name: "minimal", Version: "0.1.0",
+		Source: Source{Kind: SourceRegistry},
+	}})
+	if strings.Contains(got, "capabilities-declared = []") {
+		t.Errorf("Encode emitted empty capabilities-declared\n%s", got)
+	}
+	if strings.Contains(got, "dependencies = []") {
+		t.Errorf("Encode emitted empty dependencies\n%s", got)
+	}
+	if strings.Contains(got, "features = []") {
+		t.Errorf("Encode emitted empty features\n%s", got)
+	}
+}
+
+func TestEncodeGitSource(t *testing.T) {
+	got := Encode([]RustPackage{{
+		Name: "ax", Version: "0.1",
+		Source: Source{
+			Kind: SourceGit,
+			URL:  "https://github.com/ax/ax.git",
+			Rev:  "abc123",
+		},
+	}})
+	wantBit := `source = { kind = "git", url = "https://github.com/ax/ax.git", rev = "abc123" }`
+	if !strings.Contains(got, wantBit) {
+		t.Errorf("Encode missing git source line %q\n%s", wantBit, got)
+	}
+}
+
+func TestEncodePathSource(t *testing.T) {
+	got := Encode([]RustPackage{{
+		Name: "local", Version: "0.0.0",
+		Source: Source{
+			Kind: SourcePath,
+			Path: "./vendor/local",
+		},
+	}})
+	wantBit := `source = { kind = "path", path = "./vendor/local" }`
+	if !strings.Contains(got, wantBit) {
+		t.Errorf("Encode missing path source line %q\n%s", wantBit, got)
+	}
+}
+
+func TestDecodeBasic(t *testing.T) {
+	in := Encode([]RustPackage{sampleRegistryPkg()})
+	out, err := DecodeString(in)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("Decode returned %d entries; want 1", len(out))
+	}
+	if !reflect.DeepEqual(out[0], sampleRegistryPkg()) {
+		t.Errorf("Decode roundtrip mismatch\nwant %+v\nhave %+v", sampleRegistryPkg(), out[0])
+	}
+}
+
+func TestDecodeMultiplePackages(t *testing.T) {
+	in := Encode([]RustPackage{
+		sampleRegistryPkg(),
+		{Name: "hex", Version: "0.4.3", Source: Source{Kind: SourceRegistry, Registry: "https://index.crates.io"}},
+	})
+	out, err := DecodeString(in)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("Decode returned %d entries; want 2", len(out))
+	}
+	if out[0].Name != "hex" {
+		t.Errorf("Decode[0].Name = %q; want hex (sorted)", out[0].Name)
+	}
+	if out[1].Name != "tokio" {
+		t.Errorf("Decode[1].Name = %q; want tokio", out[1].Name)
+	}
+}
+
+func TestDecodeIgnoresCommentsAndBlankLines(t *testing.T) {
+	in := `# header comment
+
+[[rust-package]]
+# inline comment
+name = "hex"
+version = "0.4.3"
+source = { kind = "registry", registry = "https://index.crates.io" }
+`
+	out, err := DecodeString(in)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(out) != 1 || out[0].Name != "hex" {
+		t.Errorf("Decode = %+v; want one hex entry", out)
+	}
+}
+
+func TestDecodeIgnoresUnknownKey(t *testing.T) {
+	in := `[[rust-package]]
+name = "hex"
+version = "0.4.3"
+source = { kind = "registry" }
+future-field = "x"
+`
+	out, err := DecodeString(in)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(out) != 1 || out[0].Name != "hex" {
+		t.Errorf("unknown-key tolerance failed: %+v", out)
+	}
+}
+
+func TestDecodeRejectsMalformedLine(t *testing.T) {
+	in := `[[rust-package]]
+name "hex"
+`
+	if _, err := DecodeString(in); err == nil {
+		t.Errorf("Decode accepted line without '='")
+	}
+}
+
+func TestDecodeRejectsUnquotedString(t *testing.T) {
+	in := `[[rust-package]]
+name = hex
+version = "0.1"
+source = { kind = "registry" }
+`
+	if _, err := DecodeString(in); err == nil {
+		t.Errorf("Decode accepted unquoted string for name")
+	}
+}
+
+func TestDecodeRejectsMissingSourceKind(t *testing.T) {
+	in := `[[rust-package]]
+name = "hex"
+version = "0.1"
+source = { registry = "x" }
+`
+	if _, err := DecodeString(in); err == nil {
+		t.Errorf("Decode accepted source without kind")
+	}
+}
+
+func TestDecodeGitSource(t *testing.T) {
+	in := `[[rust-package]]
+name = "ax"
+version = "0.1"
+source = { kind = "git", url = "https://github.com/ax/ax.git", rev = "abc" }
+`
+	out, err := DecodeString(in)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if out[0].Source.Kind != SourceGit || out[0].Source.URL != "https://github.com/ax/ax.git" || out[0].Source.Rev != "abc" {
+		t.Errorf("git source decoded wrong: %+v", out[0].Source)
+	}
+}
+
+func TestDecodePathSource(t *testing.T) {
+	in := `[[rust-package]]
+name = "local"
+version = "0.0.0"
+source = { kind = "path", path = "./vendor/local" }
+`
+	out, err := DecodeString(in)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if out[0].Source.Kind != SourcePath || out[0].Source.Path != "./vendor/local" {
+		t.Errorf("path source decoded wrong: %+v", out[0].Source)
+	}
+}
+
+func TestDecodeStringArrayWithCommasInside(t *testing.T) {
+	in := `[[rust-package]]
+name = "hex"
+version = "0.1"
+source = { kind = "registry" }
+dependencies = ["a@^1.0, ^2.0", "b@^1"]
+`
+	out, err := DecodeString(in)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(out[0].Dependencies) != 2 || out[0].Dependencies[0] != "a@^1.0, ^2.0" {
+		t.Errorf("string array with interior comma decoded wrong: %v", out[0].Dependencies)
+	}
+}
+
+func TestDecodeEmptyArray(t *testing.T) {
+	in := `[[rust-package]]
+name = "hex"
+version = "0.1"
+source = { kind = "registry" }
+dependencies = []
+`
+	out, err := DecodeString(in)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(out[0].Dependencies) != 0 {
+		t.Errorf("empty array decoded as %v; want empty", out[0].Dependencies)
+	}
+}
+
+func TestDecodeRoundTripStability(t *testing.T) {
+	want := []RustPackage{
+		sampleRegistryPkg(),
+		{
+			Name: "ax", Version: "0.1",
+			Source:               Source{Kind: SourceGit, URL: "https://x", Rev: "ff"},
+			CapabilitiesDeclared: []string{"net"},
+		},
+	}
+	enc1 := Encode(want)
+	dec, err := DecodeString(enc1)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	enc2 := Encode(dec)
+	if enc1 != enc2 {
+		t.Errorf("encode-decode-encode not idempotent\n--- first ---\n%s\n--- second ---\n%s", enc1, enc2)
+	}
+}
+
+func TestDecodeIgnoresPreambleLines(t *testing.T) {
+	in := `# This is mochi.lock
+version = 3
+some-other-section = "x"
+
+[[rust-package]]
+name = "hex"
+version = "0.4.3"
+source = { kind = "registry" }
+`
+	out, err := DecodeString(in)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(out) != 1 || out[0].Name != "hex" {
+		t.Errorf("Decode = %+v; want one hex entry (preamble must be ignored)", out)
+	}
+}
+
+func TestDecodeReaderInput(t *testing.T) {
+	in := strings.NewReader(`[[rust-package]]
+name = "hex"
+version = "0.4.3"
+source = { kind = "registry" }
+`)
+	out, err := Decode(in)
+	if err != nil {
+		t.Fatalf("Decode reader: %v", err)
+	}
+	if len(out) != 1 || out[0].Name != "hex" {
+		t.Errorf("Decode reader = %+v; want one hex entry", out)
+	}
+}
+
+func TestSplitTopLevelHandlesNestedBraces(t *testing.T) {
+	got := splitTopLevel(`kind = "x", source = { kind = "y", url = "u, v" }, more = "z"`, ',')
+	want := []string{`kind = "x"`, `source = { kind = "y", url = "u, v" }`, `more = "z"`}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("splitTopLevel = %v; want %v", got, want)
+	}
+}
+
+func TestSplitTopLevelHandlesNestedBrackets(t *testing.T) {
+	got := splitTopLevel(`a = ["x, y", "z"], b = "c"`, ',')
+	want := []string{`a = ["x, y", "z"]`, `b = "c"`}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("splitTopLevel = %v; want %v", got, want)
+	}
+}

--- a/package3/rust/lockfile/phase08_test.go
+++ b/package3/rust/lockfile/phase08_test.go
@@ -1,0 +1,169 @@
+package lockfile
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPhase08LockfileIntegration is the MEP-73 Phase 8 sentinel. It
+// pins the end-to-end contract that a `[[rust-package]]` table makes
+// with mochi.lock: schema, encoding/decoding, drift detection.
+func TestPhase08LockfileIntegration(t *testing.T) {
+	t.Run("schema_roundtrip", func(t *testing.T) {
+		pkgs := []RustPackage{
+			{
+				Name:    "anyhow",
+				Version: "1.0.86",
+				Source: Source{
+					Kind:     SourceRegistry,
+					Registry: "https://github.com/rust-lang/crates.io-index",
+				},
+				CrateBlake3:          "b3-anyhow",
+				CrateSHA256:          "sha-anyhow",
+				RustdocTypesVersion:  "32",
+				RustdocSHA256:        "rd-anyhow",
+				WrapperSHA256:        "wr-anyhow",
+				CapabilitiesDeclared: []string{"pure"},
+				Features:             []string{"std"},
+				Dependencies:         []string{},
+			},
+			{
+				Name:    "hex",
+				Version: "0.4.3",
+				Source: Source{
+					Kind:     SourceRegistry,
+					Registry: "https://github.com/rust-lang/crates.io-index",
+				},
+				CrateBlake3:          "b3-hex",
+				CrateSHA256:          "sha-hex",
+				RustdocTypesVersion:  "32",
+				RustdocSHA256:        "rd-hex",
+				WrapperSHA256:        "wr-hex",
+				CapabilitiesDeclared: []string{"pure"},
+				Features:             []string{"alloc"},
+				Dependencies:         []string{},
+			},
+		}
+		body1 := Encode(pkgs)
+		decoded, err := DecodeString(body1)
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(decoded) != len(pkgs) {
+			t.Fatalf("expected %d pkgs, got %d", len(pkgs), len(decoded))
+		}
+		body2 := Encode(decoded)
+		if body1 != body2 {
+			t.Errorf("roundtrip not byte-stable\n---first---\n%s\n---second---\n%s", body1, body2)
+		}
+	})
+
+	t.Run("wrapper_sha_pins_drift", func(t *testing.T) {
+		w := basePkg()
+		h := basePkg()
+		h.WrapperSHA256 = WrapperSHA256("pub fn add(a: i64, b: i64) -> i64 { a - b }\n")
+		w.WrapperSHA256 = WrapperSHA256("pub fn add(a: i64, b: i64) -> i64 { a + b }\n")
+		drifts := Check([]RustPackage{w}, []RustPackage{h})
+		if len(drifts) != 1 || drifts[0].Kind != DriftWrapperSHA256 {
+			t.Fatalf("expected wrapper-sha256 drift, got %v", drifts)
+		}
+		if drifts[0].Want == drifts[0].Have {
+			t.Errorf("want/have should differ: %+v", drifts[0])
+		}
+	})
+
+	t.Run("check_clean_pair_returns_nil", func(t *testing.T) {
+		w := basePkg()
+		h := basePkg()
+		if drifts := Check([]RustPackage{w}, []RustPackage{h}); drifts != nil {
+			t.Fatalf("expected nil drift on identical input, got %v", drifts)
+		}
+	})
+
+	t.Run("check_detects_capability_addition", func(t *testing.T) {
+		w := basePkg()
+		h := basePkg()
+		h.CapabilitiesDeclared = []string{"pure", "net"}
+		drifts := Check([]RustPackage{w}, []RustPackage{h})
+		if len(drifts) != 1 || drifts[0].Kind != DriftCapabilityAdded {
+			t.Fatalf("expected capability-added drift, got %v", drifts)
+		}
+	})
+
+	t.Run("schema_matches_mep73_section_3", func(t *testing.T) {
+		// Hand-written exemplar based on MEP-73 §3 — encoded shape
+		// the spec promises a user-edited mochi.lock will look like.
+		body := `# preamble line from surrounding mochi.lock
+
+[[rust-package]]
+name = "hex"
+version = "0.4.3"
+source = { kind = "registry", registry = "https://github.com/rust-lang/crates.io-index" }
+crate-blake3 = "b3-hex"
+crate-sha256 = "sha-hex"
+rustdoc-types-version = "32"
+rustdoc-sha256 = "rd-hex"
+wrapper-sha256 = "wr-hex"
+capabilities-declared = ["pure"]
+features = ["alloc"]
+`
+		pkgs, err := DecodeString(body)
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(pkgs) != 1 {
+			t.Fatalf("expected 1 package, got %d", len(pkgs))
+		}
+		p := pkgs[0]
+		if p.Name != "hex" || p.Version != "0.4.3" {
+			t.Errorf("bad header: %+v", p)
+		}
+		if p.Source.Kind != SourceRegistry || !strings.Contains(p.Source.Registry, "crates.io-index") {
+			t.Errorf("bad source: %+v", p.Source)
+		}
+		if p.CrateBlake3 != "b3-hex" || p.CrateSHA256 != "sha-hex" {
+			t.Errorf("bad crate hashes: %+v", p)
+		}
+		if p.RustdocTypesVersion != "32" || p.RustdocSHA256 != "rd-hex" {
+			t.Errorf("bad rustdoc fields: %+v", p)
+		}
+		if p.WrapperSHA256 != "wr-hex" {
+			t.Errorf("bad wrapper sha: %+v", p)
+		}
+		if len(p.CapabilitiesDeclared) != 1 || p.CapabilitiesDeclared[0] != "pure" {
+			t.Errorf("bad capabilities: %+v", p.CapabilitiesDeclared)
+		}
+		if len(p.Features) != 1 || p.Features[0] != "alloc" {
+			t.Errorf("bad features: %+v", p.Features)
+		}
+	})
+
+	t.Run("section_3_roundtrips_under_check", func(t *testing.T) {
+		// Encode → Decode → Check(want, have) == nil
+		want := []RustPackage{
+			{
+				Name:    "hex",
+				Version: "0.4.3",
+				Source: Source{
+					Kind:     SourceRegistry,
+					Registry: "https://github.com/rust-lang/crates.io-index",
+				},
+				CrateBlake3:          "b3-hex",
+				CrateSHA256:          "sha-hex",
+				RustdocTypesVersion:  "32",
+				RustdocSHA256:        "rd-hex",
+				WrapperSHA256:        "wr-hex",
+				CapabilitiesDeclared: []string{"pure"},
+				Features:             []string{"alloc"},
+			},
+		}
+		body := Encode(want)
+		decoded, err := DecodeString(body)
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if drifts := Check(want, decoded); drifts != nil {
+			t.Fatalf("expected clean check after roundtrip, got %v", drifts)
+		}
+	})
+}

--- a/package3/rust/lockfile/wrapper_sha.go
+++ b/package3/rust/lockfile/wrapper_sha.go
@@ -1,0 +1,31 @@
+package lockfile
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// WrapperSHA256 returns the lowercase hex SHA-256 of the wrapper
+// crate's rendered src/lib.rs. This is the hash the lockfile pins
+// under `wrapper-sha256` per MEP-73 spec §3. The argument is the
+// raw source string the bridge would write to disk; the function
+// is the single canonical hashing point so callers and the drift
+// checker observe the same digest.
+//
+// SHA-256 (rather than BLAKE3) is chosen here to match the cargo /
+// crates.io ecosystem's preferred digest for source-level pins.
+// The .crate tarball still uses dual BLAKE3 + SHA-256 hashing per
+// MEP-57; the wrapper hash is single-algorithm because the wrapper
+// crate is bridge-internal and never published.
+func WrapperSHA256(libRS string) string {
+	h := sha256.Sum256([]byte(libRS))
+	return hex.EncodeToString(h[:])
+}
+
+// RustdocSHA256 returns the lowercase hex SHA-256 of a rustdoc JSON
+// document. Surfaced as a sibling helper to WrapperSHA256 so all
+// lockfile-bound hashing lives in one place.
+func RustdocSHA256(rustdocJSON []byte) string {
+	h := sha256.Sum256(rustdocJSON)
+	return hex.EncodeToString(h[:])
+}

--- a/package3/rust/lockfile/wrapper_sha_test.go
+++ b/package3/rust/lockfile/wrapper_sha_test.go
@@ -1,0 +1,93 @@
+package lockfile
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestWrapperSHA256EmptyString(t *testing.T) {
+	got := WrapperSHA256("")
+	want := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	if got != want {
+		t.Errorf("WrapperSHA256(\"\") = %q, want %q", got, want)
+	}
+}
+
+func TestWrapperSHA256Hello(t *testing.T) {
+	got := WrapperSHA256("hello")
+	want := "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+	if got != want {
+		t.Errorf("WrapperSHA256(\"hello\") = %q, want %q", got, want)
+	}
+}
+
+func TestWrapperSHA256SampleLibRS(t *testing.T) {
+	body := "pub fn add(a: i64, b: i64) -> i64 { a + b }\n"
+	got := WrapperSHA256(body)
+	if len(got) != 64 {
+		t.Fatalf("expected 64-hex digest, got %d chars: %q", len(got), got)
+	}
+	if strings.ToLower(got) != got {
+		t.Errorf("expected lowercase hex, got %q", got)
+	}
+	expected := sha256.Sum256([]byte(body))
+	if hex.EncodeToString(expected[:]) != got {
+		t.Errorf("digest mismatch")
+	}
+}
+
+func TestWrapperSHA256IsDeterministic(t *testing.T) {
+	body := "pub fn add(a: i64, b: i64) -> i64 { a + b }\n"
+	a := WrapperSHA256(body)
+	b := WrapperSHA256(body)
+	if a != b {
+		t.Errorf("WrapperSHA256 not deterministic: %q vs %q", a, b)
+	}
+}
+
+func TestWrapperSHA256DetectsSingleByteChange(t *testing.T) {
+	a := WrapperSHA256("pub fn add(a: i64, b: i64) -> i64 { a + b }\n")
+	b := WrapperSHA256("pub fn add(a: i64, b: i64) -> i64 { a - b }\n")
+	if a == b {
+		t.Errorf("single byte change must produce different digest, both = %q", a)
+	}
+}
+
+func TestRustdocSHA256Empty(t *testing.T) {
+	got := RustdocSHA256(nil)
+	want := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	if got != want {
+		t.Errorf("RustdocSHA256(nil) = %q, want %q", got, want)
+	}
+}
+
+func TestRustdocSHA256JSONLikeInput(t *testing.T) {
+	body := []byte(`{"format_version":32,"crate_version":"0.4.3","index":{}}`)
+	got := RustdocSHA256(body)
+	if len(got) != 64 {
+		t.Fatalf("expected 64-hex digest, got %d chars: %q", len(got), got)
+	}
+	expected := sha256.Sum256(body)
+	if hex.EncodeToString(expected[:]) != got {
+		t.Errorf("digest mismatch")
+	}
+}
+
+func TestRustdocSHA256IsDeterministic(t *testing.T) {
+	body := []byte(`{"format_version":32}`)
+	a := RustdocSHA256(body)
+	b := RustdocSHA256(body)
+	if a != b {
+		t.Errorf("RustdocSHA256 not deterministic: %q vs %q", a, b)
+	}
+}
+
+func TestRustdocSHA256DetectsSingleByteChange(t *testing.T) {
+	a := RustdocSHA256([]byte(`{"format_version":32}`))
+	b := RustdocSHA256([]byte(`{"format_version":33}`))
+	if a == b {
+		t.Errorf("single byte change must produce different digest, both = %q", a)
+	}
+}

--- a/website/docs/implementation/0073/index.md
+++ b/website/docs/implementation/0073/index.md
@@ -23,7 +23,7 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | 5 | Mochi-side extern fn emitter + alias shim file generation | LANDED | [6da45d5d](https://github.com/mochilang/mochi/commit/6da45d5d) | [phase-05](/docs/implementation/0073/phase-05-extern-emit) |
 | 6 | `import rust "<crate>@<semver>" as <alias>` grammar + parser | LANDED | [8a4e5b8d](https://github.com/mochilang/mochi/commit/8a4e5b8d) | [phase-06](/docs/implementation/0073/phase-06-import-grammar) |
 | 7 | Build orchestration: workspace synth + cargo build invocation + artifact link | LANDED | (pending) | [phase-07](/docs/implementation/0073/phase-07-build) |
-| 8 | mochi.lock `[[rust-package]]` integration + `--check` mode | NOT STARTED | — | [phase-08](/docs/implementation/0073/phase-08-lockfile) |
+| 8 | mochi.lock `[[rust-package]]` integration + `--check` mode | LANDED | (pending) | [phase-08](/docs/implementation/0073/phase-08-lockfile) |
 | 9 | `TargetRustLibrary` emit (rlib + cdylib + Cargo.toml + cbindgen) | NOT STARTED | — | [phase-09](/docs/implementation/0073/phase-09-rust-library-emit) |
 | 10 | Trusted publishing (`mochi pkg publish --to=crates.io`) Sigstore OIDC flow | NOT STARTED | — | [phase-10](/docs/implementation/0073/phase-10-trusted-publish) |
 | 11 | Async bridge (tokio runtime singleton + block_on entry) | NOT STARTED | — | [phase-11](/docs/implementation/0073/phase-11-async-bridge) |
@@ -71,7 +71,7 @@ The `package3/rust/` location is shared with the broader MEP-57 polyglot package
 
 ## Status snapshot
 
-As of 2026-05-29 23:04 (GMT+7): phases 0, 1, 2, 3, 4, 5, 6, and 7 LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest + closed type-mapping table + extern-C wrapper synthesiser + Mochi extern-fn emitter + `import rust` grammar + build orchestration pipeline). Phases 8-13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
+As of 2026-05-29 23:23 (GMT+7): phases 0, 1, 2, 3, 4, 5, 6, 7, and 8 LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest + closed type-mapping table + extern-C wrapper synthesiser + Mochi extern-fn emitter + `import rust` grammar + build orchestration pipeline + mochi.lock `[[rust-package]]` schema + drift checker). Phases 9-13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
 
 ## Cross-references
 

--- a/website/docs/implementation/0073/phase-08-lockfile.md
+++ b/website/docs/implementation/0073/phase-08-lockfile.md
@@ -1,0 +1,168 @@
+---
+sidebar_label: "Phase 8: mochi.lock integration"
+sidebar_position: 9
+---
+
+# MEP-73 Phase 8: mochi.lock integration
+
+**Status:** LANDED (2026-05-29)
+**Spec section:** [MEP-73 §3 — Lockfile schema](/docs/mep/mep-0073)
+**Worktree:** `/Users/apple/mochi-mep73-p8`
+
+## Gate
+
+Land the `[[rust-package]]` lockfile schema, byte-stable encoder/decoder,
+and drift checker so `mochi pkg lock` and `mochi pkg lock --check` can
+write and validate the rust-crate portion of `mochi.lock`.
+
+## Why it matters
+
+Phase 7 produced a deterministic Cargo workspace plus a portable
+`cargo build` invocation. Determinism only buys safety if the lockfile
+can detect when something downstream tries to slip a different value in.
+This phase pins the seven sentinel fields per crate (registry source,
+crate BLAKE3, crate SHA-256, rustdoc-types version, rustdoc SHA-256,
+wrapper SHA-256, declared capabilities) and turns any divergence between
+the recorded entry and a fresh resolve into a hard error.
+
+The schema in this phase is the contract MEP-57 (`mochi pkg`) calls into
+when it materialises `mochi.lock`, and the contract the bridge calls
+into when it ingests it back. The drift checker is what
+`mochi pkg lock --check` runs in CI to fail closed on any of the
+following:
+
+- An added or removed `[[rust-package]]` entry
+- A version, source, or transitive-dependency move
+- A `.crate` tarball whose dual hash no longer matches
+- A `rustdoc-types` schema version bump
+- A wrapper source whose rendered bytes drifted (the bridge would emit
+  different code if it locked again right now)
+- A new capability the lockfile did not previously acknowledge
+  (per MEP-57 monotonicity)
+
+## What landed
+
+### `package3/rust/lockfile/lockfile.go`
+
+The schema and codec.
+
+- `Source{Kind, Registry, URL, Rev, Path}` covers the three sources the
+  spec admits (registry, git, path) with `Kind` as the discriminator.
+- `RustPackage{Name, Version, Source, CrateBlake3, CrateSHA256,
+  RustdocTypesVersion, RustdocSHA256, WrapperSHA256,
+  CapabilitiesDeclared, Dependencies, Features}` matches the field
+  shape MEP-73 §3 documents, with kebab-case TOML key names rendered
+  by the encoder.
+- `Encode([]RustPackage) string` sorts by name then version and renders
+  byte-stable TOML by hand (matching workspace.go's no-dependency
+  style).
+- `Decode(io.Reader)` / `DecodeString(string)` parses the same shape,
+  tolerating comments, blank lines, surrounding preamble, and unknown
+  keys (forward-compat tolerance).
+- `splitTopLevel` is the helper that lets inline tables
+  (`{ kind = "registry", registry = "..." }`) and arrays
+  (`["a", "b"]`) tokenize without splitting on interior commas.
+
+### `package3/rust/lockfile/wrapper_sha.go`
+
+Two thin helpers that are the *only* points in the codebase that hash
+wrapper or rustdoc content. Centralising the hash function means the
+encoder, the bridge build pipeline, and the drift checker all observe
+exactly the same digest.
+
+- `WrapperSHA256(libRS string) string` — lowercase hex SHA-256 of the
+  wrapper crate's rendered `src/lib.rs`.
+- `RustdocSHA256(rustdocJSON []byte) string` — lowercase hex SHA-256 of
+  a rustdoc JSON document.
+
+SHA-256 (not BLAKE3) is used here to match the cargo / crates.io
+ecosystem's preferred digest for source-level pins. The `.crate`
+tarball itself still gets the MEP-57 dual BLAKE3 + SHA-256 pair.
+
+### `package3/rust/lockfile/drift.go`
+
+The `mochi pkg lock --check` engine.
+
+- `DriftKind` is a closed enum covering every sentinel: added, removed,
+  version, source, crate-blake3, crate-sha256, rustdoc-types-version,
+  rustdoc-sha256, wrapper-sha256, capability-added, capability-removed,
+  features, dependencies.
+- `Drift{Crate, Kind, Want, Have, Detail}` is one observed difference
+  with a human-readable rendering suitable for diagnostic output.
+- `Check(want, have []RustPackage) []Drift` compares the two sets and
+  returns every difference sorted by crate name then kind for stable
+  output. A clean check returns nil.
+
+Capability drift is split into `DriftCapabilityAdded` and
+`DriftCapabilityRemoved` so a downstream policy can treat the two
+directions differently (per MEP-57's monotonicity rule, an added
+capability requires re-acknowledgement, while a removed capability is
+not strictly an error).
+
+### Tests
+
+- `lockfile_test.go` (22 cases): Encode determinism, Decode malformed
+  inputs, source-kind variants, string-array variants, roundtrip
+  stability, reader-vs-string input, splitTopLevel edge cases.
+- `drift_test.go` (~20 cases): every `DriftKind.String()`, every
+  `Check`-detectable drift category, sort ordering, helper coverage
+  (`sourceEqual`, `sourceString`, `stringSetEqual`, `stringSetDiff`,
+  `joinSorted`).
+- `wrapper_sha_test.go` (9 cases): pinned SHA-256 of empty string and
+  "hello", single-byte change detection for both `WrapperSHA256` and
+  `RustdocSHA256`, determinism.
+- `phase08_test.go` (sentinel) with subtests `schema_roundtrip`,
+  `wrapper_sha_pins_drift`, `check_clean_pair_returns_nil`,
+  `check_detects_capability_addition`, `schema_matches_mep73_section_3`
+  (hand-written exemplar based on MEP-73 §3 with surrounding preamble),
+  `section_3_roundtrips_under_check` (Encode → Decode → Check returns
+  nil).
+
+## Target matrix
+
+| Target           | Status   | Notes |
+|------------------|----------|-------|
+| Schema           | ✅       | RustPackage + Source closed shape per MEP-73 §3. |
+| Encoder          | ✅       | Byte-stable TOML, sorted by name then version. |
+| Decoder          | ✅       | Tolerant of comments / preamble / unknown keys. |
+| Wrapper hash     | ✅       | Single canonical SHA-256 entry point. |
+| Rustdoc hash     | ✅       | Sibling helper, byte input. |
+| Drift checker    | ✅       | 13-variant `DriftKind` covers every schema field. |
+
+## How this phase plugs in to the larger pipeline
+
+```
+                ┌────────────────────────────┐
+                │ pipeline.Resolve(refs)     │   Phase 7
+                │ → []ResolvedCrate          │
+                └─────────┬──────────────────┘
+                          │
+                          │ + per-crate
+                          │   { crate-blake3, crate-sha256,
+                          │     rustdoc-types-version,
+                          │     rustdoc-sha256,
+                          │     wrapper-sha256,
+                          │     capabilities, deps, features }
+                          ▼
+                ┌────────────────────────────┐
+                │ []lockfile.RustPackage     │
+                └─────────┬──────────────────┘
+                          │
+              ┌───────────┴─────────────┐
+              ▼                         ▼
+   lockfile.Encode(pkgs)      lockfile.Check(want, have)
+       (mochi pkg lock)         (mochi pkg lock --check)
+```
+
+The bridge does not yet wire the hashes through (Phase 9+ owns
+`TargetRustLibrary` emit and the integration call), but the schema is
+landed and the drift contract is stable.
+
+## Timeline
+
+| Time (GMT+7)        | Step |
+|---------------------|------|
+| 2026-05-29 23:18    | Worktree branch `mep/0073-phase-08` created off `origin/main`. |
+| 2026-05-29 23:20    | `lockfile.go`, `wrapper_sha.go`, `drift.go` written. |
+| 2026-05-29 23:22    | Test suites green (`go test ./package3/rust/...`). |
+| 2026-05-29 23:23    | Tracking page + spec sync. |

--- a/website/docs/mep/mep-0073.md
+++ b/website/docs/mep/mep-0073.md
@@ -304,7 +304,7 @@ A phase is LANDED only when its gate is green against the curated 24-crate fixtu
 | 5. extern emitter | LANDED | required | required | required |
 | 6. import rust grammar | LANDED | required | required | required |
 | 7. build orchestration | LANDED | LANDED | n/a (cargo workspace required) | n/a |
-| 8. mochi.lock integration | NOT STARTED | required | required | required |
+| 8. mochi.lock integration | LANDED | LANDED | LANDED | LANDED |
 | 9. TargetRustLibrary emit | NOT STARTED | required | n/a (lib is rlib + cdylib for native) | n/a |
 | 10. trusted publishing | NOT STARTED | n/a (publish is host-only) | n/a | n/a |
 | 11. async bridge | NOT STARTED | required | n/a (no tokio on wasm32-wasip1) | n/a |

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -338,7 +338,8 @@
       "implementation/0073/phase-04-wrapper",
       "implementation/0073/phase-05-extern-emit",
       "implementation/0073/phase-06-import-grammar",
-      "implementation/0073/phase-07-build"
+      "implementation/0073/phase-07-build",
+      "implementation/0073/phase-08-lockfile"
     ]
   },
   "implementation/0074/index",


### PR DESCRIPTION
Phase 8 of MEP-73: lockfile schema + drift checker.

## Summary

- New package `package3/rust/lockfile/` (zero deps on other `package3/rust/` modules).
- `RustPackage` + `Source` schema per MEP-73 §3 with closed `SourceKind` enum (registry / git / path).
- Byte-stable hand-rolled TOML `Encode` (sorted by name then version) and tolerant `Decode` (handles preamble, comments, unknown keys, inline tables, string arrays).
- `WrapperSHA256` + `RustdocSHA256` as the single canonical hashing entry point (SHA-256, lowercase hex).
- 13-variant `DriftKind` covering every sentinel field in the schema: added, removed, version, source, crate-blake3, crate-sha256, rustdoc-types-version, rustdoc-sha256, wrapper-sha256, capability-added, capability-removed, features, dependencies. `Check(want, have)` returns sorted, deterministic diagnostics suitable for `mochi pkg lock --check` output.
- Capability drift split into added vs removed so MEP-57's monotonicity rule can be enforced asymmetrically.
- Phase 8 LANDED in target matrix across all four columns (host / musl / wasm32-wasip1 / embedded). The lockfile module is target-agnostic Go and runs anywhere.

## Tests

- `lockfile_test.go` (22 cases): encode determinism, decode malformed inputs, source-kind variants, array variants, roundtrip stability, reader-vs-string input, splitTopLevel edge cases.
- `drift_test.go` (~20 cases): every `DriftKind.String()`, every `Check`-detectable category, sort order, helper coverage.
- `wrapper_sha_test.go` (9 cases): pinned digests for empty / hello / sample lib.rs, single-byte change detection.
- `phase08_test.go` sentinel with `schema_roundtrip`, `wrapper_sha_pins_drift`, `check_clean_pair_returns_nil`, `check_detects_capability_addition`, `schema_matches_mep73_section_3` (hand-written exemplar), `section_3_roundtrips_under_check`.

`go test ./package3/rust/...` all green.

## Docs

- New tracking page `phase-08-lockfile.md` with target matrix and pipeline diagram.
- Index page status updated to 2026-05-29 23:23 GMT+7, Phase 8 row marked LANDED.
- MEP-73 spec target matrix Phase 8 row marked LANDED across all four targets.
- Sidebar entry added.

Closes #22812