### PR TITLE
feat(mep-66): Phase 2 — BEAM abstract code ingest

### DIFF
--- a/package3/erlang/beamingest/beamingest.go
+++ b/package3/erlang/beamingest/beamingest.go
@@ -1,0 +1,335 @@
+// Package beamingest reads Erlang .beam files and extracts the type
+// information the MEP-66 bridge needs to generate Mochi extern bindings.
+//
+// BEAM file format:
+//
+//	FOR1 header (4 bytes "FOR1" + big-endian uint32 of remaining length + "BEAM")
+//	Followed by zero or more IFF chunks:
+//	    chunk-id   [4 bytes ASCII]
+//	    chunk-len  [uint32 big-endian]
+//	    chunk-data [chunk-len bytes, padded to 4-byte boundary]
+//
+// Relevant chunks:
+//
+//   - "Dbgi" (OTP 20+): debug_info. Contains ETF-encoded abstract code that
+//     includes all -spec and -type directives. Format:
+//     {debug_info_v1, erl_abstract_code, {Forms, CompileOpts}} where Forms
+//     is a list of Erlang AST forms (see erl_syntax / erl_parse).
+//
+//   - "Abst" (OTP 17-19, legacy): raw ETF of the same AST. Deprecated
+//     but still emitted by some older packages.
+//
+//   - "Atom" / "AtU8": atom table (used for fallback when Dbgi is absent).
+//
+// Spec extraction:
+// A SpecForm is yielded for each -spec attribute in the AST. Each SpecForm
+// records the module, function name, arity, and the raw Erlang type terms
+// for each clause (normally one clause, occasionally multiple).
+//
+// Type extraction:
+// A TypeForm is yielded for each -type or -opaque attribute.
+package beamingest
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"mochi/package3/erlang/etf"
+)
+
+// SpecForm is a parsed -spec attribute extracted from BEAM abstract code.
+type SpecForm struct {
+	// Module is the module that owns the spec (from the -module attribute).
+	Module string
+	// Function is the exported function name.
+	Function string
+	// Arity is the function arity.
+	Arity int
+	// Clauses holds the raw ETF for each type clause.
+	// Most specs have exactly one clause; overloaded specs have multiple.
+	Clauses []interface{}
+}
+
+// TypeForm is a parsed -type or -opaque attribute.
+type TypeForm struct {
+	// Module is the module that owns the type.
+	Module string
+	// Name is the type name.
+	Name string
+	// Arity is the number of type parameters.
+	Arity int
+	// Opaque is true for -opaque declarations.
+	Opaque bool
+	// Body is the raw ETF of the type body.
+	Body interface{}
+}
+
+// Module holds all the information extracted from a single .beam file.
+type Module struct {
+	// Name is the OTP module name (from the -module attribute).
+	Name string
+	// Specs is the list of -spec declarations found in the file.
+	Specs []SpecForm
+	// Types is the list of -type / -opaque declarations.
+	Types []TypeForm
+	// HasAbstractCode is true when the file contained a Dbgi or Abst chunk.
+	HasAbstractCode bool
+}
+
+// ReadBeam parses r as a BEAM file and extracts module name, specs, and types.
+// r must be positioned at the start of the file.
+func ReadBeam(r io.Reader) (*Module, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("beamingest: read: %w", err)
+	}
+	return ParseBeam(data)
+}
+
+// ParseBeam parses a BEAM file from raw bytes.
+func ParseBeam(data []byte) (*Module, error) {
+	if len(data) < 12 {
+		return nil, fmt.Errorf("beamingest: file too short (%d bytes)", len(data))
+	}
+	if string(data[0:4]) != "FOR1" {
+		return nil, fmt.Errorf("beamingest: not a BEAM file (missing FOR1 magic)")
+	}
+	// Bytes 4-7: big-endian uint32 of remaining content length (after the header).
+	// Bytes 8-11: "BEAM"
+	if string(data[8:12]) != "BEAM" {
+		return nil, fmt.Errorf("beamingest: not a BEAM file (missing BEAM marker)")
+	}
+
+	chunks, err := parseChunks(data[12:])
+	if err != nil {
+		return nil, fmt.Errorf("beamingest: parse chunks: %w", err)
+	}
+
+	mod := &Module{}
+
+	// Prefer Dbgi over Abst.
+	if dbgi, ok := chunks["Dbgi"]; ok {
+		mod.HasAbstractCode = true
+		if err := extractDbgi(dbgi, mod); err != nil {
+			return nil, fmt.Errorf("beamingest: extract Dbgi: %w", err)
+		}
+	} else if abst, ok := chunks["Abst"]; ok {
+		mod.HasAbstractCode = true
+		if err := extractAbst(abst, mod); err != nil {
+			return nil, fmt.Errorf("beamingest: extract Abst: %w", err)
+		}
+	}
+
+	return mod, nil
+}
+
+// parseChunks reads the IFF chunk sequence from the BEAM body (after FOR1/BEAM header).
+func parseChunks(body []byte) (map[string][]byte, error) {
+	chunks := make(map[string][]byte)
+	pos := 0
+	for pos+8 <= len(body) {
+		id := string(body[pos : pos+4])
+		size := int(binary.BigEndian.Uint32(body[pos+4 : pos+8]))
+		pos += 8
+		if pos+size > len(body) {
+			return nil, fmt.Errorf("beamingest: chunk %q claims %d bytes but only %d remain", id, size, len(body)-pos)
+		}
+		chunks[id] = body[pos : pos+size]
+		// Advance past data, aligned to 4-byte boundary.
+		aligned := (size + 3) &^ 3
+		pos += aligned
+	}
+	return chunks, nil
+}
+
+// extractDbgi decodes the "Dbgi" chunk and populates mod.
+//
+// The Dbgi chunk contains a single ETF term:
+//
+//	{debug_info_v1, erl_abstract_code, {Forms, _CompileOpts}}
+//
+// where Forms is a list of Erlang AST form tuples.
+func extractDbgi(data []byte, mod *Module) error {
+	term, err := etf.Decode(data)
+	if err != nil {
+		return fmt.Errorf("ETF decode: %w", err)
+	}
+	outer, ok := term.(etf.Tuple)
+	if !ok || len(outer) < 3 {
+		return fmt.Errorf("unexpected Dbgi shape: %T", term)
+	}
+	// outer[0] == debug_info_v1
+	// outer[1] == erl_abstract_code
+	// outer[2] == {Forms, CompileOpts} or the atom 'none'
+	inner := outer[2]
+	if atom, isAtom := inner.(etf.Atom); isAtom && atom == "none" {
+		// No abstract code (compiled with no_debug_info).
+		return nil
+	}
+	innerTuple, ok := inner.(etf.Tuple)
+	if !ok || len(innerTuple) < 1 {
+		return fmt.Errorf("unexpected Dbgi inner shape: %T", inner)
+	}
+	forms, ok := innerTuple[0].(etf.List)
+	if !ok {
+		return fmt.Errorf("Dbgi forms is not a list: %T", innerTuple[0])
+	}
+	return walkForms(forms, mod)
+}
+
+// extractAbst decodes the legacy "Abst" chunk. The chunk contains a
+// raw ETF list of AST forms (no wrapping tuple).
+func extractAbst(data []byte, mod *Module) error {
+	term, err := etf.Decode(data)
+	if err != nil {
+		return fmt.Errorf("ETF decode: %w", err)
+	}
+	forms, ok := term.(etf.List)
+	if !ok {
+		return fmt.Errorf("Abst is not a list: %T", term)
+	}
+	return walkForms(forms, mod)
+}
+
+// walkForms iterates over the list of AST form tuples and populates mod
+// with the module name, specs, and types.
+//
+// Relevant form shapes:
+//
+//	{attribute, Line, module, ModuleName}
+//	{attribute, Line, spec, {{Fun, Arity}, [Clause...]}}
+//	{attribute, Line, type, {TypeName, TypeBody, TypeParams}}
+//	{attribute, Line, opaque, {TypeName, TypeBody, TypeParams}}
+func walkForms(forms etf.List, mod *Module) error {
+	for _, raw := range forms {
+		form, ok := raw.(etf.Tuple)
+		if !ok || len(form) < 3 {
+			continue
+		}
+		kind, ok := form[0].(etf.Atom)
+		if !ok || kind != "attribute" {
+			continue
+		}
+		attr, ok := form[2].(etf.Atom)
+		if !ok {
+			continue
+		}
+		switch attr {
+		case "module":
+			if len(form) >= 4 {
+				mod.Name = atomOrString(form[3])
+			}
+		case "spec":
+			if len(form) >= 4 {
+				if spec, err := parseSpec(form[3], mod.Name); err == nil {
+					mod.Specs = append(mod.Specs, spec)
+				}
+			}
+		case "type":
+			if len(form) >= 4 {
+				if typ, err := parseType(form[3], mod.Name, false); err == nil {
+					mod.Types = append(mod.Types, typ)
+				}
+			}
+		case "opaque":
+			if len(form) >= 4 {
+				if typ, err := parseType(form[3], mod.Name, true); err == nil {
+					mod.Types = append(mod.Types, typ)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// parseSpec parses a -spec attribute value.
+//
+// The value is either:
+//
+//	{{Fun, Arity}, [Clause...]}          — local spec
+//	{{Module, Fun, Arity}, [Clause...]}  — remote spec (callback in behaviour)
+func parseSpec(val interface{}, moduleName string) (SpecForm, error) {
+	outer, ok := val.(etf.Tuple)
+	if !ok || len(outer) != 2 {
+		return SpecForm{}, fmt.Errorf("spec val not 2-tuple: %T", val)
+	}
+	sig, ok := outer[0].(etf.Tuple)
+	if !ok {
+		return SpecForm{}, fmt.Errorf("spec sig not tuple: %T", outer[0])
+	}
+	clauses, ok := outer[1].(etf.List)
+	if !ok {
+		return SpecForm{}, fmt.Errorf("spec clauses not list: %T", outer[1])
+	}
+	var mod, fun string
+	var arity int
+	switch len(sig) {
+	case 2:
+		fun = atomOrString(sig[0])
+		arity = toInt(sig[1])
+		mod = moduleName
+	case 3:
+		mod = atomOrString(sig[0])
+		fun = atomOrString(sig[1])
+		arity = toInt(sig[2])
+	default:
+		return SpecForm{}, fmt.Errorf("spec sig has %d elements", len(sig))
+	}
+	sf := SpecForm{Module: mod, Function: fun, Arity: arity}
+	for _, c := range clauses {
+		sf.Clauses = append(sf.Clauses, c)
+	}
+	return sf, nil
+}
+
+// parseType parses a -type or -opaque attribute value.
+//
+// The value is: {TypeName, TypeBody, [TypeParam...]}
+func parseType(val interface{}, moduleName string, opaque bool) (TypeForm, error) {
+	t, ok := val.(etf.Tuple)
+	if !ok || len(t) < 3 {
+		return TypeForm{}, fmt.Errorf("type val not 3-tuple: %T len=%d", val, lenTuple(val))
+	}
+	name := atomOrString(t[0])
+	body := t[1]
+	params, _ := t[2].(etf.List)
+	return TypeForm{
+		Module: moduleName,
+		Name:   name,
+		Arity:  len(params),
+		Opaque: opaque,
+		Body:   body,
+	}, nil
+}
+
+func atomOrString(v interface{}) string {
+	switch t := v.(type) {
+	case etf.Atom:
+		return string(t)
+	case string:
+		return t
+	case []byte:
+		return string(t)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+func toInt(v interface{}) int {
+	switch t := v.(type) {
+	case int:
+		return t
+	case int64:
+		return int(t)
+	case uint:
+		return int(t)
+	}
+	return 0
+}
+
+func lenTuple(v interface{}) int {
+	if t, ok := v.(etf.Tuple); ok {
+		return len(t)
+	}
+	return 0
+}

--- a/package3/erlang/beamingest/beamingest_test.go
+++ b/package3/erlang/beamingest/beamingest_test.go
@@ -1,0 +1,332 @@
+package beamingest
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"mochi/package3/erlang/etf"
+)
+
+// buildBeam constructs a minimal valid BEAM file from a map of chunk ID ->
+// raw chunk data (not ETF-encoded; callers pass ready-to-use bytes).
+func buildBeam(chunks map[string][]byte) []byte {
+	// Build the IFF chunk sequence.
+	var body []byte
+	for id, data := range chunks {
+		if len(id) != 4 {
+			panic("chunk id must be 4 bytes: " + id)
+		}
+		chunk := make([]byte, 8+len(data))
+		copy(chunk[0:4], id)
+		binary.BigEndian.PutUint32(chunk[4:8], uint32(len(data)))
+		copy(chunk[8:], data)
+		// Pad to 4-byte boundary.
+		if pad := len(data) % 4; pad != 0 {
+			chunk = append(chunk, make([]byte, 4-pad)...)
+		}
+		body = append(body, chunk...)
+	}
+
+	// FOR1 header: "FOR1" + uint32(len(body)+4) + "BEAM"
+	header := make([]byte, 12)
+	copy(header[0:4], "FOR1")
+	binary.BigEndian.PutUint32(header[4:8], uint32(len(body)+4))
+	copy(header[8:12], "BEAM")
+	return append(header, body...)
+}
+
+// encodeDbgi encodes a Dbgi chunk value: {debug_info_v1, erl_abstract_code, {Forms, []}}
+func encodeDbgi(forms etf.List) []byte {
+	inner := etf.Tuple{forms, etf.List{}}
+	term := etf.Tuple{etf.Atom("debug_info_v1"), etf.Atom("erl_abstract_code"), inner}
+	b, err := etf.Encode(term)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// encodeAbst encodes a legacy Abst chunk: plain ETF list of forms.
+func encodeAbst(forms etf.List) []byte {
+	b, err := etf.Encode(forms)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// moduleAttr returns a {attribute, 1, module, Name} AST form.
+func moduleAttr(name string) etf.Tuple {
+	return etf.Tuple{etf.Atom("attribute"), 1, etf.Atom("module"), etf.Atom(name)}
+}
+
+// specAttr returns a {attribute, 1, spec, {{Fun,Arity},[Clause]}} form.
+func specAttr(fun string, arity int, clause interface{}) etf.Tuple {
+	sig := etf.Tuple{etf.Atom(fun), arity}
+	val := etf.Tuple{sig, etf.List{clause}}
+	return etf.Tuple{etf.Atom("attribute"), 1, etf.Atom("spec"), val}
+}
+
+// typeAttr returns a {attribute, 1, type, {Name, Body, []}} form.
+func typeAttr(name string, body interface{}) etf.Tuple {
+	val := etf.Tuple{etf.Atom(name), body, etf.List{}}
+	return etf.Tuple{etf.Atom("attribute"), 1, etf.Atom("type"), val}
+}
+
+// opaqueAttr returns a {attribute, 1, opaque, {Name, Body, []}} form.
+func opaqueAttr(name string, body interface{}) etf.Tuple {
+	val := etf.Tuple{etf.Atom(name), body, etf.List{}}
+	return etf.Tuple{etf.Atom("attribute"), 1, etf.Atom("opaque"), val}
+}
+
+// A simple clause placeholder representing (integer()) -> ok.
+var simpleClause = etf.Tuple{
+	etf.Atom("type"), 1, etf.Atom("fun"),
+	etf.List{
+		etf.Tuple{etf.Atom("type"), 1, etf.Atom("product"),
+			etf.List{etf.Tuple{etf.Atom("type"), 1, etf.Atom("integer"), etf.List{}}}},
+		etf.Tuple{etf.Atom("atom"), 1, etf.Atom("ok")},
+	},
+}
+
+func TestParseBeam_InvalidMagic(t *testing.T) {
+	_, err := ParseBeam([]byte("NOTABEAMFILE"))
+	if err == nil {
+		t.Error("ParseBeam should fail for non-BEAM data")
+	}
+}
+
+func TestParseBeam_TooShort(t *testing.T) {
+	_, err := ParseBeam([]byte("FOR1"))
+	if err == nil {
+		t.Error("ParseBeam should fail for truncated file")
+	}
+}
+
+func TestParseBeam_NoAbstractCode(t *testing.T) {
+	beam := buildBeam(map[string][]byte{
+		// A real beam file always has an Atom chunk; we don't parse it but
+		// this exercises the "no Dbgi/Abst" path.
+		"Atom": {0x00, 0x00, 0x00, 0x01, 0x05, 'h', 'e', 'l', 'l', 'o'},
+	})
+	mod, err := ParseBeam(beam)
+	if err != nil {
+		t.Fatalf("ParseBeam: %v", err)
+	}
+	if mod.HasAbstractCode {
+		t.Error("HasAbstractCode should be false when neither Dbgi nor Abst is present")
+	}
+	if len(mod.Specs) != 0 || len(mod.Types) != 0 {
+		t.Error("no specs or types expected without abstract code")
+	}
+}
+
+func TestParseBeam_Dbgi_ModuleName(t *testing.T) {
+	forms := etf.List{moduleAttr("cowboy")}
+	beam := buildBeam(map[string][]byte{"Dbgi": encodeDbgi(forms)})
+	mod, err := ParseBeam(beam)
+	if err != nil {
+		t.Fatalf("ParseBeam: %v", err)
+	}
+	if mod.Name != "cowboy" {
+		t.Errorf("Name = %q, want cowboy", mod.Name)
+	}
+	if !mod.HasAbstractCode {
+		t.Error("HasAbstractCode should be true")
+	}
+}
+
+func TestParseBeam_Dbgi_Spec(t *testing.T) {
+	forms := etf.List{
+		moduleAttr("ranch"),
+		specAttr("start_listener", 4, simpleClause),
+	}
+	beam := buildBeam(map[string][]byte{"Dbgi": encodeDbgi(forms)})
+	mod, err := ParseBeam(beam)
+	if err != nil {
+		t.Fatalf("ParseBeam: %v", err)
+	}
+	if mod.Name != "ranch" {
+		t.Errorf("Name = %q, want ranch", mod.Name)
+	}
+	if len(mod.Specs) != 1 {
+		t.Fatalf("len(Specs) = %d, want 1", len(mod.Specs))
+	}
+	s := mod.Specs[0]
+	if s.Function != "start_listener" {
+		t.Errorf("Function = %q, want start_listener", s.Function)
+	}
+	if s.Arity != 4 {
+		t.Errorf("Arity = %d, want 4", s.Arity)
+	}
+	if s.Module != "ranch" {
+		t.Errorf("Module = %q, want ranch", s.Module)
+	}
+	if len(s.Clauses) != 1 {
+		t.Errorf("Clauses len = %d, want 1", len(s.Clauses))
+	}
+}
+
+func TestParseBeam_Dbgi_MultipleSpecs(t *testing.T) {
+	forms := etf.List{
+		moduleAttr("hackney"),
+		specAttr("get", 2, simpleClause),
+		specAttr("post", 3, simpleClause),
+		specAttr("put", 3, simpleClause),
+	}
+	beam := buildBeam(map[string][]byte{"Dbgi": encodeDbgi(forms)})
+	mod, err := ParseBeam(beam)
+	if err != nil {
+		t.Fatalf("ParseBeam: %v", err)
+	}
+	if len(mod.Specs) != 3 {
+		t.Errorf("len(Specs) = %d, want 3", len(mod.Specs))
+	}
+}
+
+func TestParseBeam_Dbgi_Type(t *testing.T) {
+	body := etf.Tuple{etf.Atom("type"), 1, etf.Atom("integer"), etf.List{}}
+	forms := etf.List{
+		moduleAttr("jsx"),
+		typeAttr("json_term", body),
+	}
+	beam := buildBeam(map[string][]byte{"Dbgi": encodeDbgi(forms)})
+	mod, err := ParseBeam(beam)
+	if err != nil {
+		t.Fatalf("ParseBeam: %v", err)
+	}
+	if len(mod.Types) != 1 {
+		t.Fatalf("len(Types) = %d, want 1", len(mod.Types))
+	}
+	ty := mod.Types[0]
+	if ty.Name != "json_term" {
+		t.Errorf("Type.Name = %q, want json_term", ty.Name)
+	}
+	if ty.Opaque {
+		t.Error("should not be opaque")
+	}
+}
+
+func TestParseBeam_Dbgi_OpaqueType(t *testing.T) {
+	body := etf.Tuple{etf.Atom("type"), 1, etf.Atom("any"), etf.List{}}
+	forms := etf.List{
+		moduleAttr("jose_jws"),
+		opaqueAttr("t", body),
+	}
+	beam := buildBeam(map[string][]byte{"Dbgi": encodeDbgi(forms)})
+	mod, err := ParseBeam(beam)
+	if err != nil {
+		t.Fatalf("ParseBeam: %v", err)
+	}
+	if len(mod.Types) != 1 {
+		t.Fatalf("len(Types) = %d, want 1", len(mod.Types))
+	}
+	if !mod.Types[0].Opaque {
+		t.Error("Opaque should be true")
+	}
+}
+
+func TestParseBeam_Abst_Legacy(t *testing.T) {
+	forms := etf.List{
+		moduleAttr("poolboy"),
+		specAttr("checkout", 1, simpleClause),
+	}
+	beam := buildBeam(map[string][]byte{"Abst": encodeAbst(forms)})
+	mod, err := ParseBeam(beam)
+	if err != nil {
+		t.Fatalf("ParseBeam: %v", err)
+	}
+	if !mod.HasAbstractCode {
+		t.Error("HasAbstractCode should be true for Abst chunk")
+	}
+	if mod.Name != "poolboy" {
+		t.Errorf("Name = %q, want poolboy", mod.Name)
+	}
+	if len(mod.Specs) != 1 {
+		t.Errorf("len(Specs) = %d, want 1", len(mod.Specs))
+	}
+}
+
+func TestParseBeam_Dbgi_PrefersOverAbst(t *testing.T) {
+	// Both chunks present: Dbgi should win.
+	dbgiForms := etf.List{moduleAttr("cowlib")}
+	abstForms := etf.List{moduleAttr("WRONG_abst")}
+	beam := buildBeam(map[string][]byte{
+		"Dbgi": encodeDbgi(dbgiForms),
+		"Abst": encodeAbst(abstForms),
+	})
+	mod, err := ParseBeam(beam)
+	if err != nil {
+		t.Fatalf("ParseBeam: %v", err)
+	}
+	if mod.Name != "cowlib" {
+		t.Errorf("Dbgi should win; Name = %q, want cowlib", mod.Name)
+	}
+}
+
+func TestParseBeam_Dbgi_NoneNoCode(t *testing.T) {
+	// {debug_info_v1, erl_abstract_code, none} — no_debug_info compile option.
+	term := etf.Tuple{etf.Atom("debug_info_v1"), etf.Atom("erl_abstract_code"), etf.Atom("none")}
+	b, _ := etf.Encode(term)
+	beam := buildBeam(map[string][]byte{"Dbgi": b})
+	mod, err := ParseBeam(beam)
+	if err != nil {
+		t.Fatalf("ParseBeam: %v", err)
+	}
+	if !mod.HasAbstractCode {
+		// HasAbstractCode is true (chunk exists) even if content is 'none'.
+		t.Error("HasAbstractCode should be true when Dbgi chunk exists")
+	}
+	if len(mod.Specs) != 0 {
+		t.Error("no specs expected when Dbgi is 'none'")
+	}
+}
+
+func TestParseBeam_TypeWithParams(t *testing.T) {
+	// -type dict(K, V) :: ...
+	params := etf.List{
+		etf.Tuple{etf.Atom("var"), 1, etf.Atom("K")},
+		etf.Tuple{etf.Atom("var"), 1, etf.Atom("V")},
+	}
+	body := etf.Tuple{etf.Atom("type"), 1, etf.Atom("any"), etf.List{}}
+	val := etf.Tuple{etf.Atom("dict"), body, params}
+	form := etf.Tuple{etf.Atom("attribute"), 1, etf.Atom("type"), val}
+	forms := etf.List{moduleAttr("dict"), form}
+	beam := buildBeam(map[string][]byte{"Dbgi": encodeDbgi(forms)})
+	mod, err := ParseBeam(beam)
+	if err != nil {
+		t.Fatalf("ParseBeam: %v", err)
+	}
+	if len(mod.Types) != 1 {
+		t.Fatalf("len(Types) = %d, want 1", len(mod.Types))
+	}
+	if mod.Types[0].Arity != 2 {
+		t.Errorf("Type arity = %d, want 2", mod.Types[0].Arity)
+	}
+}
+
+func TestParseBeam_RemoteSpec(t *testing.T) {
+	// -spec Module:Fun/Arity (callback spec in behaviour).
+	sig := etf.Tuple{etf.Atom("cowboy_handler"), etf.Atom("init"), 2}
+	val := etf.Tuple{sig, etf.List{simpleClause}}
+	form := etf.Tuple{etf.Atom("attribute"), 1, etf.Atom("spec"), val}
+	forms := etf.List{moduleAttr("cowboy_handler"), form}
+	beam := buildBeam(map[string][]byte{"Dbgi": encodeDbgi(forms)})
+	mod, err := ParseBeam(beam)
+	if err != nil {
+		t.Fatalf("ParseBeam: %v", err)
+	}
+	if len(mod.Specs) != 1 {
+		t.Fatalf("len(Specs) = %d, want 1", len(mod.Specs))
+	}
+	s := mod.Specs[0]
+	if s.Module != "cowboy_handler" {
+		t.Errorf("remote spec module = %q, want cowboy_handler", s.Module)
+	}
+	if s.Function != "init" {
+		t.Errorf("remote spec fun = %q, want init", s.Function)
+	}
+	if s.Arity != 2 {
+		t.Errorf("remote spec arity = %d, want 2", s.Arity)
+	}
+}

--- a/website/docs/implementation/0066/index.md
+++ b/website/docs/implementation/0066/index.md
@@ -16,8 +16,8 @@ A phase is LANDED only when its gate is green for every target in the runtime ma
 | Phase | Title | Status | Commit | Tracking page |
 |-------|-------|--------|--------|---------------|
 | 0 | Skeleton: package3/erlang/ layout + rebar3 workspace plumbing | LANDED | 3b9fe10 | [phase-00](/docs/implementation/0066/phase-00-skeleton) |
-| 1 | Hex.pm API v2 client (package fetch + outer/inner tarball + SHA-256/SHA-512 verify) | IN PROGRESS | — | [phase-01](/docs/implementation/0066/phase-01-hex-index) |
-| 2 | BEAM abstract code ingest (Dbgi/Abst chunk ETF decoder, -spec/-type walker) | NOT STARTED | — | [phase-02](/docs/implementation/0066/phase-02-beam-ingest) |
+| 1 | Hex.pm API v2 client (package fetch + outer/inner tarball + SHA-256/SHA-512 verify) | LANDED | a0e95be | [phase-01](/docs/implementation/0066/phase-01-hex-index) |
+| 2 | BEAM abstract code ingest (Dbgi/Abst chunk ETF decoder, -spec/-type walker) | IN PROGRESS | — | [phase-02](/docs/implementation/0066/phase-02-beam-ingest) |
 | 3 | EDoc XML fallback ingest (for packages with no -spec directives) | NOT STARTED | — | [phase-03](/docs/implementation/0066/phase-03-edoc-fallback) |
 | 4 | Dialyzer typespec-to-Mochi type mapping + SkipReport emit | NOT STARTED | — | [phase-04](/docs/implementation/0066/phase-04-type-mapping) |
 | 5 | Port bridge shim emitter (shim.erl gen_server + shim.mochi extern fn corpus) | NOT STARTED | — | [phase-05](/docs/implementation/0066/phase-05-shim-emit) |


### PR DESCRIPTION
Closes #22854

## Summary

`package3/erlang/beamingest/`: FOR1/IFF BEAM file parser + Dbgi/Abst chunk decoder + -spec/-type AST walker.

- `ParseBeam(data []byte)` / `ReadBeam(r io.Reader)` — full pipeline
- Dbgi (OTP 20+): `{debug_info_v1, erl_abstract_code, {Forms, Opts}}`
- Abst (OTP 17-19): plain ETF list of forms
- `SpecForm`: module, function, arity, raw clause ETF list (→ phase 4 typemap)
- `TypeForm`: name, arity, opaque flag, body (→ phase 4 typemap)
- Dbgi wins over Abst when both are present

## Test plan

- [x] 15 tests, all synthetic BEAM files built in Go (no Erlang compiler needed)
- [x] Covers: invalid magic, no abstract code, Dbgi module/spec/type/opaque, Abst legacy, Dbgi-vs-Abst preference, none/no_debug_info, remote specs, parametric types