### PR TITLE
feat(mep-75 p4): closed PHP-to-Mochi type-mapping table

### DIFF
--- a/package3/php/typemap/typemap.go
+++ b/package3/php/typemap/typemap.go
@@ -1,4 +1,239 @@
 // Package typemap implements the closed PHP-to-Mochi type translation table
-// for the MEP-75 PHP bridge. Phase 0 ships the package stub; the full
-// implementation arrives in phase 4.
+// for the MEP-75 PHP bridge.
+//
+// The table is closed: every PHP type produces either a Mochi type or a
+// SkipReason. No open-ended inference is performed. The closed set matches
+// the design in [website/docs/research/0075/05-type-mapping.md].
+//
+// Usage:
+//
+//	m, skip, detail := typemap.Map("string", false)
+//	if skip != 0 { /* item should be SKIPPED */ }
+//	// m.MochiType is the Mochi extern-type string
 package typemap
+
+import (
+	"fmt"
+	"strings"
+
+	bridgeerrors "mochi/package3/php/errors"
+)
+
+// Direction indicates the translation direction for polymorphic types.
+type Direction int
+
+const (
+	// DirectionIn translates a PHP parameter type into a Mochi parameter type.
+	DirectionIn Direction = iota
+	// DirectionOut translates a PHP return type into a Mochi return type.
+	DirectionOut
+)
+
+// Mapping is the result of a successful PHP-to-Mochi type translation.
+type Mapping struct {
+	// PHPType is the original PHP type string as returned by ReflectionType.
+	PHPType string
+	// MochiType is the Mochi extern type expression, e.g. "string", "int",
+	// "bool", "float", "list[T]", "map[K]V", "T|nil", or an extern-type name.
+	MochiType string
+	// Nullable is true when the PHP type was nullable (?T or T|null) and the
+	// MochiType wraps the base type in T|nil.
+	Nullable bool
+	// IsPrimitive is true for scalar types (int, float, string, bool).
+	IsPrimitive bool
+}
+
+// Map translates a PHP type string (as returned by ReflectionNamedType.getName()
+// etc.) into a Mochi type Mapping, or returns a SkipReason when the type
+// cannot be safely mapped.
+//
+// nullable is true when the PHP type is declared as ?T or when allowsNull()
+// returns true for the ReflectionType. When nullable is true, the returned
+// MochiType is wrapped as "T|nil".
+//
+// dir is DirectionIn for parameter types and DirectionOut for return types.
+// It is currently only consulted for "void" (which is valid as DirectionOut
+// but not as DirectionIn).
+func Map(phpType string, nullable bool, dir Direction) (*Mapping, bridgeerrors.SkipReason, string) {
+	// Normalise: strip leading backslashes, trim spaces.
+	t := strings.TrimSpace(strings.TrimPrefix(phpType, "\\"))
+
+	// Union types ("A|B|null") — decompose and map each component.
+	if strings.Contains(t, "|") {
+		return mapUnion(t, dir)
+	}
+
+	// Intersection types ("A&B") — always skip in v1.
+	if strings.Contains(t, "&") {
+		return nil, bridgeerrors.SkipIntersection, fmt.Sprintf("intersection type %q not supported in v1", t)
+	}
+
+	skip, detail := skipPrimitive(t, dir)
+	if skip != 0 {
+		return nil, skip, detail
+	}
+
+	mochiType := primitiveMochiType(t, dir)
+	if mochiType == "" {
+		// Class/interface/enum name: map to a handle type.
+		mochiType = classHandleType(t)
+	}
+
+	if nullable {
+		mochiType = mochiType + "|nil"
+	}
+
+	m := &Mapping{
+		PHPType:     phpType,
+		MochiType:   mochiType,
+		Nullable:    nullable,
+		IsPrimitive: isPrimitive(t),
+	}
+	return m, 0, ""
+}
+
+// mapUnion handles PHP union types like "int|string", "int|null", "A|B|null".
+func mapUnion(t string, dir Direction) (*Mapping, bridgeerrors.SkipReason, string) {
+	parts := strings.Split(t, "|")
+	var nonNull []string
+	hasNull := false
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "null" || p == "NULL" {
+			hasNull = true
+		} else {
+			nonNull = append(nonNull, p)
+		}
+	}
+	if len(nonNull) == 0 {
+		return nil, bridgeerrors.SkipMixed, "union reduces to null only"
+	}
+	if len(nonNull) == 1 {
+		return Map(nonNull[0], hasNull, dir)
+	}
+	var mochiParts []string
+	for _, p := range nonNull {
+		m, skip, detail := Map(p, false, dir)
+		if skip != 0 {
+			return nil, skip, fmt.Sprintf("union component %q: %s", p, detail)
+		}
+		mochiParts = append(mochiParts, m.MochiType)
+	}
+	mochiType := strings.Join(mochiParts, "|")
+	if hasNull {
+		mochiType = mochiType + "|nil"
+	}
+	return &Mapping{
+		PHPType:     t,
+		MochiType:   mochiType,
+		Nullable:    hasNull,
+		IsPrimitive: false,
+	}, 0, ""
+}
+
+// skipPrimitive returns a SkipReason for PHP types that cannot be translated
+// in v1. Returns 0 if the type is mappable.
+func skipPrimitive(t string, _ Direction) (bridgeerrors.SkipReason, string) {
+	switch strings.ToLower(t) {
+	case "mixed":
+		return bridgeerrors.SkipMixed, "mixed type has no Mochi equivalent"
+	case "object":
+		return bridgeerrors.SkipObject, "bare object type has no Mochi equivalent"
+	case "callable":
+		return bridgeerrors.SkipCallable, "callable pseudo-type has no stable ABI"
+	case "resource":
+		return bridgeerrors.SkipResource, "PHP resource handle is pre-8.0 legacy"
+	case "never":
+		return bridgeerrors.SkipNever, "never return type represents unreachable boundary"
+	case "self", "static", "parent":
+		return bridgeerrors.SkipSelfStatic, fmt.Sprintf("%q type requires runtime dispatch", t)
+	case "array":
+		return bridgeerrors.SkipUntypedArray, "untyped array requires docblock hint for list/map inference"
+	}
+	return 0, ""
+}
+
+// primitiveMochiType maps a PHP scalar or well-known type to a Mochi type string.
+// Returns the empty string for class/interface/enum names (handled by classHandleType).
+func primitiveMochiType(t string, dir Direction) string {
+	switch strings.ToLower(t) {
+	case "int", "integer":
+		return "int"
+	case "float", "double":
+		return "float"
+	case "string":
+		return "string"
+	case "bool", "boolean":
+		return "bool"
+	case "void":
+		if dir == DirectionOut {
+			return "unit"
+		}
+		return ""
+	case "null":
+		return "nil"
+	case "true", "false":
+		return "bool"
+	case "iterable":
+		return "list[any]"
+	}
+	return ""
+}
+
+// classHandleType maps a PHP class/interface/enum FQCN to its Mochi extern
+// handle name. Namespace parts are joined in PascalCase.
+//
+// Example: "GuzzleHttp\\Client" -> "GuzzleHttpClient".
+func classHandleType(fqcn string) string {
+	fqcn = strings.TrimPrefix(fqcn, "\\")
+	parts := strings.Split(fqcn, "\\")
+	var sb strings.Builder
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		sb.WriteString(strings.ToUpper(p[:1]))
+		sb.WriteString(p[1:])
+	}
+	name := sb.String()
+	if name == "" {
+		return "OpaqueHandle"
+	}
+	return name
+}
+
+// isPrimitive returns true for PHP scalar types (int, float, string, bool).
+func isPrimitive(t string) bool {
+	switch strings.ToLower(t) {
+	case "int", "integer", "float", "double", "string", "bool", "boolean":
+		return true
+	}
+	return false
+}
+
+// MapTypedArray maps a PHP array type with explicit key and value types (from
+// a PSR-compliant docblock like "array<string, int>") to a Mochi map or list.
+// mapKeyType is "" for lists (array<T>), non-empty for maps (array<K, V>).
+func MapTypedArray(mapKeyType, valueType string) (*Mapping, bridgeerrors.SkipReason, string) {
+	if valueType == "" {
+		return nil, bridgeerrors.SkipUntypedArray, "empty value type for typed array"
+	}
+	valueM, skip, detail := Map(valueType, false, DirectionIn)
+	if skip != 0 {
+		return nil, skip, fmt.Sprintf("array value type: %s", detail)
+	}
+	if mapKeyType == "" {
+		return &Mapping{
+			PHPType:   fmt.Sprintf("array<%s>", valueType),
+			MochiType: fmt.Sprintf("list[%s]", valueM.MochiType),
+		}, 0, ""
+	}
+	keyM, skip, detail := Map(mapKeyType, false, DirectionIn)
+	if skip != 0 {
+		return nil, skip, fmt.Sprintf("array key type: %s", detail)
+	}
+	return &Mapping{
+		PHPType:   fmt.Sprintf("array<%s, %s>", mapKeyType, valueType),
+		MochiType: fmt.Sprintf("map[%s]%s", keyM.MochiType, valueM.MochiType),
+	}, 0, ""
+}

--- a/package3/php/typemap/typemap_test.go
+++ b/package3/php/typemap/typemap_test.go
@@ -1,0 +1,262 @@
+package typemap
+
+import (
+	"testing"
+
+	bridgeerrors "mochi/package3/php/errors"
+)
+
+func TestMapPrimitives(t *testing.T) {
+	cases := []struct {
+		phpType   string
+		nullable  bool
+		wantMochi string
+		wantPrim  bool
+	}{
+		{"int", false, "int", true},
+		{"integer", false, "int", true},
+		{"float", false, "float", true},
+		{"double", false, "float", true},
+		{"string", false, "string", true},
+		{"bool", false, "bool", true},
+		{"boolean", false, "bool", true},
+		{"true", false, "bool", false},
+		{"false", false, "bool", false},
+		{"null", false, "nil", false},
+		{"iterable", false, "list[any]", false},
+	}
+	for _, tc := range cases {
+		m, skip, detail := Map(tc.phpType, tc.nullable, DirectionIn)
+		if skip != 0 {
+			t.Errorf("Map(%q) unexpected skip %v: %s", tc.phpType, skip, detail)
+			continue
+		}
+		if m.MochiType != tc.wantMochi {
+			t.Errorf("Map(%q).MochiType = %q; want %q", tc.phpType, m.MochiType, tc.wantMochi)
+		}
+		if m.IsPrimitive != tc.wantPrim {
+			t.Errorf("Map(%q).IsPrimitive = %v; want %v", tc.phpType, m.IsPrimitive, tc.wantPrim)
+		}
+	}
+}
+
+func TestMapNullable(t *testing.T) {
+	m, skip, _ := Map("string", true, DirectionIn)
+	if skip != 0 {
+		t.Fatalf("unexpected skip for ?string")
+	}
+	if m.MochiType != "string|nil" {
+		t.Errorf("MochiType = %q; want string|nil", m.MochiType)
+	}
+	if !m.Nullable {
+		t.Error("Nullable should be true for ?string")
+	}
+}
+
+func TestMapVoid(t *testing.T) {
+	m, skip, _ := Map("void", false, DirectionOut)
+	if skip != 0 {
+		t.Fatalf("unexpected skip for void return type")
+	}
+	if m.MochiType != "unit" {
+		t.Errorf("void return -> %q; want unit", m.MochiType)
+	}
+}
+
+func TestMapSkipReasons(t *testing.T) {
+	cases := []struct {
+		phpType    string
+		wantSkip   bridgeerrors.SkipReason
+	}{
+		{"mixed", bridgeerrors.SkipMixed},
+		{"object", bridgeerrors.SkipObject},
+		{"callable", bridgeerrors.SkipCallable},
+		{"resource", bridgeerrors.SkipResource},
+		{"never", bridgeerrors.SkipNever},
+		{"self", bridgeerrors.SkipSelfStatic},
+		{"static", bridgeerrors.SkipSelfStatic},
+		{"parent", bridgeerrors.SkipSelfStatic},
+		{"array", bridgeerrors.SkipUntypedArray},
+	}
+	for _, tc := range cases {
+		_, skip, _ := Map(tc.phpType, false, DirectionIn)
+		if skip != tc.wantSkip {
+			t.Errorf("Map(%q) skip = %v; want %v", tc.phpType, skip, tc.wantSkip)
+		}
+	}
+}
+
+func TestMapClassHandle(t *testing.T) {
+	cases := []struct {
+		phpType   string
+		wantMochi string
+	}{
+		{`GuzzleHttp\Client`, "GuzzleHttpClient"},
+		{`GuzzleHttp\Psr7\Request`, "GuzzleHttpPsr7Request"},
+		{`Monolog\Logger`, "MonologLogger"},
+		{`Psr\Log\LoggerInterface`, "PsrLogLoggerInterface"},
+		{`\Symfony\Component\Console\Application`, "SymfonyComponentConsoleApplication"},
+	}
+	for _, tc := range cases {
+		m, skip, detail := Map(tc.phpType, false, DirectionIn)
+		if skip != 0 {
+			t.Errorf("Map(%q) unexpected skip %v: %s", tc.phpType, skip, detail)
+			continue
+		}
+		if m.MochiType != tc.wantMochi {
+			t.Errorf("Map(%q).MochiType = %q; want %q", tc.phpType, m.MochiType, tc.wantMochi)
+		}
+	}
+}
+
+func TestMapClassHandleNullable(t *testing.T) {
+	m, skip, _ := Map(`GuzzleHttp\Client`, true, DirectionIn)
+	if skip != 0 {
+		t.Fatalf("unexpected skip")
+	}
+	if m.MochiType != "GuzzleHttpClient|nil" {
+		t.Errorf("MochiType = %q; want GuzzleHttpClient|nil", m.MochiType)
+	}
+}
+
+func TestMapUnionDegenerate(t *testing.T) {
+	// int|null should map to int|nil.
+	m, skip, _ := Map("int|null", false, DirectionIn)
+	if skip != 0 {
+		t.Fatalf("unexpected skip for int|null")
+	}
+	if m.MochiType != "int|nil" {
+		t.Errorf("int|null -> %q; want int|nil", m.MochiType)
+	}
+	if !m.Nullable {
+		t.Error("Nullable should be true for int|null")
+	}
+}
+
+func TestMapUnionTwoTypes(t *testing.T) {
+	// int|string should map to int|string.
+	m, skip, _ := Map("int|string", false, DirectionIn)
+	if skip != 0 {
+		t.Fatalf("unexpected skip for int|string")
+	}
+	if m.MochiType != "int|string" {
+		t.Errorf("int|string -> %q; want int|string", m.MochiType)
+	}
+}
+
+func TestMapUnionWithNull(t *testing.T) {
+	// int|string|null -> int|string|nil.
+	m, skip, _ := Map("int|string|null", false, DirectionIn)
+	if skip != 0 {
+		t.Fatalf("unexpected skip")
+	}
+	if m.MochiType != "int|string|nil" {
+		t.Errorf("int|string|null -> %q; want int|string|nil", m.MochiType)
+	}
+}
+
+func TestMapUnionContainingSkip(t *testing.T) {
+	// int|mixed -> SkipMixed.
+	_, skip, _ := Map("int|mixed", false, DirectionIn)
+	if skip != bridgeerrors.SkipMixed {
+		t.Errorf("int|mixed skip = %v; want SkipMixed", skip)
+	}
+}
+
+func TestMapIntersection(t *testing.T) {
+	_, skip, _ := Map("A&B", false, DirectionIn)
+	if skip != bridgeerrors.SkipIntersection {
+		t.Errorf("A&B skip = %v; want SkipIntersection", skip)
+	}
+}
+
+func TestMapTypedArrayList(t *testing.T) {
+	m, skip, detail := MapTypedArray("", "string")
+	if skip != 0 {
+		t.Fatalf("MapTypedArray list unexpected skip: %v: %s", skip, detail)
+	}
+	if m.MochiType != "list[string]" {
+		t.Errorf("MochiType = %q; want list[string]", m.MochiType)
+	}
+}
+
+func TestMapTypedArrayMap(t *testing.T) {
+	m, skip, detail := MapTypedArray("string", "int")
+	if skip != 0 {
+		t.Fatalf("MapTypedArray map unexpected skip: %v: %s", skip, detail)
+	}
+	if m.MochiType != "map[string]int" {
+		t.Errorf("MochiType = %q; want map[string]int", m.MochiType)
+	}
+}
+
+func TestMapTypedArraySkipWhenValueSkips(t *testing.T) {
+	_, skip, _ := MapTypedArray("", "mixed")
+	if skip != bridgeerrors.SkipMixed {
+		t.Errorf("array<mixed> skip = %v; want SkipMixed", skip)
+	}
+}
+
+func TestMapCaseInsensitive(t *testing.T) {
+	// PHP type names are case-insensitive; ensure we handle uppercase variants.
+	cases := []struct {
+		phpType   string
+		wantMochi string
+	}{
+		{"INT", "int"},
+		{"STRING", "string"},
+		{"BOOL", "bool"},
+		{"FLOAT", "float"},
+		{"MIXED", ""},
+	}
+	for _, tc := range cases {
+		m, skip, _ := Map(tc.phpType, false, DirectionIn)
+		if tc.wantMochi == "" {
+			if skip == 0 {
+				t.Errorf("Map(%q) should skip; got %q", tc.phpType, m.MochiType)
+			}
+		} else {
+			if skip != 0 {
+				t.Errorf("Map(%q) unexpected skip %v", tc.phpType, skip)
+				continue
+			}
+			if m.MochiType != tc.wantMochi {
+				t.Errorf("Map(%q).MochiType = %q; want %q", tc.phpType, m.MochiType, tc.wantMochi)
+			}
+		}
+	}
+}
+
+func TestClassHandleType(t *testing.T) {
+	cases := []struct {
+		fqcn string
+		want string
+	}{
+		{`GuzzleHttp\Client`, "GuzzleHttpClient"},
+		{`\Foo\Bar\Baz`, "FooBarBaz"},
+		{"Logger", "Logger"},
+		{"", "OpaqueHandle"},
+	}
+	for _, tc := range cases {
+		got := classHandleType(tc.fqcn)
+		if got != tc.want {
+			t.Errorf("classHandleType(%q) = %q; want %q", tc.fqcn, got, tc.want)
+		}
+	}
+}
+
+func TestMappingFields(t *testing.T) {
+	m, skip, _ := Map("string", false, DirectionIn)
+	if skip != 0 {
+		t.Fatalf("unexpected skip")
+	}
+	if m.PHPType != "string" {
+		t.Errorf("PHPType = %q; want string", m.PHPType)
+	}
+	if !m.IsPrimitive {
+		t.Error("string should be primitive")
+	}
+	if m.Nullable {
+		t.Error("non-nullable string should not be nullable")
+	}
+}

--- a/website/docs/implementation/0075/phase-04-typemap.md
+++ b/website/docs/implementation/0075/phase-04-typemap.md
@@ -1,0 +1,57 @@
+# MEP-75 Phase 4: Closed PHP-to-Mochi Type Mapping Table
+
+**Status**: LANDED 2026-05-30 00:00 (GMT+7)
+
+## Goal
+
+Implement the closed PHP-to-Mochi type translation table under `package3/php/typemap`. Every PHP type must produce either a Mochi extern-type string or a `SkipReason` -- no open-ended inference.
+
+## Type Table
+
+| PHP Type | Mochi Type | Notes |
+|---|---|---|
+| `int`, `integer` | `int` | primitive |
+| `float`, `double` | `float` | primitive |
+| `string` | `string` | primitive |
+| `bool`, `boolean` | `bool` | primitive |
+| `?T` / `T\|null` | `T\|nil` | nullable wrapping |
+| `void` (return) | `unit` | DirectionOut only |
+| `null` | `nil` | literal null type |
+| `true`, `false` | `bool` | singleton bool types |
+| `iterable` | `list[any]` | coarse mapping |
+| `array<T>` | `list[T]` | via MapTypedArray |
+| `array<K,V>` | `map[K]V` | via MapTypedArray |
+| `FQCN` | PascalCase handle | GuzzleHttp\\Client -> GuzzleHttpClient |
+| `A\|B` | `A\|B` | true union |
+| `mixed` | -- | SkipMixed |
+| `object` | -- | SkipObject |
+| `callable` | -- | SkipCallable |
+| `resource` | -- | SkipResource |
+| `never` | -- | SkipNever |
+| `self`/`static`/`parent` | -- | SkipSelfStatic |
+| `array` (untyped) | -- | SkipUntypedArray |
+| `A&B` | -- | SkipIntersection |
+
+## Files Landed
+
+- `package3/php/typemap/typemap.go` -- full implementation
+- `package3/php/typemap/typemap_test.go` -- comprehensive test suite (15 test functions)
+
+## Test Coverage
+
+- Primitives (all PHP aliases)
+- Nullable wrapping (?T and T|null)
+- Void return type (DirectionOut)
+- All 8 SkipReason variants triggered by Map()
+- Class handle generation (FQCN -> PascalCase)
+- Nullable class handles
+- Union degenerate (int|null -> int|nil)
+- Union two types (int|string)
+- Union with null (int|string|null)
+- Union containing skip component
+- Intersection type skip
+- MapTypedArray list and map forms
+- MapTypedArray propagates skip from value type
+- Case-insensitive matching (INT, STRING, BOOL, FLOAT)
+- classHandleType edge cases (empty, leading backslash, multi-segment)
+- Mapping struct field verification


### PR DESCRIPTION
## Summary

- Implements the closed PHP-to-Mochi type translation table under `package3/php/typemap`
- Every PHP type produces a Mochi extern-type string or a `SkipReason`; no open-ended inference
- 15 test functions cover all SkipReason variants, union/intersection, typed arrays, class handles, and case-insensitive matching

## Files changed

- `package3/php/typemap/typemap.go` -- full implementation (239 lines)
- `package3/php/typemap/typemap_test.go` -- comprehensive test suite (15 test functions)
- `website/docs/implementation/0075/phase-04-typemap.md` -- phase tracking doc

## Test plan

- [x] `go test ./package3/php/typemap/...` passes
- [x] `go test ./package3/php/...` all green
- [x] `go vet ./package3/php/typemap/...` clean

Closes #22856