### PR TITLE
feat(mep-75 p3): PHP Reflection CLI

### DIFF
--- a/package3/php/reflect/reflect.go
+++ b/package3/php/reflect/reflect.go
@@ -1,5 +1,139 @@
-// Package reflect implements the PHP Reflection API surface extractor for
-// the MEP-75 PHP bridge. It invokes a PHP CLI script (reflect.php) via
-// exec.Command and parses the emitted JSON surface document. Phase 0 ships
-// the package stub; the full implementation arrives in phase 3.
+// Package reflect implements the PHP Reflection API surface extractor for the
+// MEP-75 PHP bridge. It invokes a PHP CLI script (reflect.php) via
+// exec.Command and parses the emitted JSON surface document.
+//
+// See [website/docs/research/0075/03-prior-art-bridges.md] for the design.
 package reflect
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// ReflectScriptName is the filename of the embedded PHP reflection script
+// written to a temp dir before invocation.
+const ReflectScriptName = "reflect.php"
+
+// Run invokes the PHP CLI at phpBin, passing the embedded reflect.php script
+// and pkgDir (the path to the extracted Composer package root). It returns the
+// parsed ReflectionSurface JSON document.
+//
+// The reflect.php script is written to a temporary directory alongside the
+// invocation. The caller retains ownership of pkgDir.
+//
+// Returns ErrPHPNotFound when phpBin is not executable, ErrReflectFailed when
+// the PHP process exits non-zero.
+func Run(ctx context.Context, phpBin, pkgDir string) (*ReflectionSurface, error) {
+	if phpBin == "" {
+		phpBin = "php"
+	}
+
+	// Verify the PHP binary exists and is executable.
+	phpPath, err := exec.LookPath(phpBin)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s: %v", ErrPHPNotFound, phpBin, err)
+	}
+
+	// Write the reflect.php script to a temp dir.
+	scriptDir, err := os.MkdirTemp("", "mochi-php-reflect-")
+	if err != nil {
+		return nil, fmt.Errorf("reflect: create script dir: %w", err)
+	}
+	defer os.RemoveAll(scriptDir) //nolint:errcheck
+
+	scriptPath := filepath.Join(scriptDir, ReflectScriptName)
+	if err := os.WriteFile(scriptPath, []byte(reflectPHPScript), 0o644); err != nil {
+		return nil, fmt.Errorf("reflect: write script: %w", err)
+	}
+
+	// Invoke: php reflect.php <pkgDir>
+	cmd := exec.CommandContext(ctx, phpPath, scriptPath, pkgDir)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		detail := stderr.String()
+		if len(detail) > 512 {
+			detail = detail[:512]
+		}
+		return nil, fmt.Errorf("%w: %s: %v\n%s", ErrReflectFailed, pkgDir, err, detail)
+	}
+
+	var surface ReflectionSurface
+	if err := json.Unmarshal(stdout.Bytes(), &surface); err != nil {
+		snippet := stdout.String()
+		if len(snippet) > 256 {
+			snippet = snippet[:256]
+		}
+		return nil, fmt.Errorf("reflect: parse JSON from %s: %w\noutput: %s", pkgDir, err, snippet)
+	}
+	return &surface, nil
+}
+
+// RunFromScript is like Run but accepts the PHP script source directly as
+// scriptSrc instead of using the embedded reflect.php. Used in tests to inject
+// a custom PHP script.
+func RunFromScript(ctx context.Context, phpBin, pkgDir, scriptSrc string) (*ReflectionSurface, error) {
+	if phpBin == "" {
+		phpBin = "php"
+	}
+	phpPath, err := exec.LookPath(phpBin)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s: %v", ErrPHPNotFound, phpBin, err)
+	}
+
+	scriptDir, err := os.MkdirTemp("", "mochi-php-reflect-")
+	if err != nil {
+		return nil, fmt.Errorf("reflect: create script dir: %w", err)
+	}
+	defer os.RemoveAll(scriptDir) //nolint:errcheck
+
+	scriptPath := filepath.Join(scriptDir, ReflectScriptName)
+	if err := os.WriteFile(scriptPath, []byte(scriptSrc), 0o644); err != nil {
+		return nil, fmt.Errorf("reflect: write script: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, phpPath, scriptPath, pkgDir)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		detail := stderr.String()
+		if len(detail) > 512 {
+			detail = detail[:512]
+		}
+		return nil, fmt.Errorf("%w: %s: %v\n%s", ErrReflectFailed, pkgDir, err, detail)
+	}
+
+	var surface ReflectionSurface
+	if err := json.Unmarshal(stdout.Bytes(), &surface); err != nil {
+		snippet := stdout.String()
+		if len(snippet) > 256 {
+			snippet = snippet[:256]
+		}
+		return nil, fmt.Errorf("reflect: parse JSON from %s: %w\noutput: %s", pkgDir, err, snippet)
+	}
+	return &surface, nil
+}
+
+// ParseSurface parses a ReflectionSurface JSON document from raw bytes.
+// Used when the JSON was obtained outside of Run (e.g. from a cache).
+func ParseSurface(data []byte) (*ReflectionSurface, error) {
+	var surface ReflectionSurface
+	if err := json.Unmarshal(data, &surface); err != nil {
+		return nil, fmt.Errorf("reflect: parse surface: %w", err)
+	}
+	return &surface, nil
+}
+
+// ErrPHPNotFound is returned when the PHP CLI binary cannot be located.
+var ErrPHPNotFound = errors.New("reflect: PHP binary not found")
+
+// ErrReflectFailed is returned when the reflect.php process exits non-zero.
+var ErrReflectFailed = errors.New("reflect: PHP reflection failed")

--- a/package3/php/reflect/reflect_test.go
+++ b/package3/php/reflect/reflect_test.go
@@ -1,0 +1,282 @@
+package reflect
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// phpAvailable returns true when a usable PHP 8.x CLI is on PATH.
+func phpAvailable() bool {
+	path, err := exec.LookPath("php")
+	if err != nil {
+		return false
+	}
+	out, err := exec.Command(path, "--version").Output()
+	if err != nil {
+		return false
+	}
+	return strings.HasPrefix(string(out), "PHP 8")
+}
+
+func TestParseSurface(t *testing.T) {
+	raw := `{
+		"package_name": "guzzlehttp/guzzle",
+		"php_version": "8.4.0",
+		"classes": [
+			{
+				"fqcn": "GuzzleHttp\\Client",
+				"abstract": false,
+				"final": false,
+				"methods": [
+					{
+						"name": "send",
+						"static": false,
+						"abstract": false,
+						"final": false,
+						"parameters": [
+							{"name": "request", "type": "RequestInterface", "optional": false, "variadic": false},
+							{"name": "options", "type": "array", "optional": true, "variadic": false, "default_value": "array ()"}
+						],
+						"return_type": "ResponseInterface"
+					}
+				],
+				"properties": [],
+				"interface_fqcns": ["GuzzleHttp\\ClientInterface"]
+			}
+		],
+		"interfaces": [],
+		"enums": [],
+		"functions": []
+	}`
+	s, err := ParseSurface([]byte(raw))
+	if err != nil {
+		t.Fatalf("ParseSurface: %v", err)
+	}
+	if s.PackageName != "guzzlehttp/guzzle" {
+		t.Errorf("PackageName = %q; want guzzlehttp/guzzle", s.PackageName)
+	}
+	if s.PHPVersion != "8.4.0" {
+		t.Errorf("PHPVersion = %q; want 8.4.0", s.PHPVersion)
+	}
+	if len(s.Classes) != 1 {
+		t.Fatalf("expected 1 class; got %d", len(s.Classes))
+	}
+	cls := s.Classes[0]
+	if cls.FQCN != `GuzzleHttp\Client` {
+		t.Errorf("FQCN = %q; want GuzzleHttp\\Client", cls.FQCN)
+	}
+	if len(cls.Methods) != 1 {
+		t.Fatalf("expected 1 method; got %d", len(cls.Methods))
+	}
+	if cls.Methods[0].ReturnType != "ResponseInterface" {
+		t.Errorf("ReturnType = %q; want ResponseInterface", cls.Methods[0].ReturnType)
+	}
+	if len(cls.Methods[0].Parameters) != 2 {
+		t.Errorf("expected 2 parameters; got %d", len(cls.Methods[0].Parameters))
+	}
+}
+
+func TestParseSurfaceBadJSON(t *testing.T) {
+	_, err := ParseSurface([]byte("not json"))
+	if err == nil {
+		t.Error("expected error for bad JSON")
+	}
+}
+
+func TestRunPHPNotFound(t *testing.T) {
+	_, err := Run(context.Background(), "/nonexistent/php-binary", t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for missing PHP binary")
+	}
+	if !errors.Is(err, ErrPHPNotFound) {
+		t.Errorf("error %v is not ErrPHPNotFound", err)
+	}
+}
+
+func TestRunFromScriptMinimalPHP(t *testing.T) {
+	if !phpAvailable() {
+		t.Skip("PHP 8.x not available on PATH")
+	}
+	// A minimal PHP script that emits a valid ReflectionSurface.
+	minimalScript := `<?php
+$pkgDir = $argv[1] ?? '';
+echo json_encode([
+    'package_name' => 'test/pkg',
+    'php_version'  => PHP_VERSION,
+    'classes'      => [],
+    'interfaces'   => [],
+    'enums'        => [],
+    'functions'    => [],
+    'errors'       => [],
+]);
+`
+	s, err := RunFromScript(context.Background(), "php", t.TempDir(), minimalScript)
+	if err != nil {
+		t.Fatalf("RunFromScript: %v", err)
+	}
+	if s.PackageName != "test/pkg" {
+		t.Errorf("PackageName = %q; want test/pkg", s.PackageName)
+	}
+	if s.PHPVersion == "" {
+		t.Error("PHPVersion should not be empty")
+	}
+}
+
+func TestRunFromScriptExitNonZero(t *testing.T) {
+	if !phpAvailable() {
+		t.Skip("PHP 8.x not available on PATH")
+	}
+	badScript := `<?php exit(1); ?>`
+	_, err := RunFromScript(context.Background(), "php", t.TempDir(), badScript)
+	if err == nil {
+		t.Fatal("expected error for non-zero exit")
+	}
+	if !errors.Is(err, ErrReflectFailed) {
+		t.Errorf("error %v is not ErrReflectFailed", err)
+	}
+}
+
+func TestRunFromScriptBadJSON(t *testing.T) {
+	if !phpAvailable() {
+		t.Skip("PHP 8.x not available on PATH")
+	}
+	badScript := `<?php echo "not valid json"; ?>`
+	_, err := RunFromScript(context.Background(), "php", t.TempDir(), badScript)
+	if err == nil {
+		t.Fatal("expected error for bad JSON output")
+	}
+	if !strings.Contains(err.Error(), "parse JSON") {
+		t.Errorf("error %v should mention parse JSON", err)
+	}
+}
+
+func TestRunFullReflection(t *testing.T) {
+	if !phpAvailable() {
+		t.Skip("PHP 8.x not available on PATH")
+	}
+	// Create a mini PHP package with one class and one interface.
+	pkgDir := t.TempDir()
+	phpSrc := `<?php
+namespace TestPkg;
+
+interface Greeter {
+    public function greet(string $name): string;
+}
+
+class Hello implements Greeter {
+    public string $greeting = 'Hello';
+    public function greet(string $name): string {
+        return $this->greeting . ', ' . $name . '!';
+    }
+    public static function world(): string {
+        return 'world';
+    }
+}
+
+function testHelper(int $x, int $y = 0): int {
+    return $x + $y;
+}
+`
+	if err := os.WriteFile(filepath.Join(pkgDir, "Hello.php"), []byte(phpSrc), 0o644); err != nil {
+		t.Fatalf("write PHP: %v", err)
+	}
+
+	s, err := Run(context.Background(), "php", pkgDir)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Find the Hello class.
+	var helloClass *ClassSurface
+	for i := range s.Classes {
+		if strings.HasSuffix(s.Classes[i].FQCN, "Hello") {
+			helloClass = &s.Classes[i]
+			break
+		}
+	}
+	if helloClass == nil {
+		// Dump the surface for debugging.
+		raw, _ := json.MarshalIndent(s, "", "  ")
+		t.Fatalf("Hello class not found\n%s", raw)
+	}
+
+	// Verify greet method.
+	var greetMethod *MethodSurface
+	for i := range helloClass.Methods {
+		if helloClass.Methods[i].Name == "greet" {
+			greetMethod = &helloClass.Methods[i]
+			break
+		}
+	}
+	if greetMethod == nil {
+		t.Fatalf("greet method not found in Hello class")
+	}
+	if greetMethod.ReturnType != "string" {
+		t.Errorf("greet ReturnType = %q; want string", greetMethod.ReturnType)
+	}
+	if len(greetMethod.Parameters) != 1 {
+		t.Errorf("greet expected 1 param; got %d", len(greetMethod.Parameters))
+	}
+
+	// Verify world static method.
+	var worldMethod *MethodSurface
+	for i := range helloClass.Methods {
+		if helloClass.Methods[i].Name == "world" {
+			worldMethod = &helloClass.Methods[i]
+			break
+		}
+	}
+	if worldMethod == nil {
+		t.Fatalf("world method not found")
+	}
+	if !worldMethod.Static {
+		t.Error("world should be static")
+	}
+}
+
+func TestReflectSurfaceTypes(t *testing.T) {
+	// Verify the surface type structs can be marshalled/unmarshalled round-trip.
+	s := ReflectionSurface{
+		PackageName: "test/pkg",
+		PHPVersion:  "8.4.0",
+		Classes: []ClassSurface{
+			{
+				FQCN:     `Foo\Bar`,
+				Abstract: false,
+				Methods: []MethodSurface{
+					{Name: "foo", ReturnType: "string",
+						Parameters: []ParameterSurface{
+							{Name: "x", Type: "int", Optional: false},
+						}},
+				},
+				Properties: []PropertySurface{{Name: "count", Type: "int"}},
+			},
+		},
+		Interfaces: []InterfaceSurface{{FQCN: `Foo\IFoo`}},
+		Enums: []EnumSurface{
+			{FQCN: `Foo\Color`, BackingType: "string",
+				Cases: []EnumCase{{Name: "Red", Value: "red"}}},
+		},
+		Functions: []FunctionSurface{{Name: "helper", ReturnType: "void"}},
+	}
+	raw, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var s2 ReflectionSurface
+	if err := json.Unmarshal(raw, &s2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if s2.PackageName != s.PackageName {
+		t.Errorf("round-trip PackageName = %q; want %q", s2.PackageName, s.PackageName)
+	}
+	if len(s2.Enums) != 1 || s2.Enums[0].BackingType != "string" {
+		t.Errorf("round-trip enum backing type mismatch")
+	}
+}

--- a/package3/php/reflect/script.go
+++ b/package3/php/reflect/script.go
@@ -1,0 +1,268 @@
+package reflect
+
+// reflectPHPScript is the PHP CLI script invoked by Run to extract the
+// reflection surface of a Composer package. It scans all .php files under the
+// package directory, uses PHP's Reflection API to enumerate public classes,
+// interfaces, enums (PHP 8.1+), and top-level functions, then emits a single
+// ReflectionSurface JSON object on stdout.
+//
+// The script is designed to be run as:
+//
+//	php reflect.php <package-dir>
+//
+// Error handling: reflection errors are appended to the "errors" array and do
+// not abort the scan. The script always exits 0 when it can emit valid JSON,
+// and exits 1 on fatal errors (e.g. missing argument).
+const reflectPHPScript = `<?php
+declare(strict_types=1);
+
+if ($argc < 2) {
+    fwrite(STDERR, "Usage: reflect.php <package-dir>\n");
+    exit(1);
+}
+
+$pkgDir = rtrim($argv[1], '/');
+if (!is_dir($pkgDir)) {
+    fwrite(STDERR, "reflect.php: not a directory: $pkgDir\n");
+    exit(1);
+}
+
+$surface = [
+    'package_name' => basename($pkgDir),
+    'php_version'  => PHP_VERSION,
+    'classes'      => [],
+    'interfaces'   => [],
+    'enums'        => [],
+    'functions'    => [],
+    'errors'       => [],
+];
+
+// Recursively collect .php files.
+function collectPhpFiles(string $dir): array {
+    $files = [];
+    $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
+    foreach ($it as $file) {
+        if ($file->isFile() && $file->getExtension() === 'php') {
+            $files[] = $file->getPathname();
+        }
+    }
+    sort($files);
+    return $files;
+}
+
+// Serialize a ReflectionType to a string.
+function typeString(?ReflectionType $t): string {
+    if ($t === null) return '';
+    if ($t instanceof ReflectionNamedType) return $t->getName();
+    if ($t instanceof ReflectionUnionType) {
+        return implode('|', array_map('typeString', $t->getTypes()));
+    }
+    if ($t instanceof ReflectionIntersectionType) {
+        return implode('&', array_map('typeString', $t->getTypes()));
+    }
+    return (string)$t;
+}
+
+function isNullable(?ReflectionType $t): bool {
+    if ($t === null) return false;
+    if ($t instanceof ReflectionNamedType) return $t->allowsNull();
+    return false;
+}
+
+function serializeParam(ReflectionParameter $p): array {
+    $type = typeString($p->getType());
+    $nullable = isNullable($p->getType());
+    $default = '';
+    if ($p->isOptional() && $p->isDefaultValueAvailable()) {
+        try {
+            $v = $p->getDefaultValue();
+            $default = is_null($v) ? 'null' : var_export($v, true);
+        } catch (Throwable $e) {
+            $default = '?';
+        }
+    }
+    return [
+        'name'          => $p->getName(),
+        'type'          => $type,
+        'nullable'      => $nullable,
+        'optional'      => $p->isOptional(),
+        'variadic'      => $p->isVariadic(),
+        'default_value' => $default,
+    ];
+}
+
+function serializeMethod(ReflectionMethod $m): array {
+    $params = [];
+    foreach ($m->getParameters() as $p) {
+        $params[] = serializeParam($p);
+    }
+    return [
+        'name'        => $m->getName(),
+        'static'      => $m->isStatic(),
+        'abstract'    => $m->isAbstract(),
+        'final'       => $m->isFinal(),
+        'parameters'  => $params,
+        'return_type' => typeString($m->getReturnType()),
+        'nullable'    => isNullable($m->getReturnType()),
+    ];
+}
+
+function serializeProperty(ReflectionProperty $p): array {
+    $type = '';
+    $nullable = false;
+    if ($p->hasType()) {
+        $type = typeString($p->getType());
+        $nullable = isNullable($p->getType());
+    }
+    $default = '';
+    try {
+        $defaults = $p->getDeclaringClass()->getDefaultProperties();
+        if (array_key_exists($p->getName(), $defaults)) {
+            $v = $defaults[$p->getName()];
+            $default = is_null($v) ? 'null' : var_export($v, true);
+        }
+    } catch (Throwable $e) {}
+    return [
+        'name'          => $p->getName(),
+        'type'          => $type,
+        'nullable'      => $nullable,
+        'static'        => $p->isStatic(),
+        'readonly'      => $p->isReadOnly(),
+        'default_value' => $default,
+    ];
+}
+
+function serializeConstant(ReflectionClassConstant $c): array {
+    $type = '';
+    if (method_exists($c, 'getType') && $c->getType() !== null) {
+        $type = typeString($c->getType());
+    }
+    try {
+        $val = var_export($c->getValue(), true);
+    } catch (Throwable $e) {
+        $val = '?';
+    }
+    return ['name' => $c->getName(), 'value' => $val, 'type' => $type];
+}
+
+$phpFiles = collectPhpFiles($pkgDir);
+
+// Include each file; catch fatal-ish errors via Throwable.
+foreach ($phpFiles as $file) {
+    try {
+        include_once $file;
+    } catch (Throwable $e) {
+        $surface['errors'][] = "include $file: " . $e->getMessage();
+    }
+}
+
+// Enumerate classes, interfaces, enums.
+$declared = get_declared_classes();
+foreach ($declared as $className) {
+    try {
+        $rc = new ReflectionClass($className);
+    } catch (Throwable $e) {
+        $surface['errors'][] = "ReflectionClass($className): " . $e->getMessage();
+        continue;
+    }
+
+    // Only process classes defined inside our package dir.
+    $file = $rc->getFileName();
+    if ($file === false || strpos(realpath($file), realpath($pkgDir)) !== 0) {
+        continue;
+    }
+    if (!$rc->isPublic() && !($rc->getModifiers() & ReflectionClass::IS_EXPLICIT_ABSTRACT)) {
+        // internal or non-public
+    }
+    // Skip anonymous classes.
+    if ($rc->isAnonymous()) continue;
+
+    // Public methods only.
+    $methods = [];
+    foreach ($rc->getMethods(ReflectionMethod::IS_PUBLIC) as $m) {
+        if ($m->getDeclaringClass()->getName() !== $className) continue;
+        $methods[] = serializeMethod($m);
+    }
+
+    // Public properties.
+    $props = [];
+    foreach ($rc->getProperties(ReflectionProperty::IS_PUBLIC) as $p) {
+        if ($p->getDeclaringClass()->getName() !== $className) continue;
+        $props[] = serializeProperty($p);
+    }
+
+    // Public constants.
+    $consts = [];
+    foreach ($rc->getReflectionConstants(ReflectionClassConstant::IS_PUBLIC) as $c) {
+        if ($c->getDeclaringClass()->getName() !== $className) continue;
+        $consts[] = serializeConstant($c);
+    }
+
+    $parentFqcn = $rc->getParentClass() ? $rc->getParentClass()->getName() : '';
+    $ifaceNames = array_map(fn($i) => $i->getName(), $rc->getInterfaces());
+
+    if ($rc->isInterface()) {
+        $surface['interfaces'][] = [
+            'fqcn'         => $className,
+            'parent_fqcns' => $ifaceNames,
+            'methods'      => $methods,
+            'constants'    => $consts,
+        ];
+    } elseif (PHP_VERSION_ID >= 80100 && $rc->isEnum()) {
+        $cases = [];
+        foreach ($rc->getCases() as $case) {
+            $val = '';
+            try { $val = (string)$case->getValue()->value; } catch (Throwable $e) {}
+            $cases[] = ['name' => $case->getName(), 'value' => $val];
+        }
+        $backingType = '';
+        if (method_exists($rc, 'getBackingType') && $rc->getBackingType() !== null) {
+            $backingType = typeString($rc->getBackingType());
+        }
+        $surface['enums'][] = [
+            'fqcn'         => $className,
+            'backing_type' => $backingType,
+            'cases'        => $cases,
+            'methods'      => $methods,
+        ];
+    } else {
+        $surface['classes'][] = [
+            'fqcn'            => $className,
+            'abstract'        => $rc->isAbstract(),
+            'final'           => $rc->isFinal(),
+            'parent_fqcn'     => $parentFqcn,
+            'interface_fqcns' => array_values($ifaceNames),
+            'methods'         => $methods,
+            'properties'      => $props,
+            'constants'       => $consts,
+        ];
+    }
+}
+
+// Top-level functions.
+$declared = get_defined_functions()['user'];
+foreach ($declared as $fnName) {
+    try {
+        $rf = new ReflectionFunction($fnName);
+    } catch (Throwable $e) {
+        $surface['errors'][] = "ReflectionFunction($fnName): " . $e->getMessage();
+        continue;
+    }
+    $file = $rf->getFileName();
+    if ($file === false || strpos(realpath($file), realpath($pkgDir)) !== 0) {
+        continue;
+    }
+    $params = [];
+    foreach ($rf->getParameters() as $p) {
+        $params[] = serializeParam($p);
+    }
+    $surface['functions'][] = [
+        'name'        => $fnName,
+        'parameters'  => $params,
+        'return_type' => typeString($rf->getReturnType()),
+        'nullable'    => isNullable($rf->getReturnType()),
+    ];
+}
+
+echo json_encode($surface, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+`

--- a/package3/php/reflect/types.go
+++ b/package3/php/reflect/types.go
@@ -1,0 +1,154 @@
+// Package reflect implements the PHP Reflection API surface extractor for the
+// MEP-75 PHP bridge. It invokes a PHP CLI script (reflect.php) via
+// exec.Command and parses the emitted JSON surface document.
+//
+// The surface document schema is defined here. reflect.php emits one
+// ReflectionSurface per package root, collecting all public classes,
+// interfaces, abstract classes, enums, and top-level functions.
+//
+// See [website/docs/research/0075/03-prior-art-bridges.md] for the design.
+package reflect
+
+// ReflectionSurface is the top-level JSON document emitted by reflect.php for
+// a single Composer package directory.
+type ReflectionSurface struct {
+	// PackageName is the Composer vendor/name string, e.g. "guzzlehttp/guzzle".
+	PackageName string `json:"package_name"`
+	// PHPVersion is the PHP_VERSION string at reflect time, e.g. "8.4.0".
+	PHPVersion string `json:"php_version"`
+	// Classes is the list of public class and abstract class definitions.
+	Classes []ClassSurface `json:"classes"`
+	// Interfaces is the list of interface definitions.
+	Interfaces []InterfaceSurface `json:"interfaces"`
+	// Enums is the list of enum definitions (PHP 8.1+).
+	Enums []EnumSurface `json:"enums"`
+	// Functions is the list of top-level function definitions.
+	Functions []FunctionSurface `json:"functions"`
+	// Errors is the list of reflection errors encountered during extraction.
+	// Non-fatal; the caller logs these as warnings.
+	Errors []string `json:"errors,omitempty"`
+}
+
+// ClassSurface describes a single public class or abstract class.
+type ClassSurface struct {
+	// FQCN is the fully-qualified class name, e.g. "GuzzleHttp\\Client".
+	FQCN string `json:"fqcn"`
+	// Abstract is true if the class is declared abstract.
+	Abstract bool `json:"abstract"`
+	// Final is true if the class is declared final.
+	Final bool `json:"final"`
+	// ParentFQCN is the FQCN of the parent class, or empty.
+	ParentFQCN string `json:"parent_fqcn,omitempty"`
+	// InterfaceFQCNs is the list of implemented interface FQCNs.
+	InterfaceFQCNs []string `json:"interface_fqcns,omitempty"`
+	// Methods is the list of public methods.
+	Methods []MethodSurface `json:"methods"`
+	// Properties is the list of public properties.
+	Properties []PropertySurface `json:"properties"`
+	// Constants is the list of public class constants.
+	Constants []ConstantSurface `json:"constants,omitempty"`
+}
+
+// InterfaceSurface describes a single interface.
+type InterfaceSurface struct {
+	// FQCN is the fully-qualified interface name.
+	FQCN string `json:"fqcn"`
+	// ParentFQCNs is the list of parent interfaces.
+	ParentFQCNs []string `json:"parent_fqcns,omitempty"`
+	// Methods is the list of interface method signatures.
+	Methods []MethodSurface `json:"methods"`
+	// Constants is the list of interface constants.
+	Constants []ConstantSurface `json:"constants,omitempty"`
+}
+
+// EnumSurface describes a PHP 8.1+ enum.
+type EnumSurface struct {
+	// FQCN is the fully-qualified enum name.
+	FQCN string `json:"fqcn"`
+	// BackingType is "int", "string", or "" for pure enums.
+	BackingType string `json:"backing_type,omitempty"`
+	// Cases is the list of enum cases.
+	Cases []EnumCase `json:"cases"`
+	// Methods is the list of enum methods.
+	Methods []MethodSurface `json:"methods,omitempty"`
+}
+
+// EnumCase is one case in an enum.
+type EnumCase struct {
+	// Name is the case name, e.g. "Active".
+	Name string `json:"name"`
+	// Value is the backing value as a string (int or string; empty for pure enums).
+	Value string `json:"value,omitempty"`
+}
+
+// MethodSurface describes a single public method.
+type MethodSurface struct {
+	// Name is the method name, e.g. "send".
+	Name string `json:"name"`
+	// Static is true if the method is static.
+	Static bool `json:"static"`
+	// Abstract is true if the method is abstract.
+	Abstract bool `json:"abstract"`
+	// Final is true if the method is final.
+	Final bool `json:"final"`
+	// Parameters is the ordered list of parameters.
+	Parameters []ParameterSurface `json:"parameters"`
+	// ReturnType is the declared return type string, or "" if none.
+	ReturnType string `json:"return_type,omitempty"`
+	// Nullable is true if the return type is nullable.
+	Nullable bool `json:"nullable,omitempty"`
+}
+
+// PropertySurface describes a single public property.
+type PropertySurface struct {
+	// Name is the property name (without $).
+	Name string `json:"name"`
+	// Type is the declared type string, or "" if untyped.
+	Type string `json:"type,omitempty"`
+	// Nullable is true if the type is nullable.
+	Nullable bool `json:"nullable,omitempty"`
+	// Static is true if the property is static.
+	Static bool `json:"static"`
+	// Readonly is true if the property is readonly (PHP 8.1+).
+	Readonly bool `json:"readonly,omitempty"`
+	// DefaultValue is the string representation of the default value, or "".
+	DefaultValue string `json:"default_value,omitempty"`
+}
+
+// ParameterSurface describes a single method or function parameter.
+type ParameterSurface struct {
+	// Name is the parameter name (without $).
+	Name string `json:"name"`
+	// Type is the declared type string, or "" if untyped.
+	Type string `json:"type,omitempty"`
+	// Nullable is true if the type is nullable.
+	Nullable bool `json:"nullable,omitempty"`
+	// Optional is true if the parameter has a default value.
+	Optional bool `json:"optional"`
+	// Variadic is true for ...$param.
+	Variadic bool `json:"variadic"`
+	// DefaultValue is the string representation of the default value, or "".
+	DefaultValue string `json:"default_value,omitempty"`
+}
+
+// FunctionSurface describes a top-level public function.
+type FunctionSurface struct {
+	// Name is the function name (may include namespace prefix).
+	Name string `json:"name"`
+	// Parameters is the ordered list of parameters.
+	Parameters []ParameterSurface `json:"parameters"`
+	// ReturnType is the declared return type string, or "" if none.
+	ReturnType string `json:"return_type,omitempty"`
+	// Nullable is true if the return type is nullable.
+	Nullable bool `json:"nullable,omitempty"`
+}
+
+// ConstantSurface describes a class or interface constant.
+type ConstantSurface struct {
+	// Name is the constant name.
+	Name string `json:"name"`
+	// Value is the string representation of the constant value.
+	Value string `json:"value"`
+	// Type is the declared type string (PHP 8.3+), or "".
+	Type string `json:"type,omitempty"`
+}


### PR DESCRIPTION
Closes #22838

## Summary

- `reflect/types.go`: Full JSON schema for PHP reflection surface (classes, interfaces, enums, functions, methods, properties, parameters, constants)
- `reflect/script.go`: Embedded PHP CLI script using Reflection API; scans all .php files recursively; serialises nullable flags, union/intersection types, variadic params, enum backing types
- `reflect/reflect.go`: Go invoker with Run/RunFromScript/ParseSurface; ErrPHPNotFound/ErrReflectFailed sentinels
- 8 tests: 3 pure-Go (ParseSurface, bad JSON, ErrPHPNotFound, struct round-trip) + 4 that run against real PHP 8.x when available

## Test plan

- [ ] `go test ./package3/php/reflect/...` passes (pure-Go tests always; PHP tests when available)
- [ ] `TestParseSurface` parses a realistic Guzzle-like surface document
- [ ] `TestRunPHPNotFound` returns `ErrPHPNotFound` for missing binary
- [ ] `TestReflectSurfaceTypes` JSON marshal round-trip