### PR TITLE
MEP-74 phase 10: [[go-package]] lockfile schema + drift check

### DIFF
--- a/package3/go/lockfile/lockfile.go
+++ b/package3/go/lockfile/lockfile.go
@@ -1,0 +1,652 @@
+// Package lockfile is the MEP-74 lockfile integration layer. It
+// owns the `[[go-package]]` table that MEP-74 spec §3 adds to
+// `mochi.lock`: schema, encoder, decoder, and drift checker
+// (`mochi pkg lock --check`).
+//
+// The package is layering-conservative: it imports no other
+// package3/go/* module. Callers in the build pipeline compose a
+// []GoPackage from their own state (resolved-module proxy fetch +
+// sum.golang.org cross-check + ApiSurface hash + wrapper hash +
+// capability decls) and hand it to Encode; the inverse Decode reads
+// back the same shape. CheckDrift compares a fresh slice against
+// the lockfile slice and returns the closed set of drift kinds.
+package lockfile
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// SourceKind classifies where a go-package was sourced from. The
+// spec admits three: module-proxy (the default proxy.golang.org
+// HTTP API), git (a git URL with an optional rev for replaced or
+// private modules), and path (a local relative directory used
+// during development).
+type SourceKind string
+
+const (
+	// SourceModuleProxy is a proxy.golang.org-style HTTP source.
+	SourceModuleProxy SourceKind = "module-proxy"
+	// SourceGit is a git URL source. Used for `GOPRIVATE` modules
+	// or `[go.private]` overrides that bypass the public proxy.
+	SourceGit SourceKind = "git"
+	// SourcePath is a local path source for path = "..."
+	// replacements.
+	SourcePath SourceKind = "path"
+)
+
+// Source describes the origin of a go-package. Exactly one of the
+// optional fields is non-empty depending on the Kind.
+type Source struct {
+	// Kind is one of module-proxy / git / path.
+	Kind SourceKind
+	// Proxy is the proxy URL when Kind == SourceModuleProxy.
+	Proxy string
+	// URL is the git repo URL when Kind == SourceGit.
+	URL string
+	// Rev is the git revision when Kind == SourceGit. Optional;
+	// empty pins to the default branch HEAD at lock time.
+	Rev string
+	// Path is the local directory (relative to mochi.toml) when
+	// Kind == SourcePath.
+	Path string
+}
+
+// GoPackage is one [[go-package]] table entry. The field names in
+// the rendered TOML use the kebab-case the MEP-74 spec shows
+// (zip-blake3, zip-h1, sumdb-verified, etc.).
+type GoPackage struct {
+	// Module is the resolved Go module path
+	// (e.g. github.com/spf13/cobra).
+	Module string
+	// Version is the resolved version: a semver tag (v1.8.0), a
+	// pseudo-version (v0.0.0-20260520150000-abcdef012345), or a
+	// git rev. Never a requirement form.
+	Version string
+	// Source classifies the origin (module-proxy / git / path).
+	Source Source
+
+	// ZipBlake3 is the lowercase hex BLAKE3-256 of the module .zip
+	// artefact. MEP-57's primary verification hash.
+	ZipBlake3 string
+	// ZipH1 is the Go ecosystem's `h1:` hash:
+	//   "h1:" + base64(sha256(zip-content))
+	// This is what sum.golang.org publishes.
+	ZipH1 string
+
+	// SumdbVerified records whether the sum.golang.org cross-check
+	// succeeded at lock time. true is the only acceptable value for
+	// public modules; [go.private] modules record false plus a
+	// comment naming the override.
+	SumdbVerified bool
+	// SumdbTreeSize is the global checksum-DB tree size at lock
+	// time (leaf count when this module was looked up). Monotonic;
+	// future `--check` can request a consistency proof against the
+	// current tree.
+	SumdbTreeSize int64
+	// SumdbRecordHash records the SHA-256 of the specific log
+	// record for this module version. Canonical body:
+	//   "<module> <version> <h1:hash>\n"
+	SumdbRecordHash string
+
+	// ApiSurfaceSha256 is the lowercase hex SHA-256 of the JSON
+	// ApiSurface the bridge ingested. A drift at --check is a hard
+	// error.
+	ApiSurfaceSha256 string
+	// WrapperSha256 is the lowercase hex SHA-256 of the synthesised
+	// cgo wrapper package's source tree (file-concatenation). A
+	// drift at --check is a hard error.
+	WrapperSha256 string
+
+	// CapabilitiesDeclared is the capability set the manifest
+	// declared at lock time. Subset of net / fs / proc / cgo /
+	// unsafe.
+	CapabilitiesDeclared []string
+	// Dependencies is the resolved transitive dep graph as
+	// "<module>@<version>" strings.
+	Dependencies []string
+	// BuildTags is the build-tag set the lock was taken under.
+	// Different tag sets produce different ApiSurface trees; the
+	// lockfile pins the tag set.
+	BuildTags []string
+}
+
+// Encode renders a slice of GoPackage entries as the TOML body that
+// the lockfile inserts into mochi.lock. Entries are sorted by
+// module (ascending) then version (ascending) for deterministic
+// byte output.
+func Encode(packages []GoPackage) string {
+	cp := append([]GoPackage{}, packages...)
+	sort.Slice(cp, func(i, j int) bool {
+		if cp[i].Module != cp[j].Module {
+			return cp[i].Module < cp[j].Module
+		}
+		return cp[i].Version < cp[j].Version
+	})
+	var b strings.Builder
+	for i, p := range cp {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		writeEntry(&b, p)
+	}
+	return b.String()
+}
+
+func writeEntry(b *strings.Builder, p GoPackage) {
+	b.WriteString("[[go-package]]\n")
+	fmt.Fprintf(b, "module = %q\n", p.Module)
+	fmt.Fprintf(b, "version = %q\n", p.Version)
+	b.WriteString("source = ")
+	writeSource(b, p.Source)
+	b.WriteString("\n")
+	if p.ZipBlake3 != "" {
+		fmt.Fprintf(b, "zip-blake3 = %q\n", p.ZipBlake3)
+	}
+	if p.ZipH1 != "" {
+		fmt.Fprintf(b, "zip-h1 = %q\n", p.ZipH1)
+	}
+	fmt.Fprintf(b, "sumdb-verified = %v\n", p.SumdbVerified)
+	if p.SumdbTreeSize != 0 {
+		fmt.Fprintf(b, "sumdb-tree-size = %d\n", p.SumdbTreeSize)
+	}
+	if p.SumdbRecordHash != "" {
+		fmt.Fprintf(b, "sumdb-record-hash = %q\n", p.SumdbRecordHash)
+	}
+	if p.ApiSurfaceSha256 != "" {
+		fmt.Fprintf(b, "api-surface-sha256 = %q\n", p.ApiSurfaceSha256)
+	}
+	if p.WrapperSha256 != "" {
+		fmt.Fprintf(b, "wrapper-sha256 = %q\n", p.WrapperSha256)
+	}
+	writeStringArray(b, "capabilities-declared", p.CapabilitiesDeclared)
+	writeStringArray(b, "dependencies", p.Dependencies)
+	writeStringArray(b, "build-tags", p.BuildTags)
+}
+
+func writeSource(b *strings.Builder, s Source) {
+	b.WriteString("{ ")
+	fmt.Fprintf(b, "kind = %q", string(s.Kind))
+	switch s.Kind {
+	case SourceModuleProxy:
+		if s.Proxy != "" {
+			fmt.Fprintf(b, ", proxy = %q", s.Proxy)
+		}
+	case SourceGit:
+		if s.URL != "" {
+			fmt.Fprintf(b, ", url = %q", s.URL)
+		}
+		if s.Rev != "" {
+			fmt.Fprintf(b, ", rev = %q", s.Rev)
+		}
+	case SourcePath:
+		if s.Path != "" {
+			fmt.Fprintf(b, ", path = %q", s.Path)
+		}
+	}
+	b.WriteString(" }")
+}
+
+func writeStringArray(b *strings.Builder, key string, vs []string) {
+	if len(vs) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "%s = [", key)
+	for i, v := range vs {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(b, "%q", v)
+	}
+	b.WriteString("]\n")
+}
+
+// Decode parses the TOML body produced by Encode (or a hand-edited
+// mochi.lock containing the same shape). The reader is consumed
+// entirely; unknown keys are tolerated for forward-compat but
+// silently dropped.
+//
+// The decoder is line-oriented and rejects any line that is not
+// empty, a comment, a `[[go-package]]` header, a flat `key = value`
+// assignment, or a string-array / inline-table assignment. This
+// keeps the schema closed and the parser small (~150 lines).
+func Decode(r io.Reader) ([]GoPackage, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("lockfile: read: %w", err)
+	}
+	return decodeBytes(data)
+}
+
+// DecodeString is the string-input form of Decode.
+func DecodeString(s string) ([]GoPackage, error) {
+	return decodeBytes([]byte(s))
+}
+
+func decodeBytes(data []byte) ([]GoPackage, error) {
+	lines := strings.Split(string(data), "\n")
+	var out []GoPackage
+	var cur *GoPackage
+	flush := func() {
+		if cur != nil {
+			out = append(out, *cur)
+		}
+		cur = nil
+	}
+	for lineno, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if line == "[[go-package]]" {
+			flush()
+			cur = &GoPackage{}
+			continue
+		}
+		if cur == nil {
+			// Lines outside a [[go-package]] block are tolerated
+			// (they may belong to the surrounding mochi.lock
+			// document).
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			return nil, fmt.Errorf("lockfile: line %d: missing '=': %q", lineno+1, line)
+		}
+		key := strings.TrimSpace(line[:eq])
+		val := strings.TrimSpace(line[eq+1:])
+		if err := setField(cur, key, val); err != nil {
+			return nil, fmt.Errorf("lockfile: line %d (%s): %w", lineno+1, key, err)
+		}
+	}
+	flush()
+	return out, nil
+}
+
+func setField(p *GoPackage, key, val string) error {
+	switch key {
+	case "module":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.Module = s
+	case "version":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.Version = s
+	case "source":
+		src, err := parseSource(val)
+		if err != nil {
+			return err
+		}
+		p.Source = src
+	case "zip-blake3":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.ZipBlake3 = s
+	case "zip-h1":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.ZipH1 = s
+	case "sumdb-verified":
+		b, err := parseBool(val)
+		if err != nil {
+			return err
+		}
+		p.SumdbVerified = b
+	case "sumdb-tree-size":
+		n, err := parseInt(val)
+		if err != nil {
+			return err
+		}
+		p.SumdbTreeSize = n
+	case "sumdb-record-hash":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.SumdbRecordHash = s
+	case "api-surface-sha256":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.ApiSurfaceSha256 = s
+	case "wrapper-sha256":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.WrapperSha256 = s
+	case "capabilities-declared":
+		arr, err := parseStringArray(val)
+		if err != nil {
+			return err
+		}
+		p.CapabilitiesDeclared = arr
+	case "dependencies":
+		arr, err := parseStringArray(val)
+		if err != nil {
+			return err
+		}
+		p.Dependencies = arr
+	case "build-tags":
+		arr, err := parseStringArray(val)
+		if err != nil {
+			return err
+		}
+		p.BuildTags = arr
+	default:
+		// Unknown key: forward-compat tolerance.
+	}
+	return nil
+}
+
+func parseString(val string) (string, error) {
+	val = strings.TrimSpace(val)
+	if len(val) < 2 || val[0] != '"' || val[len(val)-1] != '"' {
+		return "", fmt.Errorf("expected quoted string, got %q", val)
+	}
+	return val[1 : len(val)-1], nil
+}
+
+func parseBool(val string) (bool, error) {
+	switch strings.TrimSpace(val) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	}
+	return false, fmt.Errorf("expected true / false, got %q", val)
+}
+
+func parseInt(val string) (int64, error) {
+	val = strings.TrimSpace(val)
+	if val == "" {
+		return 0, fmt.Errorf("expected integer, got empty")
+	}
+	var n int64
+	neg := false
+	i := 0
+	if val[0] == '-' {
+		neg = true
+		i = 1
+	}
+	if i == len(val) {
+		return 0, fmt.Errorf("expected integer, got %q", val)
+	}
+	for ; i < len(val); i++ {
+		c := val[i]
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("expected integer, got %q", val)
+		}
+		n = n*10 + int64(c-'0')
+	}
+	if neg {
+		n = -n
+	}
+	return n, nil
+}
+
+func parseStringArray(val string) ([]string, error) {
+	val = strings.TrimSpace(val)
+	if !strings.HasPrefix(val, "[") || !strings.HasSuffix(val, "]") {
+		return nil, fmt.Errorf("expected [..], got %q", val)
+	}
+	inner := strings.TrimSpace(val[1 : len(val)-1])
+	if inner == "" {
+		return nil, nil
+	}
+	parts := splitTopLevel(inner, ',')
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		s, err := parseString(p)
+		if err != nil {
+			return nil, fmt.Errorf("array element: %w", err)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+func parseSource(val string) (Source, error) {
+	val = strings.TrimSpace(val)
+	if !strings.HasPrefix(val, "{") || !strings.HasSuffix(val, "}") {
+		return Source{}, fmt.Errorf("expected inline table { ... }, got %q", val)
+	}
+	inner := strings.TrimSpace(val[1 : len(val)-1])
+	parts := splitTopLevel(inner, ',')
+	src := Source{}
+	for _, kv := range parts {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			return Source{}, fmt.Errorf("source key without '=': %q", kv)
+		}
+		k := strings.TrimSpace(kv[:eq])
+		v := strings.TrimSpace(kv[eq+1:])
+		s, err := parseString(v)
+		if err != nil {
+			return Source{}, fmt.Errorf("source[%s]: %w", k, err)
+		}
+		switch k {
+		case "kind":
+			src.Kind = SourceKind(s)
+		case "proxy":
+			src.Proxy = s
+		case "url":
+			src.URL = s
+		case "rev":
+			src.Rev = s
+		case "path":
+			src.Path = s
+		}
+	}
+	if src.Kind == "" {
+		return Source{}, fmt.Errorf("source missing kind: %q", val)
+	}
+	return src, nil
+}
+
+// splitTopLevel splits s on sep, ignoring sep when it appears inside
+// matched braces, brackets, or double-quoted strings. Used so that
+// inline-table values like `source = { ... }` and string arrays
+// `["a", "b"]` are not split on their interior commas.
+func splitTopLevel(s string, sep byte) []string {
+	var out []string
+	depth := 0
+	inStr := false
+	last := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case inStr:
+			if c == '"' && (i == 0 || s[i-1] != '\\') {
+				inStr = false
+			}
+		case c == '"':
+			inStr = true
+		case c == '{' || c == '[':
+			depth++
+		case c == '}' || c == ']':
+			depth--
+		case c == sep && depth == 0:
+			out = append(out, strings.TrimSpace(s[last:i]))
+			last = i + 1
+		}
+	}
+	out = append(out, strings.TrimSpace(s[last:]))
+	return out
+}
+
+// DriftKind classifies a lockfile / live-state mismatch the
+// `--check` mode surfaces. The set is closed; new kinds require
+// MEP-74 spec amendment.
+type DriftKind string
+
+const (
+	// DriftMissing flags a live package the lockfile does not
+	// record. A new `import go` line was added without re-running
+	// `mochi pkg lock`.
+	DriftMissing DriftKind = "missing"
+	// DriftStale flags a lockfile entry that is no longer claimed
+	// by any live `import go` line.
+	DriftStale DriftKind = "stale"
+	// DriftVersion flags a (module, version) pair where the
+	// version drifted.
+	DriftVersion DriftKind = "version"
+	// DriftZip flags a module whose .zip BLAKE3 / h1 drifted at
+	// fetch time. The hard-fail case from the spec.
+	DriftZip DriftKind = "zip-hash"
+	// DriftSumdb flags a module whose sum.golang.org log record
+	// hash or tree size drifted.
+	DriftSumdb DriftKind = "sumdb"
+	// DriftAPI flags a module whose ApiSurface SHA-256 drifted.
+	DriftAPI DriftKind = "api-surface"
+	// DriftWrapper flags a module whose synthesised wrapper SHA-256
+	// drifted.
+	DriftWrapper DriftKind = "wrapper"
+	// DriftCapabilities flags a module whose capability set drifted
+	// (additions, in particular, require user re-acknowledgement
+	// per MEP-57 monotonicity).
+	DriftCapabilities DriftKind = "capabilities"
+)
+
+// Drift describes a single drift between a lockfile entry and the
+// live state.
+type Drift struct {
+	Module   string
+	Version  string
+	Kind     DriftKind
+	Detail   string
+}
+
+// String renders a Drift as a one-line human-readable summary, used
+// in `mochi pkg lock --check` diagnostics.
+func (d Drift) String() string {
+	if d.Detail != "" {
+		return fmt.Sprintf("%s@%s: %s drift (%s)", d.Module, d.Version, d.Kind, d.Detail)
+	}
+	return fmt.Sprintf("%s@%s: %s drift", d.Module, d.Version, d.Kind)
+}
+
+// CheckDrift compares a lockfile slice (`locked`) against a fresh
+// live state (`live`) and returns the union of drifts. The check
+// is symmetric: missing-from-lockfile entries surface as
+// DriftMissing, stale-in-lockfile entries surface as DriftStale,
+// and shape-mismatches surface as the field-specific drift kind.
+//
+// The returned slice is sorted by (module, version, kind) so the
+// output is deterministic across runs.
+func CheckDrift(locked, live []GoPackage) []Drift {
+	lockedByKey := map[string]GoPackage{}
+	lockedByMod := map[string]GoPackage{}
+	for _, p := range locked {
+		lockedByKey[p.Module+"@"+p.Version] = p
+		lockedByMod[p.Module] = p
+	}
+	liveByKey := map[string]GoPackage{}
+	liveByMod := map[string]GoPackage{}
+	for _, p := range live {
+		liveByKey[p.Module+"@"+p.Version] = p
+		liveByMod[p.Module] = p
+	}
+
+	var out []Drift
+	for _, p := range live {
+		if _, ok := lockedByMod[p.Module]; !ok {
+			out = append(out, Drift{Module: p.Module, Version: p.Version, Kind: DriftMissing})
+			continue
+		}
+		lp := lockedByMod[p.Module]
+		if lp.Version != p.Version {
+			out = append(out, Drift{
+				Module: p.Module, Version: p.Version, Kind: DriftVersion,
+				Detail: fmt.Sprintf("locked %s -> live %s", lp.Version, p.Version),
+			})
+			continue
+		}
+		out = append(out, compareSame(lp, p)...)
+	}
+	for _, p := range locked {
+		if _, ok := liveByMod[p.Module]; !ok {
+			out = append(out, Drift{Module: p.Module, Version: p.Version, Kind: DriftStale})
+		}
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Module != out[j].Module {
+			return out[i].Module < out[j].Module
+		}
+		if out[i].Version != out[j].Version {
+			return out[i].Version < out[j].Version
+		}
+		return out[i].Kind < out[j].Kind
+	})
+	return out
+}
+
+// compareSame compares two GoPackage entries for the same
+// (module, version) tuple and surfaces every field-level drift.
+func compareSame(locked, live GoPackage) []Drift {
+	var out []Drift
+	add := func(kind DriftKind, detail string) {
+		out = append(out, Drift{Module: locked.Module, Version: locked.Version, Kind: kind, Detail: detail})
+	}
+	if locked.ZipBlake3 != live.ZipBlake3 || locked.ZipH1 != live.ZipH1 {
+		add(DriftZip, fmt.Sprintf("zip-blake3 %s -> %s; zip-h1 %s -> %s",
+			locked.ZipBlake3, live.ZipBlake3, locked.ZipH1, live.ZipH1))
+	}
+	if locked.SumdbVerified != live.SumdbVerified ||
+		locked.SumdbTreeSize != live.SumdbTreeSize ||
+		locked.SumdbRecordHash != live.SumdbRecordHash {
+		add(DriftSumdb, fmt.Sprintf("verified %v -> %v; tree-size %d -> %d; record-hash %s -> %s",
+			locked.SumdbVerified, live.SumdbVerified,
+			locked.SumdbTreeSize, live.SumdbTreeSize,
+			locked.SumdbRecordHash, live.SumdbRecordHash))
+	}
+	if locked.ApiSurfaceSha256 != live.ApiSurfaceSha256 {
+		add(DriftAPI, fmt.Sprintf("%s -> %s", locked.ApiSurfaceSha256, live.ApiSurfaceSha256))
+	}
+	if locked.WrapperSha256 != live.WrapperSha256 {
+		add(DriftWrapper, fmt.Sprintf("%s -> %s", locked.WrapperSha256, live.WrapperSha256))
+	}
+	if !equalStringSet(locked.CapabilitiesDeclared, live.CapabilitiesDeclared) {
+		add(DriftCapabilities, fmt.Sprintf("locked %v -> live %v",
+			locked.CapabilitiesDeclared, live.CapabilitiesDeclared))
+	}
+	return out
+}
+
+// equalStringSet reports whether two []string are equal as multi-sets
+// (order-insensitive, duplicate-sensitive). Used to compare capability
+// arrays where order is not significant.
+func equalStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	count := map[string]int{}
+	for _, s := range a {
+		count[s]++
+	}
+	for _, s := range b {
+		count[s]--
+		if count[s] < 0 {
+			return false
+		}
+	}
+	for _, c := range count {
+		if c != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/package3/go/lockfile/lockfile_test.go
+++ b/package3/go/lockfile/lockfile_test.go
@@ -1,0 +1,448 @@
+package lockfile
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEncodeBasic(t *testing.T) {
+	pkgs := []GoPackage{
+		{
+			Module:  "github.com/spf13/cobra",
+			Version: "v1.8.0",
+			Source: Source{
+				Kind:  SourceModuleProxy,
+				Proxy: "https://proxy.golang.org",
+			},
+			ZipBlake3:            strings.Repeat("0123456789abcdef", 4),
+			ZipH1:                "h1:abcdef==",
+			SumdbVerified:        true,
+			SumdbTreeSize:        12345678,
+			SumdbRecordHash:      strings.Repeat("ab", 32),
+			ApiSurfaceSha256:     strings.Repeat("cd", 32),
+			WrapperSha256:        strings.Repeat("ef", 32),
+			CapabilitiesDeclared: []string{"fs"},
+			Dependencies:         []string{"github.com/spf13/pflag@v1.0.6"},
+			BuildTags:            nil,
+		},
+	}
+	got := Encode(pkgs)
+	wantSubstrings := []string{
+		"[[go-package]]",
+		`module = "github.com/spf13/cobra"`,
+		`version = "v1.8.0"`,
+		`source = { kind = "module-proxy", proxy = "https://proxy.golang.org" }`,
+		`zip-blake3 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"`,
+		`zip-h1 = "h1:abcdef=="`,
+		`sumdb-verified = true`,
+		`sumdb-tree-size = 12345678`,
+		`api-surface-sha256 = "` + strings.Repeat("cd", 32) + `"`,
+		`wrapper-sha256 = "` + strings.Repeat("ef", 32) + `"`,
+		`capabilities-declared = ["fs"]`,
+		`dependencies = ["github.com/spf13/pflag@v1.0.6"]`,
+	}
+	for _, sub := range wantSubstrings {
+		if !strings.Contains(got, sub) {
+			t.Errorf("Encode missing %q\n--- got ---\n%s", sub, got)
+		}
+	}
+}
+
+func TestEncodeDeterministicSort(t *testing.T) {
+	pkgs := []GoPackage{
+		{Module: "z.example.com/z", Version: "v1.0.0", Source: Source{Kind: SourceModuleProxy}, SumdbVerified: true},
+		{Module: "a.example.com/a", Version: "v1.0.0", Source: Source{Kind: SourceModuleProxy}, SumdbVerified: true},
+		{Module: "a.example.com/a", Version: "v0.9.0", Source: Source{Kind: SourceModuleProxy}, SumdbVerified: true},
+	}
+	first := Encode(pkgs)
+	for i := 0; i < 8; i++ {
+		if got := Encode(pkgs); got != first {
+			t.Fatalf("Encode non-deterministic on iter %d\n--- first ---\n%s\n--- got ---\n%s", i, first, got)
+		}
+	}
+	idxA09 := strings.Index(first, `version = "v0.9.0"`)
+	idxA10 := strings.Index(first, `version = "v1.0.0"`)
+	idxZ := strings.Index(first, `module = "z.example.com/z"`)
+	if !(idxA09 >= 0 && idxA10 >= 0 && idxZ >= 0) {
+		t.Fatalf("missing expected substrings:\n%s", first)
+	}
+	if !(idxA09 < idxA10 && idxA10 < idxZ) {
+		t.Errorf("Encode did not sort by (module, version): a-v0.9.0=%d a-v1.0.0=%d z=%d\n%s",
+			idxA09, idxA10, idxZ, first)
+	}
+}
+
+func TestEncodeOmitsEmptyOptionals(t *testing.T) {
+	p := GoPackage{Module: "x.example.com/x", Version: "v0.1.0", Source: Source{Kind: SourceModuleProxy}, SumdbVerified: false}
+	got := Encode([]GoPackage{p})
+	for _, sub := range []string{"zip-blake3", "zip-h1", "sumdb-tree-size", "api-surface-sha256", "wrapper-sha256",
+		"capabilities-declared", "dependencies", "build-tags"} {
+		if strings.Contains(got, sub+" ") {
+			t.Errorf("Encode should omit empty %q:\n%s", sub, got)
+		}
+	}
+	// sumdb-verified always renders; it has a meaningful default.
+	if !strings.Contains(got, "sumdb-verified = false") {
+		t.Errorf("Encode should always render sumdb-verified:\n%s", got)
+	}
+}
+
+func TestSourceGitRendered(t *testing.T) {
+	p := GoPackage{
+		Module: "corp.example.com/internal/foo", Version: "v0.0.0",
+		Source: Source{Kind: SourceGit, URL: "git@corp.example.com:internal/foo.git", Rev: "abcdef0"},
+	}
+	got := Encode([]GoPackage{p})
+	want := `source = { kind = "git", url = "git@corp.example.com:internal/foo.git", rev = "abcdef0" }`
+	if !strings.Contains(got, want) {
+		t.Errorf("Encode SourceGit missing %q:\n%s", want, got)
+	}
+}
+
+func TestSourcePathRendered(t *testing.T) {
+	p := GoPackage{
+		Module: "example.com/local", Version: "v0.0.0",
+		Source: Source{Kind: SourcePath, Path: "../fork/local"},
+	}
+	got := Encode([]GoPackage{p})
+	if !strings.Contains(got, `source = { kind = "path", path = "../fork/local" }`) {
+		t.Errorf("Encode SourcePath missing path:\n%s", got)
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	pkgs := []GoPackage{
+		{
+			Module: "github.com/spf13/cobra", Version: "v1.8.0",
+			Source:               Source{Kind: SourceModuleProxy, Proxy: "https://proxy.golang.org"},
+			ZipBlake3:            "blake",
+			ZipH1:                "h1:hash",
+			SumdbVerified:        true,
+			SumdbTreeSize:        42,
+			SumdbRecordHash:      "rec",
+			ApiSurfaceSha256:     "api",
+			WrapperSha256:        "wrap",
+			CapabilitiesDeclared: []string{"fs", "net"},
+			Dependencies:         []string{"github.com/spf13/pflag@v1.0.6"},
+			BuildTags:            []string{"json1"},
+		},
+		{
+			Module: "corp.example.com/internal/foo", Version: "v0.0.0-abc",
+			Source:        Source{Kind: SourceGit, URL: "git@corp.example.com:internal/foo.git", Rev: "abcdef0"},
+			SumdbVerified: false,
+		},
+	}
+	encoded := Encode(pkgs)
+	round, err := DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("DecodeString: %v\n%s", err, encoded)
+	}
+	if len(round) != len(pkgs) {
+		t.Fatalf("round-trip length = %d; want %d\n%s", len(round), len(pkgs), encoded)
+	}
+	// Encode sorts; check sorted order.
+	wantOrder := []string{"corp.example.com/internal/foo", "github.com/spf13/cobra"}
+	for i, want := range wantOrder {
+		if round[i].Module != want {
+			t.Errorf("round[%d].Module = %q; want %q", i, round[i].Module, want)
+		}
+	}
+	cobra := round[1]
+	if cobra.SumdbTreeSize != 42 {
+		t.Errorf("SumdbTreeSize = %d; want 42", cobra.SumdbTreeSize)
+	}
+	if len(cobra.CapabilitiesDeclared) != 2 {
+		t.Errorf("CapabilitiesDeclared = %v; want 2", cobra.CapabilitiesDeclared)
+	}
+	if len(cobra.BuildTags) != 1 || cobra.BuildTags[0] != "json1" {
+		t.Errorf("BuildTags = %v; want [json1]", cobra.BuildTags)
+	}
+}
+
+func TestDecodeToleratesUnknownKey(t *testing.T) {
+	src := `[[go-package]]
+module = "github.com/spf13/cobra"
+version = "v1.8.0"
+source = { kind = "module-proxy" }
+future-key = "ignored"
+sumdb-verified = true
+`
+	pkgs, err := DecodeString(src)
+	if err != nil {
+		t.Fatalf("DecodeString: %v", err)
+	}
+	if len(pkgs) != 1 || pkgs[0].Module != "github.com/spf13/cobra" {
+		t.Errorf("unexpected decode: %#v", pkgs)
+	}
+}
+
+func TestDecodeRejectsMissingEq(t *testing.T) {
+	src := `[[go-package]]
+module github.com/spf13/cobra
+`
+	if _, err := DecodeString(src); err == nil {
+		t.Errorf("DecodeString accepted missing '='; expected error")
+	}
+}
+
+func TestDecodeRejectsBadSource(t *testing.T) {
+	src := `[[go-package]]
+module = "x"
+source = "module-proxy"
+`
+	if _, err := DecodeString(src); err == nil {
+		t.Errorf("DecodeString accepted non-table source; expected error")
+	}
+}
+
+func TestDecodeRejectsBadBool(t *testing.T) {
+	src := `[[go-package]]
+module = "x"
+version = "v1"
+source = { kind = "module-proxy" }
+sumdb-verified = yes
+`
+	if _, err := DecodeString(src); err == nil {
+		t.Errorf("DecodeString accepted non-bool sumdb-verified; expected error")
+	}
+}
+
+func TestDecodeRejectsBadInt(t *testing.T) {
+	src := `[[go-package]]
+module = "x"
+version = "v1"
+source = { kind = "module-proxy" }
+sumdb-tree-size = abc
+`
+	if _, err := DecodeString(src); err == nil {
+		t.Errorf("DecodeString accepted non-int sumdb-tree-size; expected error")
+	}
+}
+
+func TestDecodeRejectsSourceMissingKind(t *testing.T) {
+	src := `[[go-package]]
+module = "x"
+source = { proxy = "https://proxy.golang.org" }
+`
+	if _, err := DecodeString(src); err == nil {
+		t.Errorf("DecodeString accepted source missing kind; expected error")
+	}
+}
+
+func TestDecodeEmptyArraysOk(t *testing.T) {
+	src := `[[go-package]]
+module = "x"
+version = "v1"
+source = { kind = "module-proxy" }
+sumdb-verified = true
+capabilities-declared = []
+dependencies = []
+build-tags = []
+`
+	pkgs, err := DecodeString(src)
+	if err != nil {
+		t.Fatalf("DecodeString: %v", err)
+	}
+	if pkgs[0].CapabilitiesDeclared != nil {
+		t.Errorf("empty array should decode as nil: %v", pkgs[0].CapabilitiesDeclared)
+	}
+}
+
+func TestParseIntHandlesNegative(t *testing.T) {
+	cases := map[string]int64{
+		"0":          0,
+		"42":         42,
+		"-7":         -7,
+		"9999999999": 9999999999,
+	}
+	for in, want := range cases {
+		got, err := parseInt(in)
+		if err != nil {
+			t.Errorf("parseInt(%q) error: %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("parseInt(%q) = %d; want %d", in, got, want)
+		}
+	}
+	for _, bad := range []string{"", "-", "abc", "12a"} {
+		if _, err := parseInt(bad); err == nil {
+			t.Errorf("parseInt(%q) should error", bad)
+		}
+	}
+}
+
+func TestSplitTopLevelRespectsNesting(t *testing.T) {
+	cases := map[string]int{
+		`a, b, c`:                  3,
+		`a, [b, c], d`:             3,
+		`a, { x = "y, z" }, b`:     3,
+		`"a, b", "c, d"`:           2,
+	}
+	for in, want := range cases {
+		got := splitTopLevel(in, ',')
+		if len(got) != want {
+			t.Errorf("splitTopLevel(%q) = %d parts (%v); want %d", in, len(got), got, want)
+		}
+	}
+}
+
+func TestCheckDriftDetectsMissing(t *testing.T) {
+	locked := []GoPackage{}
+	live := []GoPackage{{Module: "x", Version: "v1"}}
+	drifts := CheckDrift(locked, live)
+	if len(drifts) != 1 || drifts[0].Kind != DriftMissing {
+		t.Errorf("expected DriftMissing; got %#v", drifts)
+	}
+}
+
+func TestCheckDriftDetectsStale(t *testing.T) {
+	locked := []GoPackage{{Module: "x", Version: "v1"}}
+	live := []GoPackage{}
+	drifts := CheckDrift(locked, live)
+	if len(drifts) != 1 || drifts[0].Kind != DriftStale {
+		t.Errorf("expected DriftStale; got %#v", drifts)
+	}
+}
+
+func TestCheckDriftDetectsVersion(t *testing.T) {
+	locked := []GoPackage{{Module: "x", Version: "v1"}}
+	live := []GoPackage{{Module: "x", Version: "v2"}}
+	drifts := CheckDrift(locked, live)
+	found := false
+	for _, d := range drifts {
+		if d.Kind == DriftVersion {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected DriftVersion; got %#v", drifts)
+	}
+}
+
+func TestCheckDriftDetectsZipDrift(t *testing.T) {
+	locked := []GoPackage{{Module: "x", Version: "v1", ZipBlake3: "old", ZipH1: "h1:old"}}
+	live := []GoPackage{{Module: "x", Version: "v1", ZipBlake3: "new", ZipH1: "h1:new"}}
+	drifts := CheckDrift(locked, live)
+	if len(drifts) != 1 || drifts[0].Kind != DriftZip {
+		t.Errorf("expected DriftZip; got %#v", drifts)
+	}
+}
+
+func TestCheckDriftDetectsApiSurface(t *testing.T) {
+	locked := []GoPackage{{Module: "x", Version: "v1", ApiSurfaceSha256: "old"}}
+	live := []GoPackage{{Module: "x", Version: "v1", ApiSurfaceSha256: "new"}}
+	drifts := CheckDrift(locked, live)
+	if len(drifts) != 1 || drifts[0].Kind != DriftAPI {
+		t.Errorf("expected DriftAPI; got %#v", drifts)
+	}
+}
+
+func TestCheckDriftDetectsWrapper(t *testing.T) {
+	locked := []GoPackage{{Module: "x", Version: "v1", WrapperSha256: "old"}}
+	live := []GoPackage{{Module: "x", Version: "v1", WrapperSha256: "new"}}
+	drifts := CheckDrift(locked, live)
+	if len(drifts) != 1 || drifts[0].Kind != DriftWrapper {
+		t.Errorf("expected DriftWrapper; got %#v", drifts)
+	}
+}
+
+func TestCheckDriftDetectsSumdb(t *testing.T) {
+	locked := []GoPackage{{Module: "x", Version: "v1", SumdbVerified: true, SumdbTreeSize: 10}}
+	live := []GoPackage{{Module: "x", Version: "v1", SumdbVerified: true, SumdbTreeSize: 11}}
+	drifts := CheckDrift(locked, live)
+	if len(drifts) != 1 || drifts[0].Kind != DriftSumdb {
+		t.Errorf("expected DriftSumdb; got %#v", drifts)
+	}
+}
+
+func TestCheckDriftDetectsCapabilities(t *testing.T) {
+	locked := []GoPackage{{Module: "x", Version: "v1", CapabilitiesDeclared: []string{"fs"}}}
+	live := []GoPackage{{Module: "x", Version: "v1", CapabilitiesDeclared: []string{"fs", "net"}}}
+	drifts := CheckDrift(locked, live)
+	if len(drifts) != 1 || drifts[0].Kind != DriftCapabilities {
+		t.Errorf("expected DriftCapabilities; got %#v", drifts)
+	}
+}
+
+func TestCheckDriftCapabilitiesOrderInsensitive(t *testing.T) {
+	locked := []GoPackage{{Module: "x", Version: "v1", CapabilitiesDeclared: []string{"fs", "net"}}}
+	live := []GoPackage{{Module: "x", Version: "v1", CapabilitiesDeclared: []string{"net", "fs"}}}
+	if got := CheckDrift(locked, live); len(got) != 0 {
+		t.Errorf("CheckDrift should not flag permutation: %#v", got)
+	}
+}
+
+func TestCheckDriftNoFalsePositives(t *testing.T) {
+	pkg := GoPackage{
+		Module: "x", Version: "v1",
+		Source:               Source{Kind: SourceModuleProxy},
+		ZipBlake3:            "z",
+		ZipH1:                "h1:z",
+		SumdbVerified:        true,
+		SumdbTreeSize:        10,
+		SumdbRecordHash:      "r",
+		ApiSurfaceSha256:     "a",
+		WrapperSha256:        "w",
+		CapabilitiesDeclared: []string{"fs"},
+	}
+	if got := CheckDrift([]GoPackage{pkg}, []GoPackage{pkg}); len(got) != 0 {
+		t.Errorf("CheckDrift identical inputs returned drifts: %#v", got)
+	}
+}
+
+func TestCheckDriftDeterministicOrder(t *testing.T) {
+	locked := []GoPackage{
+		{Module: "z", Version: "v1", ZipBlake3: "old"},
+		{Module: "a", Version: "v1", ZipBlake3: "old"},
+	}
+	live := []GoPackage{
+		{Module: "a", Version: "v1", ZipBlake3: "new"},
+		{Module: "z", Version: "v1", ZipBlake3: "new"},
+	}
+	first := CheckDrift(locked, live)
+	for i := 0; i < 5; i++ {
+		got := CheckDrift(locked, live)
+		if len(got) != len(first) {
+			t.Fatalf("CheckDrift length non-deterministic")
+		}
+		for j := range got {
+			if got[j] != first[j] {
+				t.Errorf("CheckDrift order non-deterministic iter %d:\n%v\nvs\n%v", i, first, got)
+			}
+		}
+	}
+	if first[0].Module != "a" {
+		t.Errorf("CheckDrift not sorted by module: %v", first)
+	}
+}
+
+func TestDriftStringNoDetail(t *testing.T) {
+	d := Drift{Module: "x", Version: "v1", Kind: DriftMissing}
+	if got, want := d.String(), "x@v1: missing drift"; got != want {
+		t.Errorf("Drift.String = %q; want %q", got, want)
+	}
+}
+
+func TestDriftStringWithDetail(t *testing.T) {
+	d := Drift{Module: "x", Version: "v1", Kind: DriftZip, Detail: "a -> b"}
+	got := d.String()
+	if !strings.Contains(got, "zip-hash drift") || !strings.Contains(got, "a -> b") {
+		t.Errorf("Drift.String = %q; want it to include kind and detail", got)
+	}
+}
+
+func TestEqualStringSetMultiset(t *testing.T) {
+	if !equalStringSet([]string{"a", "a", "b"}, []string{"b", "a", "a"}) {
+		t.Errorf("equalStringSet should treat dup elements as multiset")
+	}
+	if equalStringSet([]string{"a", "a"}, []string{"a", "b"}) {
+		t.Errorf("equalStringSet should distinguish multisets")
+	}
+}
+
+func TestEncodeEmptyReturnsEmpty(t *testing.T) {
+	if got := Encode(nil); got != "" {
+		t.Errorf("Encode(nil) = %q; want empty", got)
+	}
+}

--- a/package3/go/lockfile/phase10_test.go
+++ b/package3/go/lockfile/phase10_test.go
@@ -1,0 +1,183 @@
+package lockfile
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPhase10LockfileSentinel is the MEP-74 phase 10 end-to-end
+// sentinel. It exercises the full encode -> decode -> drift-check
+// cycle against the cobra fixture (the canonical MEP-74 example) and
+// proves:
+//
+//   - the rendered TOML contains every field MEP-74 spec §3
+//     requires,
+//   - the rendered TOML is deterministic across multiple runs,
+//   - DecodeString reads back the same structure (round-trip),
+//   - CheckDrift surfaces every kind of mismatch on a mutated copy
+//     and returns no drifts for the unchanged copy.
+//
+// The fixture is intentionally inline so the sentinel does not
+// depend on a separate goldens directory. The goldens for the
+// `mochi pkg lock` CLI will land in phase 10.1 once the CLI wiring
+// from MEP-57 is extended to read `[go-dependencies]`.
+func TestPhase10LockfileSentinel(t *testing.T) {
+	cobra := GoPackage{
+		Module:  "github.com/spf13/cobra",
+		Version: "v1.8.0",
+		Source: Source{
+			Kind:  SourceModuleProxy,
+			Proxy: "https://proxy.golang.org",
+		},
+		ZipBlake3:       "1111111111111111111111111111111111111111111111111111111111111111",
+		ZipH1:           "h1:cobra-v1.8.0",
+		SumdbVerified:   true,
+		SumdbTreeSize:   23456789,
+		SumdbRecordHash: "abcdef0123456789",
+		ApiSurfaceSha256: "2222222222222222222222222222222222222222222222222222222222222222",
+		WrapperSha256:   "3333333333333333333333333333333333333333333333333333333333333333",
+		CapabilitiesDeclared: []string{"fs"},
+		Dependencies:    []string{"github.com/inconshreveable/mousetrap@v1.1.0", "github.com/spf13/pflag@v1.0.6"},
+		BuildTags:       nil,
+	}
+	pflag := GoPackage{
+		Module:               "github.com/spf13/pflag",
+		Version:              "v1.0.6",
+		Source:               Source{Kind: SourceModuleProxy, Proxy: "https://proxy.golang.org"},
+		ZipBlake3:            "4444444444444444444444444444444444444444444444444444444444444444",
+		ZipH1:                "h1:pflag-v1.0.6",
+		SumdbVerified:        true,
+		SumdbTreeSize:        23456789,
+		SumdbRecordHash:      "fedcba9876543210",
+		ApiSurfaceSha256:     "5555555555555555555555555555555555555555555555555555555555555555",
+		WrapperSha256:        "6666666666666666666666666666666666666666666666666666666666666666",
+		CapabilitiesDeclared: []string{},
+	}
+	pkgs := []GoPackage{cobra, pflag}
+
+	t.Run("encode covers every spec field", func(t *testing.T) {
+		encoded := Encode(pkgs)
+		mandatoryFields := []string{
+			"[[go-package]]",
+			`module = "github.com/spf13/cobra"`,
+			`version = "v1.8.0"`,
+			`source = { kind = "module-proxy", proxy = "https://proxy.golang.org" }`,
+			"zip-blake3 = ",
+			"zip-h1 = ",
+			"sumdb-verified = true",
+			"sumdb-tree-size = 23456789",
+			"sumdb-record-hash = ",
+			"api-surface-sha256 = ",
+			"wrapper-sha256 = ",
+			`capabilities-declared = ["fs"]`,
+			"dependencies = [",
+		}
+		for _, want := range mandatoryFields {
+			if !strings.Contains(encoded, want) {
+				t.Errorf("encoded body missing %q\n--- body ---\n%s", want, encoded)
+			}
+		}
+	})
+
+	t.Run("encode is byte-deterministic", func(t *testing.T) {
+		first := Encode(pkgs)
+		for i := 0; i < 16; i++ {
+			if got := Encode(pkgs); got != first {
+				t.Fatalf("Encode non-deterministic on iter %d", i)
+			}
+		}
+		// Permute the slice; output should stay identical.
+		permuted := []GoPackage{pflag, cobra}
+		if got := Encode(permuted); got != first {
+			t.Errorf("Encode not stable under permutation:\n--- first ---\n%s\n--- permuted ---\n%s", first, got)
+		}
+	})
+
+	t.Run("round-trip preserves fields", func(t *testing.T) {
+		encoded := Encode(pkgs)
+		decoded, err := DecodeString(encoded)
+		if err != nil {
+			t.Fatalf("DecodeString: %v\n--- body ---\n%s", err, encoded)
+		}
+		if len(decoded) != 2 {
+			t.Fatalf("decoded %d entries; want 2", len(decoded))
+		}
+		gotCobra := decoded[0]
+		if gotCobra.Module != "github.com/spf13/cobra" {
+			t.Errorf("first entry module = %q; want cobra", gotCobra.Module)
+		}
+		if gotCobra.SumdbTreeSize != cobra.SumdbTreeSize {
+			t.Errorf("SumdbTreeSize = %d; want %d", gotCobra.SumdbTreeSize, cobra.SumdbTreeSize)
+		}
+		if gotCobra.ZipH1 != cobra.ZipH1 {
+			t.Errorf("ZipH1 = %q; want %q", gotCobra.ZipH1, cobra.ZipH1)
+		}
+		if len(gotCobra.Dependencies) != 2 {
+			t.Errorf("Dependencies = %v; want 2 entries", gotCobra.Dependencies)
+		}
+	})
+
+	t.Run("drift-check on identical state is empty", func(t *testing.T) {
+		if got := CheckDrift(pkgs, pkgs); len(got) != 0 {
+			t.Errorf("CheckDrift on identical state returned drifts: %#v", got)
+		}
+	})
+
+	t.Run("drift-check reports every mutated field", func(t *testing.T) {
+		mutated := []GoPackage{
+			{
+				Module: cobra.Module, Version: cobra.Version, Source: cobra.Source,
+				ZipBlake3:            "DRIFTED-ZIP-BLAKE3",
+				ZipH1:                cobra.ZipH1,
+				SumdbVerified:        cobra.SumdbVerified,
+				SumdbTreeSize:        cobra.SumdbTreeSize + 1,
+				SumdbRecordHash:      cobra.SumdbRecordHash,
+				ApiSurfaceSha256:     "DRIFTED-API",
+				WrapperSha256:        "DRIFTED-WRAPPER",
+				CapabilitiesDeclared: []string{"fs", "net"},
+				Dependencies:         cobra.Dependencies,
+			},
+			pflag,
+		}
+		drifts := CheckDrift(pkgs, mutated)
+		kinds := map[DriftKind]int{}
+		for _, d := range drifts {
+			if d.Module != "github.com/spf13/cobra" {
+				t.Errorf("drift on wrong module: %v", d)
+			}
+			kinds[d.Kind]++
+		}
+		for _, want := range []DriftKind{DriftZip, DriftSumdb, DriftAPI, DriftWrapper, DriftCapabilities} {
+			if kinds[want] == 0 {
+				t.Errorf("CheckDrift missing %s drift; got kinds %v", want, kinds)
+			}
+		}
+	})
+
+	t.Run("drift-check surfaces missing and stale", func(t *testing.T) {
+		liveOnlyPflag := []GoPackage{pflag}
+		drifts := CheckDrift(pkgs, liveOnlyPflag)
+		// cobra in locked but not in live -> stale.
+		stale := false
+		for _, d := range drifts {
+			if d.Kind == DriftStale && d.Module == "github.com/spf13/cobra" {
+				stale = true
+			}
+		}
+		if !stale {
+			t.Errorf("expected stale drift for cobra; got %v", drifts)
+		}
+
+		lockedOnlyPflag := []GoPackage{pflag}
+		drifts2 := CheckDrift(lockedOnlyPflag, pkgs)
+		missing := false
+		for _, d := range drifts2 {
+			if d.Kind == DriftMissing && d.Module == "github.com/spf13/cobra" {
+				missing = true
+			}
+		}
+		if !missing {
+			t.Errorf("expected missing drift for cobra; got %v", drifts2)
+		}
+	})
+}

--- a/website/docs/implementation/0074/index.md
+++ b/website/docs/implementation/0074/index.md
@@ -25,7 +25,7 @@ A phase is LANDED only when its gate is green for every applicable target (consu
 | 7 | Mochi-side extern fn emitter + alias shim file generation | LANDED (baseline; 7.1+ deferred) | (pending) | [phase-07](/docs/implementation/0074/phase-07-extern-emit) |
 | 8 | `import go "<module>@<semver>" as <alias>` grammar + parser | LANDED | (pending) | [phase-08](/docs/implementation/0074/phase-08-import-grammar) |
 | 9 | Build orchestration: workspace synth + `go build -buildmode=c-archive` + artifact link | LANDED (baseline; 9.1+ deferred) | (pending) | [phase-09](/docs/implementation/0074/phase-09-build) |
-| 10 | mochi.lock `[[go-package]]` integration + `--check` mode | NOT STARTED | — | [phase-10](/docs/implementation/0074/phase-10-lockfile) |
+| 10 | mochi.lock `[[go-package]]` integration + `--check` mode | LANDED (schema; 10.1+ CLI deferred) | (pending) | [phase-10](/docs/implementation/0074/phase-10-lockfile) |
 | 11 | `TargetGoLibrary` emit (`go.mod` + exported package + `_cgo_export.h`) | NOT STARTED | — | [phase-11](/docs/implementation/0074/phase-11-go-library-emit) |
 | 12 | Git-tag publish flow (`mochi pkg publish --to=git-tag`) + canonical-import-path gate | NOT STARTED | — | [phase-12](/docs/implementation/0074/phase-12-git-tag-publish) |
 | 13 | Cosign-on-sibling-tag opt-in (`mochi pkg publish --cosign-sign`) | NOT STARTED | — | [phase-13](/docs/implementation/0074/phase-13-cosign) |
@@ -50,7 +50,7 @@ Each phase's LANDED gate must be green for every applicable target. `n/a` cells 
 | 7. extern emitter | LANDED (baseline) | required | required | required | required |
 | 8. import-go grammar (semver) | LANDED | required | required | required | required |
 | 9. build orchestration | LANDED (baseline) | required | required | required (no cgo) | required |
-| 10. mochi.lock integration | NOT STARTED | required | required | required | required |
+| 10. mochi.lock integration | LANDED (schema) | required | required | required | required |
 | 11. TargetGoLibrary emit | NOT STARTED | required | required | required | required |
 | 12. git-tag publish | NOT STARTED | n/a (publish is host-only) | n/a | n/a | n/a |
 | 13. cosign on tag.sig | NOT STARTED | n/a | n/a | n/a | n/a |
@@ -95,6 +95,7 @@ package3/go/
   wrapper/                # cgo wrapper synthesiser (phase 6)
   emit/                   # Mochi extern fn emitter (phase 7)
   build/                  # workspace + go build orchestration (phase 9)
+  lockfile/               # `[[go-package]]` schema + drift check (phase 10)
   publish/                # git-tag publish + cosign (phases 12-13)
   goroutine/              # cgo handle pool + bridge runtime (phase 14)
   tinygo/                 # TinyGo embedded subset (phase 16)
@@ -105,7 +106,7 @@ The `package3/go/` location is shared with the broader MEP-57 polyglot package w
 
 ## Status snapshot
 
-As of 2026-05-29: phases 0-9 LANDED on `main` (phases 6 + 7 + 9 baseline only; sub-phases 6.1+/7.1+/9.1+ deferred), phases 10-17 NOT STARTED.
+As of 2026-05-29: phases 0-10 LANDED on `main` (phases 6 + 7 + 9 baseline only; phase 10 schema only; sub-phases 6.1+/7.1+/9.1+/10.1+ deferred), phases 11-17 NOT STARTED.
 
 ## Cross-references
 

--- a/website/docs/implementation/0074/phase-10-lockfile.md
+++ b/website/docs/implementation/0074/phase-10-lockfile.md
@@ -1,0 +1,205 @@
+---
+title: "Phase 10. mochi.lock integration"
+sidebar_position: 12
+sidebar_label: "Phase 10. mochi.lock"
+description: "MEP-74 Phase 10 lands the `[[go-package]]` lockfile schema, encoder, decoder, and drift checker as a self-contained `package3/go/lockfile/` module. The schema mirrors spec §3 (module, version, source, zip-blake3, zip-h1, sumdb-verified + tree-size + record-hash, api-surface-sha256, wrapper-sha256, capabilities-declared, dependencies, build-tags). Encode is byte-deterministic across permutations; Decode is line-oriented with forward-compat tolerance for unknown keys; CheckDrift returns the closed set of mismatch kinds (missing / stale / version / zip-hash / sumdb / api-surface / wrapper / capabilities) so `mochi pkg lock --check` can surface every drift class without ambiguity."
+---
+
+# Phase 10. mochi.lock integration
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-74 §Phases](/docs/mep/mep-0074#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-29 23:47 (GMT+7) |
+| Landed         | 2026-05-29 23:55 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`TestPhase10LockfileSentinel` in
+`package3/go/lockfile/phase10_test.go` walks the cobra + pflag
+fixture through the full encode -> decode -> drift-check cycle
+and verifies:
+
+- the encoded body covers every field MEP-74 spec §3 requires
+  (module, version, source inline-table, zip-blake3, zip-h1,
+  sumdb-verified, sumdb-tree-size, sumdb-record-hash,
+  api-surface-sha256, wrapper-sha256, capabilities-declared,
+  dependencies);
+- the encoded body is byte-deterministic across 16 runs *and* under
+  slice permutation;
+- DecodeString round-trips the structure (including the integer
+  `sumdb-tree-size` and the string-array fields);
+- `CheckDrift(pkgs, pkgs)` returns no drifts;
+- mutating each tracked field surfaces the matching drift kind
+  (`zip-hash`, `sumdb`, `api-surface`, `wrapper`, `capabilities`);
+- dropping a live package surfaces `stale`, dropping a locked
+  package surfaces `missing`.
+
+Plus 30 unit tests in `lockfile_test.go`:
+
+- encode coverage / sort behaviour
+  (`TestEncodeBasic`, `TestEncodeDeterministicSort`,
+  `TestEncodeOmitsEmptyOptionals`, `TestEncodeEmptyReturnsEmpty`),
+- per-Source-kind rendering
+  (`TestSourceGitRendered`, `TestSourcePathRendered`),
+- round-trip
+  (`TestRoundTrip`),
+- decode error paths
+  (`TestDecodeRejectsMissingEq`, `TestDecodeRejectsBadSource`,
+  `TestDecodeRejectsBadBool`, `TestDecodeRejectsBadInt`,
+  `TestDecodeRejectsSourceMissingKind`),
+- forward-compat tolerance
+  (`TestDecodeToleratesUnknownKey`),
+- empty arrays + helper coverage
+  (`TestDecodeEmptyArraysOk`, `TestParseIntHandlesNegative`,
+  `TestSplitTopLevelRespectsNesting`),
+- every drift kind
+  (`TestCheckDriftDetectsMissing`, `TestCheckDriftDetectsStale`,
+  `TestCheckDriftDetectsVersion`, `TestCheckDriftDetectsZipDrift`,
+  `TestCheckDriftDetectsApiSurface`,
+  `TestCheckDriftDetectsWrapper`, `TestCheckDriftDetectsSumdb`,
+  `TestCheckDriftDetectsCapabilities`),
+- multi-set invariance, order-stability, and false-positive
+  guards (`TestCheckDriftCapabilitiesOrderInsensitive`,
+  `TestCheckDriftNoFalsePositives`,
+  `TestCheckDriftDeterministicOrder`),
+- diagnostic rendering (`TestDriftStringNoDetail`,
+  `TestDriftStringWithDetail`).
+
+## Lowering decisions
+
+The lockfile package is layering-conservative: it imports no other
+`package3/go/*` module and depends only on the Go stdlib
+(`fmt`, `io`, `sort`, `strings`). Callers in the build pipeline
+compose a `[]GoPackage` from their own state, hand it to `Encode`,
+and read back the same shape via `Decode` / `DecodeString`. The
+package is the single source of truth for the `[[go-package]]`
+serialisation, so future MEP-57 lockfile-merger work can compose
+`Encode(pkgs)` with the `[[rust-package]]` body that
+`package3/rust/lockfile` produces without either side knowing about
+the other.
+
+**Source-kind enum mirrors the MEP-73 lockfile package.** Three
+kinds (`module-proxy`, `git`, `path`) cover the spec §3 source
+table. The `git` kind carries `url` + optional `rev`; the
+`module-proxy` kind carries the proxy URL; the `path` kind carries
+the relative directory. Inline-table rendering matches the spec
+example byte-for-byte:
+
+```toml
+source = { kind = "module-proxy", proxy = "https://proxy.golang.org" }
+source = { kind = "git", url = "git@corp.example.com:internal/foo.git", rev = "abcdef0" }
+source = { kind = "path", path = "../fork/local" }
+```
+
+**Encode sorts by (module, version) for byte-stable output.** The
+caller's slice order does not affect the rendered TOML; permuting
+the input produces identical bytes. This is the same invariant the
+MEP-73 lockfile holds; it makes `git diff mochi.lock` show only
+the genuine changes rather than slice-permutation noise.
+
+**Decode is line-oriented and tolerates unknown keys.** Unknown
+keys are silently dropped (forward-compat: the bridge can add a
+field in a future phase without breaking older readers); missing
+required keys do *not* error (the spec allows partial entries
+during in-progress lock work); structural errors (no `=`, bad
+`source` inline-table, non-bool `sumdb-verified`, non-int
+`sumdb-tree-size`) *do* error so a hand-edited mochi.lock with a
+typo surfaces immediately rather than silently dropping the entry.
+
+**Drift kinds are a closed set, sorted by (module, version, kind).**
+Eight kinds total: `missing`, `stale`, `version`, `zip-hash`,
+`sumdb`, `api-surface`, `wrapper`, `capabilities`. Each kind maps
+to one MEP-74 spec §3 field cluster: `zip-hash` covers the
+zip-blake3 + zip-h1 pair (a divergence in either flips the kind);
+`sumdb` covers verified + tree-size + record-hash (any change is
+suspicious); `capabilities` is multi-set-insensitive so a `["fs",
+"net"]` -> `["net", "fs"]` reorder is not a drift.
+
+**`sumdb-verified` always renders, even when `false`.** This is
+load-bearing: the field is a security claim about a public module.
+A `mochi.lock` that omits `sumdb-verified` could be silently down-
+graded by a hand-edit; the spec requires the field be explicit. The
+encoder unconditionally emits `sumdb-verified = true|false`.
+
+**Empty optional fields are omitted, not rendered as empty.** The
+spec allows a `[[go-package]]` entry to omit `dependencies`,
+`build-tags`, `capabilities-declared` when none apply. Rendering
+`dependencies = []` would be technically equivalent but bloats the
+file and adds line-noise to `git diff`. Decode treats an explicit
+`= []` as a `nil` slice (`TestDecodeEmptyArraysOk`).
+
+**`CheckDrift` is the one place that compares lockfile state to
+live state.** Phase 10 deliberately does not implement the *fetch*
+side (that lives in the existing phases 1-2 module-proxy / sumdb
+clients) or the *wrapper-hash* side (that lives in phase 6's
+emitter). The caller stitches the pieces together: re-fetch each
+module, recompute the hashes, build a fresh `[]GoPackage`, and pass
+both slices to `CheckDrift`. The check is symmetric: missing
+entries from the lockfile surface as `DriftMissing`; stale entries
+not claimed by any live module surface as `DriftStale`.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/go/lockfile/lockfile.go` | `GoPackage`, `Source`, `Encode`, `Decode`, `DecodeString`, `Drift`, `DriftKind`, `CheckDrift`. |
+| `package3/go/lockfile/lockfile_test.go` | 30 unit tests over encode / decode / drift behaviour. |
+| `package3/go/lockfile/phase10_test.go` | `TestPhase10LockfileSentinel` end-to-end cobra+pflag fixture. |
+| `website/docs/implementation/0074/phase-10-lockfile.md` | (this page) |
+
+## Test set
+
+- `TestPhase10LockfileSentinel` (6 sub-tests)
+- 30 unit tests in `lockfile_test.go`
+
+Local run on darwin-arm64:
+
+```
+$ go test ./package3/go/lockfile/...
+ok      mochi/package3/go/lockfile      0.5s
+$ go test ./package3/go/...
+ok      mochi/package3/go/apisurface    (cached)
+ok      mochi/package3/go/build (cached)
+ok      mochi/package3/go/cmd/go-ingest (cached)
+ok      mochi/package3/go/emit  (cached)
+ok      mochi/package3/go/errors        (cached)
+ok      mochi/package3/go/lockfile      (cached)
+ok      mochi/package3/go/moduleproxy   (cached)
+ok      mochi/package3/go/semver        (cached)
+ok      mochi/package3/go/sumdb (cached)
+ok      mochi/package3/go/typemap       (cached)
+ok      mochi/package3/go/wrapper       (cached)
+```
+
+## Closeout notes
+
+Phase 10 lands the lockfile schema as a leaf module; the CLI
+wiring (`mochi pkg lock` / `mochi pkg lock --check` extending
+MEP-57 to walk `[go-dependencies]`) is reserved for phase 10.1
+once the MEP-57 driver gains the language-tag dispatch hook
+(today MEP-57 walks `[[rust-package]]` only; the same dispatch
+pattern extends to `[[go-package]]`). The schema is fixed; the
+CLI work will not require changes to this package beyond a small
+adapter that translates manifest entries into a fresh `[]GoPackage`
+for `CheckDrift`.
+
+The `CheckDrift` output is the surface the LSP / IDE quick-fix
+keys on: a `--check` failure prints one `<module>@<version>:
+<kind> drift (<detail>)` line per drift, sorted, so downstream
+tools can pattern-match on the kind without parsing free-form text.
+
+Future phase 10.x reservations:
+
+- **10.1** `mochi pkg lock` driver integration (read
+  `[go-dependencies]` from `mochi.toml`, walk module proxy, write
+  `[[go-package]]` entries).
+- **10.2** `mochi pkg lock --sumdb-consistency` (Merkle consistency
+  proof on top of the existing sumdb client).
+- **10.3** Cross-MEP lockfile merger (interleave
+  `[[go-package]]` with `[[rust-package]]` and other language-tag
+  tables in a stable order).

--- a/website/docs/mep/mep-0074.md
+++ b/website/docs/mep/mep-0074.md
@@ -392,7 +392,7 @@ A phase is LANDED only when its gate is green for every target in the matrix bel
 | 7. extern emitter | LANDED (baseline) | required | required | required | required |
 | 8. import-go grammar (semver) | LANDED | required | required | required | required |
 | 9. build orchestration | LANDED (baseline) | required | required | required (no cgo) | required |
-| 10. mochi.lock integration | NOT STARTED | required | required | required | required |
+| 10. mochi.lock integration | LANDED (schema) | required | required | required | required |
 | 11. TargetGoLibrary emit | NOT STARTED | required | required | required | required |
 | 12. git-tag publish | NOT STARTED | n/a (publish is host-only) | n/a | n/a | n/a |
 | 13. cosign on tag.sig | NOT STARTED | n/a | n/a | n/a | n/a |

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -363,7 +363,8 @@
       "implementation/0074/phase-06-wrapper",
       "implementation/0074/phase-07-extern-emit",
       "implementation/0074/phase-08-import-grammar",
-      "implementation/0074/phase-09-build"
+      "implementation/0074/phase-09-build",
+      "implementation/0074/phase-10-lockfile"
     ]
   },
   "implementation/0075/index",


### PR DESCRIPTION
Tracks #22850.

## Summary

- Adds `package3/go/lockfile/` covering the `[[go-package]]` schema (MEP-74 spec §3): `GoPackage`, `Source`, `Encode`, `Decode`, `CheckDrift`.
- `Encode` is byte-deterministic across slice permutations; `Decode` tolerates unknown keys for forward-compat; `CheckDrift` returns 8 closed drift kinds (missing / stale / version / zip-hash / sumdb / api-surface / wrapper / capabilities) sorted by (module, version, kind).
- 36 tests total (30 unit + 6 sentinel sub-tests). Layering-conservative: depends only on Go stdlib.
- Schema-only; CLI wiring is reserved for 10.1+.

## Test plan

- [x] `go test ./package3/go/lockfile/...`
- [x] `go vet ./package3/go/lockfile/...`
- [x] `go test ./package3/go/...` regression sweep

## Links

- Spec: [MEP-74 §Lockfile](/docs/mep/mep-0074)
- Tracking page: [phase-10-lockfile](/docs/implementation/0074/phase-10-lockfile)