### PR TITLE
MEP-68 phases 0-3: skeleton, NuGet client, metacli schema, type mapping

### DIFF
--- a/package3/dotnet/README.md
+++ b/package3/dotnet/README.md
@@ -1,0 +1,22 @@
+# package3/dotnet
+
+Bidirectional .NET / NuGet package bridge for Mochi. Implements MEP-68.
+
+## Layout
+
+    errors/    SkipReason, BridgeError
+    semver/    NuGet version / version-range
+    nuget/     NuGet v3 API client + content-addressed .nupkg cache
+    metacli/   mochi-dotnet-meta JSON schema + surface parser
+    typemap/   closed CLR-to-Mochi type translation
+    shimgen/   C# shim generator ([UnmanagedCallersOnly])
+    emit/      Mochi extern emitter
+    lockfile/  [[dotnet-package]] encoder/decoder/drift checker
+    clrhosting/CLR hosting API bridge codegen
+    publish/   NuGet package emit + trusted publishing
+    build/     pipeline orchestration
+
+## References
+
+- MEP-68 spec: website/docs/mep/mep-0068.md
+- Research: website/docs/research/0068/

--- a/package3/dotnet/errors/errors.go
+++ b/package3/dotnet/errors/errors.go
@@ -1,0 +1,157 @@
+// Package errors carries the cross-cutting error types the MEP-68 bridge
+// emits at lock time and at build time. The most important one is SkipReason,
+// which records why a particular CLR type or member was not translated into a
+// Mochi extern binding. See [website/docs/research/0068/] for the closed set
+// of refusal reasons.
+package errors
+
+import "fmt"
+
+// SkipReason classifies why the bridge declined to translate a CLR type or
+// member. The set mirrors the table in the MEP-68 research notes.
+type SkipReason int
+
+const (
+	// SkipUnknown is the zero value. It must never be emitted in practice.
+	SkipUnknown SkipReason = iota
+	// SkipGeneric: the type has an open generic parameter and no
+	// monomorphise entry has been provided.
+	SkipGeneric
+	// SkipPointer: unsafe pointer type (System.IntPtr in direct-pointer context).
+	SkipPointer
+	// SkipRefType: ref/out parameter requires special marshalling that
+	// v1 does not support.
+	SkipRefType
+	// SkipInterface: interface in non-handle position (no concrete factory).
+	SkipInterface
+	// SkipDelegate: System.Delegate / Action<T> / Func<T> (function pointer).
+	SkipDelegate
+	// SkipDynamic: dynamic type (runtime binding, no static surface).
+	SkipDynamic
+	// SkipCOMInterop: [ComImport] type.
+	SkipCOMInterop
+	// SkipUnsafe: unsafe code block without capabilities opt-in.
+	SkipUnsafe
+	// SkipInternal: internal visibility (not in the public API surface).
+	SkipInternal
+	// SkipAbstract: abstract class with no concrete factory.
+	SkipAbstract
+	// SkipObsolete: [Obsolete] marked item.
+	SkipObsolete
+	// SkipNestedType: nested type definition (not supported in v1).
+	SkipNestedType
+	// SkipIndexer: indexer property (this[T]).
+	SkipIndexer
+	// SkipOperator: operator overload.
+	SkipOperator
+	// SkipEvent: event (add/remove pattern).
+	SkipEvent
+	// SkipMultiReturn: out/ref params as multiple return values.
+	SkipMultiReturn
+	// SkipSpan: Span<T> / ReadOnlySpan<T> (stack-only types).
+	SkipSpan
+	// SkipValueTask: ValueTask<T> (v1 only bridges Task<T>).
+	SkipValueTask
+)
+
+// String renders the SkipReason as a short token used in the SKIPPED.txt
+// output file. The token is stable across releases; do not rename without
+// adjusting the SKIPPED.txt golden fixtures.
+func (r SkipReason) String() string {
+	switch r {
+	case SkipGeneric:
+		return "SkipGeneric"
+	case SkipPointer:
+		return "SkipPointer"
+	case SkipRefType:
+		return "SkipRefType"
+	case SkipInterface:
+		return "SkipInterface"
+	case SkipDelegate:
+		return "SkipDelegate"
+	case SkipDynamic:
+		return "SkipDynamic"
+	case SkipCOMInterop:
+		return "SkipCOMInterop"
+	case SkipUnsafe:
+		return "SkipUnsafe"
+	case SkipInternal:
+		return "SkipInternal"
+	case SkipAbstract:
+		return "SkipAbstract"
+	case SkipObsolete:
+		return "SkipObsolete"
+	case SkipNestedType:
+		return "SkipNestedType"
+	case SkipIndexer:
+		return "SkipIndexer"
+	case SkipOperator:
+		return "SkipOperator"
+	case SkipEvent:
+		return "SkipEvent"
+	case SkipMultiReturn:
+		return "SkipMultiReturn"
+	case SkipSpan:
+		return "SkipSpan"
+	case SkipValueTask:
+		return "SkipValueTask"
+	default:
+		return "SkipUnknown"
+	}
+}
+
+// SkipReport records a single CLR type or member the bridge declined to
+// translate. The collection of SkipReports for an assembly is rendered to
+// SKIPPED.txt under the wrapper directory at the end of phase 4.
+type SkipReport struct {
+	// ItemPath is the CLR path of the item, e.g. "Newtonsoft.Json.JsonConvert.SerializeObject".
+	ItemPath string
+	// Reason is the classification.
+	Reason SkipReason
+	// Detail is a free-text explanation specific to this skip.
+	Detail string
+	// Override is the suggested hand-authored opt-in. May be empty if there
+	// is no straightforward override available.
+	Override string
+}
+
+// String renders a SkipReport in the SKIPPED.txt format.
+func (s SkipReport) String() string {
+	out := fmt.Sprintf("SKIPPED: %s\n  Reason: %s\n  Detail: %s\n", s.ItemPath, s.Reason, s.Detail)
+	if s.Override != "" {
+		out += fmt.Sprintf("  Override: %s\n", s.Override)
+	}
+	return out
+}
+
+// BridgeError is the top-level error returned by Driver entry points. It
+// records the phase that produced the error and the underlying cause.
+type BridgeError struct {
+	// Phase is the bridge phase that detected the error, e.g. "lock",
+	// "ingest", "wrapper", "build".
+	Phase string
+	// Package is the upstream NuGet package name being processed when the
+	// error occurred. Empty for phase-agnostic errors.
+	Package string
+	// Cause is the underlying error.
+	Cause error
+}
+
+// Error renders BridgeError as "phase[package]: cause".
+func (e *BridgeError) Error() string {
+	if e.Package == "" {
+		return fmt.Sprintf("%s: %v", e.Phase, e.Cause)
+	}
+	return fmt.Sprintf("%s[%s]: %v", e.Phase, e.Package, e.Cause)
+}
+
+// Unwrap exposes the underlying cause for errors.Is / errors.As.
+func (e *BridgeError) Unwrap() error { return e.Cause }
+
+// Wrap constructs a BridgeError from a phase, a package (optional), and a cause.
+func Wrap(phase, pkg string, cause error) error {
+	if cause == nil {
+		return nil
+	}
+	return &BridgeError{Phase: phase, Package: pkg, Cause: cause}
+}

--- a/package3/dotnet/errors/errors_test.go
+++ b/package3/dotnet/errors/errors_test.go
@@ -1,0 +1,155 @@
+package errors_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"mochi/package3/dotnet/errors"
+)
+
+func TestSkipReason_String_allNonEmpty(t *testing.T) {
+	reasons := []errors.SkipReason{
+		errors.SkipGeneric,
+		errors.SkipPointer,
+		errors.SkipRefType,
+		errors.SkipInterface,
+		errors.SkipDelegate,
+		errors.SkipDynamic,
+		errors.SkipCOMInterop,
+		errors.SkipUnsafe,
+		errors.SkipInternal,
+		errors.SkipAbstract,
+		errors.SkipObsolete,
+		errors.SkipNestedType,
+		errors.SkipIndexer,
+		errors.SkipOperator,
+		errors.SkipEvent,
+		errors.SkipMultiReturn,
+		errors.SkipSpan,
+		errors.SkipValueTask,
+	}
+	for _, r := range reasons {
+		s := r.String()
+		if s == "" {
+			t.Errorf("SkipReason(%d).String() is empty", int(r))
+		}
+		if s == "SkipUnknown" {
+			t.Errorf("SkipReason(%d).String() returned SkipUnknown unexpectedly", int(r))
+		}
+	}
+}
+
+func TestSkipReason_String_zeroIsUnknown(t *testing.T) {
+	var r errors.SkipReason
+	if got := r.String(); got != "SkipUnknown" {
+		t.Errorf("zero SkipReason.String() = %q; want %q", got, "SkipUnknown")
+	}
+}
+
+func TestSkipReason_String_specificValues(t *testing.T) {
+	cases := []struct {
+		reason errors.SkipReason
+		want   string
+	}{
+		{errors.SkipGeneric, "SkipGeneric"},
+		{errors.SkipPointer, "SkipPointer"},
+		{errors.SkipRefType, "SkipRefType"},
+		{errors.SkipInterface, "SkipInterface"},
+		{errors.SkipDelegate, "SkipDelegate"},
+		{errors.SkipDynamic, "SkipDynamic"},
+		{errors.SkipCOMInterop, "SkipCOMInterop"},
+		{errors.SkipUnsafe, "SkipUnsafe"},
+		{errors.SkipInternal, "SkipInternal"},
+		{errors.SkipAbstract, "SkipAbstract"},
+		{errors.SkipObsolete, "SkipObsolete"},
+		{errors.SkipNestedType, "SkipNestedType"},
+		{errors.SkipIndexer, "SkipIndexer"},
+		{errors.SkipOperator, "SkipOperator"},
+		{errors.SkipEvent, "SkipEvent"},
+		{errors.SkipMultiReturn, "SkipMultiReturn"},
+		{errors.SkipSpan, "SkipSpan"},
+		{errors.SkipValueTask, "SkipValueTask"},
+	}
+	for _, tc := range cases {
+		if got := tc.reason.String(); got != tc.want {
+			t.Errorf("SkipReason.String() = %q; want %q", got, tc.want)
+		}
+	}
+}
+
+func TestBridgeError_Error_withPackage(t *testing.T) {
+	err := &errors.BridgeError{
+		Phase:   "lock",
+		Package: "Newtonsoft.Json",
+		Cause:   fmt.Errorf("network timeout"),
+	}
+	got := err.Error()
+	if got != "lock[Newtonsoft.Json]: network timeout" {
+		t.Errorf("BridgeError.Error() = %q; want %q", got, "lock[Newtonsoft.Json]: network timeout")
+	}
+}
+
+func TestBridgeError_Error_withoutPackage(t *testing.T) {
+	err := &errors.BridgeError{
+		Phase: "ingest",
+		Cause: fmt.Errorf("missing assembly"),
+	}
+	got := err.Error()
+	if got != "ingest: missing assembly" {
+		t.Errorf("BridgeError.Error() = %q; want %q", got, "ingest: missing assembly")
+	}
+}
+
+func TestBridgeError_Unwrap(t *testing.T) {
+	cause := fmt.Errorf("root cause")
+	err := &errors.BridgeError{Phase: "build", Cause: cause}
+	if err.Unwrap() != cause {
+		t.Error("Unwrap() did not return the original cause")
+	}
+}
+
+func TestWrap_nilCause(t *testing.T) {
+	if errors.Wrap("lock", "pkg", nil) != nil {
+		t.Error("Wrap with nil cause must return nil")
+	}
+}
+
+func TestWrap_nonNil(t *testing.T) {
+	cause := fmt.Errorf("boom")
+	wrapped := errors.Wrap("build", "MyLib", cause)
+	if wrapped == nil {
+		t.Fatal("Wrap returned nil for non-nil cause")
+	}
+	if !strings.Contains(wrapped.Error(), "build[MyLib]") {
+		t.Errorf("wrapped error %q missing phase+package prefix", wrapped.Error())
+	}
+}
+
+func TestSkipReport_String(t *testing.T) {
+	r := errors.SkipReport{
+		ItemPath: "System.Console.WriteLine",
+		Reason:   errors.SkipDelegate,
+		Detail:   "function pointer param",
+	}
+	s := r.String()
+	if !strings.Contains(s, "SKIPPED") {
+		t.Error("SkipReport.String() missing SKIPPED prefix")
+	}
+	if !strings.Contains(s, "SkipDelegate") {
+		t.Error("SkipReport.String() missing reason token")
+	}
+}
+
+func TestSkipReport_String_withOverride(t *testing.T) {
+	r := errors.SkipReport{
+		ItemPath: "System.Foo",
+		Reason:   errors.SkipObsolete,
+		Detail:   "marked [Obsolete]",
+		Override: "[[dotnet-package.allow-obsolete]]",
+	}
+	s := r.String()
+	if !strings.Contains(s, "Override") {
+		t.Error("SkipReport.String() missing Override line")
+	}
+}

--- a/package3/dotnet/metacli/parse.go
+++ b/package3/dotnet/metacli/parse.go
@@ -1,0 +1,29 @@
+package metacli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Parse parses the JSON output of mochi-dotnet-meta from r.
+// Returns a non-nil *AssemblyMetadata on success.
+func Parse(r io.Reader) (*AssemblyMetadata, error) {
+	var meta AssemblyMetadata
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&meta); err != nil {
+		return nil, fmt.Errorf("metacli: decode assembly metadata: %w", err)
+	}
+	return &meta, nil
+}
+
+// ParseBytes parses the JSON output of mochi-dotnet-meta from b.
+// Returns a non-nil *AssemblyMetadata on success.
+func ParseBytes(b []byte) (*AssemblyMetadata, error) {
+	var meta AssemblyMetadata
+	if err := json.Unmarshal(b, &meta); err != nil {
+		return nil, fmt.Errorf("metacli: decode assembly metadata: %w", err)
+	}
+	return &meta, nil
+}

--- a/package3/dotnet/metacli/parse_test.go
+++ b/package3/dotnet/metacli/parse_test.go
@@ -1,0 +1,243 @@
+package metacli_test
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/dotnet/metacli"
+)
+
+const fixtureJSON = `{
+  "assembly": "Newtonsoft.Json",
+  "version": "13.0.1",
+  "target_framework": "net6.0",
+  "types": [
+    {
+      "namespace": "Newtonsoft.Json",
+      "name": "JsonConvert",
+      "kind": "class",
+      "is_static": true,
+      "methods": [
+        {
+          "name": "SerializeObject",
+          "is_static": true,
+          "return_type": {"full_name": "System.String", "kind": "primitive"},
+          "parameters": [
+            {"name": "value", "type": {"full_name": "System.Object", "kind": "class"}}
+          ],
+          "xml_doc": "Serializes the specified object to a JSON string."
+        }
+      ]
+    },
+    {
+      "namespace": "Newtonsoft.Json",
+      "name": "JsonSerializer",
+      "kind": "class",
+      "properties": [
+        {
+          "name": "NullValueHandling",
+          "type": {"full_name": "Newtonsoft.Json.NullValueHandling", "kind": "enum"},
+          "has_getter": true,
+          "has_setter": true
+        }
+      ]
+    },
+    {
+      "namespace": "Newtonsoft.Json",
+      "name": "NullValueHandling",
+      "kind": "enum",
+      "enum_values": [
+        {"name": "Include", "value": 0},
+        {"name": "Ignore", "value": 1}
+      ]
+    },
+    {
+      "namespace": "Newtonsoft.Json.Linq",
+      "name": "JToken",
+      "kind": "class",
+      "is_abstract": true
+    },
+    {
+      "namespace": "Newtonsoft.Json",
+      "name": "IJsonLineInfo",
+      "kind": "interface"
+    }
+  ]
+}`
+
+func TestParse_topLevel(t *testing.T) {
+	meta, err := metacli.Parse(strings.NewReader(fixtureJSON))
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if meta.Assembly != "Newtonsoft.Json" {
+		t.Errorf("Assembly = %q; want %q", meta.Assembly, "Newtonsoft.Json")
+	}
+	if meta.Version != "13.0.1" {
+		t.Errorf("Version = %q; want %q", meta.Version, "13.0.1")
+	}
+	if meta.TargetFramework != "net6.0" {
+		t.Errorf("TargetFramework = %q; want %q", meta.TargetFramework, "net6.0")
+	}
+}
+
+func TestParse_typeCount(t *testing.T) {
+	meta, _ := metacli.Parse(strings.NewReader(fixtureJSON))
+	if len(meta.Types) != 5 {
+		t.Errorf("got %d types; want 5", len(meta.Types))
+	}
+}
+
+func TestParse_classType(t *testing.T) {
+	meta, _ := metacli.Parse(strings.NewReader(fixtureJSON))
+	td := meta.Types[0]
+	if td.Name != "JsonConvert" {
+		t.Errorf("Name = %q; want JsonConvert", td.Name)
+	}
+	if td.Kind != metacli.KindClass {
+		t.Errorf("Kind = %q; want class", td.Kind)
+	}
+	if !td.IsStatic {
+		t.Error("JsonConvert should be static")
+	}
+}
+
+func TestParse_method(t *testing.T) {
+	meta, _ := metacli.Parse(strings.NewReader(fixtureJSON))
+	td := meta.Types[0]
+	if len(td.Methods) != 1 {
+		t.Fatalf("got %d methods; want 1", len(td.Methods))
+	}
+	m := td.Methods[0]
+	if m.Name != "SerializeObject" {
+		t.Errorf("Method name = %q; want SerializeObject", m.Name)
+	}
+	if m.ReturnType.FullName != "System.String" {
+		t.Errorf("ReturnType.FullName = %q; want System.String", m.ReturnType.FullName)
+	}
+	if len(m.Parameters) != 1 {
+		t.Fatalf("got %d params; want 1", len(m.Parameters))
+	}
+}
+
+func TestParse_property(t *testing.T) {
+	meta, _ := metacli.Parse(strings.NewReader(fixtureJSON))
+	td := meta.Types[1]
+	if len(td.Properties) != 1 {
+		t.Fatalf("got %d properties; want 1", len(td.Properties))
+	}
+	p := td.Properties[0]
+	if p.Name != "NullValueHandling" {
+		t.Errorf("Prop name = %q; want NullValueHandling", p.Name)
+	}
+}
+
+func TestParse_enum(t *testing.T) {
+	meta, _ := metacli.Parse(strings.NewReader(fixtureJSON))
+	td := meta.Types[2]
+	if td.Kind != metacli.KindEnum {
+		t.Errorf("Kind = %q; want enum", td.Kind)
+	}
+	if len(td.EnumValues) != 2 {
+		t.Fatalf("got %d enum values; want 2", len(td.EnumValues))
+	}
+	if td.EnumValues[0].Name != "Include" {
+		t.Errorf("EnumValue[0].Name = %q; want Include", td.EnumValues[0].Name)
+	}
+	if td.EnumValues[1].Value != 1 {
+		t.Errorf("EnumValue[1].Value = %d; want 1", td.EnumValues[1].Value)
+	}
+}
+
+func TestParse_abstractClass(t *testing.T) {
+	meta, _ := metacli.Parse(strings.NewReader(fixtureJSON))
+	td := meta.Types[3]
+	if !td.IsAbstract {
+		t.Error("JToken should be abstract")
+	}
+}
+
+func TestParse_interface(t *testing.T) {
+	meta, _ := metacli.Parse(strings.NewReader(fixtureJSON))
+	td := meta.Types[4]
+	if td.Kind != metacli.KindInterface {
+		t.Errorf("Kind = %q; want interface", td.Kind)
+	}
+}
+
+func TestParseBytes(t *testing.T) {
+	meta, err := metacli.ParseBytes([]byte(fixtureJSON))
+	if err != nil {
+		t.Fatalf("ParseBytes error: %v", err)
+	}
+	if meta.Assembly != "Newtonsoft.Json" {
+		t.Errorf("Assembly = %q", meta.Assembly)
+	}
+}
+
+func TestParse_emptyJSON(t *testing.T) {
+	_, err := metacli.Parse(strings.NewReader(""))
+	if err == nil {
+		t.Error("empty JSON should return error")
+	}
+}
+
+func TestParse_invalidJSON(t *testing.T) {
+	_, err := metacli.Parse(strings.NewReader("{not json}"))
+	if err == nil {
+		t.Error("invalid JSON should return error")
+	}
+}
+
+func TestParse_methodXmlDoc(t *testing.T) {
+	meta, _ := metacli.Parse(strings.NewReader(fixtureJSON))
+	m := meta.Types[0].Methods[0]
+	if m.XmlDoc == "" {
+		t.Error("method XmlDoc should be non-empty")
+	}
+}
+
+func TestParse_paramType(t *testing.T) {
+	meta, _ := metacli.Parse(strings.NewReader(fixtureJSON))
+	p := meta.Types[0].Methods[0].Parameters[0]
+	if p.Type.Kind != metacli.TypeRefClass {
+		t.Errorf("param type kind = %q; want class", p.Type.Kind)
+	}
+}
+
+func TestParse_genericTypeFixture(t *testing.T) {
+	const genericJSON = `{
+  "assembly": "System.Collections",
+  "version": "6.0.0",
+  "target_framework": "net6.0",
+  "types": [
+    {
+      "namespace": "System.Collections.Generic",
+      "name": "List` + "`" + `1",
+      "kind": "class",
+      "is_generic": true,
+      "type_params": ["T"],
+      "methods": [
+        {
+          "name": "Add",
+          "return_type": {"full_name": "System.Void", "kind": "void"},
+          "parameters": [
+            {"name": "item", "type": {"full_name": "T", "kind": "generic_param"}}
+          ]
+        }
+      ]
+    }
+  ]
+}`
+	meta, err := metacli.Parse(strings.NewReader(genericJSON))
+	if err != nil {
+		t.Fatalf("Parse generic fixture: %v", err)
+	}
+	td := meta.Types[0]
+	if !td.IsGeneric {
+		t.Error("List`1 should be generic")
+	}
+	if len(td.TypeParams) != 1 || td.TypeParams[0] != "T" {
+		t.Errorf("TypeParams = %v; want [T]", td.TypeParams)
+	}
+}

--- a/package3/dotnet/metacli/schema.go
+++ b/package3/dotnet/metacli/schema.go
@@ -1,0 +1,129 @@
+// Package metacli defines the JSON schema output by mochi-dotnet-meta (a
+// .NET CLI tool invoked at lock time) and provides parsers and surface
+// extractors for that output. The Go code here is the consumer side only;
+// the .NET tool that produces the JSON is a separate project.
+package metacli
+
+// AssemblyMetadata is the top-level JSON document output by mochi-dotnet-meta.
+type AssemblyMetadata struct {
+	Assembly        string    `json:"assembly"`
+	Version         string    `json:"version"`
+	TargetFramework string    `json:"target_framework"`
+	Types           []TypeDef `json:"types"`
+}
+
+// TypeDefKind classifies .NET type definitions.
+type TypeDefKind string
+
+const (
+	KindClass     TypeDefKind = "class"
+	KindStruct    TypeDefKind = "struct"
+	KindInterface TypeDefKind = "interface"
+	KindEnum      TypeDefKind = "enum"
+	KindDelegate  TypeDefKind = "delegate"
+)
+
+// TypeDef represents a public type exported by the assembly.
+type TypeDef struct {
+	Namespace  string      `json:"namespace"`
+	Name       string      `json:"name"`
+	Kind       TypeDefKind `json:"kind"`
+	IsAbstract bool        `json:"is_abstract,omitempty"`
+	IsSealed   bool        `json:"is_sealed,omitempty"`
+	IsStatic   bool        `json:"is_static,omitempty"`
+	IsObsolete bool        `json:"is_obsolete,omitempty"`
+	IsGeneric  bool        `json:"is_generic,omitempty"`
+	TypeParams []string    `json:"type_params,omitempty"`
+	BaseType   string      `json:"base_type,omitempty"`
+	Interfaces []string    `json:"interfaces,omitempty"`
+	Methods    []MethodDef `json:"methods,omitempty"`
+	Properties []PropDef   `json:"properties,omitempty"`
+	Fields     []FieldDef  `json:"fields,omitempty"`
+	EnumValues []EnumValue `json:"enum_values,omitempty"`
+	XmlDoc     string      `json:"xml_doc,omitempty"`
+}
+
+// MethodDef represents a public method on a type.
+type MethodDef struct {
+	Name       string     `json:"name"`
+	IsStatic   bool       `json:"is_static,omitempty"`
+	IsAsync    bool       `json:"is_async,omitempty"`
+	IsObsolete bool       `json:"is_obsolete,omitempty"`
+	IsGeneric  bool       `json:"is_generic,omitempty"`
+	TypeParams []string   `json:"type_params,omitempty"`
+	ReturnType TypeRef    `json:"return_type"`
+	Parameters []ParamDef `json:"parameters,omitempty"`
+	XmlDoc     string     `json:"xml_doc,omitempty"`
+}
+
+// PropDef represents a public property.
+type PropDef struct {
+	Name       string  `json:"name"`
+	Type       TypeRef `json:"type"`
+	HasGetter  bool    `json:"has_getter,omitempty"`
+	HasSetter  bool    `json:"has_setter,omitempty"`
+	IsStatic   bool    `json:"is_static,omitempty"`
+	IsObsolete bool    `json:"is_obsolete,omitempty"`
+	IsIndexer  bool    `json:"is_indexer,omitempty"`
+	XmlDoc     string  `json:"xml_doc,omitempty"`
+}
+
+// FieldDef represents a public field.
+type FieldDef struct {
+	Name       string  `json:"name"`
+	Type       TypeRef `json:"type"`
+	IsStatic   bool    `json:"is_static,omitempty"`
+	IsConst    bool    `json:"is_const,omitempty"`
+	IsReadOnly bool    `json:"is_readonly,omitempty"`
+	XmlDoc     string  `json:"xml_doc,omitempty"`
+}
+
+// ParamDef represents a method parameter.
+type ParamDef struct {
+	Name       string  `json:"name"`
+	Type       TypeRef `json:"type"`
+	IsOut      bool    `json:"is_out,omitempty"`
+	IsRef      bool    `json:"is_ref,omitempty"`
+	IsParams   bool    `json:"is_params,omitempty"`
+	HasDefault bool    `json:"has_default,omitempty"`
+}
+
+// EnumValue represents a named constant in an enum.
+type EnumValue struct {
+	Name  string `json:"name"`
+	Value int64  `json:"value"`
+}
+
+// TypeRef is a reference to a CLR type (may be generic).
+type TypeRef struct {
+	// FullName is the fully-qualified CLR type name,
+	// e.g. "System.Collections.Generic.List`1".
+	FullName string `json:"full_name"`
+	// Kind is the type kind hint.
+	Kind TypeRefKind `json:"kind"`
+	// TypeArgs are the generic arguments (for generic_inst kind).
+	TypeArgs []TypeRef `json:"type_args,omitempty"`
+	// IsNullable is true for Nullable<T> or T? reference-nullable types.
+	IsNullable bool `json:"is_nullable,omitempty"`
+	// ArrayRank is non-zero for array types (1 = T[], 2 = T[,]).
+	ArrayRank int `json:"array_rank,omitempty"`
+}
+
+// TypeRefKind classifies how a TypeRef is used.
+type TypeRefKind string
+
+const (
+	TypeRefPrimitive    TypeRefKind = "primitive"
+	TypeRefClass        TypeRefKind = "class"
+	TypeRefStruct       TypeRefKind = "struct"
+	TypeRefInterface    TypeRefKind = "interface"
+	TypeRefEnum         TypeRefKind = "enum"
+	TypeRefArray        TypeRefKind = "array"
+	TypeRefGenericInst  TypeRefKind = "generic_inst"
+	TypeRefPointer      TypeRefKind = "pointer"
+	TypeRefByRef        TypeRefKind = "byref"
+	TypeRefGenericParam TypeRefKind = "generic_param"
+	TypeRefVoid         TypeRefKind = "void"
+	TypeRefDelegate     TypeRefKind = "delegate"
+	TypeRefDynamic      TypeRefKind = "dynamic"
+)

--- a/package3/dotnet/metacli/surface.go
+++ b/package3/dotnet/metacli/surface.go
@@ -1,0 +1,134 @@
+package metacli
+
+import "strings"
+
+// ApiSurface is the distilled public API surface of an assembly, ready for
+// type mapping and shim generation. It is analogous to rustdoc.ApiSurface in
+// package3/rust/rustdoc/.
+type ApiSurface struct {
+	Assembly        string
+	Version         string
+	TargetFramework string
+	Types           []SurfaceType
+}
+
+// SurfaceType is a public type with its translated methods and properties.
+type SurfaceType struct {
+	FullName   string // "Newtonsoft.Json.JsonConvert"
+	ShortName  string // "JsonConvert"
+	Namespace  string // "Newtonsoft.Json"
+	Kind       TypeDefKind
+	IsAbstract bool
+	IsStatic   bool
+	Methods    []SurfaceMethod
+	Properties []SurfaceProp
+}
+
+// SurfaceMethod is a translatable public method.
+type SurfaceMethod struct {
+	Name       string
+	IsStatic   bool
+	IsAsync    bool
+	ReturnType TypeRef
+	Params     []ParamDef
+	XmlDoc     string
+}
+
+// SurfaceProp is a translatable public property.
+type SurfaceProp struct {
+	Name      string
+	Type      TypeRef
+	HasGetter bool
+	HasSetter bool
+	IsStatic  bool
+	XmlDoc    string
+}
+
+// Extract builds an ApiSurface from raw AssemblyMetadata. It applies basic
+// filtering (removes types marked as obsolete, nested, delegate, or with
+// no translatable surface) without full type-mapping (that happens in the
+// typemap package).
+func Extract(meta *AssemblyMetadata) *ApiSurface {
+	if meta == nil {
+		return &ApiSurface{}
+	}
+	surface := &ApiSurface{
+		Assembly:        meta.Assembly,
+		Version:         meta.Version,
+		TargetFramework: meta.TargetFramework,
+	}
+	for _, td := range meta.Types {
+		if shouldSkipType(td) {
+			continue
+		}
+		st := buildSurfaceType(td)
+		surface.Types = append(surface.Types, st)
+	}
+	return surface
+}
+
+// shouldSkipType returns true for types that the bridge cannot translate in v1.
+func shouldSkipType(td TypeDef) bool {
+	if td.IsObsolete {
+		return true
+	}
+	if td.Kind == KindDelegate {
+		return true
+	}
+	// Nested types are identified by a '+' in the name (CLR convention).
+	if strings.Contains(td.Name, "+") {
+		return true
+	}
+	return false
+}
+
+// buildSurfaceType converts a TypeDef into a SurfaceType, filtering methods
+// and properties that should not be exposed.
+func buildSurfaceType(td TypeDef) SurfaceType {
+	ns := td.Namespace
+	name := td.Name
+	var fullName string
+	if ns != "" {
+		fullName = ns + "." + name
+	} else {
+		fullName = name
+	}
+	st := SurfaceType{
+		FullName:   fullName,
+		ShortName:  name,
+		Namespace:  ns,
+		Kind:       td.Kind,
+		IsAbstract: td.IsAbstract,
+		IsStatic:   td.IsStatic,
+	}
+	for _, m := range td.Methods {
+		if m.IsObsolete {
+			continue
+		}
+		st.Methods = append(st.Methods, SurfaceMethod{
+			Name:       m.Name,
+			IsStatic:   m.IsStatic,
+			IsAsync:    m.IsAsync,
+			ReturnType: m.ReturnType,
+			Params:     m.Parameters,
+			XmlDoc:     m.XmlDoc,
+		})
+	}
+	for _, p := range td.Properties {
+		if p.IsObsolete {
+			continue
+		}
+		if p.IsIndexer {
+			continue
+		}
+		st.Properties = append(st.Properties, SurfaceProp{
+			Name:      p.Name,
+			Type:      p.Type,
+			HasGetter: p.HasGetter,
+			HasSetter: p.HasSetter,
+			IsStatic:  p.IsStatic,
+			XmlDoc:    p.XmlDoc,
+		})
+	}
+	return st
+}

--- a/package3/dotnet/metacli/surface_test.go
+++ b/package3/dotnet/metacli/surface_test.go
@@ -1,0 +1,229 @@
+package metacli_test
+
+import (
+	"testing"
+
+	"mochi/package3/dotnet/metacli"
+)
+
+func makeTestMeta() *metacli.AssemblyMetadata {
+	return &metacli.AssemblyMetadata{
+		Assembly:        "TestLib",
+		Version:         "1.0.0",
+		TargetFramework: "net6.0",
+		Types: []metacli.TypeDef{
+			{
+				Namespace: "TestLib",
+				Name:      "PublicClass",
+				Kind:      metacli.KindClass,
+				Methods: []metacli.MethodDef{
+					{Name: "DoWork", ReturnType: metacli.TypeRef{FullName: "System.Void", Kind: metacli.TypeRefVoid}},
+				},
+			},
+			{
+				Namespace:  "TestLib",
+				Name:       "ObsoleteClass",
+				Kind:       metacli.KindClass,
+				IsObsolete: true,
+			},
+			{
+				Namespace: "TestLib",
+				Name:      "DelegateType",
+				Kind:      metacli.KindDelegate,
+			},
+			{
+				Namespace: "TestLib",
+				Name:      "Outer+Nested",
+				Kind:      metacli.KindClass,
+			},
+			{
+				Namespace:  "TestLib",
+				Name:       "AbstractBase",
+				Kind:       metacli.KindClass,
+				IsAbstract: true,
+			},
+			{
+				Namespace: "TestLib",
+				Name:      "MyEnum",
+				Kind:      metacli.KindEnum,
+				EnumValues: []metacli.EnumValue{
+					{Name: "A", Value: 0},
+				},
+			},
+		},
+	}
+}
+
+func TestExtract_typeCount(t *testing.T) {
+	meta := makeTestMeta()
+	s := metacli.Extract(meta)
+	// Expect: PublicClass, AbstractBase, MyEnum (not Obsolete, Delegate, Nested)
+	if len(s.Types) != 3 {
+		t.Errorf("got %d types; want 3", len(s.Types))
+		for _, tt := range s.Types {
+			t.Logf("  type: %s", tt.FullName)
+		}
+	}
+}
+
+func TestExtract_filtersObsolete(t *testing.T) {
+	meta := makeTestMeta()
+	s := metacli.Extract(meta)
+	for _, tt := range s.Types {
+		if tt.ShortName == "ObsoleteClass" {
+			t.Error("ObsoleteClass should be filtered out")
+		}
+	}
+}
+
+func TestExtract_filtersDelegate(t *testing.T) {
+	meta := makeTestMeta()
+	s := metacli.Extract(meta)
+	for _, tt := range s.Types {
+		if tt.ShortName == "DelegateType" {
+			t.Error("DelegateType should be filtered out")
+		}
+	}
+}
+
+func TestExtract_filtersNested(t *testing.T) {
+	meta := makeTestMeta()
+	s := metacli.Extract(meta)
+	for _, tt := range s.Types {
+		if tt.ShortName == "Outer+Nested" {
+			t.Error("nested type should be filtered out")
+		}
+	}
+}
+
+func TestExtract_shortName(t *testing.T) {
+	meta := makeTestMeta()
+	s := metacli.Extract(meta)
+	for _, tt := range s.Types {
+		if tt.FullName == "TestLib.PublicClass" {
+			if tt.ShortName != "PublicClass" {
+				t.Errorf("ShortName = %q; want PublicClass", tt.ShortName)
+			}
+			return
+		}
+	}
+	t.Error("PublicClass not found in surface")
+}
+
+func TestExtract_fullName(t *testing.T) {
+	meta := makeTestMeta()
+	s := metacli.Extract(meta)
+	for _, tt := range s.Types {
+		if tt.ShortName == "PublicClass" {
+			if tt.FullName != "TestLib.PublicClass" {
+				t.Errorf("FullName = %q; want TestLib.PublicClass", tt.FullName)
+			}
+			return
+		}
+	}
+	t.Error("PublicClass not found")
+}
+
+func TestExtract_methodExtraction(t *testing.T) {
+	meta := makeTestMeta()
+	s := metacli.Extract(meta)
+	for _, tt := range s.Types {
+		if tt.ShortName == "PublicClass" {
+			if len(tt.Methods) != 1 {
+				t.Errorf("got %d methods; want 1", len(tt.Methods))
+			}
+			if tt.Methods[0].Name != "DoWork" {
+				t.Errorf("method name = %q; want DoWork", tt.Methods[0].Name)
+			}
+			return
+		}
+	}
+	t.Error("PublicClass not found")
+}
+
+func TestExtract_filtersObsoleteMethods(t *testing.T) {
+	meta := &metacli.AssemblyMetadata{
+		Assembly: "Lib",
+		Types: []metacli.TypeDef{
+			{
+				Namespace: "Lib",
+				Name:      "Foo",
+				Kind:      metacli.KindClass,
+				Methods: []metacli.MethodDef{
+					{Name: "Good", ReturnType: metacli.TypeRef{FullName: "System.Void", Kind: metacli.TypeRefVoid}},
+					{Name: "Old", IsObsolete: true, ReturnType: metacli.TypeRef{FullName: "System.Void", Kind: metacli.TypeRefVoid}},
+				},
+			},
+		},
+	}
+	s := metacli.Extract(meta)
+	if len(s.Types) != 1 {
+		t.Fatalf("unexpected type count %d", len(s.Types))
+	}
+	for _, m := range s.Types[0].Methods {
+		if m.Name == "Old" {
+			t.Error("obsolete method should be filtered")
+		}
+	}
+}
+
+func TestExtract_filtersIndexerProperties(t *testing.T) {
+	meta := &metacli.AssemblyMetadata{
+		Assembly: "Lib",
+		Types: []metacli.TypeDef{
+			{
+				Namespace: "Lib",
+				Name:      "Bar",
+				Kind:      metacli.KindClass,
+				Properties: []metacli.PropDef{
+					{Name: "Normal", Type: metacli.TypeRef{FullName: "System.Int32", Kind: metacli.TypeRefPrimitive}, HasGetter: true},
+					{Name: "Item", IsIndexer: true, Type: metacli.TypeRef{FullName: "System.Int32", Kind: metacli.TypeRefPrimitive}},
+				},
+			},
+		},
+	}
+	s := metacli.Extract(meta)
+	if len(s.Types) != 1 {
+		t.Fatalf("unexpected type count")
+	}
+	for _, p := range s.Types[0].Properties {
+		if p.Name == "Item" {
+			t.Error("indexer property should be filtered")
+		}
+	}
+}
+
+func TestExtract_nilMeta(t *testing.T) {
+	s := metacli.Extract(nil)
+	if s == nil {
+		t.Fatal("Extract(nil) should return non-nil")
+	}
+	if len(s.Types) != 0 {
+		t.Error("Extract(nil) should return empty types")
+	}
+}
+
+func TestExtract_assemblyFields(t *testing.T) {
+	meta := makeTestMeta()
+	s := metacli.Extract(meta)
+	if s.Assembly != "TestLib" {
+		t.Errorf("Assembly = %q; want TestLib", s.Assembly)
+	}
+	if s.Version != "1.0.0" {
+		t.Errorf("Version = %q; want 1.0.0", s.Version)
+	}
+}
+
+func TestExtract_abstractFlagPreserved(t *testing.T) {
+	meta := makeTestMeta()
+	s := metacli.Extract(meta)
+	for _, tt := range s.Types {
+		if tt.ShortName == "AbstractBase" {
+			if !tt.IsAbstract {
+				t.Error("AbstractBase.IsAbstract should be true")
+			}
+			return
+		}
+	}
+	t.Error("AbstractBase not found")
+}

--- a/package3/dotnet/metacli/walk.go
+++ b/package3/dotnet/metacli/walk.go
@@ -1,0 +1,36 @@
+package metacli
+
+// WalkTypes calls fn for each SurfaceType in the ApiSurface. If fn returns
+// false the walk stops early.
+func (s *ApiSurface) WalkTypes(fn func(SurfaceType) bool) {
+	for _, t := range s.Types {
+		if !fn(t) {
+			return
+		}
+	}
+}
+
+// WalkMethods calls fn for each SurfaceMethod on every SurfaceType in the
+// ApiSurface. The SurfaceType is passed alongside the method so callers can
+// resolve the owning type. If fn returns false the walk stops early.
+func (s *ApiSurface) WalkMethods(fn func(t SurfaceType, m SurfaceMethod) bool) {
+	for _, t := range s.Types {
+		for _, m := range t.Methods {
+			if !fn(t, m) {
+				return
+			}
+		}
+	}
+}
+
+// WalkProps calls fn for each SurfaceProp on every SurfaceType in the
+// ApiSurface. If fn returns false the walk stops early.
+func (s *ApiSurface) WalkProps(fn func(t SurfaceType, p SurfaceProp) bool) {
+	for _, t := range s.Types {
+		for _, p := range t.Properties {
+			if !fn(t, p) {
+				return
+			}
+		}
+	}
+}

--- a/package3/dotnet/nuget/cache.go
+++ b/package3/dotnet/nuget/cache.go
@@ -1,0 +1,132 @@
+package nuget
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Cache is a content-addressed filesystem cache for NuGet .nupkg files.
+// Files are keyed by their SHA-512 hex digest. Cache is safe for concurrent
+// reads; concurrent writes for the same package should be avoided (writes are
+// not atomic across processes).
+//
+// Directory layout:
+//
+//	<Dir>/<sha512[:2]>/<sha512>.nupkg
+type Cache struct {
+	// Dir is the cache root directory, e.g. ~/.cache/mochi/dotnet-deps/.
+	Dir string
+}
+
+// NewCache returns a Cache rooted at dir.
+func NewCache(dir string) *Cache {
+	return &Cache{Dir: dir}
+}
+
+// Store writes the content of r into the cache for package id@version,
+// computing the SHA-512 as it writes. Returns the SHA-512 hex string and
+// number of bytes written.
+func (c *Cache) Store(id, version string, r io.Reader) (sha512hex string, nBytes int64, err error) {
+	if id == "" {
+		return "", 0, fmt.Errorf("nuget cache: empty package id")
+	}
+	if version == "" {
+		return "", 0, fmt.Errorf("nuget cache: empty version for %q", id)
+	}
+
+	// Write to a temp file while computing SHA-512.
+	if err := os.MkdirAll(c.Dir, 0o755); err != nil {
+		return "", 0, fmt.Errorf("nuget cache: mkdir %s: %w", c.Dir, err)
+	}
+	tmp, err := os.CreateTemp(c.Dir, ".nupkg-*.tmp")
+	if err != nil {
+		return "", 0, fmt.Errorf("nuget cache: create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() {
+		tmp.Close()
+		os.Remove(tmpPath)
+	}
+
+	h := sha512.New()
+	mw := io.MultiWriter(tmp, h)
+	written, copyErr := io.Copy(mw, r)
+	if copyErr != nil {
+		cleanup()
+		return "", 0, fmt.Errorf("nuget cache: write %s@%s: %w", id, version, copyErr)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return "", 0, fmt.Errorf("nuget cache: close temp: %w", err)
+	}
+
+	digest := hex.EncodeToString(h.Sum(nil))
+	dst := c.Path(digest)
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		os.Remove(tmpPath)
+		return "", 0, fmt.Errorf("nuget cache: mkdir %s: %w", filepath.Dir(dst), err)
+	}
+
+	if err := os.Rename(tmpPath, dst); err != nil {
+		// If rename fails (cross-device), fall back to copy.
+		if copyErr2 := copyFile(tmpPath, dst); copyErr2 != nil {
+			os.Remove(tmpPath)
+			return "", 0, fmt.Errorf("nuget cache: install %s: %w", dst, copyErr2)
+		}
+		os.Remove(tmpPath)
+	}
+	return digest, written, nil
+}
+
+// Path returns the absolute filesystem path for a .nupkg keyed by its
+// SHA-512 hex digest. The file may or may not exist.
+func (c *Cache) Path(sha512hex string) string {
+	return filepath.Join(c.Dir, sha512hex[:2], sha512hex+".nupkg")
+}
+
+// Has reports whether a .nupkg with the given SHA-512 hex digest is already
+// cached.
+func (c *Cache) Has(sha512hex string) bool {
+	if len(sha512hex) < 4 {
+		return false
+	}
+	_, err := os.Stat(c.Path(sha512hex))
+	return err == nil
+}
+
+// Open returns a ReadCloser for the cached .nupkg identified by sha512hex.
+// Returns an error wrapping os.ErrNotExist when no entry is cached.
+func (c *Cache) Open(sha512hex string) (io.ReadCloser, error) {
+	if len(sha512hex) < 4 {
+		return nil, fmt.Errorf("nuget cache: sha512 digest %q too short", sha512hex)
+	}
+	f, err := os.Open(c.Path(sha512hex))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("nuget cache: %q not cached: %w", sha512hex, os.ErrNotExist)
+		}
+		return nil, fmt.Errorf("nuget cache: open %q: %w", sha512hex, err)
+	}
+	return f, nil
+}
+
+// copyFile copies src to dst as a fallback for cross-device renames.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/package3/dotnet/nuget/cache_test.go
+++ b/package3/dotnet/nuget/cache_test.go
@@ -1,0 +1,146 @@
+package nuget_test
+
+import (
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"mochi/package3/dotnet/nuget"
+)
+
+func TestNewCache(t *testing.T) {
+	dir := t.TempDir()
+	c := nuget.NewCache(dir)
+	if c.Dir != dir {
+		t.Errorf("Cache.Dir = %q; want %q", c.Dir, dir)
+	}
+}
+
+func TestCache_Store_and_Has(t *testing.T) {
+	dir := t.TempDir()
+	c := nuget.NewCache(dir)
+	content := "fake nupkg data for testing"
+	digest, n, err := c.Store("MyPkg", "1.0.0", strings.NewReader(content))
+	if err != nil {
+		t.Fatalf("Store error: %v", err)
+	}
+	if n != int64(len(content)) {
+		t.Errorf("Store returned %d bytes; want %d", n, len(content))
+	}
+	if len(digest) == 0 {
+		t.Error("Store returned empty digest")
+	}
+	if !c.Has(digest) {
+		t.Error("Has should return true after Store")
+	}
+}
+
+func TestCache_Has_missing(t *testing.T) {
+	dir := t.TempDir()
+	c := nuget.NewCache(dir)
+	fakeDigest := strings.Repeat("a", 128) // 512-bit hex = 128 chars
+	if c.Has(fakeDigest) {
+		t.Error("Has should return false for uncached digest")
+	}
+}
+
+func TestCache_Has_shortDigest(t *testing.T) {
+	dir := t.TempDir()
+	c := nuget.NewCache(dir)
+	if c.Has("ab") {
+		t.Error("Has should return false for too-short digest")
+	}
+}
+
+func TestCache_Open_success(t *testing.T) {
+	dir := t.TempDir()
+	c := nuget.NewCache(dir)
+	content := "nupkg bytes"
+	digest, _, err := c.Store("Pkg", "2.0.0", strings.NewReader(content))
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	rc, err := c.Open(digest)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("Open returned %q; want %q", got, content)
+	}
+}
+
+func TestCache_Open_notFound(t *testing.T) {
+	dir := t.TempDir()
+	c := nuget.NewCache(dir)
+	fakeDigest := strings.Repeat("b", 128)
+	_, err := c.Open(fakeDigest)
+	if err == nil {
+		t.Fatal("Open of missing entry should return error")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected os.ErrNotExist, got %v", err)
+	}
+}
+
+func TestCache_Path(t *testing.T) {
+	dir := t.TempDir()
+	c := nuget.NewCache(dir)
+	digest := strings.Repeat("c", 128)
+	p := c.Path(digest)
+	if !strings.HasPrefix(p, dir) {
+		t.Errorf("Path %q should be under %q", p, dir)
+	}
+	// First two chars form the bucket prefix.
+	if !strings.Contains(p, "cc") {
+		t.Errorf("Path %q should contain bucket prefix 'cc'", p)
+	}
+}
+
+func TestCache_Store_emptyID(t *testing.T) {
+	c := nuget.NewCache(t.TempDir())
+	_, _, err := c.Store("", "1.0.0", strings.NewReader("data"))
+	if err == nil {
+		t.Error("Store with empty id should return error")
+	}
+}
+
+func TestCache_Store_emptyVersion(t *testing.T) {
+	c := nuget.NewCache(t.TempDir())
+	_, _, err := c.Store("Pkg", "", strings.NewReader("data"))
+	if err == nil {
+		t.Error("Store with empty version should return error")
+	}
+}
+
+func TestCache_Store_differentContent_differentDigest(t *testing.T) {
+	c := nuget.NewCache(t.TempDir())
+	d1, _, _ := c.Store("Pkg", "1.0.0", strings.NewReader("content one"))
+	d2, _, _ := c.Store("Pkg", "2.0.0", strings.NewReader("content two"))
+	if d1 == d2 {
+		t.Error("different content should produce different digests")
+	}
+}
+
+func TestCache_Store_sameContent_sameDigest(t *testing.T) {
+	c := nuget.NewCache(t.TempDir())
+	d1, _, _ := c.Store("Pkg", "1.0.0", strings.NewReader("same content"))
+	d2, _, _ := c.Store("Pkg", "1.0.1", strings.NewReader("same content"))
+	if d1 != d2 {
+		t.Error("identical content should produce identical digests")
+	}
+}
+
+func TestCache_Open_shortDigest(t *testing.T) {
+	c := nuget.NewCache(t.TempDir())
+	_, err := c.Open("ab")
+	if err == nil {
+		t.Error("Open with too-short digest should return error")
+	}
+}

--- a/package3/dotnet/nuget/client.go
+++ b/package3/dotnet/nuget/client.go
@@ -1,0 +1,202 @@
+package nuget
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"mochi/package3/dotnet/semver"
+)
+
+// DefaultServiceIndexURL is the canonical NuGet v3 service index endpoint.
+const DefaultServiceIndexURL = "https://api.nuget.org/v3/index.json"
+
+// DefaultFlatContainerBaseURL is the NuGet v3 flat-container base URL.
+// Package IDs are lower-cased when appended, per NuGet flat-container spec.
+const DefaultFlatContainerBaseURL = "https://api.nuget.org/v3-flatcontainer/"
+
+// DefaultDownloadURLTemplate is the .nupkg download URL template.
+// The placeholders {id} and {version} are substituted at fetch time.
+const DefaultDownloadURLTemplate = "https://api.nuget.org/v3-flatcontainer/{id}/{version}/{id}.{version}.nupkg"
+
+// DefaultUserAgent is the User-Agent header sent on outbound HTTP requests.
+const DefaultUserAgent = "mochi-dotnet-bridge/0.1 (+https://mochi-lang.dev)"
+
+// Client is a thin NuGet v3 API client. It is safe for concurrent use
+// because the underlying http.Client is. Use NewClient rather than
+// constructing a Client directly.
+type Client struct {
+	// ServiceIndexURL is the NuGet v3 service index endpoint.
+	ServiceIndexURL string
+
+	// FlatContainerBaseURL is the flat-container root URL. Must end in '/'.
+	FlatContainerBaseURL string
+
+	// DownloadURLTemplate is the .nupkg URL template. Placeholders {id} and
+	// {version} are replaced at download time.
+	DownloadURLTemplate string
+
+	// HTTP is the underlying transport. nil means use http.DefaultClient
+	// with a 30 s timeout.
+	HTTP *http.Client
+
+	// UserAgent is sent as the User-Agent header.
+	UserAgent string
+}
+
+// NewClient returns a Client pre-configured against api.nuget.org with a
+// sensible default HTTP timeout. Pass the empty string for the default
+// service index URL.
+func NewClient(serviceIndexURL string) *Client {
+	if serviceIndexURL == "" {
+		serviceIndexURL = DefaultServiceIndexURL
+	}
+	return &Client{
+		ServiceIndexURL:      serviceIndexURL,
+		FlatContainerBaseURL: DefaultFlatContainerBaseURL,
+		DownloadURLTemplate:  DefaultDownloadURLTemplate,
+		HTTP:                 &http.Client{Timeout: 30 * time.Second},
+		UserAgent:            DefaultUserAgent,
+	}
+}
+
+// FetchVersions retrieves the list of all published versions for the NuGet
+// package with the given id. Returns ErrPackageNotFound if the registry
+// responds 404.
+func (c *Client) FetchVersions(ctx context.Context, id string) ([]string, error) {
+	if id == "" {
+		return nil, fmt.Errorf("nuget: empty package id")
+	}
+	base := c.FlatContainerBaseURL
+	if base == "" {
+		base = DefaultFlatContainerBaseURL
+	}
+	if !strings.HasSuffix(base, "/") {
+		base += "/"
+	}
+	target := base + strings.ToLower(id) + "/index.json"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, fmt.Errorf("nuget: build request: %w", err)
+	}
+	c.setUA(req)
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("nuget: GET %s: %w", target, err)
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// fall through
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("%w: %s", ErrPackageNotFound, id)
+	default:
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("nuget: GET %s: status %d: %s", target, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var idx VersionsIndex
+	if err := json.NewDecoder(resp.Body).Decode(&idx); err != nil {
+		return nil, fmt.Errorf("nuget: decode versions index for %q: %w", id, err)
+	}
+	return idx.Versions, nil
+}
+
+// LatestVersion returns the highest published version of the package id that
+// satisfies req. Returns ErrVersionNotFound when no published version matches.
+func (c *Client) LatestVersion(ctx context.Context, id string, req semver.Req) (string, error) {
+	raw, err := c.FetchVersions(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	var versions []semver.Version
+	for _, s := range raw {
+		v, err := semver.Parse(s)
+		if err != nil {
+			continue // skip malformed entries from the registry
+		}
+		versions = append(versions, v)
+	}
+	best, ok := semver.MaxSatisfying(req, versions)
+	if !ok {
+		return "", fmt.Errorf("%w: %s satisfying %s", ErrVersionNotFound, id, req)
+	}
+	return best.String(), nil
+}
+
+// DownloadURLFor builds the .nupkg download URL for the given package id and
+// version using the configured DownloadURLTemplate.
+func (c *Client) DownloadURLFor(id, version string) (string, error) {
+	if id == "" {
+		return "", fmt.Errorf("nuget: empty package id")
+	}
+	if version == "" {
+		return "", fmt.Errorf("nuget: empty version for %q", id)
+	}
+	tmpl := c.DownloadURLTemplate
+	if tmpl == "" {
+		tmpl = DefaultDownloadURLTemplate
+	}
+	lowID := strings.ToLower(id)
+	lowVer := strings.ToLower(version)
+	url := strings.ReplaceAll(tmpl, "{id}", lowID)
+	url = strings.ReplaceAll(url, "{version}", lowVer)
+	return url, nil
+}
+
+// FetchPackage downloads the .nupkg for the given id and version into w.
+// Returns the number of bytes written. Returns ErrVersionNotFound on HTTP 404.
+func (c *Client) FetchPackage(ctx context.Context, id, version string, w io.Writer) (int64, error) {
+	target, err := c.DownloadURLFor(id, version)
+	if err != nil {
+		return 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return 0, fmt.Errorf("nuget: build request: %w", err)
+	}
+	c.setUA(req)
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("nuget: GET %s: %w", target, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return 0, fmt.Errorf("%w: %s@%s", ErrVersionNotFound, id, version)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return 0, fmt.Errorf("nuget: GET %s: status %d: %s", target, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return io.Copy(w, resp.Body)
+}
+
+// ErrPackageNotFound is returned when the NuGet registry has no package with
+// the given id (HTTP 404 on the versions index). Check with errors.Is.
+var ErrPackageNotFound = errors.New("nuget: package not found")
+
+// ErrVersionNotFound is returned when no published version of a package
+// satisfies the requested version range. Check with errors.Is.
+var ErrVersionNotFound = errors.New("nuget: version not found")
+
+// httpClient returns the configured HTTP client, falling back to
+// http.DefaultClient.
+func (c *Client) httpClient() *http.Client {
+	if c.HTTP != nil {
+		return c.HTTP
+	}
+	return http.DefaultClient
+}
+
+// setUA sets the User-Agent header on req if a user agent is configured.
+func (c *Client) setUA(req *http.Request) {
+	ua := c.UserAgent
+	if ua == "" {
+		ua = DefaultUserAgent
+	}
+	req.Header.Set("User-Agent", ua)
+}

--- a/package3/dotnet/nuget/client_test.go
+++ b/package3/dotnet/nuget/client_test.go
@@ -1,0 +1,194 @@
+package nuget_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"mochi/package3/dotnet/nuget"
+	"mochi/package3/dotnet/semver"
+)
+
+func newTestServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *nuget.Client) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := nuget.NewClient("")
+	c.FlatContainerBaseURL = srv.URL + "/"
+	c.DownloadURLTemplate = srv.URL + "/{id}/{version}/{id}.{version}.nupkg"
+	c.HTTP = srv.Client()
+	return srv, c
+}
+
+func TestNewClient_defaults(t *testing.T) {
+	c := nuget.NewClient("")
+	if c.ServiceIndexURL != nuget.DefaultServiceIndexURL {
+		t.Errorf("ServiceIndexURL = %q; want %q", c.ServiceIndexURL, nuget.DefaultServiceIndexURL)
+	}
+	if c.UserAgent != nuget.DefaultUserAgent {
+		t.Errorf("UserAgent = %q; want %q", c.UserAgent, nuget.DefaultUserAgent)
+	}
+	if c.HTTP == nil {
+		t.Error("HTTP client must not be nil")
+	}
+}
+
+func TestNewClient_customURL(t *testing.T) {
+	c := nuget.NewClient("https://custom.example.com/v3/index.json")
+	if c.ServiceIndexURL != "https://custom.example.com/v3/index.json" {
+		t.Errorf("ServiceIndexURL = %q", c.ServiceIndexURL)
+	}
+}
+
+func TestFetchVersions_success(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/index.json") {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(nuget.VersionsIndex{
+			Versions: []string{"1.0.0", "1.1.0", "2.0.0"},
+		})
+	})
+	versions, err := c.FetchVersions(context.Background(), "Newtonsoft.Json")
+	if err != nil {
+		t.Fatalf("FetchVersions error: %v", err)
+	}
+	if len(versions) != 3 {
+		t.Errorf("got %d versions; want 3", len(versions))
+	}
+}
+
+func TestFetchVersions_notFound(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	_, err := c.FetchVersions(context.Background(), "NoSuchPackage")
+	if !errors.Is(err, nuget.ErrPackageNotFound) {
+		t.Errorf("expected ErrPackageNotFound, got %v", err)
+	}
+}
+
+func TestFetchVersions_emptyID(t *testing.T) {
+	c := nuget.NewClient("")
+	_, err := c.FetchVersions(context.Background(), "")
+	if err == nil {
+		t.Error("empty id should return error")
+	}
+}
+
+func TestFetchVersions_serverError(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	})
+	_, err := c.FetchVersions(context.Background(), "SomePackage")
+	if err == nil {
+		t.Error("expected error on 500 response")
+	}
+}
+
+func TestLatestVersion_success(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(nuget.VersionsIndex{
+			Versions: []string{"1.0.0", "1.5.0", "2.0.0", "3.0.0"},
+		})
+	})
+	req := semver.MustParseReq("[1.0.0, 2.0.0)")
+	got, err := c.LatestVersion(context.Background(), "Pkg", req)
+	if err != nil {
+		t.Fatalf("LatestVersion error: %v", err)
+	}
+	if got != "1.5.0" {
+		t.Errorf("LatestVersion = %q; want %q", got, "1.5.0")
+	}
+}
+
+func TestLatestVersion_noneMatch(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(nuget.VersionsIndex{
+			Versions: []string{"3.0.0"},
+		})
+	})
+	req := semver.MustParseReq("[1.0.0, 2.0.0)")
+	_, err := c.LatestVersion(context.Background(), "Pkg", req)
+	if !errors.Is(err, nuget.ErrVersionNotFound) {
+		t.Errorf("expected ErrVersionNotFound, got %v", err)
+	}
+}
+
+func TestDownloadURLFor_substitution(t *testing.T) {
+	c := nuget.NewClient("")
+	url, err := c.DownloadURLFor("Newtonsoft.Json", "13.0.1")
+	if err != nil {
+		t.Fatalf("DownloadURLFor error: %v", err)
+	}
+	if !strings.Contains(url, "newtonsoft.json") {
+		t.Errorf("URL %q should contain lowercased id", url)
+	}
+	if !strings.Contains(url, "13.0.1") {
+		t.Errorf("URL %q should contain version", url)
+	}
+}
+
+func TestDownloadURLFor_emptyID(t *testing.T) {
+	c := nuget.NewClient("")
+	_, err := c.DownloadURLFor("", "1.0.0")
+	if err == nil {
+		t.Error("empty id should return error")
+	}
+}
+
+func TestDownloadURLFor_emptyVersion(t *testing.T) {
+	c := nuget.NewClient("")
+	_, err := c.DownloadURLFor("Pkg", "")
+	if err == nil {
+		t.Error("empty version should return error")
+	}
+}
+
+func TestFetchPackage_success(t *testing.T) {
+	body := []byte("fake nupkg content")
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(body)
+	})
+	var buf strings.Builder
+	n, err := c.FetchPackage(context.Background(), "Pkg", "1.0.0", &buf)
+	if err != nil {
+		t.Fatalf("FetchPackage error: %v", err)
+	}
+	if n != int64(len(body)) {
+		t.Errorf("FetchPackage wrote %d bytes; want %d", n, len(body))
+	}
+}
+
+func TestFetchPackage_notFound(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	_, err := c.FetchPackage(context.Background(), "Pkg", "1.0.0", io.Discard)
+	if !errors.Is(err, nuget.ErrVersionNotFound) {
+		t.Errorf("expected ErrVersionNotFound, got %v", err)
+	}
+}
+
+func TestErrPackageNotFound_sentinel(t *testing.T) {
+	err := nuget.ErrPackageNotFound
+	if err == nil {
+		t.Fatal("ErrPackageNotFound must not be nil")
+	}
+	if err.Error() == "" {
+		t.Error("ErrPackageNotFound.Error() must not be empty")
+	}
+}
+
+func TestErrVersionNotFound_sentinel(t *testing.T) {
+	err := nuget.ErrVersionNotFound
+	if err == nil {
+		t.Fatal("ErrVersionNotFound must not be nil")
+	}
+}

--- a/package3/dotnet/nuget/entry.go
+++ b/package3/dotnet/nuget/entry.go
@@ -1,0 +1,26 @@
+// Package nuget provides a NuGet v3 API client and content-addressed
+// .nupkg cache for the MEP-68 .NET package bridge.
+package nuget
+
+// VersionsIndex is the response from the NuGet v3 flat-container versions
+// endpoint:
+//
+//	GET https://api.nuget.org/v3-flatcontainer/{id}/index.json
+type VersionsIndex struct {
+	Versions []string `json:"versions"`
+}
+
+// ServiceIndex is the NuGet v3 service index returned from
+// https://api.nuget.org/v3/index.json. It advertises the URLs of each
+// NuGet service resource.
+type ServiceIndex struct {
+	Version   string            `json:"version"`
+	Resources []ServiceResource `json:"resources"`
+}
+
+// ServiceResource is one entry in the ServiceIndex resources array.
+type ServiceResource struct {
+	ID      string `json:"@id"`
+	Type    string `json:"@type"`
+	Comment string `json:"comment,omitempty"`
+}

--- a/package3/dotnet/semver/req.go
+++ b/package3/dotnet/semver/req.go
@@ -1,0 +1,180 @@
+package semver
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Req is a NuGet version range. NuGet supports interval notation as
+// documented at https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges.
+//
+// Accepted shapes:
+//
+//	1.0.0          minimum version (>= 1.0.0, no upper bound)
+//	[1.0.0]        exact version
+//	[1.0.0, 2.0.0) min inclusive, max exclusive
+//	[1.0.0, 2.0.0] both bounds inclusive
+//	(1.0.0,)       exclusive minimum, no upper bound
+//	(, 2.0.0)      exclusive maximum, no lower bound
+//	*              any version
+type Req struct {
+	// Min is the minimum version bound. nil means no lower bound.
+	Min *Version
+	// Max is the maximum version bound. nil means no upper bound.
+	Max *Version
+	// MinInclusive is true when the lower bound uses '['.
+	MinInclusive bool
+	// MaxInclusive is true when the upper bound uses ']'.
+	MaxInclusive bool
+
+	raw string
+}
+
+// ParseReq parses a NuGet version range string.
+func ParseReq(s string) (Req, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return Req{}, fmt.Errorf("semver req: empty string")
+	}
+	if s == "*" {
+		return Req{raw: s}, nil
+	}
+	// Interval notation starts with '[' or '('.
+	if s[0] == '[' || s[0] == '(' {
+		return parseInterval(s)
+	}
+	// Bare version string: minimum version (>= s, no upper bound).
+	v, err := Parse(s)
+	if err != nil {
+		return Req{}, fmt.Errorf("semver req: %w", err)
+	}
+	return Req{Min: &v, MinInclusive: true, raw: s}, nil
+}
+
+// MustParseReq is ParseReq but panics on error.
+func MustParseReq(s string) Req {
+	r, err := ParseReq(s)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+// String renders the original range notation.
+func (r Req) String() string {
+	if r.raw != "" {
+		return r.raw
+	}
+	return "*"
+}
+
+// Satisfies reports whether v satisfies the version range r.
+func (r Req) Satisfies(v Version) bool {
+	if r.Min != nil {
+		cmp := v.Compare(*r.Min)
+		if r.MinInclusive {
+			if cmp < 0 {
+				return false
+			}
+		} else {
+			if cmp <= 0 {
+				return false
+			}
+		}
+	}
+	if r.Max != nil {
+		cmp := v.Compare(*r.Max)
+		if r.MaxInclusive {
+			if cmp > 0 {
+				return false
+			}
+		} else {
+			if cmp >= 0 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// parseInterval handles ranges that begin with '[' or '(' and end with ']' or ')'.
+func parseInterval(s string) (Req, error) {
+	if len(s) < 2 {
+		return Req{}, fmt.Errorf("semver req: interval %q too short", s)
+	}
+	var minInc, maxInc bool
+	switch s[0] {
+	case '[':
+		minInc = true
+	case '(':
+		minInc = false
+	default:
+		return Req{}, fmt.Errorf("semver req: interval %q must start with '[' or '('", s)
+	}
+	switch s[len(s)-1] {
+	case ']':
+		maxInc = true
+	case ')':
+		maxInc = false
+	default:
+		return Req{}, fmt.Errorf("semver req: interval %q must end with ']' or ')'", s)
+	}
+	inner := strings.TrimSpace(s[1 : len(s)-1])
+
+	// Check for comma indicating two-bound range.
+	loPart, hiPart, hasComma := strings.Cut(inner, ",")
+	if !hasComma {
+		// Single-value bracket form: [1.0.0] means exact.
+		if s[0] != '[' || s[len(s)-1] != ']' {
+			return Req{}, fmt.Errorf("semver req: single-value interval must use '[' and ']'")
+		}
+		v, err := Parse(strings.TrimSpace(inner))
+		if err != nil {
+			return Req{}, fmt.Errorf("semver req: %w", err)
+		}
+		return Req{Min: &v, Max: &v, MinInclusive: true, MaxInclusive: true, raw: s}, nil
+	}
+
+	minStr := strings.TrimSpace(loPart)
+	maxStr := strings.TrimSpace(hiPart)
+
+	var minVer, maxVer *Version
+	if minStr != "" {
+		v, err := Parse(minStr)
+		if err != nil {
+			return Req{}, fmt.Errorf("semver req: lower bound: %w", err)
+		}
+		minVer = &v
+	}
+	if maxStr != "" {
+		v, err := Parse(maxStr)
+		if err != nil {
+			return Req{}, fmt.Errorf("semver req: upper bound: %w", err)
+		}
+		maxVer = &v
+	}
+	return Req{
+		Min:          minVer,
+		Max:          maxVer,
+		MinInclusive: minInc,
+		MaxInclusive: maxInc,
+		raw:          s,
+	}, nil
+}
+
+// MaxSatisfying returns the highest Version in versions that satisfies r.
+// Returns false in the second return value when no version satisfies.
+func MaxSatisfying(r Req, versions []Version) (Version, bool) {
+	var best Version
+	found := false
+	for _, v := range versions {
+		if !r.Satisfies(v) {
+			continue
+		}
+		if !found || best.Compare(v) < 0 {
+			best = v
+			found = true
+		}
+	}
+	return best, found
+}

--- a/package3/dotnet/semver/req_test.go
+++ b/package3/dotnet/semver/req_test.go
@@ -1,0 +1,179 @@
+package semver_test
+
+import (
+	"testing"
+
+	"mochi/package3/dotnet/semver"
+)
+
+func TestParseReq_valid(t *testing.T) {
+	cases := []struct {
+		input string
+	}{
+		{"1.0.0"},
+		{"[1.0.0]"},
+		{"[1.0.0, 2.0.0)"},
+		{"[1.0.0, 2.0.0]"},
+		{"(1.0.0, 2.0.0)"},
+		{"(1.0.0,)"},
+		{"(, 2.0.0)"},
+		{"*"},
+		{"1.2.3-beta"},
+		{"[1.0.0-alpha, 2.0.0)"},
+	}
+	for _, tc := range cases {
+		if _, err := semver.ParseReq(tc.input); err != nil {
+			t.Errorf("ParseReq(%q) unexpected error: %v", tc.input, err)
+		}
+	}
+}
+
+func TestParseReq_invalid(t *testing.T) {
+	cases := []string{
+		"",
+		"[",
+		"[1.0.0",
+		"1.0.0]",
+		"[a.b.c]",
+	}
+	for _, tc := range cases {
+		if _, err := semver.ParseReq(tc); err == nil {
+			t.Errorf("ParseReq(%q) expected error, got nil", tc)
+		}
+	}
+}
+
+func TestReq_Satisfies_bare(t *testing.T) {
+	req := semver.MustParseReq("1.0.0")
+	cases := []struct {
+		ver  string
+		want bool
+	}{
+		{"1.0.0", true},
+		{"1.5.0", true},
+		{"2.0.0", true},
+		{"0.9.0", false},
+		{"0.9.9", false},
+	}
+	for _, tc := range cases {
+		v := semver.MustParse(tc.ver)
+		if got := req.Satisfies(v); got != tc.want {
+			t.Errorf("(%q).Satisfies(%q) = %v; want %v", req, tc.ver, got, tc.want)
+		}
+	}
+}
+
+func TestReq_Satisfies_exact(t *testing.T) {
+	req := semver.MustParseReq("[1.2.3]")
+	cases := []struct {
+		ver  string
+		want bool
+	}{
+		{"1.2.3", true},
+		{"1.2.4", false},
+		{"1.2.2", false},
+		{"2.0.0", false},
+	}
+	for _, tc := range cases {
+		v := semver.MustParse(tc.ver)
+		if got := req.Satisfies(v); got != tc.want {
+			t.Errorf("(%q).Satisfies(%q) = %v; want %v", req, tc.ver, got, tc.want)
+		}
+	}
+}
+
+func TestReq_Satisfies_minIncMaxExc(t *testing.T) {
+	req := semver.MustParseReq("[1.0.0, 2.0.0)")
+	cases := []struct {
+		ver  string
+		want bool
+	}{
+		{"1.0.0", true},
+		{"1.5.0", true},
+		{"1.9.9", true},
+		{"2.0.0", false},
+		{"0.9.0", false},
+		{"2.0.1", false},
+	}
+	for _, tc := range cases {
+		v := semver.MustParse(tc.ver)
+		if got := req.Satisfies(v); got != tc.want {
+			t.Errorf("(%q).Satisfies(%q) = %v; want %v", req, tc.ver, got, tc.want)
+		}
+	}
+}
+
+func TestReq_Satisfies_bothInclusive(t *testing.T) {
+	req := semver.MustParseReq("[1.0.0, 2.0.0]")
+	if !req.Satisfies(semver.MustParse("2.0.0")) {
+		t.Error("[1.0.0, 2.0.0] should include 2.0.0")
+	}
+	if req.Satisfies(semver.MustParse("2.0.1")) {
+		t.Error("[1.0.0, 2.0.0] should not include 2.0.1")
+	}
+}
+
+func TestReq_Satisfies_exclusiveMin(t *testing.T) {
+	req := semver.MustParseReq("(1.0.0,)")
+	if req.Satisfies(semver.MustParse("1.0.0")) {
+		t.Error("(1.0.0,) must not include 1.0.0")
+	}
+	if !req.Satisfies(semver.MustParse("1.0.1")) {
+		t.Error("(1.0.0,) must include 1.0.1")
+	}
+}
+
+func TestReq_Satisfies_noLowerBound(t *testing.T) {
+	req := semver.MustParseReq("(, 2.0.0)")
+	if !req.Satisfies(semver.MustParse("1.9.9")) {
+		t.Error("(, 2.0.0) must include 1.9.9")
+	}
+	if req.Satisfies(semver.MustParse("2.0.0")) {
+		t.Error("(, 2.0.0) must not include 2.0.0")
+	}
+}
+
+func TestReq_Satisfies_any(t *testing.T) {
+	req := semver.MustParseReq("*")
+	for _, ver := range []string{"0.0.0", "1.0.0", "99.0.0", "1.0.0-alpha"} {
+		if !req.Satisfies(semver.MustParse(ver)) {
+			t.Errorf("* must satisfy %q", ver)
+		}
+	}
+}
+
+func TestReq_String(t *testing.T) {
+	cases := []string{"1.0.0", "[1.0.0]", "[1.0.0, 2.0.0)", "*"}
+	for _, tc := range cases {
+		r := semver.MustParseReq(tc)
+		if r.String() != tc {
+			t.Errorf("Req.String() = %q; want %q", r.String(), tc)
+		}
+	}
+}
+
+func TestMaxSatisfying(t *testing.T) {
+	versions := []semver.Version{
+		semver.MustParse("1.0.0"),
+		semver.MustParse("1.5.0"),
+		semver.MustParse("2.0.0"),
+		semver.MustParse("2.1.0"),
+	}
+	req := semver.MustParseReq("[1.0.0, 2.0.0)")
+	got, ok := semver.MaxSatisfying(req, versions)
+	if !ok {
+		t.Fatal("MaxSatisfying returned false")
+	}
+	if got.String() != "1.5.0" {
+		t.Errorf("MaxSatisfying = %q; want %q", got, "1.5.0")
+	}
+}
+
+func TestMaxSatisfying_noneMatch(t *testing.T) {
+	versions := []semver.Version{semver.MustParse("3.0.0")}
+	req := semver.MustParseReq("[1.0.0, 2.0.0)")
+	_, ok := semver.MaxSatisfying(req, versions)
+	if ok {
+		t.Error("MaxSatisfying should return false when no versions match")
+	}
+}

--- a/package3/dotnet/semver/version.go
+++ b/package3/dotnet/semver/version.go
@@ -1,0 +1,208 @@
+// Package semver implements NuGet's 4-part version scheme (Major.Minor.Patch.Revision)
+// with optional pre-release suffix. NuGet version ordering follows SemVer 2.0.0
+// with the extension that a Revision component may appear between Patch and the
+// pre-release separator.
+//
+// Reference: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning
+package semver
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Version is a parsed NuGet version. Pre-release is preserved verbatim.
+// Revision is zero for versions that omit the fourth component.
+type Version struct {
+	Major, Minor, Patch, Revision int
+	// PreRelease is the pre-release label without the leading '-', e.g.
+	// "alpha.1". Empty for stable releases.
+	PreRelease string
+}
+
+// Parse converts a NuGet version string into a Version. Invalid inputs
+// return an error.
+//
+// Accepted shapes:
+//
+//	1.2.3
+//	1.2.3.4
+//	1.2.3-beta.1
+//	1.2.3.4-rc.2
+func Parse(s string) (Version, error) {
+	if s == "" {
+		return Version{}, fmt.Errorf("semver: empty version string")
+	}
+	rest := s
+	var pre string
+	if i := strings.Index(rest, "-"); i >= 0 {
+		pre = rest[i+1:]
+		rest = rest[:i]
+	}
+	parts := strings.Split(rest, ".")
+	if len(parts) < 3 || len(parts) > 4 {
+		return Version{}, fmt.Errorf("semver: %q has %d components; want 3 or 4", s, len(parts))
+	}
+	mj, err := parseComponent(parts[0])
+	if err != nil {
+		return Version{}, fmt.Errorf("semver: %q major: %w", s, err)
+	}
+	mn, err := parseComponent(parts[1])
+	if err != nil {
+		return Version{}, fmt.Errorf("semver: %q minor: %w", s, err)
+	}
+	pt, err := parseComponent(parts[2])
+	if err != nil {
+		return Version{}, fmt.Errorf("semver: %q patch: %w", s, err)
+	}
+	var rev int
+	if len(parts) == 4 {
+		rev, err = parseComponent(parts[3])
+		if err != nil {
+			return Version{}, fmt.Errorf("semver: %q revision: %w", s, err)
+		}
+	}
+	if pre != "" {
+		if err := validatePreRelease(pre); err != nil {
+			return Version{}, fmt.Errorf("semver: %q pre-release: %w", s, err)
+		}
+	}
+	return Version{Major: mj, Minor: mn, Patch: pt, Revision: rev, PreRelease: pre}, nil
+}
+
+// MustParse is Parse but panics on error. Useful in tests and package-level
+// constants.
+func MustParse(s string) Version {
+	v, err := Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// String renders the Version in NuGet canonical form.
+func (v Version) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d.%d.%d", v.Major, v.Minor, v.Patch)
+	if v.Revision != 0 {
+		fmt.Fprintf(&b, ".%d", v.Revision)
+	}
+	if v.PreRelease != "" {
+		b.WriteByte('-')
+		b.WriteString(v.PreRelease)
+	}
+	return b.String()
+}
+
+// Compare returns -1 if v < other, 0 if equal, +1 if v > other.
+// Pre-release versions sort lower than their stable counterpart per NuGet
+// semantics.
+func (v Version) Compare(other Version) int {
+	if c := cmpInt(v.Major, other.Major); c != 0 {
+		return c
+	}
+	if c := cmpInt(v.Minor, other.Minor); c != 0 {
+		return c
+	}
+	if c := cmpInt(v.Patch, other.Patch); c != 0 {
+		return c
+	}
+	if c := cmpInt(v.Revision, other.Revision); c != 0 {
+		return c
+	}
+	return comparePreRelease(v.PreRelease, other.PreRelease)
+}
+
+// IsPreRelease reports whether the version has a pre-release label.
+func (v Version) IsPreRelease() bool { return v.PreRelease != "" }
+
+// Equal reports whether v and other compare equal.
+func (v Version) Equal(other Version) bool { return v.Compare(other) == 0 }
+
+// cmpInt compares two ints in standard signum fashion.
+func cmpInt(a, b int) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// comparePreRelease sorts pre-release labels. A stable release (empty pre)
+// sorts higher than any pre-release, mirroring NuGet ordering.
+func comparePreRelease(a, b string) int {
+	switch {
+	case a == "" && b == "":
+		return 0
+	case a == "":
+		return 1 // stable > pre-release
+	case b == "":
+		return -1
+	}
+	// Both non-empty: compare dot-delimited identifiers.
+	aIds := strings.Split(a, ".")
+	bIds := strings.Split(b, ".")
+	for i := 0; i < len(aIds) && i < len(bIds); i++ {
+		aN, aIsNum := tryParseInt(aIds[i])
+		bN, bIsNum := tryParseInt(bIds[i])
+		switch {
+		case aIsNum && bIsNum:
+			if c := cmpInt(aN, bN); c != 0 {
+				return c
+			}
+		case aIsNum:
+			return -1 // numeric < alphanumeric
+		case bIsNum:
+			return 1
+		default:
+			if c := strings.Compare(strings.ToLower(aIds[i]), strings.ToLower(bIds[i])); c != 0 {
+				return c
+			}
+		}
+	}
+	return cmpInt(len(aIds), len(bIds))
+}
+
+// parseComponent parses a single non-negative integer version component.
+func parseComponent(s string) (int, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty component")
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("non-numeric component %q", s)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("negative component %q", s)
+	}
+	return n, nil
+}
+
+// tryParseInt attempts to parse s as a non-negative integer.
+func tryParseInt(s string) (int, bool) {
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// validatePreRelease ensures the pre-release label is non-empty and contains
+// only alphanumerics, dots, and hyphens.
+func validatePreRelease(s string) error {
+	if s == "" {
+		return fmt.Errorf("empty pre-release label")
+	}
+	for _, r := range s {
+		ok := (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') ||
+			(r >= '0' && r <= '9') || r == '-' || r == '.'
+		if !ok {
+			return fmt.Errorf("invalid character %q in pre-release label", r)
+		}
+	}
+	return nil
+}

--- a/package3/dotnet/semver/version_test.go
+++ b/package3/dotnet/semver/version_test.go
@@ -1,0 +1,134 @@
+package semver_test
+
+import (
+	"testing"
+
+	"mochi/package3/dotnet/semver"
+)
+
+func TestParse_valid(t *testing.T) {
+	cases := []struct {
+		input string
+		want  semver.Version
+	}{
+		{"1.0.0", semver.Version{Major: 1}},
+		{"1.2.3", semver.Version{Major: 1, Minor: 2, Patch: 3}},
+		{"1.2.3.4", semver.Version{Major: 1, Minor: 2, Patch: 3, Revision: 4}},
+		{"0.0.0", semver.Version{}},
+		{"10.20.30", semver.Version{Major: 10, Minor: 20, Patch: 30}},
+		{"1.2.3-alpha", semver.Version{Major: 1, Minor: 2, Patch: 3, PreRelease: "alpha"}},
+		{"1.2.3-alpha.1", semver.Version{Major: 1, Minor: 2, Patch: 3, PreRelease: "alpha.1"}},
+		{"1.2.3-beta.2", semver.Version{Major: 1, Minor: 2, Patch: 3, PreRelease: "beta.2"}},
+		{"1.2.3-rc.1", semver.Version{Major: 1, Minor: 2, Patch: 3, PreRelease: "rc.1"}},
+		{"2.0.0-preview.3", semver.Version{Major: 2, PreRelease: "preview.3"}},
+		{"1.2.3.4-alpha", semver.Version{Major: 1, Minor: 2, Patch: 3, Revision: 4, PreRelease: "alpha"}},
+		{"6.0.0", semver.Version{Major: 6}},
+		{"3.14.159", semver.Version{Major: 3, Minor: 14, Patch: 159}},
+	}
+	for _, tc := range cases {
+		got, err := semver.Parse(tc.input)
+		if err != nil {
+			t.Errorf("Parse(%q) error: %v", tc.input, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("Parse(%q) = %+v; want %+v", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestParse_invalid(t *testing.T) {
+	cases := []string{
+		"",
+		"1",
+		"1.2",
+		"1.2.3.4.5",
+		"a.b.c",
+		"1.2.x",
+		"-1.0.0",
+	}
+	for _, tc := range cases {
+		if _, err := semver.Parse(tc); err == nil {
+			t.Errorf("Parse(%q) expected error, got nil", tc)
+		}
+	}
+}
+
+func TestVersion_String(t *testing.T) {
+	cases := []struct {
+		v    semver.Version
+		want string
+	}{
+		{semver.Version{Major: 1, Minor: 2, Patch: 3}, "1.2.3"},
+		{semver.Version{Major: 1, Minor: 2, Patch: 3, Revision: 4}, "1.2.3.4"},
+		{semver.Version{Major: 1, Minor: 2, Patch: 3, PreRelease: "alpha"}, "1.2.3-alpha"},
+		{semver.Version{Major: 1, Minor: 2, Patch: 3, Revision: 4, PreRelease: "beta.1"}, "1.2.3.4-beta.1"},
+		{semver.Version{}, "0.0.0"},
+	}
+	for _, tc := range cases {
+		if got := tc.v.String(); got != tc.want {
+			t.Errorf("Version.String() = %q; want %q", got, tc.want)
+		}
+	}
+}
+
+func TestVersion_Compare(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0", "1.0.0", 0},
+		{"1.0.0", "2.0.0", -1},
+		{"2.0.0", "1.0.0", 1},
+		{"1.1.0", "1.2.0", -1},
+		{"1.0.1", "1.0.2", -1},
+		{"1.0.0.1", "1.0.0.2", -1},
+		{"1.0.0.2", "1.0.0.1", 1},
+		// Stable > pre-release
+		{"1.0.0", "1.0.0-alpha", 1},
+		{"1.0.0-alpha", "1.0.0", -1},
+		// Pre-release ordering
+		{"1.0.0-alpha", "1.0.0-beta", -1},
+		{"1.0.0-beta", "1.0.0-alpha", 1},
+		{"1.0.0-alpha.1", "1.0.0-alpha.2", -1},
+		// Numeric vs string identifiers
+		{"1.0.0-1", "1.0.0-alpha", -1},
+	}
+	for _, tc := range cases {
+		a := semver.MustParse(tc.a)
+		b := semver.MustParse(tc.b)
+		got := a.Compare(b)
+		if signum(got) != signum(tc.want) {
+			t.Errorf("(%q).Compare(%q) = %d; want signum %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestVersion_IsPreRelease(t *testing.T) {
+	if semver.MustParse("1.0.0").IsPreRelease() {
+		t.Error("1.0.0 should not be pre-release")
+	}
+	if !semver.MustParse("1.0.0-alpha").IsPreRelease() {
+		t.Error("1.0.0-alpha should be pre-release")
+	}
+}
+
+func TestMustParse_panic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("MustParse of invalid string should panic")
+		}
+	}()
+	semver.MustParse("not-a-version")
+}
+
+func signum(n int) int {
+	switch {
+	case n < 0:
+		return -1
+	case n > 0:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/package3/dotnet/typemap/kind.go
+++ b/package3/dotnet/typemap/kind.go
@@ -1,0 +1,89 @@
+// Package typemap is the closed type-mapping table for MEP-68. It consumes
+// metacli.TypeRef values (the output of the assembly metadata parser) and
+// either returns a structured Mapping describing the Mochi-side type and FFI
+// representation, or an errors.SkipReason explaining why no mapping exists.
+//
+// The table is "closed": every CLR TypeRef kind either has a documented
+// mapping rule or a documented refusal class. There is no fallthrough that
+// silently produces approximated types.
+package typemap
+
+// Kind is the high-level Mochi type a CLR type lowers to.
+type Kind int
+
+const (
+	// KindUnknown is the zero value; a Mapping with KindUnknown is a
+	// programming error and must never escape the package.
+	KindUnknown Kind = iota
+	KindBool
+	KindByte
+	KindInt    // int (32-bit, widened to int in Mochi)
+	KindInt64
+	KindUInt
+	KindUInt64
+	KindFloat   // float32, widened to float in Mochi
+	KindFloat64
+	KindChar
+	KindString
+	KindBytes   // byte[] raw byte slice
+	KindUnit    // void / non-generic Task
+	KindList    // List<T>, IEnumerable<T>, T[]
+	KindMap     // Dictionary<K,V>
+	KindSet     // HashSet<T>
+	KindOption  // T? / Nullable<T>
+	KindTask    // Task<T> async return
+	KindTuple   // ValueTuple<T1,T2,...>
+	KindRecord  // struct pinned-boxed across the boundary
+	KindHandle  // opaque class/interface handle
+	KindEnum    // CLR enum mapped to Mochi int enum
+)
+
+// String returns the Mochi type name for display and extern emit.
+func (k Kind) String() string {
+	switch k {
+	case KindBool:
+		return "bool"
+	case KindByte:
+		return "byte"
+	case KindInt:
+		return "int"
+	case KindInt64:
+		return "int64"
+	case KindUInt:
+		return "uint"
+	case KindUInt64:
+		return "uint64"
+	case KindFloat:
+		return "float"
+	case KindFloat64:
+		return "float64"
+	case KindChar:
+		return "char"
+	case KindString:
+		return "string"
+	case KindBytes:
+		return "bytes"
+	case KindUnit:
+		return "unit"
+	case KindList:
+		return "list"
+	case KindMap:
+		return "map"
+	case KindSet:
+		return "set"
+	case KindOption:
+		return "option"
+	case KindTask:
+		return "task"
+	case KindTuple:
+		return "tuple"
+	case KindRecord:
+		return "record"
+	case KindHandle:
+		return "handle"
+	case KindEnum:
+		return "enum"
+	default:
+		return "unknown"
+	}
+}

--- a/package3/dotnet/typemap/kind_test.go
+++ b/package3/dotnet/typemap/kind_test.go
@@ -1,0 +1,83 @@
+package typemap_test
+
+import (
+	"testing"
+
+	"mochi/package3/dotnet/typemap"
+)
+
+func TestKind_String_allNonEmpty(t *testing.T) {
+	kinds := []typemap.Kind{
+		typemap.KindBool,
+		typemap.KindByte,
+		typemap.KindInt,
+		typemap.KindInt64,
+		typemap.KindUInt,
+		typemap.KindUInt64,
+		typemap.KindFloat,
+		typemap.KindFloat64,
+		typemap.KindChar,
+		typemap.KindString,
+		typemap.KindBytes,
+		typemap.KindUnit,
+		typemap.KindList,
+		typemap.KindMap,
+		typemap.KindSet,
+		typemap.KindOption,
+		typemap.KindTask,
+		typemap.KindTuple,
+		typemap.KindRecord,
+		typemap.KindHandle,
+		typemap.KindEnum,
+	}
+	for _, k := range kinds {
+		s := k.String()
+		if s == "" {
+			t.Errorf("Kind(%d).String() is empty", int(k))
+		}
+		if s == "unknown" {
+			t.Errorf("Kind(%d).String() returned 'unknown' for a named constant", int(k))
+		}
+	}
+}
+
+func TestKind_String_zeroIsUnknown(t *testing.T) {
+	var k typemap.Kind
+	if got := k.String(); got != "unknown" {
+		t.Errorf("zero Kind.String() = %q; want %q", got, "unknown")
+	}
+}
+
+func TestKind_String_specificValues(t *testing.T) {
+	cases := []struct {
+		k    typemap.Kind
+		want string
+	}{
+		{typemap.KindBool, "bool"},
+		{typemap.KindByte, "byte"},
+		{typemap.KindInt, "int"},
+		{typemap.KindInt64, "int64"},
+		{typemap.KindUInt, "uint"},
+		{typemap.KindUInt64, "uint64"},
+		{typemap.KindFloat, "float"},
+		{typemap.KindFloat64, "float64"},
+		{typemap.KindChar, "char"},
+		{typemap.KindString, "string"},
+		{typemap.KindBytes, "bytes"},
+		{typemap.KindUnit, "unit"},
+		{typemap.KindList, "list"},
+		{typemap.KindMap, "map"},
+		{typemap.KindSet, "set"},
+		{typemap.KindOption, "option"},
+		{typemap.KindTask, "task"},
+		{typemap.KindTuple, "tuple"},
+		{typemap.KindRecord, "record"},
+		{typemap.KindHandle, "handle"},
+		{typemap.KindEnum, "enum"},
+	}
+	for _, tc := range cases {
+		if got := tc.k.String(); got != tc.want {
+			t.Errorf("Kind.String() = %q; want %q", got, tc.want)
+		}
+	}
+}

--- a/package3/dotnet/typemap/map.go
+++ b/package3/dotnet/typemap/map.go
@@ -1,0 +1,352 @@
+package typemap
+
+import (
+	"fmt"
+	"strings"
+
+	"mochi/package3/dotnet/errors"
+	"mochi/package3/dotnet/metacli"
+)
+
+// Direction specifies whether a type appears in an input or output position.
+type Direction int
+
+const (
+	DirectionIn  Direction = iota
+	DirectionOut
+)
+
+// String renders a Direction token.
+func (d Direction) String() string {
+	if d == DirectionOut {
+		return "out"
+	}
+	return "in"
+}
+
+// primitiveTable is the closed table of CLR primitive type names to Mochi Kinds.
+var primitiveTable = map[string]Kind{
+	"System.Boolean": KindBool,
+	"System.Byte":    KindByte,
+	"System.SByte":   KindInt,
+	"System.Int16":   KindInt,
+	"System.Int32":   KindInt,
+	"System.Int64":   KindInt64,
+	"System.UInt16":  KindUInt,
+	"System.UInt32":  KindUInt,
+	"System.UInt64":  KindUInt64,
+	"System.Single":  KindFloat,
+	"System.Double":  KindFloat64,
+	"System.Char":    KindChar,
+	"System.String":  KindString,
+	"System.Void":    KindUnit,
+}
+
+// primitiveFFI maps CLR primitive names to their C# FFI representation.
+var primitiveFFI = map[string]string{
+	"System.Boolean": "byte",
+	"System.Byte":    "byte",
+	"System.SByte":   "sbyte",
+	"System.Int16":   "short",
+	"System.Int32":   "int",
+	"System.Int64":   "long",
+	"System.UInt16":  "ushort",
+	"System.UInt32":  "uint",
+	"System.UInt64":  "ulong",
+	"System.Single":  "float",
+	"System.Double":  "double",
+	"System.Char":    "char",
+	"System.String":  "byte*, int",
+	"System.Void":    "void",
+}
+
+// collectionTable1 maps generic collection types with a single type argument.
+// Key: CLR full name (without backtick), value: KindList or KindSet.
+var collectionTable1 = map[string]Kind{
+	"System.Collections.Generic.List`1":             KindList,
+	"System.Collections.Generic.IList`1":            KindList,
+	"System.Collections.Generic.IEnumerable`1":      KindList,
+	"System.Collections.Generic.IReadOnlyList`1":    KindList,
+	"System.Collections.Generic.ICollection`1":      KindList,
+	"System.Collections.Generic.IReadOnlyCollection`1": KindList,
+	"System.Collections.Generic.HashSet`1":          KindSet,
+	"System.Collections.Generic.ISet`1":             KindSet,
+}
+
+// collectionTable2 maps generic collection types with two type arguments (K,V).
+var collectionTable2 = map[string]bool{
+	"System.Collections.Generic.Dictionary`2":            true,
+	"System.Collections.Generic.IDictionary`2":           true,
+	"System.Collections.Generic.IReadOnlyDictionary`2":   true,
+	"System.Collections.Generic.SortedDictionary`2":      true,
+}
+
+// valueTupleNames is the set of ValueTuple CLR names.
+var valueTupleNames = map[string]bool{
+	"System.ValueTuple`2": true,
+	"System.ValueTuple`3": true,
+	"System.ValueTuple`4": true,
+	"System.ValueTuple`5": true,
+	"System.ValueTuple`6": true,
+	"System.ValueTuple`7": true,
+}
+
+// Map translates a metacli.TypeRef to a Mapping or returns an
+// errors.SkipReason explaining why no mapping exists.
+//
+// Return convention: when SkipReason == errors.SkipUnknown AND detail == "",
+// the Mapping is valid. Any non-zero SkipReason indicates refusal.
+func Map(t metacli.TypeRef, dir Direction) (*Mapping, errors.SkipReason, string) {
+	// Refuse unsafe/unsupported kinds first.
+	switch t.Kind {
+	case metacli.TypeRefPointer:
+		return nil, errors.SkipPointer, "unsafe pointer type requires capabilities opt-in"
+	case metacli.TypeRefByRef:
+		return nil, errors.SkipRefType, "ref/out parameter requires special marshalling"
+	case metacli.TypeRefDynamic:
+		return nil, errors.SkipDynamic, "dynamic type has no static surface"
+	case metacli.TypeRefDelegate:
+		return nil, errors.SkipDelegate, "delegate / Action / Func type is not bridged in v1"
+	case metacli.TypeRefGenericParam:
+		return nil, errors.SkipGeneric, fmt.Sprintf("unresolved generic parameter %q; declare under [dotnet.monomorphise]", t.FullName)
+	}
+
+	// Void shortcut.
+	if t.Kind == metacli.TypeRefVoid || t.FullName == "System.Void" {
+		return &Mapping{Kind: KindUnit, CLRName: "System.Void", MochiType: "unit"}, errors.SkipUnknown, ""
+	}
+
+	// Array types.
+	if t.ArrayRank > 0 || t.Kind == metacli.TypeRefArray {
+		return mapArray(t, dir)
+	}
+
+	// Primitive table lookup.
+	if k, ok := primitiveTable[t.FullName]; ok {
+		ffi := primitiveFFI[t.FullName]
+		m := &Mapping{Kind: k, CLRName: t.FullName}
+		m.FFIReprOverride = ffi
+		m.MochiType = renderMochiType(m)
+		return m, errors.SkipUnknown, ""
+	}
+
+	// Nullable<T> or IsNullable flag.
+	if t.IsNullable || t.FullName == "System.Nullable`1" {
+		return mapNullable(t, dir)
+	}
+
+	// Generic instantiation.
+	if t.Kind == metacli.TypeRefGenericInst {
+		return mapGenericInst(t, dir)
+	}
+
+	// CLR struct -> KindRecord.
+	if t.Kind == metacli.TypeRefStruct {
+		handle := shortName(t.FullName)
+		m := &Mapping{Kind: KindRecord, CLRName: t.FullName, HandleName: handle}
+		m.MochiType = renderMochiType(m)
+		return m, errors.SkipUnknown, ""
+	}
+
+	// CLR enum.
+	if t.Kind == metacli.TypeRefEnum {
+		handle := shortName(t.FullName)
+		m := &Mapping{Kind: KindEnum, CLRName: t.FullName, HandleName: handle}
+		m.MochiType = renderMochiType(m)
+		return m, errors.SkipUnknown, ""
+	}
+
+	// Non-generic Task (async void equivalent) — check before generic handle path.
+	if t.FullName == "System.Threading.Tasks.Task" {
+		m := &Mapping{Kind: KindUnit, CLRName: t.FullName}
+		m.MochiType = renderMochiType(m)
+		return m, errors.SkipUnknown, ""
+	}
+
+	// CLR class or interface -> KindHandle.
+	if t.Kind == metacli.TypeRefClass || t.Kind == metacli.TypeRefInterface {
+		return mapHandle(t)
+	}
+
+	return nil, errors.SkipUnknown, fmt.Sprintf("unhandled CLR TypeRef kind %q for %q", t.Kind, t.FullName)
+}
+
+// mapArray maps array types. byte[] -> KindBytes; T[] -> KindList<T>.
+func mapArray(t metacli.TypeRef, dir Direction) (*Mapping, errors.SkipReason, string) {
+	// byte[] is KindBytes.
+	if t.FullName == "System.Byte" || t.FullName == "System.Byte[]" {
+		m := &Mapping{Kind: KindBytes, CLRName: "System.Byte[]"}
+		m.MochiType = renderMochiType(m)
+		return m, errors.SkipUnknown, ""
+	}
+	// Generic T[] — need the element TypeRef.
+	// For array kinds, the FullName is the element type.
+	elemRef := metacli.TypeRef{FullName: t.FullName, Kind: t.Kind}
+	// If t is a TypeRefArray with TypeArgs, use them.
+	if len(t.TypeArgs) > 0 {
+		elemRef = t.TypeArgs[0]
+	} else if t.Kind == metacli.TypeRefArray {
+		// The element is described by FullName alone with a non-array kind.
+		elemRef = metacli.TypeRef{FullName: t.FullName, Kind: metacli.TypeRefClass}
+	}
+	elem, sr, det := Map(elemRef, dir)
+	if sr != errors.SkipUnknown || det != "" {
+		return nil, sr, det
+	}
+	if elem.Kind == KindByte {
+		m := &Mapping{Kind: KindBytes, CLRName: t.FullName + "[]"}
+		m.MochiType = renderMochiType(m)
+		return m, errors.SkipUnknown, ""
+	}
+	m := &Mapping{Kind: KindList, CLRName: t.FullName + "[]", Elem: elem}
+	m.MochiType = renderMochiType(m)
+	return m, errors.SkipUnknown, ""
+}
+
+// mapNullable maps Nullable<T> or T? types to KindOption<T>.
+func mapNullable(t metacli.TypeRef, dir Direction) (*Mapping, errors.SkipReason, string) {
+	if len(t.TypeArgs) == 0 {
+		return nil, errors.SkipUnknown, fmt.Sprintf("Nullable type %q missing type argument", t.FullName)
+	}
+	inner, sr, det := Map(t.TypeArgs[0], dir)
+	if sr != errors.SkipUnknown || det != "" {
+		return nil, sr, det
+	}
+	m := &Mapping{Kind: KindOption, CLRName: t.FullName, Elem: inner, Inner: inner}
+	m.MochiType = renderMochiType(m)
+	return m, errors.SkipUnknown, ""
+}
+
+// mapGenericInst maps generic instantiations: collections, Task<T>, tuples,
+// and special types like Span<T>.
+func mapGenericInst(t metacli.TypeRef, dir Direction) (*Mapping, errors.SkipReason, string) {
+	name := t.FullName
+
+	// Span<T> / ReadOnlySpan<T>.
+	if name == "System.Span`1" || name == "System.ReadOnlySpan`1" {
+		return nil, errors.SkipSpan, fmt.Sprintf("%s is a stack-only type and cannot cross the FFI boundary", name)
+	}
+
+	// ValueTask<T>.
+	if name == "System.Threading.Tasks.ValueTask`1" {
+		return nil, errors.SkipValueTask, "ValueTask<T> is not supported in v1; use Task<T> instead"
+	}
+
+	// Action<T...> / Func<T...>.
+	if strings.HasPrefix(name, "System.Action`") || strings.HasPrefix(name, "System.Func`") {
+		return nil, errors.SkipDelegate, fmt.Sprintf("%s is a delegate type not bridged in v1", name)
+	}
+
+	// Nullable<T>.
+	if name == "System.Nullable`1" {
+		return mapNullable(t, dir)
+	}
+
+	// Task<T>.
+	if name == "System.Threading.Tasks.Task`1" {
+		if len(t.TypeArgs) == 0 {
+			return nil, errors.SkipUnknown, "Task<T> missing type argument"
+		}
+		inner, sr, det := Map(t.TypeArgs[0], dir)
+		if sr != errors.SkipUnknown || det != "" {
+			return nil, sr, det
+		}
+		m := &Mapping{Kind: KindTask, CLRName: name, Elem: inner, Inner: inner}
+		m.MochiType = renderMochiType(m)
+		return m, errors.SkipUnknown, ""
+	}
+
+	// Non-generic Task (async void).
+	if name == "System.Threading.Tasks.Task" {
+		m := &Mapping{Kind: KindUnit, CLRName: name}
+		m.MochiType = renderMochiType(m)
+		return m, errors.SkipUnknown, ""
+	}
+
+	// ValueTuple<T...>.
+	if valueTupleNames[name] {
+		return mapTuple(t, dir)
+	}
+
+	// Single-arg collection types (List<T>, IEnumerable<T>, HashSet<T>, ...).
+	if kind, ok := collectionTable1[name]; ok {
+		if len(t.TypeArgs) == 0 {
+			return nil, errors.SkipUnknown, fmt.Sprintf("%s missing type argument", name)
+		}
+		elem, sr, det := Map(t.TypeArgs[0], dir)
+		if sr != errors.SkipUnknown || det != "" {
+			return nil, sr, det
+		}
+		// byte[] equivalent.
+		if kind == KindList && elem.Kind == KindByte {
+			m := &Mapping{Kind: KindBytes, CLRName: name}
+			m.MochiType = renderMochiType(m)
+			return m, errors.SkipUnknown, ""
+		}
+		m := &Mapping{Kind: kind, CLRName: name, Elem: elem}
+		m.MochiType = renderMochiType(m)
+		return m, errors.SkipUnknown, ""
+	}
+
+	// Two-arg dictionary types.
+	if collectionTable2[name] {
+		if len(t.TypeArgs) < 2 {
+			return nil, errors.SkipUnknown, fmt.Sprintf("%s missing key/value type arguments", name)
+		}
+		k, sr, det := Map(t.TypeArgs[0], dir)
+		if sr != errors.SkipUnknown || det != "" {
+			return nil, sr, det
+		}
+		v, sr2, det2 := Map(t.TypeArgs[1], dir)
+		if sr2 != errors.SkipUnknown || det2 != "" {
+			return nil, sr2, det2
+		}
+		m := &Mapping{Kind: KindMap, CLRName: name, Key: k, Value: v}
+		m.MochiType = renderMochiType(m)
+		return m, errors.SkipUnknown, ""
+	}
+
+	// Unknown generic instantiation: treat as opaque handle.
+	handle := shortName(name)
+	m := &Mapping{Kind: KindHandle, CLRName: name, HandleName: handle}
+	m.MochiType = renderMochiType(m)
+	return m, errors.SkipUnknown, ""
+}
+
+// mapTuple maps ValueTuple<T1,...,Tn> to KindTuple.
+func mapTuple(t metacli.TypeRef, dir Direction) (*Mapping, errors.SkipReason, string) {
+	if len(t.TypeArgs) == 0 {
+		return nil, errors.SkipUnknown, fmt.Sprintf("%s missing type arguments", t.FullName)
+	}
+	fields := make([]Mapping, 0, len(t.TypeArgs))
+	for i, arg := range t.TypeArgs {
+		fm, sr, det := Map(arg, dir)
+		if sr != errors.SkipUnknown || det != "" {
+			return nil, sr, fmt.Sprintf("tuple field %d: %s", i, det)
+		}
+		fields = append(fields, *fm)
+	}
+	m := &Mapping{Kind: KindTuple, CLRName: t.FullName, Fields: fields}
+	m.MochiType = renderMochiType(m)
+	return m, errors.SkipUnknown, ""
+}
+
+// mapHandle maps a class or interface TypeRef to KindHandle.
+func mapHandle(t metacli.TypeRef) (*Mapping, errors.SkipReason, string) {
+	handle := shortName(t.FullName)
+	m := &Mapping{Kind: KindHandle, CLRName: t.FullName, HandleName: handle}
+	m.MochiType = renderMochiType(m)
+	return m, errors.SkipUnknown, ""
+}
+
+// shortName returns the last dot-separated segment of a CLR full name,
+// stripping any backtick+arity suffix (e.g. "List`1" -> "List").
+func shortName(full string) string {
+	if i := strings.LastIndex(full, "."); i >= 0 {
+		full = full[i+1:]
+	}
+	if i := strings.Index(full, "`"); i >= 0 {
+		full = full[:i]
+	}
+	return full
+}

--- a/package3/dotnet/typemap/map_test.go
+++ b/package3/dotnet/typemap/map_test.go
@@ -1,0 +1,420 @@
+package typemap_test
+
+import (
+	"testing"
+
+	"mochi/package3/dotnet/errors"
+	"mochi/package3/dotnet/metacli"
+	"mochi/package3/dotnet/typemap"
+)
+
+// ref builds a simple TypeRef for testing.
+func ref(fullName string, kind metacli.TypeRefKind) metacli.TypeRef {
+	return metacli.TypeRef{FullName: fullName, Kind: kind}
+}
+
+// genericRef builds a generic_inst TypeRef.
+func genericRef(fullName string, args ...metacli.TypeRef) metacli.TypeRef {
+	return metacli.TypeRef{FullName: fullName, Kind: metacli.TypeRefGenericInst, TypeArgs: args}
+}
+
+// nullableRef builds a Nullable<T> TypeRef.
+func nullableRef(inner metacli.TypeRef) metacli.TypeRef {
+	return metacli.TypeRef{
+		FullName:   "System.Nullable`1",
+		Kind:       metacli.TypeRefGenericInst,
+		IsNullable: true,
+		TypeArgs:   []metacli.TypeRef{inner},
+	}
+}
+
+func TestMap_primitives(t *testing.T) {
+	cases := []struct {
+		fullName string
+		wantKind typemap.Kind
+		wantFFI  string
+	}{
+		{"System.Boolean", typemap.KindBool, "byte"},
+		{"System.Byte", typemap.KindByte, "byte"},
+		{"System.SByte", typemap.KindInt, "sbyte"},
+		{"System.Int16", typemap.KindInt, "short"},
+		{"System.Int32", typemap.KindInt, "int"},
+		{"System.Int64", typemap.KindInt64, "long"},
+		{"System.UInt16", typemap.KindUInt, "ushort"},
+		{"System.UInt32", typemap.KindUInt, "uint"},
+		{"System.UInt64", typemap.KindUInt64, "ulong"},
+		{"System.Single", typemap.KindFloat, "float"},
+		{"System.Double", typemap.KindFloat64, "double"},
+		{"System.Char", typemap.KindChar, "char"},
+		{"System.String", typemap.KindString, "byte*, int"},
+		{"System.Void", typemap.KindUnit, "void"},
+	}
+	for _, tc := range cases {
+		t := t
+		tc := tc
+		t.Run(tc.fullName, func(t *testing.T) {
+			m, sr, det := typemap.Map(ref(tc.fullName, metacli.TypeRefPrimitive), typemap.DirectionIn)
+			if sr != errors.SkipUnknown || det != "" {
+				t.Fatalf("Map(%s) refused: %s %s", tc.fullName, sr, det)
+			}
+			if m.Kind != tc.wantKind {
+				t.Errorf("Kind = %s; want %s", m.Kind, tc.wantKind)
+			}
+			if m.FFIRepr() != tc.wantFFI {
+				t.Errorf("FFIRepr = %q; want %q", m.FFIRepr(), tc.wantFFI)
+			}
+		})
+	}
+}
+
+func TestMap_voidTypeRef(t *testing.T) {
+	m, sr, det := typemap.Map(ref("System.Void", metacli.TypeRefVoid), typemap.DirectionOut)
+	if sr != errors.SkipUnknown || det != "" {
+		t.Fatalf("refused: %s %s", sr, det)
+	}
+	if m.Kind != typemap.KindUnit {
+		t.Errorf("Kind = %s; want unit", m.Kind)
+	}
+}
+
+func TestMap_list(t *testing.T) {
+	r := genericRef("System.Collections.Generic.List`1", ref("System.Int32", metacli.TypeRefPrimitive))
+	m, sr, det := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipUnknown || det != "" {
+		t.Fatalf("refused: %s %s", sr, det)
+	}
+	if m.Kind != typemap.KindList {
+		t.Errorf("Kind = %s; want list", m.Kind)
+	}
+	if m.Elem == nil || m.Elem.Kind != typemap.KindInt {
+		t.Error("Elem should be KindInt")
+	}
+}
+
+func TestMap_ienumerable(t *testing.T) {
+	r := genericRef("System.Collections.Generic.IEnumerable`1", ref("System.String", metacli.TypeRefPrimitive))
+	m, sr, det := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipUnknown || det != "" {
+		t.Fatalf("refused: %s %s", sr, det)
+	}
+	if m.Kind != typemap.KindList {
+		t.Errorf("Kind = %s; want list", m.Kind)
+	}
+}
+
+func TestMap_hashset(t *testing.T) {
+	r := genericRef("System.Collections.Generic.HashSet`1", ref("System.String", metacli.TypeRefPrimitive))
+	m, sr, det := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipUnknown || det != "" {
+		t.Fatalf("refused: %s %s", sr, det)
+	}
+	if m.Kind != typemap.KindSet {
+		t.Errorf("Kind = %s; want set", m.Kind)
+	}
+}
+
+func TestMap_dictionary(t *testing.T) {
+	r := genericRef("System.Collections.Generic.Dictionary`2",
+		ref("System.String", metacli.TypeRefPrimitive),
+		ref("System.Int32", metacli.TypeRefPrimitive),
+	)
+	m, sr, det := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipUnknown || det != "" {
+		t.Fatalf("refused: %s %s", sr, det)
+	}
+	if m.Kind != typemap.KindMap {
+		t.Errorf("Kind = %s; want map", m.Kind)
+	}
+	if m.Key == nil || m.Key.Kind != typemap.KindString {
+		t.Error("Key should be KindString")
+	}
+	if m.Value == nil || m.Value.Kind != typemap.KindInt {
+		t.Error("Value should be KindInt")
+	}
+}
+
+func TestMap_ireadOnlyDictionary(t *testing.T) {
+	r := genericRef("System.Collections.Generic.IReadOnlyDictionary`2",
+		ref("System.String", metacli.TypeRefPrimitive),
+		ref("System.Int64", metacli.TypeRefPrimitive),
+	)
+	m, sr, det := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipUnknown || det != "" {
+		t.Fatalf("refused: %s %s", sr, det)
+	}
+	if m.Kind != typemap.KindMap {
+		t.Errorf("Kind = %s; want map", m.Kind)
+	}
+}
+
+func TestMap_nullable(t *testing.T) {
+	r := nullableRef(ref("System.Int32", metacli.TypeRefPrimitive))
+	m, sr, det := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipUnknown || det != "" {
+		t.Fatalf("refused: %s %s", sr, det)
+	}
+	if m.Kind != typemap.KindOption {
+		t.Errorf("Kind = %s; want option", m.Kind)
+	}
+	if m.Elem == nil || m.Elem.Kind != typemap.KindInt {
+		t.Error("Elem should be KindInt")
+	}
+}
+
+func TestMap_taskT(t *testing.T) {
+	r := genericRef("System.Threading.Tasks.Task`1", ref("System.String", metacli.TypeRefPrimitive))
+	m, sr, det := typemap.Map(r, typemap.DirectionOut)
+	if sr != errors.SkipUnknown || det != "" {
+		t.Fatalf("refused: %s %s", sr, det)
+	}
+	if m.Kind != typemap.KindTask {
+		t.Errorf("Kind = %s; want task", m.Kind)
+	}
+	if m.Elem == nil || m.Elem.Kind != typemap.KindString {
+		t.Error("Elem should be KindString")
+	}
+}
+
+func TestMap_taskNonGeneric(t *testing.T) {
+	r := ref("System.Threading.Tasks.Task", metacli.TypeRefClass)
+	m, sr, det := typemap.Map(r, typemap.DirectionOut)
+	if sr != errors.SkipUnknown || det != "" {
+		t.Fatalf("refused: %s %s", sr, det)
+	}
+	if m.Kind != typemap.KindUnit {
+		t.Errorf("Kind = %s; want unit", m.Kind)
+	}
+}
+
+func TestMap_valueTuple(t *testing.T) {
+	r := genericRef("System.ValueTuple`2",
+		ref("System.Int32", metacli.TypeRefPrimitive),
+		ref("System.String", metacli.TypeRefPrimitive),
+	)
+	m, sr, det := typemap.Map(r, typemap.DirectionOut)
+	if sr != errors.SkipUnknown || det != "" {
+		t.Fatalf("refused: %s %s", sr, det)
+	}
+	if m.Kind != typemap.KindTuple {
+		t.Errorf("Kind = %s; want tuple", m.Kind)
+	}
+	if len(m.Fields) != 2 {
+		t.Errorf("Fields len = %d; want 2", len(m.Fields))
+	}
+}
+
+func TestMap_structHandle(t *testing.T) {
+	r := ref("System.Drawing.Point", metacli.TypeRefStruct)
+	m, sr, det := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipUnknown || det != "" {
+		t.Fatalf("refused: %s %s", sr, det)
+	}
+	if m.Kind != typemap.KindRecord {
+		t.Errorf("Kind = %s; want record", m.Kind)
+	}
+	if m.FFIRepr() != "nint" {
+		t.Errorf("FFIRepr = %q; want nint", m.FFIRepr())
+	}
+}
+
+func TestMap_classHandle(t *testing.T) {
+	r := ref("Newtonsoft.Json.JsonSerializer", metacli.TypeRefClass)
+	m, sr, det := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipUnknown || det != "" {
+		t.Fatalf("refused: %s %s", sr, det)
+	}
+	if m.Kind != typemap.KindHandle {
+		t.Errorf("Kind = %s; want handle", m.Kind)
+	}
+	if m.FFIRepr() != "nint" {
+		t.Errorf("FFIRepr = %q; want nint", m.FFIRepr())
+	}
+	if m.HandleName == "" {
+		t.Error("HandleName should be set")
+	}
+}
+
+func TestMap_interfaceHandle(t *testing.T) {
+	r := ref("System.IDisposable", metacli.TypeRefInterface)
+	m, sr, det := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipUnknown || det != "" {
+		t.Fatalf("refused: %s %s", sr, det)
+	}
+	if m.Kind != typemap.KindHandle {
+		t.Errorf("Kind = %s; want handle", m.Kind)
+	}
+}
+
+func TestMap_enum(t *testing.T) {
+	r := ref("System.DayOfWeek", metacli.TypeRefEnum)
+	m, sr, det := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipUnknown || det != "" {
+		t.Fatalf("refused: %s %s", sr, det)
+	}
+	if m.Kind != typemap.KindEnum {
+		t.Errorf("Kind = %s; want enum", m.Kind)
+	}
+	if m.FFIRepr() != "int" {
+		t.Errorf("FFIRepr = %q; want int", m.FFIRepr())
+	}
+}
+
+func TestMap_byteArray(t *testing.T) {
+	r := metacli.TypeRef{FullName: "System.Byte", Kind: metacli.TypeRefArray, ArrayRank: 1}
+	m, sr, det := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipUnknown || det != "" {
+		t.Fatalf("refused: %s %s", sr, det)
+	}
+	if m.Kind != typemap.KindBytes {
+		t.Errorf("Kind = %s; want bytes", m.Kind)
+	}
+}
+
+// Refusal tests.
+
+func TestMap_refuse_pointer(t *testing.T) {
+	r := ref("System.Int32*", metacli.TypeRefPointer)
+	_, sr, _ := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipPointer {
+		t.Errorf("expected SkipPointer, got %s", sr)
+	}
+}
+
+func TestMap_refuse_byRef(t *testing.T) {
+	r := ref("System.Int32", metacli.TypeRefByRef)
+	_, sr, _ := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipRefType {
+		t.Errorf("expected SkipRefType, got %s", sr)
+	}
+}
+
+func TestMap_refuse_dynamic(t *testing.T) {
+	r := ref("dynamic", metacli.TypeRefDynamic)
+	_, sr, _ := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipDynamic {
+		t.Errorf("expected SkipDynamic, got %s", sr)
+	}
+}
+
+func TestMap_refuse_delegate(t *testing.T) {
+	r := ref("System.Action", metacli.TypeRefDelegate)
+	_, sr, _ := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipDelegate {
+		t.Errorf("expected SkipDelegate, got %s", sr)
+	}
+}
+
+func TestMap_refuse_genericParam(t *testing.T) {
+	r := ref("T", metacli.TypeRefGenericParam)
+	_, sr, _ := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipGeneric {
+		t.Errorf("expected SkipGeneric, got %s", sr)
+	}
+}
+
+func TestMap_refuse_span(t *testing.T) {
+	r := genericRef("System.Span`1", ref("System.Byte", metacli.TypeRefPrimitive))
+	_, sr, _ := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipSpan {
+		t.Errorf("expected SkipSpan, got %s", sr)
+	}
+}
+
+func TestMap_refuse_readOnlySpan(t *testing.T) {
+	r := genericRef("System.ReadOnlySpan`1", ref("System.Char", metacli.TypeRefPrimitive))
+	_, sr, _ := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipSpan {
+		t.Errorf("expected SkipSpan, got %s", sr)
+	}
+}
+
+func TestMap_refuse_valueTask(t *testing.T) {
+	r := genericRef("System.Threading.Tasks.ValueTask`1", ref("System.Int32", metacli.TypeRefPrimitive))
+	_, sr, _ := typemap.Map(r, typemap.DirectionOut)
+	if sr != errors.SkipValueTask {
+		t.Errorf("expected SkipValueTask, got %s", sr)
+	}
+}
+
+func TestMap_refuse_actionGeneric(t *testing.T) {
+	r := genericRef("System.Action`1", ref("System.String", metacli.TypeRefPrimitive))
+	_, sr, _ := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipDelegate {
+		t.Errorf("expected SkipDelegate, got %s", sr)
+	}
+}
+
+func TestMap_refuse_funcGeneric(t *testing.T) {
+	r := genericRef("System.Func`2",
+		ref("System.String", metacli.TypeRefPrimitive),
+		ref("System.Int32", metacli.TypeRefPrimitive),
+	)
+	_, sr, _ := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipDelegate {
+		t.Errorf("expected SkipDelegate, got %s", sr)
+	}
+}
+
+// Mapping helpers.
+
+func TestMapping_IsScalar(t *testing.T) {
+	scalars := []typemap.Kind{
+		typemap.KindBool, typemap.KindByte, typemap.KindInt, typemap.KindInt64,
+		typemap.KindUInt, typemap.KindUInt64, typemap.KindFloat, typemap.KindFloat64,
+		typemap.KindChar, typemap.KindUnit, typemap.KindEnum,
+	}
+	for _, k := range scalars {
+		m := &typemap.Mapping{Kind: k}
+		if !m.IsScalar() {
+			t.Errorf("Kind %s should be scalar", k)
+		}
+	}
+	nonScalars := []typemap.Kind{
+		typemap.KindString, typemap.KindBytes, typemap.KindList, typemap.KindMap,
+		typemap.KindHandle, typemap.KindRecord,
+	}
+	for _, k := range nonScalars {
+		m := &typemap.Mapping{Kind: k}
+		if m.IsScalar() {
+			t.Errorf("Kind %s should not be scalar", k)
+		}
+	}
+}
+
+func TestMap_listByte_becomesBytes(t *testing.T) {
+	r := genericRef("System.Collections.Generic.List`1", ref("System.Byte", metacli.TypeRefPrimitive))
+	m, sr, det := typemap.Map(r, typemap.DirectionIn)
+	if sr != errors.SkipUnknown || det != "" {
+		t.Fatalf("refused: %s %s", sr, det)
+	}
+	if m.Kind != typemap.KindBytes {
+		t.Errorf("List<byte> should map to KindBytes, got %s", m.Kind)
+	}
+}
+
+func TestMap_mochiType_list(t *testing.T) {
+	r := genericRef("System.Collections.Generic.List`1", ref("System.Int32", metacli.TypeRefPrimitive))
+	m, _, _ := typemap.Map(r, typemap.DirectionIn)
+	if m.MochiType != "list<int>" {
+		t.Errorf("MochiType = %q; want %q", m.MochiType, "list<int>")
+	}
+}
+
+func TestMap_mochiType_map(t *testing.T) {
+	r := genericRef("System.Collections.Generic.Dictionary`2",
+		ref("System.String", metacli.TypeRefPrimitive),
+		ref("System.Boolean", metacli.TypeRefPrimitive),
+	)
+	m, _, _ := typemap.Map(r, typemap.DirectionIn)
+	if m.MochiType != "map<string,bool>" {
+		t.Errorf("MochiType = %q; want map<string,bool>", m.MochiType)
+	}
+}
+
+func TestMap_mochiType_option(t *testing.T) {
+	r := nullableRef(ref("System.Double", metacli.TypeRefPrimitive))
+	m, _, _ := typemap.Map(r, typemap.DirectionIn)
+	if m.MochiType != "?float64" {
+		t.Errorf("MochiType = %q; want ?float64", m.MochiType)
+	}
+}

--- a/package3/dotnet/typemap/mapping.go
+++ b/package3/dotnet/typemap/mapping.go
@@ -1,0 +1,180 @@
+package typemap
+
+import "strings"
+
+// Mapping is the result of translating one CLR TypeRef to a Mochi type.
+// Compound mappings (List, Map, Set, Option, Task, Tuple) carry their
+// child Mappings by pointer or slice. Failed translations return a
+// SkipReason; see map.go.
+type Mapping struct {
+	Kind Kind
+
+	// CLRName is the CLR full name (e.g. "System.Collections.Generic.List`1").
+	CLRName string
+
+	// MochiType is the rendered Mochi type string (e.g. "list<int>").
+	MochiType string
+
+	// FFIReprOverride, when non-empty, overrides the FFIRepr() return value.
+	// Used by the primitive table to supply exact C# type names.
+	FFIReprOverride string
+
+	// Elem is the element Mapping for KindList, KindSet, KindOption, KindTask.
+	Elem *Mapping
+
+	// Key and Value are populated for KindMap.
+	Key   *Mapping
+	Value *Mapping
+
+	// Inner is populated for KindOption and KindTask when Elem is used,
+	// provided as an alias for clarity.
+	Inner *Mapping
+
+	// Fields is populated for KindTuple and KindRecord in positional order.
+	Fields []Mapping
+
+	// HandleName is the CLR short name used as the extern type name for
+	// KindHandle and KindEnum.
+	HandleName string
+}
+
+// IsScalar reports whether the mapping represents a scalar (no heap
+// allocation on the Mochi side).
+func (m *Mapping) IsScalar() bool {
+	if m == nil {
+		return false
+	}
+	switch m.Kind {
+	case KindBool, KindByte, KindInt, KindInt64, KindUInt, KindUInt64,
+		KindFloat, KindFloat64, KindChar, KindUnit, KindEnum:
+		return true
+	}
+	return false
+}
+
+// FFIRepr returns the C# [UnmanagedCallersOnly]-compatible type representation
+// for use in generated shim code. Scalars map to their C# primitive type.
+// Strings are represented as "byte*, int" (UTF-8 pointer+length pair).
+// Handles and opaque records use "nint".
+func (m *Mapping) FFIRepr() string {
+	if m == nil {
+		return "void"
+	}
+	if m.FFIReprOverride != "" {
+		return m.FFIReprOverride
+	}
+	switch m.Kind {
+	case KindUnit:
+		return "void"
+	case KindBool:
+		return "byte"
+	case KindByte:
+		return "byte"
+	case KindInt:
+		return "int"
+	case KindInt64:
+		return "long"
+	case KindUInt:
+		return "uint"
+	case KindUInt64:
+		return "ulong"
+	case KindFloat:
+		return "float"
+	case KindFloat64:
+		return "double"
+	case KindChar:
+		return "char"
+	case KindString:
+		return "byte*, int"
+	case KindBytes:
+		return "byte*, int"
+	case KindEnum:
+		return "int"
+	case KindHandle, KindRecord:
+		return "nint"
+	case KindList, KindSet, KindMap, KindOption, KindTask, KindTuple:
+		return "nint"
+	}
+	return "nint"
+}
+
+// renderMochiType builds the Mochi-side type annotation string from a
+// Mapping. It is called after construction and stored in MochiType.
+func renderMochiType(m *Mapping) string {
+	if m == nil {
+		return "unknown"
+	}
+	switch m.Kind {
+	case KindBool:
+		return "bool"
+	case KindByte:
+		return "byte"
+	case KindInt:
+		return "int"
+	case KindInt64:
+		return "int64"
+	case KindUInt:
+		return "uint"
+	case KindUInt64:
+		return "uint64"
+	case KindFloat:
+		return "float"
+	case KindFloat64:
+		return "float64"
+	case KindChar:
+		return "char"
+	case KindString:
+		return "string"
+	case KindBytes:
+		return "bytes"
+	case KindUnit:
+		return "unit"
+	case KindList:
+		if m.Elem != nil {
+			return "list<" + renderMochiType(m.Elem) + ">"
+		}
+		return "list<?>"
+	case KindSet:
+		if m.Elem != nil {
+			return "set<" + renderMochiType(m.Elem) + ">"
+		}
+		return "set<?>"
+	case KindMap:
+		if m.Key != nil && m.Value != nil {
+			return "map<" + renderMochiType(m.Key) + "," + renderMochiType(m.Value) + ">"
+		}
+		return "map<?,?>"
+	case KindOption:
+		if m.Elem != nil {
+			return "?" + renderMochiType(m.Elem)
+		}
+		return "?"
+	case KindTask:
+		if m.Elem != nil {
+			return "task<" + renderMochiType(m.Elem) + ">"
+		}
+		return "task"
+	case KindTuple:
+		parts := make([]string, len(m.Fields))
+		for i := range m.Fields {
+			parts[i] = renderMochiType(&m.Fields[i])
+		}
+		return "(" + strings.Join(parts, ",") + ")"
+	case KindRecord:
+		if m.HandleName != "" {
+			return m.HandleName
+		}
+		return "record"
+	case KindHandle:
+		if m.HandleName != "" {
+			return m.HandleName
+		}
+		return "handle"
+	case KindEnum:
+		if m.HandleName != "" {
+			return m.HandleName
+		}
+		return "enum"
+	}
+	return "unknown"
+}


### PR DESCRIPTION
Closes #22842

## Summary
- Phase 0: `package3/dotnet/` skeleton, README, `errors` package (18 SkipReasons, BridgeError)
- Phase 1: NuGet 4-part semver + interval-range parser; NuGet v3 flat-container client; SHA-512 content-addressed `.nupkg` cache
- Phase 2: `mochi-dotnet-meta` JSON schema (TypeDef/MethodDef/PropDef/FieldDef/TypeRef); surface extractor with filtering
- Phase 3: closed CLR-to-Mochi type table — 14 primitives, 9 collection kinds, Nullable/Task/ValueTuple, Handle/Record/Enum, 10 refusal paths with SkipReason

## Test plan
- [ ] 129 tests pass across 5 packages: errors, semver, nuget, metacli, typemap