### PR TITLE
feat(mep-66): Phase 4 — Dialyzer typespec-to-Mochi type mapping

### DIFF
--- a/package3/erlang/typemap/typemap.go
+++ b/package3/erlang/typemap/typemap.go
@@ -1,0 +1,484 @@
+// Package typemap implements the closed Erlang-typespec-to-Mochi translation
+// table from MEP-66 research note 05 (§ "Complete translation table").
+//
+// Translation is driven by the ETF representation of Erlang type terms as
+// produced by the BEAM abstract code parser (beamingest) or, for EDoc
+// packages, by parsing the raw typespec string (edocingest).
+//
+// Erlang type term shapes (from erl_parse abstract form):
+//
+//	{type, Line, TypeName, Args}          — built-in type
+//	{atom, Line, Value}                   — atom literal (used in unions)
+//	{integer, Line, Value}                — integer literal
+//	{var, Line, VarName}                  — type variable
+//	{ann_type, Line, [{var,...}, Type]}   — annotated type (name :: Type)
+//	{remote_type, Line, [Mod, Name, Args]}— remote type (Module:TypeName)
+//	{user_type, Line, Name, Args}         — user-defined type alias
+//
+// The closed table (research note 05 §4) maps Erlang types to Mochi:
+//
+//	boolean()        → bool
+//	integer()        → int
+//	non_neg_integer()→ int   (note: Mochi int is signed 64-bit)
+//	pos_integer()    → int
+//	float()          → float
+//	atom()           → string  (atoms as strings, noted in binding)
+//	binary()         → bytes
+//	iodata()         → SKIP SkipIodata
+//	iolist()         → SKIP SkipIodata
+//	bitstring()      → SKIP SkipBitstring
+//	string()         → SKIP SkipCharlist  (Erlang string() = charlist)
+//	list(T)          → []T
+//	[T]              → []T
+//	nil/[]           → []T (empty list literal)
+//	{ok, T}          → result<T, string>  (ok/error idiom)
+//	{error, Reason}  → (part of ok/error pattern; see above)
+//	{ok,T}|{err,R}   → result<T, R>
+//	tuple()          → SKIP SkipUntypedTuple
+//	{A, B, ...}      → tuple[A, B, ...]  (typed tuple, up to 8 elements)
+//	map()            → SKIP SkipUntypedMap
+//	#{K := V}        → SKIP SkipTypedMap
+//	fun()            → SKIP SkipUntypedFun
+//	fun((A)->B)      → fn(A) B
+//	any() / term()   → SKIP SkipAnyTerm
+//	pid()            → extern "erlang.Pid"
+//	port()           → extern "erlang.Port"
+//	reference()      → extern "erlang.Reference"
+//	union 2-branch   → okError pattern check; else SkipNonOkErrorUnion
+//	union 3+ branches→ SKIP SkipComplexUnion
+//	remote_type      → SKIP SkipRemoteType
+//	recursive type   → SKIP SkipRecursiveType (detected via depth limit)
+package typemap
+
+import (
+	"fmt"
+
+	breakers "mochi/package3/erlang/errors"
+	"mochi/package3/erlang/etf"
+)
+
+// MochiType is the Mochi type string produced by the translation table.
+// It is a simplified textual representation used in the extern fn declarations.
+type MochiType string
+
+const (
+	MochiBool      MochiType = "bool"
+	MochiInt       MochiType = "int"
+	MochiFloat     MochiType = "float"
+	MochiString    MochiType = "string"
+	MochiBytes     MochiType = "bytes"
+	MochiPid       MochiType = `extern "erlang.Pid"`
+	MochiPort      MochiType = `extern "erlang.Port"`
+	MochiReference MochiType = `extern "erlang.Reference"`
+	MochiUnit      MochiType = "unit" // for the atom 'ok' alone
+)
+
+// Result represents a result<T, E> Mochi type.
+type Result struct {
+	Ok  MochiType
+	Err MochiType
+}
+
+func (r Result) String() string {
+	return fmt.Sprintf("result<%s, %s>", r.Ok, r.Err)
+}
+
+// List represents a []T Mochi type.
+type List struct {
+	Elem MochiType
+}
+
+func (l List) String() string {
+	return "[]" + string(l.Elem)
+}
+
+// Tuple represents a tuple[A, B, ...] Mochi type.
+type Tuple struct {
+	Elems []MochiType
+}
+
+func (t Tuple) String() string {
+	if len(t.Elems) == 0 {
+		return "tuple[]"
+	}
+	s := "tuple["
+	for i, e := range t.Elems {
+		if i > 0 {
+			s += ", "
+		}
+		s += string(e)
+	}
+	return s + "]"
+}
+
+// Fn represents a fn(A, B) C Mochi type.
+type Fn struct {
+	Args   []MochiType
+	Return MochiType
+}
+
+func (f Fn) String() string {
+	if len(f.Args) == 0 {
+		return "fn() " + string(f.Return)
+	}
+	s := "fn("
+	for i, a := range f.Args {
+		if i > 0 {
+			s += ", "
+		}
+		s += string(a)
+	}
+	return s + ") " + string(f.Return)
+}
+
+// TranslateResult holds the output of a successful type translation.
+// Exactly one of Scalar, ResultT, ListT, TupleT, FnT is set.
+type TranslateResult struct {
+	Scalar  MochiType
+	ResultT *Result
+	ListT   *List
+	TupleT  *Tuple
+	FnT     *Fn
+}
+
+// String renders a TranslateResult as a Mochi type string.
+func (tr TranslateResult) String() string {
+	if tr.ResultT != nil {
+		return tr.ResultT.String()
+	}
+	if tr.ListT != nil {
+		return tr.ListT.String()
+	}
+	if tr.TupleT != nil {
+		return tr.TupleT.String()
+	}
+	if tr.FnT != nil {
+		return tr.FnT.String()
+	}
+	return string(tr.Scalar)
+}
+
+// TranslateType translates a single Erlang type ETF term to a Mochi type.
+// Returns an error whose value satisfies errors.As(*BridgeError) on skip;
+// all other errors are hard failures (malformed input).
+func TranslateType(term interface{}) (TranslateResult, error) {
+	return translateType(term, 0)
+}
+
+const maxDepth = 16
+
+func translateType(term interface{}, depth int) (TranslateResult, error) {
+	if depth > maxDepth {
+		return TranslateResult{}, breakers.Wrap("typemap", "", fmt.Errorf("type recursion depth exceeded"))
+	}
+	switch t := term.(type) {
+	case etf.Tuple:
+		return translateTuple(t, depth)
+	case etf.Atom:
+		// Atom literal in a type position (e.g. 'ok' | 'error').
+		switch t {
+		case "true", "false":
+			return TranslateResult{Scalar: MochiBool}, nil
+		case "ok":
+			return TranslateResult{Scalar: MochiUnit}, nil
+		case "undefined":
+			return TranslateResult{Scalar: MochiUnit}, nil
+		}
+		// Any other atom → string (atoms as enumeration strings).
+		return TranslateResult{Scalar: MochiString}, nil
+	case etf.List:
+		if len(t) == 0 {
+			// [] (nil / empty list).
+			return TranslateResult{ListT: &List{Elem: MochiUnit}}, nil
+		}
+	}
+	return TranslateResult{}, fmt.Errorf("typemap: unhandled term type %T", term)
+}
+
+func translateTuple(t etf.Tuple, depth int) (TranslateResult, error) {
+	if len(t) == 0 {
+		return TranslateResult{}, fmt.Errorf("typemap: empty tuple term")
+	}
+	tag, ok := t[0].(etf.Atom)
+	if !ok {
+		return TranslateResult{}, fmt.Errorf("typemap: tuple tag is not atom: %T", t[0])
+	}
+
+	switch tag {
+	case "type":
+		return translateBuiltinType(t, depth)
+	case "ann_type":
+		// Annotated type: {ann_type, Line, [VarAnnotation, ActualType]}.
+		if len(t) >= 3 {
+			if list, ok := t[2].(etf.List); ok && len(list) >= 2 {
+				return translateType(list[1], depth+1)
+			}
+		}
+		return TranslateResult{}, fmt.Errorf("typemap: malformed ann_type")
+	case "atom":
+		if len(t) >= 3 {
+			if a, ok := t[2].(etf.Atom); ok {
+				return translateType(a, depth+1)
+			}
+		}
+		return TranslateResult{Scalar: MochiString}, nil
+	case "integer":
+		return TranslateResult{Scalar: MochiInt}, nil
+	case "var":
+		// Type variable — treat as any() for now; callers may use it.
+		return TranslateResult{}, &skipError{breakers.SkipAnyTerm, "type variable"}
+	case "remote_type":
+		return TranslateResult{}, &skipError{breakers.SkipRemoteType, "remote type reference"}
+	case "user_type":
+		// User-defined type alias: {user_type, Line, Name, Args}.
+		// The type body is not available here; caller must expand.
+		return TranslateResult{}, &skipError{breakers.SkipRemoteType, "user type alias (not expanded)"}
+	}
+	return TranslateResult{}, fmt.Errorf("typemap: unknown tuple tag %q", tag)
+}
+
+func translateBuiltinType(t etf.Tuple, depth int) (TranslateResult, error) {
+	if len(t) < 3 {
+		return TranslateResult{}, fmt.Errorf("typemap: type tuple too short")
+	}
+	name, ok := t[2].(etf.Atom)
+	if !ok {
+		return TranslateResult{}, fmt.Errorf("typemap: type name not atom: %T", t[2])
+	}
+	var args etf.List
+	if len(t) >= 4 {
+		args, _ = t[3].(etf.List)
+	}
+
+	switch name {
+	case "boolean":
+		return TranslateResult{Scalar: MochiBool}, nil
+	case "integer", "non_neg_integer", "pos_integer", "neg_integer":
+		return TranslateResult{Scalar: MochiInt}, nil
+	case "float":
+		return TranslateResult{Scalar: MochiFloat}, nil
+	case "atom":
+		return TranslateResult{Scalar: MochiString}, nil
+	case "binary":
+		return TranslateResult{Scalar: MochiBytes}, nil
+	case "pid":
+		return TranslateResult{Scalar: MochiPid}, nil
+	case "port":
+		return TranslateResult{Scalar: MochiPort}, nil
+	case "reference":
+		return TranslateResult{Scalar: MochiReference}, nil
+
+	case "any", "term":
+		return TranslateResult{}, &skipError{breakers.SkipAnyTerm, string(name) + "()"}
+	case "iodata", "iolist":
+		return TranslateResult{}, &skipError{breakers.SkipIodata, string(name) + "()"}
+	case "bitstring":
+		return TranslateResult{}, &skipError{breakers.SkipBitstring, "bitstring()"}
+	case "string":
+		return TranslateResult{}, &skipError{breakers.SkipCharlist, "string() is charlist in Erlang"}
+	case "tuple":
+		if len(args) == 0 {
+			return TranslateResult{}, &skipError{breakers.SkipUntypedTuple, "tuple()"}
+		}
+		// Typed tuple: {type, Line, tuple, [T1, T2, ...]}
+		// Translate each element.
+		var elems []MochiType
+		for _, arg := range args {
+			r, err := translateType(arg, depth+1)
+			if err != nil {
+				return TranslateResult{}, err
+			}
+			elems = append(elems, MochiType(r.String()))
+		}
+		return TranslateResult{TupleT: &Tuple{Elems: elems}}, nil
+	case "map":
+		if len(args) == 0 {
+			return TranslateResult{}, &skipError{breakers.SkipUntypedMap, "map()"}
+		}
+		return TranslateResult{}, &skipError{breakers.SkipTypedMap, "typed map #{...}"}
+	case "fun":
+		return translateFun(args, depth)
+	case "list":
+		if len(args) == 0 {
+			// list() — untyped list; treat as list(any) → skip.
+			return TranslateResult{}, &skipError{breakers.SkipAnyTerm, "list() (untyped)"}
+		}
+		r, err := translateType(args[0], depth+1)
+		if err != nil {
+			return TranslateResult{}, err
+		}
+		return TranslateResult{ListT: &List{Elem: MochiType(r.String())}}, nil
+	case "nil":
+		return TranslateResult{ListT: &List{Elem: MochiUnit}}, nil
+	case "union":
+		return translateUnion(args, depth)
+	case "ok":
+		return TranslateResult{Scalar: MochiUnit}, nil
+	case "nonempty_list":
+		// nonempty_list(T) — same treatment as list(T).
+		if len(args) == 0 {
+			return TranslateResult{}, &skipError{breakers.SkipAnyTerm, "nonempty_list() (untyped)"}
+		}
+		r, err := translateType(args[0], depth+1)
+		if err != nil {
+			return TranslateResult{}, err
+		}
+		return TranslateResult{ListT: &List{Elem: MochiType(r.String())}}, nil
+	case "maybe_improper_list", "nonempty_improper_list", "nonempty_maybe_improper_list":
+		return TranslateResult{}, &skipError{breakers.SkipIodata, string(name) + "()"}
+	}
+
+	// Unknown built-in type.
+	return TranslateResult{}, &skipError{breakers.SkipAnyTerm, "unknown built-in type: " + string(name)}
+}
+
+// translateFun handles the fun() type family.
+func translateFun(args etf.List, depth int) (TranslateResult, error) {
+	if len(args) == 0 {
+		return TranslateResult{}, &skipError{breakers.SkipUntypedFun, "fun() (no type annotation)"}
+	}
+	// fun(...) has one element: {type, Line, product, [ArgTypes...]} as first arg
+	// and the return type as second arg (in the outer type form).
+	// Actually the AST shape for fun((A,B)->C) is:
+	//   {type, Line, fun, [{type, Line, product, [A, B]}, C]}
+	if len(args) < 2 {
+		return TranslateResult{}, &skipError{breakers.SkipUntypedFun, "fun() (incomplete)"}
+	}
+	productTup, ok := args[0].(etf.Tuple)
+	if !ok || len(productTup) < 4 {
+		return TranslateResult{}, &skipError{breakers.SkipUntypedFun, "fun() (no product type)"}
+	}
+	productName, _ := productTup[2].(etf.Atom)
+	if productName != "product" {
+		return TranslateResult{}, &skipError{breakers.SkipUntypedFun, "fun() (unexpected product shape)"}
+	}
+	argTerms, _ := productTup[3].(etf.List)
+	retTerm := args[1]
+
+	var argTypes []MochiType
+	for _, a := range argTerms {
+		r, err := translateType(a, depth+1)
+		if err != nil {
+			return TranslateResult{}, &skipError{breakers.SkipFunArgNotInTable, fmt.Sprintf("fun arg: %v", err)}
+		}
+		argTypes = append(argTypes, MochiType(r.String()))
+	}
+	ret, err := translateType(retTerm, depth+1)
+	if err != nil {
+		return TranslateResult{}, &skipError{breakers.SkipFunArgNotInTable, fmt.Sprintf("fun return: %v", err)}
+	}
+	return TranslateResult{FnT: &Fn{Args: argTypes, Return: MochiType(ret.String())}}, nil
+}
+
+// translateUnion handles union types (2+ branches).
+func translateUnion(args etf.List, depth int) (TranslateResult, error) {
+	if len(args) < 2 {
+		// Degenerate union — treat as single type.
+		if len(args) == 1 {
+			return translateType(args[0], depth+1)
+		}
+		return TranslateResult{}, fmt.Errorf("typemap: empty union")
+	}
+	if len(args) > 2 {
+		return TranslateResult{}, &skipError{breakers.SkipComplexUnion,
+			fmt.Sprintf("union has %d branches", len(args))}
+	}
+	// Two-branch union: check for {ok, T} | {error, Reason} pattern.
+	a, b := args[0], args[1]
+	if ok, okType := matchOkTuple(a); ok {
+		if matchErrorTuple(b) {
+			return TranslateResult{ResultT: &Result{Ok: MochiType(okType.String()), Err: MochiString}}, nil
+		}
+	}
+	if ok, okType := matchOkTuple(b); ok {
+		if matchErrorTuple(a) {
+			return TranslateResult{ResultT: &Result{Ok: MochiType(okType.String()), Err: MochiString}}, nil
+		}
+	}
+	return TranslateResult{}, &skipError{breakers.SkipNonOkErrorUnion, "2-branch union does not match {ok,T}|{error,Reason}"}
+}
+
+// matchOkTuple reports whether term is {ok, T} (as an ETF tuple type form)
+// and returns the translated T if so.
+func matchOkTuple(term interface{}) (bool, TranslateResult) {
+	tup, ok := term.(etf.Tuple)
+	if !ok || len(tup) < 4 {
+		return false, TranslateResult{}
+	}
+	tag, _ := tup[0].(etf.Atom)
+	if tag != "type" {
+		return false, TranslateResult{}
+	}
+	name, _ := tup[2].(etf.Atom)
+	if name != "tuple" {
+		return false, TranslateResult{}
+	}
+	elems, _ := tup[3].(etf.List)
+	if len(elems) != 2 {
+		return false, TranslateResult{}
+	}
+	// First element must be atom 'ok'.
+	if !isAtomLiteral(elems[0], "ok") {
+		return false, TranslateResult{}
+	}
+	r, err := translateType(elems[1], 1)
+	if err != nil {
+		return false, TranslateResult{}
+	}
+	return true, r
+}
+
+// matchErrorTuple reports whether term is {error, _}.
+func matchErrorTuple(term interface{}) bool {
+	tup, ok := term.(etf.Tuple)
+	if !ok || len(tup) < 4 {
+		return false
+	}
+	tag, _ := tup[0].(etf.Atom)
+	if tag != "type" {
+		return false
+	}
+	name, _ := tup[2].(etf.Atom)
+	if name != "tuple" {
+		return false
+	}
+	elems, _ := tup[3].(etf.List)
+	if len(elems) < 1 {
+		return false
+	}
+	return isAtomLiteral(elems[0], "error")
+}
+
+func isAtomLiteral(term interface{}, want string) bool {
+	tup, ok := term.(etf.Tuple)
+	if !ok || len(tup) < 3 {
+		if a, ok := term.(etf.Atom); ok {
+			return string(a) == want
+		}
+		return false
+	}
+	tag, _ := tup[0].(etf.Atom)
+	if tag != "atom" {
+		return false
+	}
+	a, _ := tup[2].(etf.Atom)
+	return string(a) == want
+}
+
+// skipError is a lightweight skip wrapper that implements the error interface.
+type skipError struct {
+	Reason breakers.SkipReason
+	Detail string
+}
+
+func (e *skipError) Error() string {
+	return fmt.Sprintf("SKIP %s: %s", e.Reason, e.Detail)
+}
+
+// IsSkip reports whether err is a skip error and returns the reason/detail.
+func IsSkip(err error) (breakers.SkipReason, string, bool) {
+	if se, ok := err.(*skipError); ok {
+		return se.Reason, se.Detail, true
+	}
+	return 0, "", false
+}

--- a/package3/erlang/typemap/typemap_test.go
+++ b/package3/erlang/typemap/typemap_test.go
@@ -1,0 +1,349 @@
+package typemap
+
+import (
+	"testing"
+
+	breakers "mochi/package3/erlang/errors"
+	"mochi/package3/erlang/etf"
+)
+
+// Helper: build {type, 1, Name, Args} — the standard ETF form for a built-in type.
+func typeNode(name etf.Atom, args ...interface{}) etf.Tuple {
+	list := make(etf.List, len(args))
+	for i, a := range args {
+		list[i] = a
+	}
+	return etf.Tuple{etf.Atom("type"), 1, name, list}
+}
+
+// Helper: build {atom, 1, Value} — atom literal.
+func atomNode(v etf.Atom) etf.Tuple {
+	return etf.Tuple{etf.Atom("atom"), 1, v}
+}
+
+// Helper: build {integer, 1, N}.
+func intNode(n int) etf.Tuple {
+	return etf.Tuple{etf.Atom("integer"), 1, n}
+}
+
+// Helper: {type, 1, product, [A, B, ...]} for fun arg list.
+func productNode(args ...interface{}) etf.Tuple {
+	list := make(etf.List, len(args))
+	for i, a := range args {
+		list[i] = a
+	}
+	return etf.Tuple{etf.Atom("type"), 1, etf.Atom("product"), list}
+}
+
+func assertScalar(t *testing.T, term interface{}, want MochiType) {
+	t.Helper()
+	r, err := TranslateType(term)
+	if err != nil {
+		t.Fatalf("TranslateType: unexpected error: %v", err)
+	}
+	if r.Scalar != want {
+		t.Errorf("Scalar = %q, want %q", r.Scalar, want)
+	}
+}
+
+func assertSkip(t *testing.T, term interface{}, wantReason breakers.SkipReason) {
+	t.Helper()
+	_, err := TranslateType(term)
+	if err == nil {
+		t.Fatal("TranslateType should return skip error")
+	}
+	reason, _, ok := IsSkip(err)
+	if !ok {
+		t.Fatalf("error is not a skip error: %v", err)
+	}
+	if reason != wantReason {
+		t.Errorf("skip reason = %v, want %v", reason, wantReason)
+	}
+}
+
+// ---- Primitive type tests ----
+
+func TestTranslateBoolean(t *testing.T) {
+	assertScalar(t, typeNode("boolean"), MochiBool)
+}
+
+func TestTranslateInteger(t *testing.T) {
+	for _, name := range []etf.Atom{"integer", "non_neg_integer", "pos_integer", "neg_integer"} {
+		assertScalar(t, typeNode(name), MochiInt)
+	}
+}
+
+func TestTranslateFloat(t *testing.T) {
+	assertScalar(t, typeNode("float"), MochiFloat)
+}
+
+func TestTranslateAtom(t *testing.T) {
+	assertScalar(t, typeNode("atom"), MochiString)
+}
+
+func TestTranslateBinary(t *testing.T) {
+	assertScalar(t, typeNode("binary"), MochiBytes)
+}
+
+func TestTranslatePid(t *testing.T) {
+	assertScalar(t, typeNode("pid"), MochiPid)
+}
+
+func TestTranslatePort(t *testing.T) {
+	assertScalar(t, typeNode("port"), MochiPort)
+}
+
+func TestTranslateReference(t *testing.T) {
+	assertScalar(t, typeNode("reference"), MochiReference)
+}
+
+// ---- Skip tests ----
+
+func TestSkipAnyTerm(t *testing.T) {
+	assertSkip(t, typeNode("any"), breakers.SkipAnyTerm)
+	assertSkip(t, typeNode("term"), breakers.SkipAnyTerm)
+}
+
+func TestSkipIodata(t *testing.T) {
+	assertSkip(t, typeNode("iodata"), breakers.SkipIodata)
+	assertSkip(t, typeNode("iolist"), breakers.SkipIodata)
+}
+
+func TestSkipBitstring(t *testing.T) {
+	assertSkip(t, typeNode("bitstring"), breakers.SkipBitstring)
+}
+
+func TestSkipCharlist(t *testing.T) {
+	assertSkip(t, typeNode("string"), breakers.SkipCharlist)
+}
+
+func TestSkipUntypedTuple(t *testing.T) {
+	assertSkip(t, typeNode("tuple"), breakers.SkipUntypedTuple)
+}
+
+func TestSkipUntypedMap(t *testing.T) {
+	assertSkip(t, typeNode("map"), breakers.SkipUntypedMap)
+}
+
+func TestSkipTypedMap(t *testing.T) {
+	// map with arguments → typed map
+	assocNode := etf.Tuple{etf.Atom("type"), 1, etf.Atom("map_field_assoc"),
+		etf.List{typeNode("atom"), typeNode("integer")}}
+	assertSkip(t, typeNode("map", assocNode), breakers.SkipTypedMap)
+}
+
+func TestSkipUntypedFun(t *testing.T) {
+	assertSkip(t, typeNode("fun"), breakers.SkipUntypedFun)
+}
+
+func TestSkipRemoteType(t *testing.T) {
+	remote := etf.Tuple{etf.Atom("remote_type"), 1,
+		etf.List{atomNode("cowboy"), atomNode("req"), etf.List{}}}
+	assertSkip(t, remote, breakers.SkipRemoteType)
+}
+
+func TestSkipComplexUnion(t *testing.T) {
+	union := typeNode("union",
+		typeNode("atom"),
+		typeNode("integer"),
+		typeNode("binary"),
+	)
+	assertSkip(t, union, breakers.SkipComplexUnion)
+}
+
+// ---- Compound type tests ----
+
+func TestTranslateList(t *testing.T) {
+	list := typeNode("list", typeNode("integer"))
+	r, err := TranslateType(list)
+	if err != nil {
+		t.Fatalf("TranslateType: %v", err)
+	}
+	if r.ListT == nil {
+		t.Fatal("expected ListT to be set")
+	}
+	if r.ListT.Elem != MochiInt {
+		t.Errorf("ListT.Elem = %q, want %q", r.ListT.Elem, MochiInt)
+	}
+}
+
+func TestTranslateTypedTuple(t *testing.T) {
+	tup := typeNode("tuple", typeNode("integer"), typeNode("binary"))
+	r, err := TranslateType(tup)
+	if err != nil {
+		t.Fatalf("TranslateType: %v", err)
+	}
+	if r.TupleT == nil {
+		t.Fatal("expected TupleT to be set")
+	}
+	if len(r.TupleT.Elems) != 2 {
+		t.Errorf("TupleT.Elems len = %d, want 2", len(r.TupleT.Elems))
+	}
+	if r.TupleT.Elems[0] != MochiInt || r.TupleT.Elems[1] != MochiBytes {
+		t.Errorf("TupleT.Elems = %v", r.TupleT.Elems)
+	}
+}
+
+func TestTranslateOkErrorUnion(t *testing.T) {
+	// {ok, binary()} | {error, atom()}
+	okTup := typeNode("tuple", atomNode("ok"), typeNode("binary"))
+	errTup := typeNode("tuple", atomNode("error"), typeNode("atom"))
+	union := typeNode("union", okTup, errTup)
+	r, err := TranslateType(union)
+	if err != nil {
+		t.Fatalf("TranslateType: %v", err)
+	}
+	if r.ResultT == nil {
+		t.Fatal("expected ResultT to be set for ok/error union")
+	}
+	if r.ResultT.Ok != MochiBytes {
+		t.Errorf("ResultT.Ok = %q, want bytes", r.ResultT.Ok)
+	}
+}
+
+func TestTranslateOkErrorUnion_Reversed(t *testing.T) {
+	// {error, atom()} | {ok, integer()} — error first, ok second.
+	errTup := typeNode("tuple", atomNode("error"), typeNode("atom"))
+	okTup := typeNode("tuple", atomNode("ok"), typeNode("integer"))
+	union := typeNode("union", errTup, okTup)
+	r, err := TranslateType(union)
+	if err != nil {
+		t.Fatalf("TranslateType (reversed): %v", err)
+	}
+	if r.ResultT == nil {
+		t.Fatal("ResultT should be set")
+	}
+	if r.ResultT.Ok != MochiInt {
+		t.Errorf("ResultT.Ok = %q, want int", r.ResultT.Ok)
+	}
+}
+
+func TestSkipNonOkErrorUnion(t *testing.T) {
+	// Two branches but not ok/error pattern.
+	union := typeNode("union", typeNode("integer"), typeNode("binary"))
+	assertSkip(t, union, breakers.SkipNonOkErrorUnion)
+}
+
+func TestTranslateFun(t *testing.T) {
+	// fun((integer()) -> binary())
+	product := productNode(typeNode("integer"))
+	fun := typeNode("fun", product, typeNode("binary"))
+	r, err := TranslateType(fun)
+	if err != nil {
+		t.Fatalf("TranslateType fun: %v", err)
+	}
+	if r.FnT == nil {
+		t.Fatal("expected FnT to be set")
+	}
+	if len(r.FnT.Args) != 1 || r.FnT.Args[0] != MochiInt {
+		t.Errorf("FnT.Args = %v, want [int]", r.FnT.Args)
+	}
+	if r.FnT.Return != MochiBytes {
+		t.Errorf("FnT.Return = %q, want bytes", r.FnT.Return)
+	}
+}
+
+func TestTranslateFun_NoArgs(t *testing.T) {
+	// fun(() -> boolean())
+	product := productNode()
+	fun := typeNode("fun", product, typeNode("boolean"))
+	r, err := TranslateType(fun)
+	if err != nil {
+		t.Fatalf("TranslateType fun no-arg: %v", err)
+	}
+	if r.FnT == nil {
+		t.Fatal("expected FnT")
+	}
+	if len(r.FnT.Args) != 0 {
+		t.Errorf("FnT.Args should be empty, got %v", r.FnT.Args)
+	}
+	if r.FnT.Return != MochiBool {
+		t.Errorf("FnT.Return = %q, want bool", r.FnT.Return)
+	}
+}
+
+func TestTranslateAtomLiteral(t *testing.T) {
+	assertScalar(t, atomNode("ok"), MochiUnit)
+	assertScalar(t, atomNode("true"), MochiBool)
+	assertScalar(t, atomNode("false"), MochiBool)
+	// Other atoms → string
+	r, err := TranslateType(atomNode("somevalue"))
+	if err != nil {
+		t.Fatalf("TranslateType atom literal: %v", err)
+	}
+	if r.Scalar != MochiString {
+		t.Errorf("Scalar = %q, want string for atom literal", r.Scalar)
+	}
+}
+
+func TestTranslateAnnType(t *testing.T) {
+	// annotated type: {ann_type, 1, [{var,1,'X'}, {type,1,integer,[]}]}
+	varNode := etf.Tuple{etf.Atom("var"), 1, etf.Atom("X")}
+	ann := etf.Tuple{etf.Atom("ann_type"), 1, etf.List{varNode, typeNode("integer")}}
+	assertScalar(t, ann, MochiInt)
+}
+
+func TestTranslateResultString(t *testing.T) {
+	r := TranslateResult{ResultT: &Result{Ok: MochiInt, Err: MochiString}}
+	if r.String() != "result<int, string>" {
+		t.Errorf("Result.String() = %q", r.String())
+	}
+}
+
+func TestTranslateListString(t *testing.T) {
+	r := TranslateResult{ListT: &List{Elem: MochiBool}}
+	if r.String() != "[]bool" {
+		t.Errorf("List.String() = %q", r.String())
+	}
+}
+
+func TestTranslateTupleString(t *testing.T) {
+	r := TranslateResult{TupleT: &Tuple{Elems: []MochiType{MochiInt, MochiBytes}}}
+	if r.String() != "tuple[int, bytes]" {
+		t.Errorf("Tuple.String() = %q", r.String())
+	}
+}
+
+func TestTranslateFnString(t *testing.T) {
+	r := TranslateResult{FnT: &Fn{Args: []MochiType{MochiInt}, Return: MochiBool}}
+	if r.String() != "fn(int) bool" {
+		t.Errorf("Fn.String() = %q", r.String())
+	}
+}
+
+func TestTranslateNil(t *testing.T) {
+	r, err := TranslateType(typeNode("nil"))
+	if err != nil {
+		t.Fatalf("nil: %v", err)
+	}
+	if r.ListT == nil {
+		t.Error("nil should produce ListT")
+	}
+}
+
+func TestTranslateNonemptyList(t *testing.T) {
+	r, err := TranslateType(typeNode("nonempty_list", typeNode("integer")))
+	if err != nil {
+		t.Fatalf("nonempty_list: %v", err)
+	}
+	if r.ListT == nil || r.ListT.Elem != MochiInt {
+		t.Errorf("nonempty_list: unexpected result %v", r)
+	}
+}
+
+func TestIsSkip(t *testing.T) {
+	_, err := TranslateType(typeNode("any"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	reason, detail, ok := IsSkip(err)
+	if !ok {
+		t.Fatal("IsSkip = false")
+	}
+	if reason != breakers.SkipAnyTerm {
+		t.Errorf("reason = %v", reason)
+	}
+	if detail == "" {
+		t.Error("detail should not be empty")
+	}
+}

--- a/website/docs/implementation/0066/index.md
+++ b/website/docs/implementation/0066/index.md
@@ -18,8 +18,8 @@ A phase is LANDED only when its gate is green for every target in the runtime ma
 | 0 | Skeleton: package3/erlang/ layout + rebar3 workspace plumbing | LANDED | 3b9fe10 | [phase-00](/docs/implementation/0066/phase-00-skeleton) |
 | 1 | Hex.pm API v2 client (package fetch + outer/inner tarball + SHA-256/SHA-512 verify) | LANDED | a0e95be | [phase-01](/docs/implementation/0066/phase-01-hex-index) |
 | 2 | BEAM abstract code ingest (Dbgi/Abst chunk ETF decoder, -spec/-type walker) | LANDED | 99f463c | [phase-02](/docs/implementation/0066/phase-02-beam-ingest) |
-| 3 | EDoc XML fallback ingest (for packages with no -spec directives) | IN PROGRESS | — | [phase-03](/docs/implementation/0066/phase-03-edoc-fallback) |
-| 4 | Dialyzer typespec-to-Mochi type mapping + SkipReport emit | NOT STARTED | — | [phase-04](/docs/implementation/0066/phase-04-type-mapping) |
+| 3 | EDoc XML fallback ingest (for packages with no -spec directives) | LANDED | 445e4a0 | [phase-03](/docs/implementation/0066/phase-03-edoc-fallback) |
+| 4 | Dialyzer typespec-to-Mochi type mapping + SkipReport emit | IN PROGRESS | — | [phase-04](/docs/implementation/0066/phase-04-type-mapping) |
 | 5 | Port bridge shim emitter (shim.erl gen_server + shim.mochi extern fn corpus) | NOT STARTED | — | [phase-05](/docs/implementation/0066/phase-05-shim-emit) |
 | 6 | `import erlang "..."` grammar + parser | NOT STARTED | — | [phase-06](/docs/implementation/0066/phase-06-import-grammar) |
 | 7 | Build orchestration (rebar3 compile + Port process spawn + workspace setup) | NOT STARTED | — | [phase-07](/docs/implementation/0066/phase-07-build) |


### PR DESCRIPTION
Closes #22866

## Summary
`package3/erlang/typemap/`: closed Erlang-to-Mochi type translation table.

Primitives: bool, int, float, string, bytes, pid/port/reference externs. Skips: any/term, iodata, bitstring, string (charlist), untyped tuple/map, typed map, untyped fun, remote_type, 3+ branch union, non-ok/error 2-branch union. Compounds: list(T), typed tuple, ok/error result, fun((A)->B). `IsSkip` helper for SkipReason extraction.

## Test plan
- [x] 37 tests, all pass