### PR TITLE
feat(mep-75 p6): PHP glue stub emitter (MochiGlue\ wrapper classes)

### DIFF
--- a/package3/php/glue/glue.go
+++ b/package3/php/glue/glue.go
@@ -1,4 +1,271 @@
 // Package glue emits PHP-side use statements and forwarding stubs that bridge
-// the Mochi extern shims to the real Composer autoloaded classes. Phase 0
-// ships the package stub; the full implementation arrives in phase 6.
+// the Mochi extern shims to the real Composer autoloaded classes.
+//
+// Each PHP package processed by the bridge gets a corresponding set of glue
+// stubs under vendor/mochi-glue/<vendor>/<package>/. The stubs live in the
+// MochiGlue\<PascalVendor>\<PascalPackage>\ namespace prefix (reserved; no
+// upstream Packagist package uses MochiGlue\ as a prefix).
+//
+// The glue stubs wrap real Composer classes and provide stable PHP entry points
+// that Mochi-generated PHP code can call without knowing the original FQCN.
+// This decouples the generated PHP from the upstream package's namespace.
+//
+// Usage:
+//
+//	result, err := glue.Emit(surface, "guzzlehttp", "guzzle")
+//	if err != nil { ... }
+//	// result.Files maps relative file path -> PHP source text
 package glue
+
+import (
+	"fmt"
+	"strings"
+
+	"mochi/package3/php/reflect"
+	"mochi/package3/php/typemap"
+)
+
+// EmitResult holds the PHP glue files produced by Emit.
+type EmitResult struct {
+	// Files maps relative file path to PHP source content.
+	// Paths are relative to the glue output directory (e.g. "GuzzleHttpClient.php").
+	Files map[string]string
+	// Namespace is the PHP namespace for all glue stubs in this result.
+	Namespace string
+}
+
+// Emit generates PHP glue stubs for a Composer package.
+// vendor and pkg are the Composer vendor and package names (e.g. "guzzlehttp", "guzzle").
+func Emit(surface *reflect.ReflectionSurface, vendor, pkg string) (*EmitResult, error) {
+	ns := mochiGlueNS(vendor, pkg)
+	result := &EmitResult{
+		Files:     make(map[string]string),
+		Namespace: ns,
+	}
+
+	for _, cls := range surface.Classes {
+		fname, src := emitClassStub(ns, cls)
+		result.Files[fname] = src
+	}
+	for _, iface := range surface.Interfaces {
+		fname, src := emitInterfaceStub(ns, iface)
+		result.Files[fname] = src
+	}
+	for _, enum := range surface.Enums {
+		fname, src := emitEnumStub(ns, enum)
+		result.Files[fname] = src
+	}
+
+	return result, nil
+}
+
+// mochiGlueNS constructs the MochiGlue namespace for a given vendor/package.
+// "guzzlehttp"/"guzzle" -> "MochiGlue\\GuzzleHttp\\Guzzle"
+func mochiGlueNS(vendor, pkg string) string {
+	return "MochiGlue\\" + pascalCase(vendor) + "\\" + pascalCase(pkg)
+}
+
+// emitClassStub generates a PHP forwarding wrapper for a public class.
+func emitClassStub(ns string, cls reflect.ClassSurface) (string, string) {
+	handle := classHandle(cls.FQCN)
+	alias := "_" + handle
+	escapedFQCN := escapePHP(cls.FQCN)
+
+	var sb strings.Builder
+	writeHeader(&sb, ns)
+	fmt.Fprintf(&sb, "use %s as %s;\n\n", escapedFQCN, alias)
+	fmt.Fprintf(&sb, "class %s {\n", handle)
+	fmt.Fprintf(&sb, "    private %s $_inner;\n\n", alias)
+	fmt.Fprintf(&sb, "    public function __construct(%s $inner) {\n", alias)
+	fmt.Fprintf(&sb, "        $this->_inner = $inner;\n")
+	fmt.Fprintf(&sb, "    }\n\n")
+
+	for _, m := range cls.Methods {
+		if strings.HasPrefix(m.Name, "__") {
+			continue
+		}
+		if m.Static {
+			writeStaticForwarder(&sb, m, alias)
+		} else {
+			writeInstanceForwarder(&sb, m)
+		}
+	}
+
+	fmt.Fprintf(&sb, "}\n")
+	return handle + ".php", sb.String()
+}
+
+// emitInterfaceStub generates a PHP comment/alias stub for an interface.
+func emitInterfaceStub(ns string, iface reflect.InterfaceSurface) (string, string) {
+	handle := classHandle(iface.FQCN)
+	escapedFQCN := escapePHP(iface.FQCN)
+
+	var sb strings.Builder
+	writeHeader(&sb, ns)
+	fmt.Fprintf(&sb, "// Interface binding: %s\n", escapedFQCN)
+	fmt.Fprintf(&sb, "// Concrete implementations are wrapped by their own stubs.\n\n")
+	fmt.Fprintf(&sb, "use %s as _%s;\n", escapedFQCN, handle)
+	return handle + ".php", sb.String()
+}
+
+// emitEnumStub generates a PHP helper class for an enum.
+func emitEnumStub(ns string, enum reflect.EnumSurface) (string, string) {
+	handle := classHandle(enum.FQCN)
+	escapedFQCN := escapePHP(enum.FQCN)
+
+	var sb strings.Builder
+	writeHeader(&sb, ns)
+	fmt.Fprintf(&sb, "use %s as _%s;\n\n", escapedFQCN, handle)
+	fmt.Fprintf(&sb, "class %s {\n", handle)
+
+	if enum.BackingType != "" {
+		_, skip, _ := typemap.Map(enum.BackingType, false, typemap.DirectionIn)
+		if skip == 0 {
+			fmt.Fprintf(&sb, "    public static function fromValue(mixed $value): _%s {\n", handle)
+			fmt.Fprintf(&sb, "        return _%s::from($value);\n", handle)
+			fmt.Fprintf(&sb, "    }\n\n")
+		}
+	}
+
+	for _, c := range enum.Cases {
+		fmt.Fprintf(&sb, "    public static function case%s(): _%s {\n", c.Name, handle)
+		fmt.Fprintf(&sb, "        return _%s::%s;\n", handle, c.Name)
+		fmt.Fprintf(&sb, "    }\n\n")
+	}
+
+	fmt.Fprintf(&sb, "}\n")
+	return handle + ".php", sb.String()
+}
+
+// writeHeader writes the PHP file header with namespace declaration.
+func writeHeader(sb *strings.Builder, ns string) {
+	fmt.Fprintf(sb, "<?php\n")
+	fmt.Fprintf(sb, "declare(strict_types=1);\n")
+	fmt.Fprintf(sb, "namespace %s;\n\n", ns)
+}
+
+// writeInstanceForwarder writes a PHP instance method delegating to $_inner.
+func writeInstanceForwarder(sb *strings.Builder, m reflect.MethodSurface) {
+	params := phpParamList(m.Parameters)
+	args := phpArgList(m.Parameters)
+	retHint := phpReturnHint(m.ReturnType, m.Nullable)
+
+	if retHint != "" {
+		fmt.Fprintf(sb, "    public function %s(%s): %s {\n", m.Name, params, retHint)
+	} else {
+		fmt.Fprintf(sb, "    public function %s(%s) {\n", m.Name, params)
+	}
+	if m.ReturnType == "void" || m.ReturnType == "" {
+		fmt.Fprintf(sb, "        $this->_inner->%s(%s);\n", m.Name, args)
+	} else {
+		fmt.Fprintf(sb, "        return $this->_inner->%s(%s);\n", m.Name, args)
+	}
+	fmt.Fprintf(sb, "    }\n\n")
+}
+
+// writeStaticForwarder writes a PHP static method delegating to the original class.
+func writeStaticForwarder(sb *strings.Builder, m reflect.MethodSurface, alias string) {
+	params := phpParamList(m.Parameters)
+	args := phpArgList(m.Parameters)
+	retHint := phpReturnHint(m.ReturnType, m.Nullable)
+
+	if retHint != "" {
+		fmt.Fprintf(sb, "    public static function %s(%s): %s {\n", m.Name, params, retHint)
+	} else {
+		fmt.Fprintf(sb, "    public static function %s(%s) {\n", m.Name, params)
+	}
+	if m.ReturnType == "void" || m.ReturnType == "" {
+		fmt.Fprintf(sb, "        %s::%s(%s);\n", alias, m.Name, args)
+	} else {
+		fmt.Fprintf(sb, "        return %s::%s(%s);\n", alias, m.Name, args)
+	}
+	fmt.Fprintf(sb, "    }\n\n")
+}
+
+// phpParamList builds a PHP parameter list string.
+func phpParamList(params []reflect.ParameterSurface) string {
+	var parts []string
+	for _, p := range params {
+		var part string
+		switch {
+		case p.Variadic && p.Type != "":
+			part = fmt.Sprintf("%s ...$%s", p.Type, p.Name)
+		case p.Variadic:
+			part = fmt.Sprintf("...$%s", p.Name)
+		case p.Nullable && p.Type != "":
+			part = fmt.Sprintf("?%s $%s", p.Type, p.Name)
+		case p.Type != "":
+			part = fmt.Sprintf("%s $%s", p.Type, p.Name)
+		default:
+			part = fmt.Sprintf("$%s", p.Name)
+		}
+		parts = append(parts, part)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// phpArgList builds a PHP argument list (just $paramName references).
+func phpArgList(params []reflect.ParameterSurface) string {
+	var parts []string
+	for _, p := range params {
+		if p.Variadic {
+			parts = append(parts, "...$"+p.Name)
+		} else {
+			parts = append(parts, "$"+p.Name)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// phpReturnHint returns the PHP return type hint string for a method.
+func phpReturnHint(phpType string, nullable bool) string {
+	if phpType == "" {
+		return ""
+	}
+	if nullable {
+		return "?" + phpType
+	}
+	return phpType
+}
+
+// escapePHP ensures a FQCN uses single backslash separators (as PHP requires).
+func escapePHP(fqcn string) string {
+	fqcn = strings.TrimPrefix(fqcn, "\\")
+	return fqcn
+}
+
+// classHandle converts a PHP FQCN to a PascalCase handle name.
+func classHandle(fqcn string) string {
+	fqcn = strings.TrimPrefix(fqcn, "\\")
+	parts := strings.Split(fqcn, "\\")
+	var sb strings.Builder
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		sb.WriteString(strings.ToUpper(p[:1]))
+		sb.WriteString(p[1:])
+	}
+	name := sb.String()
+	if name == "" {
+		return "OpaqueHandle"
+	}
+	return name
+}
+
+// pascalCase converts a lowercase package name to PascalCase.
+// "guzzlehttp" -> "Guzzlehttp", "my-package" -> "MyPackage"
+func pascalCase(s string) string {
+	parts := strings.FieldsFunc(s, func(r rune) bool {
+		return r == '-' || r == '_'
+	})
+	var sb strings.Builder
+	for _, p := range parts {
+		if len(p) == 0 {
+			continue
+		}
+		sb.WriteString(strings.ToUpper(p[:1]))
+		sb.WriteString(p[1:])
+	}
+	return sb.String()
+}

--- a/package3/php/glue/glue_test.go
+++ b/package3/php/glue/glue_test.go
@@ -1,0 +1,289 @@
+package glue
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/php/reflect"
+)
+
+func surface(classes []reflect.ClassSurface, ifaces []reflect.InterfaceSurface, enums []reflect.EnumSurface) *reflect.ReflectionSurface {
+	return &reflect.ReflectionSurface{
+		PackageName: "test/pkg",
+		PHPVersion:  "8.4.0",
+		Classes:     classes,
+		Interfaces:  ifaces,
+		Enums:       enums,
+	}
+}
+
+func TestEmitEmpty(t *testing.T) {
+	result, err := Emit(surface(nil, nil, nil), "vendor", "pkg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Files) != 0 {
+		t.Errorf("empty surface should produce no files; got %d", len(result.Files))
+	}
+}
+
+func TestMochiGlueNamespace(t *testing.T) {
+	result, err := Emit(surface([]reflect.ClassSurface{
+		{FQCN: `Foo\Bar`, Methods: nil},
+	}, nil, nil), "guzzlehttp", "guzzle")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Namespace != `MochiGlue\Guzzlehttp\Guzzle` {
+		t.Errorf("Namespace = %q; want MochiGlue\\Guzzlehttp\\Guzzle", result.Namespace)
+	}
+}
+
+func TestEmitClassFileCreated(t *testing.T) {
+	result, err := Emit(surface([]reflect.ClassSurface{
+		{FQCN: `GuzzleHttp\Client`, Methods: nil},
+	}, nil, nil), "guzzlehttp", "guzzle")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src, ok := result.Files["GuzzleHttpClient.php"]
+	if !ok {
+		t.Fatalf("expected GuzzleHttpClient.php; got files: %v", fileKeys(result.Files))
+	}
+	if !strings.Contains(src, "class GuzzleHttpClient") {
+		t.Errorf("expected class GuzzleHttpClient; got:\n%s", src)
+	}
+	if !strings.Contains(src, "use GuzzleHttp\\Client as _GuzzleHttpClient") {
+		t.Errorf("expected use alias; got:\n%s", src)
+	}
+	if !strings.Contains(src, "declare(strict_types=1)") {
+		t.Errorf("expected strict_types; got:\n%s", src)
+	}
+}
+
+func TestEmitClassInstanceMethod(t *testing.T) {
+	result, err := Emit(surface([]reflect.ClassSurface{
+		{
+			FQCN: `Foo\Bar`,
+			Methods: []reflect.MethodSurface{
+				{Name: "doThing", ReturnType: "string", Parameters: []reflect.ParameterSurface{
+					{Name: "x", Type: "int"},
+				}},
+			},
+		},
+	}, nil, nil), "vendor", "pkg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src := result.Files["FooBar.php"]
+	if !strings.Contains(src, "public function doThing(int $x): string") {
+		t.Errorf("expected doThing method signature; got:\n%s", src)
+	}
+	if !strings.Contains(src, "return $this->_inner->doThing($x)") {
+		t.Errorf("expected delegation to _inner; got:\n%s", src)
+	}
+}
+
+func TestEmitClassStaticMethod(t *testing.T) {
+	result, err := Emit(surface([]reflect.ClassSurface{
+		{
+			FQCN: `Foo\Bar`,
+			Methods: []reflect.MethodSurface{
+				{Name: "create", Static: true, ReturnType: "string", Parameters: nil},
+			},
+		},
+	}, nil, nil), "vendor", "pkg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src := result.Files["FooBar.php"]
+	if !strings.Contains(src, "public static function create(): string") {
+		t.Errorf("expected static create method; got:\n%s", src)
+	}
+	if !strings.Contains(src, "return _FooBar::create()") {
+		t.Errorf("expected static delegation; got:\n%s", src)
+	}
+}
+
+func TestEmitMagicMethodSkipped(t *testing.T) {
+	result, err := Emit(surface([]reflect.ClassSurface{
+		{
+			FQCN: "Foo",
+			Methods: []reflect.MethodSurface{
+				{Name: "__construct", ReturnType: "void"},
+				{Name: "__get", ReturnType: "string", Parameters: []reflect.ParameterSurface{{Name: "name", Type: "string"}}},
+				{Name: "normalMethod", ReturnType: "void"},
+			},
+		},
+	}, nil, nil), "vendor", "pkg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src := result.Files["Foo.php"]
+	// The wrapper always has its own __construct for $_inner; check that the
+	// original's magic methods are not forwarded (i.e. no "->__construct" or "->__get").
+	if strings.Contains(src, "_inner->__construct") {
+		t.Errorf("magic __construct should not be forwarded; got:\n%s", src)
+	}
+	if strings.Contains(src, "_inner->__get") {
+		t.Errorf("magic __get should not be forwarded; got:\n%s", src)
+	}
+	if !strings.Contains(src, "normalMethod") {
+		t.Errorf("normalMethod should be present; got:\n%s", src)
+	}
+}
+
+func TestEmitVoidReturnNoReturn(t *testing.T) {
+	result, err := Emit(surface([]reflect.ClassSurface{
+		{
+			FQCN: "Foo",
+			Methods: []reflect.MethodSurface{
+				{Name: "run", ReturnType: "void"},
+			},
+		},
+	}, nil, nil), "vendor", "pkg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src := result.Files["Foo.php"]
+	// void method should NOT have a return statement
+	if strings.Contains(src, "return $this->_inner->run") {
+		t.Errorf("void method should not return value; got:\n%s", src)
+	}
+	if !strings.Contains(src, "$this->_inner->run()") {
+		t.Errorf("expected void delegation without return; got:\n%s", src)
+	}
+}
+
+func TestEmitNullableParam(t *testing.T) {
+	result, err := Emit(surface([]reflect.ClassSurface{
+		{
+			FQCN: "Foo",
+			Methods: []reflect.MethodSurface{
+				{Name: "bar", ReturnType: "void", Parameters: []reflect.ParameterSurface{
+					{Name: "x", Type: "string", Nullable: true},
+				}},
+			},
+		},
+	}, nil, nil), "vendor", "pkg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src := result.Files["Foo.php"]
+	if !strings.Contains(src, "?string $x") {
+		t.Errorf("expected ?string $x for nullable; got:\n%s", src)
+	}
+}
+
+func TestEmitVariadicParam(t *testing.T) {
+	result, err := Emit(surface([]reflect.ClassSurface{
+		{
+			FQCN: "Foo",
+			Methods: []reflect.MethodSurface{
+				{Name: "bar", ReturnType: "void", Parameters: []reflect.ParameterSurface{
+					{Name: "args", Type: "string", Variadic: true},
+				}},
+			},
+		},
+	}, nil, nil), "vendor", "pkg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src := result.Files["Foo.php"]
+	if !strings.Contains(src, "string ...$args") {
+		t.Errorf("expected string ...$args for variadic; got:\n%s", src)
+	}
+	if !strings.Contains(src, "...$args") {
+		t.Errorf("expected ...$args in delegation; got:\n%s", src)
+	}
+}
+
+func TestEmitInterface(t *testing.T) {
+	result, err := Emit(surface(nil, []reflect.InterfaceSurface{
+		{FQCN: `Psr\Log\LoggerInterface`},
+	}, nil), "psr", "log")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src, ok := result.Files["PsrLogLoggerInterface.php"]
+	if !ok {
+		t.Fatalf("expected PsrLogLoggerInterface.php; got %v", fileKeys(result.Files))
+	}
+	if !strings.Contains(src, "use Psr\\Log\\LoggerInterface as _PsrLogLoggerInterface") {
+		t.Errorf("expected use alias; got:\n%s", src)
+	}
+}
+
+func TestEmitPureEnum(t *testing.T) {
+	result, err := Emit(surface(nil, nil, []reflect.EnumSurface{
+		{FQCN: `Foo\Status`, BackingType: "", Cases: []reflect.EnumCase{
+			{Name: "Active"}, {Name: "Inactive"},
+		}},
+	}), "vendor", "pkg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src := result.Files["FooStatus.php"]
+	if !strings.Contains(src, "public static function caseActive(): _FooStatus") {
+		t.Errorf("expected caseActive accessor; got:\n%s", src)
+	}
+	if strings.Contains(src, "fromValue") {
+		t.Errorf("pure enum should not have fromValue; got:\n%s", src)
+	}
+}
+
+func TestEmitBackedEnum(t *testing.T) {
+	result, err := Emit(surface(nil, nil, []reflect.EnumSurface{
+		{FQCN: `Foo\Color`, BackingType: "string", Cases: []reflect.EnumCase{
+			{Name: "Red", Value: "red"},
+		}},
+	}), "vendor", "pkg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src := result.Files["FooColor.php"]
+	if !strings.Contains(src, "public static function fromValue(mixed $value): _FooColor") {
+		t.Errorf("expected fromValue; got:\n%s", src)
+	}
+	if !strings.Contains(src, "return _FooColor::from($value)") {
+		t.Errorf("expected from() delegation; got:\n%s", src)
+	}
+}
+
+func TestPascalCase(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"guzzlehttp", "Guzzlehttp"},
+		{"my-package", "MyPackage"},
+		{"psr", "Psr"},
+		{"symfony", "Symfony"},
+		{"some_pkg", "SomePkg"},
+	}
+	for _, tc := range cases {
+		got := pascalCase(tc.in)
+		if got != tc.want {
+			t.Errorf("pascalCase(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestClassHandle(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{`GuzzleHttp\Client`, "GuzzleHttpClient"},
+		{`Psr\Log\LoggerInterface`, "PsrLogLoggerInterface"},
+		{"", "OpaqueHandle"},
+	}
+	for _, tc := range cases {
+		got := classHandle(tc.in)
+		if got != tc.want {
+			t.Errorf("classHandle(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func fileKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/website/docs/implementation/0075/phase-06-glue.md
+++ b/website/docs/implementation/0075/phase-06-glue.md
@@ -1,0 +1,58 @@
+# MEP-75 Phase 6: PHP Glue Stub Emitter
+
+**Status**: LANDED 2026-05-30 00:00 (GMT+7)
+
+## Goal
+
+Implement the PHP-side glue stub emitter under `package3/php/glue`. The glue stubs bridge the Mochi extern type bindings to the real Composer autoloaded classes, providing a stable PHP wrapper layer in the `MochiGlue\<Vendor>\<Package>` namespace.
+
+## Design
+
+The `Emit()` function takes a `ReflectionSurface` and vendor/package names, and generates PHP files under the `MochiGlue\<PascalVendor>\<PascalPackage>` namespace.
+
+### Namespace convention
+
+`"guzzlehttp"/"guzzle"` -> `MochiGlue\Guzzlehttp\Guzzle`
+
+The `MochiGlue\` prefix is reserved -- no upstream Packagist package uses it.
+
+### Per-class stubs
+
+For each public class:
+- A PHP wrapper class with `private $_inner` holding the real object
+- Constructor `__construct(OrigClass $inner)` for injection
+- Instance method forwarders: `public function method(...params): RetType { return $this->_inner->method(...); }`
+- Static method forwarders: `public static function method(...): RetType { return OrigClass::method(...); }`
+- Magic methods (__construct from original, __get, etc.) are NOT forwarded
+
+### Per-interface stubs
+
+- PHP use alias: `use FQCN as _HandleName` with documentation comment
+- Concrete implementations are wrapped by their own class stubs
+
+### Per-enum stubs
+
+- `fromValue(mixed $value)` constructor for backed enums
+- `caseXxx()` static accessors for each enum case
+- Pure enums get only case accessors
+
+## Files Landed
+
+- `package3/php/glue/glue.go` -- Emit() + PHP code generators
+- `package3/php/glue/glue_test.go` -- 14 test functions
+
+## Test Coverage
+
+- Empty surface produces no files
+- Namespace generation (vendor/package -> MochiGlue namespace)
+- Class file creation with correct name
+- Instance method forwarding with typed params
+- Static method forwarding (no _inner delegation)
+- Magic method skip (__construct and __get not forwarded)
+- Void return (no return keyword)
+- Nullable parameter (?string)
+- Variadic parameter (Type ...$args)
+- Interface alias stub
+- Pure enum case accessors
+- Backed enum fromValue + case accessors
+- pascalCase and classHandle unit tests


### PR DESCRIPTION
## Summary

- Implements `Emit()` under `package3/php/glue`: generates PHP forwarding wrapper classes in the `MochiGlue\<Vendor>\<Package>` namespace
- Class stubs hold `private $_inner` with instance/static method forwarders; magic methods are not forwarded
- Interface stubs emit use aliases; enum stubs emit `fromValue` + case accessors for backed enums
- 14 test functions covering namespace generation, typed/nullable/variadic params, void return, magic method skip

## Test plan

- [x] `go test ./package3/php/glue/...` -- 14 tests pass
- [x] `go test ./package3/php/...` -- all packages green
- [x] `go vet ./package3/php/glue/...` -- clean