### PR TITLE
feat(mep-67): phase 01 Maven Central client, coordinate parser, metadata

### DIFF
--- a/package3/java/maven/client.go
+++ b/package3/java/maven/client.go
@@ -1,0 +1,140 @@
+package maven
+
+import (
+	"context"
+	"crypto/sha1"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// DefaultBaseURL is the Maven Central repository root.
+const DefaultBaseURL = "https://repo1.maven.org/maven2/"
+
+// DefaultUserAgent identifies the Mochi bridge to Maven Central servers.
+const DefaultUserAgent = "mochi-java-bridge/0.1 (+https://mochi-lang.dev)"
+
+// ErrArtifactNotFound is returned when Maven Central responds 404 for an artifact.
+var ErrArtifactNotFound = errors.New("maven: artifact not found")
+
+// ErrChecksumMismatch is returned when the downloaded JAR's SHA-1 does not match.
+var ErrChecksumMismatch = errors.New("maven: checksum mismatch")
+
+// Client is a Maven Central HTTP client. It is safe for concurrent use.
+type Client struct {
+	// BaseURL is the Maven repository root. Must end in a slash.
+	BaseURL string
+	// HTTP is the underlying transport. nil uses a 30s-timeout default client.
+	HTTP *http.Client
+	// UserAgent is sent as the User-Agent header.
+	UserAgent string
+}
+
+// NewClient returns a Client pre-configured against Maven Central.
+func NewClient(baseURL string) *Client {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	if !strings.HasSuffix(baseURL, "/") {
+		baseURL += "/"
+	}
+	return &Client{
+		BaseURL:   baseURL,
+		HTTP:      &http.Client{Timeout: 60 * time.Second},
+		UserAgent: DefaultUserAgent,
+	}
+}
+
+// FetchMetadata fetches maven-metadata.xml for the coordinate and parses it.
+func (c *Client) FetchMetadata(ctx context.Context, coord Coordinate) (*VersionMetadata, error) {
+	url := c.BaseURL + coord.MetadataPath()
+	data, err := c.getBytes(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	return parseMetadataXML(data)
+}
+
+// FetchJAR downloads the JAR for the coordinate, verifies its SHA-1 checksum,
+// and returns the raw bytes.
+func (c *Client) FetchJAR(ctx context.Context, coord Coordinate) ([]byte, error) {
+	jarURL := c.BaseURL + coord.ArtifactPath()
+	sha1URL := c.BaseURL + coord.SHA1Path()
+
+	// Fetch checksum first.
+	checksumHex, err := c.FetchChecksum(ctx, sha1URL)
+	if err != nil {
+		return nil, fmt.Errorf("maven: fetch sha1 for %s: %w", coord, err)
+	}
+
+	// Fetch the JAR.
+	data, err := c.getBytes(ctx, jarURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify SHA-1.
+	h := sha1.New()
+	h.Write(data)
+	got := fmt.Sprintf("%x", h.Sum(nil))
+	if got != checksumHex {
+		return nil, fmt.Errorf("%w: %s: want %s got %s", ErrChecksumMismatch, coord, checksumHex, got)
+	}
+	return data, nil
+}
+
+// FetchPOM downloads the POM for the coordinate.
+func (c *Client) FetchPOM(ctx context.Context, coord Coordinate) ([]byte, error) {
+	url := c.BaseURL + coord.POMPath()
+	return c.getBytes(ctx, url)
+}
+
+// FetchChecksum downloads a .sha1 or .sha256 file and returns the hex hash string.
+func (c *Client) FetchChecksum(ctx context.Context, url string) (string, error) {
+	data, err := c.getBytes(ctx, url)
+	if err != nil {
+		return "", err
+	}
+	// Some servers include spaces or newlines; trim whitespace.
+	// Some also include the filename after the hash.
+	raw := strings.TrimSpace(string(data))
+	// If there's whitespace in the middle (e.g. "abc123  guava.jar"), take the first token.
+	if idx := strings.IndexAny(raw, " \t"); idx > 0 {
+		raw = raw[:idx]
+	}
+	return raw, nil
+}
+
+// getBytes performs a GET request and returns the response body as bytes.
+// Returns ErrArtifactNotFound on 404.
+func (c *Client) getBytes(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("maven: build request: %w", err)
+	}
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+	cl := c.HTTP
+	if cl == nil {
+		cl = http.DefaultClient
+	}
+	resp, err := cl.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("maven: GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// fall through
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("%w: %s", ErrArtifactNotFound, url)
+	default:
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("maven: GET %s: status %d: %s", url, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return io.ReadAll(resp.Body)
+}

--- a/package3/java/maven/client_test.go
+++ b/package3/java/maven/client_test.go
@@ -1,0 +1,137 @@
+package maven
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// minimalJAR returns a minimal valid JAR (ZIP) with only META-INF/MANIFEST.MF.
+func minimalJAR() []byte {
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	mf, _ := w.Create("META-INF/MANIFEST.MF")
+	io.WriteString(mf, "Manifest-Version: 1.0\n")
+	w.Close()
+	return buf.Bytes()
+}
+
+func sha1Hex(data []byte) string {
+	h := sha1.New()
+	h.Write(data)
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func TestClientFetchJAR(t *testing.T) {
+	jarData := minimalJAR()
+	checksum := sha1Hex(jarData)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar":
+			w.Write(jarData)
+		case r.URL.Path == "/com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar.sha1":
+			fmt.Fprintf(w, "%s  guava-33.4.8-jre.jar\n", checksum)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL + "/")
+	coord := Coordinate{GroupID: "com.google.guava", ArtifactID: "guava", Version: "33.4.8-jre"}
+	data, err := client.FetchJAR(context.Background(), coord)
+	if err != nil {
+		t.Fatalf("FetchJAR: %v", err)
+	}
+	if !bytes.Equal(data, jarData) {
+		t.Errorf("FetchJAR returned wrong data")
+	}
+}
+
+func TestClientFetch404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL + "/")
+	coord := Coordinate{GroupID: "com.example", ArtifactID: "missing", Version: "1.0"}
+	_, err := client.FetchJAR(context.Background(), coord)
+	if !errors.Is(err, ErrArtifactNotFound) {
+		t.Errorf("FetchJAR 404: got %v; want ErrArtifactNotFound", err)
+	}
+}
+
+func TestClientFetchChecksumMismatch(t *testing.T) {
+	jarData := minimalJAR()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/com/example/foo/1.0/foo-1.0.jar":
+			w.Write(jarData)
+		case r.URL.Path == "/com/example/foo/1.0/foo-1.0.jar.sha1":
+			// Return wrong checksum.
+			fmt.Fprintf(w, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL + "/")
+	coord := Coordinate{GroupID: "com.example", ArtifactID: "foo", Version: "1.0"}
+	_, err := client.FetchJAR(context.Background(), coord)
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Errorf("FetchJAR mismatch: got %v; want ErrChecksumMismatch", err)
+	}
+}
+
+func TestClientFetchMetadata(t *testing.T) {
+	xmlData := []byte(fixtureMetadataXML)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/com/google/guava/guava/maven-metadata.xml" {
+			w.Header().Set("Content-Type", "application/xml")
+			w.Write(xmlData)
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL + "/")
+	coord := Coordinate{GroupID: "com.google.guava", ArtifactID: "guava", Version: "33.4.8-jre"}
+	meta, err := client.FetchMetadata(context.Background(), coord)
+	if err != nil {
+		t.Fatalf("FetchMetadata: %v", err)
+	}
+	if len(meta.Versions) != 3 {
+		t.Errorf("len(Versions) = %d; want 3", len(meta.Versions))
+	}
+	if meta.LatestRelease != "33.4.8-jre" {
+		t.Errorf("LatestRelease = %q; want 33.4.8-jre", meta.LatestRelease)
+	}
+}
+
+func TestClientFetchChecksum(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "abc123  guava.jar\n")
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL + "/")
+	got, err := client.FetchChecksum(context.Background(), srv.URL+"/checksum.sha1")
+	if err != nil {
+		t.Fatalf("FetchChecksum: %v", err)
+	}
+	if got != "abc123" {
+		t.Errorf("FetchChecksum = %q; want abc123", got)
+	}
+}

--- a/package3/java/maven/coord.go
+++ b/package3/java/maven/coord.go
@@ -1,0 +1,92 @@
+// Package maven provides a Maven Central client, coordinate parsing, and
+// content-addressed JAR cache for the MEP-67 Java bridge.
+package maven
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Coordinate identifies a Maven artifact uniquely as groupId:artifactId:version.
+type Coordinate struct {
+	GroupID    string
+	ArtifactID string
+	Version    string
+}
+
+// Parse parses a coordinate string in one of two formats:
+//   - "groupId:artifactId@version"  (Mochi import syntax)
+//   - "groupId:artifactId:version"  (Maven native syntax)
+func Parse(s string) (Coordinate, error) {
+	s = strings.TrimSpace(s)
+	// Try Mochi format first: groupId:artifactId@version
+	if idx := strings.LastIndex(s, "@"); idx >= 0 {
+		head := s[:idx]
+		version := s[idx+1:]
+		parts := strings.SplitN(head, ":", 2)
+		if len(parts) != 2 {
+			return Coordinate{}, fmt.Errorf("maven: invalid coordinate %q: expected groupId:artifactId@version", s)
+		}
+		return validateCoord(Coordinate{GroupID: parts[0], ArtifactID: parts[1], Version: version}, s)
+	}
+	// Try Maven native format: groupId:artifactId:version
+	parts := strings.SplitN(s, ":", 3)
+	if len(parts) != 3 {
+		return Coordinate{}, fmt.Errorf("maven: invalid coordinate %q: expected groupId:artifactId:version", s)
+	}
+	return validateCoord(Coordinate{GroupID: parts[0], ArtifactID: parts[1], Version: parts[2]}, s)
+}
+
+func validateCoord(c Coordinate, orig string) (Coordinate, error) {
+	if c.GroupID == "" {
+		return Coordinate{}, fmt.Errorf("maven: empty groupId in %q", orig)
+	}
+	if c.ArtifactID == "" {
+		return Coordinate{}, fmt.Errorf("maven: empty artifactId in %q", orig)
+	}
+	if c.Version == "" {
+		return Coordinate{}, fmt.Errorf("maven: empty version in %q", orig)
+	}
+	return c, nil
+}
+
+// GroupPath converts groupId dots to slashes (com.google.guava -> com/google/guava).
+func (c Coordinate) GroupPath() string {
+	return strings.ReplaceAll(c.GroupID, ".", "/")
+}
+
+// ArtifactPath returns the Maven repository path for the JAR, e.g.
+// "com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar".
+func (c Coordinate) ArtifactPath() string {
+	return fmt.Sprintf("%s/%s/%s/%s", c.GroupPath(), c.ArtifactID, c.Version, c.JARFilename())
+}
+
+// POMPath returns the path for the POM file.
+func (c Coordinate) POMPath() string {
+	return fmt.Sprintf("%s/%s/%s/%s-%s.pom", c.GroupPath(), c.ArtifactID, c.Version, c.ArtifactID, c.Version)
+}
+
+// SHA1Path returns the path for the SHA-1 checksum.
+func (c Coordinate) SHA1Path() string {
+	return c.ArtifactPath() + ".sha1"
+}
+
+// SHA256Path returns the path for the SHA-256 checksum (not always present).
+func (c Coordinate) SHA256Path() string {
+	return c.ArtifactPath() + ".sha256"
+}
+
+// MetadataPath returns the path for maven-metadata.xml.
+func (c Coordinate) MetadataPath() string {
+	return fmt.Sprintf("%s/%s/maven-metadata.xml", c.GroupPath(), c.ArtifactID)
+}
+
+// JARFilename returns the filename for the JAR, e.g. "guava-33.4.8-jre.jar".
+func (c Coordinate) JARFilename() string {
+	return fmt.Sprintf("%s-%s.jar", c.ArtifactID, c.Version)
+}
+
+// String returns "groupId:artifactId:version" (Maven native format).
+func (c Coordinate) String() string {
+	return fmt.Sprintf("%s:%s:%s", c.GroupID, c.ArtifactID, c.Version)
+}

--- a/package3/java/maven/coord_test.go
+++ b/package3/java/maven/coord_test.go
@@ -1,0 +1,95 @@
+package maven
+
+import (
+	"testing"
+)
+
+func TestCoordParse(t *testing.T) {
+	cases := []struct {
+		input      string
+		wantGroup  string
+		wantArt    string
+		wantVer    string
+		wantErrStr string
+	}{
+		// Mochi format
+		{"com.google.guava:guava@33.4.8-jre", "com.google.guava", "guava", "33.4.8-jre", ""},
+		{"org.apache.commons:commons-lang3@3.14.0", "org.apache.commons", "commons-lang3", "3.14.0", ""},
+		// Maven native format
+		{"com.google.guava:guava:33.4.8-jre", "com.google.guava", "guava", "33.4.8-jre", ""},
+		{"io.netty:netty-all:4.1.107.Final", "io.netty", "netty-all", "4.1.107.Final", ""},
+		// Error cases
+		{"guava@1.0", "", "", "", "invalid coordinate"},
+		{"com.foo:@1.0", "", "", "", "empty artifactId"},
+		{"", "", "", "", "invalid coordinate"},
+	}
+	for _, c := range cases {
+		coord, err := Parse(c.input)
+		if c.wantErrStr != "" {
+			if err == nil {
+				t.Errorf("Parse(%q): expected error containing %q, got nil", c.input, c.wantErrStr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Parse(%q): unexpected error: %v", c.input, err)
+			continue
+		}
+		if coord.GroupID != c.wantGroup {
+			t.Errorf("Parse(%q).GroupID = %q; want %q", c.input, coord.GroupID, c.wantGroup)
+		}
+		if coord.ArtifactID != c.wantArt {
+			t.Errorf("Parse(%q).ArtifactID = %q; want %q", c.input, coord.ArtifactID, c.wantArt)
+		}
+		if coord.Version != c.wantVer {
+			t.Errorf("Parse(%q).Version = %q; want %q", c.input, coord.Version, c.wantVer)
+		}
+	}
+}
+
+func TestCoordArtifactPath(t *testing.T) {
+	c := Coordinate{GroupID: "com.google.guava", ArtifactID: "guava", Version: "33.4.8-jre"}
+	want := "com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar"
+	if got := c.ArtifactPath(); got != want {
+		t.Errorf("ArtifactPath() = %q; want %q", got, want)
+	}
+}
+
+func TestCoordPOMPath(t *testing.T) {
+	c := Coordinate{GroupID: "com.google.guava", ArtifactID: "guava", Version: "33.4.8-jre"}
+	want := "com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.pom"
+	if got := c.POMPath(); got != want {
+		t.Errorf("POMPath() = %q; want %q", got, want)
+	}
+}
+
+func TestCoordSHA1Path(t *testing.T) {
+	c := Coordinate{GroupID: "com.google.guava", ArtifactID: "guava", Version: "33.4.8-jre"}
+	got := c.SHA1Path()
+	if got != c.ArtifactPath()+".sha1" {
+		t.Errorf("SHA1Path() = %q; want %q.sha1", got, c.ArtifactPath())
+	}
+}
+
+func TestCoordMetadataPath(t *testing.T) {
+	c := Coordinate{GroupID: "com.google.guava", ArtifactID: "guava", Version: "33.4.8-jre"}
+	want := "com/google/guava/guava/maven-metadata.xml"
+	if got := c.MetadataPath(); got != want {
+		t.Errorf("MetadataPath() = %q; want %q", got, want)
+	}
+}
+
+func TestCoordString(t *testing.T) {
+	c := Coordinate{GroupID: "com.google.guava", ArtifactID: "guava", Version: "33.4.8-jre"}
+	want := "com.google.guava:guava:33.4.8-jre"
+	if got := c.String(); got != want {
+		t.Errorf("String() = %q; want %q", got, want)
+	}
+}
+
+func TestCoordGroupPath(t *testing.T) {
+	c := Coordinate{GroupID: "com.google.guava", ArtifactID: "guava", Version: "1.0"}
+	if got := c.GroupPath(); got != "com/google/guava" {
+		t.Errorf("GroupPath() = %q; want com/google/guava", got)
+	}
+}

--- a/package3/java/maven/entry.go
+++ b/package3/java/maven/entry.go
@@ -1,0 +1,48 @@
+package maven
+
+import (
+	"encoding/xml"
+)
+
+// VersionMetadata holds the version information from maven-metadata.xml.
+type VersionMetadata struct {
+	// GroupID is the Maven groupId.
+	GroupID string
+	// ArtifactID is the Maven artifactId.
+	ArtifactID string
+	// Versions is the list of all available versions.
+	Versions []string
+	// LatestRelease is the latest release version from the metadata.
+	LatestRelease string
+	// LatestVersion is the latest version (may be a snapshot).
+	LatestVersion string
+}
+
+// mavenMetadataXML is the XML structure for maven-metadata.xml.
+type mavenMetadataXML struct {
+	XMLName    xml.Name `xml:"metadata"`
+	GroupID    string   `xml:"groupId"`
+	ArtifactID string   `xml:"artifactId"`
+	Versioning struct {
+		Latest  string `xml:"latest"`
+		Release string `xml:"release"`
+		Versions struct {
+			Version []string `xml:"version"`
+		} `xml:"versions"`
+	} `xml:"versioning"`
+}
+
+// parseMetadataXML parses maven-metadata.xml bytes into VersionMetadata.
+func parseMetadataXML(data []byte) (*VersionMetadata, error) {
+	var meta mavenMetadataXML
+	if err := xml.Unmarshal(data, &meta); err != nil {
+		return nil, err
+	}
+	return &VersionMetadata{
+		GroupID:       meta.GroupID,
+		ArtifactID:    meta.ArtifactID,
+		Versions:      meta.Versioning.Versions.Version,
+		LatestRelease: meta.Versioning.Release,
+		LatestVersion: meta.Versioning.Latest,
+	}, nil
+}

--- a/package3/java/maven/entry_test.go
+++ b/package3/java/maven/entry_test.go
@@ -1,0 +1,49 @@
+package maven
+
+import (
+	"testing"
+)
+
+const fixtureMetadataXML = `<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.google.guava</groupId>
+  <artifactId>guava</artifactId>
+  <versioning>
+    <latest>33.4.8-jre</latest>
+    <release>33.4.8-jre</release>
+    <versions>
+      <version>32.1.0-jre</version>
+      <version>33.0.0-jre</version>
+      <version>33.4.8-jre</version>
+    </versions>
+  </versioning>
+</metadata>`
+
+func TestParseMetadataXML(t *testing.T) {
+	meta, err := parseMetadataXML([]byte(fixtureMetadataXML))
+	if err != nil {
+		t.Fatalf("parseMetadataXML: %v", err)
+	}
+	if meta.GroupID != "com.google.guava" {
+		t.Errorf("GroupID = %q; want com.google.guava", meta.GroupID)
+	}
+	if meta.ArtifactID != "guava" {
+		t.Errorf("ArtifactID = %q; want guava", meta.ArtifactID)
+	}
+	if len(meta.Versions) != 3 {
+		t.Errorf("len(Versions) = %d; want 3", len(meta.Versions))
+	}
+	if meta.LatestRelease != "33.4.8-jre" {
+		t.Errorf("LatestRelease = %q; want 33.4.8-jre", meta.LatestRelease)
+	}
+	if meta.LatestVersion != "33.4.8-jre" {
+		t.Errorf("LatestVersion = %q; want 33.4.8-jre", meta.LatestVersion)
+	}
+}
+
+func TestParseMetadataXMLInvalid(t *testing.T) {
+	_, err := parseMetadataXML([]byte("not xml"))
+	if err == nil {
+		t.Error("expected error for invalid XML")
+	}
+}

--- a/package3/java/maven/phase01_test.go
+++ b/package3/java/maven/phase01_test.go
@@ -1,0 +1,115 @@
+package maven
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestPhase1MavenClient is the phase-gate sentinel test for MEP-67 phase 1.
+// It verifies the Maven Central client, coordinate parsing, and metadata parsing
+// work end-to-end with an httptest server.
+func TestPhase1MavenClient(t *testing.T) {
+	jar := makeTestJAR()
+	sha1Checksum := fmt.Sprintf("%x", sha1Sum(jar))
+	xmlData := []byte(fixtureMetadataXML)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar":
+			w.Write(jar)
+		case "/com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar.sha1":
+			fmt.Fprintf(w, "%s\n", sha1Checksum)
+		case "/com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.pom":
+			fmt.Fprintf(w, "<project><groupId>com.google.guava</groupId></project>")
+		case "/com/google/guava/guava/maven-metadata.xml":
+			w.Write(xmlData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL + "/")
+	coord, err := Parse("com.google.guava:guava@33.4.8-jre")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	t.Run("fetch_jar", func(t *testing.T) {
+		data, err := client.FetchJAR(context.Background(), coord)
+		if err != nil {
+			t.Fatalf("FetchJAR: %v", err)
+		}
+		if !bytes.Equal(data, jar) {
+			t.Errorf("FetchJAR returned wrong data")
+		}
+	})
+
+	t.Run("fetch_pom", func(t *testing.T) {
+		pom, err := client.FetchPOM(context.Background(), coord)
+		if err != nil {
+			t.Fatalf("FetchPOM: %v", err)
+		}
+		if len(pom) == 0 {
+			t.Error("FetchPOM returned empty data")
+		}
+	})
+
+	t.Run("fetch_metadata", func(t *testing.T) {
+		meta, err := client.FetchMetadata(context.Background(), coord)
+		if err != nil {
+			t.Fatalf("FetchMetadata: %v", err)
+		}
+		if len(meta.Versions) == 0 {
+			t.Error("FetchMetadata returned no versions")
+		}
+		if meta.LatestRelease == "" {
+			t.Error("FetchMetadata returned empty LatestRelease")
+		}
+	})
+
+	t.Run("not_found", func(t *testing.T) {
+		missing, _ := Parse("com.missing:lib@1.0")
+		_, err := client.FetchJAR(context.Background(), missing)
+		if !errors.Is(err, ErrArtifactNotFound) {
+			t.Errorf("expected ErrArtifactNotFound, got %v", err)
+		}
+	})
+
+	t.Run("coord_parse_both_formats", func(t *testing.T) {
+		c1, err := Parse("com.google.guava:guava@33.4.8-jre")
+		if err != nil {
+			t.Fatalf("Parse mochi format: %v", err)
+		}
+		c2, err := Parse("com.google.guava:guava:33.4.8-jre")
+		if err != nil {
+			t.Fatalf("Parse maven format: %v", err)
+		}
+		if c1.GroupID != c2.GroupID || c1.ArtifactID != c2.ArtifactID || c1.Version != c2.Version {
+			t.Error("both formats should produce same coordinate")
+		}
+	})
+}
+
+func makeTestJAR() []byte {
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	mf, _ := w.Create("META-INF/MANIFEST.MF")
+	io.WriteString(mf, "Manifest-Version: 1.0\nCreated-By: mochi-test\n")
+	w.Close()
+	return buf.Bytes()
+}
+
+func sha1Sum(data []byte) []byte {
+	h := sha1.New()
+	h.Write(data)
+	return h.Sum(nil)
+}


### PR DESCRIPTION
## Summary

- Adds `package3/java/maven/` package for MEP-67 phase 1
- `coord.go`: Coordinate type with Parse supporting Mochi and Maven formats, path helpers
- `entry.go`: VersionMetadata from maven-metadata.xml via encoding/xml
- `client.go`: HTTP client with FetchMetadata, FetchJAR (with SHA-1 verify), FetchPOM, FetchChecksum

Closes https://github.com/mochilang/mochi/issues/22868

## Test plan

- [x] `go test ./package3/java/...` passes
- [x] TestPhase1MavenClient with all sub-tests pass
- [x] Checksum mismatch and 404 error paths verified