### PR TITLE
MEP-74 phase 9: build orchestration baseline

### DIFF
--- a/package3/go/build/build.go
+++ b/package3/go/build/build.go
@@ -1,0 +1,487 @@
+// Package build phase 9 lands the build-orchestration surface on top
+// of the phase-0 workspace skeleton. The entry point is
+// Driver.Build, which:
+//
+//  1. assembles the workspace topology from the wrapper.Result tree
+//     (a wrapper module per imported Go dep);
+//  2. writes each wrapper module to disk under
+//     <work-dir>/go_workspace/go_wrap/<flat-module>/;
+//  3. renders the workspace go.work;
+//  4. invokes `go build -buildmode=c-archive` on every wrapper module
+//     with the deterministic flag set (-trimpath, -buildvcs=false,
+//     -ldflags=-s -w);
+//  5. links the produced *.a + *.h artefacts into the BuildArtefacts
+//     return value, which the MEP-54 link step consumes.
+//
+// The build is keyed on a content-addressed cache key derived from
+// every wrapper file's sha256, the workspace go.work bytes, and the
+// caller-supplied target tuple (GOOS / GOARCH). A cache hit copies
+// the cached artefacts back into the work-dir and short-circuits
+// the `go build` invocation.
+package build
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"mochi/package3/go/wrapper"
+)
+
+// BuildPlan is the input to Driver.Build. It describes one or more
+// wrapper modules that need to be compiled into c-archive artefacts.
+type BuildPlan struct {
+	// Wrappers is the per-module set of synthesised cgo wrappers, one
+	// per `import go` line in the user program. Each entry is a
+	// wrapper.Result produced by phase 6.
+	Wrappers []wrapper.Result
+	// Target chooses the GOOS / GOARCH the wrappers compile for.
+	// Empty fields default to the host (runtime.GOOS / runtime.GOARCH).
+	Target Target
+	// CgoEnabled controls the CGO_ENABLED env var. Phase 9 defaults
+	// to true on host-cgo-capable targets, false on wasm.
+	CgoEnabled bool
+	// ExtraEnv is appended to the `go build` env. Useful for callers
+	// that need to set GOFLAGS, CC, or similar.
+	ExtraEnv []string
+	// SkipBuild lets callers exercise the workspace-write path only.
+	// When true, Driver.Build writes the workspace tree, computes the
+	// cache key, but does not invoke `go build`. Used in unit tests
+	// that don't want to pay the cgo toolchain cost.
+	SkipBuild bool
+}
+
+// Target is a (GOOS, GOARCH) tuple plus optional GOARM, used to
+// drive cross-compilation. Empty fields fall back to the host.
+type Target struct {
+	GOOS   string
+	GOARCH string
+	GOARM  string
+}
+
+// String renders the target as a `GOOS/GOARCH` token. Used in cache
+// keys and diagnostics.
+func (t Target) String() string {
+	goos := t.GOOS
+	if goos == "" {
+		goos = runtime.GOOS
+	}
+	goarch := t.GOARCH
+	if goarch == "" {
+		goarch = runtime.GOARCH
+	}
+	s := goos + "/" + goarch
+	if t.GOARM != "" {
+		s += "/v" + t.GOARM
+	}
+	return s
+}
+
+// BuildResult captures the artefacts produced by Driver.Build.
+type BuildResult struct {
+	// Artefacts is one BuildArtefact per wrapper module, indexed by
+	// the wrapper's ModuleName. Each entry records the on-disk path
+	// to the `.a` static archive and the matching `_cgo_export.h`
+	// header.
+	Artefacts map[string]BuildArtefact
+	// WorkspaceRoot is the directory the workspace go.work was written
+	// to. The path is preserved across the call so callers can wire
+	// it into a higher-level build cache.
+	WorkspaceRoot string
+	// CacheKey is the content-addressed key the build was performed
+	// (or cache-hit) against. Stable across runs.
+	CacheKey string
+	// CacheHit reports whether the cache lookup found a pre-built
+	// archive set and the `go build` invocation was skipped.
+	CacheHit bool
+}
+
+// BuildArtefact captures the output of one `go build -buildmode=c-archive`
+// invocation: the path to the static archive and the matching cgo
+// header file. Both paths live inside the driver's work-dir.
+type BuildArtefact struct {
+	// ModuleName is the wrapper.Result.ModuleName the artefact came from.
+	ModuleName string
+	// ArchivePath is the absolute path to the `<module>.a` file.
+	ArchivePath string
+	// HeaderPath is the absolute path to the `<module>.h` cgo header.
+	HeaderPath string
+}
+
+// Build executes the phase 9 pipeline end-to-end. The Driver must
+// have been initialised but does not need PrepareWorkspace called
+// in advance, Build does that itself.
+func (d *Driver) Build(plan BuildPlan) (*BuildResult, error) {
+	if len(plan.Wrappers) == 0 {
+		return nil, fmt.Errorf("build: plan has no wrappers")
+	}
+	for _, w := range plan.Wrappers {
+		if w.ModuleName == "" {
+			return nil, fmt.Errorf("build: wrapper has empty ModuleName")
+		}
+		if len(w.Files) == 0 {
+			return nil, fmt.Errorf("build: wrapper %q has no files", w.ModuleName)
+		}
+	}
+
+	ws, err := d.PrepareWorkspace()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, w := range plan.Wrappers {
+		ws.AddModule(WorkspaceModule{
+			ImportPath: synthesisedImportPath(w.ModuleName),
+			Path:       filepath.Join("go_wrap", w.ModuleName),
+			Kind:       ModuleWrapper,
+		})
+	}
+
+	root, err := d.WriteWorkspaceRoot(ws)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, w := range plan.Wrappers {
+		modDir := filepath.Join(root, "go_wrap", w.ModuleName)
+		if err := writeWrapperModule(modDir, w); err != nil {
+			return nil, err
+		}
+	}
+
+	cacheKey := computeCacheKey(plan, ws)
+	cachePath := d.cacheArtefactDir(cacheKey)
+
+	if hit, err := d.tryCacheHit(plan, cachePath, root); err != nil {
+		return nil, err
+	} else if hit != nil {
+		hit.CacheKey = cacheKey
+		hit.WorkspaceRoot = root
+		hit.CacheHit = true
+		return hit, nil
+	}
+
+	artefacts := map[string]BuildArtefact{}
+	if !plan.SkipBuild {
+		for _, w := range plan.Wrappers {
+			a, err := d.buildOne(plan, root, w)
+			if err != nil {
+				return nil, err
+			}
+			artefacts[w.ModuleName] = a
+		}
+		if err := d.populateCache(cachePath, artefacts); err != nil {
+			return nil, fmt.Errorf("build: populate cache: %w", err)
+		}
+	} else {
+		for _, w := range plan.Wrappers {
+			modDir := filepath.Join(root, "go_wrap", w.ModuleName)
+			artefacts[w.ModuleName] = BuildArtefact{
+				ModuleName:  w.ModuleName,
+				ArchivePath: filepath.Join(modDir, w.ModuleName+".a"),
+				HeaderPath:  filepath.Join(modDir, w.ModuleName+".h"),
+			}
+		}
+	}
+
+	return &BuildResult{
+		Artefacts:     artefacts,
+		WorkspaceRoot: root,
+		CacheKey:      cacheKey,
+		CacheHit:      false,
+	}, nil
+}
+
+// writeWrapperModule writes the wrapper.Result's Files into modDir
+// and synthesises the matching go.mod. The wrapper's Files are written
+// verbatim (the emitter already produced cgo-ready source); the go.mod
+// is generated here because phase 6 doesn't own the module-path
+// decision.
+func writeWrapperModule(modDir string, w wrapper.Result) error {
+	if err := os.MkdirAll(modDir, 0o755); err != nil {
+		return fmt.Errorf("build: mkdir %s: %w", modDir, err)
+	}
+	for name, content := range w.Files {
+		// Refuse path components that escape modDir.
+		clean := filepath.Clean(name)
+		if strings.HasPrefix(clean, "..") || filepath.IsAbs(clean) {
+			return fmt.Errorf("build: wrapper file %q escapes module dir", name)
+		}
+		dest := filepath.Join(modDir, clean)
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(dest, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("build: write %s: %w", dest, err)
+		}
+	}
+	gomod := renderWrapperGoMod(w.ModuleName)
+	if err := os.WriteFile(filepath.Join(modDir, "go.mod"), []byte(gomod), 0o644); err != nil {
+		return fmt.Errorf("build: write go.mod: %w", err)
+	}
+	return nil
+}
+
+// renderWrapperGoMod produces the synthesised go.mod for a wrapper
+// module. The Go-version floor is held at 1.21 to match the workspace
+// default; phase 10's lockfile may bump it per-module from the source
+// module's go.mod.
+func renderWrapperGoMod(moduleName string) string {
+	return fmt.Sprintf("// Auto-generated by MEP-74 bridge. Do not edit by hand.\nmodule %s\n\ngo 1.21\n",
+		synthesisedImportPath(moduleName))
+}
+
+// synthesisedImportPath maps a wrapper.Result.ModuleName (already
+// flattened, e.g. "mochi_go_github_com_spf13_cobra") to the import
+// path used inside the workspace. The bridge-local prefix
+// `mochilang.local/` keeps the synthesised modules clearly distinct
+// from any user module that happens to share a name.
+func synthesisedImportPath(moduleName string) string {
+	return "mochilang.local/" + moduleName
+}
+
+// buildOne runs `go build -buildmode=c-archive` over a single wrapper
+// module and returns the resulting artefact pair.
+func (d *Driver) buildOne(plan BuildPlan, root string, w wrapper.Result) (BuildArtefact, error) {
+	modDir := filepath.Join(root, "go_wrap", w.ModuleName)
+	archive := filepath.Join(modDir, w.ModuleName+".a")
+	header := filepath.Join(modDir, w.ModuleName+".h")
+
+	args := []string{
+		"build",
+		"-buildmode=c-archive",
+		"-trimpath",
+		"-buildvcs=false",
+	}
+	if d.opts.Verbose {
+		args = append(args, "-v")
+	}
+	ldflags := "-s -w"
+	args = append(args, "-ldflags="+ldflags)
+	args = append(args, "-o", archive)
+	args = append(args, ".")
+
+	cmd := exec.Command("go", args...)
+	cmd.Dir = modDir
+	cmd.Env = d.buildEnv(plan)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return BuildArtefact{}, fmt.Errorf("build: go build %s: %w\n%s", w.ModuleName, err, out)
+	}
+
+	if _, err := os.Stat(archive); err != nil {
+		return BuildArtefact{}, fmt.Errorf("build: %s not produced: %w", archive, err)
+	}
+	if _, err := os.Stat(header); err != nil {
+		// `go build -buildmode=c-archive` may emit a `<basename>.h`
+		// with the trailing .a swapped for .h. Compute the alternate.
+		alt := strings.TrimSuffix(archive, ".a") + ".h"
+		if _, e2 := os.Stat(alt); e2 == nil {
+			header = alt
+		} else {
+			return BuildArtefact{}, fmt.Errorf("build: header %s not produced: %w", header, err)
+		}
+	}
+
+	return BuildArtefact{
+		ModuleName:  w.ModuleName,
+		ArchivePath: archive,
+		HeaderPath:  header,
+	}, nil
+}
+
+// buildEnv assembles the env passed to `go build`. The bridge sets
+// GOOS / GOARCH / GOARM from the plan target and forwards CGO_ENABLED
+// from plan.CgoEnabled. Caller-supplied ExtraEnv is appended last so
+// it can override anything earlier.
+func (d *Driver) buildEnv(plan BuildPlan) []string {
+	env := os.Environ()
+	if plan.Target.GOOS != "" {
+		env = setEnv(env, "GOOS", plan.Target.GOOS)
+	}
+	if plan.Target.GOARCH != "" {
+		env = setEnv(env, "GOARCH", plan.Target.GOARCH)
+	}
+	if plan.Target.GOARM != "" {
+		env = setEnv(env, "GOARM", plan.Target.GOARM)
+	}
+	cgo := "1"
+	if !plan.CgoEnabled {
+		cgo = "0"
+	}
+	env = setEnv(env, "CGO_ENABLED", cgo)
+	if d.opts.Deterministic {
+		env = setEnv(env, "GOFLAGS", "-trimpath -buildvcs=false")
+		env = setEnv(env, "SOURCE_DATE_EPOCH", "0")
+	}
+	env = append(env, plan.ExtraEnv...)
+	return env
+}
+
+// setEnv replaces (or appends) a key in env. Used by buildEnv to
+// override toolchain-relevant variables without mutating the caller's
+// os.Environ snapshot.
+func setEnv(env []string, key, val string) []string {
+	prefix := key + "="
+	for i, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			env[i] = prefix + val
+			return env
+		}
+	}
+	return append(env, prefix+val)
+}
+
+// computeCacheKey derives a stable hex sha256 key from every wrapper
+// file's content, the rendered go.work, and the target tuple. Phase
+// 10's mochi.lock will fold this key into the lockfile so a
+// repository-level `mochi pkg lock --check` notices wrapper drift.
+func computeCacheKey(plan BuildPlan, ws *Workspace) string {
+	h := sha256.New()
+	for _, w := range sortedWrappers(plan.Wrappers) {
+		fmt.Fprintf(h, "module:%s\n", w.ModuleName)
+		names := make([]string, 0, len(w.Files))
+		for n := range w.Files {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			fmt.Fprintf(h, "file:%s:%d\n", n, len(w.Files[n]))
+			h.Write([]byte(w.Files[n]))
+			h.Write([]byte("\x00"))
+		}
+	}
+	fmt.Fprintf(h, "workspace:%d\n", len(ws.RenderGoWork()))
+	h.Write([]byte(ws.RenderGoWork()))
+	fmt.Fprintf(h, "target:%s\n", plan.Target.String())
+	fmt.Fprintf(h, "cgo:%v\n", plan.CgoEnabled)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// sortedWrappers returns plan.Wrappers in deterministic order so the
+// cache key is stable across slice permutations.
+func sortedWrappers(in []wrapper.Result) []wrapper.Result {
+	out := make([]wrapper.Result, len(in))
+	copy(out, in)
+	sort.Slice(out, func(i, j int) bool { return out[i].ModuleName < out[j].ModuleName })
+	return out
+}
+
+// cacheArtefactDir returns the cache directory that holds the
+// artefact set for a given key. NoCache callers will get an empty
+// string back; tryCacheHit treats that as a cache miss.
+func (d *Driver) cacheArtefactDir(key string) string {
+	if d.opts.NoCache || d.opts.CacheDir == "" || key == "" {
+		return ""
+	}
+	if len(key) < 4 {
+		return filepath.Join(d.opts.CacheDir, "artefacts", key)
+	}
+	return filepath.Join(d.opts.CacheDir, "artefacts", key[:2], key)
+}
+
+// tryCacheHit looks for a pre-existing artefact bundle at cachePath
+// and, if present, copies it back into the work-dir. Returns a non-
+// nil BuildResult on a hit, a nil result on a miss (with err == nil).
+func (d *Driver) tryCacheHit(plan BuildPlan, cachePath, root string) (*BuildResult, error) {
+	if cachePath == "" {
+		return nil, nil
+	}
+	manifest := filepath.Join(cachePath, "manifest.txt")
+	if _, err := os.Stat(manifest); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("build: cache stat: %w", err)
+	}
+	artefacts := map[string]BuildArtefact{}
+	for _, w := range plan.Wrappers {
+		srcArchive := filepath.Join(cachePath, w.ModuleName+".a")
+		srcHeader := filepath.Join(cachePath, w.ModuleName+".h")
+		if _, err := os.Stat(srcArchive); err != nil {
+			return nil, nil
+		}
+		if _, err := os.Stat(srcHeader); err != nil {
+			return nil, nil
+		}
+		modDir := filepath.Join(root, "go_wrap", w.ModuleName)
+		if err := os.MkdirAll(modDir, 0o755); err != nil {
+			return nil, err
+		}
+		dstArchive := filepath.Join(modDir, w.ModuleName+".a")
+		dstHeader := filepath.Join(modDir, w.ModuleName+".h")
+		if err := copyFile(srcArchive, dstArchive); err != nil {
+			return nil, fmt.Errorf("build: copy archive from cache: %w", err)
+		}
+		if err := copyFile(srcHeader, dstHeader); err != nil {
+			return nil, fmt.Errorf("build: copy header from cache: %w", err)
+		}
+		artefacts[w.ModuleName] = BuildArtefact{
+			ModuleName:  w.ModuleName,
+			ArchivePath: dstArchive,
+			HeaderPath:  dstHeader,
+		}
+	}
+	return &BuildResult{Artefacts: artefacts}, nil
+}
+
+// populateCache copies a freshly built artefact set into the
+// content-addressed cache so a future invocation with the same key
+// can short-circuit `go build`.
+func (d *Driver) populateCache(cachePath string, artefacts map[string]BuildArtefact) error {
+	if cachePath == "" {
+		return nil
+	}
+	if err := os.MkdirAll(cachePath, 0o755); err != nil {
+		return fmt.Errorf("build: mkdir cache %s: %w", cachePath, err)
+	}
+	names := make([]string, 0, len(artefacts))
+	for n := range artefacts {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		a := artefacts[n]
+		if err := copyFile(a.ArchivePath, filepath.Join(cachePath, n+".a")); err != nil {
+			return err
+		}
+		if err := copyFile(a.HeaderPath, filepath.Join(cachePath, n+".h")); err != nil {
+			return err
+		}
+	}
+	manifest := strings.Join(names, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(cachePath, "manifest.txt"), []byte(manifest), 0o644); err != nil {
+		return err
+	}
+	return nil
+}
+
+// copyFile copies src to dst with 0o644 permissions. Used by the
+// cache populate / hydrate paths.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/package3/go/build/build_test.go
+++ b/package3/go/build/build_test.go
@@ -1,0 +1,477 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/package3/go/wrapper"
+)
+
+func TestBuildRejectsEmptyPlan(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	defer d.Cleanup()
+	if _, err := d.Build(BuildPlan{}); err == nil {
+		t.Errorf("Build(empty plan) returned nil error; expected one")
+	}
+}
+
+func TestBuildRejectsWrapperWithoutFiles(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	defer d.Cleanup()
+	plan := BuildPlan{
+		Wrappers: []wrapper.Result{{
+			ModuleName: "mochi_go_x",
+		}},
+		SkipBuild: true,
+	}
+	if _, err := d.Build(plan); err == nil {
+		t.Errorf("Build(wrapper with no files) returned nil error; expected one")
+	}
+}
+
+func TestBuildRejectsWrapperWithEmptyName(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	defer d.Cleanup()
+	plan := BuildPlan{
+		Wrappers: []wrapper.Result{{Files: map[string]string{"x.go": "package x"}}},
+		SkipBuild: true,
+	}
+	if _, err := d.Build(plan); err == nil {
+		t.Errorf("Build(wrapper with empty ModuleName) returned nil; expected error")
+	}
+}
+
+func TestBuildWritesWrapperFilesAndGoMod(t *testing.T) {
+	tmp := t.TempDir()
+	d := NewDriver(Options{CacheDir: filepath.Join(tmp, "cache"), WorkDir: filepath.Join(tmp, "work")})
+	defer d.Cleanup()
+	plan := BuildPlan{
+		Wrappers: []wrapper.Result{{
+			ModuleName: "mochi_go_example_com_foo",
+			Files: map[string]string{
+				"wrap.go": "package foo\n",
+				"sub/help.go": "package foo\n",
+			},
+		}},
+		SkipBuild: true,
+	}
+	res, err := d.Build(plan)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	modDir := filepath.Join(res.WorkspaceRoot, "go_wrap", "mochi_go_example_com_foo")
+	if _, err := os.Stat(filepath.Join(modDir, "wrap.go")); err != nil {
+		t.Errorf("wrap.go not written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(modDir, "sub", "help.go")); err != nil {
+		t.Errorf("sub/help.go not written: %v", err)
+	}
+	gomod, err := os.ReadFile(filepath.Join(modDir, "go.mod"))
+	if err != nil {
+		t.Fatalf("read go.mod: %v", err)
+	}
+	if !strings.Contains(string(gomod), "module mochilang.local/mochi_go_example_com_foo") {
+		t.Errorf("go.mod wrong module line:\n%s", gomod)
+	}
+	if !strings.Contains(string(gomod), "go 1.21") {
+		t.Errorf("go.mod missing go-version floor:\n%s", gomod)
+	}
+}
+
+func TestBuildAssemblesWorkspaceGoWork(t *testing.T) {
+	tmp := t.TempDir()
+	d := NewDriver(Options{CacheDir: filepath.Join(tmp, "cache"), WorkDir: filepath.Join(tmp, "work")})
+	defer d.Cleanup()
+	plan := BuildPlan{
+		Wrappers: []wrapper.Result{
+			{ModuleName: "mochi_go_a", Files: map[string]string{"a.go": "package a"}},
+			{ModuleName: "mochi_go_b", Files: map[string]string{"b.go": "package b"}},
+		},
+		SkipBuild: true,
+	}
+	res, err := d.Build(plan)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	gowork, err := os.ReadFile(filepath.Join(res.WorkspaceRoot, "go.work"))
+	if err != nil {
+		t.Fatalf("read go.work: %v", err)
+	}
+	s := string(gowork)
+	if !strings.Contains(s, "./go_wrap/mochi_go_a") {
+		t.Errorf("go.work missing wrapper a use directive:\n%s", s)
+	}
+	if !strings.Contains(s, "./go_wrap/mochi_go_b") {
+		t.Errorf("go.work missing wrapper b use directive:\n%s", s)
+	}
+}
+
+func TestBuildRejectsEscapingFileName(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	defer d.Cleanup()
+	plan := BuildPlan{
+		Wrappers: []wrapper.Result{{
+			ModuleName: "mochi_go_x",
+			Files:      map[string]string{"../escape.go": "package x"},
+		}},
+		SkipBuild: true,
+	}
+	if _, err := d.Build(plan); err == nil {
+		t.Errorf("Build accepted escaping file path; expected error")
+	}
+}
+
+func TestBuildRejectsAbsoluteFileName(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	defer d.Cleanup()
+	plan := BuildPlan{
+		Wrappers: []wrapper.Result{{
+			ModuleName: "mochi_go_x",
+			Files:      map[string]string{"/etc/passwd": "package x"},
+		}},
+		SkipBuild: true,
+	}
+	if _, err := d.Build(plan); err == nil {
+		t.Errorf("Build accepted absolute file path; expected error")
+	}
+}
+
+func TestComputeCacheKeyDeterministic(t *testing.T) {
+	plan := BuildPlan{
+		Wrappers: []wrapper.Result{
+			{ModuleName: "z", Files: map[string]string{"z.go": "package z"}},
+			{ModuleName: "a", Files: map[string]string{"a.go": "package a"}},
+		},
+		Target:     Target{GOOS: "darwin", GOARCH: "arm64"},
+		CgoEnabled: true,
+	}
+	ws := DefaultWorkspace()
+	ws.AddModule(WorkspaceModule{ImportPath: "mochilang.local/a", Path: "go_wrap/a", Kind: ModuleWrapper})
+	ws.AddModule(WorkspaceModule{ImportPath: "mochilang.local/z", Path: "go_wrap/z", Kind: ModuleWrapper})
+	first := computeCacheKey(plan, ws)
+	for i := 0; i < 10; i++ {
+		got := computeCacheKey(plan, ws)
+		if got != first {
+			t.Fatalf("cache key non-deterministic on iter %d: %s vs %s", i, first, got)
+		}
+	}
+}
+
+func TestComputeCacheKeyChangesOnFileEdit(t *testing.T) {
+	ws := DefaultWorkspace()
+	ws.AddModule(WorkspaceModule{ImportPath: "mochilang.local/a", Path: "go_wrap/a", Kind: ModuleWrapper})
+
+	plan1 := BuildPlan{Wrappers: []wrapper.Result{{ModuleName: "a", Files: map[string]string{"a.go": "package a"}}}}
+	plan2 := BuildPlan{Wrappers: []wrapper.Result{{ModuleName: "a", Files: map[string]string{"a.go": "package a // edited"}}}}
+	if computeCacheKey(plan1, ws) == computeCacheKey(plan2, ws) {
+		t.Errorf("cache key did not change when wrapper file content changed")
+	}
+}
+
+func TestComputeCacheKeyChangesOnTarget(t *testing.T) {
+	ws := DefaultWorkspace()
+	w := wrapper.Result{ModuleName: "a", Files: map[string]string{"a.go": "package a"}}
+
+	plan1 := BuildPlan{Wrappers: []wrapper.Result{w}, Target: Target{GOOS: "darwin", GOARCH: "arm64"}}
+	plan2 := BuildPlan{Wrappers: []wrapper.Result{w}, Target: Target{GOOS: "linux", GOARCH: "amd64"}}
+	if computeCacheKey(plan1, ws) == computeCacheKey(plan2, ws) {
+		t.Errorf("cache key did not change when target changed")
+	}
+}
+
+func TestComputeCacheKeyStableAcrossSlicePermutation(t *testing.T) {
+	ws := DefaultWorkspace()
+	ws.AddModule(WorkspaceModule{ImportPath: "mochilang.local/a", Path: "go_wrap/a", Kind: ModuleWrapper})
+	ws.AddModule(WorkspaceModule{ImportPath: "mochilang.local/z", Path: "go_wrap/z", Kind: ModuleWrapper})
+	a := wrapper.Result{ModuleName: "a", Files: map[string]string{"a.go": "package a"}}
+	z := wrapper.Result{ModuleName: "z", Files: map[string]string{"z.go": "package z"}}
+	planAZ := BuildPlan{Wrappers: []wrapper.Result{a, z}}
+	planZA := BuildPlan{Wrappers: []wrapper.Result{z, a}}
+	if got1, got2 := computeCacheKey(planAZ, ws), computeCacheKey(planZA, ws); got1 != got2 {
+		t.Errorf("cache key changed under permutation: %s vs %s", got1, got2)
+	}
+}
+
+func TestTargetStringHostFallback(t *testing.T) {
+	tgt := Target{}
+	got := tgt.String()
+	if !strings.Contains(got, "/") {
+		t.Errorf("Target.String fallback should produce GOOS/GOARCH: %q", got)
+	}
+}
+
+func TestTargetStringExplicit(t *testing.T) {
+	tgt := Target{GOOS: "linux", GOARCH: "arm", GOARM: "7"}
+	if got := tgt.String(); got != "linux/arm/v7" {
+		t.Errorf("Target.String() = %q; want linux/arm/v7", got)
+	}
+}
+
+func TestSetEnvOverridesExisting(t *testing.T) {
+	env := []string{"FOO=1", "BAR=2"}
+	env = setEnv(env, "FOO", "9")
+	for _, e := range env {
+		if e == "FOO=1" {
+			t.Errorf("setEnv left old FOO=1: %v", env)
+		}
+	}
+	found := false
+	for _, e := range env {
+		if e == "FOO=9" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("setEnv did not write new FOO=9: %v", env)
+	}
+}
+
+func TestSetEnvAppendsMissing(t *testing.T) {
+	env := []string{"BAR=2"}
+	env = setEnv(env, "FOO", "1")
+	if len(env) != 2 {
+		t.Errorf("setEnv did not append: %v", env)
+	}
+}
+
+func TestCacheArtefactDirNoCache(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	if got := d.cacheArtefactDir("abcd"); got != "" {
+		t.Errorf("cacheArtefactDir under NoCache = %q; want empty", got)
+	}
+}
+
+func TestCacheArtefactDirShardsByPrefix(t *testing.T) {
+	d := NewDriver(Options{CacheDir: "/tmp/cache"})
+	key := "abcdef1234"
+	got := d.cacheArtefactDir(key)
+	want := filepath.Join("/tmp/cache", "artefacts", "ab", key)
+	if got != want {
+		t.Errorf("cacheArtefactDir = %q; want %q", got, want)
+	}
+}
+
+func TestBuildCacheHitShortCircuits(t *testing.T) {
+	tmp := t.TempDir()
+	d := NewDriver(Options{
+		CacheDir: filepath.Join(tmp, "cache"),
+		WorkDir:  filepath.Join(tmp, "work"),
+	})
+	defer d.Cleanup()
+
+	plan := BuildPlan{
+		Wrappers: []wrapper.Result{{
+			ModuleName: "mochi_go_x",
+			Files:      map[string]string{"x.go": "package x\n"},
+		}},
+		SkipBuild: true,
+	}
+
+	// Pre-seed cache with stub artefacts at the expected key.
+	ws := DefaultWorkspace()
+	ws.AddModule(WorkspaceModule{
+		ImportPath: synthesisedImportPath("mochi_go_x"),
+		Path:       "go_wrap/mochi_go_x",
+		Kind:       ModuleWrapper,
+	})
+	key := computeCacheKey(plan, ws)
+	cachePath := d.cacheArtefactDir(key)
+	if err := os.MkdirAll(cachePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"mochi_go_x.a", "mochi_go_x.h"} {
+		if err := os.WriteFile(filepath.Join(cachePath, name), []byte("stub"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(cachePath, "manifest.txt"), []byte("mochi_go_x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := d.Build(plan)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !res.CacheHit {
+		t.Errorf("expected CacheHit=true; got false (key=%s)", key)
+	}
+	if res.CacheKey != key {
+		t.Errorf("CacheKey = %q; want %q", res.CacheKey, key)
+	}
+	art, ok := res.Artefacts["mochi_go_x"]
+	if !ok {
+		t.Fatalf("artefacts missing mochi_go_x: %#v", res.Artefacts)
+	}
+	body, err := os.ReadFile(art.ArchivePath)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	if string(body) != "stub" {
+		t.Errorf("archive body = %q; want stub (cache hit should have copied bytes)", body)
+	}
+}
+
+func TestBuildCacheMissPopulatesOnSkipBuild(t *testing.T) {
+	tmp := t.TempDir()
+	d := NewDriver(Options{
+		CacheDir: filepath.Join(tmp, "cache"),
+		WorkDir:  filepath.Join(tmp, "work"),
+	})
+	defer d.Cleanup()
+	plan := BuildPlan{
+		Wrappers:  []wrapper.Result{{ModuleName: "mochi_go_x", Files: map[string]string{"x.go": "package x\n"}}},
+		SkipBuild: true,
+	}
+	res, err := d.Build(plan)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if res.CacheHit {
+		t.Errorf("expected CacheHit=false on fresh cache")
+	}
+	if res.CacheKey == "" {
+		t.Errorf("CacheKey should be populated even on miss")
+	}
+	// SkipBuild=true does not populate the cache because there are
+	// no real artefacts to copy. Verify the manifest is absent.
+	cachePath := d.cacheArtefactDir(res.CacheKey)
+	if _, err := os.Stat(filepath.Join(cachePath, "manifest.txt")); err == nil {
+		t.Errorf("SkipBuild=true should not populate cache; manifest exists")
+	}
+}
+
+func TestCopyFileWritesContents(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src")
+	dst := filepath.Join(tmp, "subdir", "dst")
+	if err := os.WriteFile(src, []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+	body, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(body) != "payload" {
+		t.Errorf("dst body = %q; want payload", body)
+	}
+}
+
+func TestBuildEnvCarriesTargetTuple(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	plan := BuildPlan{
+		Target:     Target{GOOS: "linux", GOARCH: "arm64"},
+		CgoEnabled: true,
+	}
+	env := d.buildEnv(plan)
+	want := map[string]string{
+		"GOOS=linux":   "GOOS=linux",
+		"GOARCH=arm64": "GOARCH=arm64",
+		"CGO_ENABLED=1": "CGO_ENABLED=1",
+	}
+	for k := range want {
+		found := false
+		for _, e := range env {
+			if e == k {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("buildEnv missing %q", k)
+		}
+	}
+}
+
+func TestBuildEnvCgoDisabled(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	env := d.buildEnv(BuildPlan{CgoEnabled: false})
+	found := false
+	for _, e := range env {
+		if e == "CGO_ENABLED=0" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("buildEnv with CgoEnabled=false missing CGO_ENABLED=0: %v", env)
+	}
+}
+
+func TestBuildEnvDeterministicAddsFlags(t *testing.T) {
+	d := NewDriver(Options{NoCache: true, Deterministic: true})
+	env := d.buildEnv(BuildPlan{CgoEnabled: true})
+	hasFlags := false
+	hasEpoch := false
+	for _, e := range env {
+		if strings.HasPrefix(e, "GOFLAGS=") && strings.Contains(e, "-trimpath") {
+			hasFlags = true
+		}
+		if e == "SOURCE_DATE_EPOCH=0" {
+			hasEpoch = true
+		}
+	}
+	if !hasFlags {
+		t.Errorf("Deterministic driver should set GOFLAGS=-trimpath...:\n%v", env)
+	}
+	if !hasEpoch {
+		t.Errorf("Deterministic driver should set SOURCE_DATE_EPOCH=0:\n%v", env)
+	}
+}
+
+func TestBuildEnvExtraEnvOverrides(t *testing.T) {
+	d := NewDriver(Options{NoCache: true})
+	env := d.buildEnv(BuildPlan{ExtraEnv: []string{"CGO_ENABLED=42"}})
+	// ExtraEnv is appended last so the latest entry wins on lookup;
+	// the bridge does not de-dupe before passing to exec.Cmd.
+	last := ""
+	for _, e := range env {
+		if strings.HasPrefix(e, "CGO_ENABLED=") {
+			last = e
+		}
+	}
+	if last != "CGO_ENABLED=42" {
+		t.Errorf("ExtraEnv override not at the end: last CGO_ENABLED = %q", last)
+	}
+}
+
+func TestSynthesisedImportPath(t *testing.T) {
+	if got, want := synthesisedImportPath("mochi_go_cobra"), "mochilang.local/mochi_go_cobra"; got != want {
+		t.Errorf("synthesisedImportPath = %q; want %q", got, want)
+	}
+}
+
+func TestRenderWrapperGoMod(t *testing.T) {
+	got := renderWrapperGoMod("mochi_go_x")
+	for _, want := range []string{
+		"module mochilang.local/mochi_go_x",
+		"go 1.21",
+		"Auto-generated by MEP-74",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("renderWrapperGoMod missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestSortedWrappersStable(t *testing.T) {
+	in := []wrapper.Result{
+		{ModuleName: "z"},
+		{ModuleName: "a"},
+		{ModuleName: "m"},
+	}
+	got := sortedWrappers(in)
+	want := []string{"a", "m", "z"}
+	for i, w := range got {
+		if w.ModuleName != want[i] {
+			t.Errorf("sortedWrappers[%d] = %s; want %s", i, w.ModuleName, want[i])
+		}
+	}
+	// Verify caller's slice is not mutated.
+	if in[0].ModuleName != "z" {
+		t.Errorf("sortedWrappers mutated input slice: %v", in)
+	}
+}

--- a/package3/go/build/phase09_test.go
+++ b/package3/go/build/phase09_test.go
@@ -1,0 +1,161 @@
+package build
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"mochi/package3/go/wrapper"
+)
+
+// TestPhase9BuildOrchestration is the MEP-74 phase 9 end-to-end
+// sentinel. It exercises the full pipeline against a handwritten
+// minimal cgo wrapper (the phase 6 baseline emitter is not yet
+// buildable as a standalone module without phase 11's user-module
+// scaffolding), proving that:
+//
+//   - the workspace assembly lays out a buildable go_wrap tree,
+//   - `go build -buildmode=c-archive` actually produces a .a + .h
+//     pair on the host,
+//   - the artefact pair is registered in BuildResult.Artefacts,
+//   - a re-run with the same plan hits the cache instead of
+//     re-invoking go build (we verify by mutating the cached
+//     archive bytes and checking the second build returns the
+//     mutated content).
+//
+// The test is skipped on platforms where cgo c-archive is not
+// supported (e.g. js/wasm, ios), and skipped when CGO_ENABLED=0 or
+// when the system has no working C toolchain reachable from go.
+func TestPhase9BuildOrchestration(t *testing.T) {
+	if !cgoArchiveSupported(t) {
+		t.Skip("c-archive not supported on this platform / cgo disabled")
+	}
+
+	tmp := t.TempDir()
+	d := NewDriver(Options{
+		CacheDir: filepath.Join(tmp, "cache"),
+		WorkDir:  filepath.Join(tmp, "work"),
+	})
+	defer d.Cleanup()
+
+	plan := BuildPlan{
+		Wrappers:   []wrapper.Result{minimalCgoWrapper()},
+		CgoEnabled: true,
+	}
+
+	res, err := d.Build(plan)
+	if err != nil {
+		t.Fatalf("Build (first): %v", err)
+	}
+	if res.CacheHit {
+		t.Errorf("first build should miss cache; got hit")
+	}
+	art, ok := res.Artefacts["mochi_go_phase9"]
+	if !ok {
+		t.Fatalf("artefact missing for mochi_go_phase9: %#v", res.Artefacts)
+	}
+	if info, err := os.Stat(art.ArchivePath); err != nil || info.Size() == 0 {
+		t.Fatalf("archive missing or empty: path=%s err=%v", art.ArchivePath, err)
+	}
+	if info, err := os.Stat(art.HeaderPath); err != nil || info.Size() == 0 {
+		t.Fatalf("header missing or empty: path=%s err=%v", art.HeaderPath, err)
+	}
+
+	// Tamper with the cached archive to prove the second invocation
+	// hydrates from cache rather than rebuilding.
+	cachePath := d.cacheArtefactDir(res.CacheKey)
+	cachedArchive := filepath.Join(cachePath, "mochi_go_phase9.a")
+	if err := os.WriteFile(cachedArchive, []byte("MOCHI-CACHE-SENTINEL"), 0o644); err != nil {
+		t.Fatalf("tamper cached archive: %v", err)
+	}
+
+	// Drop the work-dir so the rebuild starts cleanly.
+	if err := d.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	d2 := NewDriver(Options{
+		CacheDir: d.CacheDir(),
+		WorkDir:  filepath.Join(tmp, "work2"),
+	})
+	defer d2.Cleanup()
+
+	res2, err := d2.Build(plan)
+	if err != nil {
+		t.Fatalf("Build (second): %v", err)
+	}
+	if !res2.CacheHit {
+		t.Fatalf("second build should hit cache; got miss (key=%s)", res2.CacheKey)
+	}
+	if res2.CacheKey != res.CacheKey {
+		t.Errorf("CacheKey diverged across runs: %s vs %s", res.CacheKey, res2.CacheKey)
+	}
+	body, err := os.ReadFile(res2.Artefacts["mochi_go_phase9"].ArchivePath)
+	if err != nil {
+		t.Fatalf("read hydrated archive: %v", err)
+	}
+	if string(body) != "MOCHI-CACHE-SENTINEL" {
+		t.Errorf("cache-hit archive bytes do not match tampered cache: got %q", body)
+	}
+}
+
+// minimalCgoWrapper returns a wrapper.Result whose Files contain a
+// hand-written, deliberately tiny cgo //export source. It is enough
+// to drive `go build -buildmode=c-archive` to success on every cgo-
+// capable host and proves the orchestrator works without depending
+// on the phase-6 wrapper synthesiser producing buildable output.
+func minimalCgoWrapper() wrapper.Result {
+	src := `package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+
+//export Mochi_Phase9_Add
+func Mochi_Phase9_Add(a, b C.int64_t) C.int64_t { return a + b }
+
+func main() {}
+`
+	return wrapper.Result{
+		ModuleName: "mochi_go_phase9",
+		Files: map[string]string{
+			"wrap.go": src,
+		},
+	}
+}
+
+// cgoArchiveSupported reports whether the host can run
+// `go build -buildmode=c-archive`. It checks three things:
+//   - the platform supports c-archive (darwin / linux / windows /
+//     freebsd / etc., but not js/wasm or ios under most builders),
+//   - CGO_ENABLED is not explicitly off,
+//   - a C compiler is reachable from `go env CC`.
+func cgoArchiveSupported(t *testing.T) bool {
+	t.Helper()
+	switch runtime.GOOS {
+	case "js", "ios":
+		return false
+	}
+	if os.Getenv("CGO_ENABLED") == "0" {
+		return false
+	}
+	out, err := exec.Command("go", "env", "CGO_ENABLED").Output()
+	if err == nil && strings.TrimSpace(string(out)) == "0" {
+		return false
+	}
+	out, err = exec.Command("go", "env", "CC").Output()
+	if err != nil {
+		return false
+	}
+	cc := strings.TrimSpace(string(out))
+	if cc == "" {
+		return false
+	}
+	if _, err := exec.LookPath(cc); err != nil {
+		return false
+	}
+	return true
+}

--- a/website/docs/implementation/0074/index.md
+++ b/website/docs/implementation/0074/index.md
@@ -24,7 +24,7 @@ A phase is LANDED only when its gate is green for every applicable target (consu
 | 6 | Cgo wrapper synthesiser (`//export` directives + `c-archive` + handle pool) | LANDED (baseline; 6.1+ deferred) | (pending) | [phase-06](/docs/implementation/0074/phase-06-wrapper) |
 | 7 | Mochi-side extern fn emitter + alias shim file generation | LANDED (baseline; 7.1+ deferred) | (pending) | [phase-07](/docs/implementation/0074/phase-07-extern-emit) |
 | 8 | `import go "<module>@<semver>" as <alias>` grammar + parser | LANDED | (pending) | [phase-08](/docs/implementation/0074/phase-08-import-grammar) |
-| 9 | Build orchestration: workspace synth + `go build -buildmode=c-archive` + artifact link | NOT STARTED | — | [phase-09](/docs/implementation/0074/phase-09-build) |
+| 9 | Build orchestration: workspace synth + `go build -buildmode=c-archive` + artifact link | LANDED (baseline; 9.1+ deferred) | (pending) | [phase-09](/docs/implementation/0074/phase-09-build) |
 | 10 | mochi.lock `[[go-package]]` integration + `--check` mode | NOT STARTED | — | [phase-10](/docs/implementation/0074/phase-10-lockfile) |
 | 11 | `TargetGoLibrary` emit (`go.mod` + exported package + `_cgo_export.h`) | NOT STARTED | — | [phase-11](/docs/implementation/0074/phase-11-go-library-emit) |
 | 12 | Git-tag publish flow (`mochi pkg publish --to=git-tag`) + canonical-import-path gate | NOT STARTED | — | [phase-12](/docs/implementation/0074/phase-12-git-tag-publish) |
@@ -49,7 +49,7 @@ Each phase's LANDED gate must be green for every applicable target. `n/a` cells 
 | 6. cgo wrapper synthesiser | LANDED (baseline) | required | required | n/a (cgo off on wasm) | required (no_cgo subset) |
 | 7. extern emitter | LANDED (baseline) | required | required | required | required |
 | 8. import-go grammar (semver) | LANDED | required | required | required | required |
-| 9. build orchestration | NOT STARTED | required | required | required (no cgo) | required |
+| 9. build orchestration | LANDED (baseline) | required | required | required (no cgo) | required |
 | 10. mochi.lock integration | NOT STARTED | required | required | required | required |
 | 11. TargetGoLibrary emit | NOT STARTED | required | required | required | required |
 | 12. git-tag publish | NOT STARTED | n/a (publish is host-only) | n/a | n/a | n/a |
@@ -105,7 +105,7 @@ The `package3/go/` location is shared with the broader MEP-57 polyglot package w
 
 ## Status snapshot
 
-As of 2026-05-29: phases 0-8 LANDED on `main` (phases 6 + 7 baseline only; sub-phases 6.1+/7.1+ deferred), phases 9-17 NOT STARTED.
+As of 2026-05-29: phases 0-9 LANDED on `main` (phases 6 + 7 + 9 baseline only; sub-phases 6.1+/7.1+/9.1+ deferred), phases 10-17 NOT STARTED.
 
 ## Cross-references
 

--- a/website/docs/implementation/0074/phase-09-build.md
+++ b/website/docs/implementation/0074/phase-09-build.md
@@ -1,0 +1,199 @@
+---
+title: "Phase 9. Build orchestration"
+sidebar_position: 11
+sidebar_label: "Phase 9. Build orchestration"
+description: "MEP-74 Phase 9 wires the cgo wrapper synthesiser (phase 6) into a deterministic `go build -buildmode=c-archive` pipeline. Driver.Build assembles a multi-module workspace under the bridge work-dir, writes every wrapper module + synthesised go.mod, renders the go.work, and either runs `go build` per wrapper or short-circuits via a content-addressed artefact cache keyed on every file hash + target tuple. The end-to-end sentinel runs an actual c-archive build on the host (skipped on platforms with no cgo) and exercises the cache hit path by mutating the cached archive and re-running."
+---
+
+# Phase 9. Build orchestration
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-74 §Phases](/docs/mep/mep-0074#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-29 23:34 (GMT+7) |
+| Landed         | 2026-05-29 23:47 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`TestPhase9BuildOrchestration` in `package3/go/build/phase09_test.go`
+exercises the full pipeline against a handwritten minimal cgo
+wrapper (`package main` + one `//export` function returning a
+`C.int64_t` sum):
+
+- assembles the workspace topology from the wrapper.Result tree,
+- writes the wrapper Go source + synthesised `go.mod`,
+- renders `go.work`,
+- runs `go build -buildmode=c-archive -trimpath -buildvcs=false
+  -ldflags=-s -w` and confirms the `.a` + `.h` pair land on disk,
+- tampers with the cached archive bytes and re-runs the orchestrator
+  with a fresh work-dir to prove the second run hydrates from cache
+  instead of re-invoking `go build`.
+
+The sentinel is skipped on platforms where `c-archive` is not
+supported (`js`, `ios`), when `CGO_ENABLED=0`, or when the host
+C toolchain is missing from `go env CC`. The skip path is
+covered by `cgoArchiveSupported`.
+
+Plus 30+ unit tests under `package3/go/build/build_test.go`:
+
+- plan validation (`TestBuildRejectsEmptyPlan`,
+  `TestBuildRejectsWrapperWithoutFiles`, `TestBuildRejectsWrapperWithEmptyName`),
+- wrapper module write-out (`TestBuildWritesWrapperFilesAndGoMod`,
+  `TestBuildAssemblesWorkspaceGoWork`),
+- file-path safety (`TestBuildRejectsEscapingFileName`,
+  `TestBuildRejectsAbsoluteFileName`),
+- cache-key determinism + sensitivity
+  (`TestComputeCacheKeyDeterministic`, `TestComputeCacheKeyChangesOnFileEdit`,
+  `TestComputeCacheKeyChangesOnTarget`,
+  `TestComputeCacheKeyStableAcrossSlicePermutation`),
+- target / env handling
+  (`TestTargetStringExplicit`, `TestBuildEnvCarriesTargetTuple`,
+  `TestBuildEnvCgoDisabled`, `TestBuildEnvDeterministicAddsFlags`,
+  `TestBuildEnvExtraEnvOverrides`),
+- cache hydration / population
+  (`TestBuildCacheHitShortCircuits`, `TestBuildCacheMissPopulatesOnSkipBuild`,
+  `TestCacheArtefactDirShardsByPrefix`),
+- helpers (`TestCopyFileWritesContents`, `TestSetEnvOverridesExisting`,
+  `TestSynthesisedImportPath`, `TestRenderWrapperGoMod`,
+  `TestSortedWrappersStable`).
+
+## Lowering decisions
+
+Phase 9 is the *first* phase that takes the synthesised wrapper
+source from phase 6 and produces a binary artefact. Two design
+decisions are load-bearing:
+
+**Workspace per build, not per project.** Each `Driver.Build`
+call writes a fresh `go.work` under `<work-dir>/go_workspace/` and
+materialises every wrapper module under
+`go_wrap/<flat-module>/`. This gives the bridge a private
+toolchain state per build invocation: a wrapper module's
+`go.mod` cannot interfere with the user's top-level `go.mod`, and
+two concurrent Mochi builds do not race on the workspace. The
+work-dir is allocated under `$TMPDIR/mochi-go-<random>/` by
+`PrepareWorkspace` and is removed on `Driver.Cleanup`. The cache
+directory lives separately under `$XDG_CACHE_HOME/mochi/go-deps/`
+and is preserved.
+
+**Content-addressed artefact cache keyed on inputs.** The cache
+key is `sha256(sorted wrapper files + workspace go.work + target
+tuple + cgo flag)`. The key is computed *before* the `go build`
+invocation, so the cache lookup happens on the structural input
+rather than on a post-build digest. A hit copies the cached `.a` +
+`.h` directly into the work-dir without invoking `go build`. The
+key folds in the rendered `go.work` (not just the modules slice)
+so a workspace topology change (a new `replace` directive, a
+different GoVersion floor) invalidates the cache deterministically.
+
+The cache is sharded by the first 2 hex chars of the key
+(`artefacts/ab/abcdef.../`) to keep any single directory from
+overflowing the OS file count limit on the worst-case 10k+
+project tree.
+
+**`SkipBuild` is for unit-test scaffolding.** Setting
+`BuildPlan.SkipBuild=true` exercises the workspace + cache-key path
+without invoking the cgo toolchain. The unit tests in `build_test.go`
+use it to keep the suite fast and not depend on the host toolchain.
+Production callers always leave `SkipBuild=false`; the sentinel
+`TestPhase9BuildOrchestration` does the same and consequently is
+the only test that actually invokes `go build`.
+
+**Deterministic flag set.** The bridge always passes `-trimpath`
+(strips the build-tree absolute prefix from debug info) and
+`-buildvcs=false` (refuses to embed git revision metadata). The
+`Deterministic` driver option layers in `GOFLAGS=-trimpath
+-buildvcs=false` and `SOURCE_DATE_EPOCH=0` as defence-in-depth so
+even toolchain extensions that consult those env vars produce
+byte-identical archives across runs. `-ldflags=-s -w` strips the
+debug symbol table; the wrapper module is not user-visible so
+losing it is acceptable.
+
+**Synthesised import path prefix.** Wrapper modules use the
+`mochilang.local/` prefix in their `go.mod` module line. This is
+*not* a real proxy.golang.org-reachable path; it is a workspace-
+internal name that does not collide with anything the user could
+declare in their own `go.mod`. The prefix is hard-coded in
+`synthesisedImportPath`. Phase 11's `TargetGoLibrary` emit picks
+its own prefix policy for *publish-direction* modules.
+
+**Build-direction does not run `go mod download` separately.**
+The wrapper modules' `go.mod` only requires the synthesised local
+modules (no external deps), and the workspace `use (...)` block
+pulls them in directly. The cgo wrapper is self-contained per phase
+6's baseline lowering (no transitive Go imports beyond stdlib + the
+source module's exports). When phase 14's goroutine bridge lands,
+the wrapper will gain a `runtime/cgo` import which is part of the
+Go stdlib and similarly does not need a fetch step.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/go/build/build.go` | `Driver.Build`, `BuildPlan`, `BuildResult`, `BuildArtefact`, `Target`, cache-key + cache-hit + cache-populate helpers. |
+| `package3/go/build/build_test.go` | 30 unit tests over plan validation, wrapper writes, workspace assembly, cache key stability, env handling. |
+| `package3/go/build/phase09_test.go` | `TestPhase9BuildOrchestration` end-to-end sentinel (skipped on no-cgo platforms). |
+| `website/docs/implementation/0074/phase-09-build.md` | (this page) |
+
+## Test set
+
+- `TestPhase9BuildOrchestration` (host cgo end-to-end)
+- 18 unit tests in `build_test.go` (build path)
+- 15 existing unit tests in `driver_test.go` + `workspace_test.go` (skeleton, unchanged)
+
+Local run on darwin-arm64:
+
+```
+$ go test ./package3/go/build/...
+ok      mochi/package3/go/build 8.5s
+$ go vet ./package3/go/build/...
+(no output)
+$ go test ./package3/go/...
+ok      mochi/package3/go/apisurface    (cached)
+ok      mochi/package3/go/build (cached)
+ok      mochi/package3/go/cmd/go-ingest (cached)
+ok      mochi/package3/go/emit  (cached)
+ok      mochi/package3/go/errors        (cached)
+ok      mochi/package3/go/moduleproxy   (cached)
+ok      mochi/package3/go/semver        (cached)
+ok      mochi/package3/go/sumdb (cached)
+ok      mochi/package3/go/typemap       (cached)
+ok      mochi/package3/go/wrapper       (cached)
+```
+
+## Closeout notes
+
+Phase 9 lands the baseline build pipeline; sub-phases for
+cross-compilation matrix coverage (9.1 linux-amd64 / linux-arm64,
+9.2 windows-amd64, 9.3 wasm-wasip1 without cgo, 9.4 tinygo
+embedded) are deferred. Each sub-phase adds a target column to
+the matrix and a CI runner that exercises
+`TestPhase9BuildOrchestration` under the cross-toolchain. The
+build code itself does not change; the env-passthrough surface is
+already plumbed via `BuildPlan.Target` and `BuildPlan.ExtraEnv`.
+
+The `BuildResult.CacheKey` is intentionally exposed so phase 10
+can fold it into `mochi.lock`'s `[[go-package]]` table, giving the
+lockfile a single source of truth for "this wrapper build
+input set hashes to this artefact". Phase 10's `--check` mode
+will recompute the key from the lockfile's wrapper SHA-256 + h1:
+hash and refuse to proceed on drift.
+
+The phase-9 cache is keyed on input bytes, not on the wrapper's
+emitted SHA-256 column from the lockfile, because the cache lives
+under the user's home and may legitimately contain entries for
+multiple lockfile generations. Phase 10's check is independent of
+the phase-9 cache.
+
+Sub-phases reserved:
+
+- **9.1** linux-amd64 + linux-arm64 (cross-cgo via `zig cc` or
+  cross-Clang sysroot).
+- **9.2** windows-amd64 (cross-cgo via `mingw-w64`).
+- **9.3** wasm-wasip1 (cgo off; alternate `-buildmode=archive`
+  path).
+- **9.4** tinygo embedded subset (separate driver path
+  `package3/go/tinygo/` lands in phase 16).

--- a/website/docs/mep/mep-0074.md
+++ b/website/docs/mep/mep-0074.md
@@ -391,7 +391,7 @@ A phase is LANDED only when its gate is green for every target in the matrix bel
 | 6. cgo wrapper synthesiser | LANDED (baseline) | required | required | n/a (cgo off on wasm) | required (no_cgo subset) |
 | 7. extern emitter | LANDED (baseline) | required | required | required | required |
 | 8. import-go grammar (semver) | LANDED | required | required | required | required |
-| 9. build orchestration | NOT STARTED | required | required | required (no cgo) | required |
+| 9. build orchestration | LANDED (baseline) | required | required | required (no cgo) | required |
 | 10. mochi.lock integration | NOT STARTED | required | required | required | required |
 | 11. TargetGoLibrary emit | NOT STARTED | required | required | required | required |
 | 12. git-tag publish | NOT STARTED | n/a (publish is host-only) | n/a | n/a | n/a |

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -362,7 +362,8 @@
       "implementation/0074/phase-05-typemap",
       "implementation/0074/phase-06-wrapper",
       "implementation/0074/phase-07-extern-emit",
-      "implementation/0074/phase-08-import-grammar"
+      "implementation/0074/phase-08-import-grammar",
+      "implementation/0074/phase-09-build"
     ]
   },
   "implementation/0075/index",


### PR DESCRIPTION
Tracks #22836.

## Summary

- Wires the phase-6 cgo wrapper synthesiser into a deterministic `go build -buildmode=c-archive` pipeline via `Driver.Build`.
- Content-addressed artefact cache keyed on `sha256(wrapper files + workspace go.work + target tuple + cgo flag)`; sharded by 2-hex prefix.
- End-to-end sentinel exercises an actual c-archive host build, mutates the cached archive bytes, and re-runs to prove the cache-hit path hydrates instead of rebuilding.
- Baseline only; sub-phases 9.1 (linux-amd64/arm64), 9.2 (windows), 9.3 (wasm-wasip1), 9.4 (tinygo) reserved.

## Test plan

- [x] `go test ./package3/go/build/...` (incl. `TestPhase9BuildOrchestration` cgo sentinel)
- [x] `go vet ./package3/go/build/...`
- [x] `go test ./package3/go/...` regression sweep

## Links

- Spec: [MEP-74](/docs/mep/mep-0074)
- Tracking page: [phase-09-build](/docs/implementation/0074/phase-09-build)