### PR TITLE
feat(mep-66): Phase 3 — EDoc XML fallback ingest

### DIFF
--- a/package3/erlang/edocingest/edocingest.go
+++ b/package3/erlang/edocingest/edocingest.go
@@ -1,0 +1,187 @@
+// Package edocingest is the EDoc XML fallback ingest layer for the MEP-66
+// Erlang bridge. It is invoked when a package ships neither a Dbgi chunk
+// nor an Abst chunk — which happens for packages like lager, observer_cli,
+// and cuttlefish that were compiled without debug_info.
+//
+// EDoc XML format:
+//
+// When rebar3 generates EDoc documentation, it produces one XML file per
+// module under doc/edoc/. The root element is <module> or <edoc>; function
+// documentation is under <functions><function>...</function></functions>.
+// Each <function> element may carry <typespec> children whose text content
+// is the Erlang -spec string (in Erlang term syntax, not XML).
+//
+// This ingest layer extracts:
+//  1. The module name from the <module name="..."> attribute.
+//  2. Exported function signatures from <function name="..." arity="...">.
+//  3. Type information from <typespec> children (string form only, as EDoc
+//     does not emit structured type trees — callers pass these to typemap
+//     for best-effort parsing).
+//
+// Because EDoc XML is an unofficial format and varies across rebar3/EDoc
+// versions, all extracted information is marked with SkipEDoc reason when
+// it reaches the type-mapping layer (phase 4). The ingest layer itself only
+// extracts strings; it does not attempt Erlang type-term parsing.
+package edocingest
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// FunctionDoc holds the EDoc-extracted documentation for a single exported
+// function. The type information is raw string form (Erlang syntax).
+type FunctionDoc struct {
+	// Name is the function name.
+	Name string
+	// Arity is the function arity.
+	Arity int
+	// TypeSpec is the raw -spec string extracted from the <typespec> element.
+	// Empty when no <typespec> is present.
+	TypeSpec string
+	// Doc is the plain-text documentation extracted from <p> children of
+	// the <description> element.
+	Doc string
+}
+
+// ModuleDoc is the result of parsing one EDoc XML file.
+type ModuleDoc struct {
+	// Name is the Erlang module name.
+	Name string
+	// Functions is the list of exported function documentation entries.
+	Functions []FunctionDoc
+}
+
+// ParseXML parses an EDoc XML document from r and returns the extracted
+// module documentation. Returns an error if the document is not valid EDoc
+// XML; missing or empty fields are not errors.
+func ParseXML(r io.Reader) (*ModuleDoc, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("edocingest: read: %w", err)
+	}
+	return ParseXMLBytes(data)
+}
+
+// ParseXMLBytes parses EDoc XML from raw bytes.
+func ParseXMLBytes(data []byte) (*ModuleDoc, error) {
+	dec := xml.NewDecoder(strings.NewReader(string(data)))
+	var doc ModuleDoc
+	var inFunctions bool
+	var curFun *FunctionDoc
+	var captureText string
+	var captureTarget string // "typespec" | "doc"
+
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("edocingest: XML parse: %w", err)
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			switch t.Name.Local {
+			case "module", "edoc":
+				for _, a := range t.Attr {
+					if a.Name.Local == "name" {
+						doc.Name = a.Value
+					}
+				}
+			case "functions":
+				inFunctions = true
+			case "function":
+				if inFunctions {
+					curFun = &FunctionDoc{}
+					for _, a := range t.Attr {
+						switch a.Name.Local {
+						case "name":
+							curFun.Name = a.Value
+						case "arity":
+							curFun.Arity = parseInt(a.Value)
+						}
+					}
+				}
+			case "typespec":
+				if curFun != nil {
+					captureTarget = "typespec"
+					captureText = ""
+				}
+			case "p", "div":
+				if curFun != nil && captureTarget == "" {
+					captureTarget = "doc"
+					captureText = ""
+				}
+			}
+		case xml.EndElement:
+			switch t.Name.Local {
+			case "functions":
+				inFunctions = false
+			case "function":
+				if curFun != nil {
+					doc.Functions = append(doc.Functions, *curFun)
+					curFun = nil
+					captureTarget = ""
+					captureText = ""
+				}
+			case "typespec":
+				if captureTarget == "typespec" && curFun != nil {
+					curFun.TypeSpec = strings.TrimSpace(captureText)
+					captureTarget = ""
+					captureText = ""
+				}
+			case "p", "div":
+				if captureTarget == "doc" && curFun != nil {
+					if curFun.Doc == "" {
+						curFun.Doc = strings.TrimSpace(captureText)
+					}
+					captureTarget = ""
+					captureText = ""
+				}
+			}
+		case xml.CharData:
+			if captureTarget != "" {
+				captureText += string(t)
+			}
+		}
+	}
+	return &doc, nil
+}
+
+// FunctionsWithSpec returns only the FunctionDoc entries that have a non-empty
+// TypeSpec. These are the only entries the typemap layer can attempt to translate.
+func (m *ModuleDoc) FunctionsWithSpec() []FunctionDoc {
+	var out []FunctionDoc
+	for _, f := range m.Functions {
+		if f.TypeSpec != "" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// FunctionsWithoutSpec returns FunctionDoc entries that have no TypeSpec.
+// These will produce SkipNoSpec skip reports in phase 4.
+func (m *ModuleDoc) FunctionsWithoutSpec() []FunctionDoc {
+	var out []FunctionDoc
+	for _, f := range m.Functions {
+		if f.TypeSpec == "" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func parseInt(s string) int {
+	n := 0
+	for _, ch := range s {
+		if ch < '0' || ch > '9' {
+			break
+		}
+		n = n*10 + int(ch-'0')
+	}
+	return n
+}

--- a/package3/erlang/edocingest/edocingest_test.go
+++ b/package3/erlang/edocingest/edocingest_test.go
@@ -1,0 +1,222 @@
+package edocingest
+
+import (
+	"strings"
+	"testing"
+)
+
+const edocSimple = `<?xml version="1.0" encoding="utf-8"?>
+<module name="lager">
+  <functions>
+    <function name="log" arity="3">
+      <typespec>log(Level, Module, Message) -> ok when Level :: atom(), Module :: atom(), Message :: string().</typespec>
+      <description><p>Log a message at the given level.</p></description>
+    </function>
+    <function name="start" arity="0">
+      <description><p>Start the lager application.</p></description>
+    </function>
+  </functions>
+</module>`
+
+const edocMultiFunctions = `<?xml version="1.0" encoding="utf-8"?>
+<edoc name="observer_cli">
+  <functions>
+    <function name="start" arity="0">
+      <typespec>start() -> ok | {error, term()}.</typespec>
+    </function>
+    <function name="start" arity="1">
+      <typespec>start(Opts) -> ok when Opts :: map().</typespec>
+    </function>
+    <function name="stop" arity="0">
+    </function>
+  </functions>
+</edoc>`
+
+const edocEmpty = `<?xml version="1.0" encoding="utf-8"?>
+<module name="empty_mod">
+  <functions>
+  </functions>
+</module>`
+
+const edocNoFunctions = `<?xml version="1.0" encoding="utf-8"?>
+<module name="mymod">
+</module>`
+
+func TestParseXML_ModuleName(t *testing.T) {
+	doc, err := ParseXMLBytes([]byte(edocSimple))
+	if err != nil {
+		t.Fatalf("ParseXMLBytes: %v", err)
+	}
+	if doc.Name != "lager" {
+		t.Errorf("Name = %q, want lager", doc.Name)
+	}
+}
+
+func TestParseXML_FunctionCount(t *testing.T) {
+	doc, err := ParseXMLBytes([]byte(edocSimple))
+	if err != nil {
+		t.Fatalf("ParseXMLBytes: %v", err)
+	}
+	if len(doc.Functions) != 2 {
+		t.Errorf("len(Functions) = %d, want 2", len(doc.Functions))
+	}
+}
+
+func TestParseXML_FunctionWithTypespec(t *testing.T) {
+	doc, err := ParseXMLBytes([]byte(edocSimple))
+	if err != nil {
+		t.Fatalf("ParseXMLBytes: %v", err)
+	}
+	log := doc.Functions[0]
+	if log.Name != "log" {
+		t.Errorf("Function[0].Name = %q, want log", log.Name)
+	}
+	if log.Arity != 3 {
+		t.Errorf("Function[0].Arity = %d, want 3", log.Arity)
+	}
+	if log.TypeSpec == "" {
+		t.Error("Function[0].TypeSpec should be non-empty")
+	}
+	if !strings.Contains(log.TypeSpec, "Level") {
+		t.Errorf("TypeSpec = %q, should contain 'Level'", log.TypeSpec)
+	}
+}
+
+func TestParseXML_FunctionWithoutTypespec(t *testing.T) {
+	doc, err := ParseXMLBytes([]byte(edocSimple))
+	if err != nil {
+		t.Fatalf("ParseXMLBytes: %v", err)
+	}
+	start := doc.Functions[1]
+	if start.Name != "start" {
+		t.Errorf("Function[1].Name = %q, want start", start.Name)
+	}
+	if start.TypeSpec != "" {
+		t.Errorf("Function[1].TypeSpec should be empty, got %q", start.TypeSpec)
+	}
+}
+
+func TestParseXML_FunctionDoc(t *testing.T) {
+	doc, err := ParseXMLBytes([]byte(edocSimple))
+	if err != nil {
+		t.Fatalf("ParseXMLBytes: %v", err)
+	}
+	if doc.Functions[0].Doc == "" {
+		t.Error("Function[0].Doc should be non-empty")
+	}
+}
+
+func TestParseXML_EdocRootElement(t *testing.T) {
+	// Test <edoc name="..."> root element variant.
+	doc, err := ParseXMLBytes([]byte(edocMultiFunctions))
+	if err != nil {
+		t.Fatalf("ParseXMLBytes: %v", err)
+	}
+	if doc.Name != "observer_cli" {
+		t.Errorf("Name = %q, want observer_cli", doc.Name)
+	}
+	if len(doc.Functions) != 3 {
+		t.Errorf("len(Functions) = %d, want 3", len(doc.Functions))
+	}
+}
+
+func TestParseXML_OverloadedFunction(t *testing.T) {
+	doc, err := ParseXMLBytes([]byte(edocMultiFunctions))
+	if err != nil {
+		t.Fatalf("ParseXMLBytes: %v", err)
+	}
+	// start/0 and start/1 are separate entries.
+	startCount := 0
+	for _, f := range doc.Functions {
+		if f.Name == "start" {
+			startCount++
+		}
+	}
+	if startCount != 2 {
+		t.Errorf("startCount = %d, want 2", startCount)
+	}
+}
+
+func TestFunctionsWithSpec(t *testing.T) {
+	doc, err := ParseXMLBytes([]byte(edocMultiFunctions))
+	if err != nil {
+		t.Fatalf("ParseXMLBytes: %v", err)
+	}
+	withSpec := doc.FunctionsWithSpec()
+	if len(withSpec) != 2 {
+		t.Errorf("FunctionsWithSpec len = %d, want 2 (stop has no typespec)", len(withSpec))
+	}
+}
+
+func TestFunctionsWithoutSpec(t *testing.T) {
+	doc, err := ParseXMLBytes([]byte(edocMultiFunctions))
+	if err != nil {
+		t.Fatalf("ParseXMLBytes: %v", err)
+	}
+	withoutSpec := doc.FunctionsWithoutSpec()
+	if len(withoutSpec) != 1 {
+		t.Errorf("FunctionsWithoutSpec len = %d, want 1 (only stop)", len(withoutSpec))
+	}
+	if withoutSpec[0].Name != "stop" {
+		t.Errorf("FunctionsWithoutSpec[0] = %q, want stop", withoutSpec[0].Name)
+	}
+}
+
+func TestParseXML_EmptyFunctions(t *testing.T) {
+	doc, err := ParseXMLBytes([]byte(edocEmpty))
+	if err != nil {
+		t.Fatalf("ParseXMLBytes: %v", err)
+	}
+	if len(doc.Functions) != 0 {
+		t.Errorf("len(Functions) = %d, want 0", len(doc.Functions))
+	}
+}
+
+func TestParseXML_NoFunctionsElement(t *testing.T) {
+	doc, err := ParseXMLBytes([]byte(edocNoFunctions))
+	if err != nil {
+		t.Fatalf("ParseXMLBytes: %v", err)
+	}
+	if doc.Name != "mymod" {
+		t.Errorf("Name = %q, want mymod", doc.Name)
+	}
+}
+
+func TestParseXML_Reader(t *testing.T) {
+	r := strings.NewReader(edocSimple)
+	doc, err := ParseXML(r)
+	if err != nil {
+		t.Fatalf("ParseXML: %v", err)
+	}
+	if doc.Name != "lager" {
+		t.Errorf("Name = %q, want lager", doc.Name)
+	}
+}
+
+func TestParseXML_InvalidXML(t *testing.T) {
+	_, err := ParseXMLBytes([]byte("<not valid xml>"))
+	// Invalid XML should either error or return empty — not panic.
+	// The Go xml.Decoder is lenient with some malformed inputs; the key is no panic.
+	_ = err
+}
+
+func TestParseXML_ArityParsing(t *testing.T) {
+	xml := `<?xml version="1.0"?>
+<module name="cuttlefish">
+  <functions>
+    <function name="conf_to_schema" arity="42">
+      <typespec>conf_to_schema(Conf) -> schema().</typespec>
+    </function>
+  </functions>
+</module>`
+	doc, err := ParseXMLBytes([]byte(xml))
+	if err != nil {
+		t.Fatalf("ParseXMLBytes: %v", err)
+	}
+	if len(doc.Functions) != 1 {
+		t.Fatalf("len = %d", len(doc.Functions))
+	}
+	if doc.Functions[0].Arity != 42 {
+		t.Errorf("Arity = %d, want 42", doc.Functions[0].Arity)
+	}
+}

--- a/website/docs/implementation/0066/index.md
+++ b/website/docs/implementation/0066/index.md
@@ -17,8 +17,8 @@ A phase is LANDED only when its gate is green for every target in the runtime ma
 |-------|-------|--------|--------|---------------|
 | 0 | Skeleton: package3/erlang/ layout + rebar3 workspace plumbing | LANDED | 3b9fe10 | [phase-00](/docs/implementation/0066/phase-00-skeleton) |
 | 1 | Hex.pm API v2 client (package fetch + outer/inner tarball + SHA-256/SHA-512 verify) | LANDED | a0e95be | [phase-01](/docs/implementation/0066/phase-01-hex-index) |
-| 2 | BEAM abstract code ingest (Dbgi/Abst chunk ETF decoder, -spec/-type walker) | IN PROGRESS | — | [phase-02](/docs/implementation/0066/phase-02-beam-ingest) |
-| 3 | EDoc XML fallback ingest (for packages with no -spec directives) | NOT STARTED | — | [phase-03](/docs/implementation/0066/phase-03-edoc-fallback) |
+| 2 | BEAM abstract code ingest (Dbgi/Abst chunk ETF decoder, -spec/-type walker) | LANDED | 99f463c | [phase-02](/docs/implementation/0066/phase-02-beam-ingest) |
+| 3 | EDoc XML fallback ingest (for packages with no -spec directives) | IN PROGRESS | — | [phase-03](/docs/implementation/0066/phase-03-edoc-fallback) |
 | 4 | Dialyzer typespec-to-Mochi type mapping + SkipReport emit | NOT STARTED | — | [phase-04](/docs/implementation/0066/phase-04-type-mapping) |
 | 5 | Port bridge shim emitter (shim.erl gen_server + shim.mochi extern fn corpus) | NOT STARTED | — | [phase-05](/docs/implementation/0066/phase-05-shim-emit) |
 | 6 | `import erlang "..."` grammar + parser | NOT STARTED | — | [phase-06](/docs/implementation/0066/phase-06-import-grammar) |


### PR DESCRIPTION
Closes the Phase 3 tracking issue.

## Summary
`package3/erlang/edocingest/`: pure-Go streaming XML parser for rebar3/EDoc-generated doc files. Extracts module name, function names/arities, raw typespec strings, and doc text. No external dependencies.

## Test plan
- [x] 14 tests, all pass