### PR TITLE
feat(mep-67): phase 02 content-addressed JAR cache

### DIFF
--- a/package3/java/maven/cache.go
+++ b/package3/java/maven/cache.go
@@ -1,0 +1,83 @@
+package maven
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ErrCacheMiss is returned when a requested entry is not in the cache.
+var ErrCacheMiss = errors.New("maven: cache miss")
+
+// Cache is a content-addressed store for JAR files. Entries are keyed by
+// their SHA-256 hex digest and stored at:
+//
+//	<CacheDir>/<sha256[0:2]>/<sha256[2:4]>/<sha256>.jar
+//
+// The layout matches the Rust bridge's cache (package3/rust/sparse/cache.go).
+type Cache struct {
+	dir string
+}
+
+// NewCache creates a Cache rooted at cacheDir. The directory is not created
+// eagerly; it is created on the first Put.
+func NewCache(cacheDir string) *Cache {
+	return &Cache{dir: cacheDir}
+}
+
+// Path returns the filesystem path where the given sha256hex entry would live.
+func (c *Cache) Path(sha256hex string) string {
+	if len(sha256hex) < 4 {
+		return filepath.Join(c.dir, sha256hex+".jar")
+	}
+	return filepath.Join(c.dir, sha256hex[0:2], sha256hex[2:4], sha256hex+".jar")
+}
+
+// Has returns true if the entry exists in the cache.
+func (c *Cache) Has(sha256hex string) bool {
+	_, err := os.Stat(c.Path(sha256hex))
+	return err == nil
+}
+
+// Get returns the cached entry for sha256hex, or ErrCacheMiss if not present.
+func (c *Cache) Get(sha256hex string) ([]byte, error) {
+	data, err := os.ReadFile(c.Path(sha256hex))
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("%w: %s", ErrCacheMiss, sha256hex)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("maven: cache get %s: %w", sha256hex, err)
+	}
+	return data, nil
+}
+
+// Put writes data to the cache under sha256hex. The write is atomic: data is
+// first written to a temp file in the same directory, then renamed to the
+// final path. Concurrent Puts of the same key are safe.
+func (c *Cache) Put(sha256hex string, data []byte) error {
+	dest := c.Path(sha256hex)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return fmt.Errorf("maven: cache mkdir %s: %w", filepath.Dir(dest), err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dest), "*.jar.tmp")
+	if err != nil {
+		return fmt.Errorf("maven: cache tmpfile: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		tmp.Close()
+		os.Remove(tmpPath) // no-op if rename succeeded
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		return fmt.Errorf("maven: cache write: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("maven: cache sync: %w", err)
+	}
+	tmp.Close()
+	if err := os.Rename(tmpPath, dest); err != nil {
+		return fmt.Errorf("maven: cache rename to %s: %w", dest, err)
+	}
+	return nil
+}

--- a/package3/java/maven/cache_test.go
+++ b/package3/java/maven/cache_test.go
@@ -1,0 +1,109 @@
+package maven
+
+import (
+	"errors"
+	"os"
+	"sync"
+	"testing"
+)
+
+func TestCachePutGet(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir)
+
+	key := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+	data := []byte("hello, cache!")
+	if err := c.Put(key, data); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := c.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Errorf("Get returned %q; want %q", got, data)
+	}
+}
+
+func TestCacheHas(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir)
+	key := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+	if c.Has(key) {
+		t.Error("Has() = true before Put")
+	}
+	if err := c.Put(key, []byte("data")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if !c.Has(key) {
+		t.Error("Has() = false after Put")
+	}
+}
+
+func TestCacheMiss(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir)
+	key := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+	_, err := c.Get(key)
+	if !errors.Is(err, ErrCacheMiss) {
+		t.Errorf("Get missing: got %v; want ErrCacheMiss", err)
+	}
+}
+
+func TestCachePath(t *testing.T) {
+	c := NewCache("/cache")
+	key := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+	got := c.Path(key)
+	want := "/cache/aa/bb/" + key + ".jar"
+	if got != want {
+		t.Errorf("Path() = %q; want %q", got, want)
+	}
+}
+
+func TestCacheAtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir)
+	key := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+	data := make([]byte, 10*1024) // 10 KB
+
+	const n = 20
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := c.Put(key, data); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent Put: %v", err)
+	}
+
+	got, err := c.Get(key)
+	if err != nil {
+		t.Fatalf("Get after concurrent Put: %v", err)
+	}
+	if len(got) != len(data) {
+		t.Errorf("Get returned %d bytes; want %d", len(got), len(data))
+	}
+
+	// Verify no temp files left.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		for _, sub := range []string{"aa", "bb"} {
+			_ = sub
+			subEntries, _ := os.ReadDir(dir + "/aa/bb/")
+			for _, se := range subEntries {
+				if se.Name() != key+".jar" {
+					t.Errorf("unexpected file in cache: %s", se.Name())
+				}
+			}
+		}
+		_ = e
+	}
+}

--- a/package3/java/maven/phase02_test.go
+++ b/package3/java/maven/phase02_test.go
@@ -1,0 +1,64 @@
+package maven
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestPhase2JARCache is the phase-gate sentinel test for MEP-67 phase 2.
+// It verifies the content-addressed JAR cache end-to-end.
+func TestPhase2JARCache(t *testing.T) {
+	t.Run("put_get_roundtrip", func(t *testing.T) {
+		dir := t.TempDir()
+		c := NewCache(dir)
+		key := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+		data := []byte("mep-67 test jar data")
+		if err := c.Put(key, data); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		got, err := c.Get(key)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if string(got) != string(data) {
+			t.Errorf("roundtrip mismatch: got %q, want %q", got, data)
+		}
+	})
+
+	t.Run("has_miss", func(t *testing.T) {
+		dir := t.TempDir()
+		c := NewCache(dir)
+		key := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+		if c.Has(key) {
+			t.Error("Has returns true for non-existent key")
+		}
+		_, err := c.Get(key)
+		if !errors.Is(err, ErrCacheMiss) {
+			t.Errorf("Get returns %v; want ErrCacheMiss", err)
+		}
+	})
+
+	t.Run("path_layout", func(t *testing.T) {
+		c := NewCache("/base")
+		key := "0102030405060708090a0b0c0d0e0f10112233445566778899aabbccddeeff00"
+		path := c.Path(key)
+		if path != "/base/01/02/"+key+".jar" {
+			t.Errorf("Path() = %q; want /base/01/02/%s.jar", path, key)
+		}
+	})
+
+	t.Run("idempotent_put", func(t *testing.T) {
+		dir := t.TempDir()
+		c := NewCache(dir)
+		key := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+		data := []byte("idempotent test")
+		for i := 0; i < 3; i++ {
+			if err := c.Put(key, data); err != nil {
+				t.Fatalf("Put iteration %d: %v", i, err)
+			}
+		}
+		if !c.Has(key) {
+			t.Error("Has returns false after repeated Puts")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `maven/cache.go`: content-addressed store with atomic writes, SHA-256 keyed at `<base>/<sha[0:2]>/<sha[2:4]>/<sha>.jar`
- Matches the Rust bridge cache layout

Closes $ISSUE

## Test plan

- [x] `go test ./package3/java/...` passes
- [x] TestPhase2JARCache: put_get_roundtrip, has_miss, path_layout, idempotent_put
- [x] TestCacheAtomicWrite: concurrent Puts don't corrupt