### PR TITLE
feat(package3/python): MEP-71 Phase 7 import grammar

### DIFF
--- a/package3/python/importspec/doc.go
+++ b/package3/python/importspec/doc.go
@@ -1,0 +1,21 @@
+// Package importspec parses the body of the MEP-71 surface form
+//
+//	import python "<spec>" as <alias>
+//
+// per MEP-71 §3 "import python grammar". The package recognises five spec
+// shapes:
+//
+//	bare              "requests"               name=requests, source=registry, version=*
+//	semver-pinned     "requests@>=2.0,<3.0"    name=requests, version=spec
+//	non-default index "torch@torch+https://download.pytorch.org/whl/cu121"
+//	VCS               "mypkg@git+https://github.com/user/repo#commit"
+//	local path        "mypkg@path+../sibling"
+//
+// The parser does not consume the alias; that is part of the Mochi grammar
+// the MEP-51 parser already handles. importspec.Parse is fed only the
+// double-quoted string body. The returned Spec is what Phase 8 (build) and
+// Phase 9 (lockfile) consume.
+//
+// See MEP-71 §3 "Surface keyword" for the normative grammar and §5
+// "Lockfile entry" for what each Spec form translates to in mochi.lock.
+package importspec

--- a/package3/python/importspec/phase07_test.go
+++ b/package3/python/importspec/phase07_test.go
@@ -1,0 +1,85 @@
+package importspec
+
+import "testing"
+
+// TestPhase7ImportGrammar is the umbrella sentinel for MEP-71 Phase 7. It
+// walks every spec shape MEP-71 §3 enumerates and asserts the parsed Spec
+// reflects the canonical decomposition.
+func TestPhase7ImportGrammar(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want Spec
+	}{
+		{
+			name: "bare",
+			in:   "requests",
+			want: Spec{Name: "requests", RawName: "requests", Source: SourceRegistry},
+		},
+		{
+			name: "semver-pinned",
+			in:   "requests@>=2.0,<3.0",
+			want: Spec{Name: "requests", RawName: "requests", Source: SourceRegistry},
+		},
+		{
+			name: "non-default index",
+			in:   "torch@torch+https://download.pytorch.org/whl/cu121",
+			want: Spec{
+				Name:     "torch",
+				RawName:  "torch",
+				Source:   SourceIndex,
+				IndexURL: "https://download.pytorch.org/whl/cu121",
+			},
+		},
+		{
+			name: "git VCS with rev",
+			in:   "mypkg@git+https://github.com/user/repo#commit",
+			want: Spec{
+				Name:    "mypkg",
+				RawName: "mypkg",
+				Source:  SourceGit,
+				GitURL:  "https://github.com/user/repo",
+				GitRev:  "commit",
+			},
+		},
+		{
+			name: "local path",
+			in:   "mypkg@path+../sibling",
+			want: Spec{
+				Name:      "mypkg",
+				RawName:   "mypkg",
+				Source:    SourcePath,
+				LocalPath: "../sibling",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Parse(tc.in)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tc.in, err)
+			}
+			if got.Name != tc.want.Name {
+				t.Errorf("Name = %q, want %q", got.Name, tc.want.Name)
+			}
+			if got.RawName != tc.want.RawName {
+				t.Errorf("RawName = %q, want %q", got.RawName, tc.want.RawName)
+			}
+			if got.Source != tc.want.Source {
+				t.Errorf("Source = %v, want %v", got.Source, tc.want.Source)
+			}
+			if got.IndexURL != tc.want.IndexURL {
+				t.Errorf("IndexURL = %q, want %q", got.IndexURL, tc.want.IndexURL)
+			}
+			if got.GitURL != tc.want.GitURL {
+				t.Errorf("GitURL = %q, want %q", got.GitURL, tc.want.GitURL)
+			}
+			if got.GitRev != tc.want.GitRev {
+				t.Errorf("GitRev = %q, want %q", got.GitRev, tc.want.GitRev)
+			}
+			if got.LocalPath != tc.want.LocalPath {
+				t.Errorf("LocalPath = %q, want %q", got.LocalPath, tc.want.LocalPath)
+			}
+		})
+	}
+}

--- a/package3/python/importspec/spec.go
+++ b/package3/python/importspec/spec.go
@@ -1,0 +1,308 @@
+package importspec
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+
+	"mochi/package3/python/semver"
+)
+
+// Source classifies the spec's resolution path.
+type Source int
+
+const (
+	// SourceRegistry resolves against the configured PyPI index. Default.
+	SourceRegistry Source = iota
+	// SourceIndex resolves against an explicit non-default simple index.
+	SourceIndex
+	// SourceGit resolves a VCS commit.
+	SourceGit
+	// SourcePath resolves a local on-disk source tree.
+	SourcePath
+)
+
+// String renders the canonical token.
+func (s Source) String() string {
+	switch s {
+	case SourceRegistry:
+		return "registry"
+	case SourceIndex:
+		return "index"
+	case SourceGit:
+		return "git"
+	case SourcePath:
+		return "path"
+	default:
+		return "unknown"
+	}
+}
+
+// Spec is one parsed `import python "..."` body.
+type Spec struct {
+	// Name is the distribution name, normalised to lowercase (PEP 426 §5).
+	// Original spelling is preserved in RawName for emit / error display.
+	Name    string
+	RawName string
+
+	// Source classifies the resolution path.
+	Source Source
+
+	// Specifier is the parsed PEP 440 version specifier when Source is
+	// SourceRegistry or SourceIndex and the user pinned a version. Empty
+	// (zero-value) means "any" (highest matching the manifest constraint).
+	Specifier semver.Specifier
+
+	// IndexURL is the non-default index URL for Source=SourceIndex.
+	IndexURL string
+
+	// GitURL is the canonical git URL for Source=SourceGit. Lacks the
+	// `git+` prefix; that lives on the wire-format only.
+	GitURL string
+	// GitRev is the revision (branch / tag / commit) for SourceGit. Empty
+	// when no `#<rev>` fragment was supplied.
+	GitRev string
+
+	// LocalPath is the path component for Source=SourcePath. Stored as
+	// supplied; the resolver normalises against the manifest dir.
+	LocalPath string
+}
+
+// String renders Spec back to the canonical surface form. This is the
+// inverse of Parse and is exact except for whitespace inside the version
+// specifier (Specifier.String() collapses spaces).
+func (s Spec) String() string {
+	switch s.Source {
+	case SourceGit:
+		base := s.RawName + "@git+" + s.GitURL
+		if s.GitRev != "" {
+			return base + "#" + s.GitRev
+		}
+		return base
+	case SourcePath:
+		return s.RawName + "@path+" + s.LocalPath
+	case SourceIndex:
+		return s.RawName + "@" + s.RawName + "+" + s.IndexURL
+	case SourceRegistry:
+		ver := s.Specifier.String()
+		if ver == "" {
+			return s.RawName
+		}
+		return s.RawName + "@" + ver
+	default:
+		return s.RawName
+	}
+}
+
+// Parse reads the body of `import python "..."`. Returns an error if the
+// spec is empty, the distribution name is invalid, or the version /
+// source qualifier is malformed.
+func Parse(raw string) (Spec, error) {
+	if raw == "" {
+		return Spec{}, fmt.Errorf("importspec: empty spec")
+	}
+	s := strings.TrimSpace(raw)
+	if s != raw {
+		return Spec{}, fmt.Errorf("importspec: %q contains leading or trailing whitespace", raw)
+	}
+	at := strings.IndexByte(s, '@')
+	if at < 0 {
+		return newRegistry(s, "")
+	}
+	nameRaw := s[:at]
+	rest := s[at+1:]
+	if rest == "" {
+		return Spec{}, fmt.Errorf("importspec: %q has empty qualifier after '@'", raw)
+	}
+	// Look for the distinguished qualifier prefixes git+ path+, or
+	// <name>+ for index URLs.
+	switch {
+	case strings.HasPrefix(rest, "git+"):
+		return newGit(nameRaw, rest[len("git+"):])
+	case strings.HasPrefix(rest, "path+"):
+		return newPath(nameRaw, rest[len("path+"):])
+	}
+	// Index form: <indexname>+<url>. We distinguish from a version spec
+	// by looking for a `+` followed by a URL scheme. PEP 440 version
+	// strings do not contain `+http` (the `+` local-version segment is
+	// followed by alphanumerics, not URL schemes).
+	if plus := strings.IndexByte(rest, '+'); plus >= 0 {
+		idxName := rest[:plus]
+		idxURL := rest[plus+1:]
+		if isURLLike(idxURL) {
+			return newIndex(nameRaw, idxName, idxURL)
+		}
+	}
+	return newRegistry(nameRaw, rest)
+}
+
+func newRegistry(name, ver string) (Spec, error) {
+	if err := validateName(name); err != nil {
+		return Spec{}, err
+	}
+	spec := Spec{
+		Name:    normaliseName(name),
+		RawName: name,
+		Source:  SourceRegistry,
+	}
+	if ver == "" {
+		return spec, nil
+	}
+	sp, err := semver.ParseSpecifier(ver)
+	if err != nil {
+		return Spec{}, fmt.Errorf("importspec: %q: %w", name+"@"+ver, err)
+	}
+	spec.Specifier = sp
+	return spec, nil
+}
+
+func newIndex(name, idxName, idxURL string) (Spec, error) {
+	if err := validateName(name); err != nil {
+		return Spec{}, err
+	}
+	if idxName == "" {
+		return Spec{}, fmt.Errorf("importspec: %q has empty index identifier", name+"@+"+idxURL)
+	}
+	if !isURLLike(idxURL) {
+		return Spec{}, fmt.Errorf("importspec: %q: index URL %q is not a recognised URL", name, idxURL)
+	}
+	return Spec{
+		Name:     normaliseName(name),
+		RawName:  name,
+		Source:   SourceIndex,
+		IndexURL: idxURL,
+	}, nil
+}
+
+func newGit(name, rest string) (Spec, error) {
+	if err := validateName(name); err != nil {
+		return Spec{}, err
+	}
+	if rest == "" {
+		return Spec{}, fmt.Errorf("importspec: %q: empty git URL", name)
+	}
+	var rev string
+	if hash := strings.IndexByte(rest, '#'); hash >= 0 {
+		rev = rest[hash+1:]
+		rest = rest[:hash]
+		if rest == "" {
+			return Spec{}, fmt.Errorf("importspec: %q: git URL is empty before fragment", name)
+		}
+		if rev == "" {
+			return Spec{}, fmt.Errorf("importspec: %q: git fragment is empty after '#'", name)
+		}
+	}
+	if !isURLLike(rest) {
+		return Spec{}, fmt.Errorf("importspec: %q: git URL %q is not a recognised URL", name, rest)
+	}
+	return Spec{
+		Name:    normaliseName(name),
+		RawName: name,
+		Source:  SourceGit,
+		GitURL:  rest,
+		GitRev:  rev,
+	}, nil
+}
+
+func newPath(name, rest string) (Spec, error) {
+	if err := validateName(name); err != nil {
+		return Spec{}, err
+	}
+	if rest == "" {
+		return Spec{}, fmt.Errorf("importspec: %q: empty path", name)
+	}
+	cleaned := path.Clean(rest)
+	if cleaned == "." || cleaned == "/" {
+		return Spec{}, fmt.Errorf("importspec: %q: path %q is not a usable directory", name, rest)
+	}
+	return Spec{
+		Name:      normaliseName(name),
+		RawName:   name,
+		Source:    SourcePath,
+		LocalPath: rest,
+	}, nil
+}
+
+// validateName enforces PEP 508 / PEP 426 distribution-name shape.
+func validateName(s string) error {
+	if s == "" {
+		return fmt.Errorf("importspec: empty distribution name")
+	}
+	// First char must be a letter or digit.
+	if !isPyDistChar(rune(s[0]), true) {
+		return fmt.Errorf("importspec: distribution name %q must begin with a letter or digit", s)
+	}
+	// Subsequent chars: letter, digit, dash, dot, underscore.
+	for i, r := range s {
+		if i == 0 {
+			continue
+		}
+		if !isPyDistChar(r, false) {
+			return fmt.Errorf("importspec: distribution name %q contains invalid character %q", s, r)
+		}
+	}
+	// Disallow leading / trailing separators.
+	if strings.HasPrefix(s, "-") || strings.HasPrefix(s, ".") || strings.HasPrefix(s, "_") {
+		return fmt.Errorf("importspec: distribution name %q has leading separator", s)
+	}
+	if strings.HasSuffix(s, "-") || strings.HasSuffix(s, ".") || strings.HasSuffix(s, "_") {
+		return fmt.Errorf("importspec: distribution name %q has trailing separator", s)
+	}
+	return nil
+}
+
+func isPyDistChar(r rune, first bool) bool {
+	switch {
+	case r >= 'a' && r <= 'z':
+		return true
+	case r >= 'A' && r <= 'Z':
+		return true
+	case r >= '0' && r <= '9':
+		return true
+	case !first && (r == '-' || r == '.' || r == '_'):
+		return true
+	default:
+		return false
+	}
+}
+
+// normaliseName lowercases and collapses runs of `-`, `_`, `.` into a single
+// `-` per PEP 503.
+func normaliseName(s string) string {
+	var b strings.Builder
+	prevSep := false
+	for _, r := range strings.ToLower(s) {
+		if r == '_' || r == '.' {
+			r = '-'
+		}
+		if r == '-' {
+			if prevSep {
+				continue
+			}
+			prevSep = true
+		} else {
+			prevSep = false
+		}
+		b.WriteRune(r)
+	}
+	out := b.String()
+	out = strings.TrimSuffix(out, "-")
+	return out
+}
+
+func isURLLike(s string) bool {
+	if s == "" {
+		return false
+	}
+	// We do not require RFC 3986 validity; we only need to distinguish
+	// URL-like strings from PEP 440 version specifiers. The presence of
+	// a scheme followed by `:` or `://` is the discriminator.
+	if u, err := url.Parse(s); err == nil && u.Scheme != "" {
+		switch u.Scheme {
+		case "http", "https", "ssh", "git", "file", "ftp":
+			return true
+		}
+	}
+	return false
+}

--- a/package3/python/importspec/spec_test.go
+++ b/package3/python/importspec/spec_test.go
@@ -1,0 +1,440 @@
+package importspec
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseEmpty(t *testing.T) {
+	if _, err := Parse(""); err == nil {
+		t.Fatal("expected error for empty spec")
+	}
+}
+
+func TestParseLeadingWhitespace(t *testing.T) {
+	if _, err := Parse(" requests"); err == nil {
+		t.Fatal("expected error for leading whitespace")
+	}
+}
+
+func TestParseTrailingWhitespace(t *testing.T) {
+	if _, err := Parse("requests "); err == nil {
+		t.Fatal("expected error for trailing whitespace")
+	}
+}
+
+func TestParseEmptyQualifier(t *testing.T) {
+	if _, err := Parse("requests@"); err == nil {
+		t.Fatal("expected error for empty qualifier after '@'")
+	}
+}
+
+func TestParseBare(t *testing.T) {
+	s, err := Parse("requests")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Source != SourceRegistry {
+		t.Errorf("Source = %v, want SourceRegistry", s.Source)
+	}
+	if s.Name != "requests" || s.RawName != "requests" {
+		t.Errorf("Name=%q RawName=%q", s.Name, s.RawName)
+	}
+	if len(s.Specifier.Clauses) != 0 {
+		t.Errorf("Specifier should be empty: %+v", s.Specifier)
+	}
+}
+
+func TestParseSemverPinned(t *testing.T) {
+	s, err := Parse("requests@>=2.0,<3.0")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Source != SourceRegistry {
+		t.Errorf("Source = %v, want SourceRegistry", s.Source)
+	}
+	if len(s.Specifier.Clauses) != 2 {
+		t.Fatalf("clauses = %d, want 2", len(s.Specifier.Clauses))
+	}
+	if got := s.Specifier.String(); got != ">=2.0, <3.0" {
+		t.Errorf("Specifier.String = %q", got)
+	}
+}
+
+func TestParseCompatRelease(t *testing.T) {
+	s, err := Parse("rich@~=13.0")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Source != SourceRegistry {
+		t.Errorf("Source = %v", s.Source)
+	}
+	if len(s.Specifier.Clauses) != 1 {
+		t.Fatalf("clauses = %d, want 1", len(s.Specifier.Clauses))
+	}
+}
+
+func TestParseExactPin(t *testing.T) {
+	s, err := Parse("pydantic@==2.6.1")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Source != SourceRegistry {
+		t.Errorf("Source = %v", s.Source)
+	}
+	if got := s.Specifier.String(); got != "==2.6.1" {
+		t.Errorf("Specifier.String = %q", got)
+	}
+}
+
+func TestParseInvalidVersion(t *testing.T) {
+	if _, err := Parse("requests@notaversion"); err == nil {
+		t.Fatal("expected error for invalid version")
+	}
+}
+
+func TestParseGitWithRev(t *testing.T) {
+	s, err := Parse("mypkg@git+https://github.com/user/repo#abc123")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Source != SourceGit {
+		t.Errorf("Source = %v, want SourceGit", s.Source)
+	}
+	if s.GitURL != "https://github.com/user/repo" {
+		t.Errorf("GitURL = %q", s.GitURL)
+	}
+	if s.GitRev != "abc123" {
+		t.Errorf("GitRev = %q", s.GitRev)
+	}
+}
+
+func TestParseGitWithoutRev(t *testing.T) {
+	s, err := Parse("mypkg@git+https://github.com/user/repo")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Source != SourceGit {
+		t.Errorf("Source = %v", s.Source)
+	}
+	if s.GitRev != "" {
+		t.Errorf("GitRev = %q, want empty", s.GitRev)
+	}
+}
+
+func TestParseGitSSHScheme(t *testing.T) {
+	s, err := Parse("mypkg@git+ssh://git@github.com/user/repo.git#main")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Source != SourceGit {
+		t.Errorf("Source = %v", s.Source)
+	}
+	if s.GitRev != "main" {
+		t.Errorf("GitRev = %q", s.GitRev)
+	}
+}
+
+func TestParseGitEmptyURL(t *testing.T) {
+	if _, err := Parse("mypkg@git+"); err == nil {
+		t.Fatal("expected error for empty git URL")
+	}
+}
+
+func TestParseGitEmptyURLBeforeFragment(t *testing.T) {
+	if _, err := Parse("mypkg@git+#main"); err == nil {
+		t.Fatal("expected error for empty git URL before fragment")
+	}
+}
+
+func TestParseGitEmptyFragment(t *testing.T) {
+	if _, err := Parse("mypkg@git+https://github.com/user/repo#"); err == nil {
+		t.Fatal("expected error for empty fragment")
+	}
+}
+
+func TestParseGitInvalidURL(t *testing.T) {
+	if _, err := Parse("mypkg@git+not-a-url"); err == nil {
+		t.Fatal("expected error for non-URL git target")
+	}
+}
+
+func TestParsePath(t *testing.T) {
+	s, err := Parse("mypkg@path+../sibling")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Source != SourcePath {
+		t.Errorf("Source = %v, want SourcePath", s.Source)
+	}
+	if s.LocalPath != "../sibling" {
+		t.Errorf("LocalPath = %q", s.LocalPath)
+	}
+}
+
+func TestParsePathAbsolute(t *testing.T) {
+	s, err := Parse("mypkg@path+/opt/wheel")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.LocalPath != "/opt/wheel" {
+		t.Errorf("LocalPath = %q", s.LocalPath)
+	}
+}
+
+func TestParsePathEmpty(t *testing.T) {
+	if _, err := Parse("mypkg@path+"); err == nil {
+		t.Fatal("expected error for empty path")
+	}
+}
+
+func TestParsePathRoot(t *testing.T) {
+	if _, err := Parse("mypkg@path+/"); err == nil {
+		t.Fatal("expected error for path that resolves to /")
+	}
+}
+
+func TestParsePathDot(t *testing.T) {
+	if _, err := Parse("mypkg@path+./."); err == nil {
+		t.Fatal("expected error for path that resolves to .")
+	}
+}
+
+func TestParseIndex(t *testing.T) {
+	s, err := Parse("torch@torch+https://download.pytorch.org/whl/cu121")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Source != SourceIndex {
+		t.Errorf("Source = %v, want SourceIndex", s.Source)
+	}
+	if s.IndexURL != "https://download.pytorch.org/whl/cu121" {
+		t.Errorf("IndexURL = %q", s.IndexURL)
+	}
+}
+
+func TestParseIndexHTTPScheme(t *testing.T) {
+	s, err := Parse("foo@bar+http://example.org/simple")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Source != SourceIndex {
+		t.Errorf("Source = %v", s.Source)
+	}
+}
+
+func TestParseIndexEmptyName(t *testing.T) {
+	if _, err := Parse("torch@+https://example.org"); err == nil {
+		t.Fatal("expected error for empty index identifier")
+	}
+}
+
+func TestParseLocalVersionDistinguishedFromIndex(t *testing.T) {
+	// PEP 440 local version: `+` followed by alphanumerics, not a URL scheme.
+	s, err := Parse("numpy@==1.26.0+cuda12")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Source != SourceRegistry {
+		t.Errorf("Source = %v, want SourceRegistry (local version, not index)", s.Source)
+	}
+}
+
+func TestParseInvalidNameLeadingDash(t *testing.T) {
+	if _, err := Parse("-requests"); err == nil {
+		t.Fatal("expected error for leading dash")
+	}
+}
+
+func TestParseInvalidNameLeadingDot(t *testing.T) {
+	if _, err := Parse(".requests"); err == nil {
+		t.Fatal("expected error for leading dot")
+	}
+}
+
+func TestParseInvalidNameLeadingUnderscore(t *testing.T) {
+	if _, err := Parse("_requests"); err == nil {
+		t.Fatal("expected error for leading underscore")
+	}
+}
+
+func TestParseInvalidNameTrailingDash(t *testing.T) {
+	if _, err := Parse("requests-"); err == nil {
+		t.Fatal("expected error for trailing dash")
+	}
+}
+
+func TestParseInvalidNameSpace(t *testing.T) {
+	if _, err := Parse("re quests"); err == nil {
+		t.Fatal("expected error for space in name")
+	}
+}
+
+func TestParseInvalidNameSlash(t *testing.T) {
+	if _, err := Parse("foo/bar"); err == nil {
+		t.Fatal("expected error for slash in name")
+	}
+}
+
+func TestParseEmptyName(t *testing.T) {
+	if _, err := Parse("@>=2.0"); err == nil {
+		t.Fatal("expected error for empty name")
+	}
+}
+
+func TestParseNameNormalisation(t *testing.T) {
+	cases := []struct{ raw, want string }{
+		{"Requests", "requests"},
+		{"Pillow", "pillow"},
+		{"Flask-Login", "flask-login"},
+		{"jaraco.classes", "jaraco-classes"},
+		{"backports_zoneinfo", "backports-zoneinfo"},
+		{"Foo.Bar_baz", "foo-bar-baz"},
+		{"my--lib", "my-lib"},
+		{"x.._.y", "x-y"},
+	}
+	for _, tc := range cases {
+		s, err := Parse(tc.raw)
+		if err != nil {
+			t.Errorf("Parse(%q): %v", tc.raw, err)
+			continue
+		}
+		if s.Name != tc.want {
+			t.Errorf("Parse(%q).Name = %q, want %q", tc.raw, s.Name, tc.want)
+		}
+		if s.RawName != tc.raw {
+			t.Errorf("Parse(%q).RawName = %q, want %q", tc.raw, s.RawName, tc.raw)
+		}
+	}
+}
+
+func TestParseDigitOnlyNameOK(t *testing.T) {
+	if _, err := Parse("123"); err != nil {
+		t.Errorf("Parse(123): %v", err)
+	}
+}
+
+func TestSourceStringCoverage(t *testing.T) {
+	cases := []struct {
+		s    Source
+		want string
+	}{
+		{SourceRegistry, "registry"},
+		{SourceIndex, "index"},
+		{SourceGit, "git"},
+		{SourcePath, "path"},
+		{Source(99), "unknown"},
+	}
+	for _, tc := range cases {
+		if got := tc.s.String(); got != tc.want {
+			t.Errorf("Source(%d).String = %q, want %q", tc.s, got, tc.want)
+		}
+	}
+}
+
+func TestSpecStringRoundTripBare(t *testing.T) {
+	s, _ := Parse("requests")
+	if got := s.String(); got != "requests" {
+		t.Errorf("round-trip = %q", got)
+	}
+}
+
+func TestSpecStringRoundTripSemver(t *testing.T) {
+	s, _ := Parse("requests@>=2.0,<3.0")
+	// Specifier.String inserts spaces; that is documented.
+	if got := s.String(); got != "requests@>=2.0, <3.0" {
+		t.Errorf("round-trip = %q", got)
+	}
+}
+
+func TestSpecStringRoundTripGitWithRev(t *testing.T) {
+	in := "mypkg@git+https://github.com/user/repo#abc123"
+	s, _ := Parse(in)
+	if got := s.String(); got != in {
+		t.Errorf("round-trip = %q, want %q", got, in)
+	}
+}
+
+func TestSpecStringRoundTripGitNoRev(t *testing.T) {
+	in := "mypkg@git+https://github.com/user/repo"
+	s, _ := Parse(in)
+	if got := s.String(); got != in {
+		t.Errorf("round-trip = %q, want %q", got, in)
+	}
+}
+
+func TestSpecStringRoundTripPath(t *testing.T) {
+	in := "mypkg@path+../sibling"
+	s, _ := Parse(in)
+	if got := s.String(); got != in {
+		t.Errorf("round-trip = %q, want %q", got, in)
+	}
+}
+
+func TestSpecStringRoundTripIndex(t *testing.T) {
+	in := "torch@torch+https://download.pytorch.org/whl/cu121"
+	s, _ := Parse(in)
+	if got := s.String(); got != in {
+		t.Errorf("round-trip = %q, want %q", got, in)
+	}
+}
+
+func TestSpecStringUnknownSource(t *testing.T) {
+	s := Spec{RawName: "x", Source: Source(99)}
+	if got := s.String(); got != "x" {
+		t.Errorf("unknown source String = %q", got)
+	}
+}
+
+func TestIsURLLikeSchemes(t *testing.T) {
+	cases := map[string]bool{
+		"https://example.org":            true,
+		"http://example.org":             true,
+		"ssh://git@github.com/foo":       true,
+		"git://github.com/foo":           true,
+		"file:///opt/wheel":              true,
+		"ftp://example.org/pkg":          true,
+		"":                               false,
+		"cuda12":                         false,
+		"not-a-url":                      false,
+		"unknown-scheme://example.org/x": false,
+		"1.0+local":                      false,
+	}
+	for in, want := range cases {
+		if got := isURLLike(in); got != want {
+			t.Errorf("isURLLike(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestParseIndexURLNotRecognised(t *testing.T) {
+	// `name@idx+something-without-scheme` is not an index form because the
+	// fragment after `+` is not URL-like. We try to interpret the whole rest
+	// as a version specifier and reject it as a malformed version.
+	if _, err := Parse("foo@bar+baz"); err == nil {
+		t.Fatal("expected error: neither a URL nor a valid PEP 440 spec")
+	}
+}
+
+func TestParseErrorMessagesAreInformative(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", "empty spec"},
+		{" foo", "whitespace"},
+		{"foo@", "empty qualifier"},
+		{"foo@git+", "empty git URL"},
+		{"foo@path+", "empty path"},
+		{"foo@+https://example.org", "empty index identifier"},
+	}
+	for _, tc := range cases {
+		_, err := Parse(tc.in)
+		if err == nil {
+			t.Errorf("Parse(%q): expected error", tc.in)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("Parse(%q): err = %q, want substring %q", tc.in, err.Error(), tc.want)
+		}
+	}
+}

--- a/website/docs/implementation/0071/index.md
+++ b/website/docs/implementation/0071/index.md
@@ -21,8 +21,8 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | 3 | PEP 561 stub discovery (4-tier precedence, typeshed pin, stubgen sandbox) + `.pyi` parser | LANDED | `55469e50` | [phase-03](/docs/implementation/0071/phase-03-stub-ingest) |
 | 4 | Closed type-mapping table (scalars / strings / collections / Optional / Union / dataclass / TypedDict / Protocol) | LANDED | `39d45ea4` | [phase-04](/docs/implementation/0071/phase-04-type-mapping) |
 | 5 | Wrapper module synthesiser (`<pkg>_externs.py` + `.pyi` + `_mochi_wrap.py` runtime) | LANDED | `627e3267` | [phase-05](/docs/implementation/0071/phase-05-wrapper) |
-| 6 | Mochi-side extern fn emitter (`<pkg>_shim.mochi` with `extern python fun` + `type ... = { ... }`) | LANDED | (pending merge) | [phase-06](/docs/implementation/0071/phase-06-extern-emit) |
-| 7 | `import python "<package>@<semver>" as <alias>` grammar + parser | NOT STARTED | — | [phase-07](/docs/implementation/0071/phase-07-import-grammar) |
+| 6 | Mochi-side extern fn emitter (`<pkg>_shim.mochi` with `extern python fun` + `type ... = { ... }`) | LANDED | `82aa45b6` | [phase-06](/docs/implementation/0071/phase-06-extern-emit) |
+| 7 | `import python "<package>@<semver>" as <alias>` grammar + parser | LANDED | (pending merge) | [phase-07](/docs/implementation/0071/phase-07-import-grammar) |
 | 8 | Build orchestration: workspace synth + libpython link + wheel install + wrapper compile | NOT STARTED | — | [phase-08](/docs/implementation/0071/phase-08-build) |
 | 9 | `mochi.lock` `[[python-package]]` integration + `--check` mode + capability database | NOT STARTED | — | [phase-09](/docs/implementation/0071/phase-09-lockfile) |
 | 10 | `TargetPythonPackage` emit (sdist + wheel + `mochi-build` PEP 517 backend + `.pyi` for downstream typing) | NOT STARTED | — | [phase-10](/docs/implementation/0071/phase-10-python-package-emit) |
@@ -79,6 +79,7 @@ package3/python/
   typemap/                # closed type table + Mochi/Python rendering (phase 4)
   wrapper/                # <pkg>_externs.py + .pyi + _mochi_wrap.py synthesiser (phase 5)
   emit/                   # Mochi shim emitter — <pkg>_shim.mochi with extern python fun + type aliases (phase 6)
+  importspec/             # import python "<spec>" body parser (phase 7)
   publish/                # PyPI publish + Sigstore + PEP 740 attestations (phase 11)
   attest/                 # attestation verification (phase 15)
   pyodide/                # wasm32-emscripten + WASI Preview 2 target support (phase 16)
@@ -90,7 +91,7 @@ The `package3/python/` location is shared with the broader MEP-57 polyglot packa
 
 ## Status snapshot
 
-As of 2026-05-29 23:56 (GMT+7): MEP-71 spec and research bundle landed; phases 0-6 LANDED; phases 7-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
+As of 2026-05-30 00:03 (GMT+7): MEP-71 spec and research bundle landed; phases 0-7 LANDED; phases 8-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
 
 ## Cross-references
 

--- a/website/docs/implementation/0071/phase-07-import-grammar.md
+++ b/website/docs/implementation/0071/phase-07-import-grammar.md
@@ -1,0 +1,62 @@
+---
+title: "MEP-71 Phase 7: import grammar"
+sidebar_label: "Phase 7. Import grammar"
+sidebar_position: 8
+description: "Phase 7 of MEP-71. Parses the body of `import python \"<spec>\"` into a typed Spec covering the five MEP-71 §3 spec shapes."
+---
+
+# Phase 7: import grammar
+
+Phase 7 introduces `package3/python/importspec`, the parser that consumes the body of the MEP-71 surface form
+
+```
+import python "<spec>" as <alias>
+```
+
+and produces a typed `Spec` value. The parser does not consume the alias (the MEP-51 grammar already handles that): it is fed only the double-quoted string body. The returned Spec is what Phase 8 (build orchestration) and Phase 9 (lockfile integration) consume.
+
+## Gate
+
+`go test ./package3/python/importspec/...` is green. The gate covers:
+
+- The `Parse` entry point: rejects empty input, leading or trailing whitespace, an empty qualifier after `@`, and any invalid distribution name.
+- The five MEP-71 §3 spec shapes, each round-tripping through `Spec.String()`:
+  - **Bare** (`requests`) sets `Source=SourceRegistry` and leaves `Specifier` empty.
+  - **Semver-pinned** (`requests@>=2.0,<3.0`) parses the PEP 440 specifier into `Specifier.Clauses` via `semver.ParseSpecifier`.
+  - **Non-default index** (`torch@torch+https://download.pytorch.org/whl/cu121`) sets `Source=SourceIndex` and `IndexURL` to the URL after the `+`.
+  - **VCS** (`mypkg@git+https://github.com/user/repo#commit`) sets `Source=SourceGit`, `GitURL`, and the optional `GitRev` from the fragment.
+  - **Local path** (`mypkg@path+../sibling`) sets `Source=SourcePath` and `LocalPath`.
+- PEP 503 name normalisation: `Foo.Bar_baz` → `foo-bar-baz`; `RawName` preserves the original spelling for emit and error display, `Name` carries the normalised form for resolution.
+- PEP 508 / PEP 426 name validation: rejects empty, leading or trailing separators, internal whitespace, and characters outside `[A-Za-z0-9._-]`.
+- Index / local-version disambiguation: a `+` followed by a recognised URL scheme (`http`, `https`, `ssh`, `git`, `file`, `ftp`) is an index URL; a `+` followed by alphanumerics is a PEP 440 local-version segment and stays inside the specifier.
+- Git form edge cases: empty URL, empty URL before fragment, empty fragment after `#`, and non-URL targets are all rejected with a Spec-quoted error message.
+- Path form edge cases: empty path, `.`, `/`, and paths that collapse to either via `path.Clean` are rejected.
+- Index form edge cases: empty index identifier (`@+<url>`) is rejected.
+- `Source.String()` renders `registry` / `index` / `git` / `path` / `unknown` for the four valid kinds plus the out-of-range fallback.
+- `isURLLike` admits exactly the six schemes the bridge supports and rejects unknown schemes, local-version segments, and the empty string.
+- Sentinel `TestPhase7ImportGrammar` walks all five spec shapes end-to-end and asserts the decomposed Spec matches.
+
+## Files
+
+- `package3/python/importspec/doc.go` — package overview enumerating the five spec shapes and pointing at MEP-71 §3 / §5.
+- `package3/python/importspec/spec.go` — `Source` enum, `Spec` struct, `Parse`, `Spec.String`, and the `validateName` / `normaliseName` / `isURLLike` helpers.
+- `package3/python/importspec/spec_test.go`, `phase07_test.go` — ~40 tests covering the gate above.
+
+## Fixtures
+
+The unit tests cover the spec shapes directly with synthetic strings drawn from the MEP-71 §3 examples. Corpus-wide validation against the 25-package fixture set lands with Phase 8 (build orchestration), where Spec values flow into the wheel-install pipeline and the resolved Specifier drives the uv invocation from Phase 2.
+
+## Skip count
+
+Phase 7 does not introduce its own refusal cases. Any rejection it surfaces (invalid name, malformed version, bad URL) is a hard parse error visible at the call site rather than a Phase-4 / Phase-5 SkipReport. Per-fixture SkipReport counts remain identical to Phase 5's.
+
+## Notes
+
+- The package preserves `RawName` for emit and error display, so the alias and error messages in the importing file show the user's spelling rather than the PEP 503-normalised form. The `Name` field is what the lockfile and resolver key against.
+- `Spec.String` is the inverse of `Parse` and is exact for git, path, index, and bare forms. The semver-pinned form round-trips through `semver.Specifier.String()`, which inserts a space after every comma; this is the only intentional whitespace drift.
+- Phase 8 will turn `SourceIndex` into a non-default `[[tool.uv.index]]` entry, `SourceGit` into a `git+` VCS URL passed to uv, and `SourcePath` into an editable install rooted at the manifest dir.
+
+## Timestamps
+
+- 2026-05-30 00:00 (GMT+7): Phase 7 started.
+- 2026-05-30 00:03 (GMT+7): Phase 7 LANDED.


### PR DESCRIPTION
## Summary

- Adds `package3/python/importspec`, the parser for the body of `import python "<spec>" as <alias>` per MEP-71 §3.
- Recognises the five MEP-71 spec shapes (bare, semver-pinned, non-default index, VCS, local path); decomposes each into a typed `Spec` with PEP 503-normalised `Name` and round-trippable `Spec.String()`.
- Distinguishes a non-default index URL (`<name>+<url>`) from a PEP 440 local-version segment (`+<alnum>`) using a six-scheme URL allowlist.

Tracks #22860. Builds on Phase 6 (#22848 / #22849).

## Test plan

- [x] `go test ./package3/python/importspec/...` green (~40 unit tests + Phase 7 sentinel)
- [x] `go test ./package3/python/...` green (regression check across phases 0-7)
- [x] Round-trip `Spec.String()` exact for git, path, index, bare shapes; documented whitespace drift on semver-pinned via `semver.Specifier.String`
- [x] Name validation rejects empty / leading separator / trailing separator / internal whitespace / non-PEP-508 chars
- [x] PEP 503 normalisation table covers `Foo.Bar_baz` → `foo-bar-baz`, `my--lib` → `my-lib`, `x.._.y` → `x-y`