### PR TITLE
feat(mep-71 p4): closed Python-to-Mochi type mapping table

### DIFF
--- a/package3/python/typemap/class.go
+++ b/package3/python/typemap/class.go
@@ -1,0 +1,235 @@
+package typemap
+
+import (
+	"strings"
+
+	"mochi/package3/python/errors"
+	"mochi/package3/python/stubs"
+)
+
+// ClassDecision is the result of mapping a Python class declaration.
+type ClassDecision struct {
+	// Type is the lowered MochiType (KindRecord or KindInterface). Zero-value
+	// when Skip is set.
+	Type MochiType
+	// Methods contains per-method decisions for KindRecord targets (interface
+	// methods are inlined into Type.Methods). Methods without a successful
+	// mapping appear in Skipped instead.
+	Methods []MethodDecision
+	// Skip is non-nil when the class was refused entirely.
+	Skip *errors.SkipReport
+	// Skipped is the per-member SkipReports for fields / methods that the
+	// bridge refused while the class itself was mapped.
+	Skipped []errors.SkipReport
+}
+
+// MethodDecision is the result of mapping one record / interface method.
+type MethodDecision struct {
+	Name   string
+	Method MochiMethod
+	Skip   *errors.SkipReport
+}
+
+// OK reports whether the decision produced a usable type.
+func (d ClassDecision) OK() bool { return d.Skip == nil }
+
+// MapClass lowers a stubs.ClassDecl into a Mochi record (TypedDict / frozen
+// dataclass) or interface (Protocol). Other classes refuse with
+// SkipUnsupportedTypingConstruct so the bridge does not invent surfaces for
+// arbitrary Python classes.
+func (m *Mapper) MapClass(cd stubs.ClassDecl) ClassDecision {
+	saved := m.ItemPath
+	defer func() { m.ItemPath = saved }()
+	m.ItemPath = cd.Name
+
+	switch {
+	case cd.IsProtocol:
+		return m.mapProtocol(cd)
+	case cd.IsTypedDict:
+		return m.mapTypedDict(cd)
+	case cd.IsDataclass:
+		return m.mapDataclass(cd)
+	default:
+		return ClassDecision{Skip: &errors.SkipReport{
+			ItemPath: cd.Name,
+			Reason:   errors.SkipUnsupportedTypingConstruct,
+			Detail:   "class " + cd.Name + " is neither Protocol, TypedDict, nor @dataclass; supply a hand-written extern",
+		}}
+	}
+}
+
+func (m *Mapper) mapTypedDict(cd stubs.ClassDecl) ClassDecision {
+	out := ClassDecision{Type: MochiType{Kind: KindRecord, Name: cd.Name}}
+	for _, f := range cd.Fields {
+		fd := m.mapField(cd.Name, f)
+		if fd.Skip != nil {
+			out.Skipped = append(out.Skipped, *fd.Skip)
+			continue
+		}
+		out.Type.Fields = append(out.Type.Fields, fd.Field)
+	}
+	return out
+}
+
+func (m *Mapper) mapDataclass(cd stubs.ClassDecl) ClassDecision {
+	if !classDecoratedAsFrozen(cd) {
+		return ClassDecision{Skip: &errors.SkipReport{
+			ItemPath: cd.Name,
+			Reason:   errors.SkipUnsupportedTypingConstruct,
+			Detail:   "mutable @dataclass: Mochi records are immutable; declare @dataclass(frozen=True) or provide a hand override",
+			Override: "extern python type " + cd.Name + " { ... }",
+		}}
+	}
+	out := ClassDecision{Type: MochiType{Kind: KindRecord, Name: cd.Name}}
+	for _, f := range cd.Fields {
+		fd := m.mapField(cd.Name, f)
+		if fd.Skip != nil {
+			out.Skipped = append(out.Skipped, *fd.Skip)
+			continue
+		}
+		out.Type.Fields = append(out.Type.Fields, fd.Field)
+	}
+	return out
+}
+
+func (m *Mapper) mapProtocol(cd stubs.ClassDecl) ClassDecision {
+	out := ClassDecision{Type: MochiType{Kind: KindInterface, Name: cd.Name}}
+	for _, fn := range cd.Methods {
+		md := m.mapMethod(cd.Name, fn)
+		if md.Skip != nil {
+			out.Skipped = append(out.Skipped, *md.Skip)
+			continue
+		}
+		out.Type.Methods = append(out.Type.Methods, md.Method)
+	}
+	return out
+}
+
+type fieldDecision struct {
+	Field MochiField
+	Skip  *errors.SkipReport
+}
+
+func (m *Mapper) mapField(className string, f stubs.FieldDecl) fieldDecision {
+	saved := m.ItemPath
+	defer func() { m.ItemPath = saved }()
+	m.ItemPath = className + "." + f.Name
+	d := m.Map(f.Type)
+	if !d.OK() {
+		return fieldDecision{Skip: d.Skip}
+	}
+	return fieldDecision{Field: MochiField{Name: f.Name, Type: d.Type}}
+}
+
+func (m *Mapper) mapMethod(className string, fn stubs.FuncDecl) MethodDecision {
+	saved := m.ItemPath
+	defer func() { m.ItemPath = saved }()
+	m.ItemPath = className + "." + fn.Name
+	if strings.HasPrefix(fn.Name, "__") && strings.HasSuffix(fn.Name, "__") {
+		// Dunders are not synthesised into the interface surface.
+		return MethodDecision{Skip: &errors.SkipReport{
+			ItemPath: m.ItemPath,
+			Reason:   errors.SkipDunder,
+			Detail:   "dunder methods are not exposed through the bridge",
+		}}
+	}
+	method := MochiMethod{Name: fn.Name, IsAsync: fn.IsAsync}
+	for _, p := range fn.Params {
+		if p.Name == "self" || p.Name == "cls" {
+			continue
+		}
+		switch p.Kind {
+		case stubs.ParamVarArgs, stubs.ParamKwArgs:
+			return MethodDecision{Skip: &errors.SkipReport{
+				ItemPath: m.ItemPath,
+				Reason:   errors.SkipParamSpec,
+				Detail:   "*args / **kwargs in interface method " + fn.Name,
+			}}
+		}
+		if p.Type == "" {
+			return MethodDecision{Skip: &errors.SkipReport{
+				ItemPath: m.ItemPath,
+				Reason:   errors.SkipUnsupportedTypingConstruct,
+				Detail:   "parameter " + p.Name + " has no annotation",
+			}}
+		}
+		d := m.Map(p.Type)
+		if !d.OK() {
+			return MethodDecision{Skip: d.Skip}
+		}
+		method.Params = append(method.Params, d.Type)
+	}
+	if fn.ReturnType == "" {
+		method.Return = NewScalar("None")
+	} else {
+		d := m.Map(fn.ReturnType)
+		if !d.OK() {
+			return MethodDecision{Skip: d.Skip}
+		}
+		method.Return = d.Type
+	}
+	return MethodDecision{Name: fn.Name, Method: method}
+}
+
+// MapFunction lowers a top-level FuncDecl. Returns a Decision whose Type, on
+// success, is a KindFun MochiType. Methods on a class are handled via
+// MapClass which dispatches to mapMethod above.
+func (m *Mapper) MapFunction(fn stubs.FuncDecl) Decision {
+	saved := m.ItemPath
+	defer func() { m.ItemPath = saved }()
+	m.ItemPath = fn.Name
+	var params []MochiType
+	for _, p := range fn.Params {
+		switch p.Kind {
+		case stubs.ParamVarArgs, stubs.ParamKwArgs:
+			return m.skip(errors.SkipParamSpec, "*args / **kwargs in "+fn.Name, "")
+		}
+		if p.Type == "" {
+			return m.skip(errors.SkipUnsupportedTypingConstruct,
+				"parameter "+p.Name+" has no annotation in "+fn.Name, "")
+		}
+		d := m.Map(p.Type)
+		if !d.OK() {
+			return d
+		}
+		params = append(params, d.Type)
+	}
+	var ret MochiType
+	if fn.ReturnType == "" {
+		ret = NewScalar("None")
+	} else {
+		d := m.Map(fn.ReturnType)
+		if !d.OK() {
+			return d
+		}
+		ret = d.Type
+	}
+	t := NewFun(ret, params...)
+	if fn.IsAsync {
+		t = MochiType{Kind: KindFun, Params: append(params, NewAsync(ret))}
+	}
+	return Decision{Type: t}
+}
+
+// classDecoratedAsFrozen returns true when the class's decorator list contains
+// `@dataclass(frozen=True)` (with whitespace tolerance).
+func classDecoratedAsFrozen(cd stubs.ClassDecl) bool {
+	for _, d := range cd.Decorators {
+		d = strings.TrimSpace(d)
+		// Match dataclass(... frozen=True ...) and dataclasses.dataclass(...).
+		if !strings.Contains(d, "dataclass") {
+			continue
+		}
+		paren := strings.Index(d, "(")
+		if paren < 0 {
+			continue
+		}
+		args := d[paren+1:]
+		args = strings.TrimSuffix(args, ")")
+		// Coarse but correct: any frozen=True in the args list wins.
+		if strings.Contains(strings.ReplaceAll(args, " ", ""), "frozen=True") {
+			return true
+		}
+	}
+	return false
+}

--- a/package3/python/typemap/class_test.go
+++ b/package3/python/typemap/class_test.go
@@ -1,0 +1,299 @@
+package typemap
+
+import (
+	"testing"
+
+	"mochi/package3/python/errors"
+	"mochi/package3/python/stubs"
+)
+
+func TestMapTypedDict(t *testing.T) {
+	m := &Mapper{}
+	cd := stubs.ClassDecl{
+		Name:        "Point",
+		IsTypedDict: true,
+		Fields: []stubs.FieldDecl{
+			{Name: "x", Type: "int"},
+			{Name: "y", Type: "int"},
+		},
+	}
+	d := m.MapClass(cd)
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if d.Type.Kind != KindRecord || d.Type.Name != "Point" {
+		t.Errorf("kind/name = %+v", d.Type)
+	}
+	if len(d.Type.Fields) != 2 {
+		t.Errorf("fields = %+v", d.Type.Fields)
+	}
+}
+
+func TestMapFrozenDataclass(t *testing.T) {
+	m := &Mapper{}
+	cd := stubs.ClassDecl{
+		Name:        "Point",
+		IsDataclass: true,
+		Decorators:  []string{"dataclass(frozen=True)"},
+		Fields: []stubs.FieldDecl{
+			{Name: "x", Type: "int"},
+			{Name: "y", Type: "int"},
+		},
+	}
+	d := m.MapClass(cd)
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if d.Type.Kind != KindRecord {
+		t.Errorf("got %+v", d.Type)
+	}
+}
+
+func TestMapMutableDataclassRefused(t *testing.T) {
+	m := &Mapper{}
+	cd := stubs.ClassDecl{
+		Name:        "Point",
+		IsDataclass: true,
+		Decorators:  []string{"dataclass"},
+		Fields:      []stubs.FieldDecl{{Name: "x", Type: "int"}},
+	}
+	d := m.MapClass(cd)
+	if d.OK() {
+		t.Fatal("expected refusal: mutable @dataclass")
+	}
+	if d.Skip.Override == "" {
+		t.Error("expected override suggestion in skip report")
+	}
+}
+
+func TestMapFrozenDataclassWithWhitespace(t *testing.T) {
+	m := &Mapper{}
+	cd := stubs.ClassDecl{
+		Name:        "Point",
+		IsDataclass: true,
+		Decorators:  []string{"dataclasses.dataclass(  frozen = True  )"},
+	}
+	d := m.MapClass(cd)
+	if !d.OK() {
+		t.Errorf("whitespace-tolerant detection failed: %v", d.Skip)
+	}
+}
+
+func TestMapProtocol(t *testing.T) {
+	m := &Mapper{}
+	cd := stubs.ClassDecl{
+		Name:       "Greeter",
+		IsProtocol: true,
+		Methods: []stubs.FuncDecl{
+			{
+				Name: "hello",
+				Params: []stubs.ParamDecl{
+					{Name: "self"},
+					{Name: "who", Type: "str"},
+				},
+				ReturnType: "str",
+			},
+		},
+	}
+	d := m.MapClass(cd)
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if d.Type.Kind != KindInterface || d.Type.Name != "Greeter" {
+		t.Errorf("got %+v", d.Type)
+	}
+	if len(d.Type.Methods) != 1 {
+		t.Errorf("methods = %+v", d.Type.Methods)
+	}
+}
+
+func TestMapProtocolSkipsDunder(t *testing.T) {
+	m := &Mapper{}
+	cd := stubs.ClassDecl{
+		Name:       "P",
+		IsProtocol: true,
+		Methods: []stubs.FuncDecl{
+			{Name: "__init__", Params: []stubs.ParamDecl{{Name: "self"}}, ReturnType: "None"},
+			{Name: "ok", Params: []stubs.ParamDecl{{Name: "self"}}, ReturnType: "int"},
+		},
+	}
+	d := m.MapClass(cd)
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if len(d.Type.Methods) != 1 {
+		t.Errorf("methods = %+v (dunders should be skipped)", d.Type.Methods)
+	}
+	if len(d.Skipped) != 1 || d.Skipped[0].Reason != errors.SkipDunder {
+		t.Errorf("Skipped = %+v", d.Skipped)
+	}
+}
+
+func TestMapProtocolRefusesVarArgs(t *testing.T) {
+	m := &Mapper{}
+	cd := stubs.ClassDecl{
+		Name:       "P",
+		IsProtocol: true,
+		Methods: []stubs.FuncDecl{
+			{
+				Name: "fmt",
+				Params: []stubs.ParamDecl{
+					{Name: "self"},
+					{Name: "args", Kind: stubs.ParamVarArgs, Type: "Any"},
+				},
+				ReturnType: "str",
+			},
+		},
+	}
+	d := m.MapClass(cd)
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if len(d.Skipped) != 1 || d.Skipped[0].Reason != errors.SkipParamSpec {
+		t.Errorf("Skipped = %+v", d.Skipped)
+	}
+}
+
+func TestMapProtocolUnannotatedParamSkipped(t *testing.T) {
+	m := &Mapper{}
+	cd := stubs.ClassDecl{
+		Name:       "P",
+		IsProtocol: true,
+		Methods: []stubs.FuncDecl{
+			{
+				Name: "go",
+				Params: []stubs.ParamDecl{
+					{Name: "self"},
+					{Name: "x"}, // no annotation
+				},
+				ReturnType: "int",
+			},
+		},
+	}
+	d := m.MapClass(cd)
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if len(d.Skipped) != 1 {
+		t.Errorf("Skipped = %+v", d.Skipped)
+	}
+}
+
+func TestMapPlainClassRefused(t *testing.T) {
+	m := &Mapper{}
+	cd := stubs.ClassDecl{Name: "Plain"}
+	d := m.MapClass(cd)
+	if d.OK() {
+		t.Fatal("expected refusal: plain class")
+	}
+}
+
+func TestMapTypedDictFieldSkipped(t *testing.T) {
+	m := &Mapper{}
+	cd := stubs.ClassDecl{
+		Name:        "Mixed",
+		IsTypedDict: true,
+		Fields: []stubs.FieldDecl{
+			{Name: "x", Type: "int"},
+			{Name: "y", Type: "complex"}, // refusal
+		},
+	}
+	d := m.MapClass(cd)
+	if !d.OK() {
+		t.Fatalf("class skipped: %v", d.Skip)
+	}
+	if len(d.Type.Fields) != 1 {
+		t.Errorf("fields = %+v (complex should be skipped)", d.Type.Fields)
+	}
+	if len(d.Skipped) != 1 || d.Skipped[0].Reason != errors.SkipNoComplexType {
+		t.Errorf("Skipped = %+v", d.Skipped)
+	}
+}
+
+func TestMapFunction(t *testing.T) {
+	m := &Mapper{}
+	fn := stubs.FuncDecl{
+		Name: "add",
+		Params: []stubs.ParamDecl{
+			{Name: "a", Type: "int"},
+			{Name: "b", Type: "int"},
+		},
+		ReturnType: "int",
+	}
+	d := m.MapFunction(fn)
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if got := d.Type.Render(); got != "fun(int, int): int" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestMapFunctionAsync(t *testing.T) {
+	m := &Mapper{}
+	fn := stubs.FuncDecl{
+		Name:       "fetch",
+		IsAsync:    true,
+		Params:     []stubs.ParamDecl{{Name: "url", Type: "str"}},
+		ReturnType: "bytes",
+	}
+	d := m.MapFunction(fn)
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if got := d.Type.Render(); got != "fun(string): async bytes" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestMapFunctionNoReturnDefaultsToNone(t *testing.T) {
+	m := &Mapper{}
+	fn := stubs.FuncDecl{Name: "noop"}
+	d := m.MapFunction(fn)
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if got := d.Type.Render(); got != "fun(): None" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestMapFunctionVarArgsRefused(t *testing.T) {
+	m := &Mapper{}
+	fn := stubs.FuncDecl{
+		Name: "fmt",
+		Params: []stubs.ParamDecl{
+			{Name: "args", Kind: stubs.ParamVarArgs, Type: "Any"},
+		},
+		ReturnType: "str",
+	}
+	d := m.MapFunction(fn)
+	if d.OK() {
+		t.Fatal("expected refusal")
+	}
+	if d.Skip.Reason != errors.SkipParamSpec {
+		t.Errorf("reason = %v", d.Skip.Reason)
+	}
+}
+
+func TestClassDecoratedAsFrozen(t *testing.T) {
+	cases := []struct {
+		decorators []string
+		want       bool
+	}{
+		{nil, false},
+		{[]string{"dataclass"}, false},
+		{[]string{"dataclass(frozen=True)"}, true},
+		{[]string{"dataclass( frozen = True )"}, true},
+		{[]string{"dataclasses.dataclass(frozen=True)"}, true},
+		{[]string{"dataclass(eq=True, frozen=True)"}, true},
+		{[]string{"dataclass(frozen=False)"}, false},
+		{[]string{"property"}, false},
+	}
+	for _, c := range cases {
+		got := classDecoratedAsFrozen(stubs.ClassDecl{Decorators: c.decorators})
+		if got != c.want {
+			t.Errorf("decorators=%v: got %v, want %v", c.decorators, got, c.want)
+		}
+	}
+}

--- a/package3/python/typemap/doc.go
+++ b/package3/python/typemap/doc.go
@@ -1,0 +1,50 @@
+// Package typemap implements MEP-71 Phase 4: the closed Python-to-Mochi type
+// translation table.
+//
+// The table is "closed" in the sense that every Python type expression either
+// has a fixed Mochi rendering (e.g. `int -> int`, `list[T] -> list<T>` when T
+// is in-table) or is refused with a SkipReason from package errors. The
+// bridge does not invent dynamic interop types: aggressive "everything is
+// MochiPyAny" rendering is rejected on principle. The Mochi side gets typed
+// surfaces; out-of-table items become SkipReports the user can override with
+// hand-written `extern python fun` declarations in the MEP-51 sidecar.
+//
+// The supported lowerings, drawn from MEP-71 §3 and research note 05:
+//
+//	int                      -> int
+//	float                    -> float
+//	bool                     -> bool
+//	str                      -> string
+//	bytes                    -> bytes
+//	None                     -> None
+//	list[T]                  -> list<T>           (T must be in-table)
+//	tuple[A, B, ...]         -> tuple<A, B, ...>
+//	tuple[T, ...]            -> list<T>           (homogeneous form)
+//	dict[K, V]               -> map<K, V>         (K must be str or int)
+//	set[T]                   -> set<T>
+//	frozenset[T]             -> set<T>            (read-only)
+//	Optional[T] / T | None   -> T?
+//	X | Y                    -> X | Y             (PEP 604 sum type)
+//	Callable[[A, B], R]      -> fun(A, B): R
+//	Awaitable[T]             -> async T
+//	AsyncIterator[T]         -> stream<T>
+//	Iterator[T]              -> list<T>           (materialised at boundary)
+//	TypedDict                -> record
+//	@dataclass(frozen=True)  -> record
+//	Protocol                 -> interface
+//
+// The refusal set, drawn from research note 05 §"The refusal table":
+//
+//	Any (unparameterised), object (non-Protocol position)
+//	ParamSpec, Concatenate              -> SkipParamSpec
+//	TypeVarTuple beyond declared mono   -> SkipTypeVarTuple
+//	Unresolvable forward references     -> SkipForwardRef
+//	Mutable @dataclass                  -> SkipUnsupportedTypingConstruct
+//	complex                             -> SkipNoComplexType
+//	Generator types other than Iterator / AsyncIterator
+//	cast / assert_type / reveal_type    -> SkipUnsupportedTypingConstruct
+//
+// The Mapper drives the table. Callers feed it the raw type-expression strings
+// the Phase 3 .pyi reader stored on `ModuleSurface`. Each call returns a
+// Decision carrying either a *MochiType or a *errors.SkipReport.
+package typemap

--- a/package3/python/typemap/mapper.go
+++ b/package3/python/typemap/mapper.go
@@ -1,0 +1,421 @@
+package typemap
+
+import (
+	"fmt"
+	"strings"
+
+	"mochi/package3/python/errors"
+)
+
+// Decision is the result of mapping one Python type expression.
+type Decision struct {
+	// Type is the lowered MochiType. Zero-value when Skip is set.
+	Type MochiType
+	// Skip is non-nil when the mapping was refused.
+	Skip *errors.SkipReport
+}
+
+// OK reports whether the decision produced a usable type.
+func (d Decision) OK() bool { return d.Skip == nil }
+
+// Mapper applies the closed type table to Python type expressions.
+type Mapper struct {
+	// TypeVars is the set of in-scope type variables. Names found here lower
+	// to KindTypeVar instead of refusing as an unknown identifier.
+	TypeVars map[string]bool
+	// Classes is the set of in-scope user-defined class names. Names found
+	// here lower to KindRef.
+	Classes map[string]bool
+	// AllowPartial, when true, permits Any -> ref<Any> lowering for sources
+	// marked Partial = true by Phase 3. When false (default), Any is refused.
+	AllowPartial bool
+	// ItemPath is the dotted qualified path of the item currently being
+	// mapped, used to populate the SkipReport ItemPath field.
+	ItemPath string
+}
+
+// Map parses and lowers a single Python type expression.
+func (m *Mapper) Map(expr string) Decision {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return m.skip(errors.SkipUnsupportedTypingConstruct, "empty type expression", "")
+	}
+	pt, err := ParsePyType(expr)
+	if err != nil {
+		return m.skip(errors.SkipUnsupportedTypingConstruct, err.Error(), "")
+	}
+	return m.mapNode(pt, expr)
+}
+
+// MapParsed lowers an already-parsed PyType.
+func (m *Mapper) MapParsed(pt PyType) Decision {
+	return m.mapNode(pt, pt.String())
+}
+
+func (m *Mapper) skip(reason errors.SkipReason, detail, override string) Decision {
+	return Decision{Skip: &errors.SkipReport{
+		ItemPath: m.ItemPath,
+		Reason:   reason,
+		Detail:   detail,
+		Override: override,
+	}}
+}
+
+func (m *Mapper) mapNode(pt PyType, src string) Decision {
+	switch pt.Kind {
+	case PyName:
+		return m.mapName(pt.Name)
+	case PyAttr:
+		// Strip typing / collections.abc / builtins module prefixes.
+		qn := pt.QualifiedName()
+		if qn == "" {
+			return m.skip(errors.SkipUnsupportedTypingConstruct, "non-identifier attribute base in "+src, "")
+		}
+		return m.mapQualified(qn)
+	case PySubscript:
+		return m.mapSubscript(pt)
+	case PyUnion:
+		return m.mapUnion(pt.Args)
+	case PyLiteral:
+		// Bare literal at type position: forward reference (string) or None.
+		if pt.Literal == "None" {
+			return Decision{Type: NewScalar("None")}
+		}
+		if strings.HasPrefix(pt.Literal, "\"") || strings.HasPrefix(pt.Literal, "'") {
+			// Forward reference: try to resolve against Classes / TypeVars.
+			inner := pt.Literal[1 : len(pt.Literal)-1]
+			return m.mapName(inner)
+		}
+		return m.skip(errors.SkipUnsupportedTypingConstruct, "bare literal "+pt.Literal+" at type position", "")
+	case PyEllipsis:
+		return m.skip(errors.SkipUnsupportedTypingConstruct, "bare ellipsis at type position", "")
+	default:
+		return m.skip(errors.SkipUnsupportedTypingConstruct, "unsupported type expression: "+src, "")
+	}
+}
+
+// mapName resolves an unqualified identifier.
+func (m *Mapper) mapName(name string) Decision {
+	if t, ok := lookupScalar(name); ok {
+		return Decision{Type: t}
+	}
+	if m.TypeVars[name] {
+		return Decision{Type: NewTypeVar(name)}
+	}
+	if m.Classes[name] {
+		return Decision{Type: NewRef(name)}
+	}
+	switch name {
+	case "Any":
+		if m.AllowPartial {
+			return Decision{Type: NewRef("Any")}
+		}
+		return m.skip(errors.SkipUnsupportedTypingConstruct, "Any has no Mochi counterpart",
+			"declare a concrete type via @extern python override")
+	case "object":
+		return m.skip(errors.SkipUnsupportedTypingConstruct, "object outside Protocol position", "")
+	case "complex":
+		return m.skip(errors.SkipNoComplexType, "Python complex has no Mochi counterpart", "")
+	case "Self":
+		return Decision{Type: NewRef("Self")}
+	case "List", "Tuple", "Dict", "Set", "FrozenSet", "Optional", "Union",
+		"Callable", "Awaitable", "AsyncIterator", "Iterator", "Iterable",
+		"Type", "Literal", "Final", "ClassVar", "Annotated", "TypedDict",
+		"Protocol", "TypeVar", "ParamSpec", "TypeVarTuple", "Generic",
+		"Concatenate", "Unpack", "NotRequired", "Required":
+		// Bare typing constructor without subscript: meaningless on its own.
+		return m.skip(errors.SkipUnsupportedTypingConstruct, "bare typing constructor "+name+" without subscript", "")
+	}
+	return m.skip(errors.SkipForwardRef, "unresolved name "+name, "")
+}
+
+// mapQualified resolves a dotted identifier like `typing.List`.
+func (m *Mapper) mapQualified(qn string) Decision {
+	// Strip well-known module prefixes.
+	for _, prefix := range []string{
+		"typing.", "typing_extensions.", "collections.abc.", "builtins.",
+	} {
+		if strings.HasPrefix(qn, prefix) {
+			return m.mapName(strings.TrimPrefix(qn, prefix))
+		}
+	}
+	// User-defined classes with dotted access (e.g. mod.MyClass) lower to ref.
+	parts := strings.Split(qn, ".")
+	tail := parts[len(parts)-1]
+	if m.Classes[tail] {
+		return Decision{Type: NewRef(tail)}
+	}
+	return m.skip(errors.SkipForwardRef, "unresolved qualified name "+qn, "")
+}
+
+func (m *Mapper) mapSubscript(pt PyType) Decision {
+	base := pt.Base.QualifiedName()
+	if base == "" {
+		return m.skip(errors.SkipUnsupportedTypingConstruct, "non-identifier subscript base", "")
+	}
+	// Normalise module prefix.
+	for _, prefix := range []string{
+		"typing.", "typing_extensions.", "collections.abc.", "builtins.",
+	} {
+		if strings.HasPrefix(base, prefix) {
+			base = strings.TrimPrefix(base, prefix)
+			break
+		}
+	}
+	args := pt.Args
+	switch base {
+	case "list", "List":
+		if len(args) != 1 {
+			return m.skip(errors.SkipUnsupportedTypingConstruct, fmt.Sprintf("list takes 1 type argument, got %d", len(args)), "")
+		}
+		inner := m.MapParsed(args[0])
+		if !inner.OK() {
+			return inner
+		}
+		return Decision{Type: NewList(inner.Type)}
+	case "set", "Set":
+		if len(args) != 1 {
+			return m.skip(errors.SkipUnsupportedTypingConstruct, fmt.Sprintf("set takes 1 type argument, got %d", len(args)), "")
+		}
+		inner := m.MapParsed(args[0])
+		if !inner.OK() {
+			return inner
+		}
+		return Decision{Type: NewSet(inner.Type)}
+	case "frozenset", "FrozenSet":
+		if len(args) != 1 {
+			return m.skip(errors.SkipUnsupportedTypingConstruct, fmt.Sprintf("frozenset takes 1 type argument, got %d", len(args)), "")
+		}
+		inner := m.MapParsed(args[0])
+		if !inner.OK() {
+			return inner
+		}
+		return Decision{Type: NewSet(inner.Type)}
+	case "dict", "Dict", "Mapping", "MutableMapping":
+		if len(args) != 2 {
+			return m.skip(errors.SkipUnsupportedTypingConstruct, fmt.Sprintf("dict takes 2 type arguments, got %d", len(args)), "")
+		}
+		key := m.MapParsed(args[0])
+		if !key.OK() {
+			return key
+		}
+		val := m.MapParsed(args[1])
+		if !val.OK() {
+			return val
+		}
+		if !isValidMapKey(key.Type) {
+			return m.skip(errors.SkipUnsupportedTypingConstruct,
+				"map keys must be str or an integer type, got "+key.Type.Render(), "")
+		}
+		return Decision{Type: NewMap(key.Type, val.Type)}
+	case "tuple", "Tuple":
+		// `tuple[T, ...]` is homogeneous list.
+		if len(args) == 2 && args[1].Kind == PyEllipsis {
+			inner := m.MapParsed(args[0])
+			if !inner.OK() {
+				return inner
+			}
+			return Decision{Type: NewList(inner.Type)}
+		}
+		var elems []MochiType
+		for _, a := range args {
+			d := m.MapParsed(a)
+			if !d.OK() {
+				return d
+			}
+			elems = append(elems, d.Type)
+		}
+		return Decision{Type: NewTuple(elems...)}
+	case "Optional":
+		if len(args) != 1 {
+			return m.skip(errors.SkipUnsupportedTypingConstruct, "Optional takes 1 type argument", "")
+		}
+		inner := m.MapParsed(args[0])
+		if !inner.OK() {
+			return inner
+		}
+		return Decision{Type: NewOptional(inner.Type)}
+	case "Union":
+		return m.mapUnion(args)
+	case "Callable":
+		return m.mapCallable(args)
+	case "Awaitable", "Coroutine":
+		// Coroutine[Y, S, R] -> Awaitable-ish: only R matters for our model.
+		var inner Decision
+		if base == "Awaitable" {
+			if len(args) != 1 {
+				return m.skip(errors.SkipUnsupportedTypingConstruct, "Awaitable takes 1 type argument", "")
+			}
+			inner = m.MapParsed(args[0])
+		} else {
+			if len(args) != 3 {
+				return m.skip(errors.SkipUnsupportedTypingConstruct, "Coroutine takes 3 type arguments", "")
+			}
+			inner = m.MapParsed(args[2])
+		}
+		if !inner.OK() {
+			return inner
+		}
+		return Decision{Type: NewAsync(inner.Type)}
+	case "AsyncIterator", "AsyncIterable":
+		if len(args) != 1 {
+			return m.skip(errors.SkipUnsupportedTypingConstruct, "AsyncIterator takes 1 type argument", "")
+		}
+		inner := m.MapParsed(args[0])
+		if !inner.OK() {
+			return inner
+		}
+		return Decision{Type: NewStream(inner.Type)}
+	case "Iterator", "Iterable":
+		if len(args) != 1 {
+			return m.skip(errors.SkipUnsupportedTypingConstruct, "Iterator takes 1 type argument", "")
+		}
+		inner := m.MapParsed(args[0])
+		if !inner.OK() {
+			return inner
+		}
+		return Decision{Type: NewList(inner.Type)}
+	case "Type":
+		return m.skip(errors.SkipUnsupportedTypingConstruct, "Type[X] has no Mochi counterpart", "")
+	case "Literal":
+		// Single-arm Literal of a known type collapses to that scalar.
+		if len(args) == 0 {
+			return m.skip(errors.SkipUnsupportedTypingConstruct, "Literal[] requires at least one argument", "")
+		}
+		return m.mapLiteral(args)
+	case "Final", "ClassVar":
+		if len(args) != 1 {
+			return m.skip(errors.SkipUnsupportedTypingConstruct, base+" takes 1 type argument", "")
+		}
+		return m.MapParsed(args[0])
+	case "Annotated":
+		if len(args) < 1 {
+			return m.skip(errors.SkipUnsupportedTypingConstruct, "Annotated requires a type argument", "")
+		}
+		return m.MapParsed(args[0])
+	case "ParamSpec", "Concatenate":
+		return m.skip(errors.SkipParamSpec, "ParamSpec / Concatenate is out of scope", "")
+	case "TypeVarTuple", "Unpack":
+		return m.skip(errors.SkipTypeVarTuple, "TypeVarTuple / Unpack is out of scope", "")
+	case "Generator", "AsyncGenerator":
+		return m.skip(errors.SkipUnsupportedTypingConstruct,
+			"Generator types other than Iterator / AsyncIterator are out of scope", "")
+	case "NotRequired", "Required":
+		if len(args) != 1 {
+			return m.skip(errors.SkipUnsupportedTypingConstruct, base+" takes 1 type argument", "")
+		}
+		return m.MapParsed(args[0])
+	}
+	// User-defined generic class: lower as ref<T1, T2>.
+	if m.Classes[base] {
+		ref := MochiType{Kind: KindRef, Name: base}
+		for _, a := range args {
+			d := m.MapParsed(a)
+			if !d.OK() {
+				return d
+			}
+			ref.Params = append(ref.Params, d.Type)
+		}
+		return Decision{Type: ref}
+	}
+	return m.skip(errors.SkipForwardRef, "unresolved subscript base "+base, "")
+}
+
+func (m *Mapper) mapUnion(branches []PyType) Decision {
+	if len(branches) == 0 {
+		return m.skip(errors.SkipUnsupportedTypingConstruct, "empty union", "")
+	}
+	var out []MochiType
+	for _, b := range branches {
+		d := m.MapParsed(b)
+		if !d.OK() {
+			return d
+		}
+		if d.Type.Kind == KindRef && d.Type.Name == "Any" {
+			return m.skip(errors.SkipOpenUnion, "union branch is Any", "")
+		}
+		out = append(out, d.Type)
+	}
+	return Decision{Type: NewSum(out...)}
+}
+
+func (m *Mapper) mapCallable(args []PyType) Decision {
+	if len(args) != 2 {
+		return m.skip(errors.SkipUnsupportedTypingConstruct,
+			fmt.Sprintf("Callable takes 2 arguments, got %d", len(args)), "")
+	}
+	paramsNode := args[0]
+	if paramsNode.Kind == PyEllipsis {
+		return m.skip(errors.SkipParamSpec, "Callable[..., R] is out of scope (ParamSpec-shaped)", "")
+	}
+	if paramsNode.Kind != PyTuple {
+		return m.skip(errors.SkipUnsupportedTypingConstruct, "Callable parameter list must be a bracketed sequence", "")
+	}
+	var params []MochiType
+	for _, p := range paramsNode.Args {
+		d := m.MapParsed(p)
+		if !d.OK() {
+			return d
+		}
+		params = append(params, d.Type)
+	}
+	ret := m.MapParsed(args[1])
+	if !ret.OK() {
+		return ret
+	}
+	return Decision{Type: NewFun(ret.Type, params...)}
+}
+
+func (m *Mapper) mapLiteral(args []PyType) Decision {
+	// Single-shape Literal collapses to a known scalar; mixed shapes refuse.
+	var kind MochiType
+	for _, a := range args {
+		var k MochiType
+		switch {
+		case a.Kind == PyLiteral && (strings.HasPrefix(a.Literal, "\"") || strings.HasPrefix(a.Literal, "'")):
+			k = NewScalar("string")
+		case a.Kind == PyLiteral && (a.Literal == "True" || a.Literal == "False"):
+			k = NewScalar("bool")
+		case a.Kind == PyLiteral && a.Literal == "None":
+			k = NewScalar("None")
+		case a.Kind == PyLiteral:
+			k = NewScalar("int")
+		default:
+			return m.skip(errors.SkipUnsupportedTypingConstruct, "Literal argument must be a literal, got "+a.String(), "")
+		}
+		if kind.Kind == KindUnknown {
+			kind = k
+		} else if !kind.Equal(k) {
+			return m.skip(errors.SkipUnsupportedTypingConstruct, "Literal arguments of mixed kinds are out of scope", "")
+		}
+	}
+	return Decision{Type: kind}
+}
+
+// lookupScalar is the closed scalar table.
+func lookupScalar(name string) (MochiType, bool) {
+	switch name {
+	case "int":
+		return NewScalar("int"), true
+	case "float":
+		return NewScalar("float"), true
+	case "bool":
+		return NewScalar("bool"), true
+	case "str":
+		return NewScalar("string"), true
+	case "bytes":
+		return NewScalar("bytes"), true
+	case "None", "NoneType":
+		return NewScalar("None"), true
+	}
+	return MochiType{}, false
+}
+
+// isValidMapKey is the spec rule "map keys must be str or one of the integer
+// types". `bool` is excluded because Mochi's map keys exclude bool by policy.
+func isValidMapKey(t MochiType) bool {
+	if t.Kind != KindScalar {
+		return false
+	}
+	return t.Name == "string" || t.Name == "int"
+}

--- a/package3/python/typemap/mapper_test.go
+++ b/package3/python/typemap/mapper_test.go
@@ -1,0 +1,468 @@
+package typemap
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/python/errors"
+)
+
+func TestMapScalars(t *testing.T) {
+	m := &Mapper{}
+	cases := map[string]string{
+		"int":      "int",
+		"float":    "float",
+		"bool":     "bool",
+		"str":      "string",
+		"bytes":    "bytes",
+		"None":     "None",
+		"NoneType": "None",
+	}
+	for src, want := range cases {
+		d := m.Map(src)
+		if !d.OK() {
+			t.Errorf("%q -> skip %s", src, d.Skip.Detail)
+			continue
+		}
+		if got := d.Type.Render(); got != want {
+			t.Errorf("%q -> %q, want %q", src, got, want)
+		}
+	}
+}
+
+func TestMapListVariants(t *testing.T) {
+	m := &Mapper{}
+	for _, src := range []string{"list[int]", "List[int]", "typing.List[int]"} {
+		d := m.Map(src)
+		if !d.OK() {
+			t.Errorf("%q skipped: %v", src, d.Skip)
+			continue
+		}
+		if got := d.Type.Render(); got != "list<int>" {
+			t.Errorf("%q -> %q", src, got)
+		}
+	}
+}
+
+func TestMapDict(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("Dict[str, int]")
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if got := d.Type.Render(); got != "map<string, int>" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestMapDictRefusesNonScalarKey(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("Dict[float, int]")
+	if d.OK() {
+		t.Fatal("expected refusal: float key")
+	}
+	d = m.Map("Dict[bool, int]")
+	if d.OK() {
+		t.Fatal("expected refusal: bool key")
+	}
+}
+
+func TestMapTupleHomogeneous(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("tuple[int, ...]")
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if got := d.Type.Render(); got != "list<int>" {
+		t.Errorf("tuple[T, ...] -> %q", got)
+	}
+}
+
+func TestMapTupleHeterogeneous(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("tuple[int, str, bool]")
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if got := d.Type.Render(); got != "tuple<int, string, bool>" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestMapSetAndFrozenSet(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("set[int]")
+	if !d.OK() || d.Type.Render() != "set<int>" {
+		t.Errorf("set: %+v", d)
+	}
+	d = m.Map("frozenset[int]")
+	if !d.OK() || d.Type.Render() != "set<int>" {
+		t.Errorf("frozenset: %+v", d)
+	}
+}
+
+func TestMapOptional(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("Optional[int]")
+	if !d.OK() || d.Type.Render() != "int?" {
+		t.Errorf("Optional[int]: %+v", d)
+	}
+	d = m.Map("int | None")
+	if !d.OK() || d.Type.Render() != "int?" {
+		t.Errorf("int | None: %+v", d)
+	}
+	d = m.Map("None | int")
+	if !d.OK() || d.Type.Render() != "int?" {
+		t.Errorf("None | int: %+v", d)
+	}
+}
+
+func TestMapUnion(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("int | str")
+	if !d.OK() || d.Type.Render() != "int | string" {
+		t.Errorf("int | str: %+v", d)
+	}
+	d = m.Map("int | str | None")
+	if !d.OK() || d.Type.Render() != "int | string?" {
+		t.Errorf("int | str | None: got %q", d.Type.Render())
+	}
+}
+
+func TestMapCallable(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("Callable[[int, str], bool]")
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if got := d.Type.Render(); got != "fun(int, string): bool" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestMapCallableEllipsisRefused(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("Callable[..., int]")
+	if d.OK() {
+		t.Fatal("expected refusal")
+	}
+	if d.Skip.Reason != errors.SkipParamSpec {
+		t.Errorf("reason = %v", d.Skip.Reason)
+	}
+}
+
+func TestMapAwaitable(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("Awaitable[int]")
+	if !d.OK() || d.Type.Render() != "async int" {
+		t.Errorf("got %+v", d)
+	}
+}
+
+func TestMapCoroutine(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("Coroutine[Any, Any, int]")
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if got := d.Type.Render(); got != "async int" {
+		t.Errorf("Coroutine[Y, S, R] -> %q (want async R)", got)
+	}
+}
+
+func TestMapAsyncIterator(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("AsyncIterator[int]")
+	if !d.OK() || d.Type.Render() != "stream<int>" {
+		t.Errorf("got %+v", d)
+	}
+}
+
+func TestMapIterator(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("Iterator[int]")
+	if !d.OK() || d.Type.Render() != "list<int>" {
+		t.Errorf("got %+v", d)
+	}
+}
+
+func TestMapAnyRefusedByDefault(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("Any")
+	if d.OK() {
+		t.Fatal("expected refusal")
+	}
+	if d.Skip.Reason != errors.SkipUnsupportedTypingConstruct {
+		t.Errorf("reason = %v", d.Skip.Reason)
+	}
+}
+
+func TestMapAnyAllowedWhenPartial(t *testing.T) {
+	m := &Mapper{AllowPartial: true}
+	d := m.Map("Any")
+	if !d.OK() {
+		t.Fatalf("expected mapped Any: %v", d.Skip)
+	}
+}
+
+func TestMapComplexRefused(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("complex")
+	if d.OK() {
+		t.Fatal("expected refusal")
+	}
+	if d.Skip.Reason != errors.SkipNoComplexType {
+		t.Errorf("reason = %v", d.Skip.Reason)
+	}
+}
+
+func TestMapParamSpecRefused(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("ParamSpec[P]")
+	if d.OK() {
+		t.Fatal("expected refusal")
+	}
+	if d.Skip.Reason != errors.SkipParamSpec {
+		t.Errorf("reason = %v", d.Skip.Reason)
+	}
+}
+
+func TestMapTypeVarTupleRefused(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("Unpack[Ts]")
+	if d.OK() {
+		t.Fatal("expected refusal")
+	}
+	if d.Skip.Reason != errors.SkipTypeVarTuple {
+		t.Errorf("reason = %v", d.Skip.Reason)
+	}
+}
+
+func TestMapGeneratorRefused(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("Generator[int, None, None]")
+	if d.OK() {
+		t.Fatal("expected refusal")
+	}
+}
+
+func TestMapForwardRefResolved(t *testing.T) {
+	m := &Mapper{Classes: map[string]bool{"MyClass": true}}
+	d := m.Map(`"MyClass"`)
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if d.Type.Kind != KindRef || d.Type.Name != "MyClass" {
+		t.Errorf("got %+v", d.Type)
+	}
+}
+
+func TestMapForwardRefUnresolved(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("UnknownClass")
+	if d.OK() {
+		t.Fatal("expected SkipForwardRef")
+	}
+	if d.Skip.Reason != errors.SkipForwardRef {
+		t.Errorf("reason = %v", d.Skip.Reason)
+	}
+}
+
+func TestMapTypeVar(t *testing.T) {
+	m := &Mapper{TypeVars: map[string]bool{"T": true}}
+	d := m.Map("T")
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if d.Type.Kind != KindTypeVar || d.Type.Name != "T" {
+		t.Errorf("got %+v", d.Type)
+	}
+}
+
+func TestMapTypeVarInList(t *testing.T) {
+	m := &Mapper{TypeVars: map[string]bool{"T": true}}
+	d := m.Map("List[T]")
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if d.Type.Render() != "list<T>" {
+		t.Errorf("got %q", d.Type.Render())
+	}
+}
+
+func TestMapClassRef(t *testing.T) {
+	m := &Mapper{Classes: map[string]bool{"MyClass": true}}
+	d := m.Map("MyClass")
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if d.Type.Kind != KindRef || d.Type.Name != "MyClass" {
+		t.Errorf("got %+v", d.Type)
+	}
+}
+
+func TestMapGenericClass(t *testing.T) {
+	m := &Mapper{Classes: map[string]bool{"Container": true}}
+	d := m.Map("Container[int]")
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if d.Type.Kind != KindRef || d.Type.Name != "Container" || len(d.Type.Params) != 1 {
+		t.Errorf("got %+v", d.Type)
+	}
+}
+
+func TestMapLiteralCollapsesToScalar(t *testing.T) {
+	m := &Mapper{}
+	cases := map[string]string{
+		`Literal["a"]`:           "string",
+		`Literal["a", "b", "c"]`: "string",
+		`Literal[1]`:              "int",
+		`Literal[1, 2, 3]`:        "int",
+		`Literal[True]`:           "bool",
+		`Literal[True, False]`:    "bool",
+		`Literal[None]`:           "None",
+	}
+	for src, want := range cases {
+		d := m.Map(src)
+		if !d.OK() {
+			t.Errorf("%q skipped: %v", src, d.Skip)
+			continue
+		}
+		if got := d.Type.Render(); got != want {
+			t.Errorf("%q -> %q, want %q", src, got, want)
+		}
+	}
+}
+
+func TestMapLiteralMixedRefused(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map(`Literal["a", 1]`)
+	if d.OK() {
+		t.Fatal("expected refusal: mixed Literal")
+	}
+}
+
+func TestMapFinalUnwraps(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("Final[int]")
+	if !d.OK() || d.Type.Render() != "int" {
+		t.Errorf("got %+v", d)
+	}
+}
+
+func TestMapClassVarUnwraps(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("ClassVar[int]")
+	if !d.OK() || d.Type.Render() != "int" {
+		t.Errorf("got %+v", d)
+	}
+}
+
+func TestMapAnnotatedUnwraps(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map(`Annotated[int, "range(0, 100)"]`)
+	if !d.OK() || d.Type.Render() != "int" {
+		t.Errorf("got %+v", d)
+	}
+}
+
+func TestMapNotRequiredUnwraps(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("NotRequired[int]")
+	if !d.OK() || d.Type.Render() != "int" {
+		t.Errorf("got %+v", d)
+	}
+}
+
+func TestMapTypeRefused(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("Type[int]")
+	if d.OK() {
+		t.Fatal("expected refusal")
+	}
+}
+
+func TestMapNestedSuccess(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("Dict[str, List[Optional[int]]]")
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if d.Type.Render() != "map<string, list<int?>>" {
+		t.Errorf("got %q", d.Type.Render())
+	}
+}
+
+func TestMapEmpty(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("")
+	if d.OK() {
+		t.Fatal("expected refusal on empty")
+	}
+}
+
+func TestMapItemPathPropagates(t *testing.T) {
+	m := &Mapper{ItemPath: "mod.Foo.bar"}
+	d := m.Map("complex")
+	if d.OK() {
+		t.Fatal("expected refusal")
+	}
+	if d.Skip.ItemPath != "mod.Foo.bar" {
+		t.Errorf("ItemPath = %q", d.Skip.ItemPath)
+	}
+}
+
+func TestMapBareTypingConstructorRefused(t *testing.T) {
+	m := &Mapper{}
+	for _, src := range []string{"List", "Optional", "Union", "Callable"} {
+		d := m.Map(src)
+		if d.OK() {
+			t.Errorf("%q: expected refusal", src)
+		}
+	}
+}
+
+func TestMapUnionWithAnyRefused(t *testing.T) {
+	m := &Mapper{AllowPartial: true}
+	d := m.Map("int | Any")
+	if d.OK() {
+		t.Fatal("expected SkipOpenUnion when Any appears in union (even with AllowPartial)")
+	}
+	if d.Skip.Reason != errors.SkipOpenUnion {
+		t.Errorf("reason = %v", d.Skip.Reason)
+	}
+}
+
+func TestMapBuiltinsPrefixStripped(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("builtins.int")
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if d.Type.Render() != "int" {
+		t.Errorf("got %q", d.Type.Render())
+	}
+}
+
+func TestMapCollectionsAbcStripped(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("collections.abc.Iterable[int]")
+	if !d.OK() {
+		t.Fatalf("skipped: %v", d.Skip)
+	}
+	if d.Type.Render() != "list<int>" {
+		t.Errorf("got %q", d.Type.Render())
+	}
+}
+
+func TestMapInvalidArityList(t *testing.T) {
+	m := &Mapper{}
+	d := m.Map("List[int, str]")
+	if d.OK() {
+		t.Fatal("expected refusal: list takes 1 arg")
+	}
+	if !strings.Contains(d.Skip.Detail, "1 type argument") {
+		t.Errorf("detail = %q", d.Skip.Detail)
+	}
+}

--- a/package3/python/typemap/mochitype.go
+++ b/package3/python/typemap/mochitype.go
@@ -1,0 +1,384 @@
+package typemap
+
+import (
+	"sort"
+	"strings"
+)
+
+// Kind classifies a MochiType. The set is deliberately small; the Mochi side
+// of the bridge speaks a closed subset of the Mochi type grammar.
+type Kind int
+
+const (
+	// KindUnknown is the zero value and must not appear in committed mappings.
+	KindUnknown Kind = iota
+	// KindScalar is a single named scalar (int, float, bool, string, bytes, None).
+	KindScalar
+	// KindList is `list<T>`.
+	KindList
+	// KindTuple is `tuple<A, B, ...>` (heterogeneous form). Use KindList for the
+	// homogeneous `tuple[T, ...]` form.
+	KindTuple
+	// KindMap is `map<K, V>` (K must be a scalar string or integer type).
+	KindMap
+	// KindSet is `set<T>`.
+	KindSet
+	// KindFun is `fun(P0, P1, ...): R`.
+	KindFun
+	// KindAsync is `async T`, derived from `Awaitable[T]`.
+	KindAsync
+	// KindStream is `stream<T>`, derived from `AsyncIterator[T]`.
+	KindStream
+	// KindOptional is `T?`, derived from `Optional[T]` or `T | None`.
+	KindOptional
+	// KindSum is a PEP 604 union `T1 | T2 | ...` with no None branch.
+	KindSum
+	// KindRecord is a Mochi record (TypedDict or frozen @dataclass).
+	KindRecord
+	// KindInterface is a Mochi interface (Python Protocol).
+	KindInterface
+	// KindRef is a reference to a user-defined class by name.
+	KindRef
+	// KindTypeVar is a bound polymorphic type variable left in the surface for
+	// generic functions; Phase 5 chooses whether to monomorphise.
+	KindTypeVar
+)
+
+// String renders the Kind as a stable token.
+func (k Kind) String() string {
+	switch k {
+	case KindScalar:
+		return "scalar"
+	case KindList:
+		return "list"
+	case KindTuple:
+		return "tuple"
+	case KindMap:
+		return "map"
+	case KindSet:
+		return "set"
+	case KindFun:
+		return "fun"
+	case KindAsync:
+		return "async"
+	case KindStream:
+		return "stream"
+	case KindOptional:
+		return "optional"
+	case KindSum:
+		return "sum"
+	case KindRecord:
+		return "record"
+	case KindInterface:
+		return "interface"
+	case KindRef:
+		return "ref"
+	case KindTypeVar:
+		return "typevar"
+	default:
+		return "unknown"
+	}
+}
+
+// MochiType is the lowered representation of a Python type expression.
+// Every field is optional and only meaningful for specific Kinds. The
+// constructors below produce well-formed values.
+type MochiType struct {
+	Kind Kind
+	// Name is the scalar / ref / typevar identifier ("int", "string", "MyClass", "T").
+	Name string
+	// Params is the parameter list for parameterised kinds:
+	//   list<T>      -> Params = [T]
+	//   tuple<A, B>  -> Params = [A, B]
+	//   map<K, V>    -> Params = [K, V]
+	//   set<T>       -> Params = [T]
+	//   fun(P0): R   -> Params = [P0, ..., R]   (return type is the last entry)
+	//   async T      -> Params = [T]
+	//   stream<T>    -> Params = [T]
+	//   optional T   -> Params = [T]
+	//   sum T1 | T2  -> Params = [T1, T2, ...]
+	Params []MochiType
+	// Fields are the named members of a record.
+	Fields []MochiField
+	// Methods are the surface methods of an interface.
+	Methods []MochiMethod
+}
+
+// MochiField is one named record field.
+type MochiField struct {
+	Name string
+	Type MochiType
+}
+
+// MochiMethod is one interface method.
+type MochiMethod struct {
+	Name   string
+	Params []MochiType
+	Return MochiType
+	IsAsync bool
+}
+
+// NewScalar constructs a scalar type.
+func NewScalar(name string) MochiType { return MochiType{Kind: KindScalar, Name: name} }
+
+// NewRef constructs a reference to a user-defined type.
+func NewRef(name string) MochiType { return MochiType{Kind: KindRef, Name: name} }
+
+// NewTypeVar constructs a bound type variable.
+func NewTypeVar(name string) MochiType { return MochiType{Kind: KindTypeVar, Name: name} }
+
+// NewList constructs `list<T>`.
+func NewList(t MochiType) MochiType { return MochiType{Kind: KindList, Params: []MochiType{t}} }
+
+// NewSet constructs `set<T>`.
+func NewSet(t MochiType) MochiType { return MochiType{Kind: KindSet, Params: []MochiType{t}} }
+
+// NewMap constructs `map<K, V>`.
+func NewMap(k, v MochiType) MochiType {
+	return MochiType{Kind: KindMap, Params: []MochiType{k, v}}
+}
+
+// NewTuple constructs `tuple<A, B, ...>`.
+func NewTuple(elems ...MochiType) MochiType {
+	return MochiType{Kind: KindTuple, Params: append([]MochiType(nil), elems...)}
+}
+
+// NewFun constructs `fun(P0, ...): R`. The return type is appended as the
+// final Params element.
+func NewFun(ret MochiType, params ...MochiType) MochiType {
+	all := append([]MochiType(nil), params...)
+	all = append(all, ret)
+	return MochiType{Kind: KindFun, Params: all}
+}
+
+// NewAsync constructs `async T`.
+func NewAsync(t MochiType) MochiType { return MochiType{Kind: KindAsync, Params: []MochiType{t}} }
+
+// NewStream constructs `stream<T>`.
+func NewStream(t MochiType) MochiType { return MochiType{Kind: KindStream, Params: []MochiType{t}} }
+
+// NewOptional constructs `T?`. If t is already optional, it is returned as-is.
+func NewOptional(t MochiType) MochiType {
+	if t.Kind == KindOptional {
+		return t
+	}
+	return MochiType{Kind: KindOptional, Params: []MochiType{t}}
+}
+
+// NewSum constructs `T1 | T2 | ...`. If there's only one branch it is
+// returned directly. A None branch is converted into a wrapping Optional.
+func NewSum(branches ...MochiType) MochiType {
+	none := false
+	var nonNone []MochiType
+	for _, b := range branches {
+		if b.Kind == KindScalar && b.Name == "None" {
+			none = true
+			continue
+		}
+		nonNone = append(nonNone, b)
+	}
+	if len(nonNone) == 0 {
+		return NewScalar("None")
+	}
+	var inner MochiType
+	if len(nonNone) == 1 {
+		inner = nonNone[0]
+	} else {
+		inner = MochiType{Kind: KindSum, Params: nonNone}
+	}
+	if none {
+		return NewOptional(inner)
+	}
+	return inner
+}
+
+// Return returns the return-type component of a KindFun MochiType. Panics if
+// Kind is not KindFun.
+func (m MochiType) Return() MochiType {
+	if m.Kind != KindFun {
+		panic("typemap: Return called on non-fun MochiType")
+	}
+	if len(m.Params) == 0 {
+		return NewScalar("None")
+	}
+	return m.Params[len(m.Params)-1]
+}
+
+// FunParams returns the parameter slice of a KindFun (excluding the return).
+func (m MochiType) FunParams() []MochiType {
+	if m.Kind != KindFun {
+		panic("typemap: FunParams called on non-fun MochiType")
+	}
+	if len(m.Params) == 0 {
+		return nil
+	}
+	return m.Params[:len(m.Params)-1]
+}
+
+// Render produces the canonical Mochi-side string representation of the
+// MochiType. The output is stable across releases and is used in generated
+// extern declarations.
+func (m MochiType) Render() string {
+	var b strings.Builder
+	m.renderInto(&b)
+	return b.String()
+}
+
+func (m MochiType) renderInto(b *strings.Builder) {
+	switch m.Kind {
+	case KindScalar, KindRef, KindTypeVar:
+		b.WriteString(m.Name)
+	case KindList:
+		b.WriteString("list<")
+		m.Params[0].renderInto(b)
+		b.WriteString(">")
+	case KindSet:
+		b.WriteString("set<")
+		m.Params[0].renderInto(b)
+		b.WriteString(">")
+	case KindMap:
+		b.WriteString("map<")
+		m.Params[0].renderInto(b)
+		b.WriteString(", ")
+		m.Params[1].renderInto(b)
+		b.WriteString(">")
+	case KindTuple:
+		b.WriteString("tuple<")
+		for i, p := range m.Params {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			p.renderInto(b)
+		}
+		b.WriteString(">")
+	case KindAsync:
+		b.WriteString("async ")
+		m.Params[0].renderInto(b)
+	case KindStream:
+		b.WriteString("stream<")
+		m.Params[0].renderInto(b)
+		b.WriteString(">")
+	case KindOptional:
+		m.Params[0].renderInto(b)
+		b.WriteString("?")
+	case KindSum:
+		for i, p := range m.Params {
+			if i > 0 {
+				b.WriteString(" | ")
+			}
+			p.renderInto(b)
+		}
+	case KindFun:
+		b.WriteString("fun(")
+		params := m.FunParams()
+		for i, p := range params {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			p.renderInto(b)
+		}
+		b.WriteString("): ")
+		m.Return().renderInto(b)
+	case KindRecord:
+		b.WriteString("record ")
+		b.WriteString(m.Name)
+		b.WriteString(" { ")
+		names := make([]string, 0, len(m.Fields))
+		index := make(map[string]MochiField, len(m.Fields))
+		for _, f := range m.Fields {
+			names = append(names, f.Name)
+			index[f.Name] = f
+		}
+		sort.Strings(names)
+		for i, n := range names {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(n)
+			b.WriteString(": ")
+			index[n].Type.renderInto(b)
+		}
+		b.WriteString(" }")
+	case KindInterface:
+		b.WriteString("interface ")
+		b.WriteString(m.Name)
+		b.WriteString(" { ")
+		names := make([]string, 0, len(m.Methods))
+		index := make(map[string]MochiMethod, len(m.Methods))
+		for _, mm := range m.Methods {
+			names = append(names, mm.Name)
+			index[mm.Name] = mm
+		}
+		sort.Strings(names)
+		for i, n := range names {
+			if i > 0 {
+				b.WriteString("; ")
+			}
+			mm := index[n]
+			if mm.IsAsync {
+				b.WriteString("async ")
+			}
+			b.WriteString(n)
+			b.WriteString("(")
+			for j, p := range mm.Params {
+				if j > 0 {
+					b.WriteString(", ")
+				}
+				p.renderInto(b)
+			}
+			b.WriteString("): ")
+			mm.Return.renderInto(b)
+		}
+		b.WriteString(" }")
+	default:
+		b.WriteString("<unknown>")
+	}
+}
+
+// Equal reports structural equality. Two MochiTypes are equal when their
+// Kinds, Names, and recursive Params / Fields / Methods all match.
+func (m MochiType) Equal(other MochiType) bool {
+	if m.Kind != other.Kind || m.Name != other.Name {
+		return false
+	}
+	if len(m.Params) != len(other.Params) {
+		return false
+	}
+	for i := range m.Params {
+		if !m.Params[i].Equal(other.Params[i]) {
+			return false
+		}
+	}
+	if len(m.Fields) != len(other.Fields) {
+		return false
+	}
+	for i := range m.Fields {
+		if m.Fields[i].Name != other.Fields[i].Name {
+			return false
+		}
+		if !m.Fields[i].Type.Equal(other.Fields[i].Type) {
+			return false
+		}
+	}
+	if len(m.Methods) != len(other.Methods) {
+		return false
+	}
+	for i := range m.Methods {
+		a, c := m.Methods[i], other.Methods[i]
+		if a.Name != c.Name || a.IsAsync != c.IsAsync {
+			return false
+		}
+		if !a.Return.Equal(c.Return) {
+			return false
+		}
+		if len(a.Params) != len(c.Params) {
+			return false
+		}
+		for j := range a.Params {
+			if !a.Params[j].Equal(c.Params[j]) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/package3/python/typemap/mochitype_test.go
+++ b/package3/python/typemap/mochitype_test.go
@@ -1,0 +1,281 @@
+package typemap
+
+import "testing"
+
+func TestKindString(t *testing.T) {
+	cases := map[Kind]string{
+		KindScalar:    "scalar",
+		KindList:      "list",
+		KindTuple:     "tuple",
+		KindMap:       "map",
+		KindSet:       "set",
+		KindFun:       "fun",
+		KindAsync:     "async",
+		KindStream:    "stream",
+		KindOptional:  "optional",
+		KindSum:       "sum",
+		KindRecord:    "record",
+		KindInterface: "interface",
+		KindRef:       "ref",
+		KindTypeVar:   "typevar",
+		KindUnknown:   "unknown",
+		Kind(99):      "unknown",
+	}
+	for k, want := range cases {
+		if got := k.String(); got != want {
+			t.Errorf("Kind(%d).String() = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestRenderScalars(t *testing.T) {
+	for _, n := range []string{"int", "float", "bool", "string", "bytes", "None"} {
+		if got := NewScalar(n).Render(); got != n {
+			t.Errorf("NewScalar(%q).Render() = %q", n, got)
+		}
+	}
+}
+
+func TestRenderList(t *testing.T) {
+	got := NewList(NewScalar("int")).Render()
+	if got != "list<int>" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderNestedList(t *testing.T) {
+	got := NewList(NewList(NewScalar("int"))).Render()
+	if got != "list<list<int>>" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderMap(t *testing.T) {
+	got := NewMap(NewScalar("string"), NewScalar("int")).Render()
+	if got != "map<string, int>" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderSet(t *testing.T) {
+	got := NewSet(NewScalar("int")).Render()
+	if got != "set<int>" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderTuple(t *testing.T) {
+	got := NewTuple(NewScalar("int"), NewScalar("string"), NewScalar("bool")).Render()
+	if got != "tuple<int, string, bool>" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderOptional(t *testing.T) {
+	got := NewOptional(NewScalar("int")).Render()
+	if got != "int?" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderNestedOptionalIdempotent(t *testing.T) {
+	got := NewOptional(NewOptional(NewScalar("int"))).Render()
+	if got != "int?" {
+		t.Errorf("got %q (Optional should idempotently flatten)", got)
+	}
+}
+
+func TestRenderSumNoNone(t *testing.T) {
+	got := NewSum(NewScalar("int"), NewScalar("string")).Render()
+	if got != "int | string" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderSumWithNoneBecomesOptional(t *testing.T) {
+	got := NewSum(NewScalar("int"), NewScalar("None")).Render()
+	if got != "int?" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderSumSingleBranch(t *testing.T) {
+	got := NewSum(NewScalar("int")).Render()
+	if got != "int" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderSumAllNoneCollapses(t *testing.T) {
+	got := NewSum(NewScalar("None"), NewScalar("None")).Render()
+	if got != "None" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderAsync(t *testing.T) {
+	got := NewAsync(NewScalar("int")).Render()
+	if got != "async int" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderStream(t *testing.T) {
+	got := NewStream(NewScalar("int")).Render()
+	if got != "stream<int>" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderFun(t *testing.T) {
+	got := NewFun(NewScalar("bool"), NewScalar("int"), NewScalar("string")).Render()
+	if got != "fun(int, string): bool" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderFunNoParams(t *testing.T) {
+	got := NewFun(NewScalar("int")).Render()
+	if got != "fun(): int" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderRef(t *testing.T) {
+	got := NewRef("MyClass").Render()
+	if got != "MyClass" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderTypeVar(t *testing.T) {
+	got := NewTypeVar("T").Render()
+	if got != "T" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderRecord(t *testing.T) {
+	r := MochiType{
+		Kind: KindRecord,
+		Name: "Point",
+		Fields: []MochiField{
+			{Name: "x", Type: NewScalar("int")},
+			{Name: "y", Type: NewScalar("int")},
+		},
+	}
+	got := r.Render()
+	if got != "record Point { x: int, y: int }" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderRecordFieldsSorted(t *testing.T) {
+	r := MochiType{
+		Kind: KindRecord,
+		Name: "Mix",
+		Fields: []MochiField{
+			{Name: "z", Type: NewScalar("int")},
+			{Name: "a", Type: NewScalar("string")},
+		},
+	}
+	got := r.Render()
+	if got != "record Mix { a: string, z: int }" {
+		t.Errorf("got %q (fields must render sorted)", got)
+	}
+}
+
+func TestRenderInterface(t *testing.T) {
+	i := MochiType{
+		Kind: KindInterface,
+		Name: "Greeter",
+		Methods: []MochiMethod{
+			{Name: "hello", Params: []MochiType{NewScalar("string")}, Return: NewScalar("string")},
+		},
+	}
+	got := i.Render()
+	if got != "interface Greeter { hello(string): string }" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderInterfaceMethodsSorted(t *testing.T) {
+	i := MochiType{
+		Kind: KindInterface,
+		Name: "Mix",
+		Methods: []MochiMethod{
+			{Name: "z", Return: NewScalar("int")},
+			{Name: "a", Return: NewScalar("string")},
+		},
+	}
+	got := i.Render()
+	if got != "interface Mix { a(): string; z(): int }" {
+		t.Errorf("got %q (methods must render sorted)", got)
+	}
+}
+
+func TestRenderAsyncInterfaceMethod(t *testing.T) {
+	i := MochiType{
+		Kind: KindInterface,
+		Name: "Fetcher",
+		Methods: []MochiMethod{
+			{Name: "fetch", IsAsync: true, Params: []MochiType{NewScalar("string")}, Return: NewScalar("bytes")},
+		},
+	}
+	got := i.Render()
+	if got != "interface Fetcher { async fetch(string): bytes }" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestEqual(t *testing.T) {
+	a := NewList(NewMap(NewScalar("string"), NewScalar("int")))
+	b := NewList(NewMap(NewScalar("string"), NewScalar("int")))
+	if !a.Equal(b) {
+		t.Error("expected structural equality")
+	}
+	c := NewList(NewMap(NewScalar("string"), NewScalar("float")))
+	if a.Equal(c) {
+		t.Error("differing inner type should compare unequal")
+	}
+}
+
+func TestEqualRecords(t *testing.T) {
+	a := MochiType{Kind: KindRecord, Name: "P", Fields: []MochiField{{Name: "x", Type: NewScalar("int")}}}
+	b := MochiType{Kind: KindRecord, Name: "P", Fields: []MochiField{{Name: "x", Type: NewScalar("int")}}}
+	if !a.Equal(b) {
+		t.Error("expected equality")
+	}
+	c := MochiType{Kind: KindRecord, Name: "P", Fields: []MochiField{{Name: "x", Type: NewScalar("float")}}}
+	if a.Equal(c) {
+		t.Error("differing field type should compare unequal")
+	}
+}
+
+func TestFunReturnAndParams(t *testing.T) {
+	t1 := NewFun(NewScalar("bool"), NewScalar("int"), NewScalar("string"))
+	if t1.Return().Render() != "bool" {
+		t.Errorf("Return = %q", t1.Return().Render())
+	}
+	if len(t1.FunParams()) != 2 {
+		t.Errorf("FunParams = %d", len(t1.FunParams()))
+	}
+}
+
+func TestReturnPanicsOnNonFun(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic")
+		}
+	}()
+	_ = NewScalar("int").Return()
+}
+
+func TestFunParamsPanicsOnNonFun(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic")
+		}
+	}()
+	_ = NewScalar("int").FunParams()
+}

--- a/package3/python/typemap/phase04_test.go
+++ b/package3/python/typemap/phase04_test.go
@@ -1,0 +1,190 @@
+package typemap
+
+import (
+	"testing"
+
+	"mochi/package3/python/errors"
+	"mochi/package3/python/stubs"
+)
+
+// TestPhase4TypeMapping is the umbrella sentinel for MEP-71 Phase 4. It walks
+// the closed type table end-to-end: scalar / collection / union / Optional /
+// Callable / class lowerings plus the refusal set.
+func TestPhase4TypeMapping(t *testing.T) {
+	t.Run("scalar_table", func(t *testing.T) {
+		m := &Mapper{}
+		cases := map[string]string{
+			"int":      "int",
+			"float":    "float",
+			"bool":     "bool",
+			"str":      "string",
+			"bytes":    "bytes",
+			"None":     "None",
+			"NoneType": "None",
+		}
+		for src, want := range cases {
+			d := m.Map(src)
+			if !d.OK() {
+				t.Errorf("scalar %q skipped: %v", src, d.Skip)
+				continue
+			}
+			if got := d.Type.Render(); got != want {
+				t.Errorf("scalar %q -> %q, want %q", src, got, want)
+			}
+		}
+	})
+
+	t.Run("collection_table", func(t *testing.T) {
+		m := &Mapper{}
+		cases := map[string]string{
+			"list[int]":                 "list<int>",
+			"List[int]":                 "list<int>",
+			"set[int]":                  "set<int>",
+			"frozenset[int]":            "set<int>",
+			"dict[str, int]":            "map<string, int>",
+			"Dict[str, int]":            "map<string, int>",
+			"tuple[int, str]":           "tuple<int, string>",
+			"tuple[int, ...]":           "list<int>",
+			"Iterator[int]":             "list<int>",
+			"AsyncIterator[int]":        "stream<int>",
+			"Awaitable[int]":            "async int",
+			"Coroutine[Any, Any, int]":  "async int",
+			"collections.abc.Iterable[int]": "list<int>",
+		}
+		for src, want := range cases {
+			d := m.Map(src)
+			if !d.OK() {
+				t.Errorf("collection %q skipped: %v", src, d.Skip)
+				continue
+			}
+			if got := d.Type.Render(); got != want {
+				t.Errorf("collection %q -> %q, want %q", src, got, want)
+			}
+		}
+	})
+
+	t.Run("union_and_optional", func(t *testing.T) {
+		m := &Mapper{}
+		cases := map[string]string{
+			"Optional[int]":     "int?",
+			"int | None":        "int?",
+			"None | int":        "int?",
+			"int | str":         "int | string",
+			"int | str | None":  "int | string?",
+			"Union[int, str]":   "int | string",
+		}
+		for src, want := range cases {
+			d := m.Map(src)
+			if !d.OK() {
+				t.Errorf("union %q skipped: %v", src, d.Skip)
+				continue
+			}
+			if got := d.Type.Render(); got != want {
+				t.Errorf("union %q -> %q, want %q", src, got, want)
+			}
+		}
+	})
+
+	t.Run("callable", func(t *testing.T) {
+		m := &Mapper{}
+		d := m.Map("Callable[[int, str], bool]")
+		if !d.OK() || d.Type.Render() != "fun(int, string): bool" {
+			t.Errorf("got %+v", d)
+		}
+	})
+
+	t.Run("refusal_set", func(t *testing.T) {
+		m := &Mapper{}
+		refusals := map[string]errors.SkipReason{
+			"Any":                        errors.SkipUnsupportedTypingConstruct,
+			"complex":                    errors.SkipNoComplexType,
+			"object":                     errors.SkipUnsupportedTypingConstruct,
+			"ParamSpec[P]":               errors.SkipParamSpec,
+			"Callable[..., int]":         errors.SkipParamSpec,
+			"Unpack[Ts]":                 errors.SkipTypeVarTuple,
+			"Generator[int, None, None]": errors.SkipUnsupportedTypingConstruct,
+			"Type[int]":                  errors.SkipUnsupportedTypingConstruct,
+			"UnknownClass":               errors.SkipForwardRef,
+			"Dict[float, int]":           errors.SkipUnsupportedTypingConstruct,
+		}
+		for src, want := range refusals {
+			d := m.Map(src)
+			if d.OK() {
+				t.Errorf("%q: expected refusal", src)
+				continue
+			}
+			if d.Skip.Reason != want {
+				t.Errorf("%q: reason = %v, want %v", src, d.Skip.Reason, want)
+			}
+		}
+	})
+
+	t.Run("class_mappings", func(t *testing.T) {
+		m := &Mapper{}
+		// TypedDict
+		td := stubs.ClassDecl{
+			Name:        "Point",
+			IsTypedDict: true,
+			Fields: []stubs.FieldDecl{
+				{Name: "x", Type: "int"},
+				{Name: "y", Type: "int"},
+			},
+		}
+		dd := m.MapClass(td)
+		if !dd.OK() || dd.Type.Kind != KindRecord || len(dd.Type.Fields) != 2 {
+			t.Errorf("TypedDict: %+v", dd)
+		}
+		// Frozen dataclass
+		fd := stubs.ClassDecl{
+			Name:        "Vec",
+			IsDataclass: true,
+			Decorators:  []string{"dataclass(frozen=True)"},
+			Fields:      []stubs.FieldDecl{{Name: "v", Type: "list[int]"}},
+		}
+		dd = m.MapClass(fd)
+		if !dd.OK() || dd.Type.Kind != KindRecord {
+			t.Errorf("frozen dataclass: %+v", dd)
+		}
+		// Mutable dataclass refused
+		mu := stubs.ClassDecl{Name: "Mut", IsDataclass: true, Decorators: []string{"dataclass"}}
+		dd = m.MapClass(mu)
+		if dd.OK() {
+			t.Error("mutable dataclass should be refused")
+		}
+		// Protocol
+		pr := stubs.ClassDecl{
+			Name:       "Greeter",
+			IsProtocol: true,
+			Methods: []stubs.FuncDecl{
+				{
+					Name: "hello",
+					Params: []stubs.ParamDecl{
+						{Name: "self"},
+						{Name: "who", Type: "str"},
+					},
+					ReturnType: "str",
+				},
+			},
+		}
+		dd = m.MapClass(pr)
+		if !dd.OK() || dd.Type.Kind != KindInterface || len(dd.Type.Methods) != 1 {
+			t.Errorf("Protocol: %+v", dd)
+		}
+	})
+
+	t.Run("partial_allows_any", func(t *testing.T) {
+		m := &Mapper{AllowPartial: true}
+		d := m.Map("Any")
+		if !d.OK() {
+			t.Fatalf("AllowPartial should map Any: %v", d.Skip)
+		}
+	})
+
+	t.Run("nested_round_trip", func(t *testing.T) {
+		m := &Mapper{}
+		d := m.Map("Dict[str, List[Optional[int]]]")
+		if !d.OK() || d.Type.Render() != "map<string, list<int?>>" {
+			t.Errorf("got %+v", d)
+		}
+	})
+}

--- a/package3/python/typemap/pytype.go
+++ b/package3/python/typemap/pytype.go
@@ -1,0 +1,335 @@
+package typemap
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// PyKind classifies a node in the parsed Python type expression AST.
+type PyKind int
+
+const (
+	// PyName is a bare identifier (`int`, `T`, `List`).
+	PyName PyKind = iota
+	// PyAttr is an attribute access (`typing.List`, `collections.abc.Iterable`).
+	PyAttr
+	// PySubscript is `Base[Arg, Arg, ...]`.
+	PySubscript
+	// PyTuple is the bracketed sequence used inside Callable's first argument:
+	// `Callable[[A, B], R]` -> the [A, B] is a PyTuple.
+	PyTuple
+	// PyUnion is `X | Y | Z` (PEP 604).
+	PyUnion
+	// PyLiteral is a literal value: `"abc"`, `1`, `True`, `None`. Also used for
+	// PEP 484 forward references which are written as string literals.
+	PyLiteral
+	// PyEllipsis is `...`.
+	PyEllipsis
+)
+
+// PyType is a node in the Python type expression AST. Only the fields
+// relevant to the Kind are populated.
+type PyType struct {
+	Kind PyKind
+	// Name is the identifier for PyName, the attribute name for PyAttr.
+	Name string
+	// Base is the receiver for PyAttr / PySubscript.
+	Base *PyType
+	// Args is the bracketed argument list for PySubscript / PyTuple, or the
+	// branches for PyUnion.
+	Args []PyType
+	// Literal is the raw literal token for PyLiteral (including surrounding
+	// quotes for string literals).
+	Literal string
+}
+
+// String renders the PyType back to its source form. Mostly used in tests and
+// error messages.
+func (p PyType) String() string {
+	switch p.Kind {
+	case PyName:
+		return p.Name
+	case PyAttr:
+		return p.Base.String() + "." + p.Name
+	case PySubscript:
+		var args []string
+		for _, a := range p.Args {
+			args = append(args, a.String())
+		}
+		return p.Base.String() + "[" + strings.Join(args, ", ") + "]"
+	case PyTuple:
+		var args []string
+		for _, a := range p.Args {
+			args = append(args, a.String())
+		}
+		return "[" + strings.Join(args, ", ") + "]"
+	case PyUnion:
+		var branches []string
+		for _, a := range p.Args {
+			branches = append(branches, a.String())
+		}
+		return strings.Join(branches, " | ")
+	case PyLiteral:
+		return p.Literal
+	case PyEllipsis:
+		return "..."
+	}
+	return "<bad>"
+}
+
+// QualifiedName returns the dotted identifier path for PyName / PyAttr, e.g.
+// "typing.List". Returns the empty string for non-identifier kinds.
+func (p PyType) QualifiedName() string {
+	switch p.Kind {
+	case PyName:
+		return p.Name
+	case PyAttr:
+		base := p.Base.QualifiedName()
+		if base == "" {
+			return ""
+		}
+		return base + "." + p.Name
+	}
+	return ""
+}
+
+// ParsePyType parses a Python type expression string into a PyType tree.
+//
+// Supported grammar (intentionally narrow):
+//
+//	type        := union
+//	union       := primary ( '|' primary )*
+//	primary     := atom ( '[' arglist ']' | '.' NAME )*
+//	atom        := NAME | NUMBER | STRING | 'None' | 'True' | 'False' | '...' | '(' type ')'
+//	arglist     := arg ( ',' arg )*
+//	arg         := type | '[' arglist ']'   // the bracketed list form is for Callable
+//
+// String literals are kept as the raw token (including quotes) so callers can
+// distinguish forward references from a bare identifier.
+func ParsePyType(src string) (PyType, error) {
+	p := &pyParser{src: strings.TrimSpace(src)}
+	t, err := p.parseUnion()
+	if err != nil {
+		return PyType{}, err
+	}
+	p.skipWS()
+	if p.pos < len(p.src) {
+		return PyType{}, fmt.Errorf("pytype: trailing input at offset %d: %q", p.pos, p.src[p.pos:])
+	}
+	return t, nil
+}
+
+type pyParser struct {
+	src string
+	pos int
+}
+
+func (p *pyParser) skipWS() {
+	for p.pos < len(p.src) && (p.src[p.pos] == ' ' || p.src[p.pos] == '\t') {
+		p.pos++
+	}
+}
+
+func (p *pyParser) parseUnion() (PyType, error) {
+	first, err := p.parsePrimary()
+	if err != nil {
+		return PyType{}, err
+	}
+	var branches []PyType
+	for {
+		p.skipWS()
+		if p.pos >= len(p.src) || p.src[p.pos] != '|' {
+			break
+		}
+		p.pos++
+		next, err := p.parsePrimary()
+		if err != nil {
+			return PyType{}, err
+		}
+		if len(branches) == 0 {
+			branches = append(branches, first)
+		}
+		branches = append(branches, next)
+	}
+	if len(branches) > 0 {
+		return PyType{Kind: PyUnion, Args: branches}, nil
+	}
+	return first, nil
+}
+
+func (p *pyParser) parsePrimary() (PyType, error) {
+	atom, err := p.parseAtom()
+	if err != nil {
+		return PyType{}, err
+	}
+	for {
+		p.skipWS()
+		if p.pos >= len(p.src) {
+			return atom, nil
+		}
+		switch p.src[p.pos] {
+		case '[':
+			p.pos++
+			args, err := p.parseArglist()
+			if err != nil {
+				return PyType{}, err
+			}
+			p.skipWS()
+			if p.pos >= len(p.src) || p.src[p.pos] != ']' {
+				return PyType{}, fmt.Errorf("pytype: missing ']' at offset %d", p.pos)
+			}
+			p.pos++
+			base := atom
+			atom = PyType{Kind: PySubscript, Base: &base, Args: args}
+		case '.':
+			p.pos++
+			name, err := p.parseIdent()
+			if err != nil {
+				return PyType{}, err
+			}
+			base := atom
+			atom = PyType{Kind: PyAttr, Base: &base, Name: name}
+		default:
+			return atom, nil
+		}
+	}
+}
+
+func (p *pyParser) parseArglist() ([]PyType, error) {
+	var args []PyType
+	for {
+		p.skipWS()
+		if p.pos >= len(p.src) {
+			return nil, fmt.Errorf("pytype: unterminated argument list")
+		}
+		if p.src[p.pos] == ']' {
+			return args, nil
+		}
+		if p.src[p.pos] == '[' {
+			// Callable[[A, B], R] form: the first arg is itself a bracketed list.
+			p.pos++
+			inner, err := p.parseArglist()
+			if err != nil {
+				return nil, err
+			}
+			p.skipWS()
+			if p.pos >= len(p.src) || p.src[p.pos] != ']' {
+				return nil, fmt.Errorf("pytype: missing ']' inside arglist at offset %d", p.pos)
+			}
+			p.pos++
+			args = append(args, PyType{Kind: PyTuple, Args: inner})
+		} else {
+			t, err := p.parseUnion()
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, t)
+		}
+		p.skipWS()
+		if p.pos < len(p.src) && p.src[p.pos] == ',' {
+			p.pos++
+			continue
+		}
+		return args, nil
+	}
+}
+
+func (p *pyParser) parseAtom() (PyType, error) {
+	p.skipWS()
+	if p.pos >= len(p.src) {
+		return PyType{}, fmt.Errorf("pytype: unexpected end of input")
+	}
+	c := p.src[p.pos]
+	switch {
+	case c == '(':
+		p.pos++
+		inner, err := p.parseUnion()
+		if err != nil {
+			return PyType{}, err
+		}
+		p.skipWS()
+		if p.pos >= len(p.src) || p.src[p.pos] != ')' {
+			return PyType{}, fmt.Errorf("pytype: missing ')' at offset %d", p.pos)
+		}
+		p.pos++
+		return inner, nil
+	case c == '.':
+		// `...`
+		if p.pos+2 < len(p.src) && p.src[p.pos+1] == '.' && p.src[p.pos+2] == '.' {
+			p.pos += 3
+			return PyType{Kind: PyEllipsis}, nil
+		}
+		return PyType{}, fmt.Errorf("pytype: unexpected '.' at offset %d", p.pos)
+	case c == '"' || c == '\'':
+		return p.parseStringLiteral()
+	case c >= '0' && c <= '9':
+		return p.parseNumberLiteral()
+	case c == '-':
+		return p.parseNumberLiteral()
+	case isIdentStart(rune(c)):
+		name, err := p.parseIdent()
+		if err != nil {
+			return PyType{}, err
+		}
+		switch name {
+		case "True", "False", "None":
+			return PyType{Kind: PyLiteral, Literal: name}, nil
+		}
+		return PyType{Kind: PyName, Name: name}, nil
+	}
+	return PyType{}, fmt.Errorf("pytype: unexpected character %q at offset %d", c, p.pos)
+}
+
+func (p *pyParser) parseIdent() (string, error) {
+	p.skipWS()
+	start := p.pos
+	if p.pos >= len(p.src) || !isIdentStart(rune(p.src[p.pos])) {
+		return "", fmt.Errorf("pytype: expected identifier at offset %d", p.pos)
+	}
+	p.pos++
+	for p.pos < len(p.src) && isIdentCont(rune(p.src[p.pos])) {
+		p.pos++
+	}
+	return p.src[start:p.pos], nil
+}
+
+func (p *pyParser) parseStringLiteral() (PyType, error) {
+	q := p.src[p.pos]
+	start := p.pos
+	p.pos++
+	for p.pos < len(p.src) {
+		if p.src[p.pos] == '\\' && p.pos+1 < len(p.src) {
+			p.pos += 2
+			continue
+		}
+		if p.src[p.pos] == q {
+			p.pos++
+			return PyType{Kind: PyLiteral, Literal: p.src[start:p.pos]}, nil
+		}
+		p.pos++
+	}
+	return PyType{}, fmt.Errorf("pytype: unterminated string at offset %d", start)
+}
+
+func (p *pyParser) parseNumberLiteral() (PyType, error) {
+	start := p.pos
+	if p.src[p.pos] == '-' {
+		p.pos++
+	}
+	for p.pos < len(p.src) && (p.src[p.pos] >= '0' && p.src[p.pos] <= '9' || p.src[p.pos] == '.') {
+		p.pos++
+	}
+	if start == p.pos {
+		return PyType{}, fmt.Errorf("pytype: invalid number at offset %d", start)
+	}
+	return PyType{Kind: PyLiteral, Literal: p.src[start:p.pos]}, nil
+}
+
+func isIdentStart(r rune) bool {
+	return r == '_' || unicode.IsLetter(r)
+}
+
+func isIdentCont(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}

--- a/package3/python/typemap/pytype_test.go
+++ b/package3/python/typemap/pytype_test.go
@@ -1,0 +1,242 @@
+package typemap
+
+import "testing"
+
+func TestParsePyTypeName(t *testing.T) {
+	p, err := ParsePyType("int")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Kind != PyName || p.Name != "int" {
+		t.Errorf("%+v", p)
+	}
+}
+
+func TestParsePyTypeQualified(t *testing.T) {
+	p, err := ParsePyType("typing.List")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Kind != PyAttr || p.Name != "List" {
+		t.Errorf("%+v", p)
+	}
+	if p.QualifiedName() != "typing.List" {
+		t.Errorf("qualified = %q", p.QualifiedName())
+	}
+}
+
+func TestParsePyTypeDoubleAttribute(t *testing.T) {
+	p, err := ParsePyType("collections.abc.Iterable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.QualifiedName() != "collections.abc.Iterable" {
+		t.Errorf("qualified = %q", p.QualifiedName())
+	}
+}
+
+func TestParsePyTypeSubscript(t *testing.T) {
+	p, err := ParsePyType("List[int]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Kind != PySubscript {
+		t.Fatalf("kind = %v", p.Kind)
+	}
+	if p.Base.Name != "List" {
+		t.Errorf("base = %+v", p.Base)
+	}
+	if len(p.Args) != 1 || p.Args[0].Name != "int" {
+		t.Errorf("args = %+v", p.Args)
+	}
+}
+
+func TestParsePyTypeNestedSubscript(t *testing.T) {
+	p, err := ParsePyType("Dict[str, List[int]]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p.Args) != 2 {
+		t.Fatalf("args = %+v", p.Args)
+	}
+	if p.Args[1].Kind != PySubscript || p.Args[1].Base.Name != "List" {
+		t.Errorf("nested = %+v", p.Args[1])
+	}
+}
+
+func TestParsePyTypeQualifiedSubscript(t *testing.T) {
+	p, err := ParsePyType("typing.Dict[str, int]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Kind != PySubscript {
+		t.Fatalf("kind = %v", p.Kind)
+	}
+	if p.Base.QualifiedName() != "typing.Dict" {
+		t.Errorf("base = %q", p.Base.QualifiedName())
+	}
+}
+
+func TestParsePyTypeUnion(t *testing.T) {
+	p, err := ParsePyType("int | str")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Kind != PyUnion {
+		t.Fatalf("kind = %v", p.Kind)
+	}
+	if len(p.Args) != 2 {
+		t.Errorf("branches = %+v", p.Args)
+	}
+}
+
+func TestParsePyTypeUnionMany(t *testing.T) {
+	p, err := ParsePyType("int | str | bool | None")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p.Args) != 4 {
+		t.Errorf("branches = %+v", p.Args)
+	}
+}
+
+func TestParsePyTypeOptional(t *testing.T) {
+	p, err := ParsePyType("Optional[int]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Kind != PySubscript || p.Base.Name != "Optional" {
+		t.Errorf("%+v", p)
+	}
+}
+
+func TestParsePyTypeCallable(t *testing.T) {
+	p, err := ParsePyType("Callable[[int, str], bool]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Kind != PySubscript || len(p.Args) != 2 {
+		t.Fatalf("%+v", p)
+	}
+	if p.Args[0].Kind != PyTuple || len(p.Args[0].Args) != 2 {
+		t.Errorf("params = %+v", p.Args[0])
+	}
+	if p.Args[1].Name != "bool" {
+		t.Errorf("return = %+v", p.Args[1])
+	}
+}
+
+func TestParsePyTypeCallableEllipsis(t *testing.T) {
+	p, err := ParsePyType("Callable[..., int]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Args[0].Kind != PyEllipsis {
+		t.Errorf("params = %+v", p.Args[0])
+	}
+}
+
+func TestParsePyTypeTupleEllipsis(t *testing.T) {
+	p, err := ParsePyType("tuple[int, ...]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p.Args) != 2 || p.Args[1].Kind != PyEllipsis {
+		t.Errorf("%+v", p)
+	}
+}
+
+func TestParsePyTypeForwardRef(t *testing.T) {
+	p, err := ParsePyType(`"MyClass"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Kind != PyLiteral || p.Literal != `"MyClass"` {
+		t.Errorf("%+v", p)
+	}
+}
+
+func TestParsePyTypeLiteralValues(t *testing.T) {
+	cases := []string{
+		`Literal["a"]`,
+		`Literal[1]`,
+		`Literal[True]`,
+		`Literal[None]`,
+		`Literal["a", "b", "c"]`,
+	}
+	for _, src := range cases {
+		if _, err := ParsePyType(src); err != nil {
+			t.Errorf("%q: %v", src, err)
+		}
+	}
+}
+
+func TestParsePyTypeNoneLiteral(t *testing.T) {
+	p, err := ParsePyType("None")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Kind != PyLiteral || p.Literal != "None" {
+		t.Errorf("%+v", p)
+	}
+}
+
+func TestParsePyTypeParens(t *testing.T) {
+	p, err := ParsePyType("(int | str)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Kind != PyUnion {
+		t.Errorf("%+v", p)
+	}
+}
+
+func TestParsePyTypeError(t *testing.T) {
+	cases := []string{
+		"List[",
+		"List]",
+		"int |",
+		"|int",
+		"((int)",
+		`"unterminated`,
+	}
+	for _, src := range cases {
+		if _, err := ParsePyType(src); err == nil {
+			t.Errorf("%q: expected error", src)
+		}
+	}
+}
+
+func TestParsePyTypeTrailingInput(t *testing.T) {
+	if _, err := ParsePyType("int foo"); err == nil {
+		t.Error("expected trailing input error")
+	}
+}
+
+func TestPyTypeStringRoundTrip(t *testing.T) {
+	cases := []string{
+		"int",
+		"typing.List",
+		"List[int]",
+		"Dict[str, int]",
+		"Callable[[int, str], bool]",
+		"int | str",
+	}
+	for _, src := range cases {
+		p, err := ParsePyType(src)
+		if err != nil {
+			t.Errorf("%q: %v", src, err)
+			continue
+		}
+		if p.String() != src {
+			t.Errorf("round-trip: got %q, want %q", p.String(), src)
+		}
+	}
+}
+
+func TestQualifiedNameNonIdent(t *testing.T) {
+	p := PyType{Kind: PyLiteral, Literal: `"x"`}
+	if p.QualifiedName() != "" {
+		t.Error("QualifiedName should be empty for non-ident")
+	}
+}

--- a/website/docs/implementation/0071/index.md
+++ b/website/docs/implementation/0071/index.md
@@ -18,8 +18,8 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | 0 | Skeleton: `package3/python/` layout + `Driver` / `Venv` / `SkipReason` / `BridgeError` | LANDED | `8e1ef75f` | [phase-00](/docs/implementation/0071/phase-00-skeleton) |
 | 1 | Simple-index client (PEP 503 HTML + PEP 691 JSON + PEP 700 metadata, sha256 + blake3 download verify) | LANDED | `3dfc4490` | [phase-01](/docs/implementation/0071/phase-01-simple-index) |
 | 2 | uv resolver bridge (subprocess + lockfile parsing) + PEP 751 pylock.toml round-trip | LANDED | `a38cb023` | [phase-02](/docs/implementation/0071/phase-02-uv-resolver) |
-| 3 | PEP 561 stub discovery (4-tier precedence, typeshed pin, stubgen sandbox) + `.pyi` parser | LANDED | (pending merge) | [phase-03](/docs/implementation/0071/phase-03-stub-ingest) |
-| 4 | Closed type-mapping table (scalars / strings / collections / Optional / Union / dataclass / TypedDict / Protocol) | NOT STARTED | — | [phase-04](/docs/implementation/0071/phase-04-type-mapping) |
+| 3 | PEP 561 stub discovery (4-tier precedence, typeshed pin, stubgen sandbox) + `.pyi` parser | LANDED | `55469e50` | [phase-03](/docs/implementation/0071/phase-03-stub-ingest) |
+| 4 | Closed type-mapping table (scalars / strings / collections / Optional / Union / dataclass / TypedDict / Protocol) | LANDED | (pending merge) | [phase-04](/docs/implementation/0071/phase-04-type-mapping) |
 | 5 | Wrapper module synthesiser (CPython extension `.so` + `_mochi_wrap.py` + `.pyi`) | NOT STARTED | — | [phase-05](/docs/implementation/0071/phase-05-wrapper) |
 | 6 | Mochi-side extern fn emitter + alias shim file generation + sidecar (`*_externs.py`) loader | NOT STARTED | — | [phase-06](/docs/implementation/0071/phase-06-extern-emit) |
 | 7 | `import python "<package>@<semver>" as <alias>` grammar + parser | NOT STARTED | — | [phase-07](/docs/implementation/0071/phase-07-import-grammar) |

--- a/website/docs/implementation/0071/phase-04-type-mapping.md
+++ b/website/docs/implementation/0071/phase-04-type-mapping.md
@@ -1,0 +1,110 @@
+---
+title: "Phase 4. type mapping table"
+sidebar_position: 6
+sidebar_label: "Phase 4. type mapping"
+description: "MEP-71 Phase 4 lands the closed Python-to-Mochi type translation table, the type expression parser, and the SkipReason-emitting Mapper."
+---
+
+# Phase 4. type mapping table
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-71 §Phases](/docs/mep/mep-0071#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-29 23:26 (GMT+7) |
+| Landed         | 2026-05-29 23:34 (GMT+7) |
+| Tracking issue | (filled by automation) |
+| Tracking PR    | (filled by automation) |
+| Commit         | (filled by automation) |
+
+## Gate
+
+`TestPhase4TypeMapping` in `package3/python/typemap/phase04_test.go` with subtests:
+
+- `scalar_table`. The 7 scalar lowerings (`int`, `float`, `bool`, `str`, `bytes`, `None`, `NoneType`).
+- `collection_table`. The 13 collection lowerings covering `list` / `List`, `set` / `frozenset`, `dict` / `Dict`, `tuple` heterogeneous + homogeneous (`tuple[T, ...]` -> `list<T>`), `Iterator` / `Iterable`, `AsyncIterator`, `Awaitable`, `Coroutine[Y, S, R]` reduced to `async R`, `collections.abc.Iterable` prefix stripping.
+- `union_and_optional`. `Optional[int]` and `int | None` (both orderings) collapse to `int?`. `int | str` becomes `int | string`. `int | str | None` becomes `int | string?`. The legacy `Union[int, str]` form parses identically.
+- `callable`. `Callable[[int, str], bool]` lowers to `fun(int, string): bool`.
+- `refusal_set`. The 10 refusal cases: `Any` (without `AllowPartial`), `complex`, `object` outside Protocol, `ParamSpec[P]`, `Callable[..., int]`, `Unpack[Ts]`, `Generator[int, None, None]`, `Type[int]`, unresolved forward references, and `Dict[float, int]` (non-scalar map key).
+- `class_mappings`. TypedDict -> KindRecord, frozen `@dataclass` -> KindRecord, mutable `@dataclass` -> refusal with override suggestion, Protocol -> KindInterface.
+- `partial_allows_any`. With `AllowPartial = true` (PEP 561 partial marker or stubgen output), `Any` maps to `ref<Any>` instead of refusing.
+- `nested_round_trip`. `Dict[str, List[Optional[int]]]` -> `map<string, list<int?>>`.
+
+The package-level coverage:
+
+- `package3/python/typemap/mochitype_test.go`. Kind rendering over 16 cases including the unknown / out-of-range sentinel. Render of every supported kind: scalars, list, nested list, map, set, tuple, Optional (idempotent nesting), sum (no None / with None / single branch / all-None collapse), async, stream, fun (with and without params), ref, typevar, record (with field-name sort), interface (with method-name sort and async-method prefix). Structural Equal across lists / records / fields. Panics on Return / FunParams when Kind is not KindFun.
+- `package3/python/typemap/pytype_test.go`. Parses bare names, qualified attributes (`typing.List`, `collections.abc.Iterable`), subscripts (single and nested), qualified subscripts (`typing.Dict[str, int]`), unions (2-branch and many-branch), Optional, Callable with bracketed-list parameters, Callable with ellipsis (`Callable[..., int]`), homogeneous tuples (`tuple[int, ...]`), forward-reference string literals, Literal value lists (string / int / bool / None / multi-value), bare `None`, parenthesised unions, trailing input rejection, and 6 explicit error cases (unterminated subscript, leading `|`, unbalanced parens, unterminated string). String round-trip across 6 canonical shapes. `QualifiedName` returns empty for non-identifier kinds.
+- `package3/python/typemap/mapper_test.go`. Scalars, list variants (bare lowercase / capitalised / `typing.`-prefixed), dict, dict-rejects-non-scalar-key (float and bool), homogeneous + heterogeneous tuples, set / frozenset, Optional in both syntaxes, Union with and without None, Callable, Callable-ellipsis-refused, Awaitable, Coroutine[Y, S, R] reduced, AsyncIterator -> stream, Iterator -> list, Any refused by default and accepted under AllowPartial, complex refused, ParamSpec / Unpack / Generator refused, forward references resolved against `Classes` and unresolved otherwise, TypeVars resolved against `TypeVars`, generic user-defined classes lowered to `KindRef` with parametric Params, `Literal` collapsing to scalar for single-shape values and refused for mixed-shape, `Final` / `ClassVar` / `Annotated` / `NotRequired` unwrap to the inner type, `Type[X]` refused, deep nesting (`Dict[str, List[Optional[int]]]`), empty-string refusal, `ItemPath` propagation into `SkipReport`, bare typing constructors refused, union-with-Any refused with `SkipOpenUnion` even when `AllowPartial`, `builtins.` and `collections.abc.` prefix stripping, list with wrong arity rejected with informative detail.
+- `package3/python/typemap/class_test.go`. TypedDict -> record (2 fields), frozen `@dataclass` -> record, mutable `@dataclass` -> refusal with non-empty Override, whitespace-tolerant frozen detection (`dataclasses.dataclass(  frozen = True  )`), Protocol -> interface with one method, Protocol dunders skipped into `Skipped` with `SkipDunder`, `*args` / `**kwargs` in Protocol method -> `SkipParamSpec`, unannotated Protocol parameter -> `SkipUnsupportedTypingConstruct`, plain class (no Protocol / TypedDict / dataclass) refused entirely, TypedDict field with `complex` -> field skipped into `Skipped` while class still maps, top-level function mapping (sync return, async wraps return in `NewAsync`, missing return defaults to `None`, `*args` refused), `classDecoratedAsFrozen` over 8 decorator shapes.
+
+## Lowering decisions
+
+The type mapping pipeline is three stages:
+
+1. **Parse** the raw type-expression string via `ParsePyType` into a `PyType` AST. The grammar is intentionally narrow: names, qualified attributes, subscripts, unions, ellipsis, literals (including string forward references), and parenthesised groups. The parser is hand-rolled (no Python AST library); it covers the constructs that appear in `.pyi` files without trying to handle arbitrary Python expressions.
+2. **Lower** the PyType into a `MochiType` via the `Mapper`. The mapper holds the closed table, the in-scope `TypeVars`, the in-scope `Classes`, and the `AllowPartial` flag. Out-of-table items return a `Decision` carrying a `*errors.SkipReport` with the correct `SkipReason` from MEP-71's research note 05.
+3. **Render** the MochiType via `Render` into the canonical Mochi-side string. Record fields and interface methods sort alphabetically so the rendering is deterministic across stub iterations.
+
+The closed scalar table is `int -> int`, `float -> float`, `bool -> bool`, `str -> string`, `bytes -> bytes`, `None / NoneType -> None`. Mochi's `string` (not `str`) is the canonical scalar name.
+
+Container lowerings follow the spec table. The two non-obvious decisions:
+
+- `dict[K, V]` rejects non-scalar keys. The spec restricts K to `str` or an integer type; we further exclude `bool` because Mochi's map key set excludes `bool` by policy.
+- `tuple[T, ...]` collapses to `list<T>`. The homogeneous form is structurally a list; preserving "tuple" would suggest a fixed-length type that the source doesn't claim. Phase 5 will not be surprised by this lowering because tuples and lists share the same iteration / indexing surface on the Mochi side.
+- `Iterator[T]` materialises to `list<T>` at the wrapper boundary. The Mochi caller does not see Python's lazy iteration; the wrapper consumes the iterator and hands back a fully materialised list. This is the spec's intentional choice (research note 05 §"Iterators at the boundary").
+
+Union and Optional are unified through `NewSum`: a union with any `None` branch becomes an Optional wrapping the non-None branches; a union with no None remains a sum; a single-branch sum collapses to the branch directly. This is the spec's PEP 604 lowering rule.
+
+`Callable[[A, B], R]` becomes a `KindFun` MochiType with Params = `[A, B, R]` (the return type is the final entry). `Callable[..., R]` is refused with `SkipParamSpec`: the bridge does not synthesise opaque variadic dispatch surfaces.
+
+`Awaitable[T]` becomes `async T`; `Coroutine[Y, S, R]` reduces to `async R` (the yield and send types are not part of the Mochi async surface). `AsyncIterator[T]` becomes `stream<T>`.
+
+`Annotated[T, ...]`, `Final[T]`, `ClassVar[T]`, `NotRequired[T]`, and `Required[T]` all unwrap to the inner T. The metadata is preserved by Phase 5 in the wrapper-generation step, not in the type signature.
+
+`Literal[v, ...]` collapses to the scalar that matches all literal arguments. Mixed-kind Literal (e.g. `Literal["a", 1]`) is refused; this is the spec's narrowing-dependent refusal rule.
+
+Class mappings (`MapClass`) dispatch on the Phase 3 ClassDecl flags:
+
+- `IsTypedDict` -> KindRecord. Fields are mapped one by one; a field whose type is out-of-table is appended to `Skipped` while the class still maps successfully (the user can pick up the report and decide whether to write an override or accept the narrower interface).
+- `IsDataclass` -> KindRecord only when the decorator list contains `frozen=True` (whitespace-tolerant detection); mutable dataclasses are refused with an `Override` suggestion the user can paste into the sidecar.
+- `IsProtocol` -> KindInterface. Methods are mapped; dunders skip with `SkipDunder`; `*args` / `**kwargs` skip with `SkipParamSpec`; unannotated parameters skip with `SkipUnsupportedTypingConstruct`. The `self` / `cls` parameter is dropped silently because Mochi interfaces do not carry it.
+- Plain classes (no flag) refuse entirely with `SkipUnsupportedTypingConstruct`: the bridge does not invent a record / interface surface for arbitrary Python classes.
+
+The deliberate "closed table, refuse on miss" decision is documented in `package3/python/typemap/doc.go`. We do not invent dynamic interop types (no MochiPyAny). The user can always opt back in via a hand-written `extern python fun` declaration in the MEP-51 sidecar.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/python/typemap/doc.go` | Package doc (closed table, refusal set) |
+| `package3/python/typemap/mochitype.go` | `Kind`, `MochiType`, `MochiField`, `MochiMethod`, constructors, `Render`, `Equal` |
+| `package3/python/typemap/pytype.go` | `PyKind`, `PyType`, `ParsePyType` (hand-rolled recursive-descent parser) |
+| `package3/python/typemap/mapper.go` | `Mapper`, `Decision`, `Map`, `MapParsed`, the closed scalar / container / union / Callable / Literal lowering table |
+| `package3/python/typemap/class.go` | `ClassDecision`, `MapClass`, `MapFunction`, field / method / function lowerings |
+| `package3/python/typemap/mochitype_test.go` | MochiType render + Equal tests |
+| `package3/python/typemap/pytype_test.go` | PyType parser tests |
+| `package3/python/typemap/mapper_test.go` | Closed-table behaviour tests + refusal set tests |
+| `package3/python/typemap/class_test.go` | Class lowering tests (TypedDict / dataclass / Protocol) + function lowering |
+| `package3/python/typemap/phase04_test.go` | `TestPhase4TypeMapping` sentinel with 8 subtests |
+
+## Test set
+
+- `TestPhase4TypeMapping/scalar_table`
+- `TestPhase4TypeMapping/collection_table`
+- `TestPhase4TypeMapping/union_and_optional`
+- `TestPhase4TypeMapping/callable`
+- `TestPhase4TypeMapping/refusal_set`
+- `TestPhase4TypeMapping/class_mappings`
+- `TestPhase4TypeMapping/partial_allows_any`
+- `TestPhase4TypeMapping/nested_round_trip`
+- All `package3/python/typemap/...` unit tests.
+
+## Closeout notes
+
+Phase 4 is the type-policy chokepoint. Every Python type that crosses into Mochi flows through this table. Adding a new lowering means adding a case to `Mapper.mapName` / `Mapper.mapSubscript` and a test row in `mapper_test.go`; removing one means tightening the refusal set with a fresh `SkipReason` (and a SKIPPED.txt golden update on Phase 5's fixture corpus, when Phase 5 lands).
+
+The Mapper does not know about Phase 3's `ModuleSurface` directly. The caller (Phase 5 / 6) walks the surface, sets `ItemPath` to the dotted Python path of the item being mapped (e.g. `httpx.AsyncClient.send`), invokes `Map` / `MapClass` / `MapFunction`, and collects the SkipReports. This separation means the type policy stays in `typemap/` and the walking + emission stays in `wrapper/` and `emit/` once those phases land.
+
+The `AllowPartial` flag is the bridge into Phase 3's `StubSource.Partial`. When the upstream source did not commit to full types, the mapper lowers `Any` to `ref<Any>` instead of refusing; downstream phases will emit the wrapper symbol with a dynamic boundary call. Phase 5 is responsible for honouring the `--allow-partial` CLI flag and threading it through into the Mapper.
+
+No CPython runtime, no mypy install, and no typeshed checkout is required for any test in this phase. The mapper consumes plain strings; the tests construct stubs.ClassDecl values inline rather than parsing real `.pyi` files (Phase 3's tests already cover that surface).


### PR DESCRIPTION
Closes #22826.

## Summary

- Closed Python-to-Mochi type mapping table per MEP-71 §3
- PEP 484 / PEP 604 type expression parser (hand-rolled recursive descent)
- Class dispatch: Protocol → Interface, TypedDict → Record, frozen @dataclass → Record
- Refusal set: Any/object/complex/ParamSpec/TypeVarTuple/Generator/forward refs (with override hints where the user can usefully act)
- ~120 tests across mochitype, pytype, mapper, class, plus an umbrella phase04 sentinel

## Test plan

- [x] `go test ./package3/python/typemap/...` green
- [x] phase04 sentinel exercises scalar / collection / union / Callable / class lowerings + refusal set
- [x] Nested round-trip: `Dict[str, List[Optional[int]]]` → `map<string, list<int?>>`
- [x] AllowPartial flag lets `Any` lower to `ref<Any>` when PEP 561 partial marker is set

Spec: [MEP-71](https://mochi-lang.dev/docs/mep/mep-0071)
Tracking: [phase-04](https://mochi-lang.dev/docs/implementation/0071/phase-04-type-mapping)