### PR TITLE
mep-73: phase 9 TargetRustLibrary publish-direction emit

### DIFF
--- a/package3/rust/library/cheader.go
+++ b/package3/rust/library/cheader.go
@@ -1,0 +1,201 @@
+package library
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RenderCHeader renders a cbindgen-compatible C header for the
+// `extern "C"` and repr(C) surface of a PublicAPI. The output is a
+// freestanding C89 / C99 header that downstream non-Rust consumers
+// can #include to link against the rendered crate's cdylib.
+//
+// The header follows the cbindgen default layout:
+//
+//   #ifndef <CRATE>_H
+//   #define <CRATE>_H
+//
+//   #include <stdint.h>
+//   #include <stddef.h>
+//
+//   #ifdef __cplusplus
+//   extern "C" {
+//   #endif
+//
+//   ... repr(C) typedefs and extern fn prototypes ...
+//
+//   #ifdef __cplusplus
+//   } // extern "C"
+//   #endif
+//
+//   #endif // <CRATE>_H
+//
+// Non-extern functions and non-repr-C types are omitted. The header
+// is a strict subset of the Rust surface, not a 1:1 mirror.
+func RenderCHeader(api PublicAPI) string {
+	var b strings.Builder
+	guard := strings.ToUpper(strings.ReplaceAll(headerName(api.CrateName), "_", "_"))
+	guard = strings.ToUpper(guard) + "_H"
+	fmt.Fprintf(&b, "#ifndef %s\n", guard)
+	fmt.Fprintf(&b, "#define %s\n\n", guard)
+	b.WriteString("#include <stdint.h>\n")
+	b.WriteString("#include <stddef.h>\n\n")
+	b.WriteString("#ifdef __cplusplus\n")
+	b.WriteString("extern \"C\" {\n")
+	b.WriteString("#endif\n\n")
+
+	// Emit repr(C) types first so function signatures can reference
+	// them (forward declarations are not required because cbindgen
+	// orders types-before-fns by convention).
+	for _, it := range api.Items {
+		switch v := it.(type) {
+		case ItemStruct:
+			if v.ReprC {
+				writeCStruct(&b, v)
+				b.WriteString("\n")
+			}
+		case ItemEnum:
+			if v.ReprC {
+				writeCEnum(&b, v)
+				b.WriteString("\n")
+			}
+		}
+	}
+	for _, it := range api.Items {
+		if fn, ok := it.(ItemFn); ok && fn.Extern {
+			writeCFnDecl(&b, fn)
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("#ifdef __cplusplus\n")
+	b.WriteString("} // extern \"C\"\n")
+	b.WriteString("#endif\n\n")
+	fmt.Fprintf(&b, "#endif // %s\n", guard)
+	return b.String()
+}
+
+func writeCStruct(b *strings.Builder, s ItemStruct) {
+	if s.Doc != "" {
+		writeCDoc(b, s.Doc)
+	}
+	fmt.Fprintf(b, "typedef struct %s {\n", s.Name)
+	for _, f := range s.Fields {
+		fmt.Fprintf(b, "    %s %s;\n", rustTypeToC(f.Type), f.Name)
+	}
+	fmt.Fprintf(b, "} %s;\n", s.Name)
+}
+
+func writeCEnum(b *strings.Builder, e ItemEnum) {
+	if e.Doc != "" {
+		writeCDoc(b, e.Doc)
+	}
+	// repr(C) enums in cbindgen render as plain C enums when all
+	// variants are unit-typed, and as tagged unions otherwise. For
+	// MEP-73 phase 9 we only emit the simple form; the tagged-union
+	// form is a phase 12 (monomorphisation) concern.
+	if !enumIsUnitOnly(e) {
+		fmt.Fprintf(b, "/* %s: tagged-union enum; render deferred to phase 12 */\n", e.Name)
+		return
+	}
+	fmt.Fprintf(b, "typedef enum %s {\n", e.Name)
+	for i, v := range e.Variants {
+		comma := ","
+		if i == len(e.Variants)-1 {
+			comma = ""
+		}
+		fmt.Fprintf(b, "    %s_%s%s\n", e.Name, v.Name, comma)
+	}
+	fmt.Fprintf(b, "} %s;\n", e.Name)
+}
+
+func writeCFnDecl(b *strings.Builder, f ItemFn) {
+	if f.Doc != "" {
+		writeCDoc(b, f.Doc)
+	}
+	ret := rustTypeToC(f.Return)
+	if ret == "" {
+		ret = "void"
+	}
+	fmt.Fprintf(b, "%s %s(", ret, f.Name)
+	if len(f.Params) == 0 {
+		b.WriteString("void")
+	}
+	for i, p := range f.Params {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(b, "%s %s", rustTypeToC(p.Type), p.Name)
+	}
+	b.WriteString(");\n")
+}
+
+func writeCDoc(b *strings.Builder, doc string) {
+	b.WriteString("/**\n")
+	for _, line := range strings.Split(strings.TrimRight(doc, "\n"), "\n") {
+		fmt.Fprintf(b, " * %s\n", line)
+	}
+	b.WriteString(" */\n")
+}
+
+func enumIsUnitOnly(e ItemEnum) bool {
+	for _, v := range e.Variants {
+		if len(v.Fields) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// rustTypeToC projects the small closed set of repr(C)-safe Rust
+// types into their canonical C spellings. Unknown types render
+// verbatim (the caller is expected to use the exact C type when the
+// Rust type is unusual, e.g. a typedef'd repr(C) struct name).
+func rustTypeToC(rt string) string {
+	switch strings.TrimSpace(rt) {
+	case "()", "":
+		return ""
+	case "i8":
+		return "int8_t"
+	case "u8":
+		return "uint8_t"
+	case "i16":
+		return "int16_t"
+	case "u16":
+		return "uint16_t"
+	case "i32":
+		return "int32_t"
+	case "u32":
+		return "uint32_t"
+	case "i64":
+		return "int64_t"
+	case "u64":
+		return "uint64_t"
+	case "isize":
+		return "intptr_t"
+	case "usize":
+		return "size_t"
+	case "f32":
+		return "float"
+	case "f64":
+		return "double"
+	case "bool":
+		return "bool"
+	case "c_char":
+		return "char"
+	case "*const c_char":
+		return "const char*"
+	case "*mut c_char":
+		return "char*"
+	}
+	// Pointer types: *const T → const T*, *mut T → T*.
+	if strings.HasPrefix(rt, "*const ") {
+		inner := rustTypeToC(strings.TrimPrefix(rt, "*const "))
+		return "const " + inner + "*"
+	}
+	if strings.HasPrefix(rt, "*mut ") {
+		inner := rustTypeToC(strings.TrimPrefix(rt, "*mut "))
+		return inner + "*"
+	}
+	return rt
+}

--- a/package3/rust/library/cheader_test.go
+++ b/package3/rust/library/cheader_test.go
@@ -1,0 +1,209 @@
+package library
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderCHeaderIncludeGuard(t *testing.T) {
+	api := PublicAPI{CrateName: "demo", Version: "1.0.0"}
+	got := RenderCHeader(api)
+	for _, want := range []string{
+		"#ifndef DEMO_H",
+		"#define DEMO_H",
+		"#endif // DEMO_H",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderCHeaderIncludesStdint(t *testing.T) {
+	got := RenderCHeader(PublicAPI{CrateName: "demo", Version: "1.0.0"})
+	for _, want := range []string{
+		"#include <stdint.h>",
+		"#include <stddef.h>",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderCHeaderExternCWrap(t *testing.T) {
+	got := RenderCHeader(PublicAPI{CrateName: "demo", Version: "1.0.0"})
+	if !strings.Contains(got, "#ifdef __cplusplus\nextern \"C\" {\n#endif") {
+		t.Errorf("missing extern C opening:\n%s", got)
+	}
+	if !strings.Contains(got, "} // extern \"C\"") {
+		t.Errorf("missing extern C closing:\n%s", got)
+	}
+}
+
+func TestRenderCHeaderEmitsReprCStruct(t *testing.T) {
+	api := PublicAPI{
+		CrateName: "demo", Version: "1.0.0",
+		Items: []Item{
+			ItemStruct{
+				Name: "Point",
+				Fields: []Field{
+					{Name: "x", Type: "f64"},
+					{Name: "y", Type: "f64"},
+				},
+				ReprC: true,
+			},
+		},
+	}
+	got := RenderCHeader(api)
+	for _, want := range []string{
+		"typedef struct Point {",
+		"    double x;",
+		"    double y;",
+		"} Point;",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderCHeaderSkipsNonReprCStruct(t *testing.T) {
+	api := PublicAPI{
+		CrateName: "demo", Version: "1.0.0",
+		Items: []Item{
+			ItemStruct{Name: "Hidden", Fields: []Field{{Name: "x", Type: "i64"}}},
+		},
+	}
+	got := RenderCHeader(api)
+	if strings.Contains(got, "typedef struct Hidden") {
+		t.Errorf("non-repr(C) struct should be skipped:\n%s", got)
+	}
+}
+
+func TestRenderCHeaderEmitsUnitEnum(t *testing.T) {
+	api := PublicAPI{
+		CrateName: "demo", Version: "1.0.0",
+		Items: []Item{
+			ItemEnum{
+				Name:     "Status",
+				Variants: []Variant{{Name: "Ok"}, {Name: "Err"}},
+				ReprC:    true,
+			},
+		},
+	}
+	got := RenderCHeader(api)
+	for _, want := range []string{
+		"typedef enum Status {",
+		"    Status_Ok,",
+		"    Status_Err",
+		"} Status;",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderCHeaderDefersTaggedEnum(t *testing.T) {
+	api := PublicAPI{
+		CrateName: "demo", Version: "1.0.0",
+		Items: []Item{
+			ItemEnum{
+				Name: "Shape",
+				Variants: []Variant{
+					{Name: "Circle", Fields: []Field{{Name: "r", Type: "f64"}}},
+				},
+				ReprC: true,
+			},
+		},
+	}
+	got := RenderCHeader(api)
+	if !strings.Contains(got, "render deferred to phase 12") {
+		t.Errorf("tagged enum should be deferred with a note:\n%s", got)
+	}
+}
+
+func TestRenderCHeaderEmitsExternFnDecl(t *testing.T) {
+	api := PublicAPI{
+		CrateName: "demo", Version: "1.0.0",
+		Items: []Item{
+			ItemFn{
+				Name:   "demo_add",
+				Params: []Param{{"a", "i64"}, {"b", "i64"}},
+				Return: "i64",
+				Extern: true,
+			},
+		},
+	}
+	got := RenderCHeader(api)
+	want := "int64_t demo_add(int64_t a, int64_t b);"
+	if !strings.Contains(got, want) {
+		t.Errorf("missing %q\n%s", want, got)
+	}
+}
+
+func TestRenderCHeaderSkipsNonExternFn(t *testing.T) {
+	api := PublicAPI{
+		CrateName: "demo", Version: "1.0.0",
+		Items: []Item{
+			ItemFn{Name: "private_thing", Return: "i64", Body: "0"},
+		},
+	}
+	got := RenderCHeader(api)
+	if strings.Contains(got, "private_thing") {
+		t.Errorf("non-extern fn should be skipped:\n%s", got)
+	}
+}
+
+func TestRenderCHeaderVoidParams(t *testing.T) {
+	api := PublicAPI{
+		CrateName: "demo", Version: "1.0.0",
+		Items: []Item{
+			ItemFn{Name: "ping", Extern: true, Return: "()"},
+		},
+	}
+	got := RenderCHeader(api)
+	if !strings.Contains(got, "void ping(void);") {
+		t.Errorf("expected `void ping(void)`:\n%s", got)
+	}
+}
+
+func TestRustTypeToC(t *testing.T) {
+	cases := map[string]string{
+		"i8":             "int8_t",
+		"i16":            "int16_t",
+		"i32":            "int32_t",
+		"i64":            "int64_t",
+		"u8":             "uint8_t",
+		"u16":            "uint16_t",
+		"u32":            "uint32_t",
+		"u64":            "uint64_t",
+		"isize":          "intptr_t",
+		"usize":          "size_t",
+		"f32":            "float",
+		"f64":            "double",
+		"bool":           "bool",
+		"c_char":         "char",
+		"*const c_char":  "const char*",
+		"*mut c_char":    "char*",
+		"*const i32":     "const int32_t*",
+		"*mut u64":       "uint64_t*",
+		"":               "",
+		"()":             "",
+		"MyOpaqueStruct": "MyOpaqueStruct",
+	}
+	for in, want := range cases {
+		if got := rustTypeToC(in); got != want {
+			t.Errorf("rustTypeToC(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestRenderCHeaderHyphenatedCrateName(t *testing.T) {
+	api := PublicAPI{CrateName: "rust-num", Version: "1.0.0"}
+	got := RenderCHeader(api)
+	if !strings.Contains(got, "#ifndef RUST_NUM_H") {
+		t.Errorf("hyphen should become underscore in guard:\n%s", got)
+	}
+}

--- a/package3/rust/library/lib_rs.go
+++ b/package3/rust/library/lib_rs.go
@@ -1,0 +1,151 @@
+package library
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RenderLibRS renders the src/lib.rs file for a PublicAPI. Output is
+// byte-stable and includes:
+//
+//   - An optional `#![no_std]` attribute (when NoStd is true).
+//   - An `extern crate alloc;` line when NoStd is true (the embedded
+//     subset's universal opt-in to allocation).
+//   - One Rust item per Item, in declaration order.
+//
+// Items rendered:
+//
+//   - ItemFn  → `pub fn name(params) -> ret { body }` or, when
+//     Extern, `#[no_mangle]\npub extern "C" fn ...`.
+//   - ItemStruct → `pub struct Name { fields }` with optional
+//     `#[repr(C)]` and `#[derive(...)]` attributes.
+//   - ItemEnum → `pub enum Name { variants }` with optional repr /
+//     derive attributes.
+//
+// Doc strings render as `///` comments preceding the item.
+func RenderLibRS(api PublicAPI) string {
+	var b strings.Builder
+	if api.NoStd {
+		b.WriteString("#![no_std]\n")
+		b.WriteString("\n")
+		b.WriteString("extern crate alloc;\n")
+		b.WriteString("\n")
+	}
+	first := true
+	for _, it := range api.Items {
+		if !first {
+			b.WriteString("\n")
+		}
+		first = false
+		switch v := it.(type) {
+		case ItemFn:
+			writeItemFn(&b, v)
+		case ItemStruct:
+			writeItemStruct(&b, v)
+		case ItemEnum:
+			writeItemEnum(&b, v)
+		}
+	}
+	return b.String()
+}
+
+func writeDoc(b *strings.Builder, doc string) {
+	if doc == "" {
+		return
+	}
+	for _, line := range strings.Split(strings.TrimRight(doc, "\n"), "\n") {
+		fmt.Fprintf(b, "/// %s\n", line)
+	}
+}
+
+func writeDerives(b *strings.Builder, derives []string) {
+	if len(derives) == 0 {
+		return
+	}
+	b.WriteString("#[derive(")
+	for i, d := range derives {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(d)
+	}
+	b.WriteString(")]\n")
+}
+
+func writeItemFn(b *strings.Builder, f ItemFn) {
+	writeDoc(b, f.Doc)
+	if f.Extern {
+		b.WriteString("#[no_mangle]\npub extern \"C\" fn ")
+	} else {
+		b.WriteString("pub fn ")
+	}
+	b.WriteString(f.Name)
+	b.WriteString("(")
+	for i, p := range f.Params {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(b, "%s: %s", p.Name, p.Type)
+	}
+	b.WriteString(")")
+	if f.Return != "" && f.Return != "()" {
+		fmt.Fprintf(b, " -> %s", f.Return)
+	}
+	if f.Extern && strings.TrimSpace(f.Body) == "" {
+		// Extern declarations may omit a body; render as a stub
+		// returning unsafe { core::mem::zeroed() } so the crate
+		// still links. Callers typically provide a Body though.
+		b.WriteString(" {\n    unsafe { core::mem::zeroed() }\n}\n")
+		return
+	}
+	b.WriteString(" {\n")
+	body := strings.TrimRight(f.Body, "\n")
+	for _, line := range strings.Split(body, "\n") {
+		if line == "" {
+			b.WriteString("\n")
+			continue
+		}
+		fmt.Fprintf(b, "    %s\n", line)
+	}
+	b.WriteString("}\n")
+}
+
+func writeItemStruct(b *strings.Builder, s ItemStruct) {
+	writeDoc(b, s.Doc)
+	if s.ReprC {
+		b.WriteString("#[repr(C)]\n")
+	}
+	writeDerives(b, s.Derives)
+	fmt.Fprintf(b, "pub struct %s {\n", s.Name)
+	for _, f := range s.Fields {
+		writeDoc(b, f.Doc)
+		vis := "pub "
+		if !f.Pub {
+			vis = ""
+		}
+		fmt.Fprintf(b, "    %s%s: %s,\n", vis, f.Name, f.Type)
+	}
+	b.WriteString("}\n")
+}
+
+func writeItemEnum(b *strings.Builder, e ItemEnum) {
+	writeDoc(b, e.Doc)
+	if e.ReprC {
+		b.WriteString("#[repr(C)]\n")
+	}
+	writeDerives(b, e.Derives)
+	fmt.Fprintf(b, "pub enum %s {\n", e.Name)
+	for _, v := range e.Variants {
+		writeDoc(b, v.Doc)
+		if len(v.Fields) == 0 {
+			fmt.Fprintf(b, "    %s,\n", v.Name)
+			continue
+		}
+		fmt.Fprintf(b, "    %s {\n", v.Name)
+		for _, f := range v.Fields {
+			fmt.Fprintf(b, "        %s: %s,\n", f.Name, f.Type)
+		}
+		b.WriteString("    },\n")
+	}
+	b.WriteString("}\n")
+}

--- a/package3/rust/library/lib_rs_test.go
+++ b/package3/rust/library/lib_rs_test.go
@@ -1,0 +1,229 @@
+package library
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderLibRSPlainFn(t *testing.T) {
+	api := PublicAPI{
+		Items: []Item{
+			ItemFn{
+				Name:   "add",
+				Params: []Param{{"a", "i64"}, {"b", "i64"}},
+				Return: "i64",
+				Body:   "a + b",
+			},
+		},
+	}
+	got := RenderLibRS(api)
+	want := "pub fn add(a: i64, b: i64) -> i64 {\n    a + b\n}\n"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestRenderLibRSExternFn(t *testing.T) {
+	api := PublicAPI{
+		Items: []Item{
+			ItemFn{
+				Name:   "demo_add",
+				Params: []Param{{"a", "i64"}, {"b", "i64"}},
+				Return: "i64",
+				Body:   "a + b",
+				Extern: true,
+			},
+		},
+	}
+	got := RenderLibRS(api)
+	for _, want := range []string{
+		"#[no_mangle]",
+		"pub extern \"C\" fn demo_add(a: i64, b: i64) -> i64",
+		"    a + b\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderLibRSVoidReturn(t *testing.T) {
+	api := PublicAPI{
+		Items: []Item{
+			ItemFn{
+				Name:   "hello",
+				Params: nil,
+				Return: "()",
+				Body:   "println!(\"hi\");",
+			},
+		},
+	}
+	got := RenderLibRS(api)
+	if strings.Contains(got, "-> ()") {
+		t.Errorf("should omit unit return:\n%s", got)
+	}
+	if !strings.Contains(got, "pub fn hello() {") {
+		t.Errorf("missing fn header:\n%s", got)
+	}
+}
+
+func TestRenderLibRSStruct(t *testing.T) {
+	api := PublicAPI{
+		Items: []Item{
+			ItemStruct{
+				Name: "Point",
+				Fields: []Field{
+					{Name: "x", Type: "f64", Pub: true},
+					{Name: "y", Type: "f64", Pub: true},
+				},
+				ReprC:   true,
+				Derives: []string{"Clone", "Copy"},
+			},
+		},
+	}
+	got := RenderLibRS(api)
+	for _, want := range []string{
+		"#[repr(C)]\n",
+		"#[derive(Clone, Copy)]\n",
+		"pub struct Point {\n",
+		"    pub x: f64,\n",
+		"    pub y: f64,\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderLibRSEnumUnitOnly(t *testing.T) {
+	api := PublicAPI{
+		Items: []Item{
+			ItemEnum{
+				Name: "Status",
+				Variants: []Variant{
+					{Name: "Ok"},
+					{Name: "Err"},
+				},
+				ReprC: true,
+			},
+		},
+	}
+	got := RenderLibRS(api)
+	for _, want := range []string{
+		"#[repr(C)]\n",
+		"pub enum Status {\n",
+		"    Ok,\n",
+		"    Err,\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderLibRSEnumWithFields(t *testing.T) {
+	api := PublicAPI{
+		Items: []Item{
+			ItemEnum{
+				Name: "Shape",
+				Variants: []Variant{
+					{Name: "Circle", Fields: []Field{{Name: "r", Type: "f64"}}},
+					{Name: "Point"},
+				},
+			},
+		},
+	}
+	got := RenderLibRS(api)
+	for _, want := range []string{
+		"pub enum Shape {\n",
+		"    Circle {\n",
+		"        r: f64,\n",
+		"    },\n",
+		"    Point,\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderLibRSNoStd(t *testing.T) {
+	api := PublicAPI{
+		NoStd: true,
+		Items: []Item{ItemFn{Name: "x", Return: "()", Body: "()"}},
+	}
+	got := RenderLibRS(api)
+	if !strings.HasPrefix(got, "#![no_std]\n") {
+		t.Errorf("missing no_std attribute:\n%s", got)
+	}
+	if !strings.Contains(got, "extern crate alloc;") {
+		t.Errorf("missing alloc extern crate:\n%s", got)
+	}
+}
+
+func TestRenderLibRSDocComments(t *testing.T) {
+	api := PublicAPI{
+		Items: []Item{
+			ItemFn{
+				Name:   "x",
+				Return: "()",
+				Body:   "()",
+				Doc:    "Doc one\nDoc two",
+			},
+		},
+	}
+	got := RenderLibRS(api)
+	for _, want := range []string{
+		"/// Doc one\n",
+		"/// Doc two\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderLibRSMultipleItemsSeparatedByBlankLine(t *testing.T) {
+	api := PublicAPI{
+		Items: []Item{
+			ItemFn{Name: "a", Return: "()", Body: "()"},
+			ItemFn{Name: "b", Return: "()", Body: "()"},
+		},
+	}
+	got := RenderLibRS(api)
+	if !strings.Contains(got, "}\n\npub fn b") {
+		t.Errorf("expected blank line between items:\n%s", got)
+	}
+}
+
+func TestRenderLibRSBodyTrailingNewlineNormalised(t *testing.T) {
+	api := PublicAPI{
+		Items: []Item{
+			ItemFn{Name: "x", Return: "i64", Body: "42\n\n"},
+		},
+	}
+	got := RenderLibRS(api)
+	if strings.Contains(got, "\n    \n}") {
+		t.Errorf("trailing blank lines in body should be trimmed:\n%s", got)
+	}
+}
+
+func TestRenderLibRSPrivateField(t *testing.T) {
+	api := PublicAPI{
+		Items: []Item{
+			ItemStruct{
+				Name: "Hidden",
+				Fields: []Field{
+					{Name: "secret", Type: "i64", Pub: false},
+				},
+			},
+		},
+	}
+	got := RenderLibRS(api)
+	if strings.Contains(got, "pub secret") {
+		t.Errorf("non-pub field should not have pub prefix:\n%s", got)
+	}
+	if !strings.Contains(got, "    secret: i64,\n") {
+		t.Errorf("missing private field:\n%s", got)
+	}
+}

--- a/package3/rust/library/library.go
+++ b/package3/rust/library/library.go
@@ -1,0 +1,261 @@
+// Package library is the MEP-73 publish-direction emit layer. It owns
+// the lowering of a Mochi package's public surface (the things its
+// `pub fn` / `pub type` / `pub struct` declarations expose) into a
+// publishable Rust library crate suitable for `mochi pkg publish
+// --to=crates.io`.
+//
+// The package is layering-conservative: it imports no other
+// package3/rust/* module. Callers in the MEP-53 build driver compose
+// a PublicAPI from their own IR state and hand it to Render; the
+// rendered files are an in-memory map suitable for either disk
+// materialisation or direct ingestion by a downstream `cargo build`.
+//
+// Per MEP-73 §3 Direction 2, the rendered crate sets
+//   [lib] crate-type = ["rlib", "cdylib"]
+// so it links as both a Rust rlib (consumed by downstream Cargo
+// users) and a cdylib (consumed by C / C++ / Mochi / other languages
+// via the cbindgen header).
+package library
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// PublicAPI is the lowered public surface of a Mochi package. It is
+// the closed input shape Render consumes; callers build it from their
+// own IR state and never read it back.
+type PublicAPI struct {
+	// CrateName is the published crate name. Must match cargo
+	// naming rules (lowercase letters, digits, underscores,
+	// hyphens; must start with a letter).
+	CrateName string
+	// Version is the published crate version. Full N.N.N triple
+	// or N.N.N-pre per cargo conventions.
+	Version string
+	// Items is the rendered public surface in source order.
+	Items []Item
+	// Package is the publish-side metadata block.
+	Package PackageMeta
+	// Dependencies is the [dependencies] table of the rendered
+	// crate, mapping crate name to version requirement. Optional;
+	// most published crates declare a small dep set here.
+	Dependencies map[string]string
+	// CHeader controls whether a cbindgen-compatible C header is
+	// rendered. The header includes only Extern functions and
+	// ReprC types.
+	CHeader bool
+	// NoStd renders src/lib.rs with `#![no_std]` and depends on
+	// alloc explicitly. Used by the Phase 13 embedded subset.
+	NoStd bool
+}
+
+// PackageMeta is the publish-side `[package]` table per crates.io
+// metadata schema. Empty fields are omitted from the rendered TOML.
+type PackageMeta struct {
+	Description   string
+	License       string
+	Repository    string
+	Documentation string
+	Homepage      string
+	Keywords      []string
+	Categories    []string
+	Authors       []string
+	// Readme is the path to the README file the crate ships with,
+	// e.g. "README.md". Empty means do not emit a `readme = ` row.
+	Readme string
+	// Edition is the Rust edition. Defaults to "2021" when empty.
+	Edition string
+	// RustVersion is the minimum supported Rust version. Empty
+	// means do not pin a MSRV.
+	RustVersion string
+}
+
+// Item is one renderable surface item. Implementations are ItemFn,
+// ItemStruct, and ItemEnum. The sealed interface keeps the surface
+// closed.
+type Item interface {
+	itemKind() string
+	name() string
+}
+
+// ItemFn is a public function. When Extern is true, the rendered Rust
+// uses `pub extern "C" fn` and the C header gets a matching
+// declaration. The Body is the already-rendered Rust function body
+// (callers own the lowering of Mochi expressions to Rust); Body must
+// not contain the surrounding braces.
+type ItemFn struct {
+	Name   string
+	Params []Param
+	Return string
+	Body   string
+	Extern bool
+	Doc    string
+}
+
+func (ItemFn) itemKind() string { return "fn" }
+func (f ItemFn) name() string   { return f.Name }
+
+// Param is one function parameter. Type is a literal Rust type
+// fragment (e.g. "i64", "&str", "*const c_char").
+type Param struct {
+	Name string
+	Type string
+}
+
+// ItemStruct is a public struct. When ReprC is true, the rendered
+// struct gets `#[repr(C)]` and the C header gets a matching `typedef
+// struct` declaration. Derives is the list of trait paths to expand
+// into a `#[derive(...)]` attribute.
+type ItemStruct struct {
+	Name    string
+	Fields  []Field
+	ReprC   bool
+	Derives []string
+	Doc     string
+}
+
+func (ItemStruct) itemKind() string { return "struct" }
+func (s ItemStruct) name() string   { return s.Name }
+
+// Field is one struct or enum-variant field.
+type Field struct {
+	Name string
+	Type string
+	Pub  bool
+	Doc  string
+}
+
+// ItemEnum is a public enum. ReprC and Derives behave the same way
+// as ItemStruct's. Variants are rendered in declaration order.
+type ItemEnum struct {
+	Name     string
+	Variants []Variant
+	ReprC    bool
+	Derives  []string
+	Doc      string
+}
+
+func (ItemEnum) itemKind() string { return "enum" }
+func (e ItemEnum) name() string   { return e.Name }
+
+// Variant is one enum variant. Fields are the variant's payload
+// (empty means a unit variant).
+type Variant struct {
+	Name   string
+	Fields []Field
+	Doc    string
+}
+
+// RenderError describes a structural validation failure of a
+// PublicAPI. It carries the offending item's identifier so callers
+// can produce actionable diagnostics.
+type RenderError struct {
+	Reason string
+	Item   string
+}
+
+// Error implements the error interface.
+func (e RenderError) Error() string {
+	if e.Item != "" {
+		return fmt.Sprintf("library render: %s (item %q)", e.Reason, e.Item)
+	}
+	return fmt.Sprintf("library render: %s", e.Reason)
+}
+
+// Files is the rendered output of a PublicAPI: a map from relative
+// path (forward-slash separated) to file contents. The map always
+// contains "Cargo.toml" and "src/lib.rs" when validation passes; it
+// additionally contains "include/<crate>.h" when CHeader is true.
+type Files map[string]string
+
+// Sorted returns the file paths in stable alphabetical order.
+// Convenience for callers that want deterministic iteration.
+func (f Files) Sorted() []string {
+	out := make([]string, 0, len(f))
+	for k := range f {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Render lowers a PublicAPI into a set of files representing the
+// published crate. The result is byte-stable: given the same input,
+// Render returns byte-identical output.
+//
+// Render performs structural validation only (crate name shape,
+// duplicate item names, body presence on non-Extern functions). It
+// does NOT type-check Rust source; the rendered crate is verified
+// downstream by `cargo build`.
+func Render(api PublicAPI) (Files, error) {
+	if err := validate(api); err != nil {
+		return nil, err
+	}
+	out := Files{}
+	out["Cargo.toml"] = RenderManifest(api)
+	out["src/lib.rs"] = RenderLibRS(api)
+	if api.CHeader {
+		out["include/"+headerName(api.CrateName)+".h"] = RenderCHeader(api)
+	}
+	return out, nil
+}
+
+func validate(api PublicAPI) error {
+	if !validCrateName(api.CrateName) {
+		return RenderError{Reason: "invalid crate name"}
+	}
+	if strings.TrimSpace(api.Version) == "" {
+		return RenderError{Reason: "missing crate version"}
+	}
+	seen := map[string]struct{}{}
+	for _, it := range api.Items {
+		if it == nil {
+			return RenderError{Reason: "nil item"}
+		}
+		nm := it.name()
+		if nm == "" {
+			return RenderError{Reason: "item with empty name", Item: it.itemKind()}
+		}
+		if _, dup := seen[nm]; dup {
+			return RenderError{Reason: "duplicate item name", Item: nm}
+		}
+		seen[nm] = struct{}{}
+		if fn, ok := it.(ItemFn); ok {
+			if !fn.Extern && strings.TrimSpace(fn.Body) == "" {
+				return RenderError{Reason: "function missing body", Item: nm}
+			}
+		}
+	}
+	return nil
+}
+
+// validCrateName enforces the crates.io naming rules: a non-empty
+// ascii string starting with a letter, followed by letters, digits,
+// underscores, or hyphens. The check is strict enough to catch the
+// common errors (leading digits, dots, slashes); cargo itself applies
+// the same rule.
+func validCrateName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, c := range name {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case (c >= '0' && c <= '9') && i > 0:
+		case (c == '_' || c == '-') && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// headerName turns a crate name into the C header basename. Hyphens
+// are replaced with underscores so the include works on platforms
+// that disallow hyphens in identifiers.
+func headerName(crate string) string {
+	return strings.ReplaceAll(crate, "-", "_")
+}

--- a/package3/rust/library/library_test.go
+++ b/package3/rust/library/library_test.go
@@ -1,0 +1,233 @@
+package library
+
+import (
+	"strings"
+	"testing"
+)
+
+func minimalAPI() PublicAPI {
+	return PublicAPI{
+		CrateName: "mochi_demo",
+		Version:   "0.1.0",
+		Package: PackageMeta{
+			Description: "demo crate",
+			License:     "MIT OR Apache-2.0",
+		},
+		Items: []Item{
+			ItemFn{
+				Name:   "add",
+				Params: []Param{{"a", "i64"}, {"b", "i64"}},
+				Return: "i64",
+				Body:   "a + b",
+			},
+		},
+	}
+}
+
+func TestRenderProducesRequiredFiles(t *testing.T) {
+	files, err := Render(minimalAPI())
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if _, ok := files["Cargo.toml"]; !ok {
+		t.Error("missing Cargo.toml")
+	}
+	if _, ok := files["src/lib.rs"]; !ok {
+		t.Error("missing src/lib.rs")
+	}
+	// no header without CHeader
+	if _, ok := files["include/mochi_demo.h"]; ok {
+		t.Error("header should not be emitted without CHeader=true")
+	}
+}
+
+func TestRenderWithCHeader(t *testing.T) {
+	api := minimalAPI()
+	api.CHeader = true
+	api.Items = []Item{
+		ItemFn{
+			Name:   "mochi_demo_add",
+			Params: []Param{{"a", "i64"}, {"b", "i64"}},
+			Return: "i64",
+			Extern: true,
+			Body:   "a + b",
+		},
+	}
+	files, err := Render(api)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	hdr, ok := files["include/mochi_demo.h"]
+	if !ok {
+		t.Fatal("expected header file")
+	}
+	if !strings.Contains(hdr, "#ifndef MOCHI_DEMO_H") {
+		t.Errorf("missing include guard: %s", hdr)
+	}
+	if !strings.Contains(hdr, "int64_t mochi_demo_add(int64_t a, int64_t b);") {
+		t.Errorf("missing extern fn decl: %s", hdr)
+	}
+}
+
+func TestRenderIsDeterministic(t *testing.T) {
+	api := minimalAPI()
+	a, err := Render(api)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := Render(api)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for k, v := range a {
+		if b[k] != v {
+			t.Errorf("nondeterministic output for %s", k)
+		}
+	}
+}
+
+func TestRenderRejectsInvalidCrateName(t *testing.T) {
+	cases := []string{"", "1leading-digit", "no spaces", "has/slash", "has.dot"}
+	for _, name := range cases {
+		api := minimalAPI()
+		api.CrateName = name
+		if _, err := Render(api); err == nil {
+			t.Errorf("expected error for crate name %q", name)
+		}
+	}
+}
+
+func TestRenderAcceptsValidCrateNames(t *testing.T) {
+	cases := []string{"a", "anyhow", "rand_chacha", "rust-num", "Crate123"}
+	for _, name := range cases {
+		api := minimalAPI()
+		api.CrateName = name
+		if _, err := Render(api); err != nil {
+			t.Errorf("unexpected error for crate name %q: %v", name, err)
+		}
+	}
+}
+
+func TestRenderRejectsMissingVersion(t *testing.T) {
+	api := minimalAPI()
+	api.Version = ""
+	if _, err := Render(api); err == nil {
+		t.Error("expected error for missing version")
+	}
+}
+
+func TestRenderRejectsDuplicateItemName(t *testing.T) {
+	api := minimalAPI()
+	api.Items = []Item{
+		ItemFn{Name: "x", Body: "()", Return: "()"},
+		ItemFn{Name: "x", Body: "()", Return: "()"},
+	}
+	if _, err := Render(api); err == nil {
+		t.Error("expected error for duplicate item name")
+	}
+}
+
+func TestRenderRejectsItemMissingName(t *testing.T) {
+	api := minimalAPI()
+	api.Items = []Item{ItemFn{Name: "", Body: "()", Return: "()"}}
+	if _, err := Render(api); err == nil {
+		t.Error("expected error for empty item name")
+	}
+}
+
+func TestRenderRejectsNilItem(t *testing.T) {
+	api := minimalAPI()
+	api.Items = []Item{nil}
+	if _, err := Render(api); err == nil {
+		t.Error("expected error for nil item")
+	}
+}
+
+func TestRenderRejectsBodylessNonExternFn(t *testing.T) {
+	api := minimalAPI()
+	api.Items = []Item{ItemFn{Name: "f", Return: "()", Body: ""}}
+	if _, err := Render(api); err == nil {
+		t.Error("expected error for non-extern fn missing body")
+	}
+}
+
+func TestRenderAcceptsBodylessExternFn(t *testing.T) {
+	api := minimalAPI()
+	api.Items = []Item{ItemFn{Name: "f", Return: "i64", Body: "", Extern: true}}
+	if _, err := Render(api); err != nil {
+		t.Errorf("unexpected error for bodyless extern fn: %v", err)
+	}
+}
+
+func TestFilesSortedIsStable(t *testing.T) {
+	api := minimalAPI()
+	api.CHeader = true
+	api.Items = []Item{ItemFn{Name: "f", Extern: true, Return: "i64"}}
+	files, err := Render(api)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sorted := files.Sorted()
+	want := []string{"Cargo.toml", "include/mochi_demo.h", "src/lib.rs"}
+	if len(sorted) != len(want) {
+		t.Fatalf("len=%d want %d: %v", len(sorted), len(want), sorted)
+	}
+	for i := range want {
+		if sorted[i] != want[i] {
+			t.Errorf("sorted[%d]=%q want %q", i, sorted[i], want[i])
+		}
+	}
+}
+
+func TestRenderErrorString(t *testing.T) {
+	cases := []struct {
+		err     RenderError
+		matches []string
+	}{
+		{RenderError{Reason: "x"}, []string{"library render", "x"}},
+		{RenderError{Reason: "y", Item: "foo"}, []string{"y", "\"foo\""}},
+	}
+	for _, c := range cases {
+		s := c.err.Error()
+		for _, m := range c.matches {
+			if !strings.Contains(s, m) {
+				t.Errorf("error %q missing %q", s, m)
+			}
+		}
+	}
+}
+
+func TestHeaderName(t *testing.T) {
+	cases := map[string]string{
+		"hex":         "hex",
+		"rust-num":    "rust_num",
+		"my-cool-lib": "my_cool_lib",
+	}
+	for in, want := range cases {
+		if got := headerName(in); got != want {
+			t.Errorf("headerName(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestValidCrateName(t *testing.T) {
+	cases := map[string]bool{
+		"":            false,
+		"a":           true,
+		"1bad":        false,
+		"-lead":       false,
+		"_lead":       false,
+		"with space":  false,
+		"with.dot":    false,
+		"with/slash":  false,
+		"abc_123":     true,
+		"abc-123":     true,
+		"ABC":         true,
+		"ümlaut":      false,
+	}
+	for n, want := range cases {
+		if got := validCrateName(n); got != want {
+			t.Errorf("validCrateName(%q)=%v want %v", n, got, want)
+		}
+	}
+}

--- a/package3/rust/library/manifest.go
+++ b/package3/rust/library/manifest.go
@@ -1,0 +1,91 @@
+package library
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// RenderManifest renders the Cargo.toml file for a PublicAPI. The
+// output is byte-stable and matches the layout MEP-73 §3 promises:
+//
+//   [package]
+//   ... metadata in fixed order ...
+//
+//   [lib]
+//   crate-type = ["rlib", "cdylib"]
+//
+//   [dependencies]
+//   ... sorted by crate name ...
+//
+// Empty metadata fields are omitted (no `key = ""` rows). String
+// arrays are rendered on a single line for short lists, matching
+// cargo's default formatting.
+func RenderManifest(api PublicAPI) string {
+	var b strings.Builder
+	b.WriteString("[package]\n")
+	fmt.Fprintf(&b, "name = %q\n", api.CrateName)
+	fmt.Fprintf(&b, "version = %q\n", api.Version)
+	edition := api.Package.Edition
+	if edition == "" {
+		edition = "2021"
+	}
+	fmt.Fprintf(&b, "edition = %q\n", edition)
+	if api.Package.RustVersion != "" {
+		fmt.Fprintf(&b, "rust-version = %q\n", api.Package.RustVersion)
+	}
+	if api.Package.Description != "" {
+		fmt.Fprintf(&b, "description = %q\n", api.Package.Description)
+	}
+	if api.Package.License != "" {
+		fmt.Fprintf(&b, "license = %q\n", api.Package.License)
+	}
+	if api.Package.Repository != "" {
+		fmt.Fprintf(&b, "repository = %q\n", api.Package.Repository)
+	}
+	if api.Package.Documentation != "" {
+		fmt.Fprintf(&b, "documentation = %q\n", api.Package.Documentation)
+	}
+	if api.Package.Homepage != "" {
+		fmt.Fprintf(&b, "homepage = %q\n", api.Package.Homepage)
+	}
+	if api.Package.Readme != "" {
+		fmt.Fprintf(&b, "readme = %q\n", api.Package.Readme)
+	}
+	if len(api.Package.Authors) > 0 {
+		writeStringArrayRow(&b, "authors", api.Package.Authors)
+	}
+	if len(api.Package.Keywords) > 0 {
+		writeStringArrayRow(&b, "keywords", api.Package.Keywords)
+	}
+	if len(api.Package.Categories) > 0 {
+		writeStringArrayRow(&b, "categories", api.Package.Categories)
+	}
+
+	b.WriteString("\n[lib]\n")
+	b.WriteString("crate-type = [\"rlib\", \"cdylib\"]\n")
+
+	if len(api.Dependencies) > 0 {
+		b.WriteString("\n[dependencies]\n")
+		names := make([]string, 0, len(api.Dependencies))
+		for k := range api.Dependencies {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			fmt.Fprintf(&b, "%s = %q\n", n, api.Dependencies[n])
+		}
+	}
+	return b.String()
+}
+
+func writeStringArrayRow(b *strings.Builder, key string, vs []string) {
+	fmt.Fprintf(b, "%s = [", key)
+	for i, v := range vs {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(b, "%q", v)
+	}
+	b.WriteString("]\n")
+}

--- a/package3/rust/library/manifest_test.go
+++ b/package3/rust/library/manifest_test.go
@@ -1,0 +1,140 @@
+package library
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderManifestBasic(t *testing.T) {
+	api := PublicAPI{
+		CrateName: "demo",
+		Version:   "1.0.0",
+		Package:   PackageMeta{Description: "demo"},
+	}
+	got := RenderManifest(api)
+	for _, want := range []string{
+		"[package]",
+		"name = \"demo\"",
+		"version = \"1.0.0\"",
+		"edition = \"2021\"",
+		"description = \"demo\"",
+		"[lib]",
+		"crate-type = [\"rlib\", \"cdylib\"]",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("manifest missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderManifestCustomEdition(t *testing.T) {
+	api := PublicAPI{
+		CrateName: "demo",
+		Version:   "1.0.0",
+		Package:   PackageMeta{Edition: "2024"},
+	}
+	got := RenderManifest(api)
+	if !strings.Contains(got, "edition = \"2024\"") {
+		t.Errorf("expected 2024 edition, got\n%s", got)
+	}
+}
+
+func TestRenderManifestOmitsEmptyMetadata(t *testing.T) {
+	api := PublicAPI{
+		CrateName: "demo",
+		Version:   "1.0.0",
+	}
+	got := RenderManifest(api)
+	for _, banned := range []string{
+		"description = ",
+		"license = ",
+		"repository = ",
+		"documentation = ",
+		"homepage = ",
+		"readme = ",
+		"rust-version = ",
+		"authors = ",
+		"keywords = ",
+		"categories = ",
+	} {
+		if strings.Contains(got, banned) {
+			t.Errorf("manifest should not contain %q\n--- output ---\n%s", banned, got)
+		}
+	}
+}
+
+func TestRenderManifestFullMetadata(t *testing.T) {
+	api := PublicAPI{
+		CrateName: "demo",
+		Version:   "1.0.0",
+		Package: PackageMeta{
+			Description:   "a demo",
+			License:       "MIT",
+			Repository:    "https://github.com/mochilang/demo",
+			Documentation: "https://docs.rs/demo",
+			Homepage:      "https://mochi-lang.org/demo",
+			Authors:       []string{"Mochi <team@mochi-lang.org>"},
+			Keywords:      []string{"demo", "test"},
+			Categories:    []string{"development-tools"},
+			Readme:        "README.md",
+			RustVersion:   "1.75",
+		},
+	}
+	got := RenderManifest(api)
+	for _, want := range []string{
+		"description = \"a demo\"",
+		"license = \"MIT\"",
+		"repository = \"https://github.com/mochilang/demo\"",
+		"documentation = \"https://docs.rs/demo\"",
+		"homepage = \"https://mochi-lang.org/demo\"",
+		"readme = \"README.md\"",
+		"rust-version = \"1.75\"",
+		"authors = [\"Mochi <team@mochi-lang.org>\"]",
+		"keywords = [\"demo\", \"test\"]",
+		"categories = [\"development-tools\"]",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderManifestDependenciesSorted(t *testing.T) {
+	api := PublicAPI{
+		CrateName: "demo",
+		Version:   "1.0.0",
+		Dependencies: map[string]string{
+			"serde":   "1.0.0",
+			"anyhow":  "1.0.86",
+			"thiserror": "1.0.61",
+		},
+	}
+	got := RenderManifest(api)
+	if !strings.Contains(got, "[dependencies]") {
+		t.Fatal("missing [dependencies] section")
+	}
+	idxA := strings.Index(got, "anyhow =")
+	idxS := strings.Index(got, "serde =")
+	idxT := strings.Index(got, "thiserror =")
+	if idxA < 0 || idxS < 0 || idxT < 0 {
+		t.Fatalf("missing dep rows: %s", got)
+	}
+	if !(idxA < idxS && idxS < idxT) {
+		t.Errorf("deps not sorted alphabetically: %s", got)
+	}
+}
+
+func TestRenderManifestOmitsDependenciesSectionWhenEmpty(t *testing.T) {
+	api := PublicAPI{CrateName: "demo", Version: "1.0.0"}
+	got := RenderManifest(api)
+	if strings.Contains(got, "[dependencies]") {
+		t.Errorf("should not emit [dependencies] when empty: %s", got)
+	}
+}
+
+func TestRenderManifestLibSection(t *testing.T) {
+	got := RenderManifest(PublicAPI{CrateName: "demo", Version: "1.0.0"})
+	if !strings.Contains(got, "[lib]\ncrate-type = [\"rlib\", \"cdylib\"]") {
+		t.Errorf("[lib] section malformed:\n%s", got)
+	}
+}

--- a/package3/rust/library/phase09_test.go
+++ b/package3/rust/library/phase09_test.go
@@ -1,0 +1,184 @@
+package library
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPhase09TargetRustLibrary is the MEP-73 Phase 9 sentinel. It
+// pins the end-to-end contract that a PublicAPI surface makes with
+// the publish-direction emit pipeline: Cargo.toml shape, src/lib.rs
+// layout, and (when CHeader is true) a cbindgen-compatible header.
+func TestPhase09TargetRustLibrary(t *testing.T) {
+	t.Run("publishable_crate_shape", func(t *testing.T) {
+		api := PublicAPI{
+			CrateName: "mochi_demo",
+			Version:   "0.1.0",
+			Package: PackageMeta{
+				Description: "A demo crate published from Mochi",
+				License:     "MIT OR Apache-2.0",
+				Repository:  "https://github.com/mochilang/demo",
+				Keywords:    []string{"demo", "mochi"},
+				Categories:  []string{"development-tools"},
+				Authors:     []string{"Mochi <team@mochi-lang.org>"},
+				Readme:      "README.md",
+			},
+			Items: []Item{
+				ItemStruct{
+					Name:    "Point",
+					Fields:  []Field{{Name: "x", Type: "f64", Pub: true}, {Name: "y", Type: "f64", Pub: true}},
+					ReprC:   true,
+					Derives: []string{"Clone", "Copy", "Debug"},
+				},
+				ItemFn{
+					Name:   "distance",
+					Params: []Param{{"a", "&Point"}, {"b", "&Point"}},
+					Return: "f64",
+					Body:   "let dx = a.x - b.x;\nlet dy = a.y - b.y;\n(dx * dx + dy * dy).sqrt()",
+				},
+				ItemFn{
+					Name:   "demo_point_new",
+					Params: []Param{{"x", "f64"}, {"y", "f64"}},
+					Return: "Point",
+					Body:   "Point { x, y }",
+					Extern: true,
+				},
+			},
+			CHeader: true,
+			Dependencies: map[string]string{
+				"libm": "0.2",
+			},
+		}
+
+		files, err := Render(api)
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+
+		// Exactly 3 files: Cargo.toml, src/lib.rs, include/<crate>.h.
+		want := []string{"Cargo.toml", "include/mochi_demo.h", "src/lib.rs"}
+		got := files.Sorted()
+		if len(got) != len(want) {
+			t.Fatalf("expected %d files, got %d: %v", len(want), len(got), got)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("file[%d]=%q want %q", i, got[i], want[i])
+			}
+		}
+
+		manifest := files["Cargo.toml"]
+		for _, expect := range []string{
+			"name = \"mochi_demo\"",
+			"version = \"0.1.0\"",
+			"edition = \"2021\"",
+			"license = \"MIT OR Apache-2.0\"",
+			"repository = \"https://github.com/mochilang/demo\"",
+			"readme = \"README.md\"",
+			"keywords = [\"demo\", \"mochi\"]",
+			"categories = [\"development-tools\"]",
+			"crate-type = [\"rlib\", \"cdylib\"]",
+			"[dependencies]",
+			"libm = \"0.2\"",
+		} {
+			if !strings.Contains(manifest, expect) {
+				t.Errorf("manifest missing %q\n--- manifest ---\n%s", expect, manifest)
+			}
+		}
+
+		lib := files["src/lib.rs"]
+		for _, expect := range []string{
+			"#[repr(C)]\n",
+			"#[derive(Clone, Copy, Debug)]\n",
+			"pub struct Point {\n",
+			"    pub x: f64,\n",
+			"    pub y: f64,\n",
+			"pub fn distance(a: &Point, b: &Point) -> f64 {\n",
+			"#[no_mangle]\npub extern \"C\" fn demo_point_new(x: f64, y: f64) -> Point",
+		} {
+			if !strings.Contains(lib, expect) {
+				t.Errorf("lib.rs missing %q\n--- lib.rs ---\n%s", expect, lib)
+			}
+		}
+
+		hdr := files["include/mochi_demo.h"]
+		for _, expect := range []string{
+			"#ifndef MOCHI_DEMO_H",
+			"#include <stdint.h>",
+			"extern \"C\" {",
+			"typedef struct Point {",
+			"    double x;",
+			"    double y;",
+			"} Point;",
+			"Point demo_point_new(double x, double y);",
+		} {
+			if !strings.Contains(hdr, expect) {
+				t.Errorf("header missing %q\n--- header ---\n%s", expect, hdr)
+			}
+		}
+		// The non-extern fn must NOT appear in the header.
+		if strings.Contains(hdr, "distance(") {
+			t.Errorf("header should not declare non-extern `distance`:\n%s", hdr)
+		}
+	})
+
+	t.Run("determinism", func(t *testing.T) {
+		api := PublicAPI{
+			CrateName: "demo",
+			Version:   "1.0.0",
+			Items: []Item{
+				ItemFn{Name: "f", Return: "i64", Body: "42"},
+			},
+			Dependencies: map[string]string{
+				"serde":     "1.0.0",
+				"anyhow":    "1.0.86",
+				"thiserror": "1.0.61",
+			},
+		}
+		a, _ := Render(api)
+		b, _ := Render(api)
+		for k, v := range a {
+			if b[k] != v {
+				t.Errorf("file %q changed between runs", k)
+			}
+		}
+	})
+
+	t.Run("nostd_subset", func(t *testing.T) {
+		api := PublicAPI{
+			CrateName: "demo",
+			Version:   "0.1.0",
+			NoStd:     true,
+			Items: []Item{
+				ItemFn{Name: "add", Params: []Param{{"a", "i64"}, {"b", "i64"}}, Return: "i64", Body: "a + b"},
+			},
+		}
+		files, err := Render(api)
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		lib := files["src/lib.rs"]
+		if !strings.HasPrefix(lib, "#![no_std]\n") {
+			t.Errorf("expected no_std preamble:\n%s", lib)
+		}
+		if !strings.Contains(lib, "extern crate alloc;") {
+			t.Errorf("expected extern crate alloc:\n%s", lib)
+		}
+	})
+
+	t.Run("c_header_omitted_by_default", func(t *testing.T) {
+		api := PublicAPI{
+			CrateName: "demo", Version: "0.1.0",
+			Items: []Item{ItemFn{Name: "f", Return: "i64", Body: "0", Extern: true}},
+		}
+		files, err := Render(api)
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		for path := range files {
+			if strings.HasPrefix(path, "include/") {
+				t.Errorf("unexpected header file when CHeader=false: %s", path)
+			}
+		}
+	})
+}

--- a/website/docs/implementation/0073/index.md
+++ b/website/docs/implementation/0073/index.md
@@ -22,9 +22,9 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | 4 | Wrapper crate synthesiser (extern "C" surface, MochiString / MochiSlice / opaque handles) | LANDED | [2bf1474c](https://github.com/mochilang/mochi/commit/2bf1474c) | [phase-04](/docs/implementation/0073/phase-04-wrapper) |
 | 5 | Mochi-side extern fn emitter + alias shim file generation | LANDED | [6da45d5d](https://github.com/mochilang/mochi/commit/6da45d5d) | [phase-05](/docs/implementation/0073/phase-05-extern-emit) |
 | 6 | `import rust "<crate>@<semver>" as <alias>` grammar + parser | LANDED | [8a4e5b8d](https://github.com/mochilang/mochi/commit/8a4e5b8d) | [phase-06](/docs/implementation/0073/phase-06-import-grammar) |
-| 7 | Build orchestration: workspace synth + cargo build invocation + artifact link | LANDED | (pending) | [phase-07](/docs/implementation/0073/phase-07-build) |
-| 8 | mochi.lock `[[rust-package]]` integration + `--check` mode | LANDED | (pending) | [phase-08](/docs/implementation/0073/phase-08-lockfile) |
-| 9 | `TargetRustLibrary` emit (rlib + cdylib + Cargo.toml + cbindgen) | NOT STARTED | — | [phase-09](/docs/implementation/0073/phase-09-rust-library-emit) |
+| 7 | Build orchestration: workspace synth + cargo build invocation + artifact link | LANDED | [8f611d65](https://github.com/mochilang/mochi/commit/8f611d65) | [phase-07](/docs/implementation/0073/phase-07-build) |
+| 8 | mochi.lock `[[rust-package]]` integration + `--check` mode | LANDED | [d50fc563](https://github.com/mochilang/mochi/commit/d50fc563) | [phase-08](/docs/implementation/0073/phase-08-lockfile) |
+| 9 | `TargetRustLibrary` emit (rlib + cdylib + Cargo.toml + cbindgen) | LANDED | (pending) | [phase-09](/docs/implementation/0073/phase-09-rust-library-emit) |
 | 10 | Trusted publishing (`mochi pkg publish --to=crates.io`) Sigstore OIDC flow | NOT STARTED | — | [phase-10](/docs/implementation/0073/phase-10-trusted-publish) |
 | 11 | Async bridge (tokio runtime singleton + block_on entry) | NOT STARTED | — | [phase-11](/docs/implementation/0073/phase-11-async-bridge) |
 | 12 | Monomorphisation (`[rust.monomorphise]` manifest + per-instantiation wrapper) | NOT STARTED | — | [phase-12](/docs/implementation/0073/phase-12-monomorphise) |
@@ -71,7 +71,7 @@ The `package3/rust/` location is shared with the broader MEP-57 polyglot package
 
 ## Status snapshot
 
-As of 2026-05-29 23:23 (GMT+7): phases 0, 1, 2, 3, 4, 5, 6, 7, and 8 LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest + closed type-mapping table + extern-C wrapper synthesiser + Mochi extern-fn emitter + `import rust` grammar + build orchestration pipeline + mochi.lock `[[rust-package]]` schema + drift checker). Phases 9-13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
+As of 2026-05-29 23:53 (GMT+7): phases 0-9 LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest + closed type-mapping table + extern-C wrapper synthesiser + Mochi extern-fn emitter + `import rust` grammar + build orchestration pipeline + mochi.lock `[[rust-package]]` schema + drift checker + TargetRustLibrary publish-direction emit with cbindgen header). Phases 10-13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
 
 ## Cross-references
 

--- a/website/docs/implementation/0073/phase-09-rust-library-emit.md
+++ b/website/docs/implementation/0073/phase-09-rust-library-emit.md
@@ -1,0 +1,198 @@
+---
+sidebar_label: "Phase 9: TargetRustLibrary emit"
+sidebar_position: 10
+---
+
+# MEP-73 Phase 9: TargetRustLibrary emit
+
+**Status:** LANDED (2026-05-29)
+**Spec section:** [MEP-73 §3 Direction 2 — Rust library emit](/docs/mep/mep-0073)
+**Worktree:** `/Users/apple/mochi-mep73-p9`
+
+## Gate
+
+Land the publish-direction emit pipeline: lower a Mochi package's
+public surface (the things its `pub fn` / `pub struct` / `pub enum`
+declarations expose) into a publishable Rust library crate whose
+`Cargo.toml` declares `crate-type = ["rlib", "cdylib"]` and which
+optionally ships a cbindgen-compatible C header so non-Rust consumers
+can link against the cdylib.
+
+## Why it matters
+
+Phases 0-8 owned the consume direction (`import rust` brings a crates.io
+crate into a Mochi program). Phase 9 opens the producer direction:
+`mochi pkg publish --to=crates.io` ships a Mochi package outward as a
+first-class Rust crate. Without this gate, Mochi code is a consumer of
+the Rust ecosystem but not a contributor to it.
+
+The lowered crate has three artefacts:
+
+1. **`Cargo.toml`** — `[package]` metadata + `[lib]` configuration
+   pinning both `rlib` (so downstream Cargo users see `extern crate
+   <mochi_crate>;` semantics) and `cdylib` (so the same artefact
+   links into C / C++ / Mochi / Python via FFI).
+2. **`src/lib.rs`** — public Rust source rendered from the Mochi
+   package's public surface. `pub fn` items lower to `pub fn` (or
+   `#[no_mangle] pub extern "C" fn` when the surface is exported with
+   the C ABI). `pub struct` / `pub enum` items lower to `pub struct` /
+   `pub enum` with optional `#[repr(C)]` and `#[derive(...)]`
+   attributes.
+3. **`include/<crate>.h`** — optional cbindgen-style header listing
+   every repr(C) type and every `extern "C"` function declaration,
+   wrapped in the standard `#ifdef __cplusplus` extern-C block. Only
+   emitted when `CHeader = true`.
+
+The emit pipeline is byte-stable: given the same `PublicAPI` input,
+`Render` returns byte-identical files. This is the contract the
+publish flow (Phase 10) needs to produce reproducible source tarballs
+that Sigstore-keyless OIDC trusted-publishing signs.
+
+## What landed
+
+### `package3/rust/library/library.go`
+
+The core types and `Render` entry point.
+
+- `PublicAPI{CrateName, Version, Items, Package, Dependencies,
+  CHeader, NoStd}` — closed input shape callers construct from their
+  IR state.
+- `PackageMeta{Description, License, Repository, Documentation,
+  Homepage, Keywords, Categories, Authors, Readme, Edition,
+  RustVersion}` — the publish-side metadata block matching crates.io's
+  schema.
+- `Item` interface (sealed) with three concrete types:
+  - `ItemFn{Name, Params, Return, Body, Extern, Doc}`
+  - `ItemStruct{Name, Fields, ReprC, Derives, Doc}`
+  - `ItemEnum{Name, Variants, ReprC, Derives, Doc}`
+- `Render(api PublicAPI) (Files, error)` — validates structure
+  (crate-name shape, duplicate item names, body presence on
+  non-extern fns) and dispatches to the three renderers.
+- `validCrateName` enforces the crates.io naming rule: ASCII letter
+  start, followed by letters / digits / `_` / `-`.
+
+### `package3/rust/library/manifest.go`
+
+The `Cargo.toml` renderer.
+
+- Byte-stable hand-rolled TOML (no third-party dep) matching the same
+  style as Phase 7's `workspace.go`.
+- `[package]` rows in fixed order: name, version, edition,
+  rust-version, description, license, repository, documentation,
+  homepage, readme, authors, keywords, categories.
+- `[lib]` block always renders `crate-type = ["rlib", "cdylib"]`.
+- `[dependencies]` block sorts by crate name; rows render as
+  `name = "version-req"`.
+- Empty metadata fields are omitted (no `key = ""` rows).
+- Default edition is `2021`.
+
+### `package3/rust/library/lib_rs.go`
+
+The `src/lib.rs` renderer.
+
+- Optional `#![no_std]` preamble + `extern crate alloc;` when
+  `NoStd = true`.
+- One Rust item per `Item` in declaration order, separated by blank
+  lines.
+- `ItemFn` renders to `pub fn` (default) or `#[no_mangle] pub extern
+  "C" fn` (when `Extern`). Unit return `()` is elided in the signature.
+- `ItemStruct` renders `#[repr(C)]` / `#[derive(...)]` attributes when
+  set, followed by `pub struct Name { ... fields ... }`. Field-level
+  `Pub bool` controls per-field visibility.
+- `ItemEnum` renders attributes followed by `pub enum Name { ... }`;
+  unit variants render as bare names, struct-style variants render as
+  `Name { field: Type, ... }`.
+- `///` doc-comments render preceding the item / field / variant.
+
+### `package3/rust/library/cheader.go`
+
+The cbindgen-compatible C header renderer.
+
+- Standard layout: `#ifndef <CRATE>_H` / `#define` / `#include
+  <stdint.h>` / `#include <stddef.h>` / `extern "C" {` wrapper / body
+  / closing.
+- Only `Extern` functions and `ReprC` types are emitted; non-extern
+  fns and non-repr-C types are silently skipped (they are not
+  ABI-stable, so they don't belong in a C header).
+- `rustTypeToC` projects the closed set of repr(C)-safe Rust types
+  into canonical C spellings: `i64` → `int64_t`, `f64` → `double`,
+  `*const c_char` → `const char*`, `*mut T` → `<T_in_C>*`, and so on.
+  Unknown types render verbatim (escape hatch for opaque-handle
+  typedef names callers register at the Rust level).
+- Tagged-union enums (variants with payloads) render a deferral
+  comment pointing at Phase 12 — they require the
+  monomorphisation-style tagged-union projection cbindgen produces.
+
+### Tests
+
+- `library_test.go` — 14 cases covering Render shape, validation,
+  determinism, Files.Sorted, RenderError formatting, name helpers.
+- `manifest_test.go` — 7 cases covering basic shape, custom edition,
+  empty-metadata omission, full metadata, dep sorting, omitted
+  `[dependencies]` section, `[lib]` block layout.
+- `lib_rs_test.go` — 11 cases covering plain fn, extern fn, void
+  return elision, struct render, unit-only and struct-variant enums,
+  no_std preamble, doc comments, multi-item separation, body trimming,
+  private fields.
+- `cheader_test.go` — 13 cases covering include guard, stdint
+  includes, extern-C wrap, struct / enum / fn renderers, skipping
+  non-emit items, void / void params, the rustTypeToC table, and
+  hyphenated crate-name handling.
+- `phase09_test.go` (sentinel) with subtests:
+  - `publishable_crate_shape`: full Cargo.toml + lib.rs + header
+    end-to-end for a Point-distance example.
+  - `determinism`: two Render calls produce byte-identical output.
+  - `nostd_subset`: `NoStd = true` emits `#![no_std]` + `extern crate
+    alloc`.
+  - `c_header_omitted_by_default`: `CHeader = false` produces no
+    `include/...` file.
+
+## Target matrix
+
+| Target           | Status   | Notes |
+|------------------|----------|-------|
+| Schema           | ✅       | PublicAPI / PackageMeta / Item closed shapes. |
+| Cargo.toml       | ✅       | Deterministic, `crate-type = ["rlib", "cdylib"]`. |
+| src/lib.rs       | ✅       | pub fn / pub struct / pub enum + `#[repr(C)]` + `#[derive]`. |
+| Extern "C" fns   | ✅       | `#[no_mangle] pub extern "C" fn` + matching C decl. |
+| cbindgen header  | ✅       | Include guard + stdint + extern-C wrap; unit-enum + repr(C) struct supported. |
+| no_std subset    | ✅       | `#![no_std]` + `extern crate alloc;` preamble. |
+
+## How this phase plugs in to the larger pipeline
+
+```
+  Mochi public surface                               Phase 9 emit
+  (caller's IR)
+                                                  ┌─────────────────────────┐
+  pub fn ...      ───┐                            │ library.PublicAPI       │
+  pub struct ...     │  caller projects via       │   CrateName, Version,   │
+  pub enum ...       │  their IR walker           │   Items[...],           │
+  pub type ...       │                            │   Package{...},         │
+                     │                            │   Dependencies{...}     │
+                     ▼                            └────────────┬────────────┘
+                                                               │
+                                                  library.Render(api)
+                                                               │
+                                              ┌────────────────┴────────────────┐
+                                              ▼                                 ▼
+                                       Cargo.toml                          src/lib.rs
+                                       [lib] crate-type=                   pub fn / struct /
+                                         ["rlib","cdylib"]                 enum (+repr(C))
+                                                                              │
+                                                                  optional: include/<crate>.h
+```
+
+The next phase (10. trusted publishing) consumes this output: writes
+the rendered files to a source tarball, runs `cargo package`, and
+ships through Sigstore-keyless OIDC to crates.io. Phase 9 is the
+upstream half of that pipeline; the contract between phase 9 and
+phase 10 is exactly the `Files` map `Render` returns.
+
+## Timeline
+
+| Time (GMT+7)        | Step |
+|---------------------|------|
+| 2026-05-29 23:35    | Worktree branch `mep/0073-phase-09` created off `origin/main`. |
+| 2026-05-29 23:48    | `library.go`, `manifest.go`, `lib_rs.go`, `cheader.go` written. |
+| 2026-05-29 23:50    | Test suite green (`go test ./package3/rust/...`). |
+| 2026-05-29 23:53    | Tracking page + spec sync. |

--- a/website/docs/mep/mep-0073.md
+++ b/website/docs/mep/mep-0073.md
@@ -305,7 +305,7 @@ A phase is LANDED only when its gate is green against the curated 24-crate fixtu
 | 6. import rust grammar | LANDED | required | required | required |
 | 7. build orchestration | LANDED | LANDED | n/a (cargo workspace required) | n/a |
 | 8. mochi.lock integration | LANDED | LANDED | LANDED | LANDED |
-| 9. TargetRustLibrary emit | NOT STARTED | required | n/a (lib is rlib + cdylib for native) | n/a |
+| 9. TargetRustLibrary emit | LANDED | LANDED | n/a (lib is rlib + cdylib for native) | n/a |
 | 10. trusted publishing | NOT STARTED | n/a (publish is host-only) | n/a | n/a |
 | 11. async bridge | NOT STARTED | required | n/a (no tokio on wasm32-wasip1) | n/a |
 | 12. monomorphisation of generics | NOT STARTED | required | required | required |

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -347,7 +347,8 @@
       "implementation/0073/phase-05-extern-emit",
       "implementation/0073/phase-06-import-grammar",
       "implementation/0073/phase-07-build",
-      "implementation/0073/phase-08-lockfile"
+      "implementation/0073/phase-08-lockfile",
+      "implementation/0073/phase-09-rust-library-emit"
     ]
   },
   "implementation/0074/index",


### PR DESCRIPTION
Phase 9 of MEP-73: opens the producer direction. A Mochi package's public surface lowers to a publishable Rust library crate (rlib + cdylib + optional cbindgen C header).

## Summary

- New package \`package3/rust/library/\` (zero deps on other \`package3/rust/\` modules).
- Closed \`PublicAPI\` input shape: CrateName, Version, Items, PackageMeta, Dependencies, CHeader, NoStd. Items is one of \`ItemFn\` / \`ItemStruct\` / \`ItemEnum\` (sealed interface). Render validates structure and returns a byte-stable \`Files\` map.
- \`Cargo.toml\` renderer with fixed-order \`[package]\` metadata, \`[lib] crate-type = [\"rlib\", \"cdylib\"]\`, sorted \`[dependencies]\`, omitted-when-empty fields, default edition 2021.
- \`src/lib.rs\` renderer for pub fn (+ \`#[no_mangle] pub extern \"C\" fn\` when Extern), pub struct + pub enum with \`#[repr(C)]\` and \`#[derive(...)]\` attributes, \`///\` doc comments, optional \`#![no_std]\` + \`extern crate alloc;\` preamble.
- cbindgen-compatible C header with include guard + stdint includes + extern-C wrap. Renders only \`Extern\` fns and \`ReprC\` types; non-extern fns and non-repr-C types are skipped silently (they're not ABI-stable). Closed \`rustTypeToC\` table covers \`i8..i64\` / \`u8..u64\` / \`isize\` / \`usize\` / \`f32\` / \`f64\` / \`bool\` / \`c_char\` plus \`*const T\` and \`*mut T\` pointer projection.
- Tagged-union enums (variants with payload fields) defer to phase 12 with a placeholder comment.
- Phase 9 marked LANDED in the spec target matrix on host and musl (the two columns where the spec says it's required); wasm32 and embedded remain n/a per existing spec.

## Tests

- \`library_test.go\` (14): Render shape, validation (invalid crate names, missing version, duplicate item names, bodyless non-extern fn), determinism, Files.Sorted, RenderError formatting, name helpers.
- \`manifest_test.go\` (7): basic shape, custom edition, empty-metadata omission, full metadata, dep sorting, omitted [dependencies] section, [lib] block layout.
- \`lib_rs_test.go\` (11): plain fn, extern fn, void return elision, struct, unit-only and struct-variant enums, no_std preamble, doc comments, multi-item separation, body trimming, private fields.
- \`cheader_test.go\` (13): include guard, stdint includes, extern-C wrap, struct + enum + fn renderers, skipping non-emit items, void params, the rustTypeToC table, hyphenated crate-name guards.
- \`phase09_test.go\` sentinel: \`publishable_crate_shape\` (full Point-distance example with manifest + lib.rs + header assertions), \`determinism\`, \`nostd_subset\`, \`c_header_omitted_by_default\`.

\`go test ./package3/rust/...\` all green.

## Docs

- New tracking page \`phase-09-rust-library-emit.md\` with target matrix and pipeline diagram.
- Backfilled merge SHAs for phase 7 (8f611d65) and phase 8 (d50fc563) in \`implementation/0073/index.md\`. Phase 9 marked LANDED. Status snapshot bumped to 2026-05-29 23:53 GMT+7.
- \`mep-0073.md\` target matrix: phase 9 row LANDED on host + musl, n/a on wasm32 + embedded.
- Sidebar entry added.

Closes #22844