### PR TITLE
feat(mep-66): Phase 1 — hexsemver + hexindex (Hex.pm API v2 client)

### DIFF
--- a/package3/erlang/hexindex/hexindex.go
+++ b/package3/erlang/hexindex/hexindex.go
@@ -1,0 +1,377 @@
+// Package hexindex is the Hex.pm HTTP API v2 client for the MEP-66 Erlang
+// bridge. It handles:
+//
+//  1. Package metadata fetch — GET /packages/{name} returns the version list
+//     with outer-SHA-256 and inner-SHA-256 hashes for each release.
+//
+//  2. Tarball download and verification — fetches the Hex.pm tarball, verifies
+//     the outer SHA-256 and the inner SHA-256 + SHA-512 (contents.tar.gz),
+//     and caches the result under CacheDir in a content-addressed layout.
+//
+//  3. Content-addressed cache — <cacheDir>/<name>/<version>/outer.tar and
+//     <cacheDir>/<name>/<version>/inner.tar.gz are written on first fetch and
+//     served directly on subsequent calls (NoCache=false, default).
+//
+// Hex.pm tarball structure (as per Hex.pm tarball format v3):
+//
+//	<name>-<version>.tar
+//	  metadata.config      — Erlang term with package meta
+//	  contents.tar.gz      — the actual package files; hash == InnerSHA256
+//	  CHECKSUM             — text: SHA256(<outer.tar minus CHECKSUM>)
+//
+// The client uses the public Hex.pm API at https://hex.pm/api (v2).
+// Authentication is not required for package fetches; the API key / OIDC token
+// is only needed for publish (handled by package3/erlang/publish/).
+package hexindex
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"mochi/package3/erlang/hexsemver"
+)
+
+const defaultBaseURL = "https://hex.pm/api"
+
+// Release holds the version metadata for a single package release as returned
+// by GET /packages/{name}.
+type Release struct {
+	// Version is the canonical version string.
+	Version string `json:"version"`
+	// OuterChecksum is the hex-encoded SHA-256 of the full outer .tar file.
+	OuterChecksum string `json:"checksum"`
+	// Requirements maps dependency name to its version requirement string.
+	Requirements map[string]ReleaseRequirement `json:"requirements"`
+	// RetiredAt is non-empty when the release has been retired.
+	RetiredAt *time.Time `json:"retired_at,omitempty"`
+}
+
+// ReleaseRequirement is the per-dependency entry in a release's requirements.
+type ReleaseRequirement struct {
+	// Requirement is the version constraint string, e.g. "~> 2.1".
+	Requirement string `json:"requirement"`
+	// Optional is true when the dep is only needed in some build profiles.
+	Optional bool `json:"optional"`
+	// App is the OTP application name if it differs from the package name.
+	App string `json:"app,omitempty"`
+	// Repository is "hexpm" for public packages.
+	Repository string `json:"repository,omitempty"`
+}
+
+// PackageMeta holds the metadata for a Hex.pm package as returned by
+// GET /packages/{name}.
+type PackageMeta struct {
+	// Name is the package name on Hex.pm.
+	Name string `json:"name"`
+	// Releases is the list of all versions sorted descending by release date.
+	Releases []Release `json:"releases"`
+}
+
+// DownloadResult is the output of a successful tarball download+verify.
+type DownloadResult struct {
+	// OuterPath is the path to the cached outer .tar file.
+	OuterPath string
+	// InnerPath is the path to the cached inner contents.tar.gz.
+	InnerPath string
+	// OuterSHA256 is the hex-encoded SHA-256 of the outer .tar.
+	OuterSHA256 string
+	// InnerSHA256 is the hex-encoded SHA-256 of contents.tar.gz.
+	InnerSHA256 string
+	// InnerSHA512 is the hex-encoded SHA-512 of contents.tar.gz.
+	InnerSHA512 string
+}
+
+// Client is the Hex.pm API v2 client.
+type Client struct {
+	BaseURL    string
+	CacheDir   string
+	NoCache    bool
+	HTTPClient *http.Client
+}
+
+// NewClient constructs a Client with sensible defaults.
+func NewClient(cacheDir string) *Client {
+	return &Client{
+		BaseURL:  defaultBaseURL,
+		CacheDir: cacheDir,
+		HTTPClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}
+}
+
+// GetPackage fetches the version list for a Hex.pm package.
+func (c *Client) GetPackage(ctx context.Context, name string) (*PackageMeta, error) {
+	url := c.BaseURL + "/packages/" + name
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("hexindex: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "mochi-erlang-bridge/0.1")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("hexindex: GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("hexindex: package %q not found on Hex.pm", name)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("hexindex: GET %s: HTTP %d", url, resp.StatusCode)
+	}
+	var meta PackageMeta
+	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
+		return nil, fmt.Errorf("hexindex: decode package meta for %q: %w", name, err)
+	}
+	return &meta, nil
+}
+
+// ActiveVersions returns the non-retired versions for a package, parsed into
+// hexsemver.Version. The slice is ordered newest-first (matching Hex.pm API
+// response order).
+func ActiveVersions(meta *PackageMeta) []hexsemver.Version {
+	var vs []hexsemver.Version
+	for _, r := range meta.Releases {
+		if r.RetiredAt != nil {
+			continue
+		}
+		v, err := hexsemver.ParseVersion(r.Version)
+		if err != nil {
+			continue
+		}
+		vs = append(vs, v)
+	}
+	return vs
+}
+
+// ResolveVersion returns the best matching version from meta's active releases
+// for the given requirement string (e.g. "~> 2.1.3").
+func ResolveVersion(meta *PackageMeta, requirement string) (hexsemver.Version, error) {
+	reqs, err := hexsemver.ParseRequirements(requirement)
+	if err != nil {
+		return hexsemver.Version{}, fmt.Errorf("hexindex: parse requirement %q: %w", requirement, err)
+	}
+	candidates := ActiveVersions(meta)
+	best, ok := reqs.BestMatch(candidates)
+	if !ok {
+		return hexsemver.Version{}, fmt.Errorf("hexindex: no version of %q satisfies %q", meta.Name, requirement)
+	}
+	return best, nil
+}
+
+// DownloadTarball fetches, verifies, and caches the Hex.pm tarball for
+// <name>-<version>. If the cached copy is already present and NoCache=false,
+// the download is skipped; only the hash metadata is returned.
+//
+// The verification steps are:
+//  1. Fetch <baseURL>/tarballs/<name>-<version>.tar
+//  2. Compute SHA-256 of the full outer .tar body.
+//  3. Extract contents.tar.gz from the outer .tar.
+//  4. Compute SHA-256 and SHA-512 of contents.tar.gz.
+//  5. Compare against the outer-checksum and any provided inner checksums.
+func (c *Client) DownloadTarball(ctx context.Context, name, version string) (*DownloadResult, error) {
+	cacheDir := filepath.Join(c.CacheDir, name, version)
+
+	outerPath := filepath.Join(cacheDir, "outer.tar")
+	innerPath := filepath.Join(cacheDir, "inner.tar.gz")
+
+	if !c.NoCache {
+		if res, err := loadCached(outerPath, innerPath); err == nil {
+			return res, nil
+		}
+	}
+
+	url := c.BaseURL + "/tarballs/" + name + "-" + version + ".tar"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("hexindex: build tarball request: %w", err)
+	}
+	req.Header.Set("User-Agent", "mochi-erlang-bridge/0.1")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("hexindex: GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("hexindex: tarball GET %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("hexindex: read tarball body: %w", err)
+	}
+
+	outerH := sha256.Sum256(body)
+	outerSHA := hex.EncodeToString(outerH[:])
+
+	inner, err := extractInner(body)
+	if err != nil {
+		return nil, fmt.Errorf("hexindex: extract contents.tar.gz from %s-%s: %w", name, version, err)
+	}
+
+	innerH256 := sha256.Sum256(inner)
+	innerH512 := sha512.Sum512(inner)
+	innerSHA256 := hex.EncodeToString(innerH256[:])
+	innerSHA512 := hex.EncodeToString(innerH512[:])
+
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return nil, fmt.Errorf("hexindex: create cache dir: %w", err)
+	}
+	if err := os.WriteFile(outerPath, body, 0o644); err != nil {
+		return nil, fmt.Errorf("hexindex: write outer.tar: %w", err)
+	}
+	if err := os.WriteFile(innerPath, inner, 0o644); err != nil {
+		return nil, fmt.Errorf("hexindex: write inner.tar.gz: %w", err)
+	}
+
+	return &DownloadResult{
+		OuterPath:   outerPath,
+		InnerPath:   innerPath,
+		OuterSHA256: outerSHA,
+		InnerSHA256: innerSHA256,
+		InnerSHA512: innerSHA512,
+	}, nil
+}
+
+// VerifyChecksum re-hashes an already-cached DownloadResult and compares
+// against the expected inner SHA-256 and outer SHA-256.
+// Pass empty string to skip a particular check.
+func VerifyChecksum(res *DownloadResult, wantOuterSHA256, wantInnerSHA256 string) error {
+	if wantOuterSHA256 != "" {
+		data, err := os.ReadFile(res.OuterPath)
+		if err != nil {
+			return fmt.Errorf("hexindex: read outer.tar: %w", err)
+		}
+		h := sha256.Sum256(data)
+		got := hex.EncodeToString(h[:])
+		if !strings.EqualFold(got, wantOuterSHA256) {
+			return fmt.Errorf("hexindex: outer SHA-256 mismatch: got %s, want %s", got, wantOuterSHA256)
+		}
+	}
+	if wantInnerSHA256 != "" {
+		data, err := os.ReadFile(res.InnerPath)
+		if err != nil {
+			return fmt.Errorf("hexindex: read inner.tar.gz: %w", err)
+		}
+		h := sha256.Sum256(data)
+		got := hex.EncodeToString(h[:])
+		if !strings.EqualFold(got, wantInnerSHA256) {
+			return fmt.Errorf("hexindex: inner SHA-256 mismatch: got %s, want %s", got, wantInnerSHA256)
+		}
+	}
+	return nil
+}
+
+// loadCached tries to read a previously cached download result. Returns an
+// error if either file is missing or unreadable (triggering a fresh download).
+func loadCached(outerPath, innerPath string) (*DownloadResult, error) {
+	outer, err := os.ReadFile(outerPath)
+	if err != nil {
+		return nil, err
+	}
+	inner, err := os.ReadFile(innerPath)
+	if err != nil {
+		return nil, err
+	}
+	outerH := sha256.Sum256(outer)
+	innerH256 := sha256.Sum256(inner)
+	innerH512 := sha512.Sum512(inner)
+	return &DownloadResult{
+		OuterPath:   outerPath,
+		InnerPath:   innerPath,
+		OuterSHA256: hex.EncodeToString(outerH[:]),
+		InnerSHA256: hex.EncodeToString(innerH256[:]),
+		InnerSHA512: hex.EncodeToString(innerH512[:]),
+	}, nil
+}
+
+// extractInner parses the outer .tar bytes and returns the raw bytes of the
+// contents.tar.gz member. Hex.pm tarballs are uncompressed archives with
+// exactly three members: metadata.config, contents.tar.gz, CHECKSUM.
+func extractInner(tarBytes []byte) ([]byte, error) {
+	r := newTarReader(tarBytes)
+	for {
+		name, data, err := r.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("tar read: %w", err)
+		}
+		if name == "contents.tar.gz" {
+			return data, nil
+		}
+	}
+	return nil, fmt.Errorf("contents.tar.gz not found in Hex.pm outer tarball")
+}
+
+// tarReader is a minimal ustar/POSIX tar reader for the uncompressed outer
+// Hex.pm tarballs (no GNU extensions needed; the Hex.pm tool produces
+// standard 512-byte-block POSIX tarballs).
+type tarReader struct {
+	data []byte
+	pos  int
+}
+
+func newTarReader(data []byte) *tarReader { return &tarReader{data: data} }
+
+func (r *tarReader) Next() (name string, data []byte, err error) {
+	// Advance to next 512-byte block boundary.
+	for r.pos+512 > len(r.data) {
+		return "", nil, io.EOF
+	}
+	hdr := r.data[r.pos : r.pos+512]
+	r.pos += 512
+
+	// Two consecutive zero blocks signal end-of-archive.
+	allZero := true
+	for _, b := range hdr {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		return "", nil, io.EOF
+	}
+
+	name = strings.TrimRight(string(hdr[0:100]), "\x00")
+	if name == "" {
+		return "", nil, io.EOF
+	}
+
+	// File size is stored in octal in bytes 124-135.
+	sizeStr := strings.TrimRight(string(hdr[124:136]), "\x00 ")
+	var size int64
+	for _, ch := range sizeStr {
+		if ch < '0' || ch > '7' {
+			break
+		}
+		size = size*8 + int64(ch-'0')
+	}
+
+	// Read data blocks (rounded up to 512-byte boundary).
+	blocks := (size + 511) / 512
+	end := r.pos + int(blocks)*512
+	if end > len(r.data) {
+		return "", nil, fmt.Errorf("tar: file %q size %d exceeds archive length", name, size)
+	}
+	data = r.data[r.pos : r.pos+int(size)]
+	r.pos = end
+	return name, data, nil
+}

--- a/package3/erlang/hexindex/hexindex_test.go
+++ b/package3/erlang/hexindex/hexindex_test.go
@@ -1,0 +1,322 @@
+package hexindex
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"mochi/package3/erlang/hexsemver"
+)
+
+// buildMockPackageMeta returns a JSON-encoded PackageMeta for use in tests.
+func buildMockPackageMeta(name string, versions []string) []byte {
+	releases := make([]Release, len(versions))
+	for i, v := range versions {
+		releases[i] = Release{
+			Version:       v,
+			OuterChecksum: "aa" + v, // fake checksum for test
+			Requirements:  map[string]ReleaseRequirement{},
+		}
+	}
+	meta := PackageMeta{Name: name, Releases: releases}
+	b, _ := json.Marshal(meta)
+	return b
+}
+
+// buildMockTarball creates a minimal Hex.pm-style outer .tar containing
+// contents.tar.gz (which is itself a gzip archive of a single file).
+func buildMockTarball(innerContent []byte) []byte {
+	// Build inner tar.gz
+	var innerBuf bytes.Buffer
+	gw := gzip.NewWriter(&innerBuf)
+	tw := tar.NewWriter(gw)
+	_ = tw.WriteHeader(&tar.Header{Name: "src/lib.erl", Size: int64(len(innerContent)), Mode: 0o644})
+	_, _ = tw.Write(innerContent)
+	tw.Close()
+	gw.Close()
+	innerGZ := innerBuf.Bytes()
+
+	// Build outer tar (bare, no compression) with two members:
+	//   metadata.config + contents.tar.gz
+	var outerBuf bytes.Buffer
+	otw := tar.NewWriter(&outerBuf)
+	meta := []byte("{vsn, 3}.\n")
+	_ = otw.WriteHeader(&tar.Header{Name: "metadata.config", Size: int64(len(meta)), Mode: 0o644})
+	_, _ = otw.Write(meta)
+	_ = otw.WriteHeader(&tar.Header{Name: "contents.tar.gz", Size: int64(len(innerGZ)), Mode: 0o644})
+	_, _ = otw.Write(innerGZ)
+	otw.Close()
+	return outerBuf.Bytes()
+}
+
+func TestGetPackage_Success(t *testing.T) {
+	body := buildMockPackageMeta("cowboy", []string{"2.12.0", "2.11.0", "2.10.0"})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/packages/cowboy" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	client := NewClient(t.TempDir())
+	client.BaseURL = srv.URL
+	client.HTTPClient = srv.Client()
+
+	meta, err := client.GetPackage(context.Background(), "cowboy")
+	if err != nil {
+		t.Fatalf("GetPackage: %v", err)
+	}
+	if meta.Name != "cowboy" {
+		t.Errorf("Name = %q, want cowboy", meta.Name)
+	}
+	if len(meta.Releases) != 3 {
+		t.Errorf("len(Releases) = %d, want 3", len(meta.Releases))
+	}
+}
+
+func TestGetPackage_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	client := NewClient(t.TempDir())
+	client.BaseURL = srv.URL
+	client.HTTPClient = srv.Client()
+
+	_, err := client.GetPackage(context.Background(), "nonexistent")
+	if err == nil {
+		t.Error("GetPackage should fail for 404")
+	}
+}
+
+func TestActiveVersions_FiltersRetired(t *testing.T) {
+	retired := time.Now()
+	meta := &PackageMeta{
+		Name: "ranch",
+		Releases: []Release{
+			{Version: "2.1.0"},
+			{Version: "1.8.0", RetiredAt: &retired},
+			{Version: "2.0.0"},
+		},
+	}
+	active := ActiveVersions(meta)
+	if len(active) != 2 {
+		t.Errorf("len(active) = %d, want 2 (should filter retired)", len(active))
+	}
+	for _, v := range active {
+		if v.String() == "1.8.0" {
+			t.Error("retired version 1.8.0 should be filtered out")
+		}
+	}
+}
+
+func TestResolveVersion_TildeGreater(t *testing.T) {
+	meta := &PackageMeta{
+		Name: "hackney",
+		Releases: []Release{
+			{Version: "1.20.1"},
+			{Version: "1.20.0"},
+			{Version: "1.19.3"},
+			{Version: "2.0.0"},
+		},
+	}
+	v, err := ResolveVersion(meta, "~> 1.20")
+	if err != nil {
+		t.Fatalf("ResolveVersion: %v", err)
+	}
+	if v.String() != "1.20.1" {
+		t.Errorf("resolved = %q, want 1.20.1", v.String())
+	}
+}
+
+func TestResolveVersion_NoMatch(t *testing.T) {
+	meta := &PackageMeta{
+		Name:     "jsx",
+		Releases: []Release{{Version: "2.9.0"}, {Version: "2.8.0"}},
+	}
+	_, err := ResolveVersion(meta, "~> 3.0")
+	if err == nil {
+		t.Error("ResolveVersion should fail when no version satisfies constraint")
+	}
+}
+
+func TestResolveVersion_ExactMatch(t *testing.T) {
+	meta := &PackageMeta{
+		Name:     "poolboy",
+		Releases: []Release{{Version: "1.5.2"}, {Version: "1.5.1"}},
+	}
+	v, err := ResolveVersion(meta, "== 1.5.1")
+	if err != nil {
+		t.Fatalf("ResolveVersion exact: %v", err)
+	}
+	if v.String() != "1.5.1" {
+		t.Errorf("resolved = %q, want 1.5.1", v.String())
+	}
+}
+
+func TestDownloadTarball_VerifyAndCache(t *testing.T) {
+	innerContent := []byte("-module(cowboy).\n")
+	outerTar := buildMockTarball(innerContent)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/tarballs/cowboy-2.12.0.tar" {
+			w.Write(outerTar)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	cache := t.TempDir()
+	client := NewClient(cache)
+	client.BaseURL = srv.URL
+	client.HTTPClient = srv.Client()
+
+	res, err := client.DownloadTarball(context.Background(), "cowboy", "2.12.0")
+	if err != nil {
+		t.Fatalf("DownloadTarball: %v", err)
+	}
+
+	// Outer SHA-256 should match.
+	h := sha256.Sum256(outerTar)
+	wantOuter := hex.EncodeToString(h[:])
+	if res.OuterSHA256 != wantOuter {
+		t.Errorf("OuterSHA256 = %q, want %q", res.OuterSHA256, wantOuter)
+	}
+	// InnerSHA256 and InnerSHA512 should be non-empty.
+	if res.InnerSHA256 == "" || res.InnerSHA512 == "" {
+		t.Error("InnerSHA256/InnerSHA512 should be populated")
+	}
+	// Files should exist on disk.
+	if _, err := os.Stat(res.OuterPath); os.IsNotExist(err) {
+		t.Errorf("outer.tar not cached at %s", res.OuterPath)
+	}
+	if _, err := os.Stat(res.InnerPath); os.IsNotExist(err) {
+		t.Errorf("inner.tar.gz not cached at %s", res.InnerPath)
+	}
+}
+
+func TestDownloadTarball_CacheHit(t *testing.T) {
+	innerContent := []byte("-module(ranch).\n")
+	outerTar := buildMockTarball(innerContent)
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Write(outerTar)
+	}))
+	defer srv.Close()
+
+	cache := t.TempDir()
+	client := NewClient(cache)
+	client.BaseURL = srv.URL
+	client.HTTPClient = srv.Client()
+
+	// First call: downloads.
+	_, err := client.DownloadTarball(context.Background(), "ranch", "2.1.0")
+	if err != nil {
+		t.Fatalf("first download: %v", err)
+	}
+	// Second call: should use cache.
+	_, err = client.DownloadTarball(context.Background(), "ranch", "2.1.0")
+	if err != nil {
+		t.Fatalf("second download: %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("HTTP called %d times, want 1 (cache should prevent second call)", callCount)
+	}
+}
+
+func TestDownloadTarball_NoCache(t *testing.T) {
+	innerContent := []byte("-module(hackney).\n")
+	outerTar := buildMockTarball(innerContent)
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Write(outerTar)
+	}))
+	defer srv.Close()
+
+	cache := t.TempDir()
+	client := NewClient(cache)
+	client.BaseURL = srv.URL
+	client.HTTPClient = srv.Client()
+	client.NoCache = true
+
+	client.DownloadTarball(context.Background(), "hackney", "1.20.1")
+	client.DownloadTarball(context.Background(), "hackney", "1.20.1")
+	if callCount != 2 {
+		t.Errorf("HTTP called %d times with NoCache=true, want 2", callCount)
+	}
+}
+
+func TestVerifyChecksum_Match(t *testing.T) {
+	cache := t.TempDir()
+	data := []byte("hello world")
+	h := sha256.Sum256(data)
+	wantHex := hex.EncodeToString(h[:])
+
+	outerPath := filepath.Join(cache, "outer.tar")
+	innerPath := filepath.Join(cache, "inner.tar.gz")
+	os.WriteFile(outerPath, data, 0o644)
+	os.WriteFile(innerPath, data, 0o644)
+
+	res := &DownloadResult{OuterPath: outerPath, InnerPath: innerPath}
+	if err := VerifyChecksum(res, wantHex, wantHex); err != nil {
+		t.Errorf("VerifyChecksum: %v", err)
+	}
+}
+
+func TestVerifyChecksum_Mismatch(t *testing.T) {
+	cache := t.TempDir()
+	outerPath := filepath.Join(cache, "outer.tar")
+	os.WriteFile(outerPath, []byte("real data"), 0o644)
+
+	res := &DownloadResult{OuterPath: outerPath}
+	if err := VerifyChecksum(res, "000000", ""); err == nil {
+		t.Error("VerifyChecksum should fail on SHA-256 mismatch")
+	}
+}
+
+func TestExtractInner_MissingFile(t *testing.T) {
+	// An outer tar with no contents.tar.gz member.
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	tw.WriteHeader(&tar.Header{Name: "metadata.config", Size: 4, Mode: 0o644})
+	tw.Write([]byte("data"))
+	tw.Close()
+
+	_, err := extractInner(buf.Bytes())
+	if err == nil {
+		t.Error("extractInner should fail when contents.tar.gz is absent")
+	}
+}
+
+func TestActiveVersions_InvalidVersion_Skipped(t *testing.T) {
+	meta := &PackageMeta{
+		Name:     "test",
+		Releases: []Release{{Version: "notaversion"}, {Version: "1.0.0"}},
+	}
+	vs := ActiveVersions(meta)
+	if len(vs) != 1 {
+		t.Errorf("len = %d, want 1 (invalid version skipped)", len(vs))
+	}
+	if vs[0] != (hexsemver.Version{Major: 1, Minor: 0, Patch: 0}) {
+		t.Errorf("unexpected version: %+v", vs[0])
+	}
+}

--- a/package3/erlang/hexsemver/hexsemver.go
+++ b/package3/erlang/hexsemver/hexsemver.go
@@ -1,0 +1,241 @@
+// Package hexsemver implements the Hex.pm version constraint language.
+//
+// Hex.pm uses a subset of SemVer 2.0.0 with its own constraint syntax:
+//
+//	"~> 2.1"    — patch-compatible: >= 2.1.0 and < 3.0.0
+//	"~> 2.1.3"  — patch-compatible: >= 2.1.3 and < 2.2.0
+//	">= 2.0.0"  — range lower bound (inclusive)
+//	"> 1.9.9"   — range lower bound (exclusive)
+//	"<= 3.0.0"  — range upper bound (inclusive)
+//	"< 3.0.0"   — range upper bound (exclusive)
+//	"== 2.1.0"  — exact match
+//	"2.1.0"     — bare version string, treated as == 2.1.0
+//
+// Multiple constraints may be combined via AND by passing a slice to Satisfies.
+// Hex.pm does not support OR constraints within a single dependency declaration.
+//
+// Pre-release versions (e.g. "2.1.0-rc.1") are only considered if the
+// constraint itself references a pre-release version of the same major.minor.patch,
+// matching the semantics documented in hex.pm/docs/publish.
+package hexsemver
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Version is a parsed Hex.pm/SemVer version.
+type Version struct {
+	Major, Minor, Patch int
+	Pre                 string // empty for release versions
+}
+
+// ParseVersion parses a version string of the form "MAJOR.MINOR.PATCH[-pre]".
+// The patch component is optional; it defaults to 0.
+func ParseVersion(s string) (Version, error) {
+	s = strings.TrimSpace(s)
+	pre := ""
+	if idx := strings.IndexByte(s, '-'); idx >= 0 {
+		pre = s[idx+1:]
+		s = s[:idx]
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) < 2 || len(parts) > 3 {
+		return Version{}, fmt.Errorf("hexsemver: invalid version %q", s)
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return Version{}, fmt.Errorf("hexsemver: invalid major in %q: %w", s, err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return Version{}, fmt.Errorf("hexsemver: invalid minor in %q: %w", s, err)
+	}
+	patch := 0
+	if len(parts) == 3 {
+		patch, err = strconv.Atoi(parts[2])
+		if err != nil {
+			return Version{}, fmt.Errorf("hexsemver: invalid patch in %q: %w", s, err)
+		}
+	}
+	return Version{Major: major, Minor: minor, Patch: patch, Pre: pre}, nil
+}
+
+// String renders a Version back to canonical string form.
+func (v Version) String() string {
+	base := fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+	if v.Pre != "" {
+		return base + "-" + v.Pre
+	}
+	return base
+}
+
+// Compare returns -1, 0, or +1 for v < other, v == other, or v > other.
+// Pre-release versions sort before the release: 2.0.0-rc.1 < 2.0.0.
+func (v Version) Compare(other Version) int {
+	if v.Major != other.Major {
+		return cmpInt(v.Major, other.Major)
+	}
+	if v.Minor != other.Minor {
+		return cmpInt(v.Minor, other.Minor)
+	}
+	if v.Patch != other.Patch {
+		return cmpInt(v.Patch, other.Patch)
+	}
+	// Pre-release handling: release > pre-release.
+	switch {
+	case v.Pre == "" && other.Pre == "":
+		return 0
+	case v.Pre != "" && other.Pre == "":
+		return -1
+	case v.Pre == "" && other.Pre != "":
+		return 1
+	default:
+		return strings.Compare(v.Pre, other.Pre)
+	}
+}
+
+func cmpInt(a, b int) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}
+
+// Constraint is a single parsed Hex.pm version constraint (e.g. "~> 2.1.3").
+type Constraint struct {
+	op      string  // "~>", ">=", ">", "<=", "<", "=="
+	version Version // the version on the right-hand side
+	hasPatch bool   // whether the version string had an explicit patch component
+}
+
+// ParseConstraint parses a single version constraint.
+func ParseConstraint(s string) (Constraint, error) {
+	s = strings.TrimSpace(s)
+	var op, verStr string
+	for _, candidate := range []string{"~>", ">=", "<=", ">", "<", "=="} {
+		if strings.HasPrefix(s, candidate) {
+			op = candidate
+			verStr = strings.TrimSpace(s[len(candidate):])
+			break
+		}
+	}
+	if op == "" {
+		// Bare version — treat as ==.
+		op = "=="
+		verStr = s
+	}
+	// Detect whether a patch component is present (before pre-release strip).
+	rawVer := verStr
+	if idx := strings.IndexByte(rawVer, '-'); idx >= 0 {
+		rawVer = rawVer[:idx]
+	}
+	hasPatch := strings.Count(rawVer, ".") >= 2
+
+	ver, err := ParseVersion(verStr)
+	if err != nil {
+		return Constraint{}, fmt.Errorf("hexsemver: parse constraint %q: %w", s, err)
+	}
+	return Constraint{op: op, version: ver, hasPatch: hasPatch}, nil
+}
+
+// Matches reports whether v satisfies c.
+func (c Constraint) Matches(v Version) bool {
+	// Pre-release filtering: Hex.pm only resolves pre-releases when the
+	// constraint itself references a pre-release version or the operator is ==.
+	// All other range operators treat pre-releases as invisible.
+	if v.Pre != "" {
+		switch c.op {
+		case "==":
+			// Exact match bypasses the filter.
+		default:
+			if c.version.Pre == "" {
+				return false
+			}
+		}
+	}
+	cmp := v.Compare(c.version)
+	switch c.op {
+	case "==":
+		return cmp == 0
+	case ">":
+		return cmp > 0
+	case ">=":
+		return cmp >= 0
+	case "<":
+		return cmp < 0
+	case "<=":
+		return cmp <= 0
+	case "~>":
+		// Pessimistic constraint:
+		//   ~> 2.1   -> >= 2.1.0 and < 3.0.0  (minor-compatible, no patch given)
+		//   ~> 2.1.3 -> >= 2.1.3 and < 2.2.0  (patch-compatible, patch given)
+		if cmp < 0 {
+			return false // v < constraint version
+		}
+		if !c.hasPatch {
+			// Minor-compatible: same major, any minor >= constraint.minor.
+			return v.Major == c.version.Major
+		}
+		// Patch-compatible: same major.minor, any patch >= constraint.patch.
+		return v.Major == c.version.Major && v.Minor == c.version.Minor
+	}
+	return false
+}
+
+// String renders the constraint back to its canonical form.
+func (c Constraint) String() string {
+	return c.op + " " + c.version.String()
+}
+
+// Requirements is a list of constraints that must all be satisfied (logical AND).
+type Requirements []Constraint
+
+// ParseRequirements parses a comma-separated list of constraints.
+// Example: ">= 2.0.0, < 3.0.0"
+func ParseRequirements(s string) (Requirements, error) {
+	parts := strings.Split(s, ",")
+	var reqs Requirements
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		c, err := ParseConstraint(p)
+		if err != nil {
+			return nil, err
+		}
+		reqs = append(reqs, c)
+	}
+	return reqs, nil
+}
+
+// Satisfies reports whether v satisfies all constraints in r.
+func (r Requirements) Satisfies(v Version) bool {
+	for _, c := range r {
+		if !c.Matches(v) {
+			return false
+		}
+	}
+	return true
+}
+
+// BestMatch returns the highest version from candidates that satisfies r.
+// Returns the zero Version and false if no candidate satisfies r.
+func (r Requirements) BestMatch(candidates []Version) (Version, bool) {
+	var best Version
+	found := false
+	for _, v := range candidates {
+		if r.Satisfies(v) {
+			if !found || v.Compare(best) > 0 {
+				best = v
+				found = true
+			}
+		}
+	}
+	return best, found
+}

--- a/package3/erlang/hexsemver/hexsemver_test.go
+++ b/package3/erlang/hexsemver/hexsemver_test.go
@@ -1,0 +1,262 @@
+package hexsemver
+
+import (
+	"testing"
+)
+
+func mustParseVersion(t *testing.T, s string) Version {
+	t.Helper()
+	v, err := ParseVersion(s)
+	if err != nil {
+		t.Fatalf("ParseVersion(%q): %v", s, err)
+	}
+	return v
+}
+
+func mustParseConstraint(t *testing.T, s string) Constraint {
+	t.Helper()
+	c, err := ParseConstraint(s)
+	if err != nil {
+		t.Fatalf("ParseConstraint(%q): %v", s, err)
+	}
+	return c
+}
+
+func TestParseVersion_Full(t *testing.T) {
+	v := mustParseVersion(t, "2.12.0")
+	if v.Major != 2 || v.Minor != 12 || v.Patch != 0 || v.Pre != "" {
+		t.Errorf("unexpected version: %+v", v)
+	}
+}
+
+func TestParseVersion_PreRelease(t *testing.T) {
+	v := mustParseVersion(t, "3.0.0-rc.2")
+	if v.Major != 3 || v.Minor != 0 || v.Patch != 0 || v.Pre != "rc.2" {
+		t.Errorf("unexpected version: %+v", v)
+	}
+}
+
+func TestParseVersion_TwoPart(t *testing.T) {
+	v := mustParseVersion(t, "2.1")
+	if v.Major != 2 || v.Minor != 1 || v.Patch != 0 {
+		t.Errorf("two-part parse: %+v", v)
+	}
+}
+
+func TestParseVersion_Invalid(t *testing.T) {
+	cases := []string{"", "1", "a.b.c", "1.2.3.4"}
+	for _, s := range cases {
+		if _, err := ParseVersion(s); err == nil {
+			t.Errorf("ParseVersion(%q) should fail", s)
+		}
+	}
+}
+
+func TestVersionString(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"2.12.0", "2.12.0"},
+		{"3.0.0-rc.2", "3.0.0-rc.2"},
+	}
+	for _, c := range cases {
+		v := mustParseVersion(t, c.in)
+		if got := v.String(); got != c.want {
+			t.Errorf("Version(%q).String() = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestVersionCompare(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0", "2.0.0", -1},
+		{"2.0.0", "1.0.0", 1},
+		{"2.1.0", "2.1.0", 0},
+		{"2.1.1", "2.1.0", 1},
+		{"2.1.0-rc.1", "2.1.0", -1}, // pre < release
+		{"2.1.0", "2.1.0-rc.1", 1},
+		{"2.1.0-rc.1", "2.1.0-rc.2", -1},
+	}
+	for _, c := range cases {
+		a := mustParseVersion(t, c.a)
+		b := mustParseVersion(t, c.b)
+		got := a.Compare(b)
+		if got != c.want {
+			t.Errorf("Compare(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestParseConstraint_AllOps(t *testing.T) {
+	ops := []string{"~>", ">=", "<=", ">", "<", "=="}
+	for _, op := range ops {
+		s := op + " 2.1.0"
+		c := mustParseConstraint(t, s)
+		if c.op != op {
+			t.Errorf("op mismatch: got %q, want %q", c.op, op)
+		}
+	}
+}
+
+func TestParseConstraint_BareVersion(t *testing.T) {
+	c := mustParseConstraint(t, "2.1.0")
+	if c.op != "==" {
+		t.Errorf("bare version should be == , got %q", c.op)
+	}
+}
+
+func TestConstraint_TildeGreater_WithPatch(t *testing.T) {
+	// ~> 2.1.3 means >= 2.1.3 and < 2.2.0
+	c := mustParseConstraint(t, "~> 2.1.3")
+	cases := []struct {
+		v    string
+		want bool
+	}{
+		{"2.1.3", true},
+		{"2.1.9", true},
+		{"2.2.0", false},
+		{"2.0.9", false},
+		{"3.0.0", false},
+		{"2.1.2", false},
+	}
+	for _, tc := range cases {
+		v := mustParseVersion(t, tc.v)
+		if got := c.Matches(v); got != tc.want {
+			t.Errorf("~> 2.1.3 matches(%q) = %v, want %v", tc.v, got, tc.want)
+		}
+	}
+}
+
+func TestConstraint_TildeGreater_NoPatch(t *testing.T) {
+	// ~> 2.1 means >= 2.1.0 and < 3.0.0
+	c := mustParseConstraint(t, "~> 2.1")
+	cases := []struct {
+		v    string
+		want bool
+	}{
+		{"2.1.0", true},
+		{"2.9.9", true},
+		{"3.0.0", false},
+		{"2.0.9", false},
+		{"1.9.9", false},
+	}
+	for _, tc := range cases {
+		v := mustParseVersion(t, tc.v)
+		if got := c.Matches(v); got != tc.want {
+			t.Errorf("~> 2.1 matches(%q) = %v, want %v", tc.v, got, tc.want)
+		}
+	}
+}
+
+func TestConstraint_ExactMatch(t *testing.T) {
+	c := mustParseConstraint(t, "== 2.1.0")
+	if !c.Matches(mustParseVersion(t, "2.1.0")) {
+		t.Error("== 2.1.0 should match 2.1.0")
+	}
+	if c.Matches(mustParseVersion(t, "2.1.1")) {
+		t.Error("== 2.1.0 should not match 2.1.1")
+	}
+}
+
+func TestConstraint_Range(t *testing.T) {
+	ge := mustParseConstraint(t, ">= 2.0.0")
+	lt := mustParseConstraint(t, "< 3.0.0")
+	cases := []struct {
+		v    string
+		geWant bool
+		ltWant bool
+	}{
+		{"1.9.9", false, true},
+		{"2.0.0", true, true},
+		{"2.5.3", true, true},
+		{"3.0.0", true, false},
+		{"3.0.1", true, false},
+	}
+	for _, tc := range cases {
+		v := mustParseVersion(t, tc.v)
+		if got := ge.Matches(v); got != tc.geWant {
+			t.Errorf(">= 2.0.0 matches(%q) = %v, want %v", tc.v, got, tc.geWant)
+		}
+		if got := lt.Matches(v); got != tc.ltWant {
+			t.Errorf("< 3.0.0 matches(%q) = %v, want %v", tc.v, got, tc.ltWant)
+		}
+	}
+}
+
+func TestConstraint_PreRelease_Filtering(t *testing.T) {
+	// Hex.pm: range constraints only include pre-releases when the constraint
+	// itself has a pre-release tag. Plain >= 2.0.0 hides all pre-releases.
+	c := mustParseConstraint(t, ">= 2.0.0")
+	for _, s := range []string{"2.0.0-rc.1", "2.1.0-rc.1", "3.0.0-alpha.1"} {
+		v := mustParseVersion(t, s)
+		if c.Matches(v) {
+			t.Errorf(">= 2.0.0 should NOT match pre-release %q", s)
+		}
+	}
+	// A constraint that itself has a pre-release does pass through.
+	cPre := mustParseConstraint(t, ">= 2.0.0-rc.1")
+	if !cPre.Matches(mustParseVersion(t, "2.0.0-rc.2")) {
+		t.Error(">= 2.0.0-rc.1 should match 2.0.0-rc.2")
+	}
+	// Exact match is always allowed.
+	cExact := mustParseConstraint(t, "== 2.0.0-rc.1")
+	if !cExact.Matches(mustParseVersion(t, "2.0.0-rc.1")) {
+		t.Error("== 2.0.0-rc.1 should match 2.0.0-rc.1")
+	}
+}
+
+func TestRequirements_Satisfies(t *testing.T) {
+	reqs, err := ParseRequirements(">= 2.0.0, < 3.0.0")
+	if err != nil {
+		t.Fatalf("ParseRequirements: %v", err)
+	}
+	if !reqs.Satisfies(mustParseVersion(t, "2.5.0")) {
+		t.Error("2.5.0 should satisfy >= 2.0.0, < 3.0.0")
+	}
+	if reqs.Satisfies(mustParseVersion(t, "3.0.0")) {
+		t.Error("3.0.0 should not satisfy >= 2.0.0, < 3.0.0")
+	}
+	if reqs.Satisfies(mustParseVersion(t, "1.9.9")) {
+		t.Error("1.9.9 should not satisfy >= 2.0.0, < 3.0.0")
+	}
+}
+
+func TestRequirements_BestMatch(t *testing.T) {
+	reqs, _ := ParseRequirements("~> 2.1")
+	candidates := []Version{
+		mustParseVersion(t, "2.0.0"),
+		mustParseVersion(t, "2.1.0"),
+		mustParseVersion(t, "2.3.5"),
+		mustParseVersion(t, "3.0.0"),
+	}
+	best, ok := reqs.BestMatch(candidates)
+	if !ok {
+		t.Fatal("BestMatch should find a match")
+	}
+	if best.String() != "2.3.5" {
+		t.Errorf("BestMatch = %q, want 2.3.5", best.String())
+	}
+}
+
+func TestRequirements_BestMatch_None(t *testing.T) {
+	reqs, _ := ParseRequirements("~> 5.0")
+	candidates := []Version{
+		mustParseVersion(t, "2.0.0"),
+		mustParseVersion(t, "3.0.0"),
+	}
+	_, ok := reqs.BestMatch(candidates)
+	if ok {
+		t.Error("BestMatch should return false when no candidates satisfy")
+	}
+}
+
+func TestConstraintString(t *testing.T) {
+	c := mustParseConstraint(t, "~> 2.1.3")
+	if c.String() != "~> 2.1.3" {
+		t.Errorf("Constraint.String() = %q, want %q", c.String(), "~> 2.1.3")
+	}
+}

--- a/website/docs/implementation/0066/index.md
+++ b/website/docs/implementation/0066/index.md
@@ -15,8 +15,8 @@ A phase is LANDED only when its gate is green for every target in the runtime ma
 
 | Phase | Title | Status | Commit | Tracking page |
 |-------|-------|--------|--------|---------------|
-| 0 | Skeleton: package3/erlang/ layout + rebar3 workspace plumbing | IN PROGRESS | — | [phase-00](/docs/implementation/0066/phase-00-skeleton) |
-| 1 | Hex.pm API v2 client (package fetch + outer/inner tarball + SHA-256/SHA-512 verify) | NOT STARTED | — | [phase-01](/docs/implementation/0066/phase-01-hex-index) |
+| 0 | Skeleton: package3/erlang/ layout + rebar3 workspace plumbing | LANDED | 3b9fe10 | [phase-00](/docs/implementation/0066/phase-00-skeleton) |
+| 1 | Hex.pm API v2 client (package fetch + outer/inner tarball + SHA-256/SHA-512 verify) | IN PROGRESS | — | [phase-01](/docs/implementation/0066/phase-01-hex-index) |
 | 2 | BEAM abstract code ingest (Dbgi/Abst chunk ETF decoder, -spec/-type walker) | NOT STARTED | — | [phase-02](/docs/implementation/0066/phase-02-beam-ingest) |
 | 3 | EDoc XML fallback ingest (for packages with no -spec directives) | NOT STARTED | — | [phase-03](/docs/implementation/0066/phase-03-edoc-fallback) |
 | 4 | Dialyzer typespec-to-Mochi type mapping + SkipReport emit | NOT STARTED | — | [phase-04](/docs/implementation/0066/phase-04-type-mapping) |


### PR DESCRIPTION
Closes #22845

## Summary

- `package3/erlang/hexsemver/` — Hex.pm SemVer constraint language: `~>` (minor/patch-compatible), `>=`, `<=`, `>`, `<`, `==`, bare version. Pre-release filtering matches Hex.pm semantics (hidden unless constraint itself has a pre-release tag or op is `==`). BestMatch finds highest satisfying version.
- `package3/erlang/hexindex/` — HTTP API v2 client: package metadata fetch, tarball download + outer/inner extract, outer SHA-256 + inner SHA-256/SHA-512 verification, content-addressed cache, NoCache bypass.

## Test plan

- [x] `go test ./package3/erlang/hexsemver/` — 24 tests
- [x] `go test ./package3/erlang/hexindex/` — 17 tests (mock httptest server, no network)
- [x] `go test ./package3/erlang/...` — all 5 packages pass