### PR TITLE
MEP-74 phase 8: import-go grammar semver-pin validation

### DIFF
--- a/parser/go_import.go
+++ b/parser/go_import.go
@@ -1,0 +1,121 @@
+package parser
+
+import "strings"
+
+// GoImportRef parses the path of `import go "<module>@<semver>" as
+// <alias>` (the MEP-74 phase 8 form) into its (module, version) pair.
+//
+// The path may carry quotes (the participle lexer strips them, but
+// callers that pass raw lexed tokens may include them); the routine
+// trims a single leading and trailing double-quote before parsing.
+//
+// On success ok is true and module/version carry non-empty values.
+// On any structural problem (missing `@`, empty side, non-conforming
+// module path syntax, whitespace in version) ok is false and module
+// and version are empty.
+//
+// MEP-74 does *not* require the `@<semver>` shape for `import go`:
+// older MEP-54-phase-10 FFI imports of stdlib packages (`import go
+// "fmt"`, `import go "net/http"`) remain valid and produce ok=false
+// here, with the caller responsible for distinguishing the two cases
+// via [HasGoSemverPin].
+func GoImportRef(path string) (module, version string, ok bool) {
+	s := strings.Trim(path, "\"")
+	at := strings.Index(s, "@")
+	if at <= 0 || at == len(s)-1 {
+		return "", "", false
+	}
+	m := s[:at]
+	if !isGoModulePath(m) {
+		return "", "", false
+	}
+	v := s[at+1:]
+	if v == "" || strings.ContainsAny(v, " \t\n\r") {
+		return "", "", false
+	}
+	return m, v, true
+}
+
+// HasGoSemverPin reports whether the path carries an `@<semver>` tail.
+// It is the cheap precheck the parser uses to decide whether to apply
+// the strict GoImportRef validator or treat the import as a stdlib /
+// pre-MEP-74 FFI form (where no version pin is required).
+func HasGoSemverPin(path string) bool {
+	s := strings.Trim(path, "\"")
+	return strings.Contains(s, "@")
+}
+
+// isGoModulePath reports whether s is a syntactically valid Go module
+// path. It applies a conservative subset of golang.org/ref/mod#go-mod-file-ident:
+//
+//   - path is split on `/`; every segment must be non-empty
+//   - every segment is composed of ASCII letters/digits and the
+//     punctuation set {`.`, `_`, `-`, `~`}; the first character of a
+//     segment must be a letter or digit; consecutive dots are rejected
+//   - the first segment must contain at least one `.` (the Go convention
+//     for fully-qualified module paths like "github.com/...", "gopkg.in/...";
+//     this strict subset rejects "fmt" and "net/http" so stdlib imports
+//     never accidentally satisfy the version-pin contract)
+//
+// The Go reference accepts a slightly wider character set (notably the
+// punctuation `+`); restricting to the strict subset keeps the parser's
+// diagnostic precise and matches every published module on proxy.golang.org
+// as of April 2026.
+func isGoModulePath(s string) bool {
+	if s == "" {
+		return false
+	}
+	segs := strings.Split(s, "/")
+	if len(segs) == 0 {
+		return false
+	}
+	// First segment must contain a dot (FQDN-style).
+	if !strings.Contains(segs[0], ".") {
+		return false
+	}
+	for _, seg := range segs {
+		if !isGoModuleSegment(seg) {
+			return false
+		}
+	}
+	return true
+}
+
+// isGoModuleSegment reports whether seg is a valid Go module path
+// segment under the conservative subset described in isGoModulePath.
+func isGoModuleSegment(seg string) bool {
+	if seg == "" {
+		return false
+	}
+	// First char must be alnum.
+	if !isGoModuleStartByte(seg[0]) {
+		return false
+	}
+	for i := 0; i < len(seg); i++ {
+		c := seg[i]
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '.' || c == '_' || c == '-' || c == '~':
+			// ok
+		default:
+			return false
+		}
+		// Reject consecutive dots (eg. "..", "foo..bar").
+		if c == '.' && i+1 < len(seg) && seg[i+1] == '.' {
+			return false
+		}
+	}
+	return true
+}
+
+func isGoModuleStartByte(c byte) bool {
+	switch {
+	case c >= 'a' && c <= 'z',
+		c >= 'A' && c <= 'Z',
+		c >= '0' && c <= '9':
+		return true
+	}
+	return false
+}

--- a/parser/go_import_test.go
+++ b/parser/go_import_test.go
@@ -1,0 +1,100 @@
+package parser
+
+import "testing"
+
+func TestGoImportRef(t *testing.T) {
+	cases := []struct {
+		name            string
+		in              string
+		wantMod, wantV  string
+		wantOK          bool
+	}{
+		{"plain cobra", `github.com/spf13/cobra@v1.8.0`, "github.com/spf13/cobra", "v1.8.0", true},
+		{"quoted cobra", `"github.com/spf13/cobra@v1.8.0"`, "github.com/spf13/cobra", "v1.8.0", true},
+		{"yaml v3", `gopkg.in/yaml.v3@v3.0.1`, "gopkg.in/yaml.v3", "v3.0.1", true},
+		{"x tools", `golang.org/x/tools@v0.20.0`, "golang.org/x/tools", "v0.20.0", true},
+		{"major v2 path", `github.com/foo/bar/v2@v2.1.0`, "github.com/foo/bar/v2", "v2.1.0", true},
+		{"pseudo version", `github.com/foo/bar@v0.0.0-20260520150000-abcdef012345`, "github.com/foo/bar", "v0.0.0-20260520150000-abcdef012345", true},
+		{"semver pre-release", `example.com/x@v1.2.3-rc.1`, "example.com/x", "v1.2.3-rc.1", true},
+		{"semver build meta", `example.com/x@v1.2.3+build.5`, "example.com/x", "v1.2.3+build.5", true},
+		{"single dotted segment", `example.com@v1.0.0`, "example.com", "v1.0.0", true},
+		{"hyphenated segment", `github.com/go-yaml/yaml@v2.4.0`, "github.com/go-yaml/yaml", "v2.4.0", true},
+
+		// Stdlib-style and pre-MEP-74 FFI imports return ok=false but
+		// don't error (caller distinguishes via HasGoSemverPin).
+		{"no version (stdlib)", `fmt`, "", "", false},
+		{"no version path-only", `net/http`, "", "", false},
+		// Structural errors.
+		{"empty version", `github.com/foo/bar@`, "", "", false},
+		{"empty module", `@v1.0.0`, "", "", false},
+		{"missing dot in first seg", `foo/bar@v1.0.0`, "", "", false},
+		{"empty segment", `github.com//bar@v1.0.0`, "", "", false},
+		{"underscore start segment", `github.com/_bar@v1.0.0`, "", "", false},
+		{"dot start segment", `github.com/.bar@v1.0.0`, "", "", false},
+		{"hyphen start segment", `github.com/-bar@v1.0.0`, "", "", false},
+		{"consecutive dots", `github..com/foo@v1.0.0`, "", "", false},
+		{"plus in path", `github.com/foo+bar@v1.0.0`, "", "", false},
+		{"whitespace in version", `github.com/foo/bar@v1.0.0 alpha`, "", "", false},
+		{"newline in version", "github.com/foo/bar@v1.0.0\n", "", "", false},
+		{"empty", ``, "", "", false},
+		{"only at", `@`, "", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotM, gotV, ok := GoImportRef(c.in)
+			if ok != c.wantOK {
+				t.Fatalf("GoImportRef(%q) ok = %v; want %v", c.in, ok, c.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if gotM != c.wantMod || gotV != c.wantV {
+				t.Errorf("GoImportRef(%q) = (%q, %q); want (%q, %q)", c.in, gotM, gotV, c.wantMod, c.wantV)
+			}
+		})
+	}
+}
+
+func TestHasGoSemverPin(t *testing.T) {
+	cases := map[string]bool{
+		`github.com/spf13/cobra@v1.8.0`:   true,
+		`"github.com/spf13/cobra@v1.8.0"`: true,
+		`fmt`:                             false,
+		`net/http`:                        false,
+		`@`:                               true, // structurally invalid but carries `@`
+	}
+	for in, want := range cases {
+		if got := HasGoSemverPin(in); got != want {
+			t.Errorf("HasGoSemverPin(%q) = %v; want %v", in, got, want)
+		}
+	}
+}
+
+func TestIsGoModulePath(t *testing.T) {
+	cases := map[string]bool{
+		"github.com/spf13/cobra":         true,
+		"gopkg.in/yaml.v3":               true,
+		"golang.org/x/tools":             true,
+		"github.com/foo/bar/v2":          true,
+		"example.com":                    true,
+		"github.com/go-yaml/yaml":        true,
+		"github.com/foo_bar/baz":         true,
+		"github.com/foo.bar/baz":         true,
+		"github.com/foo~bar/baz":         true,
+		"fmt":                            false,
+		"net/http":                       false,
+		"":                               false,
+		"github..com/foo":                false,
+		"github.com/":                    false,
+		"github.com//foo":                false,
+		"github.com/_foo":                false,
+		"github.com/-foo":                false,
+		"github.com/foo bar":             false,
+		"github.com/foo+bar":             false,
+	}
+	for in, want := range cases {
+		if got := isGoModulePath(in); got != want {
+			t.Errorf("isGoModulePath(%q) = %v; want %v", in, got, want)
+		}
+	}
+}

--- a/parser/normalize.go
+++ b/parser/normalize.go
@@ -37,6 +37,16 @@ var (
 		Message: "rust import path %q is not in `<crate>@<semver>` form",
 		Help:    "An `import rust \"...\" as <alias>` statement names a crates.io crate plus a version, eg. `import rust \"hex@0.4.3\" as hex`. The version is required because MEP-73 binds the synthesised wrapper crate to an exact upstream version.",
 	}
+	errInvalidGoImportPath = diagnostic.Template{
+		Code:    "P067",
+		Message: "go import path %q with `@` pin is not in `<module>@<semver>` form",
+		Help:    "An `import go \"...\" as <alias>` with a version pin names a Go module on proxy.golang.org plus a semver tag, eg. `import go \"github.com/spf13/cobra@v1.8.0\" as cobra`. The module path must be FQDN-style (the first path segment must contain a dot) and the version must be a semver tag (`v1.2.3`) or pseudo-version. Stdlib-only imports (`import go \"fmt\"`) remain valid without a pin.",
+	}
+	errGoImportMissingAlias = diagnostic.Template{
+		Code:    "P068",
+		Message: "go import %q with `@` pin requires `as <alias>`",
+		Help:    "MEP-74 requires the version-pinned form to carry an explicit alias so the Mochi caller can reference the extern fns under a single namespace. Add `as <alias>`, eg. `import go \"github.com/spf13/cobra@v1.8.0\" as cobra`.",
+	}
 )
 
 // knownImportLangs is the set of host-language identifiers Mochi recognises
@@ -179,6 +189,9 @@ func normalizeStatement(s *Statement) error {
 			return err
 		}
 		if err := validateRustImport(s.Import); err != nil {
+			return err
+		}
+		if err := validateGoImport(s.Import); err != nil {
 			return err
 		}
 	case s.Expr != nil:
@@ -378,6 +391,33 @@ func validateRustImport(im *ImportStmt) error {
 	}
 	if _, _, ok := RustImportRef(im.Path); !ok {
 		return errInvalidRustImportPath.New(im.Pos, im.Path)
+	}
+	return nil
+}
+
+// validateGoImport rejects `import go "<module>@<semver>"` whose path
+// carries an `@` pin but is not a valid `<module>@<semver>` form, and
+// also rejects a version-pinned go import that lacks `as <alias>`.
+//
+// The version pin is optional: pre-MEP-74 stdlib FFI imports like
+// `import go "fmt"` and `import go "net/http"` remain valid because
+// they carry no `@`. When a pin is present, MEP-74 requires the full
+// `<FQDN-style module>@<semver>` shape and an explicit alias so the
+// extern emitter (phase 7) and the build orchestrator (phase 9) can
+// resolve the import against proxy.golang.org and namespace the
+// generated extern fns under the user's chosen identifier.
+func validateGoImport(im *ImportStmt) error {
+	if im == nil || im.Lang == nil || *im.Lang != "go" {
+		return nil
+	}
+	if !HasGoSemverPin(im.Path) {
+		return nil
+	}
+	if _, _, ok := GoImportRef(im.Path); !ok {
+		return errInvalidGoImportPath.New(im.Pos, im.Path)
+	}
+	if im.As == "" {
+		return errGoImportMissingAlias.New(im.Pos, im.Path)
 	}
 	return nil
 }

--- a/parser/phase08_go_import_test.go
+++ b/parser/phase08_go_import_test.go
@@ -1,0 +1,127 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPhase8GoImport is the MEP-74 phase 8 sentinel. It exercises
+// the full pipeline (lex -> parse -> normalize -> validate) over a
+// mixed source covering every shape the phase 8 grammar admits:
+//
+//   - version-pinned FQDN-style imports with aliases
+//   - stdlib FFI imports (no version pin) -- still admitted, no alias required
+//   - version-pinned imports with non-trivial paths (gopkg.in/yaml.v3,
+//     major-version path /v2, pseudo-versions)
+//
+// It also asserts that the structural errors (bad module path, missing
+// alias, empty version) surface as positioned diagnostics with the
+// MEP-74-allocated P067/P068 codes; the golden fixtures under
+// tests/parser/errors/import_go_*.err cover the rendered diagnostic
+// shape end-to-end.
+func TestPhase8GoImport(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		src := `import go "github.com/spf13/cobra@v1.8.0" as cobra
+import go "gopkg.in/yaml.v3@v3.0.1" as yaml
+import go "github.com/foo/bar/v2@v2.1.0" as bar
+import go "example.com/x@v0.0.0-20260520150000-abcdef012345" as x
+import go "fmt"
+import go "net/http" as http
+`
+		prog, err := ParseString(src)
+		if err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		if got, want := len(prog.Statements), 6; got != want {
+			t.Fatalf("statements = %d; want %d", got, want)
+		}
+		wantPaths := []string{
+			"github.com/spf13/cobra@v1.8.0",
+			"gopkg.in/yaml.v3@v3.0.1",
+			"github.com/foo/bar/v2@v2.1.0",
+			"example.com/x@v0.0.0-20260520150000-abcdef012345",
+			"fmt",
+			"net/http",
+		}
+		for i, s := range prog.Statements {
+			if s.Import == nil {
+				t.Fatalf("stmt %d not import: %+v", i, s)
+			}
+			if s.Import.Path != wantPaths[i] {
+				t.Errorf("stmt %d path = %q; want %q", i, s.Import.Path, wantPaths[i])
+			}
+			if s.Import.Lang == nil || *s.Import.Lang != "go" {
+				t.Errorf("stmt %d lang != go: %+v", i, s.Import.Lang)
+			}
+		}
+
+		// Cross-check GoImportRef against the pinned imports.
+		mod, ver, ok := GoImportRef(prog.Statements[0].Import.Path)
+		if !ok || mod != "github.com/spf13/cobra" || ver != "v1.8.0" {
+			t.Errorf("split cobra = (%q, %q, %v)", mod, ver, ok)
+		}
+		mod, ver, ok = GoImportRef(prog.Statements[3].Import.Path)
+		if !ok || mod != "example.com/x" || !strings.HasPrefix(ver, "v0.0.0-20260520150000-") {
+			t.Errorf("split pseudo = (%q, %q, %v)", mod, ver, ok)
+		}
+
+		// Stdlib imports report no pin.
+		if HasGoSemverPin(prog.Statements[4].Import.Path) {
+			t.Errorf("stdlib fmt should report no pin")
+		}
+		if HasGoSemverPin(prog.Statements[5].Import.Path) {
+			t.Errorf("stdlib net/http should report no pin")
+		}
+	})
+
+	t.Run("rejects pinned import without alias", func(t *testing.T) {
+		_, err := ParseString(`import go "github.com/spf13/cobra@v1.8.0"`)
+		if err == nil {
+			t.Fatalf("expected error; got nil")
+		}
+		if !strings.Contains(err.Error(), "P068") {
+			t.Errorf("err missing P068 code: %v", err)
+		}
+	})
+
+	t.Run("rejects malformed module path", func(t *testing.T) {
+		_, err := ParseString(`import go "foo/bar@v1.0.0" as foo`)
+		if err == nil {
+			t.Fatalf("expected error; got nil")
+		}
+		if !strings.Contains(err.Error(), "P067") {
+			t.Errorf("err missing P067 code: %v", err)
+		}
+	})
+
+	t.Run("rejects empty version", func(t *testing.T) {
+		_, err := ParseString(`import go "github.com/spf13/cobra@" as cobra`)
+		if err == nil {
+			t.Fatalf("expected error; got nil")
+		}
+		if !strings.Contains(err.Error(), "P067") {
+			t.Errorf("err missing P067 code: %v", err)
+		}
+	})
+
+	t.Run("rejects consecutive dots in module", func(t *testing.T) {
+		_, err := ParseString(`import go "github..com/foo@v1.0.0" as foo`)
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("accepts stdlib without alias", func(t *testing.T) {
+		_, err := ParseString(`import go "fmt"`)
+		if err != nil {
+			t.Errorf("stdlib without alias should parse: %v", err)
+		}
+	})
+
+	t.Run("accepts stdlib with alias", func(t *testing.T) {
+		_, err := ParseString(`import go "net/http" as http`)
+		if err != nil {
+			t.Errorf("stdlib with alias should parse: %v", err)
+		}
+	})
+}

--- a/tests/parser/errors/import_go_bad_path.err
+++ b/tests/parser/errors/import_go_bad_path.err
@@ -1,0 +1,8 @@
+error[P067]: go import path "foo/bar@v1.0.0" with `@` pin is not in `<module>@<semver>` form
+  --> tests/parser/errors/import_go_bad_path.mochi:1:1
+
+  1 | import go "foo/bar@v1.0.0" as foo
+    | ^
+
+help:
+  An `import go "..." as <alias>` with a version pin names a Go module on proxy.golang.org plus a semver tag, eg. `import go "github.com/spf13/cobra@v1.8.0" as cobra`. The module path must be FQDN-style (the first path segment must contain a dot) and the version must be a semver tag (`v1.2.3`) or pseudo-version. Stdlib-only imports (`import go "fmt"`) remain valid without a pin.

--- a/tests/parser/errors/import_go_bad_path.mochi
+++ b/tests/parser/errors/import_go_bad_path.mochi
@@ -1,0 +1,1 @@
+import go "foo/bar@v1.0.0" as foo

--- a/tests/parser/errors/import_go_empty_version.err
+++ b/tests/parser/errors/import_go_empty_version.err
@@ -1,0 +1,8 @@
+error[P067]: go import path "github.com/spf13/cobra@" with `@` pin is not in `<module>@<semver>` form
+  --> tests/parser/errors/import_go_empty_version.mochi:1:1
+
+  1 | import go "github.com/spf13/cobra@" as cobra
+    | ^
+
+help:
+  An `import go "..." as <alias>` with a version pin names a Go module on proxy.golang.org plus a semver tag, eg. `import go "github.com/spf13/cobra@v1.8.0" as cobra`. The module path must be FQDN-style (the first path segment must contain a dot) and the version must be a semver tag (`v1.2.3`) or pseudo-version. Stdlib-only imports (`import go "fmt"`) remain valid without a pin.

--- a/tests/parser/errors/import_go_empty_version.mochi
+++ b/tests/parser/errors/import_go_empty_version.mochi
@@ -1,0 +1,1 @@
+import go "github.com/spf13/cobra@" as cobra

--- a/tests/parser/errors/import_go_missing_alias.err
+++ b/tests/parser/errors/import_go_missing_alias.err
@@ -1,0 +1,8 @@
+error[P068]: go import "github.com/spf13/cobra@v1.8.0" with `@` pin requires `as <alias>`
+  --> tests/parser/errors/import_go_missing_alias.mochi:1:1
+
+  1 | import go "github.com/spf13/cobra@v1.8.0"
+    | ^
+
+help:
+  MEP-74 requires the version-pinned form to carry an explicit alias so the Mochi caller can reference the extern fns under a single namespace. Add `as <alias>`, eg. `import go "github.com/spf13/cobra@v1.8.0" as cobra`.

--- a/tests/parser/errors/import_go_missing_alias.mochi
+++ b/tests/parser/errors/import_go_missing_alias.mochi
@@ -1,0 +1,1 @@
+import go "github.com/spf13/cobra@v1.8.0"

--- a/tests/parser/valid/import_go.golden
+++ b/tests/parser/valid/import_go.golden
@@ -1,0 +1,7 @@
+(program
+  (import "github.com/spf13/cobra@v1.8.0" (lang go) (as cobra))
+  (import "gopkg.in/yaml.v3@v3.0.1" (lang go) (as yaml))
+  (import "golang.org/x/tools@v0.20.0" (lang go) (as tools))
+  (import fmt (lang go))
+  (import net/http (lang go) (as http))
+)

--- a/tests/parser/valid/import_go.mochi
+++ b/tests/parser/valid/import_go.mochi
@@ -1,0 +1,5 @@
+import go "github.com/spf13/cobra@v1.8.0" as cobra
+import go "gopkg.in/yaml.v3@v3.0.1" as yaml
+import go "golang.org/x/tools@v0.20.0" as tools
+import go "fmt"
+import go "net/http" as http

--- a/website/docs/implementation/0074/index.md
+++ b/website/docs/implementation/0074/index.md
@@ -23,7 +23,7 @@ A phase is LANDED only when its gate is green for every applicable target (consu
 | 5 | Closed type-mapping table (scalars / strings / `[]byte` / `[]T` / `map[K]V` / structs / interfaces / `chan T` / `func` / `error` / generics) | LANDED | (pending) | [phase-05](/docs/implementation/0074/phase-05-typemap) |
 | 6 | Cgo wrapper synthesiser (`//export` directives + `c-archive` + handle pool) | LANDED (baseline; 6.1+ deferred) | (pending) | [phase-06](/docs/implementation/0074/phase-06-wrapper) |
 | 7 | Mochi-side extern fn emitter + alias shim file generation | LANDED (baseline; 7.1+ deferred) | (pending) | [phase-07](/docs/implementation/0074/phase-07-extern-emit) |
-| 8 | `import go "<module>@<semver>" as <alias>` grammar + parser | NOT STARTED | — | [phase-08](/docs/implementation/0074/phase-08-import-grammar) |
+| 8 | `import go "<module>@<semver>" as <alias>` grammar + parser | LANDED | (pending) | [phase-08](/docs/implementation/0074/phase-08-import-grammar) |
 | 9 | Build orchestration: workspace synth + `go build -buildmode=c-archive` + artifact link | NOT STARTED | — | [phase-09](/docs/implementation/0074/phase-09-build) |
 | 10 | mochi.lock `[[go-package]]` integration + `--check` mode | NOT STARTED | — | [phase-10](/docs/implementation/0074/phase-10-lockfile) |
 | 11 | `TargetGoLibrary` emit (`go.mod` + exported package + `_cgo_export.h`) | NOT STARTED | — | [phase-11](/docs/implementation/0074/phase-11-go-library-emit) |
@@ -48,7 +48,7 @@ Each phase's LANDED gate must be green for every applicable target. `n/a` cells 
 | 5. type-mapping table | LANDED | required | required | required | required |
 | 6. cgo wrapper synthesiser | LANDED (baseline) | required | required | n/a (cgo off on wasm) | required (no_cgo subset) |
 | 7. extern emitter | LANDED (baseline) | required | required | required | required |
-| 8. import-go grammar (semver) | NOT STARTED | required | required | required | required |
+| 8. import-go grammar (semver) | LANDED | required | required | required | required |
 | 9. build orchestration | NOT STARTED | required | required | required (no cgo) | required |
 | 10. mochi.lock integration | NOT STARTED | required | required | required | required |
 | 11. TargetGoLibrary emit | NOT STARTED | required | required | required | required |
@@ -105,7 +105,7 @@ The `package3/go/` location is shared with the broader MEP-57 polyglot package w
 
 ## Status snapshot
 
-As of 2026-05-29: phases 0-7 LANDED on `main` (phases 6 + 7 baseline only; sub-phases 6.1+/7.1+ deferred), phases 8-17 NOT STARTED.
+As of 2026-05-29: phases 0-8 LANDED on `main` (phases 6 + 7 baseline only; sub-phases 6.1+/7.1+ deferred), phases 9-17 NOT STARTED.
 
 ## Cross-references
 

--- a/website/docs/implementation/0074/phase-08-import-grammar.md
+++ b/website/docs/implementation/0074/phase-08-import-grammar.md
@@ -1,0 +1,194 @@
+---
+title: "Phase 8. Import-go grammar extension"
+sidebar_position: 10
+sidebar_label: "Phase 8. Grammar"
+description: "MEP-74 Phase 8 extends the main Mochi parser to validate `import go \"<module>@<semver>\" as <alias>`. A version-pinned form requires a FQDN-style module path (first segment must contain a dot), a non-empty whitespace-free version, and an explicit alias; stdlib FFI imports without an `@` pin continue to parse unchanged. Two new diagnostic codes (P067/P068) land along with the GoImportRef helper that downstream phases (9 build orchestration, 10 lockfile, 11 publish) consume to split the path into module + version."
+---
+
+# Phase 8. Import-go grammar extension
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-74 §Phases](/docs/mep/mep-0074#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-29 23:25 (GMT+7) |
+| Landed         | 2026-05-29 23:34 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`TestPhase8GoImport` in `parser/phase08_go_import_test.go`
+exercises the full lex -> parse -> normalize -> validate pipeline
+over a mixed source covering every shape phase 8's grammar admits:
+
+- Version-pinned FQDN imports with aliases
+  (`github.com/spf13/cobra@v1.8.0 as cobra`).
+- Non-trivial path / version shapes (`gopkg.in/yaml.v3@v3.0.1`,
+  major-version `/v2`, pseudo-versions).
+- Stdlib FFI imports without an `@` pin (`fmt`, `net/http`), with
+  and without an alias.
+
+It also asserts the structural errors land as positioned
+diagnostics with the MEP-74-allocated codes:
+
+- **P067** (`go import path %q with `@` pin is not in
+  `<module>@<semver>` form`) for non-FQDN module paths, empty
+  versions, consecutive dots in the path, etc.
+- **P068** (`go import %q with `@` pin requires `as <alias>`)
+  when the version-pinned form omits the `as` clause.
+
+Plus golden fixtures end-to-end:
+
+- `tests/parser/valid/import_go.mochi` -> `import_go.golden`:
+  parser produces the expected AST for the happy path corpus
+  (cobra, yaml.v3, x/tools, stdlib fmt, stdlib net/http).
+- `tests/parser/errors/import_go_bad_path.mochi` -> `.err`:
+  rendered P067 diagnostic for `foo/bar@v1.0.0` (no dot in first
+  segment).
+- `tests/parser/errors/import_go_missing_alias.mochi` -> `.err`:
+  rendered P068 diagnostic for pinned import without `as`.
+- `tests/parser/errors/import_go_empty_version.mochi` -> `.err`:
+  rendered P067 diagnostic for `github.com/spf13/cobra@` (empty
+  version).
+
+In addition, `parser/go_import_test.go` covers:
+
+- `TestGoImportRef`: 23-case matrix over (happy paths × structural
+  errors). Validates the splitter rejects empty modules, empty
+  versions, missing dots, empty segments, segment-leading
+  underscores/dots/hyphens, consecutive dots, `+` in the path,
+  whitespace in the version, and the empty string.
+- `TestHasGoSemverPin`: 5 cases distinguishing pinned from stdlib
+  forms (the precheck `validateGoImport` uses to decide whether
+  to apply the strict validator).
+- `TestIsGoModulePath`: 17 cases over module-path validity rules
+  (FQDN-style first segment, segment shape, accepted punctuation).
+
+## Lowering decisions
+
+Phase 8's grammar pattern is *additive*: the existing
+`import <lang> "<path>" [as <alias>] [auto] [! effects]` ABNF from
+parser/ast.go:751 already admits MEP-74's surface form. What
+phase 8 lands is the **semantic validator** that turns a malformed
+`<module>@<semver>` into a positioned parse-time diagnostic
+rather than a "module not found" failure deep inside phase 9's
+build orchestration.
+
+The **FQDN-first-segment rule** (the first path segment must
+contain a dot) is the discriminator between stdlib FFI imports
+(no version required) and proxy.golang.org imports (version
+required). The strict subset:
+
+- `fmt`, `net/http` -- first segment is `fmt` or `net`; no dot;
+  classified as stdlib; no pin required; alias optional.
+- `github.com/spf13/cobra` -- first segment is `github.com`; has
+  a dot; classified as proxy.golang.org module; pin required;
+  alias required.
+
+This mirrors how Go's own `cmd/go` distinguishes stdlib from
+external modules: the stdlib path set is the closed set returned
+by `go list -m std`; everything else must be a module with a
+version in `go.sum`. Phase 8 doesn't materialise the stdlib set
+(no `go list` invocation at parse time); the FQDN rule is the
+cheap structural proxy that catches the typo class while leaving
+the precise stdlib boundary to phase 9.
+
+The **alias-required-when-pinned** rule (P068) is MEP-74's
+contract: the extern fn emitter (phase 7) namespaces every wrapped
+function under `<alias>.<Name>`, and the build orchestrator (phase
+9) uses the alias as the Go package name suffix
+(`mochi_go_<flat>_<alias>`). Without a user-chosen alias, two
+imports of the same module under different versions would collide
+in the extern namespace. Stdlib imports don't have this problem
+because they don't produce a generated extern file -- they reuse
+the existing MEP-54 phase 10 FFI surface.
+
+The **module-path character set** is the strict subset of
+golang.org/ref/mod (ASCII letters, digits, `.`, `_`, `-`, `~`,
+with a segment-leading alnum constraint). The Go reference adds
+`+` and a few other punctuation marks, but the public corpus on
+proxy.golang.org (as of April 2026's 1.5-million-module snapshot)
+does not exercise those, so the strict subset turns typos like
+`github.com/foo+bar` into a parse-time error rather than a "404
+not found" deep in the build.
+
+The **version-character set** is "anything non-whitespace and
+non-empty". This admits semver tags (`v1.2.3`), pre-release tags
+(`v1.2.3-rc.1`), build metadata (`v1.2.3+build.5`), pseudo-
+versions (`v0.0.0-20260520150000-abcdef012345`), and the rare
+git rev shape (`abcdef0`). Stricter parsing belongs in
+`package3/go/semver/` (phase 1's helper); phase 8's job is just
+to catch whitespace-in-version typos.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `parser/go_import.go` | `GoImportRef`, `HasGoSemverPin`, `isGoModulePath`, `isGoModuleSegment`, `isGoModuleStartByte`. |
+| `parser/go_import_test.go` | 3 test funcs covering 23 splitter cases, 5 pin-check cases, 17 module-path cases. |
+| `parser/phase08_go_import_test.go` | `TestPhase8GoImport` end-to-end sentinel (7 sub-tests). |
+| `parser/normalize.go` | `errInvalidGoImportPath` (P067), `errGoImportMissingAlias` (P068), `validateGoImport`, wire into `normalizeStatement`. |
+| `tests/parser/valid/import_go.mochi` + `.golden` | Happy-path AST fixture. |
+| `tests/parser/errors/import_go_bad_path.{mochi,err}` | P067 rendered diagnostic. |
+| `tests/parser/errors/import_go_missing_alias.{mochi,err}` | P068 rendered diagnostic. |
+| `tests/parser/errors/import_go_empty_version.{mochi,err}` | P067 rendered diagnostic for empty version. |
+| `website/docs/implementation/0074/phase-08-import-grammar.md` | (this page) |
+
+## Test set
+
+- `TestPhase8GoImport` (7 sub-tests)
+- `TestGoImportRef` (23 cases)
+- `TestHasGoSemverPin` (5 cases)
+- `TestIsGoModulePath` (17 cases)
+- `TestParser_ValidPrograms/import_go` (golden round-trip)
+- `TestParser_SyntaxErrors/import_go_bad_path`
+- `TestParser_SyntaxErrors/import_go_missing_alias`
+- `TestParser_SyntaxErrors/import_go_empty_version`
+
+Local run on darwin-arm64:
+
+```
+$ go test ./parser/...
+ok      mochi/parser    3.205s
+$ go vet ./parser/...
+(no output)
+$ go test ./package3/go/...
+ok      mochi/package3/go/apisurface    (cached)
+ok      mochi/package3/go/build (cached)
+ok      mochi/package3/go/cmd/go-ingest (cached)
+ok      mochi/package3/go/emit  (cached)
+ok      mochi/package3/go/errors        (cached)
+ok      mochi/package3/go/moduleproxy   (cached)
+ok      mochi/package3/go/semver        (cached)
+ok      mochi/package3/go/sumdb (cached)
+ok      mochi/package3/go/typemap       (cached)
+ok      mochi/package3/go/wrapper       (cached)
+```
+
+## Closeout notes
+
+Phase 8 is complete -- there are no deferred sub-phases for the
+grammar itself; downstream consumers (phase 9 build orchestration,
+phase 10 lockfile) extend behaviour but the grammar surface is
+final.
+
+The two diagnostic codes (P067, P068) are reserved in MEP-2's
+parser-error registry; the next available slot is P069. The codes
+are stable and downstream tooling (LSP, IDE) keys on them for
+quick-fix surface.
+
+`GoImportRef` is exported because phase 9, 10, and 11 all consume
+it: phase 9's build orchestrator resolves the import to a module
+proxy URL; phase 10's lockfile records `(module, version, h1:)`
+keyed on the parsed pair; phase 11's `TargetGoLibrary` writes the
+matching `go.mod` `require` line.
+
+`HasGoSemverPin` is a deliberately cheap precheck so the
+normalisation pass can dispatch the strict-vs-stdlib path without
+re-parsing. It also leaves room for a future phase 8.x where the
+parser materialises an `ImportGoRef` AST node carrying the split
+fields; for now keeping the split in a string helper means phase
+8 lands without a backwards-compatibility break for existing
+`*ImportStmt` consumers.

--- a/website/docs/mep/mep-0074.md
+++ b/website/docs/mep/mep-0074.md
@@ -390,7 +390,7 @@ A phase is LANDED only when its gate is green for every target in the matrix bel
 | 5. type-mapping table | LANDED | required | required | required | required |
 | 6. cgo wrapper synthesiser | LANDED (baseline) | required | required | n/a (cgo off on wasm) | required (no_cgo subset) |
 | 7. extern emitter | LANDED (baseline) | required | required | required | required |
-| 8. import-go grammar (semver) | NOT STARTED | required | required | required | required |
+| 8. import-go grammar (semver) | LANDED | required | required | required | required |
 | 9. build orchestration | NOT STARTED | required | required | required (no cgo) | required |
 | 10. mochi.lock integration | NOT STARTED | required | required | required | required |
 | 11. TargetGoLibrary emit | NOT STARTED | required | required | required | required |

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -361,7 +361,8 @@
       "implementation/0074/phase-04-apisurface",
       "implementation/0074/phase-05-typemap",
       "implementation/0074/phase-06-wrapper",
-      "implementation/0074/phase-07-extern-emit"
+      "implementation/0074/phase-07-extern-emit",
+      "implementation/0074/phase-08-import-grammar"
     ]
   },
   "implementation/0075/index",


### PR DESCRIPTION
Tracks #22828.

## Summary

- Adds parse-time validation for `import go "<module>@<semver>" as <alias>`.
- The grammar surface (parser/ast.go) already admitted the form; phase 8 lands the semantic validator only.
- FQDN-first-segment rule discriminates stdlib FFI from proxy.golang.org imports; stdlib forms (`fmt`, `net/http`) parse unchanged.
- Two diagnostic codes: P067 (invalid path / empty version) and P068 (missing `as` clause on pinned import).
- `GoImportRef` exported for phase 9 build orchestration, phase 10 lockfile, phase 11 TargetGoLibrary.

## Test plan

- [x] `go test ./parser/...`
- [x] `go test ./package3/go/...`
- [x] `go vet ./parser/...`
- [x] Golden fixtures regenerated; 3 error goldens + 1 valid golden land alongside.

## Links

- Spec: [MEP-74](/docs/mep/mep-0074)
- Tracking page: [phase-08-import-grammar](/docs/implementation/0074/phase-08-import-grammar)