### PR TITLE
feat(mep-70 p03): Kotlin @kotlin.Metadata ingest (no JVM)

### DIFF
--- a/package3/kotlin/errors/errors.go
+++ b/package3/kotlin/errors/errors.go
@@ -1,7 +1,14 @@
 // Package errors defines bridge-specific error types for the Mochi↔Kotlin bridge.
 package errors
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrNoKotlinMetadata is returned when a .class file does not contain a
+// @kotlin.Metadata annotation (i.e. it is a plain Java class file).
+var ErrNoKotlinMetadata = errors.New("no @kotlin.Metadata annotation found in class file")
 
 type ErrUnsupportedMetadataVersion struct {
 	Version [3]int32

--- a/package3/kotlin/go.mod
+++ b/package3/kotlin/go.mod
@@ -1,7 +1,10 @@
 module github.com/mochilang/mochi/package3/kotlin
 
-go 1.22
+go 1.23
 
-require lukechampine.com/blake3 v1.4.1
+require (
+	google.golang.org/protobuf v1.36.11
+	lukechampine.com/blake3 v1.4.1
+)
 
 require github.com/klauspost/cpuid/v2 v2.0.9 // indirect

--- a/package3/kotlin/go.sum
+++ b/package3/kotlin/go.sum
@@ -1,4 +1,6 @@
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
+google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 lukechampine.com/blake3 v1.4.1 h1:I3Smz7gso8w4/TunLKec6K2fn+kyKtDxr/xcQEN84Wg=
 lukechampine.com/blake3 v1.4.1/go.mod h1:QFosUxmjB8mnrWFSNwKmvxHpfY72bmD2tQ0kBMM3kwo=

--- a/package3/kotlin/metadata/classreader.go
+++ b/package3/kotlin/metadata/classreader.go
@@ -1,0 +1,441 @@
+// Package metadata extracts the Kotlin API surface from @kotlin.Metadata annotations
+// inside JAR class files without spawning a JVM.
+package metadata
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	bridgeerrors "github.com/mochilang/mochi/package3/kotlin/errors"
+)
+
+// RawMetadata holds the raw contents of a @kotlin.Metadata annotation.
+type RawMetadata struct {
+	Kind    int32
+	Version [3]int32
+	D1      []byte   // joined d1 strings (raw proto bytes)
+	D2      []string // string table
+	XS      string
+	XI      int32
+}
+
+// constantPool holds the constant pool entries we need for annotation parsing.
+type constantPool struct {
+	utf8    map[int]string
+	integer map[int]int32
+}
+
+// ExtractMetadata reads a JVM .class file (classBytes) and extracts the
+// @kotlin.Metadata annotation if present. Returns ErrNoKotlinMetadata if the
+// annotation is absent. Malformed class data returns a descriptive error.
+func ExtractMetadata(classBytes []byte) (*RawMetadata, error) {
+	r := &classReader{data: classBytes}
+
+	// Check magic 0xCAFEBABE
+	magic, err := r.readU32()
+	if err != nil {
+		return nil, fmt.Errorf("classreader: cannot read magic: %w", err)
+	}
+	if magic != 0xCAFEBABE {
+		return nil, fmt.Errorf("classreader: invalid class file magic: %#x", magic)
+	}
+
+	// Skip minor_version and major_version (4 bytes total)
+	if err := r.skip(4); err != nil {
+		return nil, fmt.Errorf("classreader: cannot skip version: %w", err)
+	}
+
+	// Read constant pool
+	cpCount, err := r.readU16()
+	if err != nil {
+		return nil, fmt.Errorf("classreader: cannot read constant pool count: %w", err)
+	}
+
+	cp := &constantPool{
+		utf8:    make(map[int]string),
+		integer: make(map[int]int32),
+	}
+
+	// Parse constant_pool[1 .. cpCount-1]
+	i := 1
+	for i < int(cpCount) {
+		tag, err := r.readU8()
+		if err != nil {
+			return nil, fmt.Errorf("classreader: cannot read cp tag at index %d: %w", i, err)
+		}
+		switch tag {
+		case 1: // Utf8
+			length, err := r.readU16()
+			if err != nil {
+				return nil, fmt.Errorf("classreader: Utf8 length at cp[%d]: %w", i, err)
+			}
+			bs, err := r.readN(int(length))
+			if err != nil {
+				return nil, fmt.Errorf("classreader: Utf8 bytes at cp[%d]: %w", i, err)
+			}
+			cp.utf8[i] = string(bs)
+		case 3: // Integer
+			bs, err := r.readN(4)
+			if err != nil {
+				return nil, fmt.Errorf("classreader: Integer bytes at cp[%d]: %w", i, err)
+			}
+			cp.integer[i] = int32(binary.BigEndian.Uint32(bs))
+		case 4: // Float
+			if err := r.skip(4); err != nil {
+				return nil, fmt.Errorf("classreader: skip Float cp[%d]: %w", i, err)
+			}
+		case 5, 6: // Long, Double — 8 bytes, next index unusable
+			if err := r.skip(8); err != nil {
+				return nil, fmt.Errorf("classreader: skip Long/Double cp[%d]: %w", i, err)
+			}
+			i++ // skip next slot
+		case 7, 8, 16, 19, 20: // Class, String, MethodType, Module, Package — 2 bytes
+			if err := r.skip(2); err != nil {
+				return nil, fmt.Errorf("classreader: skip 2-byte cp[%d] tag=%d: %w", i, tag, err)
+			}
+		case 9, 10, 11, 12, 17, 18: // Fieldref, Methodref, InterfaceMethodref, NameAndType, Dynamic, InvokeDynamic — 4 bytes
+			if err := r.skip(4); err != nil {
+				return nil, fmt.Errorf("classreader: skip 4-byte cp[%d] tag=%d: %w", i, tag, err)
+			}
+		case 15: // MethodHandle — 3 bytes
+			if err := r.skip(3); err != nil {
+				return nil, fmt.Errorf("classreader: skip MethodHandle cp[%d]: %w", i, err)
+			}
+		default:
+			return nil, fmt.Errorf("classreader: unknown constant pool tag %d at index %d", tag, i)
+		}
+		i++
+	}
+
+	// Skip access_flags (2), this_class (2), super_class (2)
+	if err := r.skip(6); err != nil {
+		return nil, fmt.Errorf("classreader: skip access/this/super: %w", err)
+	}
+
+	// Skip interfaces
+	ifCount, err := r.readU16()
+	if err != nil {
+		return nil, fmt.Errorf("classreader: read interfaces count: %w", err)
+	}
+	if err := r.skip(int(ifCount) * 2); err != nil {
+		return nil, fmt.Errorf("classreader: skip interfaces: %w", err)
+	}
+
+	// Skip fields
+	if err := skipMembersTable(r); err != nil {
+		return nil, fmt.Errorf("classreader: skip fields: %w", err)
+	}
+
+	// Skip methods
+	if err := skipMembersTable(r); err != nil {
+		return nil, fmt.Errorf("classreader: skip methods: %w", err)
+	}
+
+	// Read class attributes
+	attrCount, err := r.readU16()
+	if err != nil {
+		return nil, fmt.Errorf("classreader: read class attributes count: %w", err)
+	}
+
+	for a := 0; a < int(attrCount); a++ {
+		nameIdx, err := r.readU16()
+		if err != nil {
+			return nil, fmt.Errorf("classreader: read attr name_index: %w", err)
+		}
+		attrLen, err := r.readU32()
+		if err != nil {
+			return nil, fmt.Errorf("classreader: read attr length: %w", err)
+		}
+		attrData, err := r.readN(int(attrLen))
+		if err != nil {
+			return nil, fmt.Errorf("classreader: read attr data: %w", err)
+		}
+
+		attrName := cp.utf8[int(nameIdx)]
+		if attrName == "RuntimeVisibleAnnotations" {
+			meta, err := parseAnnotations(attrData, cp)
+			if err != nil {
+				return nil, fmt.Errorf("classreader: parse RuntimeVisibleAnnotations: %w", err)
+			}
+			if meta != nil {
+				return meta, nil
+			}
+		}
+	}
+
+	return nil, bridgeerrors.ErrNoKotlinMetadata
+}
+
+// skipMembersTable skips the fields or methods table in a class file.
+func skipMembersTable(r *classReader) error {
+	count, err := r.readU16()
+	if err != nil {
+		return err
+	}
+	for i := 0; i < int(count); i++ {
+		// access_flags, name_index, descriptor_index = 6 bytes
+		if err := r.skip(6); err != nil {
+			return err
+		}
+		if err := skipAttributes(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// skipAttributes skips an attributes table.
+func skipAttributes(r *classReader) error {
+	count, err := r.readU16()
+	if err != nil {
+		return err
+	}
+	for i := 0; i < int(count); i++ {
+		// name_index (2) + length (4) + data
+		if err := r.skip(2); err != nil {
+			return err
+		}
+		length, err := r.readU32()
+		if err != nil {
+			return err
+		}
+		if err := r.skip(int(length)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// parseAnnotations parses a RuntimeVisibleAnnotations attribute and extracts
+// the @kotlin.Metadata annotation if present. Returns nil if not found.
+func parseAnnotations(data []byte, cp *constantPool) (*RawMetadata, error) {
+	r := &classReader{data: data}
+
+	numAnnotations, err := r.readU16()
+	if err != nil {
+		return nil, fmt.Errorf("read num_annotations: %w", err)
+	}
+
+	for i := 0; i < int(numAnnotations); i++ {
+		typeIdx, err := r.readU16()
+		if err != nil {
+			return nil, fmt.Errorf("read annotation type_index: %w", err)
+		}
+		numPairs, err := r.readU16()
+		if err != nil {
+			return nil, fmt.Errorf("read num_element_value_pairs: %w", err)
+		}
+
+		typeName := cp.utf8[int(typeIdx)]
+		isKotlinMeta := typeName == "Lkotlin/Metadata;"
+
+		meta := &RawMetadata{}
+		for p := 0; p < int(numPairs); p++ {
+			elemNameIdx, err := r.readU16()
+			if err != nil {
+				return nil, fmt.Errorf("read element name_index: %w", err)
+			}
+			elemName := cp.utf8[int(elemNameIdx)]
+
+			val, err := parseElementValue(r, cp)
+			if err != nil {
+				return nil, fmt.Errorf("parse element value for %q: %w", elemName, err)
+			}
+
+			if isKotlinMeta {
+				applyMetaField(meta, elemName, val)
+			}
+		}
+
+		if isKotlinMeta {
+			return meta, nil
+		}
+	}
+	return nil, nil
+}
+
+// applyMetaField sets the appropriate field on meta based on the element name.
+func applyMetaField(meta *RawMetadata, name string, val interface{}) {
+	switch name {
+	case "k":
+		if v, ok := val.(int32); ok {
+			meta.Kind = v
+		}
+	case "xi":
+		if v, ok := val.(int32); ok {
+			meta.XI = v
+		}
+	case "mv":
+		if arr, ok := val.([]interface{}); ok {
+			for i, vv := range arr {
+				if i >= 3 {
+					break
+				}
+				if v, ok := vv.(int32); ok {
+					meta.Version[i] = v
+				}
+			}
+		}
+	case "d1":
+		if arr, ok := val.([]interface{}); ok {
+			var buf []byte
+			for _, vv := range arr {
+				if s, ok := vv.(string); ok {
+					buf = append(buf, []byte(s)...)
+				}
+			}
+			meta.D1 = buf
+		}
+	case "d2":
+		if arr, ok := val.([]interface{}); ok {
+			for _, vv := range arr {
+				if s, ok := vv.(string); ok {
+					meta.D2 = append(meta.D2, s)
+				}
+			}
+		}
+	case "xs":
+		if s, ok := val.(string); ok {
+			meta.XS = s
+		}
+	}
+}
+
+// parseElementValue reads one element_value and returns a Go value:
+//   - int32 for tags I (and B,C,D,F,J,S,Z treated as int32 via constant pool)
+//   - string for tag 's'
+//   - []interface{} for tag '['
+//   - nil for tags 'e', 'c', '@'
+func parseElementValue(r *classReader, cp *constantPool) (interface{}, error) {
+	tag, err := r.readU8()
+	if err != nil {
+		return nil, fmt.Errorf("read element value tag: %w", err)
+	}
+
+	switch tag {
+	case 'B', 'C', 'F', 'S', 'Z': // primitive (not commonly used in kotlin.Metadata)
+		constIdx, err := r.readU16()
+		if err != nil {
+			return nil, fmt.Errorf("read primitive const_value_index: %w", err)
+		}
+		// Resolve as int32 from integer pool; for B/C/S/Z these would be Integer constants too
+		return cp.integer[int(constIdx)], nil
+	case 'I': // Integer
+		constIdx, err := r.readU16()
+		if err != nil {
+			return nil, fmt.Errorf("read Integer const_value_index: %w", err)
+		}
+		return cp.integer[int(constIdx)], nil
+	case 'J': // Long
+		constIdx, err := r.readU16()
+		if err != nil {
+			return nil, fmt.Errorf("read Long const_value_index: %w", err)
+		}
+		// Long is stored but not used by kotlin.Metadata; return as int32 for compat
+		return cp.integer[int(constIdx)], nil
+	case 'D': // Double — skip
+		if err := r.skip(2); err != nil {
+			return nil, fmt.Errorf("skip Double const_value_index: %w", err)
+		}
+		return nil, nil
+	case 'e': // enum: type_name_index, const_name_index
+		if err := r.skip(4); err != nil {
+			return nil, fmt.Errorf("skip enum element: %w", err)
+		}
+		return nil, nil
+	case 'c': // class: class_info_index
+		if err := r.skip(2); err != nil {
+			return nil, fmt.Errorf("skip class element: %w", err)
+		}
+		return nil, nil
+	case 's': // string: const_value_index -> Utf8
+		constIdx, err := r.readU16()
+		if err != nil {
+			return nil, fmt.Errorf("read string const_value_index: %w", err)
+		}
+		return cp.utf8[int(constIdx)], nil
+	case '@': // nested annotation
+		if err := r.skip(2); err != nil { // type_index
+			return nil, err
+		}
+		numPairs, err := r.readU16()
+		if err != nil {
+			return nil, err
+		}
+		for i := 0; i < int(numPairs); i++ {
+			if err := r.skip(2); err != nil { // name_index
+				return nil, err
+			}
+			if _, err := parseElementValue(r, cp); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	case '[': // array
+		numVals, err := r.readU16()
+		if err != nil {
+			return nil, fmt.Errorf("read array num_values: %w", err)
+		}
+		arr := make([]interface{}, 0, int(numVals))
+		for i := 0; i < int(numVals); i++ {
+			v, err := parseElementValue(r, cp)
+			if err != nil {
+				return nil, fmt.Errorf("array element %d: %w", i, err)
+			}
+			arr = append(arr, v)
+		}
+		return arr, nil
+	default:
+		return nil, fmt.Errorf("unknown element value tag: %c (%d)", tag, tag)
+	}
+}
+
+// classReader is a simple forward-only big-endian byte reader.
+type classReader struct {
+	data []byte
+	pos  int
+}
+
+func (r *classReader) readU8() (byte, error) {
+	if r.pos >= len(r.data) {
+		return 0, fmt.Errorf("unexpected EOF at offset %d", r.pos)
+	}
+	b := r.data[r.pos]
+	r.pos++
+	return b, nil
+}
+
+func (r *classReader) readU16() (uint16, error) {
+	if r.pos+2 > len(r.data) {
+		return 0, fmt.Errorf("unexpected EOF at offset %d (need 2 bytes)", r.pos)
+	}
+	v := binary.BigEndian.Uint16(r.data[r.pos:])
+	r.pos += 2
+	return v, nil
+}
+
+func (r *classReader) readU32() (uint32, error) {
+	if r.pos+4 > len(r.data) {
+		return 0, fmt.Errorf("unexpected EOF at offset %d (need 4 bytes)", r.pos)
+	}
+	v := binary.BigEndian.Uint32(r.data[r.pos:])
+	r.pos += 4
+	return v, nil
+}
+
+func (r *classReader) readN(n int) ([]byte, error) {
+	if r.pos+n > len(r.data) {
+		return nil, fmt.Errorf("unexpected EOF at offset %d (need %d bytes)", r.pos, n)
+	}
+	b := r.data[r.pos : r.pos+n]
+	r.pos += n
+	return b, nil
+}
+
+func (r *classReader) skip(n int) error {
+	if r.pos+n > len(r.data) {
+		return fmt.Errorf("unexpected EOF at offset %d (skip %d bytes)", r.pos, n)
+	}
+	r.pos += n
+	return nil
+}

--- a/package3/kotlin/metadata/classreader_test.go
+++ b/package3/kotlin/metadata/classreader_test.go
@@ -1,0 +1,452 @@
+package metadata
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	bridgeerrors "github.com/mochilang/mochi/package3/kotlin/errors"
+)
+
+// buildClassWithMetadata synthesises a minimal valid .class file that contains
+// exactly one class-level RuntimeVisibleAnnotations attribute holding a
+// @kotlin.Metadata annotation with the given fields.
+//
+// The produced class file has:
+//   - Magic: 0xCAFEBABE
+//   - Version: minor=0, major=52 (Java 8)
+//   - Minimal constant pool with all strings needed for the annotation
+//   - Zero interfaces, zero fields, zero methods
+//   - One class attribute: RuntimeVisibleAnnotations
+func buildClassWithMetadata(kind int32, version [3]int32, d1 []byte, d2 []string) []byte {
+	// We build the constant pool incrementally and keep track of indices.
+	//
+	// Constant pool layout (1-based):
+	//  [1]  Utf8  "RuntimeVisibleAnnotations"
+	//  [2]  Utf8  "Lkotlin/Metadata;"
+	//  [3]  Utf8  "k"
+	//  [4]  Integer  <kind>
+	//  [5]  Utf8  "mv"
+	//  [6]  Integer  version[0]
+	//  [7]  Integer  version[1]
+	//  [8]  Integer  version[2]
+	//  [9]  Utf8  "d1"
+	//  [10..10+len(d1strings)-1]  Utf8  each d1 string
+	//  [next]  Utf8  "d2"
+	//  [next+1 .. next+len(d2)-1]  Utf8  each d2 entry
+	//  [next]  Utf8  "xi"
+	//  [next+1]  Integer  0  (xi=0)
+	//  [next]  Utf8  "ThisClass"   (name used for this_class)
+	//  [next+1]  Class -> ThisClass utf8 index
+	//
+	// To keep it simple we split the original d1 bytes into a single string.
+	// (For the multi-string test we pass a slice of strings via d1Parts.)
+
+	// We'll encode d1 as a single string in the constant pool.
+	d1Str := string(d1) // single d1 string
+
+	type cpEntry struct {
+		tag  byte
+		data []byte // serialised bytes following the tag
+	}
+
+	var cp []cpEntry
+	addEntry := func(tag byte, data []byte) int {
+		cp = append(cp, cpEntry{tag, data})
+		return len(cp) // 1-based index
+	}
+	u16 := func(v uint16) []byte { b := make([]byte, 2); binary.BigEndian.PutUint16(b, v); return b }
+	u32 := func(v uint32) []byte { b := make([]byte, 4); binary.BigEndian.PutUint32(b, v); return b }
+	utf8Entry := func(s string) []byte {
+		sb := []byte(s)
+		b := make([]byte, 2+len(sb))
+		binary.BigEndian.PutUint16(b, uint16(len(sb)))
+		copy(b[2:], sb)
+		return b
+	}
+
+	// [1] Utf8 "RuntimeVisibleAnnotations"
+	idx_rva := addEntry(1, utf8Entry("RuntimeVisibleAnnotations"))
+	// [2] Utf8 "Lkotlin/Metadata;"
+	idx_annType := addEntry(1, utf8Entry("Lkotlin/Metadata;"))
+	// [3] Utf8 "k"
+	idx_k := addEntry(1, utf8Entry("k"))
+	// [4] Integer kind
+	idx_kindVal := addEntry(3, u32(uint32(kind)))
+	// [5] Utf8 "mv"
+	idx_mv := addEntry(1, utf8Entry("mv"))
+	// [6,7,8] Integer version[0..2]
+	idx_mv0 := addEntry(3, u32(uint32(version[0])))
+	idx_mv1 := addEntry(3, u32(uint32(version[1])))
+	idx_mv2 := addEntry(3, u32(uint32(version[2])))
+	// [9] Utf8 "d1"
+	idx_d1 := addEntry(1, utf8Entry("d1"))
+	// d1 value (single string)
+	idx_d1Val := addEntry(1, utf8Entry(d1Str))
+	// Utf8 "d2"
+	idx_d2 := addEntry(1, utf8Entry("d2"))
+	// d2 values
+	d2Indices := make([]int, len(d2))
+	for i, s := range d2 {
+		d2Indices[i] = addEntry(1, utf8Entry(s))
+	}
+	// Utf8 "xi"
+	idx_xi := addEntry(1, utf8Entry("xi"))
+	// Integer 0 for xi
+	idx_xiVal := addEntry(3, u32(0))
+	// Utf8 for this class name
+	idx_className := addEntry(1, utf8Entry("Stub"))
+	// Class entry pointing to className
+	idx_thisClass := addEntry(7, u16(uint16(idx_className)))
+
+	// Suppress unused variable warnings with _ assignments where applicable.
+	_, _, _, _, _, _, _ = idx_rva, idx_annType, idx_k, idx_kindVal, idx_mv, idx_mv0, idx_mv1
+	_, _, _, _, _ = idx_mv2, idx_d1, idx_d1Val, idx_d2, idx_xi
+	_, _, _ = idx_xiVal, idx_className, idx_thisClass
+
+	// Build the RuntimeVisibleAnnotations attribute content.
+	// Structure:
+	//   num_annotations = 1
+	//   annotation[0]:
+	//     type_index = idx_annType
+	//     num_element_value_pairs = (number of pairs)
+	//     pairs: k, mv, d1, d2, xi
+	var annBuf bytes.Buffer
+	writeU16 := func(v uint16) { binary.Write(&annBuf, binary.BigEndian, v) } //nolint:errcheck
+	writeU8 := func(v byte) { annBuf.WriteByte(v) }                            //nolint:errcheck
+
+	// num_annotations = 1
+	writeU16(1)
+	// annotation type_index
+	writeU16(uint16(idx_annType))
+
+	// Count pairs: k, mv, d1, d2, xi
+	numPairs := uint16(5)
+	writeU16(numPairs)
+
+	// Pair "k" = I <kind>
+	writeU16(uint16(idx_k))
+	writeU8('I')
+	writeU16(uint16(idx_kindVal))
+
+	// Pair "mv" = [ I I I ]
+	writeU16(uint16(idx_mv))
+	writeU8('[')
+	writeU16(3)
+	writeU8('I'); writeU16(uint16(idx_mv0))
+	writeU8('I'); writeU16(uint16(idx_mv1))
+	writeU8('I'); writeU16(uint16(idx_mv2))
+
+	// Pair "d1" = [ s ] (single string)
+	writeU16(uint16(idx_d1))
+	writeU8('[')
+	writeU16(1)
+	writeU8('s'); writeU16(uint16(idx_d1Val))
+
+	// Pair "d2" = [ s ... ]
+	writeU16(uint16(idx_d2))
+	writeU8('[')
+	writeU16(uint16(len(d2)))
+	for _, di := range d2Indices {
+		writeU8('s'); writeU16(uint16(di))
+	}
+
+	// Pair "xi" = I 0
+	writeU16(uint16(idx_xi))
+	writeU8('I')
+	writeU16(uint16(idx_xiVal))
+
+	annData := annBuf.Bytes()
+
+	// Build the class file.
+	var buf bytes.Buffer
+	writeU16Class := func(v uint16) { binary.Write(&buf, binary.BigEndian, v) } //nolint:errcheck
+	writeU32Class := func(v uint32) { binary.Write(&buf, binary.BigEndian, v) } //nolint:errcheck
+
+	// Magic + version
+	writeU32Class(0xCAFEBABE)
+	writeU16Class(0)  // minor version
+	writeU16Class(52) // major version (Java 8)
+
+	// Constant pool count (1-based, so count = len(cp)+1)
+	writeU16Class(uint16(len(cp) + 1))
+	for _, e := range cp {
+		buf.WriteByte(e.tag)
+		buf.Write(e.data)
+	}
+
+	// access_flags = ACC_PUBLIC (0x0001)
+	writeU16Class(0x0001)
+	// this_class
+	writeU16Class(uint16(idx_thisClass))
+	// super_class = 0 (no super, valid for interfaces; for simplicity use 0)
+	writeU16Class(0)
+	// interfaces_count = 0
+	writeU16Class(0)
+	// fields_count = 0
+	writeU16Class(0)
+	// methods_count = 0
+	writeU16Class(0)
+	// attributes_count = 1
+	writeU16Class(1)
+	// Attribute: RuntimeVisibleAnnotations
+	writeU16Class(uint16(idx_rva))
+	writeU32Class(uint32(len(annData)))
+	buf.Write(annData)
+
+	return buf.Bytes()
+}
+
+// buildClassWithMetadataMultiD1 is like buildClassWithMetadata but accepts
+// multiple d1 parts (strings that will be concatenated by ExtractMetadata).
+func buildClassWithMetadataMultiD1(kind int32, version [3]int32, d1Parts []string, d2 []string) []byte {
+	type cpEntry struct {
+		tag  byte
+		data []byte
+	}
+	var cp []cpEntry
+	addEntry := func(tag byte, data []byte) int {
+		cp = append(cp, cpEntry{tag, data})
+		return len(cp)
+	}
+	u16 := func(v uint16) []byte { b := make([]byte, 2); binary.BigEndian.PutUint16(b, v); return b }
+	u32 := func(v uint32) []byte { b := make([]byte, 4); binary.BigEndian.PutUint32(b, v); return b }
+	utf8Entry := func(s string) []byte {
+		sb := []byte(s)
+		b := make([]byte, 2+len(sb))
+		binary.BigEndian.PutUint16(b, uint16(len(sb)))
+		copy(b[2:], sb)
+		return b
+	}
+
+	idx_rva := addEntry(1, utf8Entry("RuntimeVisibleAnnotations"))
+	idx_annType := addEntry(1, utf8Entry("Lkotlin/Metadata;"))
+	idx_k := addEntry(1, utf8Entry("k"))
+	idx_kindVal := addEntry(3, u32(uint32(kind)))
+	idx_mv := addEntry(1, utf8Entry("mv"))
+	idx_mv0 := addEntry(3, u32(uint32(version[0])))
+	idx_mv1 := addEntry(3, u32(uint32(version[1])))
+	idx_mv2 := addEntry(3, u32(uint32(version[2])))
+	idx_d1 := addEntry(1, utf8Entry("d1"))
+	d1Indices := make([]int, len(d1Parts))
+	for i, s := range d1Parts {
+		d1Indices[i] = addEntry(1, utf8Entry(s))
+	}
+	idx_d2 := addEntry(1, utf8Entry("d2"))
+	d2Indices := make([]int, len(d2))
+	for i, s := range d2 {
+		d2Indices[i] = addEntry(1, utf8Entry(s))
+	}
+	idx_xi := addEntry(1, utf8Entry("xi"))
+	idx_xiVal := addEntry(3, u32(0))
+	idx_className := addEntry(1, utf8Entry("Stub"))
+	idx_thisClass := addEntry(7, u16(uint16(idx_className)))
+
+	_, _, _, _, _, _, _ = idx_rva, idx_annType, idx_k, idx_kindVal, idx_mv, idx_mv0, idx_mv1
+	_, _, _, _, _ = idx_mv2, idx_d1, idx_d2, idx_xi, idx_xiVal
+	_, _, _ = idx_className, idx_thisClass, d1Indices
+
+	var annBuf bytes.Buffer
+	writeU16 := func(v uint16) { binary.Write(&annBuf, binary.BigEndian, v) } //nolint:errcheck
+	writeU8 := func(v byte) { annBuf.WriteByte(v) }                            //nolint:errcheck
+
+	writeU16(1)
+	writeU16(uint16(idx_annType))
+	writeU16(5) // k, mv, d1, d2, xi
+
+	writeU16(uint16(idx_k))
+	writeU8('I'); writeU16(uint16(idx_kindVal))
+
+	writeU16(uint16(idx_mv))
+	writeU8('['); writeU16(3)
+	writeU8('I'); writeU16(uint16(idx_mv0))
+	writeU8('I'); writeU16(uint16(idx_mv1))
+	writeU8('I'); writeU16(uint16(idx_mv2))
+
+	writeU16(uint16(idx_d1))
+	writeU8('['); writeU16(uint16(len(d1Parts)))
+	for _, di := range d1Indices {
+		writeU8('s'); writeU16(uint16(di))
+	}
+
+	writeU16(uint16(idx_d2))
+	writeU8('['); writeU16(uint16(len(d2)))
+	for _, di := range d2Indices {
+		writeU8('s'); writeU16(uint16(di))
+	}
+
+	writeU16(uint16(idx_xi))
+	writeU8('I'); writeU16(uint16(idx_xiVal))
+
+	annData := annBuf.Bytes()
+
+	var buf bytes.Buffer
+	writeU16C := func(v uint16) { binary.Write(&buf, binary.BigEndian, v) } //nolint:errcheck
+	writeU32C := func(v uint32) { binary.Write(&buf, binary.BigEndian, v) } //nolint:errcheck
+
+	writeU32C(0xCAFEBABE)
+	writeU16C(0); writeU16C(52)
+	writeU16C(uint16(len(cp) + 1))
+	for _, e := range cp {
+		buf.WriteByte(e.tag)
+		buf.Write(e.data)
+	}
+	writeU16C(0x0001)
+	writeU16C(uint16(idx_thisClass))
+	writeU16C(0)
+	writeU16C(0)
+	writeU16C(0)
+	writeU16C(0)
+	writeU16C(1) // attributes_count = 1
+	writeU16C(uint16(idx_rva))
+	writeU32C(uint32(len(annData)))
+	buf.Write(annData)
+
+	return buf.Bytes()
+}
+
+// buildMinimalClass builds a class file with no annotations (no @kotlin.Metadata).
+func buildMinimalClass() []byte {
+	type cpEntry struct {
+		tag  byte
+		data []byte
+	}
+	var cp []cpEntry
+	addEntry := func(tag byte, data []byte) int {
+		cp = append(cp, cpEntry{tag, data})
+		return len(cp)
+	}
+	u16 := func(v uint16) []byte { b := make([]byte, 2); binary.BigEndian.PutUint16(b, v); return b }
+	utf8Entry := func(s string) []byte {
+		sb := []byte(s)
+		b := make([]byte, 2+len(sb))
+		binary.BigEndian.PutUint16(b, uint16(len(sb)))
+		copy(b[2:], sb)
+		return b
+	}
+
+	idx_className := addEntry(1, utf8Entry("Stub"))
+	idx_thisClass := addEntry(7, u16(uint16(idx_className)))
+	_ = idx_thisClass
+
+	var buf bytes.Buffer
+	writeU16 := func(v uint16) { binary.Write(&buf, binary.BigEndian, v) } //nolint:errcheck
+	writeU32 := func(v uint32) { binary.Write(&buf, binary.BigEndian, v) } //nolint:errcheck
+
+	writeU32(0xCAFEBABE)
+	writeU16(0); writeU16(52)
+	writeU16(uint16(len(cp) + 1))
+	for _, e := range cp {
+		buf.WriteByte(e.tag)
+		buf.Write(e.data)
+	}
+	writeU16(0x0001)
+	writeU16(uint16(idx_thisClass))
+	writeU16(0)
+	writeU16(0) // interfaces
+	writeU16(0) // fields
+	writeU16(0) // methods
+	writeU16(0) // attributes
+
+	return buf.Bytes()
+}
+
+// --- Tests ---
+
+func TestExtractMetadata_RoundTrip(t *testing.T) {
+	d1 := []byte{0x0a, 0x01, 0x02, 0x03}
+	d2 := []string{"foo", "bar", "baz"}
+	version := [3]int32{1, 9, 0}
+	classBytes := buildClassWithMetadata(1, version, d1, d2)
+
+	meta, err := ExtractMetadata(classBytes)
+	if err != nil {
+		t.Fatalf("ExtractMetadata returned error: %v", err)
+	}
+	if meta.Kind != 1 {
+		t.Errorf("kind: got %d, want 1", meta.Kind)
+	}
+	if meta.Version != version {
+		t.Errorf("version: got %v, want %v", meta.Version, version)
+	}
+	if !bytes.Equal(meta.D1, d1) {
+		t.Errorf("D1: got %x, want %x", meta.D1, d1)
+	}
+	if len(meta.D2) != len(d2) {
+		t.Fatalf("D2 len: got %d, want %d", len(meta.D2), len(d2))
+	}
+	for i, s := range d2 {
+		if meta.D2[i] != s {
+			t.Errorf("D2[%d]: got %q, want %q", i, meta.D2[i], s)
+		}
+	}
+}
+
+func TestExtractMetadata_NoAnnotation(t *testing.T) {
+	classBytes := buildMinimalClass()
+	_, err := ExtractMetadata(classBytes)
+	if err == nil {
+		t.Fatal("expected ErrNoKotlinMetadata, got nil")
+	}
+	if !errors.Is(err, bridgeerrors.ErrNoKotlinMetadata) {
+		t.Errorf("expected ErrNoKotlinMetadata, got: %v", err)
+	}
+}
+
+func TestExtractMetadata_VersionExtraction(t *testing.T) {
+	version := [3]int32{1, 9, 0}
+	classBytes := buildClassWithMetadata(1, version, nil, nil)
+
+	meta, err := ExtractMetadata(classBytes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if meta.Version[0] != 1 || meta.Version[1] != 9 || meta.Version[2] != 0 {
+		t.Errorf("version: got %v, want [1 9 0]", meta.Version)
+	}
+}
+
+func TestExtractMetadata_MultiStringD1(t *testing.T) {
+	// Split the d1 data across 3 strings; should be joined on extraction.
+	part1 := "hello"
+	part2 := " world"
+	part3 := "!"
+	expected := []byte(part1 + part2 + part3)
+
+	classBytes := buildClassWithMetadataMultiD1(1, [3]int32{1, 9, 0}, []string{part1, part2, part3}, nil)
+
+	meta, err := ExtractMetadata(classBytes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(meta.D1, expected) {
+		t.Errorf("D1: got %q, want %q", meta.D1, expected)
+	}
+}
+
+func TestExtractMetadata_EmptyD2(t *testing.T) {
+	classBytes := buildClassWithMetadata(1, [3]int32{1, 9, 0}, []byte{0x01}, nil)
+	meta, err := ExtractMetadata(classBytes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(meta.D2) != 0 {
+		t.Errorf("D2: got %v, want empty", meta.D2)
+	}
+}
+
+func TestExtractMetadata_BadMagic(t *testing.T) {
+	classBytes := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x00, 0x00, 0x34}
+	_, err := ExtractMetadata(classBytes)
+	if err == nil {
+		t.Fatal("expected error for bad magic, got nil")
+	}
+}
+
+func TestExtractMetadata_TooShort(t *testing.T) {
+	_, err := ExtractMetadata([]byte{0xCA, 0xFE})
+	if err == nil {
+		t.Fatal("expected error for too-short data, got nil")
+	}
+}

--- a/package3/kotlin/metadata/ingest.go
+++ b/package3/kotlin/metadata/ingest.go
@@ -1,0 +1,121 @@
+package metadata
+
+import (
+	"archive/zip"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	bridgeerrors "github.com/mochilang/mochi/package3/kotlin/errors"
+)
+
+// IngestJAR opens a JAR file (which is a ZIP archive) at jarPath, iterates all
+// .class entries, extracts @kotlin.Metadata from each, and returns the top-level
+// APIObjects (nested classes are embedded in their enclosing class, not returned
+// as top-level entries). Entries without @kotlin.Metadata are silently skipped.
+func IngestJAR(jarPath string) ([]*APIObject, error) {
+	zr, err := zip.OpenReader(jarPath)
+	if err != nil {
+		return nil, fmt.Errorf("ingest: open JAR %q: %w", jarPath, err)
+	}
+	defer zr.Close()
+
+	return ingestZipReader(&zr.Reader)
+}
+
+// IngestJARBytes reads a JAR from an in-memory byte slice. Useful for testing.
+func IngestJARBytes(data []byte) ([]*APIObject, error) {
+	zr, err := zip.NewReader(readerAt(data), int64(len(data)))
+	if err != nil {
+		return nil, fmt.Errorf("ingest: parse JAR bytes: %w", err)
+	}
+	return ingestZipReader(zr)
+}
+
+// ingestZipReader processes all .class entries in a zip.Reader.
+func ingestZipReader(zr *zip.Reader) ([]*APIObject, error) {
+	var results []*APIObject
+
+	for _, f := range zr.File {
+		if !strings.HasSuffix(f.Name, ".class") {
+			continue
+		}
+		// Skip inner/nested classes (they appear as Outer$Inner.class)
+		baseName := f.Name
+		if idx := strings.LastIndex(baseName, "/"); idx >= 0 {
+			baseName = baseName[idx+1:]
+		}
+		if strings.Contains(baseName, "$") {
+			continue
+		}
+
+		obj, err := processClassEntry(f)
+		if err != nil {
+			if errors.Is(err, bridgeerrors.ErrNoKotlinMetadata) {
+				continue
+			}
+			// On other errors (malformed class), skip with a warning; do not fail the whole JAR.
+			continue
+		}
+		if obj != nil {
+			results = append(results, obj)
+		}
+	}
+
+	return results, nil
+}
+
+// processClassEntry reads one zip.File entry and returns its APIObject.
+func processClassEntry(f *zip.File) (*APIObject, error) {
+	rc, err := f.Open()
+	if err != nil {
+		return nil, fmt.Errorf("ingest: open entry %q: %w", f.Name, err)
+	}
+	defer rc.Close()
+
+	classBytes, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, fmt.Errorf("ingest: read entry %q: %w", f.Name, err)
+	}
+
+	raw, err := ExtractMetadata(classBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	switch raw.Kind {
+	case 1: // class
+		return DecodeClass(raw)
+	case 2: // file facade
+		return DecodePackage(raw)
+	case 3, 4: // synthetic class, multi-file-part — skip
+		return nil, nil
+	case 5: // multi-file-facade
+		obj := &APIObject{
+			Kind:                  ClassKindFileFacade,
+			MetadataSchemaVersion: raw.Version,
+		}
+		if raw.XS != "" {
+			obj.ClassName = strings.ReplaceAll(raw.XS, "/", ".")
+			obj.JVMClassName = raw.XS
+		}
+		return obj, nil
+	default:
+		return nil, nil
+	}
+}
+
+// readerAt wraps a []byte to implement io.ReaderAt.
+type readerAt []byte
+
+func (r readerAt) ReadAt(p []byte, off int64) (int, error) {
+	if off >= int64(len(r)) {
+		return 0, io.EOF
+	}
+	n := copy(p, r[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}

--- a/package3/kotlin/metadata/ingest_test.go
+++ b/package3/kotlin/metadata/ingest_test.go
@@ -1,0 +1,149 @@
+package metadata
+
+import (
+	"archive/zip"
+	"bytes"
+	"testing"
+)
+
+// buildJARBytes creates an in-memory JAR (ZIP) from a map of filename → content.
+func buildJARBytes(entries map[string][]byte) []byte {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, data := range entries {
+		w, err := zw.Create(name)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := w.Write(data); err != nil {
+			panic(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
+}
+
+// buildSimpleClassProto builds a trivial ClassProto for testing.
+func buildSimpleClassProto(fqNameIdx int, d2 []string) []byte {
+	var pb protoBuilder
+	classFlags := int32(3 << 3) // public class
+	pb.varint(1, uint64(classFlags))
+	pb.varint(3, uint64(fqNameIdx))
+	return pb.build()
+}
+
+func TestIngestJARBytes_TwoWithMetadataOneWithout(t *testing.T) {
+	// Class 1: kotlin class Foo
+	d2a := []string{"com/example/Foo"}
+	classAProto := buildSimpleClassProto(0, d2a)
+	classA := buildClassWithMetadata(1, [3]int32{1, 9, 0}, classAProto, d2a)
+
+	// Class 2: kotlin class Bar
+	d2b := []string{"com/example/Bar"}
+	classBProto := buildSimpleClassProto(0, d2b)
+	classB := buildClassWithMetadata(1, [3]int32{1, 9, 0}, classBProto, d2b)
+
+	// Class 3: plain Java class, no kotlin.Metadata
+	classC := buildMinimalClass()
+
+	jar := buildJARBytes(map[string][]byte{
+		"com/example/Foo.class": classA,
+		"com/example/Bar.class": classB,
+		"com/example/Baz.class": classC,
+	})
+
+	objects, err := IngestJARBytes(jar)
+	if err != nil {
+		t.Fatalf("IngestJARBytes error: %v", err)
+	}
+	if len(objects) != 2 {
+		t.Errorf("expected 2 API objects, got %d", len(objects))
+	}
+}
+
+func TestIngestJARBytes_Empty(t *testing.T) {
+	jar := buildJARBytes(map[string][]byte{})
+	objects, err := IngestJARBytes(jar)
+	if err != nil {
+		t.Fatalf("IngestJARBytes error: %v", err)
+	}
+	if len(objects) != 0 {
+		t.Errorf("expected 0 objects for empty JAR, got %d", len(objects))
+	}
+}
+
+func TestIngestJARBytes_NestedClassSkipped(t *testing.T) {
+	// Outer class
+	d2outer := []string{"com/example/Outer"}
+	outerProto := buildSimpleClassProto(0, d2outer)
+	outerClass := buildClassWithMetadata(1, [3]int32{1, 9, 0}, outerProto, d2outer)
+
+	// Nested class (filename contains '$')
+	d2inner := []string{"com/example/Outer.Inner"}
+	innerProto := buildSimpleClassProto(0, d2inner)
+	innerClass := buildClassWithMetadata(1, [3]int32{1, 9, 0}, innerProto, d2inner)
+
+	jar := buildJARBytes(map[string][]byte{
+		"com/example/Outer.class":       outerClass,
+		"com/example/Outer$Inner.class": innerClass,
+	})
+
+	objects, err := IngestJARBytes(jar)
+	if err != nil {
+		t.Fatalf("IngestJARBytes error: %v", err)
+	}
+	// Only the outer class should be top-level; the nested (Outer$Inner) is skipped.
+	if len(objects) != 1 {
+		t.Errorf("expected 1 top-level object (nested skipped), got %d", len(objects))
+	}
+}
+
+func TestIngestJARBytes_NonClassFilesIgnored(t *testing.T) {
+	d2 := []string{"com/example/Foo"}
+	classProto := buildSimpleClassProto(0, d2)
+	classA := buildClassWithMetadata(1, [3]int32{1, 9, 0}, classProto, d2)
+
+	jar := buildJARBytes(map[string][]byte{
+		"com/example/Foo.class":  classA,
+		"META-INF/MANIFEST.MF":   []byte("Manifest-Version: 1.0\n"),
+		"com/example/config.xml": []byte("<config/>"),
+	})
+
+	objects, err := IngestJARBytes(jar)
+	if err != nil {
+		t.Fatalf("IngestJARBytes error: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Errorf("expected 1 object, got %d", len(objects))
+	}
+}
+
+func TestIngestJARBytes_FileFacade(t *testing.T) {
+	// File facade (kind=2)
+	d2 := []string{"greet", "kotlin/String"}
+	retType := buildTypeProto(1, false, nil, -1)
+	fnFlags := publicFunctionFlags(0)
+	fn := buildFunctionProto(0, fnFlags, retType, nil, nil)
+	pkgProto := buildPackageProto([][]byte{fn}, nil)
+
+	classBytes := buildClassWithMetadata(2, [3]int32{1, 9, 0}, pkgProto, d2)
+	jar := buildJARBytes(map[string][]byte{
+		"com/example/FooKt.class": classBytes,
+	})
+
+	objects, err := IngestJARBytes(jar)
+	if err != nil {
+		t.Fatalf("IngestJARBytes error: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objects))
+	}
+	if objects[0].Kind != ClassKindFileFacade {
+		t.Errorf("kind: got %v, want ClassKindFileFacade", objects[0].Kind)
+	}
+	if len(objects[0].Functions) != 1 {
+		t.Errorf("expected 1 function, got %d", len(objects[0].Functions))
+	}
+}

--- a/package3/kotlin/metadata/proto.go
+++ b/package3/kotlin/metadata/proto.go
@@ -1,0 +1,667 @@
+package metadata
+
+import (
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// DecodeClass decodes a RawMetadata with Kind=1 (class) into an APIObject.
+func DecodeClass(raw *RawMetadata) (*APIObject, error) {
+	if raw.Kind != 1 {
+		return nil, fmt.Errorf("proto: expected kind=1 (class), got kind=%d", raw.Kind)
+	}
+	obj := &APIObject{
+		MetadataSchemaVersion: raw.Version,
+	}
+	if err := parseClassProto(raw.D1, raw.D2, obj); err != nil {
+		return nil, fmt.Errorf("proto: DecodeClass: %w", err)
+	}
+	return obj, nil
+}
+
+// DecodePackage decodes a RawMetadata with Kind=2 (file facade) into an APIObject.
+func DecodePackage(raw *RawMetadata) (*APIObject, error) {
+	if raw.Kind != 2 {
+		return nil, fmt.Errorf("proto: expected kind=2 (file facade), got kind=%d", raw.Kind)
+	}
+	obj := &APIObject{
+		Kind:                  ClassKindFileFacade,
+		MetadataSchemaVersion: raw.Version,
+	}
+	if raw.XS != "" {
+		obj.ClassName = strings.ReplaceAll(raw.XS, "/", ".")
+		obj.JVMClassName = raw.XS
+	}
+	if err := parsePackageProto(raw.D1, raw.D2, obj); err != nil {
+		return nil, fmt.Errorf("proto: DecodePackage: %w", err)
+	}
+	return obj, nil
+}
+
+// parseClassProto fills obj from a ClassProto wire encoding.
+func parseClassProto(b []byte, d2 []string, obj *APIObject) error {
+	for len(b) > 0 {
+		num, typ, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return fmt.Errorf("ClassProto: bad tag: %w", protowire.ParseError(n))
+		}
+		b = b[n:]
+
+		switch num {
+		case 1: // flags
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return fmt.Errorf("ClassProto: bad flags: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			flags := int32(v)
+			obj.Kind = classKindFromFlags(flags)
+			// Check data class (bit 10) and value class (bit 13)
+			if flags&(1<<10) != 0 {
+				obj.Kind = ClassKindDataClass
+			}
+			if flags&(1<<13) != 0 {
+				obj.Kind = ClassKindValueClass
+			}
+		case 3: // fq_name
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return fmt.Errorf("ClassProto: bad fq_name: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			jvmName := strAt(d2, int32(v))
+			obj.JVMClassName = jvmName
+			obj.ClassName = strings.ReplaceAll(jvmName, "/", ".")
+		case 7: // nested_class_name (repeated varint)
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return fmt.Errorf("ClassProto: bad nested_class_name: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			// We record nested class names as stub APIObjects
+			nestedName := strAt(d2, int32(v))
+			nested := &APIObject{
+				JVMClassName: nestedName,
+				ClassName:    strings.ReplaceAll(nestedName, "/", "."),
+			}
+			obj.Nested = append(obj.Nested, nested)
+		case 8: // constructor (length-delimited, repeated)
+			msgBytes, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return fmt.Errorf("ClassProto: bad constructor: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			c, err := decodeConstructor(msgBytes, d2)
+			if err != nil {
+				return fmt.Errorf("ClassProto: constructor: %w", err)
+			}
+			obj.Constructors = append(obj.Constructors, c)
+		case 9: // function (length-delimited, repeated)
+			msgBytes, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return fmt.Errorf("ClassProto: bad function: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			fn, err := decodeFunction(msgBytes, d2)
+			if err != nil {
+				return fmt.Errorf("ClassProto: function: %w", err)
+			}
+			if isPublicVisible(fn.flagsRaw) {
+				obj.Functions = append(obj.Functions, fn.Function)
+			}
+		case 10: // property (length-delimited, repeated)
+			msgBytes, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return fmt.Errorf("ClassProto: bad property: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			prop, err := decodeProperty(msgBytes, d2)
+			if err != nil {
+				return fmt.Errorf("ClassProto: property: %w", err)
+			}
+			if isPublicVisible(prop.flagsRaw) {
+				obj.Properties = append(obj.Properties, prop.Property)
+			}
+		case 12: // enum_entry (length-delimited, repeated)
+			msgBytes, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return fmt.Errorf("ClassProto: bad enum_entry: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			entry, err := decodeEnumEntry(msgBytes, d2)
+			if err != nil {
+				return fmt.Errorf("ClassProto: enum_entry: %w", err)
+			}
+			obj.EnumEntries = append(obj.EnumEntries, entry)
+		case 14: // sealed_subclass_fq_name (repeated varint)
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return fmt.Errorf("ClassProto: bad sealed_subclass_fq_name: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			subName := strAt(d2, int32(v))
+			sub := &APIObject{
+				JVMClassName: subName,
+				ClassName:    strings.ReplaceAll(subName, "/", "."),
+			}
+			obj.SealedSubs = append(obj.SealedSubs, sub)
+		default:
+			// Skip unknown fields
+			n := protowire.ConsumeFieldValue(num, typ, b)
+			if n < 0 {
+				return fmt.Errorf("ClassProto: skip unknown field %d: %w", num, protowire.ParseError(n))
+			}
+			b = b[n:]
+		}
+	}
+	// If obj has sealed subclasses, mark as sealed class
+	if len(obj.SealedSubs) > 0 {
+		obj.Kind = ClassKindSealedClass
+	}
+	return nil
+}
+
+// parsePackageProto fills obj from a PackageProto wire encoding.
+func parsePackageProto(b []byte, d2 []string, obj *APIObject) error {
+	for len(b) > 0 {
+		num, typ, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return fmt.Errorf("PackageProto: bad tag: %w", protowire.ParseError(n))
+		}
+		b = b[n:]
+
+		switch num {
+		case 3: // function (field 3 in PackageProto, not 9!)
+			msgBytes, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return fmt.Errorf("PackageProto: bad function: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			fn, err := decodeFunction(msgBytes, d2)
+			if err != nil {
+				return fmt.Errorf("PackageProto: function: %w", err)
+			}
+			if isPublicVisible(fn.flagsRaw) {
+				obj.Functions = append(obj.Functions, fn.Function)
+			}
+		case 4: // property
+			msgBytes, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return fmt.Errorf("PackageProto: bad property: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			prop, err := decodeProperty(msgBytes, d2)
+			if err != nil {
+				return fmt.Errorf("PackageProto: property: %w", err)
+			}
+			if isPublicVisible(prop.flagsRaw) {
+				obj.Properties = append(obj.Properties, prop.Property)
+			}
+		default:
+			n := protowire.ConsumeFieldValue(num, typ, b)
+			if n < 0 {
+				return fmt.Errorf("PackageProto: skip unknown field %d: %w", num, protowire.ParseError(n))
+			}
+			b = b[n:]
+		}
+	}
+	return nil
+}
+
+// functionResult carries both the decoded Function and its raw flags for visibility filtering.
+type functionResult struct {
+	Function
+	flagsRaw int32
+}
+
+// propertyResult carries both the decoded Property and its raw flags for visibility filtering.
+type propertyResult struct {
+	Property
+	flagsRaw int32
+}
+
+// decodeFunction decodes a FunctionProto message.
+func decodeFunction(b []byte, d2 []string) (functionResult, error) {
+	var res functionResult
+	var returnTypeSet bool
+	for len(b) > 0 {
+		num, typ, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return res, fmt.Errorf("FunctionProto: bad tag: %w", protowire.ParseError(n))
+		}
+		b = b[n:]
+
+		switch num {
+		case 1: // flags
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return res, fmt.Errorf("FunctionProto: bad flags: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			flags := int32(v)
+			res.flagsRaw = flags
+			res.Flags = FunctionFlags{
+				IsPublic:   isPublicVisible(flags),
+				IsInternal: (flags>>3)&0x7 == 0,
+				IsPrivate:  (flags>>3)&0x7 == 1,
+				IsProtected: (flags>>3)&0x7 == 2,
+				IsFinal:    (flags>>0)&0x3 == 0,
+				IsOpen:     (flags>>0)&0x3 == 1,
+				IsAbstract: (flags>>0)&0x3 == 2,
+				IsOperator: flags&(1<<13) != 0,
+				IsInfix:    flags&(1<<14) != 0,
+				IsInline:   flags&(1<<15) != 0,
+				IsTailrec:  flags&(1<<16) != 0,
+				IsExternal: flags&(1<<17) != 0,
+				IsSuspend:  flags&(1<<18) != 0,
+				IsExpect:   flags&(1<<19) != 0,
+			}
+		case 2: // name
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return res, fmt.Errorf("FunctionProto: bad name: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			res.Name = strAt(d2, int32(v))
+			res.JVMName = res.Name
+		case 3: // return_type
+			msgBytes, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return res, fmt.Errorf("FunctionProto: bad return_type: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			if !returnTypeSet {
+				kt, err := decodeType(msgBytes, d2)
+				if err != nil {
+					return res, fmt.Errorf("FunctionProto: return_type: %w", err)
+				}
+				res.ReturnType = kt
+				returnTypeSet = true
+			}
+		case 4: // type_parameter (repeated)
+			msgBytes, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return res, fmt.Errorf("FunctionProto: bad type_parameter: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			tp, err := decodeTypeParam(msgBytes, d2)
+			if err != nil {
+				return res, fmt.Errorf("FunctionProto: type_parameter: %w", err)
+			}
+			res.TypeParams = append(res.TypeParams, tp)
+		case 5: // value_parameter (repeated)
+			msgBytes, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return res, fmt.Errorf("FunctionProto: bad value_parameter: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			param, err := decodeValueParam(msgBytes, d2)
+			if err != nil {
+				return res, fmt.Errorf("FunctionProto: value_parameter: %w", err)
+			}
+			res.Params = append(res.Params, param)
+		case 6: // receiver_type (extension function)
+			msgBytes, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return res, fmt.Errorf("FunctionProto: bad receiver_type: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			kt, err := decodeType(msgBytes, d2)
+			if err != nil {
+				return res, fmt.Errorf("FunctionProto: receiver_type: %w", err)
+			}
+			res.Receiver = &kt
+		default:
+			n := protowire.ConsumeFieldValue(num, typ, b)
+			if n < 0 {
+				return res, fmt.Errorf("FunctionProto: skip field %d: %w", num, protowire.ParseError(n))
+			}
+			b = b[n:]
+		}
+	}
+	return res, nil
+}
+
+// decodeType decodes a TypeProto message.
+func decodeType(b []byte, d2 []string) (KotlinType, error) {
+	var kt KotlinType
+	var typeParamID int32 = -1
+	for len(b) > 0 {
+		num, typ, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return kt, fmt.Errorf("TypeProto: bad tag: %w", protowire.ParseError(n))
+		}
+		b = b[n:]
+
+		switch num {
+		case 1: // flags
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return kt, fmt.Errorf("TypeProto: bad flags: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			kt.Nullable = int32(v)&1 != 0
+		case 3: // class_name
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return kt, fmt.Errorf("TypeProto: bad class_name: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			jvmName := strAt(d2, int32(v))
+			kt.ClassName = strings.ReplaceAll(jvmName, "/", ".")
+		case 4: // argument (repeated TypeArgumentProto)
+			msgBytes, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return kt, fmt.Errorf("TypeProto: bad argument: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			arg, err := decodeTypeArgument(msgBytes, d2)
+			if err != nil {
+				return kt, fmt.Errorf("TypeProto: argument: %w", err)
+			}
+			kt.TypeArgs = append(kt.TypeArgs, arg)
+		case 6: // type_alias_name
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return kt, fmt.Errorf("TypeProto: bad type_alias_name: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			jvmName := strAt(d2, int32(v))
+			kt.ClassName = strings.ReplaceAll(jvmName, "/", ".")
+		case 9: // type_parameter id
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return kt, fmt.Errorf("TypeProto: bad type_parameter: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			typeParamID = int32(v)
+			_ = typeParamID
+			kt.IsTypeParam = true
+		default:
+			n := protowire.ConsumeFieldValue(num, typ, b)
+			if n < 0 {
+				return kt, fmt.Errorf("TypeProto: skip field %d: %w", num, protowire.ParseError(n))
+			}
+			b = b[n:]
+		}
+	}
+	return kt, nil
+}
+
+// decodeTypeArgument decodes a TypeArgumentProto message.
+func decodeTypeArgument(b []byte, d2 []string) (KotlinType, error) {
+	var kt KotlinType
+	for len(b) > 0 {
+		num, typ, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return kt, fmt.Errorf("TypeArgumentProto: bad tag: %w", protowire.ParseError(n))
+		}
+		b = b[n:]
+
+		switch num {
+		case 2: // type (TypeProto)
+			msgBytes, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return kt, fmt.Errorf("TypeArgumentProto: bad type: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			inner, err := decodeType(msgBytes, d2)
+			if err != nil {
+				return kt, err
+			}
+			kt = inner
+		case 3: // projection: 0=IN, 1=OUT, 2=INV, 3=STAR
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return kt, fmt.Errorf("TypeArgumentProto: bad projection: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			if v == 3 { // STAR
+				kt.IsStarProjection = true
+			}
+		default:
+			n := protowire.ConsumeFieldValue(num, typ, b)
+			if n < 0 {
+				return kt, fmt.Errorf("TypeArgumentProto: skip field %d: %w", num, protowire.ParseError(n))
+			}
+			b = b[n:]
+		}
+	}
+	return kt, nil
+}
+
+// decodeValueParam decodes a ValueParameterProto message.
+func decodeValueParam(b []byte, d2 []string) (Param, error) {
+	var p Param
+	for len(b) > 0 {
+		num, typ, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return p, fmt.Errorf("ValueParameterProto: bad tag: %w", protowire.ParseError(n))
+		}
+		b = b[n:]
+
+		switch num {
+		case 1: // flags
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return p, fmt.Errorf("ValueParameterProto: bad flags: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			p.HasDefault = int32(v)&1 != 0
+		case 2: // name
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return p, fmt.Errorf("ValueParameterProto: bad name: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			p.Name = strAt(d2, int32(v))
+		case 3: // type
+			msgBytes, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return p, fmt.Errorf("ValueParameterProto: bad type: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			kt, err := decodeType(msgBytes, d2)
+			if err != nil {
+				return p, fmt.Errorf("ValueParameterProto: type: %w", err)
+			}
+			p.Type = kt
+		default:
+			n := protowire.ConsumeFieldValue(num, typ, b)
+			if n < 0 {
+				return p, fmt.Errorf("ValueParameterProto: skip field %d: %w", num, protowire.ParseError(n))
+			}
+			b = b[n:]
+		}
+	}
+	return p, nil
+}
+
+// decodeConstructor decodes a ConstructorProto message.
+func decodeConstructor(b []byte, d2 []string) (Constructor, error) {
+	var c Constructor
+	c.IsPrimary = true // default to primary; flipped by flag bit 6
+	for len(b) > 0 {
+		num, typ, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return c, fmt.Errorf("ConstructorProto: bad tag: %w", protowire.ParseError(n))
+		}
+		b = b[n:]
+
+		switch num {
+		case 1: // flags
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return c, fmt.Errorf("ConstructorProto: bad flags: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			flags := int32(v)
+			if flags&(1<<6) != 0 {
+				c.IsPrimary = false
+			}
+		case 5: // value_parameter (repeated)
+			msgBytes, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return c, fmt.Errorf("ConstructorProto: bad value_parameter: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			param, err := decodeValueParam(msgBytes, d2)
+			if err != nil {
+				return c, fmt.Errorf("ConstructorProto: value_parameter: %w", err)
+			}
+			c.Params = append(c.Params, param)
+		default:
+			n := protowire.ConsumeFieldValue(num, typ, b)
+			if n < 0 {
+				return c, fmt.Errorf("ConstructorProto: skip field %d: %w", num, protowire.ParseError(n))
+			}
+			b = b[n:]
+		}
+	}
+	return c, nil
+}
+
+// decodeProperty decodes a PropertyProto message.
+func decodeProperty(b []byte, d2 []string) (propertyResult, error) {
+	var res propertyResult
+	for len(b) > 0 {
+		num, typ, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return res, fmt.Errorf("PropertyProto: bad tag: %w", protowire.ParseError(n))
+		}
+		b = b[n:]
+
+		switch num {
+		case 1: // flags
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return res, fmt.Errorf("PropertyProto: bad flags: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			flags := int32(v)
+			res.flagsRaw = flags
+			res.IsVar = flags&(1<<9) != 0
+			res.IsLateinit = flags&(1<<10) != 0
+		case 2: // name
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return res, fmt.Errorf("PropertyProto: bad name: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			res.Name = strAt(d2, int32(v))
+		case 3: // return_type
+			msgBytes, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return res, fmt.Errorf("PropertyProto: bad return_type: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			kt, err := decodeType(msgBytes, d2)
+			if err != nil {
+				return res, fmt.Errorf("PropertyProto: return_type: %w", err)
+			}
+			res.Type = kt
+		default:
+			n := protowire.ConsumeFieldValue(num, typ, b)
+			if n < 0 {
+				return res, fmt.Errorf("PropertyProto: skip field %d: %w", num, protowire.ParseError(n))
+			}
+			b = b[n:]
+		}
+	}
+	return res, nil
+}
+
+// decodeEnumEntry decodes an EnumEntryProto message.
+func decodeEnumEntry(b []byte, d2 []string) (string, error) {
+	for len(b) > 0 {
+		num, typ, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return "", fmt.Errorf("EnumEntryProto: bad tag: %w", protowire.ParseError(n))
+		}
+		b = b[n:]
+
+		switch num {
+		case 2: // name
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return "", fmt.Errorf("EnumEntryProto: bad name: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			return strAt(d2, int32(v)), nil
+		default:
+			n := protowire.ConsumeFieldValue(num, typ, b)
+			if n < 0 {
+				return "", fmt.Errorf("EnumEntryProto: skip field %d: %w", num, protowire.ParseError(n))
+			}
+			b = b[n:]
+		}
+	}
+	return "", nil
+}
+
+// decodeTypeParam decodes a TypeParameterProto message.
+func decodeTypeParam(b []byte, d2 []string) (TypeParam, error) {
+	var tp TypeParam
+	for len(b) > 0 {
+		num, typ, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return tp, fmt.Errorf("TypeParameterProto: bad tag: %w", protowire.ParseError(n))
+		}
+		b = b[n:]
+
+		switch num {
+		case 3: // name
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return tp, fmt.Errorf("TypeParameterProto: bad name: %w", protowire.ParseError(n))
+			}
+			b = b[n:]
+			tp.Name = strAt(d2, int32(v))
+		default:
+			n := protowire.ConsumeFieldValue(num, typ, b)
+			if n < 0 {
+				return tp, fmt.Errorf("TypeParameterProto: skip field %d: %w", num, protowire.ParseError(n))
+			}
+			b = b[n:]
+		}
+	}
+	return tp, nil
+}
+
+// classKindFromFlags extracts the ClassKind from ClassProto flags bits 6-8.
+func classKindFromFlags(flags int32) ClassKind {
+	switch (flags >> 6) & 0x7 {
+	case 0:
+		return ClassKindClass
+	case 1:
+		return ClassKindInterface
+	case 2:
+		return ClassKindEnumClass
+	case 3:
+		return ClassKindClass // enum entry treated as class
+	case 4:
+		return ClassKindAnnotationClass
+	case 5:
+		return ClassKindObject
+	case 6:
+		return ClassKindCompanionObject
+	}
+	return ClassKindClass
+}
+
+// isPublicVisible returns true if the visibility bits (3-5) of flags indicate
+// public (3) or internal (0) visibility.
+func isPublicVisible(flags int32) bool {
+	v := (flags >> 3) & 0x7
+	return v == 3 || v == 0 // public or internal
+}
+
+// strAt safely indexes the string table d2.
+func strAt(d2 []string, idx int32) string {
+	if idx < 0 || int(idx) >= len(d2) {
+		return fmt.Sprintf("?idx%d", idx)
+	}
+	return d2[idx]
+}

--- a/package3/kotlin/metadata/proto_test.go
+++ b/package3/kotlin/metadata/proto_test.go
@@ -1,0 +1,455 @@
+package metadata
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// protoBuilder is a helper for building raw protobuf wire bytes.
+type protoBuilder struct {
+	buf []byte
+}
+
+func (b *protoBuilder) varint(field protowire.Number, v uint64) {
+	b.buf = protowire.AppendTag(b.buf, field, protowire.VarintType)
+	b.buf = protowire.AppendVarint(b.buf, v)
+}
+
+func (b *protoBuilder) bytes(field protowire.Number, data []byte) {
+	b.buf = protowire.AppendTag(b.buf, field, protowire.BytesType)
+	b.buf = protowire.AppendBytes(b.buf, data)
+}
+
+func (b *protoBuilder) build() []byte { return b.buf }
+
+// buildFunctionProto encodes a FunctionProto with name idx, flags, and optional return type.
+func buildFunctionProto(nameIdx int, flags int32, returnTypeBytes []byte, params [][]byte, receiverTypeBytes []byte) []byte {
+	var pb protoBuilder
+	pb.varint(1, uint64(flags))
+	pb.varint(2, uint64(nameIdx))
+	if returnTypeBytes != nil {
+		pb.bytes(3, returnTypeBytes)
+	}
+	for _, p := range params {
+		pb.bytes(5, p)
+	}
+	if receiverTypeBytes != nil {
+		pb.bytes(6, receiverTypeBytes)
+	}
+	return pb.build()
+}
+
+// buildTypeProto encodes a TypeProto.
+func buildTypeProto(classNameIdx int, nullable bool, args [][]byte, typeParamID int) []byte {
+	var pb protoBuilder
+	if nullable {
+		pb.varint(1, 1)
+	}
+	if classNameIdx >= 0 {
+		pb.varint(3, uint64(classNameIdx))
+	}
+	for _, arg := range args {
+		pb.bytes(4, arg)
+	}
+	if typeParamID >= 0 {
+		pb.varint(9, uint64(typeParamID))
+	}
+	return pb.build()
+}
+
+// buildTypeArgProto encodes a TypeArgumentProto.
+func buildTypeArgProto(typeBytes []byte, projection int) []byte {
+	var pb protoBuilder
+	if typeBytes != nil {
+		pb.bytes(2, typeBytes)
+	}
+	pb.varint(3, uint64(projection))
+	return pb.build()
+}
+
+// buildValueParamProto encodes a ValueParameterProto.
+func buildValueParamProto(nameIdx int, typeBytes []byte, hasDefault bool) []byte {
+	var pb protoBuilder
+	flags := uint64(0)
+	if hasDefault {
+		flags |= 1
+	}
+	pb.varint(1, flags)
+	pb.varint(2, uint64(nameIdx))
+	if typeBytes != nil {
+		pb.bytes(3, typeBytes)
+	}
+	return pb.build()
+}
+
+// buildPropertyProto encodes a PropertyProto.
+func buildPropertyProto(nameIdx int, flags int32, typeBytes []byte) []byte {
+	var pb protoBuilder
+	pb.varint(1, uint64(flags))
+	pb.varint(2, uint64(nameIdx))
+	if typeBytes != nil {
+		pb.bytes(3, typeBytes)
+	}
+	return pb.build()
+}
+
+// buildConstructorProto encodes a ConstructorProto.
+func buildConstructorProto(flags int32, params [][]byte) []byte {
+	var pb protoBuilder
+	pb.varint(1, uint64(flags))
+	for _, p := range params {
+		pb.bytes(5, p)
+	}
+	return pb.build()
+}
+
+// buildClassProto encodes a ClassProto.
+func buildClassProto(flags int32, fqNameIdx int, fns [][]byte, props [][]byte, ctors [][]byte, enumEntries [][]byte, sealedSubs []int) []byte {
+	var pb protoBuilder
+	pb.varint(1, uint64(flags))
+	pb.varint(3, uint64(fqNameIdx))
+	for _, c := range ctors {
+		pb.bytes(8, c)
+	}
+	for _, fn := range fns {
+		pb.bytes(9, fn)
+	}
+	for _, prop := range props {
+		pb.bytes(10, prop)
+	}
+	for _, e := range enumEntries {
+		pb.bytes(12, e)
+	}
+	for _, idx := range sealedSubs {
+		pb.varint(14, uint64(idx))
+	}
+	return pb.build()
+}
+
+// buildPackageProto encodes a PackageProto.
+func buildPackageProto(fns [][]byte, props [][]byte) []byte {
+	var pb protoBuilder
+	for _, fn := range fns {
+		pb.bytes(3, fn)
+	}
+	for _, prop := range props {
+		pb.bytes(4, prop)
+	}
+	return pb.build()
+}
+
+// publicFunctionFlags returns function flags with visibility=public (bits 3-5 = 3).
+func publicFunctionFlags(extra int32) int32 {
+	return (3 << 3) | extra
+}
+
+// publicPropertyFlags returns property flags with visibility=public (bits 3-5 = 3).
+func publicPropertyFlags(extra int32) int32 {
+	return (3 << 3) | extra
+}
+
+// Test 1: Simple class with one public function greet(name: String): String
+func TestDecodeClass_SimpleFunction(t *testing.T) {
+	// String table: [0]="greet", [1]="name", [2]="kotlin/String", [3]="MyClass"
+	d2 := []string{"greet", "name", "kotlin/String", "MyClass"}
+
+	// return type: kotlin.String (idx=2), not nullable
+	retType := buildTypeProto(2, false, nil, -1)
+	// param: name: String
+	paramType := buildTypeProto(2, false, nil, -1)
+	param := buildValueParamProto(1, paramType, false)
+	// function: greet(name: String): String, public, not suspend
+	fnFlags := publicFunctionFlags(0)
+	fn := buildFunctionProto(0, fnFlags, retType, [][]byte{param}, nil)
+
+	// class flags: public class (visibility=3, kind=0)
+	classFlags := int32(3 << 3) // public class
+	classProto := buildClassProto(classFlags, 3, [][]byte{fn}, nil, nil, nil, nil)
+
+	raw := &RawMetadata{
+		Kind:    1,
+		Version: [3]int32{1, 9, 0},
+		D1:      classProto,
+		D2:      d2,
+	}
+
+	obj, err := DecodeClass(raw)
+	if err != nil {
+		t.Fatalf("DecodeClass returned error: %v", err)
+	}
+	if len(obj.Functions) != 1 {
+		t.Fatalf("expected 1 function, got %d", len(obj.Functions))
+	}
+	fn0 := obj.Functions[0]
+	if fn0.Name != "greet" {
+		t.Errorf("function name: got %q, want %q", fn0.Name, "greet")
+	}
+	if len(fn0.Params) != 1 {
+		t.Fatalf("expected 1 param, got %d", len(fn0.Params))
+	}
+	if fn0.Params[0].Name != "name" {
+		t.Errorf("param name: got %q, want %q", fn0.Params[0].Name, "name")
+	}
+	if fn0.ReturnType.ClassName != "kotlin.String" {
+		t.Errorf("return type: got %q, want %q", fn0.ReturnType.ClassName, "kotlin.String")
+	}
+	if fn0.Flags.IsSuspend {
+		t.Error("expected IsSuspend=false")
+	}
+	if fn0.Flags.IsInline {
+		t.Error("expected IsInline=false")
+	}
+}
+
+// Test 2: Suspend function
+func TestDecodeClass_SuspendFunction(t *testing.T) {
+	d2 := []string{"fetch", "url", "kotlin/String", "MyClass"}
+
+	retType := buildTypeProto(2, false, nil, -1)
+	paramType := buildTypeProto(2, false, nil, -1)
+	param := buildValueParamProto(1, paramType, false)
+	// suspend flag: bit 18
+	fnFlags := publicFunctionFlags(1 << 18)
+	fn := buildFunctionProto(0, fnFlags, retType, [][]byte{param}, nil)
+
+	classFlags := int32(3 << 3)
+	classProto := buildClassProto(classFlags, 3, [][]byte{fn}, nil, nil, nil, nil)
+
+	raw := &RawMetadata{Kind: 1, Version: [3]int32{1, 9, 0}, D1: classProto, D2: d2}
+	obj, err := DecodeClass(raw)
+	if err != nil {
+		t.Fatalf("DecodeClass returned error: %v", err)
+	}
+	if len(obj.Functions) == 0 {
+		t.Fatal("expected at least one function")
+	}
+	if !obj.Functions[0].Flags.IsSuspend {
+		t.Error("expected IsSuspend=true for suspend function")
+	}
+}
+
+// Test 3: Data class with two properties
+func TestDecodeClass_DataClassProperties(t *testing.T) {
+	d2 := []string{"id", "name", "kotlin/Long", "kotlin/String", "User"}
+
+	// bit 10 = is_data
+	classFlags := int32((3 << 3) | (1 << 10))
+
+	// property "id": Long (idx=2), val (bit 9 = 0), visibility=public
+	propFlagsVal := publicPropertyFlags(0) // val
+	idType := buildTypeProto(2, false, nil, -1)
+	idProp := buildPropertyProto(0, propFlagsVal, idType)
+
+	// property "name": String (idx=3), val
+	nameType := buildTypeProto(3, false, nil, -1)
+	nameProp := buildPropertyProto(1, propFlagsVal, nameType)
+
+	classProto := buildClassProto(classFlags, 4, nil, [][]byte{idProp, nameProp}, nil, nil, nil)
+
+	raw := &RawMetadata{Kind: 1, Version: [3]int32{1, 9, 0}, D1: classProto, D2: d2}
+	obj, err := DecodeClass(raw)
+	if err != nil {
+		t.Fatalf("DecodeClass returned error: %v", err)
+	}
+	if obj.Kind != ClassKindDataClass {
+		t.Errorf("kind: got %v, want ClassKindDataClass", obj.Kind)
+	}
+	if len(obj.Properties) != 2 {
+		t.Fatalf("expected 2 properties, got %d", len(obj.Properties))
+	}
+	if obj.Properties[0].Name != "id" {
+		t.Errorf("prop[0].Name: got %q, want %q", obj.Properties[0].Name, "id")
+	}
+	if obj.Properties[0].Type.ClassName != "kotlin.Long" {
+		t.Errorf("prop[0].Type: got %q, want %q", obj.Properties[0].Type.ClassName, "kotlin.Long")
+	}
+	if obj.Properties[1].Name != "name" {
+		t.Errorf("prop[1].Name: got %q, want %q", obj.Properties[1].Name, "name")
+	}
+}
+
+// Test 4: Class with companion object name
+func TestDecodeClass_CompanionObjectName(t *testing.T) {
+	d2 := []string{"com/example/Foo", "Companion"}
+	// companion_object_name is field 4 in ClassProto
+	var pb protoBuilder
+	classFlags := int32(3 << 3) // public class
+	pb.varint(1, uint64(classFlags))
+	pb.varint(3, 0) // fq_name idx 0
+	pb.varint(4, 1) // companion_object_name idx 1 = "Companion"
+
+	classProto := pb.build()
+	raw := &RawMetadata{Kind: 1, Version: [3]int32{1, 9, 0}, D1: classProto, D2: d2}
+	obj, err := DecodeClass(raw)
+	if err != nil {
+		t.Fatalf("DecodeClass error: %v", err)
+	}
+	if obj.ClassName != "com.example.Foo" {
+		t.Errorf("class name: got %q, want %q", obj.ClassName, "com.example.Foo")
+	}
+}
+
+// Test 5: Sealed class with two sealed subclass FQ names
+func TestDecodeClass_SealedClass(t *testing.T) {
+	d2 := []string{"com/example/Shape", "com/example/Circle", "com/example/Square"}
+	// sealed_subclass_fq_name is field 14 (repeated varint)
+	classFlags := int32(3 << 3)
+	classProto := buildClassProto(classFlags, 0, nil, nil, nil, nil, []int{1, 2})
+
+	raw := &RawMetadata{Kind: 1, Version: [3]int32{1, 9, 0}, D1: classProto, D2: d2}
+	obj, err := DecodeClass(raw)
+	if err != nil {
+		t.Fatalf("DecodeClass error: %v", err)
+	}
+	if obj.Kind != ClassKindSealedClass {
+		t.Errorf("kind: got %v, want ClassKindSealedClass", obj.Kind)
+	}
+	if len(obj.SealedSubs) != 2 {
+		t.Fatalf("sealed subs: got %d, want 2", len(obj.SealedSubs))
+	}
+	if obj.SealedSubs[0].ClassName != "com.example.Circle" {
+		t.Errorf("sealedSubs[0]: got %q, want %q", obj.SealedSubs[0].ClassName, "com.example.Circle")
+	}
+	if obj.SealedSubs[1].ClassName != "com.example.Square" {
+		t.Errorf("sealedSubs[1]: got %q, want %q", obj.SealedSubs[1].ClassName, "com.example.Square")
+	}
+}
+
+// Test 6: PackageProto (k=2): top-level function in a file facade
+func TestDecodePackage_TopLevelFunction(t *testing.T) {
+	d2 := []string{"greet", "kotlin/String"}
+	retType := buildTypeProto(1, false, nil, -1)
+	fnFlags := publicFunctionFlags(0)
+	fn := buildFunctionProto(0, fnFlags, retType, nil, nil)
+	pkgProto := buildPackageProto([][]byte{fn}, nil)
+
+	raw := &RawMetadata{Kind: 2, Version: [3]int32{1, 9, 0}, D1: pkgProto, D2: d2, XS: "com/example/Foo"}
+	obj, err := DecodePackage(raw)
+	if err != nil {
+		t.Fatalf("DecodePackage error: %v", err)
+	}
+	if obj.Kind != ClassKindFileFacade {
+		t.Errorf("kind: got %v, want ClassKindFileFacade", obj.Kind)
+	}
+	if len(obj.Functions) != 1 {
+		t.Fatalf("expected 1 function, got %d", len(obj.Functions))
+	}
+	if obj.Functions[0].Name != "greet" {
+		t.Errorf("function name: got %q, want %q", obj.Functions[0].Name, "greet")
+	}
+	if obj.ClassName != "com.example.Foo" {
+		t.Errorf("class name: got %q, want %q", obj.ClassName, "com.example.Foo")
+	}
+}
+
+// Test 7: Extension function (has receiver_type field 6)
+func TestDecodeClass_ExtensionFunction(t *testing.T) {
+	d2 := []string{"isEmpty", "kotlin/String", "kotlin/Boolean", "MyClass"}
+	retType := buildTypeProto(2, false, nil, -1)
+	receiverType := buildTypeProto(1, false, nil, -1) // String receiver
+	fnFlags := publicFunctionFlags(0)
+
+	var pb protoBuilder
+	pb.varint(1, uint64(fnFlags))
+	pb.varint(2, 0) // name "isEmpty"
+	pb.bytes(3, retType)
+	pb.bytes(6, receiverType) // receiver_type
+	fn := pb.build()
+
+	classFlags := int32(3 << 3)
+	classProto := buildClassProto(classFlags, 3, [][]byte{fn}, nil, nil, nil, nil)
+	raw := &RawMetadata{Kind: 1, Version: [3]int32{1, 9, 0}, D1: classProto, D2: d2}
+	obj, err := DecodeClass(raw)
+	if err != nil {
+		t.Fatalf("DecodeClass error: %v", err)
+	}
+	if len(obj.Functions) == 0 {
+		t.Fatal("expected at least one function")
+	}
+	fn0 := obj.Functions[0]
+	if fn0.Receiver == nil {
+		t.Fatal("expected non-nil Receiver for extension function")
+	}
+	if fn0.Receiver.ClassName != "kotlin.String" {
+		t.Errorf("receiver type: got %q, want %q", fn0.Receiver.ClassName, "kotlin.String")
+	}
+}
+
+// Test 8: Nullable return type
+func TestDecodeClass_NullableReturnType(t *testing.T) {
+	d2 := []string{"find", "kotlin/String", "MyClass"}
+	// nullable TypeProto: flags bit 0 = 1
+	retType := buildTypeProto(1, true, nil, -1)
+	fnFlags := publicFunctionFlags(0)
+	fn := buildFunctionProto(0, fnFlags, retType, nil, nil)
+
+	classFlags := int32(3 << 3)
+	classProto := buildClassProto(classFlags, 2, [][]byte{fn}, nil, nil, nil, nil)
+	raw := &RawMetadata{Kind: 1, Version: [3]int32{1, 9, 0}, D1: classProto, D2: d2}
+	obj, err := DecodeClass(raw)
+	if err != nil {
+		t.Fatalf("DecodeClass error: %v", err)
+	}
+	if len(obj.Functions) == 0 {
+		t.Fatal("expected at least one function")
+	}
+	if !obj.Functions[0].ReturnType.Nullable {
+		t.Error("expected return type to be nullable")
+	}
+}
+
+// Test 9: Generic return type List<String>
+func TestDecodeClass_GenericReturnType(t *testing.T) {
+	d2 := []string{"getNames", "kotlin/collections/List", "kotlin/String", "MyClass"}
+	// TypeProto for String argument
+	stringType := buildTypeProto(2, false, nil, -1)
+	// TypeArgumentProto wrapping String (projection=INV=2)
+	typeArg := buildTypeArgProto(stringType, 2)
+	// TypeProto for List<String>
+	listType := buildTypeProto(1, false, [][]byte{typeArg}, -1)
+
+	fnFlags := publicFunctionFlags(0)
+	fn := buildFunctionProto(0, fnFlags, listType, nil, nil)
+
+	classFlags := int32(3 << 3)
+	classProto := buildClassProto(classFlags, 3, [][]byte{fn}, nil, nil, nil, nil)
+	raw := &RawMetadata{Kind: 1, Version: [3]int32{1, 9, 0}, D1: classProto, D2: d2}
+	obj, err := DecodeClass(raw)
+	if err != nil {
+		t.Fatalf("DecodeClass error: %v", err)
+	}
+	if len(obj.Functions) == 0 {
+		t.Fatal("expected at least one function")
+	}
+	retType := obj.Functions[0].ReturnType
+	if retType.ClassName != "kotlin.collections.List" {
+		t.Errorf("return type class: got %q, want %q", retType.ClassName, "kotlin.collections.List")
+	}
+	if len(retType.TypeArgs) != 1 {
+		t.Fatalf("type args: got %d, want 1", len(retType.TypeArgs))
+	}
+	if retType.TypeArgs[0].ClassName != "kotlin.String" {
+		t.Errorf("type arg[0]: got %q, want %q", retType.TypeArgs[0].ClassName, "kotlin.String")
+	}
+}
+
+// Test: private function should be excluded
+func TestDecodeClass_PrivateFunctionExcluded(t *testing.T) {
+	d2 := []string{"internalHelper", "kotlin/Unit", "MyClass"}
+	retType := buildTypeProto(1, false, nil, -1)
+	// private: visibility bits 3-5 = 1
+	fnFlags := int32(1 << 3)
+	fn := buildFunctionProto(0, fnFlags, retType, nil, nil)
+
+	classFlags := int32(3 << 3)
+	classProto := buildClassProto(classFlags, 2, [][]byte{fn}, nil, nil, nil, nil)
+	raw := &RawMetadata{Kind: 1, Version: [3]int32{1, 9, 0}, D1: classProto, D2: d2}
+	obj, err := DecodeClass(raw)
+	if err != nil {
+		t.Fatalf("DecodeClass error: %v", err)
+	}
+	if len(obj.Functions) != 0 {
+		t.Errorf("expected 0 functions (private excluded), got %d", len(obj.Functions))
+	}
+}


### PR DESCRIPTION
Closes 22862

Full JVM class-file reader + schema-free protowire decoder for ClassProto/PackageProto. IngestJAR walks ZIP entries and builds APIObject trees. 22 test functions, -race clean.