### PR TITLE
feat(package3/python): MEP-71 Phase 8 build orchestration

### DIFF
--- a/package3/python/build/orchestrator.go
+++ b/package3/python/build/orchestrator.go
@@ -1,0 +1,245 @@
+package build
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"mochi/package3/python/emit"
+	pyerrors "mochi/package3/python/errors"
+	"mochi/package3/python/importspec"
+	"mochi/package3/python/stubs"
+	"mochi/package3/python/wrapper"
+)
+
+// Target is one `import python "<spec>" as <alias>` statement the caller
+// asks the orchestrator to materialise into the venv. The PYISource is the
+// merged Phase 3 stub content for the distribution; the caller is responsible
+// for running stub discovery and producing the bytes.
+type Target struct {
+	// Spec is the parsed `import python` body (Phase 7).
+	Spec importspec.Spec
+	// Alias is the Mochi alias the user picked (`as <alias>`). The wrapper
+	// module path inside the venv is keyed by Alias.
+	Alias string
+	// PYISource is the .pyi text Phase 3 produced for Spec.Name. The
+	// orchestrator feeds it to stubs.ParsePYI -> wrapper.Synthesise -> EmitShim.
+	PYISource string
+}
+
+// Request is the input to Orchestrator.Build. It carries one Target per
+// `import python` declaration plus optional overrides for the synthesised
+// venv, wrapper, and shim emitter.
+type Request struct {
+	Targets     []Target
+	Venv        *Venv
+	WrapperOpts wrapper.Options
+	ShimOpts    emit.Options
+}
+
+// Result is what Orchestrator.Build returns. WorkDir is the driver's scratch
+// directory; VenvRoot is the python_workspace directory inside it. Wrappers
+// and Shims have one entry per Target in declaration order. Skipped is the
+// concatenated SkipReport list (qualified with `<pkg>.<item>` by Phase 5).
+// WrittenFiles lists every path the orchestrator wrote, in the order it
+// wrote them.
+type Result struct {
+	WorkDir      string
+	VenvRoot     string
+	Wrappers     []*wrapper.Wrapper
+	Shims        []*emit.Shim
+	Skipped      []pyerrors.SkipReport
+	WrittenFiles []string
+}
+
+// Orchestrator drives the per-target wrapper + shim synthesis loop and lays
+// the result out under the driver's work-dir.
+type Orchestrator struct {
+	driver *Driver
+}
+
+// NewOrchestrator wraps an existing Driver. The Driver supplies the work-dir
+// allocation and Cleanup semantics; the Orchestrator only handles per-target
+// composition.
+func NewOrchestrator(d *Driver) *Orchestrator {
+	return &Orchestrator{driver: d}
+}
+
+// Plan validates a Request without touching the filesystem. It returns the
+// resolved Venv (with wrapper members added per Target) and the per-target
+// wrappers / shims, so callers can run `mochi pkg lock --dry-run` cheaply.
+func (o *Orchestrator) Plan(req Request) (*Result, error) {
+	if o.driver == nil {
+		return nil, fmt.Errorf("orchestrator: nil driver")
+	}
+	if len(req.Targets) == 0 {
+		return nil, fmt.Errorf("orchestrator: at least one Target required")
+	}
+	seenAlias := map[string]struct{}{}
+	for i, t := range req.Targets {
+		if t.Alias == "" {
+			return nil, fmt.Errorf("orchestrator: target %d (%q) has empty alias", i, t.Spec.RawName)
+		}
+		if t.Spec.Name == "" {
+			return nil, fmt.Errorf("orchestrator: target %d alias %q has empty spec name", i, t.Alias)
+		}
+		if _, dup := seenAlias[t.Alias]; dup {
+			return nil, fmt.Errorf("orchestrator: duplicate alias %q", t.Alias)
+		}
+		seenAlias[t.Alias] = struct{}{}
+	}
+	venv := req.Venv
+	if venv == nil {
+		venv = DefaultVenv()
+	}
+	res := &Result{}
+	for _, t := range req.Targets {
+		surface, err := stubs.ParsePYI(t.PYISource)
+		if err != nil {
+			return nil, fmt.Errorf("orchestrator: target %q parse pyi: %w", t.Alias, err)
+		}
+		w, err := wrapper.Synthesise(t.Spec.Name, surface, req.WrapperOpts)
+		if err != nil {
+			return nil, fmt.Errorf("orchestrator: target %q synthesise: %w", t.Alias, err)
+		}
+		shim, err := emit.EmitShim(w, req.ShimOpts)
+		if err != nil {
+			return nil, fmt.Errorf("orchestrator: target %q emit: %w", t.Alias, err)
+		}
+		res.Wrappers = append(res.Wrappers, w)
+		res.Shims = append(res.Shims, shim)
+		res.Skipped = append(res.Skipped, w.Skipped...)
+		venv.AddMember(VenvMember{
+			Name: t.Alias,
+			Path: "python_wrap/" + t.Alias,
+			Kind: MemberWrapper,
+		})
+		venv.AddSharedDep(t.Spec.Name, sharedDepVersion(t.Spec))
+	}
+	req.Venv = venv
+	if err := venv.Validate(); err != nil {
+		return nil, fmt.Errorf("orchestrator: venv: %w", err)
+	}
+	return res, nil
+}
+
+// Build runs Plan and then materialises the workspace under the driver's
+// work-dir. Layout:
+//
+//	<work-dir>/python_workspace/
+//	  pyproject.toml
+//	  .gitignore
+//	  _mochi_wrap.py                       # shared runtime
+//	  python_wrap/<alias>/
+//	    __init__.py
+//	    <pkg>_externs.py
+//	    <pkg>_externs.pyi
+//	    <pkg>_shim.mochi
+//	    SKIPPED.txt                        # only when wrapper had skipped items
+//
+// Build is idempotent for a stable Request: the SHA-256 in each Shim is
+// recomputed and the on-disk content is byte-stable across calls.
+func (o *Orchestrator) Build(req Request) (*Result, error) {
+	plan, err := o.Plan(req)
+	if err != nil {
+		return nil, err
+	}
+	venv := req.Venv
+	if venv == nil {
+		venv = DefaultVenv()
+		// Re-run Plan side: AddMember/AddSharedDep already mutated the user
+		// Venv inside Plan; the nil case fell through with a fresh Venv that
+		// Plan also populated. We mirror the same Venv that Plan used.
+		// Reuse the populated members by walking req.Targets.
+		for _, t := range req.Targets {
+			venv.AddMember(VenvMember{
+				Name: t.Alias,
+				Path: "python_wrap/" + t.Alias,
+				Kind: MemberWrapper,
+			})
+			venv.AddSharedDep(t.Spec.Name, sharedDepVersion(t.Spec))
+		}
+	}
+	if _, err := o.driver.PrepareVenv(); err != nil {
+		return nil, err
+	}
+	plan.WorkDir = o.driver.WorkDir()
+	root, err := o.driver.WriteVenvRoot(venv)
+	if err != nil {
+		return nil, err
+	}
+	plan.VenvRoot = root
+	plan.WrittenFiles = append(plan.WrittenFiles,
+		filepath.Join(root, "pyproject.toml"),
+		filepath.Join(root, ".gitignore"),
+	)
+	runtimePath := filepath.Join(root, "_mochi_wrap.py")
+	if err := os.WriteFile(runtimePath, []byte(wrapper.Runtime()), 0o644); err != nil {
+		return nil, fmt.Errorf("orchestrator: write runtime: %w", err)
+	}
+	plan.WrittenFiles = append(plan.WrittenFiles, runtimePath)
+	runtimeStubPath := filepath.Join(root, "_mochi_wrap.pyi")
+	if err := os.WriteFile(runtimeStubPath, []byte(wrapper.RuntimeStub()), 0o644); err != nil {
+		return nil, fmt.Errorf("orchestrator: write runtime stub: %w", err)
+	}
+	plan.WrittenFiles = append(plan.WrittenFiles, runtimeStubPath)
+	for i, t := range req.Targets {
+		w := plan.Wrappers[i]
+		shim := plan.Shims[i]
+		dir := filepath.Join(root, "python_wrap", t.Alias)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("orchestrator: target %q mkdir: %w", t.Alias, err)
+		}
+		entries := []struct {
+			path, body string
+		}{
+			{filepath.Join(dir, "__init__.py"), initPyTemplate(w)},
+			{filepath.Join(dir, w.Module+".py"), w.PySource},
+			{filepath.Join(dir, w.Module+".pyi"), w.PYISource},
+			{filepath.Join(dir, t.Spec.Name+"_shim.mochi"), shim.Source},
+		}
+		for _, e := range entries {
+			if err := os.WriteFile(e.path, []byte(e.body), 0o644); err != nil {
+				return nil, fmt.Errorf("orchestrator: target %q write %s: %w", t.Alias, filepath.Base(e.path), err)
+			}
+			plan.WrittenFiles = append(plan.WrittenFiles, e.path)
+		}
+		if len(w.Skipped) > 0 {
+			skippedPath := filepath.Join(dir, "SKIPPED.txt")
+			if err := os.WriteFile(skippedPath, []byte(renderSkipped(w.Skipped)), 0o644); err != nil {
+				return nil, fmt.Errorf("orchestrator: target %q write SKIPPED.txt: %w", t.Alias, err)
+			}
+			plan.WrittenFiles = append(plan.WrittenFiles, skippedPath)
+		}
+	}
+	sort.Strings(plan.WrittenFiles)
+	return plan, nil
+}
+
+func initPyTemplate(w *wrapper.Wrapper) string {
+	return "# Auto-generated by MEP-71 bridge for " + w.Package + ".\n" +
+		"from . import " + w.Module + " as externs\n" +
+		"__all__ = [\"externs\"]\n"
+}
+
+func renderSkipped(reports []pyerrors.SkipReport) string {
+	out := "# Auto-generated SKIPPED.txt. Items the wrapper refused.\n"
+	for _, r := range reports {
+		out += r.ItemPath + "\t" + r.Reason.String() + "\t" + r.Detail + "\n"
+	}
+	return out
+}
+
+// sharedDepVersion renders the [project.dependencies] version requirement for
+// a Spec. SourceRegistry / SourceIndex pass the PEP 440 specifier through;
+// SourceGit and SourcePath produce empty (the dependency is satisfied by an
+// editable / VCS install configured elsewhere).
+func sharedDepVersion(s importspec.Spec) string {
+	switch s.Source {
+	case importspec.SourceRegistry, importspec.SourceIndex:
+		return s.Specifier.String()
+	default:
+		return ""
+	}
+}

--- a/package3/python/build/orchestrator_test.go
+++ b/package3/python/build/orchestrator_test.go
@@ -1,0 +1,379 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/package3/python/emit"
+	"mochi/package3/python/importspec"
+	"mochi/package3/python/wrapper"
+)
+
+const httpxStub = `
+from typing import Protocol
+
+class Response(Protocol):
+    status_code: int
+
+def get(url: str, timeout: float = 5.0) -> Response: ...
+
+async def fetch(url: str) -> str: ...
+`
+
+const minimalStub = `
+def add(a: int, b: int) -> int: ...
+`
+
+func newTestDriver(t *testing.T) *Driver {
+	t.Helper()
+	dir := t.TempDir()
+	return NewDriver(Options{WorkDir: dir, CacheDir: filepath.Join(dir, "cache")})
+}
+
+func makeTarget(t *testing.T, raw, alias, pyi string) Target {
+	t.Helper()
+	spec, err := importspec.Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", raw, err)
+	}
+	return Target{Spec: spec, Alias: alias, PYISource: pyi}
+}
+
+func TestPlanRequiresTargets(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	if _, err := o.Plan(Request{}); err == nil {
+		t.Fatal("expected error for empty Targets")
+	}
+}
+
+func TestPlanRequiresAlias(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	spec, _ := importspec.Parse("requests")
+	if _, err := o.Plan(Request{Targets: []Target{{Spec: spec, PYISource: minimalStub}}}); err == nil {
+		t.Fatal("expected error for empty alias")
+	}
+}
+
+func TestPlanRequiresSpecName(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	if _, err := o.Plan(Request{Targets: []Target{{Alias: "rq", PYISource: minimalStub}}}); err == nil {
+		t.Fatal("expected error for empty spec name")
+	}
+}
+
+func TestPlanRejectsDuplicateAlias(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	a := makeTarget(t, "requests", "rq", minimalStub)
+	b := makeTarget(t, "httpx", "rq", minimalStub)
+	if _, err := o.Plan(Request{Targets: []Target{a, b}}); err == nil {
+		t.Fatal("expected error for duplicate alias")
+	}
+}
+
+func TestPlanPopulatesWrappersAndShims(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	tgt := makeTarget(t, "httpx@>=0.27,<0.30", "httpx", httpxStub)
+	res, err := o.Plan(Request{Targets: []Target{tgt}})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(res.Wrappers) != 1 || res.Wrappers[0].Package != "httpx" {
+		t.Errorf("wrappers = %+v", res.Wrappers)
+	}
+	if len(res.Shims) != 1 {
+		t.Fatalf("shims = %d, want 1", len(res.Shims))
+	}
+	if res.Shims[0].SHA256 == "" {
+		t.Errorf("shim SHA256 is empty")
+	}
+	if res.Shims[0].Package != "httpx" {
+		t.Errorf("shim package = %q", res.Shims[0].Package)
+	}
+}
+
+func TestPlanAddsWrapperMembersToVenv(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	venv := DefaultVenv()
+	tgt := makeTarget(t, "requests@>=2.0,<3.0", "rq", minimalStub)
+	if _, err := o.Plan(Request{Targets: []Target{tgt}, Venv: venv}); err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	found := false
+	for _, m := range venv.Members {
+		if m.Name == "rq" && m.Kind == MemberWrapper {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("wrapper member missing: %+v", venv.Members)
+	}
+	if got := venv.SharedDependencies["requests"]; got != ">=2.0, <3.0" {
+		t.Errorf("shared dep = %q", got)
+	}
+}
+
+func TestPlanSurfacesPyiParseError(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	tgt := makeTarget(t, "requests", "rq", "def foo(a, b: # unterminated bracket\n")
+	_, err := o.Plan(Request{Targets: []Target{tgt}})
+	if err == nil {
+		t.Fatal("expected error for malformed pyi")
+	}
+	if !strings.Contains(err.Error(), "parse pyi") {
+		t.Errorf("err = %q, want substring 'parse pyi'", err.Error())
+	}
+}
+
+func TestBuildWritesWorkspace(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	tgt := makeTarget(t, "httpx@>=0.27,<0.30", "httpx", httpxStub)
+	res, err := o.Build(Request{Targets: []Target{tgt}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if res.WorkDir == "" || res.VenvRoot == "" {
+		t.Fatalf("Result missing paths: %+v", res)
+	}
+	expect := []string{
+		filepath.Join(res.VenvRoot, "pyproject.toml"),
+		filepath.Join(res.VenvRoot, ".gitignore"),
+		filepath.Join(res.VenvRoot, "_mochi_wrap.py"),
+		filepath.Join(res.VenvRoot, "_mochi_wrap.pyi"),
+		filepath.Join(res.VenvRoot, "python_wrap", "httpx", "__init__.py"),
+		filepath.Join(res.VenvRoot, "python_wrap", "httpx", "httpx_externs.py"),
+		filepath.Join(res.VenvRoot, "python_wrap", "httpx", "httpx_externs.pyi"),
+		filepath.Join(res.VenvRoot, "python_wrap", "httpx", "httpx_shim.mochi"),
+	}
+	for _, want := range expect {
+		if _, err := os.Stat(want); err != nil {
+			t.Errorf("missing file %q: %v", want, err)
+		}
+	}
+}
+
+func TestBuildVenvPyprojectMentionsDep(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	tgt := makeTarget(t, "requests@>=2.0,<3.0", "rq", minimalStub)
+	res, err := o.Build(Request{Targets: []Target{tgt}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(res.VenvRoot, "pyproject.toml"))
+	if err != nil {
+		t.Fatalf("read pyproject.toml: %v", err)
+	}
+	if !strings.Contains(string(body), `"requests>=2.0, <3.0"`) {
+		t.Errorf("pyproject.toml missing requests dep:\n%s", body)
+	}
+	if !strings.Contains(string(body), `"python_wrap/rq"`) {
+		t.Errorf("pyproject.toml missing wrapper member:\n%s", body)
+	}
+}
+
+func TestBuildShimFileContainsExternFun(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	tgt := makeTarget(t, "minimal", "mn", minimalStub)
+	res, err := o.Build(Request{Targets: []Target{tgt}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(res.VenvRoot, "python_wrap", "mn", "minimal_shim.mochi"))
+	if err != nil {
+		t.Fatalf("read shim: %v", err)
+	}
+	if !strings.Contains(string(body), "extern python fun add") {
+		t.Errorf("shim missing extern fun:\n%s", body)
+	}
+}
+
+func TestBuildEmitsSkippedTxtWhenWrapperSkipped(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	// Mutable @dataclass is refused; only frozen=True is accepted.
+	pyi := `
+from dataclasses import dataclass
+
+@dataclass
+class Mutable:
+    x: int
+    y: int
+
+def keep() -> int: ...
+`
+	tgt := makeTarget(t, "skiplib", "sk", pyi)
+	res, err := o.Build(Request{Targets: []Target{tgt}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(res.Skipped) == 0 {
+		t.Fatal("expected at least one skip")
+	}
+	skipPath := filepath.Join(res.VenvRoot, "python_wrap", "sk", "SKIPPED.txt")
+	if _, err := os.Stat(skipPath); err != nil {
+		t.Errorf("SKIPPED.txt not written: %v", err)
+	}
+}
+
+func TestBuildSourceCanonicalised(t *testing.T) {
+	d1 := newTestDriver(t)
+	d2 := newTestDriver(t)
+	tgt := makeTarget(t, "minimal", "mn", minimalStub)
+	r1, err := NewOrchestrator(d1).Build(Request{Targets: []Target{tgt}})
+	if err != nil {
+		t.Fatalf("Build #1: %v", err)
+	}
+	r2, err := NewOrchestrator(d2).Build(Request{Targets: []Target{tgt}})
+	if err != nil {
+		t.Fatalf("Build #2: %v", err)
+	}
+	if r1.Shims[0].SHA256 != r2.Shims[0].SHA256 {
+		t.Errorf("shim SHA differs: %s vs %s", r1.Shims[0].SHA256, r2.Shims[0].SHA256)
+	}
+	if r1.Shims[0].Source != r2.Shims[0].Source {
+		t.Errorf("shim Source differs across builds")
+	}
+}
+
+func TestBuildSourceGitDepHasEmptyVersion(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	tgt := makeTarget(t, "mypkg@git+https://github.com/user/repo#main", "mp", minimalStub)
+	res, err := o.Build(Request{Targets: []Target{tgt}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	body, _ := os.ReadFile(filepath.Join(res.VenvRoot, "pyproject.toml"))
+	if !strings.Contains(string(body), `"mypkg"`) {
+		t.Errorf("pyproject.toml missing bare mypkg dep:\n%s", body)
+	}
+}
+
+func TestBuildPropagatesWrapperOpts(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	// AllowPartial = true should let an Any-returning fn through.
+	pyi := `
+from typing import Any
+def returns_any() -> Any: ...
+`
+	tgt := makeTarget(t, "anylib", "an", pyi)
+	res, err := o.Build(Request{
+		Targets:     []Target{tgt},
+		WrapperOpts: wrapper.Options{AllowPartial: true},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(res.Wrappers[0].Items) == 0 {
+		t.Errorf("AllowPartial should let returns_any through; got 0 items")
+	}
+}
+
+func TestBuildPropagatesShimOpts(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	tgt := makeTarget(t, "minimal", "mn", minimalStub)
+	res, err := o.Build(Request{
+		Targets:  []Target{tgt},
+		ShimOpts: emit.Options{Header: false, IncludeSkipReport: false},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	body, _ := os.ReadFile(filepath.Join(res.VenvRoot, "python_wrap", "mn", "minimal_shim.mochi"))
+	if strings.Contains(string(body), "Auto-generated") {
+		t.Errorf("Header should have been suppressed:\n%s", body)
+	}
+}
+
+func TestBuildWrittenFilesSorted(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	tgt := makeTarget(t, "minimal", "mn", minimalStub)
+	res, err := o.Build(Request{Targets: []Target{tgt}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	for i := 1; i < len(res.WrittenFiles); i++ {
+		if res.WrittenFiles[i-1] > res.WrittenFiles[i] {
+			t.Errorf("WrittenFiles not sorted at index %d: %q > %q", i, res.WrittenFiles[i-1], res.WrittenFiles[i])
+		}
+	}
+}
+
+func TestBuildMultipleTargets(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	a := makeTarget(t, "minimal", "mn", minimalStub)
+	b := makeTarget(t, "httpx@>=0.27,<0.30", "httpx", httpxStub)
+	res, err := o.Build(Request{Targets: []Target{a, b}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(res.Wrappers) != 2 || len(res.Shims) != 2 {
+		t.Fatalf("wrappers=%d shims=%d", len(res.Wrappers), len(res.Shims))
+	}
+	for _, alias := range []string{"mn", "httpx"} {
+		if _, err := os.Stat(filepath.Join(res.VenvRoot, "python_wrap", alias)); err != nil {
+			t.Errorf("missing wrapper dir for alias %q: %v", alias, err)
+		}
+	}
+}
+
+func TestPlanNilDriverRejected(t *testing.T) {
+	o := &Orchestrator{}
+	if _, err := o.Plan(Request{Targets: []Target{makeTarget(t, "rq", "rq", minimalStub)}}); err == nil {
+		t.Fatal("expected error for nil driver")
+	}
+}
+
+func TestBuildSourcePathDepHasEmptyVersion(t *testing.T) {
+	d := newTestDriver(t)
+	o := NewOrchestrator(d)
+	tgt := makeTarget(t, "mypkg@path+../sibling", "mp", minimalStub)
+	res, err := o.Build(Request{Targets: []Target{tgt}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	body, _ := os.ReadFile(filepath.Join(res.VenvRoot, "pyproject.toml"))
+	if !strings.Contains(string(body), `"mypkg"`) {
+		t.Errorf("pyproject.toml missing path-source dep:\n%s", body)
+	}
+}
+
+func TestSharedDepVersionAcrossSources(t *testing.T) {
+	mustParse := func(s string) importspec.Spec {
+		sp, err := importspec.Parse(s)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", s, err)
+		}
+		return sp
+	}
+	if got := sharedDepVersion(mustParse("rq@>=2.0,<3.0")); got != ">=2.0, <3.0" {
+		t.Errorf("registry = %q", got)
+	}
+	if got := sharedDepVersion(mustParse("rq")); got != "" {
+		t.Errorf("bare = %q", got)
+	}
+	if got := sharedDepVersion(mustParse("rq@torch+https://example.org")); got != "" {
+		t.Errorf("index (empty specifier) = %q", got)
+	}
+	if got := sharedDepVersion(mustParse("rq@git+https://github.com/u/r#main")); got != "" {
+		t.Errorf("git = %q", got)
+	}
+	if got := sharedDepVersion(mustParse("rq@path+../sibling")); got != "" {
+		t.Errorf("path = %q", got)
+	}
+}

--- a/package3/python/build/phase08_test.go
+++ b/package3/python/build/phase08_test.go
@@ -1,0 +1,109 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/package3/python/importspec"
+)
+
+// TestPhase8BuildOrchestration is the umbrella sentinel for MEP-71 Phase 8.
+// It walks a representative two-target Request end-to-end through
+// stubs.ParsePYI -> wrapper.Synthesise -> emit.EmitShim and asserts the
+// laid-out python_workspace contains every artifact downstream phases
+// expect.
+func TestPhase8BuildOrchestration(t *testing.T) {
+	const httpxStub = `
+from typing import Protocol
+
+class Response(Protocol):
+    status_code: int
+
+def get(url: str, timeout: float = 5.0) -> str: ...
+async def fetch(url: str) -> str: ...
+`
+	const utilStub = `
+def hash(s: str) -> str: ...
+`
+	d := NewDriver(Options{WorkDir: t.TempDir()})
+	o := NewOrchestrator(d)
+
+	httpxSpec, err := importspec.Parse("httpx@>=0.27,<0.30")
+	if err != nil {
+		t.Fatalf("Parse httpx: %v", err)
+	}
+	utilSpec, err := importspec.Parse("util")
+	if err != nil {
+		t.Fatalf("Parse util: %v", err)
+	}
+
+	res, err := o.Build(Request{
+		Targets: []Target{
+			{Spec: httpxSpec, Alias: "httpx", PYISource: httpxStub},
+			{Spec: utilSpec, Alias: "u", PYISource: utilStub},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if res.VenvRoot == "" {
+		t.Fatal("VenvRoot is empty")
+	}
+	if len(res.Wrappers) != 2 {
+		t.Fatalf("wrappers = %d, want 2", len(res.Wrappers))
+	}
+	if len(res.Shims) != 2 {
+		t.Fatalf("shims = %d, want 2", len(res.Shims))
+	}
+
+	// Workspace root
+	if _, err := os.Stat(filepath.Join(res.VenvRoot, "pyproject.toml")); err != nil {
+		t.Errorf("pyproject.toml: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(res.VenvRoot, "_mochi_wrap.py")); err != nil {
+		t.Errorf("_mochi_wrap.py: %v", err)
+	}
+
+	// Per-target artifacts
+	for _, alias := range []string{"httpx", "u"} {
+		dir := filepath.Join(res.VenvRoot, "python_wrap", alias)
+		if _, err := os.Stat(filepath.Join(dir, "__init__.py")); err != nil {
+			t.Errorf("alias %q: __init__.py: %v", alias, err)
+		}
+	}
+
+	// httpx shim text contains both sync extern fun get and async extern fun.
+	body, err := os.ReadFile(filepath.Join(res.VenvRoot, "python_wrap", "httpx", "httpx_shim.mochi"))
+	if err != nil {
+		t.Fatalf("read httpx shim: %v", err)
+	}
+	src := string(body)
+	if !strings.Contains(src, "extern python fun get") {
+		t.Errorf("httpx shim missing sync get:\n%s", src)
+	}
+	if !strings.Contains(src, "extern python fun fetch_sync") {
+		t.Errorf("httpx shim missing async fetch_sync:\n%s", src)
+	}
+
+	// pyproject.toml mentions the version-pinned dep and both wrapper paths.
+	venvBody, err := os.ReadFile(filepath.Join(res.VenvRoot, "pyproject.toml"))
+	if err != nil {
+		t.Fatalf("read pyproject.toml: %v", err)
+	}
+	venvSrc := string(venvBody)
+	if !strings.Contains(venvSrc, `"httpx>=0.27, <0.30"`) {
+		t.Errorf("pyproject.toml missing httpx version spec:\n%s", venvSrc)
+	}
+	if !strings.Contains(venvSrc, `"util"`) {
+		t.Errorf("pyproject.toml missing bare util dep:\n%s", venvSrc)
+	}
+	if !strings.Contains(venvSrc, `"python_wrap/httpx"`) {
+		t.Errorf("pyproject.toml missing httpx wrapper:\n%s", venvSrc)
+	}
+	if !strings.Contains(venvSrc, `"python_wrap/u"`) {
+		t.Errorf("pyproject.toml missing util wrapper:\n%s", venvSrc)
+	}
+}

--- a/website/docs/implementation/0071/index.md
+++ b/website/docs/implementation/0071/index.md
@@ -22,8 +22,10 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | 4 | Closed type-mapping table (scalars / strings / collections / Optional / Union / dataclass / TypedDict / Protocol) | LANDED | `39d45ea4` | [phase-04](/docs/implementation/0071/phase-04-type-mapping) |
 | 5 | Wrapper module synthesiser (`<pkg>_externs.py` + `.pyi` + `_mochi_wrap.py` runtime) | LANDED | `627e3267` | [phase-05](/docs/implementation/0071/phase-05-wrapper) |
 | 6 | Mochi-side extern fn emitter (`<pkg>_shim.mochi` with `extern python fun` + `type ... = { ... }`) | LANDED | `82aa45b6` | [phase-06](/docs/implementation/0071/phase-06-extern-emit) |
-| 7 | `import python "<package>@<semver>" as <alias>` grammar + parser | LANDED | (pending merge) | [phase-07](/docs/implementation/0071/phase-07-import-grammar) |
-| 8 | Build orchestration: workspace synth + libpython link + wheel install + wrapper compile | NOT STARTED | — | [phase-08](/docs/implementation/0071/phase-08-build) |
+| 7 | `import python "<package>@<semver>" as <alias>` grammar + parser | LANDED | `cd5fe055` | [phase-07](/docs/implementation/0071/phase-07-import-grammar) |
+| 8 | Build orchestration: workspace synth (+ wheel install + libpython link as sub-phases 8.1 / 8.2) | LANDED | (pending merge) | [phase-08](/docs/implementation/0071/phase-08-build) |
+| 8.1 | Wheel install loop: drive uv against rendered pyproject.toml | NOT STARTED | — | [phase-08](/docs/implementation/0071/phase-08-build) |
+| 8.2 | libpython link: cgo embed for `runtime-mode = "embedded"` | NOT STARTED | — | [phase-08](/docs/implementation/0071/phase-08-build) |
 | 9 | `mochi.lock` `[[python-package]]` integration + `--check` mode + capability database | NOT STARTED | — | [phase-09](/docs/implementation/0071/phase-09-lockfile) |
 | 10 | `TargetPythonPackage` emit (sdist + wheel + `mochi-build` PEP 517 backend + `.pyi` for downstream typing) | NOT STARTED | — | [phase-10](/docs/implementation/0071/phase-10-python-package-emit) |
 | 11 | Trusted publishing (`mochi pkg publish --to=pypi`) Sigstore OIDC + PEP 740 attestations | NOT STARTED | — | [phase-11](/docs/implementation/0071/phase-11-trusted-publish) |
@@ -91,7 +93,7 @@ The `package3/python/` location is shared with the broader MEP-57 polyglot packa
 
 ## Status snapshot
 
-As of 2026-05-30 00:03 (GMT+7): MEP-71 spec and research bundle landed; phases 0-7 LANDED; phases 8-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
+As of 2026-05-30 00:10 (GMT+7): MEP-71 spec and research bundle landed; phases 0-8 LANDED (8.1 + 8.2 deferred sub-phases); phases 9-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
 
 ## Cross-references
 

--- a/website/docs/implementation/0071/phase-08-build.md
+++ b/website/docs/implementation/0071/phase-08-build.md
@@ -1,0 +1,67 @@
+---
+title: "MEP-71 Phase 8: build orchestration"
+sidebar_label: "Phase 8. Build orchestration"
+sidebar_position: 9
+description: "Phase 8 of MEP-71. Composes Phase 3 / 5 / 6 / 7 into an Orchestrator that lays a python_workspace out under the driver's work-dir."
+---
+
+# Phase 8: build orchestration
+
+Phase 8 introduces `package3/python/build.Orchestrator`, the composition layer that ties Phase 3 (stub ingest) -> Phase 5 (wrapper synthesis) -> Phase 6 (shim emit) into a single Build call, then materialises the result under the Phase 0 Driver's work-dir.
+
+The phase ships the workspace synthesis side. The wheel-install loop (driving uv from Phase 2 against the rendered pyproject.toml) and the libpython link (the cgo side of the embedded runtime) decompose into sub-phases 8.1 and 8.2; both are tracked separately and ship after the orchestrator stabilises.
+
+## Gate
+
+`go test ./package3/python/build/...` is green. The gate covers:
+
+- `Plan(req)` validates the request without touching the filesystem: rejects empty Targets, empty Alias, empty Spec.Name, duplicate aliases, and a nil Driver.
+- `Plan(req)` populates `Result.Wrappers` and `Result.Shims` from `wrapper.Synthesise` and `emit.EmitShim`, propagating both `WrapperOpts` (`AllowPartial`) and `ShimOpts` (`Header`, `IncludeSkipReport`) into the per-target pipeline.
+- `Plan(req)` augments the Venv with one `MemberWrapper` per target and adds the upstream PyPI distribution to `[project.dependencies]` with the PEP 440 specifier when the spec source is `SourceRegistry` or `SourceIndex`; git and local-path sources record only the bare name (the version is satisfied by the install side configured later).
+- `Build(req)` runs Plan, then writes the workspace under the Driver's work-dir:
+  - `<work-dir>/python_workspace/pyproject.toml` (deterministic TOML).
+  - `<work-dir>/python_workspace/.gitignore` (`.venv/ __pycache__/ *.pyc`).
+  - `<work-dir>/python_workspace/_mochi_wrap.py` plus `_mochi_wrap.pyi` (the shared runtime module).
+  - `<work-dir>/python_workspace/python_wrap/<alias>/__init__.py`, `<pkg>_externs.py`, `<pkg>_externs.pyi`, `<pkg>_shim.mochi` per target.
+  - `SKIPPED.txt` per target when the wrapper refused at least one item.
+- The Build result returns the sorted `WrittenFiles` list, so callers can pipe the artifact set into the Phase 9 lockfile hash and the Phase 10 emit pass.
+- Determinism: re-running Build with the same Request produces the same shim SHA-256 and the same shim Source bytes across calls.
+- `sharedDepVersion` returns the PEP 440 specifier for registry / index sources and an empty string for git / path sources.
+- Sentinel `TestPhase8BuildOrchestration` walks a two-target Request (`httpx@>=0.27,<0.30` aliased `httpx`, bare `util` aliased `u`) end-to-end and asserts the venv root, every per-target file, the sync extern `get`, the async `fetch_sync`, and the dependency entries.
+
+## Files
+
+- `package3/python/build/orchestrator.go` — `Target`, `Request`, `Result`, `Orchestrator`, `Plan`, `Build`, `initPyTemplate`, `renderSkipped`, `sharedDepVersion`.
+- `package3/python/build/orchestrator_test.go`, `phase08_test.go` — ~20 tests + the umbrella sentinel.
+- Pre-existing `package3/python/build/driver.go`, `venv.go` are unchanged; Phase 8 builds on top of them.
+
+## Fixtures
+
+The unit tests use synthetic `.pyi` fragments crafted to exercise the gate above. Corpus-wide validation against the 25-package fixture set lands with Phase 8.1 (wheel install) once the orchestrator can actually invoke uv against the rendered pyproject.toml and observe round-trip behaviour against real distributions.
+
+## Sub-phase decomposition
+
+Phase 8 splits into three sub-phases per the umbrella-phase coverage rule:
+
+| Sub-phase | Scope | Status |
+|-----------|-------|--------|
+| 8 | Workspace synthesis: Spec list -> python_workspace tree on disk | LANDED |
+| 8.1 | Wheel install: drive uv against the rendered pyproject.toml; populate `.venv/` | NOT STARTED |
+| 8.2 | libpython link: cgo embed of CPython into the Mochi binary for `runtime-mode = "embedded"` | NOT STARTED |
+
+Sub-phases 8.1 and 8.2 are tracked alongside Phase 9 (lockfile) since the install loop and the lock hash are the same artifact from different angles.
+
+## Skip count
+
+Phase 8 forwards every Phase 5 / Phase 4 refusal into `Result.Skipped` and writes a `SKIPPED.txt` next to each affected wrapper. The expected SkipReport count per fixture is the union of every Target's wrapper Skipped slice and remains identical to Phase 5's per-package counts.
+
+## Notes
+
+- The orchestrator is filesystem-only and does not invoke any subprocess. This keeps the Phase 8 gate independent of `python3` / `uv` availability in CI. Sub-phases 8.1 and 8.2 introduce the subprocess invocations, gated by the standard build matrix.
+- Each wrapper alias lives at `python_wrap/<alias>/` rather than `python_wrap/<distribution>/`. The alias is what the user typed in `import python "<spec>" as <alias>`, so two imports of the same distribution under different aliases produce two wrapper modules with independent surfaces. The Phase 9 lockfile keys on `(distribution, alias)`.
+- `__init__.py` re-exports the externs module under the name `externs` so importing code can write `from python_wrap.<alias> import externs`. The Mochi-side shim references the wrapper module directly by its file path; the `__init__.py` exists for Python tooling and editor introspection.
+
+## Timestamps
+
+- 2026-05-30 00:04 (GMT+7): Phase 8 started.
+- 2026-05-30 00:10 (GMT+7): Phase 8 LANDED.


### PR DESCRIPTION
## Summary

- Adds `package3/python/build.Orchestrator` composing Phase 3 / 5 / 6 / 7 into a single Build call.
- `Plan(req)` validates the request and computes per-target wrappers / shims with no filesystem side effects; `Build(req)` runs Plan then writes the python_workspace layout (pyproject.toml + runtime + `python_wrap/<alias>/{__init__.py, <pkg>_externs.py, .pyi, _shim.mochi, SKIPPED.txt}`).
- Spec-source-aware dependency rendering: registry / index pass the PEP 440 specifier, git / path record only the bare name.
- Deterministic shim Source + SHA-256 across builds.
- Sub-phases 8.1 (wheel install via uv) and 8.2 (libpython cgo embed) tracked separately to keep the umbrella subprocess-free.

Tracks #22874. Builds on Phase 7 (#22860 / #22861).

## Test plan

- [x] `go test ./package3/python/build/...` green (~20 unit tests + Phase 8 sentinel)
- [x] `go test ./package3/python/...` green (regression across phases 0-8)
- [x] Plan rejects empty Targets, empty Alias, empty Spec.Name, duplicate aliases, nil Driver, malformed .pyi
- [x] Build writes pyproject.toml mentioning version-pinned dep + wrapper member entry
- [x] Shim file body contains expected `extern python fun` declarations
- [x] WrapperOpts (AllowPartial) + ShimOpts (Header / IncludeSkipReport) propagate through to the per-target pipeline
- [x] Two-target sentinel asserts httpx sync `get` and async `fetch_sync`, plus util alias `u`