### PR TITLE
feat(mep-75 p2): content-addressed Composer dist cache

### DIFF
--- a/package3/php/cache/cache.go
+++ b/package3/php/cache/cache.go
@@ -1,4 +1,200 @@
 // Package cache implements the content-addressed Composer dist fetcher and
-// SHA-256 cache for the MEP-75 PHP bridge. Phase 0 ships the package stub;
-// the full implementation arrives in phase 2.
+// SHA-256 cache for the MEP-75 PHP bridge.
+//
+// Dist archives (zip files from Packagist) are stored under:
+//
+//	<root>/<sha256-hex[0:2]>/<sha256-hex[2:]>.zip
+//
+// The sha256 is computed after download and verified against the expected
+// value from the Packagist dist info. This layout matches the MEP-75 spec §8.
+//
+// See [website/docs/research/0075/04-packagist-ingest.md] for the design.
 package cache
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Cache is a filesystem-backed content-addressed store for Composer dist
+// archives. Safe for concurrent use; Store operations are atomic via
+// tmp-then-rename on the same filesystem.
+type Cache struct {
+	// Root is the cache root directory, e.g. ~/.cache/mochi/php-deps.
+	Root string
+	// HTTP is the underlying transport for dist downloads.
+	HTTP *http.Client
+	// UserAgent is sent with outbound download requests.
+	UserAgent string
+}
+
+const defaultUserAgent = "mochi-php-bridge/0.1 (+https://mochi-lang.dev)"
+
+// NewCache returns a Cache rooted at root.
+func NewCache(root string) *Cache {
+	return &Cache{
+		Root:      root,
+		HTTP:      &http.Client{Timeout: 60 * time.Second},
+		UserAgent: defaultUserAgent,
+	}
+}
+
+// DistPath returns the absolute filesystem path for the given SHA-256 hex
+// digest. Does not check whether the file exists.
+func (c *Cache) DistPath(sha256hex string) (string, error) {
+	if err := validateSHA256Hex(sha256hex); err != nil {
+		return "", err
+	}
+	return filepath.Join(c.Root, sha256hex[:2], sha256hex[2:]+".zip"), nil
+}
+
+// Has reports whether a dist archive with the given SHA-256 digest is cached.
+func (c *Cache) Has(sha256hex string) bool {
+	path, err := c.DistPath(sha256hex)
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(path)
+	return err == nil
+}
+
+// Store downloads the dist archive from distURL, verifies SHA-256 against
+// expectedSHA256 (lowercase hex, may be empty to skip), and stores it at the
+// content-addressed path. Returns the cache path and the verified digest.
+//
+// If the digest is already cached (fast path), the download is skipped.
+// If verification fails or the download errors, no partial file is left on disk.
+func (c *Cache) Store(ctx context.Context, distURL, expectedSHA256 string) (string, string, error) {
+	if expectedSHA256 != "" && c.Has(expectedSHA256) {
+		path, err := c.DistPath(expectedSHA256)
+		return path, expectedSHA256, err
+	}
+
+	stagingDir := filepath.Join(c.Root, ".tmp")
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
+		return "", "", fmt.Errorf("cache: mkdir staging: %w", err)
+	}
+	tmp, err := os.CreateTemp(stagingDir, "php-dist-*.zip.tmp")
+	if err != nil {
+		return "", "", fmt.Errorf("cache: create tmp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() {
+		tmp.Close()
+		os.Remove(tmpPath) //nolint:errcheck
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, distURL, nil)
+	if err != nil {
+		cleanup()
+		return "", "", fmt.Errorf("cache: build request: %w", err)
+	}
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+	httpClient := c.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		cleanup()
+		return "", "", fmt.Errorf("cache: GET %s: %w", distURL, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		cleanup()
+		return "", "", fmt.Errorf("%w: %s", ErrDistNotFound, distURL)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		cleanup()
+		return "", "", fmt.Errorf("cache: GET %s: status %d: %s", distURL, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	h := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmp, h), resp.Body); err != nil {
+		cleanup()
+		return "", "", fmt.Errorf("cache: copy %s: %w", distURL, err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return "", "", fmt.Errorf("cache: close tmp: %w", err)
+	}
+
+	gotSHA := hex.EncodeToString(h.Sum(nil))
+	if expectedSHA256 != "" && gotSHA != expectedSHA256 {
+		os.Remove(tmpPath)
+		return "", "", fmt.Errorf("%w: %s: have %s want %s", ErrChecksumMismatch, distURL, gotSHA, expectedSHA256)
+	}
+
+	dst, err := c.DistPath(gotSHA)
+	if err != nil {
+		os.Remove(tmpPath)
+		return "", "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		os.Remove(tmpPath)
+		return "", "", fmt.Errorf("cache: mkdir %s: %w", filepath.Dir(dst), err)
+	}
+	if err := os.Rename(tmpPath, dst); err != nil {
+		os.Remove(tmpPath)
+		return "", "", fmt.Errorf("cache: rename to %s: %w", dst, err)
+	}
+	return dst, gotSHA, nil
+}
+
+// Load opens a cached dist archive by SHA-256 hex digest. The caller must close
+// the returned ReadCloser.
+func (c *Cache) Load(sha256hex string) (io.ReadCloser, error) {
+	path, err := c.DistPath(sha256hex)
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w: %s", ErrDistNotCached, sha256hex)
+		}
+		return nil, fmt.Errorf("cache: open %s: %w", path, err)
+	}
+	return f, nil
+}
+
+// HashReader computes the SHA-256 of the data in r without storing anything.
+func HashReader(r io.Reader) (string, error) {
+	h := sha256.New()
+	if _, err := io.Copy(h, r); err != nil {
+		return "", fmt.Errorf("cache: hash: %w", err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func validateSHA256Hex(s string) error {
+	if len(s) != 64 {
+		return fmt.Errorf("cache: sha256 hex %q: expected 64 chars, got %d", s, len(s))
+	}
+	if _, err := hex.DecodeString(s); err != nil {
+		return fmt.Errorf("cache: sha256 hex %q: invalid hex: %w", s, err)
+	}
+	return nil
+}
+
+// ErrDistNotFound is returned when the dist archive URL returns HTTP 404.
+var ErrDistNotFound = errors.New("cache: dist archive not found")
+
+// ErrChecksumMismatch is returned when the downloaded archive's SHA-256 does
+// not match the expected value.
+var ErrChecksumMismatch = errors.New("cache: dist checksum mismatch")
+
+// ErrDistNotCached is returned by Load when the requested digest is not cached.
+var ErrDistNotCached = errors.New("cache: dist not cached")

--- a/package3/php/cache/cache_test.go
+++ b/package3/php/cache/cache_test.go
@@ -1,0 +1,266 @@
+package cache
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func sha256Hex(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+const zeroDigest = "0000000000000000000000000000000000000000000000000000000000000000"
+
+func TestNewCacheDefaults(t *testing.T) {
+	c := NewCache("/tmp/test-cache")
+	if c.Root != "/tmp/test-cache" {
+		t.Errorf("Root = %q; want /tmp/test-cache", c.Root)
+	}
+	if c.HTTP == nil {
+		t.Error("HTTP should be non-nil by default")
+	}
+	if c.UserAgent == "" {
+		t.Error("UserAgent should be non-empty by default")
+	}
+}
+
+func TestDistPath(t *testing.T) {
+	c := NewCache("/cache")
+	digest := strings.Repeat("ab", 32) // 64 valid hex chars
+	path, err := c.DistPath(digest)
+	if err != nil {
+		t.Fatalf("DistPath: %v", err)
+	}
+	wantDir := filepath.Join("/cache", "ab")
+	if !strings.HasPrefix(path, wantDir) {
+		t.Errorf("DistPath = %q; should start with %q", path, wantDir)
+	}
+	if !strings.HasSuffix(path, ".zip") {
+		t.Errorf("DistPath = %q; should end with .zip", path)
+	}
+}
+
+func TestDistPathInvalidDigest(t *testing.T) {
+	c := NewCache("/cache")
+	cases := []string{"", "short", strings.Repeat("g", 64)}
+	for _, bad := range cases {
+		_, err := c.DistPath(bad)
+		if err == nil {
+			t.Errorf("DistPath(%q) should return error", bad)
+		}
+	}
+}
+
+func TestHasReturnsFalseWhenMissing(t *testing.T) {
+	c := NewCache(t.TempDir())
+	if c.Has(sha256Hex([]byte("nonexistent"))) {
+		t.Error("Has should return false for missing file")
+	}
+}
+
+func TestStoreAndLoad(t *testing.T) {
+	payload := []byte("fake zip archive contents")
+	expectedSHA := sha256Hex(payload)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(payload) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	c := NewCache(t.TempDir())
+	path, gotSHA, err := c.Store(context.Background(), srv.URL+"/dist.zip", expectedSHA)
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if gotSHA != expectedSHA {
+		t.Errorf("returned SHA %q != expected %q", gotSHA, expectedSHA)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("cached file %q not found: %v", path, err)
+	}
+
+	rc, err := c.Load(gotSHA)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer rc.Close()
+	got, _ := io.ReadAll(rc)
+	if !bytes.Equal(got, payload) {
+		t.Errorf("Load returned %q; want %q", got, payload)
+	}
+}
+
+func TestStoreFastPath(t *testing.T) {
+	payload := []byte("cached payload")
+	expectedSHA := sha256Hex(payload)
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Write(payload) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	c := NewCache(t.TempDir())
+	if _, _, err := c.Store(context.Background(), srv.URL+"/dist.zip", expectedSHA); err != nil {
+		t.Fatalf("first Store: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 server call; got %d", calls)
+	}
+	if _, _, err := c.Store(context.Background(), srv.URL+"/dist.zip", expectedSHA); err != nil {
+		t.Fatalf("second Store: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("fast-path: expected still 1 server call; got %d", calls)
+	}
+}
+
+func TestStoreChecksumMismatch(t *testing.T) {
+	payload := []byte("payload")
+	wrongExpected := sha256Hex([]byte("different content"))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(payload) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	c := NewCache(t.TempDir())
+	_, _, err := c.Store(context.Background(), srv.URL+"/dist.zip", wrongExpected)
+	if err == nil {
+		t.Fatal("expected error for checksum mismatch")
+	}
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Errorf("error %v is not ErrChecksumMismatch", err)
+	}
+}
+
+func TestStore404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewCache(t.TempDir())
+	_, _, err := c.Store(context.Background(), srv.URL+"/missing.zip", "")
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if !errors.Is(err, ErrDistNotFound) {
+		t.Errorf("error %v is not ErrDistNotFound", err)
+	}
+}
+
+func TestStore500(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewCache(t.TempDir())
+	_, _, err := c.Store(context.Background(), srv.URL+"/dist.zip", "")
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error %v should mention status 500", err)
+	}
+}
+
+func TestStoreNoExpectedSHA(t *testing.T) {
+	payload := []byte("archive without known sha")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(payload) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	c := NewCache(t.TempDir())
+	path, gotSHA, err := c.Store(context.Background(), srv.URL+"/dist.zip", "")
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if gotSHA != sha256Hex(payload) {
+		t.Errorf("SHA mismatch: %q != %q", gotSHA, sha256Hex(payload))
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("file not found at %q: %v", path, err)
+	}
+}
+
+func TestLoadNotCached(t *testing.T) {
+	c := NewCache(t.TempDir())
+	_, err := c.Load(sha256Hex([]byte("not downloaded")))
+	if err == nil {
+		t.Fatal("expected error for uncached digest")
+	}
+	if !errors.Is(err, ErrDistNotCached) {
+		t.Errorf("error %v is not ErrDistNotCached", err)
+	}
+}
+
+func TestHashReader(t *testing.T) {
+	data := []byte("hello world")
+	want := sha256Hex(data)
+	got, err := HashReader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("HashReader: %v", err)
+	}
+	if got != want {
+		t.Errorf("HashReader = %q; want %q", got, want)
+	}
+}
+
+func TestUserAgentSent(t *testing.T) {
+	var gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.Write([]byte("data")) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	c := NewCache(t.TempDir())
+	c.Store(context.Background(), srv.URL+"/dist.zip", "") //nolint:errcheck
+	if !strings.Contains(gotUA, "mochi-php-bridge") {
+		t.Errorf("User-Agent %q should contain mochi-php-bridge", gotUA)
+	}
+}
+
+func TestValidateSHA256Hex(t *testing.T) {
+	if err := validateSHA256Hex(zeroDigest); err != nil {
+		t.Errorf("validateSHA256Hex(zeros) = %v; want nil", err)
+	}
+	if err := validateSHA256Hex("abc"); err == nil {
+		t.Error("validateSHA256Hex(short) should error")
+	}
+	if err := validateSHA256Hex(strings.Repeat("zz", 32)); err == nil {
+		t.Error("validateSHA256Hex(non-hex) should error")
+	}
+}
+
+func TestHasReturnsTrueAfterStore(t *testing.T) {
+	payload := []byte("presence test")
+	sha := sha256Hex(payload)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(payload) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	c := NewCache(t.TempDir())
+	if c.Has(sha) {
+		t.Error("Has should be false before Store")
+	}
+	if _, _, err := c.Store(context.Background(), srv.URL+"/dist.zip", sha); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if !c.Has(sha) {
+		t.Error("Has should be true after Store")
+	}
+}


### PR DESCRIPTION
Closes #22832

## Summary

- `cache/cache.go`: SHA-256 content-addressed cache for Composer dist archives; DistPath uses `<sha256[0:2]>/<sha256[2:]>.zip` layout; Store downloads + verifies + atomic-renames; fast-path skips download when digest cached; Load returns ReadCloser
- 15 tests: path shapes, invalid digest, HTTP mock store/load round-trip, fast-path idempotence, checksum mismatch, 404/500, no-expected-SHA, User-Agent header

## Test plan

- [ ] `go test ./package3/php/cache/...` passes (15 tests)
- [ ] `TestStoreChecksumMismatch` returns `ErrChecksumMismatch`
- [ ] `TestStoreFastPath` shows only 1 HTTP call on second Store
- [ ] `TestStore404` returns `ErrDistNotFound`