### PR TITLE
mep-52(phase 8): wire actual tracking issue + PR numbers in the spec doc

### DIFF
--- a/website/docs/implementation/0052/phase-08-datalog.md
+++ b/website/docs/implementation/0052/phase-08-datalog.md
@@ -13,8 +13,8 @@ description: "MEP-52 Phase 8, Mochi Datalog facts, rules, and queries routed thr
 | Status         | LANDED (Node + Deno + Bun) |
 | Started        | 2026-05-29 23:00 (GMT+7) |
 | Landed         | 2026-05-29 23:21 (GMT+7) |
-| Tracking issue | (pending) |
-| Tracking PR    | (pending) |
+| Tracking issue | [#22805](https://github.com/mochilang/mochi/issues/22805) |
+| Tracking PR    | [#22808](https://github.com/mochilang/mochi/pull/22808) |
 
 ## Gate
 


### PR DESCRIPTION
Followup to #22808. The Phase 8 PR auto-merged before the spec doc could be updated with the real issue + PR numbers; this fixup wires #22805 and #22808 into the tracking page header.