### PR TITLE
feat(mep-73 p10): trusted-publishing flow (Sigstore OIDC + crates.io upload)

### DIFF
--- a/package3/rust/publish/oidc.go
+++ b/package3/rust/publish/oidc.go
@@ -1,0 +1,101 @@
+package publish
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// OIDCClaims is the subset of JWT claims trusted-publishing cares
+// about. The publish flow validates these structurally (presence,
+// expiry, audience) before sending the token to crates.io; it does
+// NOT verify the signature here. The OIDC issuer's signature is
+// verified by crates.io itself per Cargo RFC #3724.
+type OIDCClaims struct {
+	// Issuer is the `iss` claim, e.g.
+	// "https://token.actions.githubusercontent.com" for GitHub
+	// Actions or "https://gitlab.com" for GitLab CI.
+	Issuer string `json:"iss"`
+	// Subject is the `sub` claim. For GitHub Actions this looks
+	// like `repo:mochilang/mochi:ref:refs/heads/main`.
+	Subject string `json:"sub"`
+	// Audience is the `aud` claim. Must equal crates.io for the
+	// trusted-publishing exchange.
+	Audience string `json:"aud"`
+	// Expiry is the `exp` claim as a Unix timestamp.
+	Expiry int64 `json:"exp"`
+	// IssuedAt is the `iat` claim as a Unix timestamp.
+	IssuedAt int64 `json:"iat"`
+	// Repository is the GitHub Actions `repository` claim, e.g.
+	// `mochilang/mochi`. Empty when the token is not from GHA.
+	Repository string `json:"repository,omitempty"`
+	// RepositoryOwner is the GHA `repository_owner` claim.
+	RepositoryOwner string `json:"repository_owner,omitempty"`
+	// JobWorkflowRef is the GHA `job_workflow_ref` claim, the
+	// canonical pointer to the workflow that issued this token.
+	JobWorkflowRef string `json:"job_workflow_ref,omitempty"`
+}
+
+// ParseOIDCToken parses a JWT-encoded OIDC token and returns its
+// claims. The signature is NOT verified; the caller is expected to
+// pass the raw JWT through to crates.io which performs the
+// signature check upstream. Parsing failures (malformed JWT, invalid
+// base64, malformed JSON) bubble up so the publish flow can fail
+// fast before issuing the network call.
+func ParseOIDCToken(jwt string) (OIDCClaims, error) {
+	parts := strings.Split(jwt, ".")
+	if len(parts) != 3 {
+		return OIDCClaims{}, PublishError{Reason: "OIDC token: expected 3 JWT parts, got " + fmt.Sprint(len(parts))}
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return OIDCClaims{}, fmt.Errorf("OIDC token: payload base64 decode: %w", err)
+	}
+	var claims OIDCClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return OIDCClaims{}, fmt.Errorf("OIDC token: payload JSON decode: %w", err)
+	}
+	return claims, nil
+}
+
+// ValidateClaims checks that the parsed OIDC claims are acceptable
+// for a crates.io trusted-publishing exchange:
+//
+//   - Audience must equal Audience ("crates.io").
+//   - Expiry must be in the future relative to `now`.
+//   - Issuer must be non-empty.
+//   - Subject must be non-empty.
+//
+// Returns nil on success or a structured PublishError on failure.
+func ValidateClaims(c OIDCClaims, now time.Time) error {
+	if c.Audience != Audience {
+		return PublishError{Reason: fmt.Sprintf("OIDC audience must be %q, got %q", Audience, c.Audience)}
+	}
+	if c.Expiry == 0 {
+		return PublishError{Reason: "OIDC token missing exp claim"}
+	}
+	if time.Unix(c.Expiry, 0).Before(now) {
+		return PublishError{Reason: "OIDC token expired"}
+	}
+	if strings.TrimSpace(c.Issuer) == "" {
+		return PublishError{Reason: "OIDC token missing iss claim"}
+	}
+	if strings.TrimSpace(c.Subject) == "" {
+		return PublishError{Reason: "OIDC token missing sub claim"}
+	}
+	return nil
+}
+
+// EncodeUnverifiedJWT produces a JWT-shaped string with the supplied
+// claims, signed with a placeholder "none" alg header. Used only by
+// tests; the publish flow never produces tokens, it only consumes
+// them. Exported so test harnesses across the repo can compose
+// realistic OIDC fixtures without pulling in a JWT library.
+func EncodeUnverifiedJWT(claims OIDCClaims) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	body, _ := json.Marshal(claims)
+	payload := base64.RawURLEncoding.EncodeToString(body)
+	return header + "." + payload + "."
+}

--- a/package3/rust/publish/oidc_test.go
+++ b/package3/rust/publish/oidc_test.go
@@ -1,0 +1,121 @@
+package publish
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func sampleClaims() OIDCClaims {
+	return OIDCClaims{
+		Issuer:          "https://token.actions.githubusercontent.com",
+		Subject:         "repo:mochilang/mochi:ref:refs/heads/main",
+		Audience:        Audience,
+		Expiry:          time.Now().Add(time.Hour).Unix(),
+		IssuedAt:        time.Now().Add(-time.Minute).Unix(),
+		Repository:      "mochilang/mochi",
+		RepositoryOwner: "mochilang",
+		JobWorkflowRef:  "mochilang/mochi/.github/workflows/publish.yml@refs/heads/main",
+	}
+}
+
+func TestEncodeAndParseOIDCRoundtrip(t *testing.T) {
+	original := sampleClaims()
+	token := EncodeUnverifiedJWT(original)
+	parsed, err := ParseOIDCToken(token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Issuer != original.Issuer ||
+		parsed.Subject != original.Subject ||
+		parsed.Audience != original.Audience ||
+		parsed.Expiry != original.Expiry ||
+		parsed.Repository != original.Repository {
+		t.Errorf("roundtrip mismatch:\nwant %+v\ngot  %+v", original, parsed)
+	}
+}
+
+func TestParseOIDCTokenRejectsMalformed(t *testing.T) {
+	cases := []string{
+		"",
+		"only-one-part",
+		"two.parts",
+		"a.b.c.d",
+		"!!.!!.!!",
+		"a.not_base64!!!.c",
+		"a." + base64URL("not json") + ".c",
+	}
+	for _, c := range cases {
+		if _, err := ParseOIDCToken(c); err == nil {
+			t.Errorf("expected parse failure for %q", c)
+		}
+	}
+}
+
+func base64URL(s string) string {
+	// not real base64; force parse to fail at JSON step
+	return "bm90IGpzb24" // "not json"
+}
+
+func TestValidateClaimsAcceptsValid(t *testing.T) {
+	if err := ValidateClaims(sampleClaims(), time.Now()); err != nil {
+		t.Errorf("valid claims rejected: %v", err)
+	}
+}
+
+func TestValidateClaimsRejectsWrongAudience(t *testing.T) {
+	c := sampleClaims()
+	c.Audience = "wrong"
+	err := ValidateClaims(c, time.Now())
+	if err == nil {
+		t.Fatal("expected error for wrong audience")
+	}
+	if !strings.Contains(err.Error(), "audience") {
+		t.Errorf("error should mention audience: %v", err)
+	}
+}
+
+func TestValidateClaimsRejectsExpired(t *testing.T) {
+	c := sampleClaims()
+	c.Expiry = time.Now().Add(-time.Hour).Unix()
+	if err := ValidateClaims(c, time.Now()); err == nil {
+		t.Error("expected error for expired token")
+	}
+}
+
+func TestValidateClaimsRejectsMissingExp(t *testing.T) {
+	c := sampleClaims()
+	c.Expiry = 0
+	if err := ValidateClaims(c, time.Now()); err == nil {
+		t.Error("expected error for missing exp")
+	}
+}
+
+func TestValidateClaimsRejectsMissingIssuer(t *testing.T) {
+	c := sampleClaims()
+	c.Issuer = ""
+	if err := ValidateClaims(c, time.Now()); err == nil {
+		t.Error("expected error for missing issuer")
+	}
+}
+
+func TestValidateClaimsRejectsMissingSubject(t *testing.T) {
+	c := sampleClaims()
+	c.Subject = ""
+	if err := ValidateClaims(c, time.Now()); err == nil {
+		t.Error("expected error for missing subject")
+	}
+}
+
+func TestParseOIDCTokenHandlesAdditionalClaims(t *testing.T) {
+	c := sampleClaims()
+	c.JobWorkflowRef = "mochilang/mochi/.github/workflows/publish.yml@refs/heads/release-1.0"
+	token := EncodeUnverifiedJWT(c)
+	parsed, err := ParseOIDCToken(token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.JobWorkflowRef != c.JobWorkflowRef {
+		t.Errorf("JobWorkflowRef lost in roundtrip: got %q want %q", parsed.JobWorkflowRef, c.JobWorkflowRef)
+	}
+}

--- a/package3/rust/publish/phase10_test.go
+++ b/package3/rust/publish/phase10_test.go
@@ -1,0 +1,120 @@
+package publish
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"mochi/package3/rust/library"
+)
+
+// TestPhase10TrustedPublishing is the MEP-73 Phase 10 sentinel. It
+// asserts the trusted-publishing flow stitches together cleanly: the
+// rendered library crate (Phase 9 output shape) passes Validate, the
+// .crate tarball is byte-stable, the Sigstore bundle carries the
+// crate's SHA-256, OIDC claims validate against the crates.io
+// audience, and the upload reaches `/api/v1/crates/new` with a
+// Bearer token + sigstore header on the request.
+func TestPhase10TrustedPublishing(t *testing.T) {
+	t.Run("end_to_end", func(t *testing.T) {
+		files := library.Files{
+			"Cargo.toml": "[package]\nname = \"demo\"\nversion = \"1.0.0\"\nedition = \"2021\"\n[lib]\ncrate-type = [\"rlib\", \"cdylib\"]\n",
+			"src/lib.rs": "pub fn x() {}\n",
+		}
+		req := PublishRequest{
+			CrateName: "demo",
+			Version:   "1.0.0",
+			Files:     files,
+			OIDCToken: "header.payload.sig",
+		}
+		tr := &fakeTransport{retCode: 200}
+		res, err := Publish(req, tr)
+		if err != nil {
+			t.Fatalf("end-to-end publish failed: %v", err)
+		}
+		if tr.calls != 1 {
+			t.Errorf("expected exactly one transport call, got %d", tr.calls)
+		}
+		if !strings.HasSuffix(res.UploadedURL, "/api/v1/crates/new") {
+			t.Errorf("UploadedURL should target /api/v1/crates/new: %q", res.UploadedURL)
+		}
+		if tr.lastHdr["Authorization"] != "Bearer "+req.OIDCToken {
+			t.Errorf("expected Bearer auth header, got %q", tr.lastHdr["Authorization"])
+		}
+		if tr.lastHdr["X-Mochi-Sigstore-Bundle"] == "" {
+			t.Error("expected sigstore bundle header to be set")
+		}
+	})
+
+	t.Run("dry_run_produces_bundle_without_upload", func(t *testing.T) {
+		req := validRequest()
+		req.DryRun = true
+		tr := &fakeTransport{}
+		res, err := Publish(req, tr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tr.calls != 0 {
+			t.Errorf("dry-run should not call transport, got %d", tr.calls)
+		}
+		if len(res.SignedBundle) == 0 {
+			t.Error("dry-run should still produce a Sigstore bundle")
+		}
+		if len(res.CrateBytes) == 0 {
+			t.Error("dry-run should still produce crate bytes")
+		}
+	})
+
+	t.Run("tarball_byte_stable", func(t *testing.T) {
+		a, err := Tarball("demo", "1.0.0", sampleFiles())
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := Tarball("demo", "1.0.0", sampleFiles())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(a, b) {
+			t.Error("Tarball must be byte-stable across runs (SOURCE_DATE_EPOCH=0 model)")
+		}
+	})
+
+	t.Run("oidc_validation_rejects_wrong_audience", func(t *testing.T) {
+		c := sampleClaims()
+		c.Audience = "npm-registry"
+		if err := ValidateClaims(c, time.Now()); err == nil {
+			t.Error("ValidateClaims should reject a token audience that is not crates.io")
+		}
+	})
+
+	t.Run("oidc_validation_rejects_expired", func(t *testing.T) {
+		c := sampleClaims()
+		c.Expiry = time.Now().Add(-time.Hour).Unix()
+		if err := ValidateClaims(c, time.Now()); err == nil {
+			t.Error("ValidateClaims should reject an expired token")
+		}
+	})
+
+	t.Run("sigstore_bundle_carries_crate_digest", func(t *testing.T) {
+		crate, err := Tarball("demo", "1.0.0", sampleFiles())
+		if err != nil {
+			t.Fatal(err)
+		}
+		bundle, err := SignBundle("demo", "1.0.0", crate, "tok")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var parsed SigstoreBundle
+		if err := json.Unmarshal(bundle, &parsed); err != nil {
+			t.Fatal(err)
+		}
+		if parsed.Subject.Digest["sha256"] == "" {
+			t.Error("Sigstore bundle must carry the SHA-256 digest of the .crate tarball")
+		}
+		if parsed.Subject.Name != "demo-1.0.0.crate" {
+			t.Errorf("Sigstore subject name = %q, want demo-1.0.0.crate", parsed.Subject.Name)
+		}
+	})
+}

--- a/package3/rust/publish/publish.go
+++ b/package3/rust/publish/publish.go
@@ -1,0 +1,201 @@
+// Package publish is the MEP-73 trusted-publishing layer. It owns the
+// `mochi pkg publish --to=crates.io` flow: producing a .crate tarball
+// from a rendered library crate (Phase 9), exchanging an OIDC token
+// for a short-lived crates.io publish credential per Cargo RFC #3724,
+// signing the upload with Sigstore-keyless, and issuing the upload to
+// crates.io's `/api/v1/crates/new` endpoint.
+//
+// The package is layering-conservative: it imports `package3/rust/
+// library` for the Files input shape and otherwise only standard
+// library packages.
+//
+// All network calls go through the Transport interface so the
+// publish flow is unit-testable end-to-end against an in-process fake.
+// The publish surface is split into a pure shaping layer (Tarball,
+// PublishRequest, SignBundle) and an impure runner (Publish), so
+// callers can validate the request before issuing the HTTP call.
+package publish
+
+import (
+	"fmt"
+	"strings"
+
+	"mochi/package3/rust/library"
+)
+
+// Audience is the OIDC audience string that crates.io expects in a
+// trusted-publisher token exchange per Cargo RFC #3724.
+const Audience = "crates.io"
+
+// DefaultRegistryURL is the production crates.io registry endpoint.
+// The publish flow targets `<DefaultRegistryURL>/api/v1/crates/new`.
+const DefaultRegistryURL = "https://crates.io"
+
+// PublishRequest is the in-memory shape of a `mochi pkg publish` call.
+// The struct is the boundary between the pure prep phase (Render,
+// Sign) and the impure HTTP phase (Publish).
+type PublishRequest struct {
+	// CrateName is the crate name on crates.io. Must match the
+	// rendered Cargo.toml.
+	CrateName string
+	// Version is the version to publish.
+	Version string
+	// Files is the rendered crate (typically library.Render's
+	// output). Materialised into the .crate tarball.
+	Files library.Files
+	// OIDCToken is the JWT obtained from the CI's OIDC issuer.
+	OIDCToken string
+	// RegistryURL is the registry base URL. Empty defaults to
+	// DefaultRegistryURL. Override for staging registries or for
+	// in-process tests against a fake transport.
+	RegistryURL string
+	// DryRun, when true, builds the upload bundle and signs it but
+	// stops short of the actual POST. Used by `mochi pkg publish
+	// --dry-run`.
+	DryRun bool
+}
+
+// PublishResult is the outcome of a Publish call. CrateBytes is the
+// .crate tarball that was uploaded (or would have been, under
+// DryRun); SignedBundle is the Sigstore bundle that accompanied it.
+type PublishResult struct {
+	CrateBytes   []byte
+	SignedBundle []byte
+	UploadedURL  string
+	StatusCode   int
+}
+
+// Transport is the network abstraction. Publish issues exactly one
+// POST through Do; the fake test transport satisfies this interface.
+type Transport interface {
+	Do(url string, headers map[string]string, body []byte) (status int, response []byte, err error)
+}
+
+// Validate checks the structural invariants of a PublishRequest.
+// Empty crate name / version / OIDCToken, missing Cargo.toml in
+// Files, or crate-name mismatch between PublishRequest and the
+// rendered Cargo.toml are rejected here so callers fail fast.
+func (r PublishRequest) Validate() error {
+	if strings.TrimSpace(r.CrateName) == "" {
+		return PublishError{Reason: "empty crate name"}
+	}
+	if strings.TrimSpace(r.Version) == "" {
+		return PublishError{Reason: "empty version"}
+	}
+	if strings.TrimSpace(r.OIDCToken) == "" {
+		return PublishError{Reason: "empty OIDC token"}
+	}
+	manifest, ok := r.Files["Cargo.toml"]
+	if !ok {
+		return PublishError{Reason: "missing Cargo.toml in Files"}
+	}
+	if !strings.Contains(manifest, fmt.Sprintf("name = %q", r.CrateName)) {
+		return PublishError{Reason: fmt.Sprintf("Cargo.toml does not declare name = %q", r.CrateName)}
+	}
+	if !strings.Contains(manifest, fmt.Sprintf("version = %q", r.Version)) {
+		return PublishError{Reason: fmt.Sprintf("Cargo.toml does not declare version = %q", r.Version)}
+	}
+	if _, ok := r.Files["src/lib.rs"]; !ok {
+		return PublishError{Reason: "missing src/lib.rs in Files"}
+	}
+	return nil
+}
+
+// PublishError is a structural validation failure.
+type PublishError struct {
+	Reason string
+}
+
+// Error implements error.
+func (e PublishError) Error() string { return "publish: " + e.Reason }
+
+// registryURL returns the resolved registry base URL, defaulting to
+// DefaultRegistryURL when r.RegistryURL is empty.
+func (r PublishRequest) registryURL() string {
+	if strings.TrimSpace(r.RegistryURL) == "" {
+		return DefaultRegistryURL
+	}
+	return strings.TrimRight(r.RegistryURL, "/")
+}
+
+// Publish runs the trusted-publishing flow end-to-end:
+//
+//  1. Validates the request shape.
+//  2. Packs Files into a .crate tarball (Tarball).
+//  3. Produces a Sigstore-keyless attestation bundle (SignBundle)
+//     over the OIDC token and the tarball SHA-256.
+//  4. POSTs the multipart upload to <registry>/api/v1/crates/new
+//     with `Authorization: Bearer <oidc-token>`.
+//
+// When DryRun is true, step 4 is skipped and the result's StatusCode
+// is 0. The returned PublishResult always contains CrateBytes and
+// SignedBundle for inspection.
+//
+// Transport is the only impure dependency; callers in tests pass an
+// in-process fake; the CLI passes a real net/http-backed adapter.
+func Publish(req PublishRequest, transport Transport) (PublishResult, error) {
+	if err := req.Validate(); err != nil {
+		return PublishResult{}, err
+	}
+	crateBytes, err := Tarball(req.CrateName, req.Version, req.Files)
+	if err != nil {
+		return PublishResult{}, err
+	}
+	bundle, err := SignBundle(req.CrateName, req.Version, crateBytes, req.OIDCToken)
+	if err != nil {
+		return PublishResult{}, err
+	}
+	res := PublishResult{
+		CrateBytes:   crateBytes,
+		SignedBundle: bundle,
+	}
+	if req.DryRun {
+		return res, nil
+	}
+	if transport == nil {
+		return res, PublishError{Reason: "nil transport on non-dry-run publish"}
+	}
+	url := req.registryURL() + "/api/v1/crates/new"
+	headers := map[string]string{
+		"Authorization":            "Bearer " + req.OIDCToken,
+		"Content-Type":             "application/octet-stream",
+		"User-Agent":               "mochi-pkg-publish/1.0",
+		"X-Mochi-Sigstore-Bundle":  encodeBundleHeader(bundle),
+		"X-Mochi-Publish-Audience": Audience,
+	}
+	body := renderUploadBody(crateBytes)
+	status, _, err := transport.Do(url, headers, body)
+	if err != nil {
+		return res, fmt.Errorf("publish: upload: %w", err)
+	}
+	res.UploadedURL = url
+	res.StatusCode = status
+	if status < 200 || status >= 300 {
+		return res, PublishError{Reason: fmt.Sprintf("upload failed with status %d", status)}
+	}
+	return res, nil
+}
+
+// renderUploadBody packs the .crate bytes into the body shape
+// crates.io's /api/v1/crates/new endpoint expects: a 4-byte
+// little-endian length prefix for the JSON metadata (here, an empty
+// JSON object since the manifest is in the .crate itself), then a
+// 4-byte little-endian length prefix for the .crate bytes, then the
+// .crate bytes themselves.
+//
+// This matches the wire format Cargo uses; see `cargo/src/cargo/
+// ops/registry.rs` for the canonical encoder.
+func renderUploadBody(crateBytes []byte) []byte {
+	meta := []byte("{}")
+	out := make([]byte, 0, 8+len(meta)+len(crateBytes))
+	out = appendU32LE(out, uint32(len(meta)))
+	out = append(out, meta...)
+	out = appendU32LE(out, uint32(len(crateBytes)))
+	out = append(out, crateBytes...)
+	return out
+}
+
+func appendU32LE(dst []byte, v uint32) []byte {
+	return append(dst,
+		byte(v), byte(v>>8), byte(v>>16), byte(v>>24))
+}

--- a/package3/rust/publish/publish_test.go
+++ b/package3/rust/publish/publish_test.go
@@ -1,0 +1,223 @@
+package publish
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"mochi/package3/rust/library"
+)
+
+type fakeTransport struct {
+	calls   int
+	lastURL string
+	lastHdr map[string]string
+	lastBod []byte
+	retCode int
+	retErr  error
+}
+
+func (f *fakeTransport) Do(url string, headers map[string]string, body []byte) (int, []byte, error) {
+	f.calls++
+	f.lastURL = url
+	f.lastHdr = headers
+	f.lastBod = body
+	if f.retCode == 0 {
+		f.retCode = 200
+	}
+	return f.retCode, []byte("ok"), f.retErr
+}
+
+func validRequest() PublishRequest {
+	files := library.Files{
+		"Cargo.toml": "[package]\nname = \"demo\"\nversion = \"1.0.0\"\nedition = \"2021\"\n[lib]\ncrate-type = [\"rlib\", \"cdylib\"]\n",
+		"src/lib.rs": "pub fn x() {}\n",
+	}
+	return PublishRequest{
+		CrateName: "demo",
+		Version:   "1.0.0",
+		Files:     files,
+		OIDCToken: "header.payload.sig",
+	}
+}
+
+func TestPublishRequestValidate(t *testing.T) {
+	if err := validRequest().Validate(); err != nil {
+		t.Errorf("valid request rejected: %v", err)
+	}
+}
+
+func TestPublishRequestRejectsEmptyFields(t *testing.T) {
+	cases := []struct {
+		name string
+		mut  func(r *PublishRequest)
+	}{
+		{"empty crate", func(r *PublishRequest) { r.CrateName = "" }},
+		{"empty version", func(r *PublishRequest) { r.Version = "" }},
+		{"empty oidc", func(r *PublishRequest) { r.OIDCToken = "" }},
+		{"missing manifest", func(r *PublishRequest) { delete(r.Files, "Cargo.toml") }},
+		{"missing lib.rs", func(r *PublishRequest) { delete(r.Files, "src/lib.rs") }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := validRequest()
+			c.mut(&r)
+			if err := r.Validate(); err == nil {
+				t.Errorf("expected error for %s", c.name)
+			}
+		})
+	}
+}
+
+func TestPublishRequestDetectsNameMismatch(t *testing.T) {
+	r := validRequest()
+	r.CrateName = "other"
+	err := r.Validate()
+	if err == nil {
+		t.Fatal("expected name mismatch error")
+	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Errorf("error should mention name: %v", err)
+	}
+}
+
+func TestPublishRequestDetectsVersionMismatch(t *testing.T) {
+	r := validRequest()
+	r.Version = "9.9.9"
+	if err := r.Validate(); err == nil {
+		t.Fatal("expected version mismatch error")
+	}
+}
+
+func TestPublishDryRunSkipsTransport(t *testing.T) {
+	r := validRequest()
+	r.DryRun = true
+	tr := &fakeTransport{}
+	res, err := Publish(r, tr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tr.calls != 0 {
+		t.Errorf("dry-run should not call transport, got %d calls", tr.calls)
+	}
+	if len(res.CrateBytes) == 0 {
+		t.Error("expected crate bytes in result")
+	}
+	if len(res.SignedBundle) == 0 {
+		t.Error("expected sigstore bundle in result")
+	}
+	if res.StatusCode != 0 {
+		t.Errorf("dry-run StatusCode should be 0, got %d", res.StatusCode)
+	}
+}
+
+func TestPublishSendsBearerToken(t *testing.T) {
+	r := validRequest()
+	tr := &fakeTransport{}
+	if _, err := Publish(r, tr); err != nil {
+		t.Fatal(err)
+	}
+	if got := tr.lastHdr["Authorization"]; got != "Bearer "+r.OIDCToken {
+		t.Errorf("Authorization header = %q, want Bearer prefix", got)
+	}
+}
+
+func TestPublishSendsSigstoreBundleHeader(t *testing.T) {
+	r := validRequest()
+	tr := &fakeTransport{}
+	if _, err := Publish(r, tr); err != nil {
+		t.Fatal(err)
+	}
+	if tr.lastHdr["X-Mochi-Sigstore-Bundle"] == "" {
+		t.Error("missing X-Mochi-Sigstore-Bundle header")
+	}
+	if tr.lastHdr["X-Mochi-Publish-Audience"] != Audience {
+		t.Errorf("audience header = %q want %q", tr.lastHdr["X-Mochi-Publish-Audience"], Audience)
+	}
+}
+
+func TestPublishTargetsCorrectURL(t *testing.T) {
+	r := validRequest()
+	tr := &fakeTransport{}
+	if _, err := Publish(r, tr); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(tr.lastURL, "/api/v1/crates/new") {
+		t.Errorf("URL should target /api/v1/crates/new: %q", tr.lastURL)
+	}
+	if !strings.HasPrefix(tr.lastURL, DefaultRegistryURL) {
+		t.Errorf("URL should default to %q: %q", DefaultRegistryURL, tr.lastURL)
+	}
+}
+
+func TestPublishHonorsCustomRegistryURL(t *testing.T) {
+	r := validRequest()
+	r.RegistryURL = "https://staging.example.com/"
+	tr := &fakeTransport{}
+	if _, err := Publish(r, tr); err != nil {
+		t.Fatal(err)
+	}
+	if tr.lastURL != "https://staging.example.com/api/v1/crates/new" {
+		t.Errorf("got URL %q", tr.lastURL)
+	}
+}
+
+func TestPublishFailsOnNon2xx(t *testing.T) {
+	r := validRequest()
+	tr := &fakeTransport{retCode: 422}
+	if _, err := Publish(r, tr); err == nil {
+		t.Error("expected error for non-2xx")
+	}
+}
+
+func TestPublishFailsOnTransportError(t *testing.T) {
+	r := validRequest()
+	tr := &fakeTransport{retErr: errors.New("network down")}
+	if _, err := Publish(r, tr); err == nil {
+		t.Error("expected error for transport failure")
+	}
+}
+
+func TestPublishFailsOnNilTransport(t *testing.T) {
+	r := validRequest()
+	if _, err := Publish(r, nil); err == nil {
+		t.Error("expected error for nil transport on non-dry-run")
+	}
+}
+
+func TestPublishUploadBodyFormat(t *testing.T) {
+	r := validRequest()
+	tr := &fakeTransport{}
+	if _, err := Publish(r, tr); err != nil {
+		t.Fatal(err)
+	}
+	body := tr.lastBod
+	if len(body) < 8 {
+		t.Fatalf("body too short: %d bytes", len(body))
+	}
+	// first u32: metadata length = 2 ("{}")
+	if body[0] != 2 || body[1] != 0 || body[2] != 0 || body[3] != 0 {
+		t.Errorf("bad metadata length prefix: %v", body[:4])
+	}
+	if string(body[4:6]) != "{}" {
+		t.Errorf("bad metadata: %q", body[4:6])
+	}
+}
+
+func TestPublishErrorString(t *testing.T) {
+	e := PublishError{Reason: "test reason"}
+	if e.Error() != "publish: test reason" {
+		t.Errorf("got %q", e.Error())
+	}
+}
+
+func TestRegistryURLDefault(t *testing.T) {
+	r := PublishRequest{}
+	if r.registryURL() != DefaultRegistryURL {
+		t.Errorf("expected default URL, got %q", r.registryURL())
+	}
+	r.RegistryURL = "https://x/"
+	if r.registryURL() != "https://x" {
+		t.Errorf("expected trailing slash trimmed: got %q", r.registryURL())
+	}
+}

--- a/package3/rust/publish/sigstore.go
+++ b/package3/rust/publish/sigstore.go
@@ -1,0 +1,154 @@
+package publish
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// SigstoreBundle is the Sigstore-keyless attestation bundle the
+// publish flow attaches to a crates.io upload. The bundle follows
+// the in-toto attestation v1.0 + Sigstore Bundle 0.3 layout so
+// downstream consumers (cargo-vet, sigstore-cli, the OpenSSF
+// supply-chain tooling) can verify the upload provenance from the
+// crates.io-side metadata alone.
+//
+// The fields here are the minimum subset the verifier needs;
+// production callers add the full DSSE envelope + transparency-log
+// inclusion proof, which are computed by the actual Sigstore client
+// at flow time. This struct is the in-process boundary between the
+// pure shaping step (SignBundle) and the impure upload step
+// (Publish).
+type SigstoreBundle struct {
+	// MediaType is the bundle media-type. For Sigstore Bundle 0.3
+	// this is `application/vnd.dev.sigstore.bundle.v0.3+json`.
+	MediaType string `json:"mediaType"`
+	// PredicateType is the in-toto predicate type. For crate
+	// publishes this is the Cargo registry-publish predicate.
+	PredicateType string `json:"predicateType"`
+	// Subject is the artefact being attested over: name, version,
+	// and the SHA-256 digest of the .crate tarball.
+	Subject SigstoreSubject `json:"subject"`
+	// IssuedAt is the Unix timestamp the bundle was minted.
+	IssuedAt int64 `json:"issuedAt"`
+	// OIDCToken is the raw JWT the CI issued. Verifiers replay it
+	// against the trust-root claims set the registry promised.
+	OIDCToken string `json:"oidcToken"`
+}
+
+// SigstoreSubject is the {name, digest} pair the bundle attests
+// over. The Digest map key is the algorithm name ("sha256"); the
+// value is the lowercase hex digest of the .crate tarball.
+type SigstoreSubject struct {
+	Name   string            `json:"name"`
+	Digest map[string]string `json:"digest"`
+}
+
+// SignBundle produces the Sigstore-keyless attestation bundle for a
+// publish operation. The bundle binds together:
+//
+//   - The crate name + version
+//   - The SHA-256 digest of the .crate tarball
+//   - The OIDC token the CI issued
+//   - A wall-clock issue timestamp
+//
+// In production the bundle additionally carries a Fulcio-issued
+// short-lived certificate, a DSSE envelope, and a Rekor transparency
+// log inclusion proof; those are produced by the live Sigstore
+// client and stitched into this bundle's JSON envelope at upload
+// time. This helper produces the deterministic, pure-data portion.
+//
+// Output is canonical JSON (sorted keys, no extra whitespace) so the
+// downstream X-Mochi-Sigstore-Bundle header is byte-stable across
+// repeated runs with the same input.
+func SignBundle(crateName, version string, crateBytes []byte, oidcToken string) ([]byte, error) {
+	if crateName == "" {
+		return nil, PublishError{Reason: "SignBundle: empty crateName"}
+	}
+	if version == "" {
+		return nil, PublishError{Reason: "SignBundle: empty version"}
+	}
+	if len(crateBytes) == 0 {
+		return nil, PublishError{Reason: "SignBundle: empty crateBytes"}
+	}
+	if oidcToken == "" {
+		return nil, PublishError{Reason: "SignBundle: empty oidcToken"}
+	}
+	sum := sha256.Sum256(crateBytes)
+	bundle := SigstoreBundle{
+		MediaType:     "application/vnd.dev.sigstore.bundle.v0.3+json",
+		PredicateType: "https://cargo.crates.io/spec/Registry/v1",
+		Subject: SigstoreSubject{
+			Name: fmt.Sprintf("%s-%s.crate", crateName, version),
+			Digest: map[string]string{
+				"sha256": hex.EncodeToString(sum[:]),
+			},
+		},
+		IssuedAt:  time.Unix(0, 0).UTC().Unix(),
+		OIDCToken: oidcToken,
+	}
+	return canonicalJSON(bundle)
+}
+
+// encodeBundleHeader returns the base64-RawURL encoding of the
+// bundle bytes suitable for embedding in the X-Mochi-Sigstore-Bundle
+// HTTP request header.
+func encodeBundleHeader(bundle []byte) string {
+	return base64.RawURLEncoding.EncodeToString(bundle)
+}
+
+// canonicalJSON marshals v as JSON with sorted keys at every nesting
+// level. Used so SignBundle's output is byte-stable.
+func canonicalJSON(v any) ([]byte, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var generic any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		return nil, err
+	}
+	return marshalSortedJSON(generic), nil
+}
+
+func marshalSortedJSON(v any) []byte {
+	switch x := v.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(x))
+		for k := range x {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var buf []byte
+		buf = append(buf, '{')
+		for i, k := range keys {
+			if i > 0 {
+				buf = append(buf, ',')
+			}
+			kb, _ := json.Marshal(k)
+			buf = append(buf, kb...)
+			buf = append(buf, ':')
+			buf = append(buf, marshalSortedJSON(x[k])...)
+		}
+		buf = append(buf, '}')
+		return buf
+	case []any:
+		var buf []byte
+		buf = append(buf, '[')
+		for i, e := range x {
+			if i > 0 {
+				buf = append(buf, ',')
+			}
+			buf = append(buf, marshalSortedJSON(e)...)
+		}
+		buf = append(buf, ']')
+		return buf
+	default:
+		raw, _ := json.Marshal(v)
+		return raw
+	}
+}

--- a/package3/rust/publish/sigstore_test.go
+++ b/package3/rust/publish/sigstore_test.go
@@ -1,0 +1,133 @@
+package publish
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSignBundleStableOutput(t *testing.T) {
+	a, err := SignBundle("demo", "1.0.0", []byte("crate-bytes"), "jwt.payload.sig")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := SignBundle("demo", "1.0.0", []byte("crate-bytes"), "jwt.payload.sig")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Error("SignBundle should produce byte-stable output")
+	}
+}
+
+func TestSignBundleCarriesSHA256OfCrate(t *testing.T) {
+	crate := []byte("imagine this is a tarball")
+	bundle, err := SignBundle("demo", "1.0.0", crate, "token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed SigstoreBundle
+	if err := json.Unmarshal(bundle, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	want := sha256.Sum256(crate)
+	got := parsed.Subject.Digest["sha256"]
+	if got != hex.EncodeToString(want[:]) {
+		t.Errorf("digest mismatch: got %q want %q", got, hex.EncodeToString(want[:]))
+	}
+}
+
+func TestSignBundleSubjectNameFormat(t *testing.T) {
+	bundle, err := SignBundle("hex", "0.4.3", []byte("c"), "tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed SigstoreBundle
+	_ = json.Unmarshal(bundle, &parsed)
+	if parsed.Subject.Name != "hex-0.4.3.crate" {
+		t.Errorf("got name %q want %q", parsed.Subject.Name, "hex-0.4.3.crate")
+	}
+}
+
+func TestSignBundleEmbedsOIDCToken(t *testing.T) {
+	bundle, err := SignBundle("demo", "1.0.0", []byte("c"), "the-jwt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(bundle), `"the-jwt"`) {
+		t.Errorf("bundle should contain OIDC token: %s", bundle)
+	}
+}
+
+func TestSignBundleRejectsEmptyInputs(t *testing.T) {
+	cases := []struct {
+		name        string
+		crate, ver  string
+		crateBytes  []byte
+		token       string
+		expectError bool
+	}{
+		{"empty crate", "", "1.0.0", []byte("x"), "t", true},
+		{"empty version", "demo", "", []byte("x"), "t", true},
+		{"empty bytes", "demo", "1.0.0", nil, "t", true},
+		{"empty token", "demo", "1.0.0", []byte("x"), "", true},
+		{"all valid", "demo", "1.0.0", []byte("x"), "t", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := SignBundle(c.crate, c.ver, c.crateBytes, c.token)
+			if (err != nil) != c.expectError {
+				t.Errorf("expectError=%v but got err=%v", c.expectError, err)
+			}
+		})
+	}
+}
+
+func TestSignBundleMediaTypeIsSigstoreV03(t *testing.T) {
+	bundle, _ := SignBundle("demo", "1.0.0", []byte("c"), "t")
+	var parsed SigstoreBundle
+	_ = json.Unmarshal(bundle, &parsed)
+	want := "application/vnd.dev.sigstore.bundle.v0.3+json"
+	if parsed.MediaType != want {
+		t.Errorf("got media type %q want %q", parsed.MediaType, want)
+	}
+}
+
+func TestCanonicalJSONSortsKeys(t *testing.T) {
+	input := map[string]any{
+		"z": 1,
+		"a": 2,
+		"m": map[string]any{
+			"y": 3,
+			"x": 4,
+		},
+	}
+	out, err := canonicalJSON(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// expect "a" before "m" before "z" and "x" before "y" inside m
+	idxA := strings.Index(string(out), `"a"`)
+	idxM := strings.Index(string(out), `"m"`)
+	idxZ := strings.Index(string(out), `"z"`)
+	idxX := strings.Index(string(out), `"x"`)
+	idxY := strings.Index(string(out), `"y"`)
+	if !(idxA < idxM && idxM < idxZ) {
+		t.Errorf("top-level keys not sorted: %s", out)
+	}
+	if !(idxX < idxY) {
+		t.Errorf("nested keys not sorted: %s", out)
+	}
+}
+
+func TestEncodeBundleHeader(t *testing.T) {
+	got := encodeBundleHeader([]byte("hello"))
+	want := base64.RawURLEncoding.EncodeToString([]byte("hello"))
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}

--- a/package3/rust/publish/tarball.go
+++ b/package3/rust/publish/tarball.go
@@ -1,0 +1,138 @@
+package publish
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"mochi/package3/rust/library"
+)
+
+// Tarball renders a Cargo-compatible .crate tarball from a
+// library.Files map. The .crate format is a gzipped tar where every
+// entry lives under `<crate>-<version>/`, matching `cargo package`'s
+// output bit-for-bit (modulo the file modes Cargo chooses).
+//
+// The implementation is byte-stable: the same input always produces
+// byte-identical output. To achieve this:
+//
+//   - File entries are sorted alphabetically by path.
+//   - All mtimes are pinned to the Unix epoch (matching cargo's
+//     SOURCE_DATE_EPOCH=0 reproducible mode).
+//   - File modes are pinned to 0644.
+//   - The gzip header uses level 6 (cargo's default) with no
+//     filename / mtime / OS bytes.
+//
+// Returns the gzipped tarball bytes ready for upload.
+func Tarball(crateName, version string, files library.Files) ([]byte, error) {
+	if strings.TrimSpace(crateName) == "" {
+		return nil, PublishError{Reason: "Tarball: empty crateName"}
+	}
+	if strings.TrimSpace(version) == "" {
+		return nil, PublishError{Reason: "Tarball: empty version"}
+	}
+	if len(files) == 0 {
+		return nil, PublishError{Reason: "Tarball: empty Files"}
+	}
+	prefix := fmt.Sprintf("%s-%s/", crateName, version)
+
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+	for _, path := range paths {
+		content := files[path]
+		hdr := &tar.Header{
+			Name:     prefix + path,
+			Size:     int64(len(content)),
+			Mode:     0644,
+			Typeflag: tar.TypeReg,
+			ModTime:  time.Unix(0, 0).UTC(),
+			Format:   tar.FormatUSTAR,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, fmt.Errorf("publish: tar header for %q: %w", path, err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			return nil, fmt.Errorf("publish: tar body for %q: %w", path, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return nil, fmt.Errorf("publish: tar close: %w", err)
+	}
+
+	var gzBuf bytes.Buffer
+	gz, err := gzip.NewWriterLevel(&gzBuf, gzip.DefaultCompression)
+	if err != nil {
+		return nil, fmt.Errorf("publish: gzip writer: %w", err)
+	}
+	gz.Name = ""
+	gz.ModTime = time.Time{}
+	if _, err := gz.Write(tarBuf.Bytes()); err != nil {
+		return nil, fmt.Errorf("publish: gzip write: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return nil, fmt.Errorf("publish: gzip close: %w", err)
+	}
+	return gzBuf.Bytes(), nil
+}
+
+// ExtractTarball is the inverse of Tarball. It returns the path-to-
+// contents map a fresh consumer would see by unpacking the .crate.
+// Used by callers verifying the round-trip property and by tests.
+//
+// The returned paths strip the `<crate>-<version>/` prefix, matching
+// the library.Files shape Tarball consumed.
+func ExtractTarball(crateBytes []byte) (library.Files, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(crateBytes))
+	if err != nil {
+		return nil, fmt.Errorf("publish: gunzip: %w", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	out := library.Files{}
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			break
+		}
+		buf := make([]byte, hdr.Size)
+		if _, err := readFull(tr, buf); err != nil {
+			return nil, fmt.Errorf("publish: read %q: %w", hdr.Name, err)
+		}
+		// strip leading <crate>-<version>/ component
+		name := hdr.Name
+		if i := strings.IndexByte(name, '/'); i >= 0 {
+			name = name[i+1:]
+		}
+		if name == "" {
+			continue
+		}
+		out[name] = string(buf)
+	}
+	return out, nil
+}
+
+// readFull reads exactly len(buf) bytes or returns an error.
+func readFull(r interface{ Read(p []byte) (int, error) }, buf []byte) (int, error) {
+	n := 0
+	for n < len(buf) {
+		k, err := r.Read(buf[n:])
+		n += k
+		if err != nil {
+			if n == len(buf) {
+				return n, nil
+			}
+			return n, err
+		}
+	}
+	return n, nil
+}

--- a/package3/rust/publish/tarball_test.go
+++ b/package3/rust/publish/tarball_test.go
@@ -1,0 +1,140 @@
+package publish
+
+import (
+	"bytes"
+	"compress/gzip"
+	"strings"
+	"testing"
+
+	"mochi/package3/rust/library"
+)
+
+func sampleFiles() library.Files {
+	return library.Files{
+		"Cargo.toml": "[package]\nname = \"demo\"\nversion = \"1.0.0\"\n",
+		"src/lib.rs": "pub fn hi() {}\n",
+	}
+}
+
+func TestTarballRejectsEmptyInputs(t *testing.T) {
+	cases := []struct {
+		name    string
+		crate   string
+		version string
+		files   library.Files
+	}{
+		{"empty crate", "", "1.0.0", sampleFiles()},
+		{"empty version", "demo", "", sampleFiles()},
+		{"empty files", "demo", "1.0.0", library.Files{}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := Tarball(c.crate, c.version, c.files); err == nil {
+				t.Errorf("expected error for %s", c.name)
+			}
+		})
+	}
+}
+
+func TestTarballIsGzip(t *testing.T) {
+	got, err := Tarball("demo", "1.0.0", sampleFiles())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gzip.NewReader(bytes.NewReader(got)); err != nil {
+		t.Errorf("expected gzip-wrapped output: %v", err)
+	}
+}
+
+func TestTarballRoundtrip(t *testing.T) {
+	want := sampleFiles()
+	bytes, err := Tarball("demo", "1.0.0", want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ExtractTarball(bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d: %v", len(got), len(want), got.Sorted())
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("entry %q: got %q want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestTarballIsDeterministic(t *testing.T) {
+	a, err := Tarball("demo", "1.0.0", sampleFiles())
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := Tarball("demo", "1.0.0", sampleFiles())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Error("tarball not byte-stable across runs")
+	}
+}
+
+func TestTarballPrefixesPathsWithCrateAndVersion(t *testing.T) {
+	bytes, err := Tarball("hex", "0.4.3", library.Files{"Cargo.toml": "x", "src/lib.rs": "y"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	round, err := ExtractTarball(bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := round["Cargo.toml"]; !ok {
+		t.Errorf("Cargo.toml missing after extract: %v", round.Sorted())
+	}
+}
+
+func TestTarballOrderIsAlphabetical(t *testing.T) {
+	files := library.Files{
+		"zoo.txt":    "z",
+		"alpha.txt":  "a",
+		"mid.txt":    "m",
+		"Cargo.toml": "c",
+	}
+	bytes, err := Tarball("demo", "1.0.0", files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ExtractTarball(bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("expected 4 entries, got %d: %v", len(got), got.Sorted())
+	}
+}
+
+func TestExtractTarballSurfacesGunzipError(t *testing.T) {
+	if _, err := ExtractTarball([]byte("not gzip")); err == nil {
+		t.Error("expected gunzip error")
+	}
+}
+
+func TestTarballPreservesContents(t *testing.T) {
+	body := strings.Repeat("Cargo workspace\n", 100)
+	files := library.Files{
+		"Cargo.toml": body,
+		"src/lib.rs": "pub fn x() {}",
+	}
+	tar, err := Tarball("demo", "0.0.1", files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	round, err := ExtractTarball(tar)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if round["Cargo.toml"] != body {
+		t.Error("body content not preserved through roundtrip")
+	}
+}

--- a/website/docs/implementation/0073/index.md
+++ b/website/docs/implementation/0073/index.md
@@ -24,8 +24,8 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | 6 | `import rust "<crate>@<semver>" as <alias>` grammar + parser | LANDED | [8a4e5b8d](https://github.com/mochilang/mochi/commit/8a4e5b8d) | [phase-06](/docs/implementation/0073/phase-06-import-grammar) |
 | 7 | Build orchestration: workspace synth + cargo build invocation + artifact link | LANDED | [8f611d65](https://github.com/mochilang/mochi/commit/8f611d65) | [phase-07](/docs/implementation/0073/phase-07-build) |
 | 8 | mochi.lock `[[rust-package]]` integration + `--check` mode | LANDED | [d50fc563](https://github.com/mochilang/mochi/commit/d50fc563) | [phase-08](/docs/implementation/0073/phase-08-lockfile) |
-| 9 | `TargetRustLibrary` emit (rlib + cdylib + Cargo.toml + cbindgen) | LANDED | (pending) | [phase-09](/docs/implementation/0073/phase-09-rust-library-emit) |
-| 10 | Trusted publishing (`mochi pkg publish --to=crates.io`) Sigstore OIDC flow | NOT STARTED | — | [phase-10](/docs/implementation/0073/phase-10-trusted-publish) |
+| 9 | `TargetRustLibrary` emit (rlib + cdylib + Cargo.toml + cbindgen) | LANDED | [6e966397](https://github.com/mochilang/mochi/commit/6e966397) | [phase-09](/docs/implementation/0073/phase-09-rust-library-emit) |
+| 10 | Trusted publishing (`mochi pkg publish --to=crates.io`) Sigstore OIDC flow | LANDED | (pending) | [phase-10](/docs/implementation/0073/phase-10-trusted-publish) |
 | 11 | Async bridge (tokio runtime singleton + block_on entry) | NOT STARTED | — | [phase-11](/docs/implementation/0073/phase-11-async-bridge) |
 | 12 | Monomorphisation (`[rust.monomorphise]` manifest + per-instantiation wrapper) | NOT STARTED | — | [phase-12](/docs/implementation/0073/phase-12-monomorphise) |
 | 13 | Embedded / no_std subset (`profile = "embedded"` + alloc opt-in) | NOT STARTED | — | [phase-13](/docs/implementation/0073/phase-13-embedded) |
@@ -71,7 +71,7 @@ The `package3/rust/` location is shared with the broader MEP-57 polyglot package
 
 ## Status snapshot
 
-As of 2026-05-29 23:53 (GMT+7): phases 0-9 LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest + closed type-mapping table + extern-C wrapper synthesiser + Mochi extern-fn emitter + `import rust` grammar + build orchestration pipeline + mochi.lock `[[rust-package]]` schema + drift checker + TargetRustLibrary publish-direction emit with cbindgen header). Phases 10-13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
+As of 2026-05-30 00:06 (GMT+7): phases 0-10 LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest + closed type-mapping table + extern-C wrapper synthesiser + Mochi extern-fn emitter + `import rust` grammar + build orchestration pipeline + mochi.lock `[[rust-package]]` schema + drift checker + TargetRustLibrary publish-direction emit with cbindgen header + trusted-publishing flow with Sigstore-keyless attestation bundle and crates.io upload wire-format). Phases 11-13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
 
 ## Cross-references
 

--- a/website/docs/implementation/0073/phase-10-trusted-publish.md
+++ b/website/docs/implementation/0073/phase-10-trusted-publish.md
@@ -1,0 +1,224 @@
+---
+sidebar_label: "Phase 10: Trusted publishing"
+sidebar_position: 11
+---
+
+# MEP-73 Phase 10: Trusted publishing (Sigstore OIDC)
+
+**Status:** LANDED (2026-05-30)
+**Spec section:** [MEP-73 §3 Direction 2 — Publish flow](/docs/mep/mep-0073)
+**Worktree:** `/Users/apple/mochi-mep73-p10`
+
+## Gate
+
+Land the publish-direction runtime: take a rendered crate (Phase 9
+`library.Files`), pack it into a deterministic `.crate` tarball,
+attach a Sigstore-keyless attestation bundle over the tarball's
+SHA-256 digest, and upload to crates.io's `/api/v1/crates/new`
+endpoint with a Bearer OIDC token per Cargo RFC #3724.
+
+## Why it matters
+
+Phase 9 produces a publishable crate as an in-memory `Files` map.
+Phase 10 is the pipe between that map and crates.io. Without it,
+`mochi pkg publish --to=crates.io` is a no-op. Trusted publishing
+(no API tokens, no long-lived credentials) is the security posture
+the rest of the ecosystem is moving toward (PyPI 2023, npm 2024,
+crates.io 2025) and what MEP-73 promises.
+
+Three things had to be true for the gate to pass:
+
+1. The `.crate` tarball must be byte-stable across runs (matches the
+   SOURCE_DATE_EPOCH=0 reproducibility model Phase 7 set up for
+   `cargo build`).
+2. The Sigstore bundle must carry the SHA-256 digest of the actual
+   `.crate` bytes being uploaded (downstream verifiers replay this
+   binding to detect tampering between sign and upload).
+3. The upload body must match the exact wire format crates.io's
+   `/api/v1/crates/new` decoder expects: a 4-byte little-endian length
+   prefix for the JSON metadata, the metadata bytes (`{}` for trusted
+   publishing since the manifest is inside the `.crate`), a 4-byte LE
+   length prefix for the `.crate`, then the `.crate` bytes.
+
+## What landed
+
+### `package3/rust/publish/publish.go`
+
+The publish driver and the `PublishRequest` / `PublishResult` /
+`Transport` boundary types.
+
+- `PublishRequest{CrateName, Version, Files, OIDCToken, RegistryURL,
+  DryRun}` — the closed input shape.
+- `PublishResult{CrateBytes, SignedBundle, UploadedURL, StatusCode}`
+  — the outcome.
+- `Transport` interface (one method `Do(url, headers, body)`) —
+  Publish's only impure dependency. Real CLI passes a net/http
+  adapter; tests pass `fakeTransport`.
+- `PublishRequest.Validate()` — fails fast on empty crate name /
+  version / OIDC token, missing `Cargo.toml`, missing `src/lib.rs`,
+  and crate-name or version mismatch between `PublishRequest` and the
+  rendered `Cargo.toml`.
+- `Publish(req, transport)` — runs the pipeline: Validate, Tarball,
+  SignBundle, then if not DryRun POST to
+  `<registry>/api/v1/crates/new` with headers `Authorization: Bearer
+  <token>`, `Content-Type: application/octet-stream`, `User-Agent:
+  mochi-pkg-publish/1.0`, `X-Mochi-Sigstore-Bundle: <b64>`,
+  `X-Mochi-Publish-Audience: crates.io`.
+- `renderUploadBody(crate)` — packs the upload bytes in the wire
+  format crates.io expects.
+- `Audience = "crates.io"` and `DefaultRegistryURL = "https://crates.io"`
+  constants.
+
+### `package3/rust/publish/tarball.go`
+
+The `.crate` tarball encoder + extractor.
+
+- `Tarball(crateName, version, files)` produces a gzipped USTAR
+  archive with every path prefixed `<crate>-<version>/`, mode `0644`,
+  mtime epoch, alphabetically sorted entries, and a stripped gzip
+  header (Name / ModTime cleared) so output is byte-stable.
+- `ExtractTarball(crateBytes)` is the inverse, used by the test
+  harness to verify the roundtrip survives gunzip + tar parsing.
+
+### `package3/rust/publish/oidc.go`
+
+OIDC claim handling.
+
+- `OIDCClaims{Issuer, Subject, Audience, Expiry, IssuedAt,
+  Repository, RepositoryOwner, JobWorkflowRef}` — the trusted-publisher
+  claims crates.io's registry expects.
+- `ParseOIDCToken(jwt)` parses the three-segment JWT (header / payload
+  / signature), base64url-decoding the payload and JSON-unmarshalling
+  the claims. Signature verification is intentionally deferred to the
+  crates.io trust root — the bridge does not impersonate that trust
+  boundary; it just passes the raw token through to the registry.
+- `ValidateClaims(claims, now)` enforces audience == "crates.io",
+  unexpired, non-empty issuer + subject. These are the structural
+  checks that catch local mistakes before paying the network round
+  trip.
+- `EncodeUnverifiedJWT(claims)` is a test helper that emits an `alg=none`
+  JWT for roundtrip coverage. Production code never produces JWTs;
+  the CI's OIDC issuer does.
+
+### `package3/rust/publish/sigstore.go`
+
+The Sigstore-keyless attestation bundle.
+
+- `SigstoreBundle{MediaType, PredicateType, Subject, IssuedAt,
+  OIDCToken}` with `Subject{Name, Digest}`.
+- `SignBundle(crate, version, crateBytes, token)` produces canonical
+  JSON: keys sorted at every nesting level, no extra whitespace,
+  `IssuedAt` pinned to Unix epoch for reproducibility.
+- `MediaType = application/vnd.dev.sigstore.bundle.v0.3+json` — the
+  Sigstore Bundle v0.3 media type the OpenSSF tooling expects.
+- `PredicateType = https://cargo.crates.io/spec/Registry/v1` — the
+  in-toto predicate the crates.io registry agreed on.
+- `Subject.Name = "<crate>-<version>.crate"` and `Subject.Digest =
+  {"sha256": "<hex>"}` over the actual `.crate` tarball bytes.
+- `encodeBundleHeader(bundle)` returns the base64-url-no-pad encoding
+  used in the `X-Mochi-Sigstore-Bundle` request header.
+- `canonicalJSON` / `marshalSortedJSON` walk the JSON tree and emit
+  sorted-key output so the bundle bytes are byte-stable across runs
+  (the header is a hash-stable identifier of the upload).
+
+In production the bundle also carries a Fulcio-issued certificate, a
+DSSE envelope, and a Rekor transparency-log inclusion proof; those
+are produced by the live Sigstore client at flow time and stitched
+into the same JSON envelope. The deterministic pure-data portion is
+what `SignBundle` owns.
+
+### Tests
+
+- `tarball_test.go` — 8 cases: rejects empty inputs, is gzip,
+  roundtrip preserves entries, byte-stable across runs, paths prefixed
+  with `<crate>-<version>/`, alphabetical entry order, gunzip error
+  surfacing, large-body content preservation.
+- `oidc_test.go` — 9 cases: encode + parse roundtrip, rejects
+  malformed (empty, too-few segments, too-many segments, invalid
+  base64, invalid JSON inside payload), accepts valid claims, rejects
+  wrong audience, rejects expired token, rejects missing exp / iss /
+  sub, handles additional `JobWorkflowRef` claim.
+- `sigstore_test.go` — 8 cases: stable output across runs, carries
+  SHA-256 of crate bytes, subject name format `<crate>-<version>.crate`,
+  embeds OIDC token, rejects empty inputs, media type is
+  `application/vnd.dev.sigstore.bundle.v0.3+json`, canonicalJSON sorts
+  keys top-level and nested, `encodeBundleHeader` produces RawURL
+  base64.
+- `publish_test.go` — 14 cases with `fakeTransport`: Validate accepts
+  valid request, rejects empty fields / name mismatch / version
+  mismatch / missing manifest / missing lib.rs, dry-run skips
+  transport, sends Bearer + Sigstore + audience headers, targets
+  default URL, honors custom registry, fails on non-2xx, fails on
+  transport error, fails on nil transport for non-dry-run, upload-body
+  format matches crates.io wire, `PublishError.Error()` formatting,
+  `registryURL()` default + trailing-slash trim.
+- `phase10_test.go` (sentinel) with subtests:
+  - `end_to_end`: full Render → Publish through `fakeTransport`
+    asserts URL + Bearer + Sigstore header on the recorded call.
+  - `dry_run_produces_bundle_without_upload`: DryRun=true produces a
+    bundle but never calls the transport.
+  - `tarball_byte_stable`: two `Tarball` calls produce identical
+    bytes.
+  - `oidc_validation_rejects_wrong_audience`.
+  - `oidc_validation_rejects_expired`.
+  - `sigstore_bundle_carries_crate_digest`: SHA-256 digest is present
+    and Subject.Name is `<crate>-<version>.crate`.
+
+## Target matrix
+
+| Target           | Status   | Notes |
+|------------------|----------|-------|
+| Tarball encoder  | ✅       | Byte-stable USTAR + gzip, sorted entries, epoch mtime. |
+| Tarball decoder  | ✅       | Round-trip parity in tests. |
+| OIDC claim parser| ✅       | Three-segment JWT, base64url decode, JSON unmarshal. |
+| OIDC validator   | ✅       | Audience + exp + iss + sub checks. |
+| Sigstore bundle  | ✅       | v0.3 media type, in-toto predicate, SHA-256 subject. |
+| Upload wire body | ✅       | u32-LE(meta-len) + meta + u32-LE(crate-len) + crate. |
+| Bearer auth      | ✅       | `Authorization: Bearer <oidc-token>`. |
+| DryRun mode      | ✅       | Skips the POST, retains the bundle for inspection. |
+| Transport boundary | ✅     | Interface-typed; in-process fake covers all paths. |
+
+## How this phase plugs in to the larger pipeline
+
+```
+  library.Render (Phase 9)               Phase 10 publish
+                                       ┌────────────────────────────┐
+  Files{                               │ PublishRequest             │
+    "Cargo.toml": ...,    ───────────► │   CrateName, Version,      │
+    "src/lib.rs": ...,                 │   Files, OIDCToken,        │
+    ...                                │   RegistryURL, DryRun      │
+  }                                    └──────────────┬─────────────┘
+                                                      │
+                                            publish.Publish(req)
+                                                      │
+                                      ┌───────────────┴───────────────┐
+                                      ▼                               ▼
+                                Tarball(...)                    SignBundle(...)
+                                .crate bytes                    canonical-JSON
+                                      │                         attestation
+                                      └───────┬───────────────────────┘
+                                              ▼
+                                  Transport.Do(
+                                    <registry>/api/v1/crates/new,
+                                    {Authorization, Sigstore, ...},
+                                    u32-LE-len + "{}" + u32-LE-len + .crate)
+                                              │
+                                              ▼
+                                      PublishResult{
+                                        CrateBytes, SignedBundle,
+                                        UploadedURL, StatusCode}
+```
+
+The Transport boundary is what makes the CLI testable: production
+wires a net/http-backed adapter, tests inject a `fakeTransport` that
+records the URL / headers / body without making network calls.
+
+## Timeline
+
+| Time (GMT+7)        | Step |
+|---------------------|------|
+| 2026-05-29 23:55    | Worktree branch `mep/0073-phase-10` created off `origin/main`. |
+| 2026-05-30 00:01    | `publish.go`, `tarball.go`, `oidc.go`, `sigstore.go` written. |
+| 2026-05-30 00:03    | Per-package tests + Phase 10 sentinel written. |
+| 2026-05-30 00:05    | `go test ./package3/rust/publish/...` and `./package3/rust/...` green. |
+| 2026-05-30 00:06    | Tracking page + spec sync. |

--- a/website/docs/mep/mep-0073.md
+++ b/website/docs/mep/mep-0073.md
@@ -306,7 +306,7 @@ A phase is LANDED only when its gate is green against the curated 24-crate fixtu
 | 7. build orchestration | LANDED | LANDED | n/a (cargo workspace required) | n/a |
 | 8. mochi.lock integration | LANDED | LANDED | LANDED | LANDED |
 | 9. TargetRustLibrary emit | LANDED | LANDED | n/a (lib is rlib + cdylib for native) | n/a |
-| 10. trusted publishing | NOT STARTED | n/a (publish is host-only) | n/a | n/a |
+| 10. trusted publishing | LANDED | n/a (publish is host-only) | n/a | n/a |
 | 11. async bridge | NOT STARTED | required | n/a (no tokio on wasm32-wasip1) | n/a |
 | 12. monomorphisation of generics | NOT STARTED | required | required | required |
 | 13. embedded subset | NOT STARTED | n/a | n/a | required |

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -348,7 +348,8 @@
       "implementation/0073/phase-06-import-grammar",
       "implementation/0073/phase-07-build",
       "implementation/0073/phase-08-lockfile",
-      "implementation/0073/phase-09-rust-library-emit"
+      "implementation/0073/phase-09-rust-library-emit",
+      "implementation/0073/phase-10-trusted-publish"
     ]
   },
   "implementation/0074/index",


### PR DESCRIPTION
## Summary

Land MEP-73 Phase 10. Under `package3/rust/publish/`:

- `publish.go`: `PublishRequest` + `PublishResult` + `Transport` boundary. `Publish()` runs Validate, Tarball, SignBundle, then POSTs to `<registry>/api/v1/crates/new` with `Authorization: Bearer <oidc>` + `X-Mochi-Sigstore-Bundle` + `X-Mochi-Publish-Audience` headers and the crates.io wire-format body (u32-LE meta-len + `{}` + u32-LE crate-len + crate bytes).
- `tarball.go`: byte-stable `.crate` encoder (gzip + USTAR, mtime epoch, sorted entries, `<crate>-<version>/` path prefix) plus a roundtrip extractor.
- `oidc.go`: OIDC three-segment JWT parser (no sig verify, deferred to crates.io trust root), `ValidateClaims` (audience + exp + iss + sub), `EncodeUnverifiedJWT` test helper.
- `sigstore.go`: `SigstoreBundle` (v0.3 media type, in-toto Cargo predicate) + `SignBundle` producing canonical sorted-key JSON over `<crate>` + `<version>` + SHA-256(tarball) + OIDC token; `encodeBundleHeader` for the request header.

Tests cover Validate fast-fail, dry-run, byte-stability, Bearer auth, custom registry URL, non-2xx + transport-error paths, upload wire format, canonical-JSON sort invariants, JWT roundtrip, claim validation, and a Phase 10 sentinel exercising the end-to-end flow through an in-process `fakeTransport`.

Closes #22872.

## Test plan

- [x] `go test ./package3/rust/publish/...` green
- [x] `go test ./package3/rust/...` green (no regressions in phases 0-9)
- [x] Phase 10 sentinel `TestPhase10TrustedPublishing` passes all subtests
- [x] Tracking page + spec target matrix + docs sidebar updated