### PR TITLE
feat(package3/python): MEP-71 Phase 9 lockfile integration

### DIFF
--- a/package3/python/lockfile/capabilities.go
+++ b/package3/python/lockfile/capabilities.go
@@ -1,0 +1,119 @@
+package lockfile
+
+import (
+	"sort"
+
+	"mochi/package3/python/typemap"
+	"mochi/package3/python/wrapper"
+)
+
+// Capability tokens are the closed vocabulary the lockfile records and the
+// Phase 15 attestation gate verifies against. The set is intentionally small
+// so the lockfile diff stays human-readable; richer per-item capability data
+// stays on the wrapper side.
+const (
+	CapAsync     = "async"
+	CapDataclass = "dataclass"
+	CapProtocol  = "protocol"
+	CapCallable  = "callable"
+	CapStream    = "stream"
+	CapMap       = "map"
+	CapSet       = "set"
+	CapList      = "list"
+	CapOptional  = "optional"
+	CapSum       = "sum"
+	CapTuple     = "tuple"
+	CapConstant  = "constant"
+	CapTypeVar   = "typevar"
+)
+
+// ExtractCapabilities walks a wrapper.Wrapper and returns the sorted, deduped
+// capability list. The classification is intentionally conservative: only
+// concrete Mochi type shapes contribute, so a wrapper whose surface fits
+// inside scalars + records + functions emits an empty list (records produce
+// the "dataclass" token, functions produce "callable").
+func ExtractCapabilities(w *wrapper.Wrapper) []string {
+	if w == nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for _, it := range w.Items {
+		if it.IsAsync {
+			seen[CapAsync] = struct{}{}
+		}
+		switch it.Kind {
+		case wrapper.ItemRecord:
+			seen[CapDataclass] = struct{}{}
+		case wrapper.ItemInterface:
+			seen[CapProtocol] = struct{}{}
+		case wrapper.ItemConstant:
+			seen[CapConstant] = struct{}{}
+		}
+		walkMochiType(it.Type, seen)
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func walkMochiType(t typemap.MochiType, seen map[string]struct{}) {
+	switch t.Kind {
+	case typemap.KindList:
+		seen[CapList] = struct{}{}
+		walkParams(t, seen)
+	case typemap.KindSet:
+		seen[CapSet] = struct{}{}
+		walkParams(t, seen)
+	case typemap.KindMap:
+		seen[CapMap] = struct{}{}
+		walkParams(t, seen)
+	case typemap.KindOptional:
+		seen[CapOptional] = struct{}{}
+		walkParams(t, seen)
+	case typemap.KindSum:
+		seen[CapSum] = struct{}{}
+		walkParams(t, seen)
+	case typemap.KindTuple:
+		seen[CapTuple] = struct{}{}
+		walkParams(t, seen)
+	case typemap.KindFun:
+		seen[CapCallable] = struct{}{}
+		walkParams(t, seen)
+	case typemap.KindAsync:
+		seen[CapAsync] = struct{}{}
+		walkParams(t, seen)
+	case typemap.KindStream:
+		seen[CapStream] = struct{}{}
+		walkParams(t, seen)
+	case typemap.KindRecord:
+		seen[CapDataclass] = struct{}{}
+		for _, f := range t.Fields {
+			walkMochiType(f.Type, seen)
+		}
+	case typemap.KindInterface:
+		seen[CapProtocol] = struct{}{}
+		for _, m := range t.Methods {
+			if m.IsAsync {
+				seen[CapAsync] = struct{}{}
+			}
+			for _, p := range m.Params {
+				walkMochiType(p, seen)
+			}
+			walkMochiType(m.Return, seen)
+		}
+	case typemap.KindTypeVar:
+		seen[CapTypeVar] = struct{}{}
+	}
+}
+
+func walkParams(t typemap.MochiType, seen map[string]struct{}) {
+	for _, p := range t.Params {
+		walkMochiType(p, seen)
+	}
+}

--- a/package3/python/lockfile/diff.go
+++ b/package3/python/lockfile/diff.go
@@ -1,0 +1,174 @@
+package lockfile
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// DiffKind classifies how two manifest entries differ.
+type DiffKind int
+
+const (
+	// DiffAdded marks an entry present in the new manifest only.
+	DiffAdded DiffKind = iota
+	// DiffRemoved marks an entry present in the old manifest only.
+	DiffRemoved
+	// DiffChanged marks an entry whose fields changed between manifests.
+	DiffChanged
+)
+
+func (k DiffKind) String() string {
+	switch k {
+	case DiffAdded:
+		return "added"
+	case DiffRemoved:
+		return "removed"
+	case DiffChanged:
+		return "changed"
+	}
+	return "unknown"
+}
+
+// DiffEntry is one delta line in a manifest comparison. Old is nil for added
+// entries; New is nil for removed entries; both are set for changed entries
+// and the Fields slice lists the keys that diverged.
+type DiffEntry struct {
+	Kind   DiffKind
+	Key    string
+	Old    *Entry
+	New    *Entry
+	Fields []string
+}
+
+// String renders the DiffEntry in a single-line `kind key (fields)` form
+// suitable for the `mochi pkg lock --check` exit summary.
+func (de DiffEntry) String() string {
+	if len(de.Fields) > 0 {
+		return fmt.Sprintf("%s %s (%s)", de.Kind, de.Key, strings.Join(de.Fields, ","))
+	}
+	return fmt.Sprintf("%s %s", de.Kind, de.Key)
+}
+
+// Diff is the ordered list of differences between two manifests.
+type Diff struct {
+	Entries []DiffEntry
+}
+
+// Empty reports whether the two manifests are identical.
+func (d Diff) Empty() bool { return len(d.Entries) == 0 }
+
+// String renders the diff as a newline-joined block.
+func (d Diff) String() string {
+	parts := make([]string, len(d.Entries))
+	for i, e := range d.Entries {
+		parts[i] = e.String()
+	}
+	return strings.Join(parts, "\n")
+}
+
+// CompareManifests returns the Diff between old (the on-disk lockfile) and
+// new (the freshly-Planned manifest). The comparison key is
+// `<name>:<alias>`.
+func CompareManifests(old, new Manifest) Diff {
+	keyOld := indexByKey(old)
+	keyNew := indexByKey(new)
+	allKeys := mergedKeys(keyOld, keyNew)
+	d := Diff{}
+	for _, k := range allKeys {
+		o, oOK := keyOld[k]
+		n, nOK := keyNew[k]
+		switch {
+		case oOK && nOK:
+			if fields := entryFieldDiff(o, n); len(fields) > 0 {
+				oCopy, nCopy := o, n
+				d.Entries = append(d.Entries, DiffEntry{Kind: DiffChanged, Key: k, Old: &oCopy, New: &nCopy, Fields: fields})
+			}
+		case nOK:
+			nCopy := n
+			d.Entries = append(d.Entries, DiffEntry{Kind: DiffAdded, Key: k, New: &nCopy})
+		case oOK:
+			oCopy := o
+			d.Entries = append(d.Entries, DiffEntry{Kind: DiffRemoved, Key: k, Old: &oCopy})
+		}
+	}
+	return d
+}
+
+// Check returns nil when the two manifests are identical, an error containing
+// the rendered Diff otherwise. This is the kernel of `mochi pkg lock --check`.
+func Check(old, new Manifest) error {
+	d := CompareManifests(old, new)
+	if d.Empty() {
+		return nil
+	}
+	return fmt.Errorf("lockfile drift:\n%s", d.String())
+}
+
+func indexByKey(m Manifest) map[string]Entry {
+	idx := make(map[string]Entry, len(m.Entries))
+	for _, e := range m.Entries {
+		idx[e.Name+":"+e.Alias] = e
+	}
+	return idx
+}
+
+func mergedKeys(a, b map[string]Entry) []string {
+	set := map[string]struct{}{}
+	for k := range a {
+		set[k] = struct{}{}
+	}
+	for k := range b {
+		set[k] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func entryFieldDiff(a, b Entry) []string {
+	var f []string
+	if a.Source != b.Source {
+		f = append(f, "source")
+	}
+	if a.Version != b.Version {
+		f = append(f, "version")
+	}
+	if a.Specifier != b.Specifier {
+		f = append(f, "specifier")
+	}
+	if a.IndexURL != b.IndexURL {
+		f = append(f, "index-url")
+	}
+	if a.GitURL != b.GitURL {
+		f = append(f, "git-url")
+	}
+	if a.GitRev != b.GitRev {
+		f = append(f, "git-rev")
+	}
+	if a.LocalPath != b.LocalPath {
+		f = append(f, "local-path")
+	}
+	if a.WrapperSHA256 != b.WrapperSHA256 {
+		f = append(f, "wrapper-sha256")
+	}
+	if !stringSliceEqual(a.Capabilities, b.Capabilities) {
+		f = append(f, "capabilities")
+	}
+	return f
+}
+
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/package3/python/lockfile/doc.go
+++ b/package3/python/lockfile/doc.go
@@ -1,0 +1,23 @@
+// Package lockfile is the MEP-71 Phase 9 implementation of the
+// `[[python-package]]` table that lives inside the workspace mochi.lock.
+//
+// Each entry records:
+//
+//   - The PyPI distribution name (PEP 503-normalised) plus the user's alias.
+//   - The resolution source: registry / index / git / path.
+//   - The exact resolved version (for registry / index) or VCS revision
+//     (for git) or path (for path).
+//   - The Phase 6 shim SHA-256 (`wrapper-sha256`) so `mochi pkg lock --check`
+//     can detect surface drift between the recorded lock and the current
+//     wrapper output.
+//   - A sorted capability list extracted from the wrapper surface (async,
+//     dataclass, protocol, callable, awaitable). Phase 15 verifies these
+//     against the attestation set.
+//
+// The package provides both directions of the round-trip plus a Diff /
+// Check helper for the `mochi pkg lock --check` mode.
+//
+// See MEP-71 §5 "Lockfile entry" for the normative schema. The TOML output
+// is hand-rendered (no third-party encoder) so the bytes are stable for
+// hashing.
+package lockfile

--- a/package3/python/lockfile/entry.go
+++ b/package3/python/lockfile/entry.go
@@ -1,0 +1,76 @@
+package lockfile
+
+import "sort"
+
+// SchemaVersion is the currently emitted lockfile schema number. Bump when
+// the entry shape changes; Parse refuses any version it does not know.
+const SchemaVersion = 1
+
+// Source classifies how the entry was resolved. Mirrors importspec.Source
+// but uses string tokens so the TOML on-disk form is human-readable.
+type Source string
+
+const (
+	SourceRegistry Source = "registry"
+	SourceIndex    Source = "index"
+	SourceGit      Source = "git"
+	SourcePath     Source = "path"
+)
+
+// Valid reports whether s is one of the four known sources.
+func (s Source) Valid() bool {
+	switch s {
+	case SourceRegistry, SourceIndex, SourceGit, SourcePath:
+		return true
+	}
+	return false
+}
+
+// Entry is one `[[python-package]]` table.
+type Entry struct {
+	// Name is the PEP 503-normalised distribution name.
+	Name string
+	// Alias is the Mochi alias the user picked in `import python ... as alias`.
+	Alias string
+	// Source is the resolution source.
+	Source Source
+	// Version is the exact resolved version for SourceRegistry / SourceIndex.
+	// Empty for SourceGit (use GitRev) and SourcePath.
+	Version string
+	// Specifier preserves the original PEP 440 spec from the import body.
+	Specifier string
+	// IndexURL is set when Source = SourceIndex.
+	IndexURL string
+	// GitURL is set when Source = SourceGit.
+	GitURL string
+	// GitRev is set when Source = SourceGit.
+	GitRev string
+	// LocalPath is set when Source = SourcePath.
+	LocalPath string
+	// WrapperSHA256 is the Phase 6 emit.Shim.SHA256, hex-encoded.
+	WrapperSHA256 string
+	// Capabilities is the sorted, deduped list of capability tokens used by
+	// the wrapped surface. The list shape is documented in
+	// capabilities.go::ExtractCapabilities.
+	Capabilities []string
+}
+
+// Manifest is the full `[[python-package]]` array for a workspace.
+type Manifest struct {
+	// Version is the schema version. Always SchemaVersion when produced by
+	// this package; preserved when round-tripped through Parse for forward
+	// compatibility reporting.
+	Version int
+	// Entries is sorted by (Name, Alias) for determinism.
+	Entries []Entry
+}
+
+// Sort sorts the entries in canonical order: (Name, Alias) ascending.
+func (m *Manifest) Sort() {
+	sort.SliceStable(m.Entries, func(i, j int) bool {
+		if m.Entries[i].Name != m.Entries[j].Name {
+			return m.Entries[i].Name < m.Entries[j].Name
+		}
+		return m.Entries[i].Alias < m.Entries[j].Alias
+	})
+}

--- a/package3/python/lockfile/from_build.go
+++ b/package3/python/lockfile/from_build.go
@@ -1,0 +1,75 @@
+package lockfile
+
+import (
+	"fmt"
+
+	"mochi/package3/python/build"
+	"mochi/package3/python/importspec"
+)
+
+// FromBuildResult converts a build.Result + the originating Request into a
+// canonical Manifest. The Manifest is sorted on return.
+//
+// The Version field on each Entry holds the resolved version. Phase 9 does
+// not perform resolution itself; it forwards what the Request's spec already
+// carries (a pinned `==N.N.N` becomes Version=N.N.N, an open `>=N` keeps
+// Version empty). Sub-phase 8.1 will populate Version from the uv resolver
+// output once the install loop lands.
+func FromBuildResult(req build.Request, res *build.Result) (Manifest, error) {
+	if res == nil {
+		return Manifest{}, fmt.Errorf("lockfile: nil build.Result")
+	}
+	if len(req.Targets) != len(res.Wrappers) || len(req.Targets) != len(res.Shims) {
+		return Manifest{}, fmt.Errorf("lockfile: Request/Result target count mismatch (req=%d wrappers=%d shims=%d)",
+			len(req.Targets), len(res.Wrappers), len(res.Shims))
+	}
+	m := Manifest{Version: SchemaVersion}
+	for i, t := range req.Targets {
+		entry := Entry{
+			Name:          t.Spec.Name,
+			Alias:         t.Alias,
+			Source:        toSource(t.Spec.Source),
+			Specifier:     t.Spec.Specifier.String(),
+			IndexURL:      t.Spec.IndexURL,
+			GitURL:        t.Spec.GitURL,
+			GitRev:        t.Spec.GitRev,
+			LocalPath:     t.Spec.LocalPath,
+			WrapperSHA256: res.Shims[i].SHA256,
+			Capabilities:  ExtractCapabilities(res.Wrappers[i]),
+		}
+		entry.Version = pinnedVersion(t.Spec)
+		m.Entries = append(m.Entries, entry)
+	}
+	m.Sort()
+	return m, nil
+}
+
+func toSource(s importspec.Source) Source {
+	switch s {
+	case importspec.SourceRegistry:
+		return SourceRegistry
+	case importspec.SourceIndex:
+		return SourceIndex
+	case importspec.SourceGit:
+		return SourceGit
+	case importspec.SourcePath:
+		return SourcePath
+	}
+	return ""
+}
+
+// pinnedVersion returns the exact version a SourceRegistry / SourceIndex spec
+// pins to (`==N.N.N`), or empty when the spec is open-ended or a non-registry
+// source.
+func pinnedVersion(s importspec.Spec) string {
+	if s.Source != importspec.SourceRegistry && s.Source != importspec.SourceIndex {
+		return ""
+	}
+	if len(s.Specifier.Clauses) == 1 {
+		c := s.Specifier.Clauses[0]
+		if c.Op.String() == "==" {
+			return c.Version.String()
+		}
+	}
+	return ""
+}

--- a/package3/python/lockfile/lockfile_test.go
+++ b/package3/python/lockfile/lockfile_test.go
@@ -1,0 +1,382 @@
+package lockfile
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/package3/python/build"
+	"mochi/package3/python/importspec"
+)
+
+const minimalStub = `def add(a: int, b: int) -> int: ...`
+
+const recordStub = `
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class Pair:
+    first: int
+    second: int
+
+def make() -> Pair: ...
+`
+
+const asyncStub = `
+async def fetch(url: str) -> str: ...
+`
+
+func makeBuildResult(t *testing.T, raw, alias, pyi string) (build.Request, *build.Result) {
+	t.Helper()
+	spec, err := importspec.Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", raw, err)
+	}
+	d := build.NewDriver(build.Options{WorkDir: t.TempDir(), CacheDir: filepath.Join(t.TempDir(), "cache")})
+	o := build.NewOrchestrator(d)
+	req := build.Request{Targets: []build.Target{{Spec: spec, Alias: alias, PYISource: pyi}}}
+	res, err := o.Build(req)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return req, res
+}
+
+func TestSourceValid(t *testing.T) {
+	for _, s := range []Source{SourceRegistry, SourceIndex, SourceGit, SourcePath} {
+		if !s.Valid() {
+			t.Errorf("Source(%q) reports invalid", s)
+		}
+	}
+	if Source("nonsense").Valid() {
+		t.Errorf("invalid source slipped through")
+	}
+}
+
+func TestManifestSortByNameThenAlias(t *testing.T) {
+	m := Manifest{Entries: []Entry{
+		{Name: "z", Alias: "a"},
+		{Name: "a", Alias: "b"},
+		{Name: "a", Alias: "a"},
+	}}
+	m.Sort()
+	if m.Entries[0].Name != "a" || m.Entries[0].Alias != "a" {
+		t.Errorf("first = %+v", m.Entries[0])
+	}
+	if m.Entries[2].Name != "z" {
+		t.Errorf("last = %+v", m.Entries[2])
+	}
+}
+
+func TestFromBuildResultRegistryEntry(t *testing.T) {
+	req, res := makeBuildResult(t, "minimal", "mn", minimalStub)
+	m, err := FromBuildResult(req, res)
+	if err != nil {
+		t.Fatalf("FromBuildResult: %v", err)
+	}
+	if len(m.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(m.Entries))
+	}
+	e := m.Entries[0]
+	if e.Name != "minimal" || e.Alias != "mn" || e.Source != SourceRegistry {
+		t.Errorf("entry = %+v", e)
+	}
+	if e.WrapperSHA256 == "" {
+		t.Errorf("WrapperSHA256 is empty")
+	}
+}
+
+func TestFromBuildResultExactPinPopulatesVersion(t *testing.T) {
+	req, res := makeBuildResult(t, "pydantic@==2.6.1", "pyd", minimalStub)
+	m, _ := FromBuildResult(req, res)
+	if m.Entries[0].Version != "2.6.1" {
+		t.Errorf("Version = %q, want 2.6.1", m.Entries[0].Version)
+	}
+}
+
+func TestFromBuildResultOpenRangeLeavesVersionEmpty(t *testing.T) {
+	req, res := makeBuildResult(t, "requests@>=2.0,<3.0", "rq", minimalStub)
+	m, _ := FromBuildResult(req, res)
+	if m.Entries[0].Version != "" {
+		t.Errorf("Version = %q, want empty", m.Entries[0].Version)
+	}
+	if m.Entries[0].Specifier != ">=2.0, <3.0" {
+		t.Errorf("Specifier = %q", m.Entries[0].Specifier)
+	}
+}
+
+func TestFromBuildResultGitEntry(t *testing.T) {
+	req, res := makeBuildResult(t, "mypkg@git+https://github.com/user/repo#main", "mp", minimalStub)
+	m, _ := FromBuildResult(req, res)
+	e := m.Entries[0]
+	if e.Source != SourceGit {
+		t.Errorf("Source = %q", e.Source)
+	}
+	if e.GitURL != "https://github.com/user/repo" || e.GitRev != "main" {
+		t.Errorf("Git fields: url=%q rev=%q", e.GitURL, e.GitRev)
+	}
+}
+
+func TestFromBuildResultPathEntry(t *testing.T) {
+	req, res := makeBuildResult(t, "mypkg@path+../sibling", "mp", minimalStub)
+	m, _ := FromBuildResult(req, res)
+	e := m.Entries[0]
+	if e.Source != SourcePath {
+		t.Errorf("Source = %q", e.Source)
+	}
+	if e.LocalPath != "../sibling" {
+		t.Errorf("LocalPath = %q", e.LocalPath)
+	}
+}
+
+func TestFromBuildResultIndexEntry(t *testing.T) {
+	req, res := makeBuildResult(t, "torch@torch+https://download.pytorch.org/whl/cu121", "tc", minimalStub)
+	m, _ := FromBuildResult(req, res)
+	e := m.Entries[0]
+	if e.Source != SourceIndex || e.IndexURL == "" {
+		t.Errorf("Index fields: source=%q url=%q", e.Source, e.IndexURL)
+	}
+}
+
+func TestFromBuildResultMismatchRejected(t *testing.T) {
+	_, err := FromBuildResult(build.Request{Targets: []build.Target{{Alias: "x"}}}, &build.Result{})
+	if err == nil {
+		t.Fatal("expected error for mismatched counts")
+	}
+}
+
+func TestFromBuildResultNilResult(t *testing.T) {
+	if _, err := FromBuildResult(build.Request{}, nil); err == nil {
+		t.Fatal("expected error for nil Result")
+	}
+}
+
+func TestRenderTOMLRoundTrip(t *testing.T) {
+	m := Manifest{Version: SchemaVersion, Entries: []Entry{
+		{
+			Name:          "requests",
+			Alias:         "rq",
+			Source:        SourceRegistry,
+			Specifier:     ">=2.0, <3.0",
+			WrapperSHA256: "deadbeef",
+			Capabilities:  []string{"callable", "optional"},
+		},
+		{
+			Name:          "mypkg",
+			Alias:         "mp",
+			Source:        SourceGit,
+			GitURL:        "https://github.com/user/repo",
+			GitRev:        "main",
+			WrapperSHA256: "cafebabe",
+		},
+	}}
+	src := RenderTOML(m)
+	back, err := ParseTOML(src)
+	if err != nil {
+		t.Fatalf("ParseTOML: %v\n%s", err, src)
+	}
+	if len(back.Entries) != 2 {
+		t.Fatalf("round-trip entries = %d", len(back.Entries))
+	}
+	// Sorted by name: mypkg before requests.
+	if back.Entries[0].Name != "mypkg" {
+		t.Errorf("first entry = %+v", back.Entries[0])
+	}
+	rq := back.Entries[1]
+	if rq.Specifier != ">=2.0, <3.0" || rq.WrapperSHA256 != "deadbeef" {
+		t.Errorf("rq = %+v", rq)
+	}
+	if len(rq.Capabilities) != 2 {
+		t.Errorf("capabilities = %v", rq.Capabilities)
+	}
+}
+
+func TestRenderTOMLOmitsEmptyOptionals(t *testing.T) {
+	m := Manifest{Entries: []Entry{{Name: "x", Alias: "x", Source: SourceRegistry}}}
+	src := RenderTOML(m)
+	for _, key := range []string{"index-url", "git-url", "git-rev", "local-path", "wrapper-sha256", "specifier", "capabilities"} {
+		if strings.Contains(src, key) {
+			t.Errorf("rendered output contains optional %q:\n%s", key, src)
+		}
+	}
+	if strings.Contains(src, "\nversion =") {
+		t.Errorf("rendered output contains optional version:\n%s", src)
+	}
+}
+
+func TestRenderTOMLDeterministic(t *testing.T) {
+	m := Manifest{Version: SchemaVersion, Entries: []Entry{
+		{Name: "b", Alias: "b", Source: SourceRegistry},
+		{Name: "a", Alias: "a", Source: SourceRegistry},
+	}}
+	one := RenderTOML(m)
+	two := RenderTOML(m)
+	if one != two {
+		t.Errorf("RenderTOML not deterministic")
+	}
+}
+
+func TestParseTOMLRejectsUnknownSchemaVersion(t *testing.T) {
+	src := "schema-version = 99\n[[python-package]]\nname=\"x\"\nalias=\"x\"\nsource=\"registry\"\n"
+	if _, err := ParseTOML(src); err == nil {
+		t.Fatal("expected error for unknown schema-version")
+	}
+}
+
+func TestParseTOMLRejectsMissingSchemaVersion(t *testing.T) {
+	src := "[[python-package]]\nname=\"x\"\nalias=\"x\"\nsource=\"registry\"\n"
+	if _, err := ParseTOML(src); err == nil {
+		t.Fatal("expected error for missing schema-version")
+	}
+}
+
+func TestParseTOMLRejectsInvalidSource(t *testing.T) {
+	src := "schema-version = 1\n[[python-package]]\nname=\"x\"\nalias=\"x\"\nsource=\"madeup\"\n"
+	if _, err := ParseTOML(src); err == nil {
+		t.Fatal("expected error for invalid source")
+	}
+}
+
+func TestParseTOMLRejectsMissingRequiredField(t *testing.T) {
+	src := "schema-version = 1\n[[python-package]]\nname=\"x\"\nsource=\"registry\"\n"
+	if _, err := ParseTOML(src); err == nil {
+		t.Fatal("expected error for missing alias")
+	}
+}
+
+func TestExtractCapabilitiesAsync(t *testing.T) {
+	req, res := makeBuildResult(t, "asynclib", "as", asyncStub)
+	m, _ := FromBuildResult(req, res)
+	found := false
+	for _, c := range m.Entries[0].Capabilities {
+		if c == CapAsync {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("async capability missing: %v", m.Entries[0].Capabilities)
+	}
+}
+
+func TestExtractCapabilitiesDataclass(t *testing.T) {
+	req, res := makeBuildResult(t, "reclib", "rc", recordStub)
+	m, _ := FromBuildResult(req, res)
+	found := false
+	for _, c := range m.Entries[0].Capabilities {
+		if c == CapDataclass {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("dataclass capability missing: %v", m.Entries[0].Capabilities)
+	}
+}
+
+func TestExtractCapabilitiesNil(t *testing.T) {
+	if ExtractCapabilities(nil) != nil {
+		t.Errorf("nil wrapper should produce nil capabilities")
+	}
+}
+
+func TestCompareManifestsEmpty(t *testing.T) {
+	a := Manifest{Entries: []Entry{{Name: "x", Alias: "x", Source: SourceRegistry}}}
+	b := Manifest{Entries: []Entry{{Name: "x", Alias: "x", Source: SourceRegistry}}}
+	d := CompareManifests(a, b)
+	if !d.Empty() {
+		t.Errorf("diff = %v", d.String())
+	}
+}
+
+func TestCompareManifestsAdded(t *testing.T) {
+	a := Manifest{}
+	b := Manifest{Entries: []Entry{{Name: "x", Alias: "x", Source: SourceRegistry}}}
+	d := CompareManifests(a, b)
+	if len(d.Entries) != 1 || d.Entries[0].Kind != DiffAdded {
+		t.Errorf("diff = %+v", d.Entries)
+	}
+}
+
+func TestCompareManifestsRemoved(t *testing.T) {
+	a := Manifest{Entries: []Entry{{Name: "x", Alias: "x", Source: SourceRegistry}}}
+	b := Manifest{}
+	d := CompareManifests(a, b)
+	if len(d.Entries) != 1 || d.Entries[0].Kind != DiffRemoved {
+		t.Errorf("diff = %+v", d.Entries)
+	}
+}
+
+func TestCompareManifestsChanged(t *testing.T) {
+	a := Manifest{Entries: []Entry{{Name: "x", Alias: "x", Source: SourceRegistry, Version: "1.0"}}}
+	b := Manifest{Entries: []Entry{{Name: "x", Alias: "x", Source: SourceRegistry, Version: "2.0"}}}
+	d := CompareManifests(a, b)
+	if len(d.Entries) != 1 || d.Entries[0].Kind != DiffChanged {
+		t.Errorf("diff = %+v", d.Entries)
+	}
+	if d.Entries[0].Fields[0] != "version" {
+		t.Errorf("fields = %v", d.Entries[0].Fields)
+	}
+}
+
+func TestCheckMatching(t *testing.T) {
+	a := Manifest{Entries: []Entry{{Name: "x", Alias: "x", Source: SourceRegistry}}}
+	b := Manifest{Entries: []Entry{{Name: "x", Alias: "x", Source: SourceRegistry}}}
+	if err := Check(a, b); err != nil {
+		t.Errorf("Check(matching) = %v", err)
+	}
+}
+
+func TestCheckMismatching(t *testing.T) {
+	a := Manifest{Entries: []Entry{{Name: "x", Alias: "x", Source: SourceRegistry, Version: "1.0"}}}
+	b := Manifest{Entries: []Entry{{Name: "x", Alias: "x", Source: SourceRegistry, Version: "2.0"}}}
+	err := Check(a, b)
+	if err == nil {
+		t.Fatal("expected drift error")
+	}
+	if !strings.Contains(err.Error(), "version") {
+		t.Errorf("err = %q", err.Error())
+	}
+}
+
+func TestDiffEntryString(t *testing.T) {
+	de := DiffEntry{Kind: DiffChanged, Key: "x:y", Fields: []string{"a", "b"}}
+	if got := de.String(); got != "changed x:y (a,b)" {
+		t.Errorf("String = %q", got)
+	}
+	de2 := DiffEntry{Kind: DiffAdded, Key: "x:y"}
+	if got := de2.String(); got != "added x:y" {
+		t.Errorf("String = %q", got)
+	}
+}
+
+func TestDiffKindStringCoverage(t *testing.T) {
+	cases := []struct {
+		k    DiffKind
+		want string
+	}{
+		{DiffAdded, "added"},
+		{DiffRemoved, "removed"},
+		{DiffChanged, "changed"},
+		{DiffKind(99), "unknown"},
+	}
+	for _, tc := range cases {
+		if got := tc.k.String(); got != tc.want {
+			t.Errorf("DiffKind(%d).String = %q, want %q", tc.k, got, tc.want)
+		}
+	}
+}
+
+func TestRoundTripFromBuild(t *testing.T) {
+	req, res := makeBuildResult(t, "asynclib@>=1.0,<2.0", "as", asyncStub)
+	original, err := FromBuildResult(req, res)
+	if err != nil {
+		t.Fatalf("FromBuildResult: %v", err)
+	}
+	src := RenderTOML(original)
+	parsed, err := ParseTOML(src)
+	if err != nil {
+		t.Fatalf("ParseTOML: %v\n%s", err, src)
+	}
+	if err := Check(original, parsed); err != nil {
+		t.Errorf("round-trip drift:\n%v\nrendered:\n%s", err, src)
+	}
+}

--- a/package3/python/lockfile/parse.go
+++ b/package3/python/lockfile/parse.go
@@ -1,0 +1,85 @@
+package lockfile
+
+import (
+	"fmt"
+
+	"mochi/package3/python/toml"
+)
+
+// ParseTOML reads a serialised manifest back into structured form. Unknown
+// schema versions are rejected so a future writer cannot silently change the
+// shape under an older reader.
+func ParseTOML(src string) (Manifest, error) {
+	tree, err := toml.Parse(src)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("lockfile: parse: %w", err)
+	}
+	dec := toml.NewDecoder(tree)
+	version, present, err := dec.Int("schema-version")
+	if err != nil {
+		return Manifest{}, err
+	}
+	if !present {
+		return Manifest{}, fmt.Errorf("lockfile: missing required key %q", "schema-version")
+	}
+	if int(version) != SchemaVersion {
+		return Manifest{}, fmt.Errorf("lockfile: unsupported schema-version %d (this build understands %d)", version, SchemaVersion)
+	}
+	m := Manifest{Version: int(version)}
+	arr, _, err := dec.TableArray("python-package")
+	if err != nil {
+		return Manifest{}, err
+	}
+	for i, sub := range arr {
+		e, err := decodeEntry(sub)
+		if err != nil {
+			return Manifest{}, fmt.Errorf("lockfile: entry %d: %w", i, err)
+		}
+		m.Entries = append(m.Entries, e)
+	}
+	m.Sort()
+	return m, nil
+}
+
+func decodeEntry(d *toml.Decoder) (Entry, error) {
+	name, err := d.StringRequired("name")
+	if err != nil {
+		return Entry{}, err
+	}
+	alias, err := d.StringRequired("alias")
+	if err != nil {
+		return Entry{}, err
+	}
+	source, err := d.StringRequired("source")
+	if err != nil {
+		return Entry{}, err
+	}
+	e := Entry{Name: name, Alias: alias, Source: Source(source)}
+	if !e.Source.Valid() {
+		return Entry{}, fmt.Errorf("invalid source %q", source)
+	}
+	for _, opt := range []struct {
+		key string
+		ptr *string
+	}{
+		{"version", &e.Version},
+		{"specifier", &e.Specifier},
+		{"index-url", &e.IndexURL},
+		{"git-url", &e.GitURL},
+		{"git-rev", &e.GitRev},
+		{"local-path", &e.LocalPath},
+		{"wrapper-sha256", &e.WrapperSHA256},
+	} {
+		s, _, err := d.String(opt.key)
+		if err != nil {
+			return Entry{}, err
+		}
+		*opt.ptr = s
+	}
+	caps, _, err := d.StringArray("capabilities")
+	if err != nil {
+		return Entry{}, err
+	}
+	e.Capabilities = caps
+	return e, nil
+}

--- a/package3/python/lockfile/phase09_test.go
+++ b/package3/python/lockfile/phase09_test.go
@@ -1,0 +1,127 @@
+package lockfile
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/python/build"
+	"mochi/package3/python/importspec"
+)
+
+// TestPhase9LockfileIntegration is the umbrella sentinel for MEP-71 Phase 9.
+// It runs a two-target Build, converts the Result into a Manifest, round-trips
+// through TOML, runs Check across an artificial drift, and asserts the
+// `--check` mode error surfaces both an added entry and a wrapper-sha256
+// change.
+func TestPhase9LockfileIntegration(t *testing.T) {
+	httpxSpec, err := importspec.Parse("httpx@==0.27.2")
+	if err != nil {
+		t.Fatalf("Parse httpx: %v", err)
+	}
+	utilSpec, err := importspec.Parse("util")
+	if err != nil {
+		t.Fatalf("Parse util: %v", err)
+	}
+	d := build.NewDriver(build.Options{WorkDir: t.TempDir()})
+	o := build.NewOrchestrator(d)
+	req := build.Request{Targets: []build.Target{
+		{Spec: httpxSpec, Alias: "httpx", PYISource: `async def fetch(url: str) -> str: ...
+def get(url: str) -> str: ...`},
+		{Spec: utilSpec, Alias: "u", PYISource: `
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class Pair:
+    a: int
+    b: int
+
+def make() -> Pair: ...
+`},
+	}}
+	res, err := o.Build(req)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	manifest, err := FromBuildResult(req, res)
+	if err != nil {
+		t.Fatalf("FromBuildResult: %v", err)
+	}
+
+	if manifest.Version != SchemaVersion {
+		t.Errorf("Version = %d", manifest.Version)
+	}
+	if len(manifest.Entries) != 2 {
+		t.Fatalf("entries = %d", len(manifest.Entries))
+	}
+
+	// Verify the httpx entry pinned to ==0.27.2 produced Version=0.27.2.
+	var httpxEntry, utilEntry Entry
+	for _, e := range manifest.Entries {
+		switch e.Name {
+		case "httpx":
+			httpxEntry = e
+		case "util":
+			utilEntry = e
+		}
+	}
+	if httpxEntry.Version != "0.27.2" {
+		t.Errorf("httpx Version = %q, want 0.27.2", httpxEntry.Version)
+	}
+	if httpxEntry.WrapperSHA256 == "" {
+		t.Errorf("httpx WrapperSHA256 is empty")
+	}
+	asyncFound := false
+	for _, c := range httpxEntry.Capabilities {
+		if c == CapAsync {
+			asyncFound = true
+		}
+	}
+	if !asyncFound {
+		t.Errorf("httpx async capability missing: %v", httpxEntry.Capabilities)
+	}
+	dcFound := false
+	for _, c := range utilEntry.Capabilities {
+		if c == CapDataclass {
+			dcFound = true
+		}
+	}
+	if !dcFound {
+		t.Errorf("util dataclass capability missing: %v", utilEntry.Capabilities)
+	}
+
+	// TOML round-trip.
+	src := RenderTOML(manifest)
+	parsed, err := ParseTOML(src)
+	if err != nil {
+		t.Fatalf("ParseTOML: %v\n%s", err, src)
+	}
+	if err := Check(manifest, parsed); err != nil {
+		t.Errorf("round-trip drift: %v\nrendered:\n%s", err, src)
+	}
+
+	// --check drift scenario: add a third entry + flip a wrapper hash.
+	drifted := manifest
+	drifted.Entries = append([]Entry(nil), manifest.Entries...)
+	for i := range drifted.Entries {
+		if drifted.Entries[i].Name == "httpx" {
+			drifted.Entries[i].WrapperSHA256 = "0000"
+		}
+	}
+	drifted.Entries = append(drifted.Entries, Entry{
+		Name:   "ghost",
+		Alias:  "gh",
+		Source: SourceRegistry,
+	})
+	drifted.Sort()
+	err = Check(manifest, drifted)
+	if err == nil {
+		t.Fatal("expected --check to surface drift")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "added ghost:gh") {
+		t.Errorf("Check err missing added: %q", msg)
+	}
+	if !strings.Contains(msg, "changed httpx:httpx") || !strings.Contains(msg, "wrapper-sha256") {
+		t.Errorf("Check err missing changed wrapper-sha256: %q", msg)
+	}
+}

--- a/package3/python/lockfile/render.go
+++ b/package3/python/lockfile/render.go
@@ -1,0 +1,81 @@
+package lockfile
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RenderTOML produces a deterministic TOML document for the manifest. The
+// schema:
+//
+//	# Auto-generated. Do not edit by hand. Regenerate via `mochi pkg lock`.
+//	schema-version = 1
+//
+//	[[python-package]]
+//	name = "..."
+//	alias = "..."
+//	source = "registry"
+//	version = "2.6.1"
+//	specifier = ">=2.0, <3.0"
+//	wrapper-sha256 = "..."
+//	capabilities = ["async", "dataclass"]
+//
+// Optional fields are omitted when empty. The order inside each table is
+// fixed; the order across tables matches Manifest.Entries (sorted by
+// (Name, Alias)).
+func RenderTOML(m Manifest) string {
+	out := m
+	out.Sort()
+	v := out.Version
+	if v == 0 {
+		v = SchemaVersion
+	}
+	var b strings.Builder
+	b.WriteString("# Auto-generated MEP-71 python lockfile. Do not edit by hand.\n")
+	b.WriteString("# Regenerate via `mochi pkg lock`.\n")
+	fmt.Fprintf(&b, "schema-version = %d\n", v)
+	b.WriteString("\n")
+	for _, e := range out.Entries {
+		renderEntry(&b, e)
+	}
+	return b.String()
+}
+
+func renderEntry(b *strings.Builder, e Entry) {
+	b.WriteString("[[python-package]]\n")
+	fmt.Fprintf(b, "name = %q\n", e.Name)
+	fmt.Fprintf(b, "alias = %q\n", e.Alias)
+	fmt.Fprintf(b, "source = %q\n", string(e.Source))
+	if e.Version != "" {
+		fmt.Fprintf(b, "version = %q\n", e.Version)
+	}
+	if e.Specifier != "" {
+		fmt.Fprintf(b, "specifier = %q\n", e.Specifier)
+	}
+	if e.IndexURL != "" {
+		fmt.Fprintf(b, "index-url = %q\n", e.IndexURL)
+	}
+	if e.GitURL != "" {
+		fmt.Fprintf(b, "git-url = %q\n", e.GitURL)
+	}
+	if e.GitRev != "" {
+		fmt.Fprintf(b, "git-rev = %q\n", e.GitRev)
+	}
+	if e.LocalPath != "" {
+		fmt.Fprintf(b, "local-path = %q\n", e.LocalPath)
+	}
+	if e.WrapperSHA256 != "" {
+		fmt.Fprintf(b, "wrapper-sha256 = %q\n", e.WrapperSHA256)
+	}
+	if len(e.Capabilities) > 0 {
+		b.WriteString("capabilities = [")
+		for i, c := range e.Capabilities {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			fmt.Fprintf(b, "%q", c)
+		}
+		b.WriteString("]\n")
+	}
+	b.WriteString("\n")
+}

--- a/website/docs/implementation/0071/index.md
+++ b/website/docs/implementation/0071/index.md
@@ -23,10 +23,10 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | 5 | Wrapper module synthesiser (`<pkg>_externs.py` + `.pyi` + `_mochi_wrap.py` runtime) | LANDED | `627e3267` | [phase-05](/docs/implementation/0071/phase-05-wrapper) |
 | 6 | Mochi-side extern fn emitter (`<pkg>_shim.mochi` with `extern python fun` + `type ... = { ... }`) | LANDED | `82aa45b6` | [phase-06](/docs/implementation/0071/phase-06-extern-emit) |
 | 7 | `import python "<package>@<semver>" as <alias>` grammar + parser | LANDED | `cd5fe055` | [phase-07](/docs/implementation/0071/phase-07-import-grammar) |
-| 8 | Build orchestration: workspace synth (+ wheel install + libpython link as sub-phases 8.1 / 8.2) | LANDED | (pending merge) | [phase-08](/docs/implementation/0071/phase-08-build) |
+| 8 | Build orchestration: workspace synth (+ wheel install + libpython link as sub-phases 8.1 / 8.2) | LANDED | `a8ec48f3` | [phase-08](/docs/implementation/0071/phase-08-build) |
 | 8.1 | Wheel install loop: drive uv against rendered pyproject.toml | NOT STARTED | — | [phase-08](/docs/implementation/0071/phase-08-build) |
 | 8.2 | libpython link: cgo embed for `runtime-mode = "embedded"` | NOT STARTED | — | [phase-08](/docs/implementation/0071/phase-08-build) |
-| 9 | `mochi.lock` `[[python-package]]` integration + `--check` mode + capability database | NOT STARTED | — | [phase-09](/docs/implementation/0071/phase-09-lockfile) |
+| 9 | `mochi.lock` `[[python-package]]` integration + `--check` mode + capability database | LANDED | (pending merge) | [phase-09](/docs/implementation/0071/phase-09-lockfile) |
 | 10 | `TargetPythonPackage` emit (sdist + wheel + `mochi-build` PEP 517 backend + `.pyi` for downstream typing) | NOT STARTED | — | [phase-10](/docs/implementation/0071/phase-10-python-package-emit) |
 | 11 | Trusted publishing (`mochi pkg publish --to=pypi`) Sigstore OIDC + PEP 740 attestations | NOT STARTED | — | [phase-11](/docs/implementation/0071/phase-11-trusted-publish) |
 | 12 | Async bridge (asyncio.run per-call + persistent loop opt-in + cross-loop hazard guards) | NOT STARTED | — | [phase-12](/docs/implementation/0071/phase-12-async-bridge) |
@@ -82,6 +82,7 @@ package3/python/
   wrapper/                # <pkg>_externs.py + .pyi + _mochi_wrap.py synthesiser (phase 5)
   emit/                   # Mochi shim emitter — <pkg>_shim.mochi with extern python fun + type aliases (phase 6)
   importspec/             # import python "<spec>" body parser (phase 7)
+  lockfile/               # mochi.lock [[python-package]] table + --check diff + capability database (phase 9)
   publish/                # PyPI publish + Sigstore + PEP 740 attestations (phase 11)
   attest/                 # attestation verification (phase 15)
   pyodide/                # wasm32-emscripten + WASI Preview 2 target support (phase 16)
@@ -93,7 +94,7 @@ The `package3/python/` location is shared with the broader MEP-57 polyglot packa
 
 ## Status snapshot
 
-As of 2026-05-30 00:10 (GMT+7): MEP-71 spec and research bundle landed; phases 0-8 LANDED (8.1 + 8.2 deferred sub-phases); phases 9-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
+As of 2026-05-30 00:17 (GMT+7): MEP-71 spec and research bundle landed; phases 0-9 LANDED (8.1 + 8.2 deferred sub-phases); phases 10-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
 
 ## Cross-references
 

--- a/website/docs/implementation/0071/phase-09-lockfile.md
+++ b/website/docs/implementation/0071/phase-09-lockfile.md
@@ -1,0 +1,59 @@
+---
+title: "MEP-71 Phase 9: lockfile integration"
+sidebar_label: "Phase 9. Lockfile"
+sidebar_position: 10
+description: "Phase 9 of MEP-71. Adds the `[[python-package]]` table for mochi.lock plus `--check` drift detection plus a closed-vocabulary capability database."
+---
+
+# Phase 9: lockfile integration
+
+Phase 9 introduces `package3/python/lockfile`, the package that produces and consumes the `[[python-package]]` array inside mochi.lock. The phase covers three responsibilities:
+
+1. **Schema**: the on-disk TOML shape that each `import python` declaration pins to.
+2. **`--check` mode**: a deterministic Diff between the on-disk lock and what `Plan` would currently produce, used by the `mochi pkg lock --check` CLI gate to refuse drift in CI.
+3. **Capability database**: a sorted, closed-vocabulary list of capability tokens extracted from the Phase 5 `Wrapper.Items`, recorded on each entry so Phase 15 (attestation verification) can verify the surface against the attested set.
+
+## Gate
+
+`go test ./package3/python/lockfile/...` is green. The gate covers:
+
+- `Source.Valid()` admits exactly the four MEP-71 §5 sources (`registry`, `index`, `git`, `path`) and rejects everything else.
+- `Manifest.Sort` is `(Name, Alias)` ascending for deterministic round-trips.
+- `FromBuildResult(req, res)` converts a Phase 8 Build result into a Manifest: every Target produces one Entry with the spec source, the original PEP 440 specifier, the resolved version when the spec is `==N.N.N`, the wrapper SHA-256, and the extracted capability list. Mismatched req / res counts and nil results are rejected.
+- `RenderTOML(m)` produces a deterministic TOML document with one `[[python-package]]` table per entry. Optional fields (version, specifier, index-url, git-url, git-rev, local-path, wrapper-sha256, capabilities) are omitted when empty so the lock stays compact.
+- `ParseTOML(src)` reads the document back: rejects an unknown `schema-version`, a missing `schema-version`, and any entry missing a required key (`name`, `alias`, `source`) or holding an unknown source token.
+- Round-trip: `Check(FromBuildResult(req, res), ParseTOML(RenderTOML(...)))` returns nil.
+- `CompareManifests` and `Check` classify every per-entry delta as `added` / `removed` / `changed`; `changed` reports the field set that diverged. The diff key is `<Name>:<Alias>` so the same distribution under two aliases shows up as two independent entries.
+- `ExtractCapabilities(w)` walks `wrapper.Wrapper.Items` and the lowered `typemap.MochiType` tree, emitting tokens from the closed vocabulary: `async`, `dataclass`, `protocol`, `callable`, `stream`, `map`, `set`, `list`, `optional`, `sum`, `tuple`, `constant`, `typevar`. A wrapper whose surface is empty produces a nil list.
+- Sentinel `TestPhase9LockfileIntegration` walks a two-target Build through `FromBuildResult` -> `RenderTOML` -> `ParseTOML` -> `Check`, asserts the pinned httpx version surfaces, the async + dataclass capabilities are recorded, and `Check` against an artificially drifted manifest surfaces both an added ghost entry and a flipped `wrapper-sha256`.
+
+## Files
+
+- `package3/python/lockfile/doc.go` — package overview pointing at MEP-71 §5.
+- `package3/python/lockfile/entry.go` — `SchemaVersion`, `Source`, `Entry`, `Manifest`, `Manifest.Sort`.
+- `package3/python/lockfile/capabilities.go` — capability token constants and `ExtractCapabilities`.
+- `package3/python/lockfile/from_build.go` — `FromBuildResult` plus the `toSource` and `pinnedVersion` helpers.
+- `package3/python/lockfile/render.go` — `RenderTOML` and `renderEntry`.
+- `package3/python/lockfile/parse.go` — `ParseTOML` and `decodeEntry`, layered on `package3/python/toml`.
+- `package3/python/lockfile/diff.go` — `DiffKind`, `DiffEntry`, `Diff`, `CompareManifests`, `Check`.
+- `package3/python/lockfile/lockfile_test.go`, `phase09_test.go` — ~30 tests + the Phase 9 sentinel.
+
+## Fixtures
+
+The unit tests use synthetic `.pyi` fragments (the same minimal / record / async shapes Phase 8 uses) to exercise the gate. Corpus-wide validation against the 25-package fixture set lands with sub-phase 8.1 (wheel install) once the resolver populates the `version` field with real resolved versions; today the Phase 9 sentinel keys on pinned `==N.N.N` specs.
+
+## Skip count
+
+Phase 9 introduces no new refusal cases. The Phase 5 / Phase 4 `SkipReport`s already surface through `Result.Skipped` from Phase 8; Phase 9 keeps them out of the lockfile entirely (they belong to the per-wrapper `SKIPPED.txt`, not the lock).
+
+## Notes
+
+- The lockfile is keyed on `(distribution, alias)`. Two imports of the same PyPI distribution under different aliases produce two independent lockfile entries; each carries its own wrapper SHA-256 because the alias drives the wrapper module path. This matches Phase 8's per-alias `python_wrap/<alias>/` layout.
+- The TOML encoder is hand-rolled (no third-party library) so the rendered bytes stay stable for hashing the workspace lock. The parser reuses `package3/python/toml`.
+- Capability tokens are intentionally coarse. Phase 15 will gate attestation requirements per token (e.g. an attested wrapper must declare its `callable` surface); the closed vocabulary keeps the audit log human-readable.
+- `--check` mode (`mochi pkg lock --check`) is implemented by the `Check` function plus the CLI plumbing that lives in MEP-57 (the polyglot workspace lock); the CLI gate calls `lockfile.Check(onDisk, FromBuildResult(req, res))` and surfaces the diff verbatim on non-zero exit.
+
+## Timestamps
+
+- 2026-05-30 00:11 (GMT+7): Phase 9 started.
+- 2026-05-30 00:17 (GMT+7): Phase 9 LANDED.


### PR DESCRIPTION
## Summary

- Adds `package3/python/lockfile` covering the `[[python-package]]` schema, `--check` drift detection, and the closed-vocabulary capability database.
- `RenderTOML` / `ParseTOML` produce a hand-rolled deterministic TOML round-trip on top of `package3/python/toml`; optional fields omitted when empty.
- `FromBuildResult` converts Phase 8 outputs into a canonical Manifest with spec source, PEP 440 specifier, exact-pin -> Version, Phase 6 shim SHA-256, and the extracted capabilities.
- `Check(old, new)` is the kernel of `mochi pkg lock --check`: classifies per-entry deltas as added / removed / changed (with field set) and returns a human-readable error on drift.
- `ExtractCapabilities` walks `wrapper.Items` and the lowered MochiType tree and emits a sorted, deduped list from the closed token vocabulary that Phase 15 will gate attestations against.

Tracks #22892. Builds on Phase 8 (#22874 / #22875).

## Test plan

- [x] `go test ./package3/python/lockfile/...` green (~30 unit tests + Phase 9 sentinel)
- [x] `go test ./package3/python/...` green (regression across phases 0-9)
- [x] Round-trip through Render -> Parse preserves every entry
- [x] `Check` surfaces both added and changed entries with the correct field set
- [x] Capability extraction emits `async` for async functions, `dataclass` for frozen records
- [x] Schema-version drift, missing required keys, and invalid source tokens are all rejected