### PR TITLE
feat(mep-75 p5): Mochi extern emitter + SKIPPED.txt

### DIFF
--- a/package3/php/externemit/externemit.go
+++ b/package3/php/externemit/externemit.go
@@ -1,4 +1,288 @@
 // Package externemit synthesises Mochi extern fn / extern type declarations
-// from a translated PHP surface document. Phase 0 ships the package stub;
-// the full implementation arrives in phase 5.
+// from a translated PHP surface document (package3/php/reflect.ReflectionSurface).
+//
+// For each public class, interface, enum, and top-level function in the surface,
+// the emitter produces:
+//
+//   - An `extern type` declaration for every class/interface/enum handle.
+//   - An `extern fn` declaration for every public method and top-level function
+//     whose parameter and return types are all in the closed type table.
+//
+// Items that cannot be translated (mixed, untyped array, magic methods, variadic
+// parameters, self/static/parent return types, etc.) are collected as SkipReport
+// entries. The caller may write these to a SKIPPED.txt file alongside the shim.
+//
+// Usage:
+//
+//	result, err := externemit.Emit(surface)
+//	if err != nil { ... }
+//	// result.MochiSource is the .mochi shim file text
+//	// result.Skips contains the untranslatable items
 package externemit
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	bridgeerrors "mochi/package3/php/errors"
+	"mochi/package3/php/reflect"
+	"mochi/package3/php/typemap"
+)
+
+// EmitResult holds the output of an Emit call.
+type EmitResult struct {
+	// MochiSource is the complete .mochi shim file content, ready to write to disk.
+	MochiSource string
+	// Skips is the list of items that could not be translated.
+	Skips []bridgeerrors.SkipReport
+}
+
+// Emit translates a PHP reflection surface into Mochi extern declarations.
+func Emit(surface *reflect.ReflectionSurface) (*EmitResult, error) {
+	e := &emitter{pkg: surface.PackageName}
+
+	for _, cls := range surface.Classes {
+		e.emitClass(cls)
+	}
+	for _, iface := range surface.Interfaces {
+		e.emitInterface(iface)
+	}
+	for _, enum := range surface.Enums {
+		e.emitEnum(enum)
+	}
+	for _, fn := range surface.Functions {
+		e.emitFunction(fn)
+	}
+
+	return &EmitResult{
+		MochiSource: e.render(),
+		Skips:       e.skips,
+	}, nil
+}
+
+// FormatSKIPPED returns the text of a SKIPPED.txt file for the given skip list.
+func FormatSKIPPED(pkg string, skips []bridgeerrors.SkipReport) string {
+	if len(skips) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# SKIPPED items for package %q\n", pkg)
+	fmt.Fprintf(&sb, "# These items could not be automatically translated to Mochi extern declarations.\n")
+	fmt.Fprintf(&sb, "# Add hand-written extern fn overrides in your Mochi source to use them.\n\n")
+	for _, s := range skips {
+		fmt.Fprintf(&sb, "%s", s.String())
+	}
+	return sb.String()
+}
+
+// emitter accumulates extern declarations and skip reports.
+type emitter struct {
+	pkg   string
+	lines []string
+	skips []bridgeerrors.SkipReport
+}
+
+func (e *emitter) addLine(s string) {
+	e.lines = append(e.lines, s)
+}
+
+func (e *emitter) addSkip(path string, reason bridgeerrors.SkipReason, detail string) {
+	e.skips = append(e.skips, bridgeerrors.SkipReport{
+		ItemPath: path,
+		Reason:   reason,
+		Detail:   detail,
+	})
+}
+
+func (e *emitter) render() string {
+	if len(e.lines) == 0 {
+		return ""
+	}
+	return strings.Join(e.lines, "\n") + "\n"
+}
+
+// emitClass emits extern type + extern fn declarations for a public class.
+func (e *emitter) emitClass(cls reflect.ClassSurface) {
+	handle := classHandle(cls.FQCN)
+	e.addLine(fmt.Sprintf("extern type %s", handle))
+	e.addLine("")
+
+	for _, m := range cls.Methods {
+		path := fmt.Sprintf("%s::%s::%s", e.pkg, cls.FQCN, m.Name)
+		e.emitMethod(path, handle, m)
+	}
+}
+
+// emitInterface emits extern type + extern fn declarations for an interface.
+func (e *emitter) emitInterface(iface reflect.InterfaceSurface) {
+	handle := classHandle(iface.FQCN)
+	e.addLine(fmt.Sprintf("extern type %s", handle))
+	e.addLine("")
+
+	for _, m := range iface.Methods {
+		path := fmt.Sprintf("%s::%s::%s", e.pkg, iface.FQCN, m.Name)
+		e.emitMethod(path, handle, m)
+	}
+}
+
+// emitEnum emits extern type for a PHP enum, plus a fromValue constructor for
+// backed enums and any public methods.
+func (e *emitter) emitEnum(enum reflect.EnumSurface) {
+	handle := classHandle(enum.FQCN)
+	e.addLine(fmt.Sprintf("extern type %s", handle))
+	e.addLine("")
+
+	if enum.BackingType != "" {
+		backM, skip, detail := typemap.Map(enum.BackingType, false, typemap.DirectionIn)
+		if skip != 0 {
+			e.addSkip(e.pkg+"::"+enum.FQCN+"::fromValue", skip, detail)
+		} else {
+			fnName := toSnakeCase(handle) + "_from_value"
+			e.addLine(fmt.Sprintf("extern fn %s(value: %s) -> %s", fnName, backM.MochiType, handle))
+			e.addLine("")
+		}
+	}
+
+	for _, m := range enum.Methods {
+		path := fmt.Sprintf("%s::%s::%s", e.pkg, enum.FQCN, m.Name)
+		e.emitMethod(path, handle, m)
+	}
+}
+
+// emitFunction emits an extern fn for a top-level PHP function.
+func (e *emitter) emitFunction(fn reflect.FunctionSurface) {
+	path := e.pkg + "::" + fn.Name
+
+	retType, skip, detail := mapReturnType(fn.ReturnType, fn.Nullable)
+	if skip != 0 {
+		e.addSkip(path+" (return)", skip, detail)
+		return
+	}
+
+	params, paramSkip, paramDetail := mapParamList(path, fn.Parameters)
+	if paramSkip != 0 {
+		e.addSkip(path, paramSkip, paramDetail)
+		return
+	}
+
+	fnName := toSnakeCase(strings.ReplaceAll(fn.Name, "\\", "_"))
+	e.addLine(fmt.Sprintf("extern fn %s(%s) -> %s", fnName, params, retType))
+	e.addLine("")
+}
+
+// emitMethod emits an extern fn for a class/interface/enum method.
+func (e *emitter) emitMethod(path, handle string, m reflect.MethodSurface) {
+	if strings.HasPrefix(m.Name, "__") {
+		e.addSkip(path, bridgeerrors.SkipMagicMethod, "magic method not bridgeable via extern fn")
+		return
+	}
+
+	retType, skip, detail := mapReturnType(m.ReturnType, m.Nullable)
+	if skip != 0 {
+		e.addSkip(path+" (return)", skip, detail)
+		return
+	}
+
+	var paramParts []string
+	if !m.Static {
+		paramParts = append(paramParts, fmt.Sprintf("self: %s", handle))
+	}
+
+	for _, p := range m.Parameters {
+		if p.Variadic {
+			e.addSkip(path+"::$"+p.Name, bridgeerrors.SkipVararg, "variadic parameter")
+			return
+		}
+		if p.Type == "" {
+			e.addSkip(path+"::$"+p.Name, bridgeerrors.SkipMixed, "untyped parameter (implicit mixed)")
+			return
+		}
+		pm, pSkip, pDetail := typemap.Map(p.Type, p.Nullable, typemap.DirectionIn)
+		if pSkip != 0 {
+			e.addSkip(path+"::$"+p.Name, pSkip, pDetail)
+			return
+		}
+		paramParts = append(paramParts, fmt.Sprintf("%s: %s", safeIdent(p.Name), pm.MochiType))
+	}
+
+	params := strings.Join(paramParts, ", ")
+	fnName := toSnakeCase(handle) + "_" + toSnakeCase(m.Name)
+	e.addLine(fmt.Sprintf("extern fn %s(%s) -> %s", fnName, params, retType))
+	e.addLine("")
+}
+
+// mapReturnType maps a PHP return type string to a Mochi return type string.
+// An empty return type (no annotation) is treated as "unit".
+func mapReturnType(phpType string, nullable bool) (string, bridgeerrors.SkipReason, string) {
+	if phpType == "" {
+		return "unit", 0, ""
+	}
+	m, skip, detail := typemap.Map(phpType, nullable, typemap.DirectionOut)
+	if skip != 0 {
+		return "", skip, detail
+	}
+	return m.MochiType, 0, ""
+}
+
+// mapParamList maps a slice of ParameterSurface to a Mochi param string.
+func mapParamList(_ string, params []reflect.ParameterSurface) (string, bridgeerrors.SkipReason, string) {
+	var parts []string
+	for _, p := range params {
+		if p.Variadic {
+			return "", bridgeerrors.SkipVararg, "variadic parameter $" + p.Name
+		}
+		if p.Type == "" {
+			return "", bridgeerrors.SkipMixed, fmt.Sprintf("untyped parameter $%s (implicit mixed)", p.Name)
+		}
+		pm, skip, detail := typemap.Map(p.Type, p.Nullable, typemap.DirectionIn)
+		if skip != 0 {
+			return "", skip, fmt.Sprintf("$%s: %s", p.Name, detail)
+		}
+		parts = append(parts, fmt.Sprintf("%s: %s", safeIdent(p.Name), pm.MochiType))
+	}
+	return strings.Join(parts, ", "), 0, ""
+}
+
+// classHandle converts a PHP FQCN to a Mochi extern type handle name.
+// "GuzzleHttp\\Client" -> "GuzzleHttpClient"
+func classHandle(fqcn string) string {
+	fqcn = strings.TrimPrefix(fqcn, "\\")
+	parts := strings.Split(fqcn, "\\")
+	var sb strings.Builder
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		sb.WriteString(strings.ToUpper(p[:1]))
+		sb.WriteString(p[1:])
+	}
+	name := sb.String()
+	if name == "" {
+		return "OpaqueHandle"
+	}
+	return name
+}
+
+// toSnakeCase converts a PascalCase or camelCase identifier to snake_case.
+// "GuzzleHttpClient" -> "guzzle_http_client"
+// "send" -> "send"
+func toSnakeCase(s string) string {
+	var sb strings.Builder
+	for i, r := range s {
+		if unicode.IsUpper(r) {
+			if i > 0 {
+				sb.WriteByte('_')
+			}
+			sb.WriteRune(unicode.ToLower(r))
+		} else {
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
+// safeIdent returns a safe Mochi identifier for a PHP parameter name.
+func safeIdent(name string) string {
+	return name
+}

--- a/package3/php/externemit/externemit_test.go
+++ b/package3/php/externemit/externemit_test.go
@@ -1,0 +1,369 @@
+package externemit
+
+import (
+	"strings"
+	"testing"
+
+	bridgeerrors "mochi/package3/php/errors"
+	"mochi/package3/php/reflect"
+)
+
+func surface(classes []reflect.ClassSurface, ifaces []reflect.InterfaceSurface, enums []reflect.EnumSurface, fns []reflect.FunctionSurface) *reflect.ReflectionSurface {
+	return &reflect.ReflectionSurface{
+		PackageName: "test/pkg",
+		PHPVersion:  "8.4.0",
+		Classes:     classes,
+		Interfaces:  ifaces,
+		Enums:       enums,
+		Functions:   fns,
+	}
+}
+
+func TestEmitEmpty(t *testing.T) {
+	result, err := Emit(surface(nil, nil, nil, nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.MochiSource != "" {
+		t.Errorf("empty surface should produce empty source; got %q", result.MochiSource)
+	}
+	if len(result.Skips) != 0 {
+		t.Errorf("empty surface should produce no skips; got %d", len(result.Skips))
+	}
+}
+
+func TestEmitClassExternType(t *testing.T) {
+	s := surface([]reflect.ClassSurface{
+		{FQCN: `GuzzleHttp\Client`, Methods: nil},
+	}, nil, nil, nil)
+	result, err := Emit(s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.MochiSource, "extern type GuzzleHttpClient") {
+		t.Errorf("expected extern type GuzzleHttpClient; got:\n%s", result.MochiSource)
+	}
+}
+
+func TestEmitSimpleMethod(t *testing.T) {
+	s := surface([]reflect.ClassSurface{
+		{
+			FQCN: `Foo\Bar`,
+			Methods: []reflect.MethodSurface{
+				{
+					Name:       "doThing",
+					ReturnType: "string",
+					Parameters: []reflect.ParameterSurface{
+						{Name: "x", Type: "int"},
+					},
+				},
+			},
+		},
+	}, nil, nil, nil)
+	result, err := Emit(s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Expect: extern fn foo_bar_do_thing(self: FooBar, x: int) -> string
+	if !strings.Contains(result.MochiSource, "extern fn foo_bar_do_thing(self: FooBar, x: int) -> string") {
+		t.Errorf("expected extern fn foo_bar_do_thing; got:\n%s", result.MochiSource)
+	}
+}
+
+func TestEmitStaticMethod(t *testing.T) {
+	s := surface([]reflect.ClassSurface{
+		{
+			FQCN: `Foo\Bar`,
+			Methods: []reflect.MethodSurface{
+				{
+					Name:       "create",
+					Static:     true,
+					ReturnType: "string",
+					Parameters: nil,
+				},
+			},
+		},
+	}, nil, nil, nil)
+	result, err := Emit(s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Static: no self parameter
+	if !strings.Contains(result.MochiSource, "extern fn foo_bar_create() -> string") {
+		t.Errorf("expected extern fn foo_bar_create() -> string; got:\n%s", result.MochiSource)
+	}
+}
+
+func TestEmitMagicMethodSkipped(t *testing.T) {
+	s := surface([]reflect.ClassSurface{
+		{
+			FQCN: "Foo",
+			Methods: []reflect.MethodSurface{
+				{Name: "__construct", ReturnType: "void"},
+				{Name: "__get", ReturnType: "string", Parameters: []reflect.ParameterSurface{{Name: "name", Type: "string"}}},
+			},
+		},
+	}, nil, nil, nil)
+	result, err := Emit(s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Skips) != 2 {
+		t.Errorf("expected 2 skips for magic methods; got %d", len(result.Skips))
+	}
+	for _, sk := range result.Skips {
+		if sk.Reason != bridgeerrors.SkipMagicMethod {
+			t.Errorf("expected SkipMagicMethod; got %v for %s", sk.Reason, sk.ItemPath)
+		}
+	}
+}
+
+func TestEmitVariadicParamSkipped(t *testing.T) {
+	s := surface([]reflect.ClassSurface{
+		{
+			FQCN: "Foo",
+			Methods: []reflect.MethodSurface{
+				{
+					Name:       "bar",
+					ReturnType: "void",
+					Parameters: []reflect.ParameterSurface{
+						{Name: "args", Type: "string", Variadic: true},
+					},
+				},
+			},
+		},
+	}, nil, nil, nil)
+	result, err := Emit(s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Skips) != 1 {
+		t.Errorf("expected 1 skip for variadic; got %d", len(result.Skips))
+	}
+	if result.Skips[0].Reason != bridgeerrors.SkipVararg {
+		t.Errorf("expected SkipVararg; got %v", result.Skips[0].Reason)
+	}
+}
+
+func TestEmitUntypedParamSkipped(t *testing.T) {
+	s := surface([]reflect.ClassSurface{
+		{
+			FQCN: "Foo",
+			Methods: []reflect.MethodSurface{
+				{
+					Name:       "bar",
+					ReturnType: "string",
+					Parameters: []reflect.ParameterSurface{
+						{Name: "x"}, // no type
+					},
+				},
+			},
+		},
+	}, nil, nil, nil)
+	result, err := Emit(s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Skips) != 1 {
+		t.Errorf("expected 1 skip for untyped param; got %d", len(result.Skips))
+	}
+	if result.Skips[0].Reason != bridgeerrors.SkipMixed {
+		t.Errorf("expected SkipMixed for untyped; got %v", result.Skips[0].Reason)
+	}
+}
+
+func TestEmitMixedReturnSkipped(t *testing.T) {
+	s := surface([]reflect.ClassSurface{
+		{
+			FQCN: "Foo",
+			Methods: []reflect.MethodSurface{
+				{Name: "bar", ReturnType: "mixed"},
+			},
+		},
+	}, nil, nil, nil)
+	result, err := Emit(s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for _, sk := range result.Skips {
+		if sk.Reason == bridgeerrors.SkipMixed {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected SkipMixed for mixed return; got skips: %v", result.Skips)
+	}
+}
+
+func TestEmitNoReturnAnnotation(t *testing.T) {
+	// A method with no return type annotation should map to -> unit.
+	s := surface([]reflect.ClassSurface{
+		{
+			FQCN: "Foo",
+			Methods: []reflect.MethodSurface{
+				{Name: "run", ReturnType: ""},
+			},
+		},
+	}, nil, nil, nil)
+	result, err := Emit(s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.MochiSource, "-> unit") {
+		t.Errorf("expected -> unit for no return annotation; got:\n%s", result.MochiSource)
+	}
+}
+
+func TestEmitInterface(t *testing.T) {
+	s := surface(nil, []reflect.InterfaceSurface{
+		{
+			FQCN: `Psr\Log\LoggerInterface`,
+			Methods: []reflect.MethodSurface{
+				{Name: "log", ReturnType: "void", Parameters: []reflect.ParameterSurface{
+					{Name: "level", Type: "string"},
+					{Name: "message", Type: "string"},
+				}},
+			},
+		},
+	}, nil, nil)
+	result, err := Emit(s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.MochiSource, "extern type PsrLogLoggerInterface") {
+		t.Errorf("expected extern type PsrLogLoggerInterface; got:\n%s", result.MochiSource)
+	}
+	if !strings.Contains(result.MochiSource, "extern fn psr_log_logger_interface_log(self: PsrLogLoggerInterface, level: string, message: string) -> unit") {
+		t.Errorf("expected log fn; got:\n%s", result.MochiSource)
+	}
+}
+
+func TestEmitPureEnum(t *testing.T) {
+	s := surface(nil, nil, []reflect.EnumSurface{
+		{FQCN: `Foo\Status`, BackingType: "", Cases: []reflect.EnumCase{
+			{Name: "Active"}, {Name: "Inactive"},
+		}},
+	}, nil)
+	result, err := Emit(s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.MochiSource, "extern type FooStatus") {
+		t.Errorf("expected extern type FooStatus; got:\n%s", result.MochiSource)
+	}
+	// Pure enum: no fromValue
+	if strings.Contains(result.MochiSource, "from_value") {
+		t.Errorf("pure enum should not have from_value; got:\n%s", result.MochiSource)
+	}
+}
+
+func TestEmitBackedEnum(t *testing.T) {
+	s := surface(nil, nil, []reflect.EnumSurface{
+		{FQCN: `Foo\Color`, BackingType: "string", Cases: []reflect.EnumCase{
+			{Name: "Red", Value: "red"},
+		}},
+	}, nil)
+	result, err := Emit(s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.MochiSource, "extern fn foo_color_from_value(value: string) -> FooColor") {
+		t.Errorf("expected from_value fn; got:\n%s", result.MochiSource)
+	}
+}
+
+func TestEmitTopLevelFunction(t *testing.T) {
+	s := surface(nil, nil, nil, []reflect.FunctionSurface{
+		{
+			Name:       `MyNs\helper`,
+			ReturnType: "int",
+			Parameters: []reflect.ParameterSurface{
+				{Name: "x", Type: "int"},
+				{Name: "y", Type: "int"},
+			},
+		},
+	})
+	result, err := Emit(s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.MochiSource, "extern fn my_ns_helper(x: int, y: int) -> int") {
+		t.Errorf("expected my_ns_helper fn; got:\n%s", result.MochiSource)
+	}
+}
+
+func TestEmitNullableParam(t *testing.T) {
+	s := surface([]reflect.ClassSurface{
+		{
+			FQCN: "Foo",
+			Methods: []reflect.MethodSurface{
+				{
+					Name:       "bar",
+					ReturnType: "void",
+					Parameters: []reflect.ParameterSurface{
+						{Name: "x", Type: "string", Nullable: true},
+					},
+				},
+			},
+		},
+	}, nil, nil, nil)
+	result, err := Emit(s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.MochiSource, "x: string|nil") {
+		t.Errorf("expected x: string|nil for nullable param; got:\n%s", result.MochiSource)
+	}
+}
+
+func TestFormatSKIPPED(t *testing.T) {
+	skips := []bridgeerrors.SkipReport{
+		{ItemPath: "test/pkg::Foo::bar", Reason: bridgeerrors.SkipMixed, Detail: "mixed type"},
+	}
+	out := FormatSKIPPED("test/pkg", skips)
+	if !strings.Contains(out, "test/pkg::Foo::bar") {
+		t.Errorf("SKIPPED.txt missing item path; got:\n%s", out)
+	}
+	if !strings.Contains(out, "SkipMixed") {
+		t.Errorf("SKIPPED.txt missing reason; got:\n%s", out)
+	}
+}
+
+func TestFormatSKIPPEDEmpty(t *testing.T) {
+	out := FormatSKIPPED("test/pkg", nil)
+	if out != "" {
+		t.Errorf("empty skips should produce empty SKIPPED.txt; got %q", out)
+	}
+}
+
+func TestToSnakeCase(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"GuzzleHttpClient", "guzzle_http_client"},
+		{"send", "send"},
+		{"doThing", "do_thing"},
+		{"XMLParser", "x_m_l_parser"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := toSnakeCase(tc.in)
+		if got != tc.want {
+			t.Errorf("toSnakeCase(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestClassHandle(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{`GuzzleHttp\Client`, "GuzzleHttpClient"},
+		{`Psr\Log\LoggerInterface`, "PsrLogLoggerInterface"},
+		{"", "OpaqueHandle"},
+		{`\Foo\Bar`, "FooBar"},
+	}
+	for _, tc := range cases {
+		got := classHandle(tc.in)
+		if got != tc.want {
+			t.Errorf("classHandle(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/website/docs/implementation/0075/phase-05-externemit.md
+++ b/website/docs/implementation/0075/phase-05-externemit.md
@@ -1,0 +1,58 @@
+# MEP-75 Phase 5: Mochi Extern Emitter + SKIPPED.txt
+
+**Status**: LANDED 2026-05-30 00:00 (GMT+7)
+
+## Goal
+
+Implement the Mochi extern fn / extern type emitter under `package3/php/externemit`. Given a PHP reflection surface, the emitter produces:
+
+- `extern type` declarations for every public class, interface, and enum
+- `extern fn` declarations for every translatable public method and top-level function
+- A `SKIPPED.txt` report for items that cannot be translated
+
+## Emitter Design
+
+The emitter walks the `ReflectionSurface` and calls `typemap.Map` for each parameter and return type. On success it accumulates extern declarations; on failure it appends a `SkipReport`.
+
+### Naming conventions
+
+- Type handles: PascalCase from FQCN (GuzzleHttp\\Client -> GuzzleHttpClient)
+- Method fns: `snake_case(handle) + "_" + snake_case(method)`, e.g. `guzzle_http_client_send`
+- Static methods: no `self` receiver parameter
+- Top-level functions: `snake_case(namespace_fn_name)`
+- Backed enum constructor: `snake_case(handle) + "_from_value"`
+
+### Skip rules
+
+| Condition | Reason |
+|---|---|
+| Magic method (__construct, __get, etc.) | SkipMagicMethod |
+| Variadic parameter | SkipVararg |
+| Untyped parameter (no annotation) | SkipMixed |
+| Return type mixed/object/callable/etc. | SkipMixed / SkipObject / etc. |
+| array (untyped) parameter | SkipUntypedArray |
+| Intersection type A&B | SkipIntersection |
+
+## Files Landed
+
+- `package3/php/externemit/externemit.go` -- Emit() + FormatSKIPPED()
+- `package3/php/externemit/externemit_test.go` -- 16 test functions
+
+## Test Coverage
+
+- Empty surface produces no output and no skips
+- Class extern type declaration
+- Instance method with receiver and typed parameters
+- Static method (no self receiver)
+- Magic methods skip with SkipMagicMethod
+- Variadic parameters skip with SkipVararg
+- Untyped parameters skip with SkipMixed
+- Mixed return type skips
+- No return annotation maps to unit
+- Interface extern type + method
+- Pure enum extern type (no fromValue)
+- Backed enum fromValue constructor
+- Top-level function emission
+- Nullable parameter (string|nil)
+- FormatSKIPPED with entries and empty
+- toSnakeCase and classHandle unit tests


### PR DESCRIPTION
## Summary

- Implements `Emit()` under `package3/php/externemit`: translates a PHP `ReflectionSurface` into `extern type` and `extern fn` Mochi declarations
- Skipped items (magic methods, variadic, untyped params, mixed/object return types) collected as `SkipReport` entries
- `FormatSKIPPED()` renders skip reports to SKIPPED.txt format for user guidance
- Backed enums get a `fromValue` constructor; static methods omit self receiver

## Test plan

- [x] `go test ./package3/php/externemit/...` -- 16 test functions pass
- [x] `go test ./package3/php/...` -- all packages green
- [x] `go vet ./package3/php/externemit/...` -- clean

Closes #22870