### PR TITLE
MEP-74 phase 12: git-tag publish flow

### DIFF
--- a/package3/go/publish/env.go
+++ b/package3/go/publish/env.go
@@ -1,0 +1,7 @@
+package publish
+
+import "os"
+
+// getenv is the os.Environ wrapper the runner uses. It is split out
+// so unit tests can stub it without touching real process env.
+var getenv = func() []string { return os.Environ() }

--- a/package3/go/publish/phase12_test.go
+++ b/package3/go/publish/phase12_test.go
@@ -1,0 +1,202 @@
+package publish
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/package3/go/library"
+)
+
+// TestPhase12GitTagPublishSentinel is the MEP-74 phase 12 end-to-end
+// sentinel. It exercises the full publish flow against a local
+// bare-repo fixture (no network) and proves:
+//
+//   - library.Emit -> Publish.Validate -> Publish.Run produces a
+//     real git working tree whose committed tree matches the
+//     emitted Files map byte-for-byte;
+//   - the tag and the commit both end up in the bare-repo remote;
+//   - a downstream `git clone` of the remote checks out the
+//     publish commit, the publish tag resolves on the clone, and
+//     `go build ./...` against the clone succeeds (the publish
+//     does not break the buildability of the underlying library
+//     module);
+//   - DryRun mode leaves the local tree intact (commit + tag both
+//     present locally) but the remote bare-repo stays empty.
+func TestPhase12GitTagPublishSentinel(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("go not available: %v", err)
+	}
+
+	root := t.TempDir()
+	remoteRoot := filepath.Join(root, "remote.git")
+	if err := runCmd(t, root, "git", "init", "--bare", remoteRoot); err != nil {
+		t.Fatalf("init bare remote: %v", err)
+	}
+
+	api := library.PublicAPI{
+		ModulePath:  "example.com/mochi/calc",
+		PackageName: "calc",
+		Version:     "v0.2.0",
+		GoVersion:   "1.21",
+		Meta: library.PackageMeta{
+			DocComment:  "Package calc is a tiny calculator published by Mochi.",
+			Description: "Tiny calculator",
+			License:     "MIT",
+			LicenseText: "MIT License\n\nCopyright (c) 2026 Mochi.\n",
+		},
+		Items: []library.Item{
+			library.ItemConst{Name: "Version", Type: "string", Value: "\"v0.2.0\""},
+			library.ItemFunc{Name: "Add",
+				Params:  []library.Param{{Name: "a", Type: "int64"}, {Name: "b", Type: "int64"}},
+				Results: []library.Result{{Type: "int64"}},
+				Body:    "return a + b",
+			},
+		},
+	}
+	files, err := library.Emit(api)
+	if err != nil {
+		t.Fatalf("library.Emit: %v", err)
+	}
+
+	t.Run("happy path publishes and remote receives tag", func(t *testing.T) {
+		req := PublishRequest{
+			Files:         files,
+			ModulePath:    api.ModulePath,
+			Tag:           "v0.2.0",
+			RemoteURL:     "file://" + remoteRoot,
+			Author:        Author{Name: "Mochi CI", Email: "ci@mochi-lang.org"},
+			WorkspaceRoot: filepath.Join(root, "ws-happy"),
+		}
+		res, err := Publish(req, NewExecRunner())
+		if err != nil {
+			t.Fatalf("Publish: %v", err)
+		}
+		if !res.Pushed {
+			t.Fatalf("expected Pushed=true")
+		}
+		if len(res.CommitSHA) < 40 {
+			t.Errorf("CommitSHA looks short: %q", res.CommitSHA)
+		}
+
+		// The remote should have the tag and the commit now.
+		out, err := combinedOutput(remoteRoot, "git", "tag", "-l")
+		if err != nil {
+			t.Fatalf("list remote tags: %v\n%s", err, out)
+		}
+		if !strings.Contains(out, "v0.2.0") {
+			t.Errorf("remote does not have tag v0.2.0:\n%s", out)
+		}
+
+		// Clone the bare repo and verify the publish.
+		clonePath := filepath.Join(root, "consumer-clone")
+		if out, err := combinedOutput(root, "git", "clone", "file://"+remoteRoot, clonePath); err != nil {
+			t.Fatalf("clone remote: %v\n%s", err, out)
+		}
+		if out, err := combinedOutput(clonePath, "git", "checkout", "v0.2.0"); err != nil {
+			t.Fatalf("checkout tag: %v\n%s", err, out)
+		}
+		// The emitted go.mod / doc.go / calc.go must all be there.
+		for _, want := range []string{"go.mod", "doc.go", "calc.go", "LICENSE"} {
+			path := filepath.Join(clonePath, want)
+			if _, err := os.Stat(path); err != nil {
+				t.Errorf("clone missing %s: %v", want, err)
+			}
+		}
+		// `go build ./...` against the cloned tree must succeed.
+		out, err = goCmd(clonePath, "go", "build", "./...")
+		if err != nil {
+			t.Errorf("go build on clone failed: %v\n%s", err, out)
+		}
+	})
+
+	t.Run("dry run does not touch the remote", func(t *testing.T) {
+		req := PublishRequest{
+			Files:         files,
+			ModulePath:    api.ModulePath,
+			Tag:           "v0.3.0",
+			RemoteURL:     "file://" + remoteRoot,
+			Author:        Author{Name: "Mochi CI", Email: "ci@mochi-lang.org"},
+			WorkspaceRoot: filepath.Join(root, "ws-dry"),
+			DryRun:        true,
+		}
+		res, err := Publish(req, NewExecRunner())
+		if err != nil {
+			t.Fatalf("Publish dry-run: %v", err)
+		}
+		if res.Pushed {
+			t.Errorf("DryRun should report Pushed=false")
+		}
+		// Local tag still present.
+		out, err := combinedOutput(req.WorkspaceRoot, "git", "tag", "-l")
+		if err != nil {
+			t.Fatalf("local tag -l: %v\n%s", err, out)
+		}
+		if !strings.Contains(out, "v0.3.0") {
+			t.Errorf("local tag v0.3.0 missing under DryRun:\n%s", out)
+		}
+		// Remote tag must NOT have v0.3.0.
+		out, _ = combinedOutput(remoteRoot, "git", "tag", "-l")
+		if strings.Contains(out, "v0.3.0") {
+			t.Errorf("remote should not have v0.3.0 under DryRun; got:\n%s", out)
+		}
+	})
+
+	t.Run("canonical import path mismatch is blocked", func(t *testing.T) {
+		req := PublishRequest{
+			Files:         files,
+			ModulePath:    "example.com/wrong",
+			Tag:           "v0.4.0",
+			RemoteURL:     "file://" + remoteRoot,
+			Author:        Author{Name: "Mochi CI", Email: "ci@mochi-lang.org"},
+			WorkspaceRoot: filepath.Join(root, "ws-mismatch"),
+		}
+		_, err := Publish(req, NewExecRunner())
+		if err == nil {
+			t.Errorf("expected canonical-import-path mismatch error")
+		}
+		if !strings.Contains(err.Error(), "go.mod declares module") {
+			t.Errorf("unexpected error text: %v", err)
+		}
+	})
+}
+
+func runCmd(t *testing.T, dir, name string, args ...string) error {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("%s %v failed: %v\n%s", name, args, err, out)
+	}
+	return err
+}
+
+func combinedOutput(dir, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func goCmd(dir, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	gocache, _ := os.MkdirTemp("", "gocache-")
+	gomodcache, _ := os.MkdirTemp("", "gomodcache-")
+	defer os.RemoveAll(gocache)
+	defer os.RemoveAll(gomodcache)
+	cmd.Env = append(os.Environ(),
+		"GOCACHE="+gocache,
+		"GOMODCACHE="+gomodcache,
+		"GOFLAGS=",
+		"GO111MODULE=on",
+	)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}

--- a/package3/go/publish/publish.go
+++ b/package3/go/publish/publish.go
@@ -1,0 +1,275 @@
+// Package publish is the MEP-74 phase 12 git-tag publish flow. It
+// owns the `mochi pkg publish --to=go+git+<repo-url>@<tag>` driver:
+// taking a rendered Go library module (typically the output of
+// `package3/go/library.Emit`), materialising it into a fresh git
+// working tree, validating the canonical-import-path invariant
+// (the go.mod `module` directive must match the configured remote
+// repo URL one-to-one), committing, tagging with the provided
+// semver tag, and (unless DryRun) pushing both the commit and the
+// tag to the configured remote.
+//
+// The package is layering-conservative: it imports
+// `package3/go/library` for the Files input shape and
+// `package3/go/semver` for the tag validator, and otherwise depends
+// only on the Go stdlib. All side effects flow through a small
+// command runner (see runner.go) so the publish driver is
+// end-to-end unit-testable against a local bare-repo fixture
+// without touching a real registry or remote.
+//
+// The publish surface is split into a pure shaping layer
+// (PublishRequest.Validate, CanonicalImportPath) and an impure
+// runner (Publish) so callers can validate the request before
+// touching git. The runner is idempotent over the workspace root:
+// passing the same WorkspaceRoot twice rebuilds the tree from
+// scratch.
+package publish
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"mochi/package3/go/library"
+	"mochi/package3/go/semver"
+)
+
+// ErrPublish is the package-wide error sentinel. Per-call failures
+// embed it via fmt.Errorf("%w: ...", ErrPublish, ...) so callers can
+// errors.Is-match without parsing message text.
+var ErrPublish = errors.New("publish")
+
+// PublishRequest is the in-memory shape of a `mochi pkg publish`
+// invocation. The struct is the boundary between the pure prep
+// phase (Validate, CanonicalImportPath) and the impure runner
+// (Publish), so callers can fully validate the request before
+// touching git.
+type PublishRequest struct {
+	// Files is the rendered Go module to publish (typically the
+	// output of library.Emit). Required. Must contain go.mod.
+	Files library.EmitResult
+	// ModulePath is the canonical Go module path the consumer
+	// will write in their `import` statements (e.g.
+	// "github.com/mochilang/calc"). Required. Cross-validated
+	// against the go.mod `module` directive AND the RemoteURL by
+	// CanonicalImportPath.
+	ModulePath string
+	// Tag is the semver tag to apply to the commit, in `v` form
+	// (e.g. "v0.1.0"). Required. Cross-validated by
+	// semver.IsValid.
+	Tag string
+	// RemoteURL is the git remote URL to push to (e.g.
+	// "file:///tmp/repo.git", "git@github.com:mochilang/calc.git").
+	// Required (even under DryRun the URL is recorded as the
+	// `origin` remote so a follow-up retry can finish the push).
+	RemoteURL string
+	// Author is the git author/committer recorded on the publish
+	// commit. Required.
+	Author Author
+	// CommitMessage is the publish commit subject. Optional;
+	// defaults to "publish <tag>".
+	CommitMessage string
+	// DefaultBranch is the branch the publish commit is pushed
+	// to (and the local branch the working tree initialises on).
+	// Optional; defaults to "main".
+	DefaultBranch string
+	// WorkspaceRoot is the directory where the publish working
+	// tree is assembled. Optional; when empty, Publish creates a
+	// temp directory and records the path in PublishResult.
+	WorkspaceRoot string
+	// DryRun skips the `git push` step but still performs every
+	// local action (init, commit, tag). Used by `mochi pkg
+	// publish --dry-run`.
+	DryRun bool
+}
+
+// Author is the git author/committer pair recorded on the publish
+// commit.
+type Author struct {
+	Name, Email string
+}
+
+// PublishResult is the outcome of a Publish call. CommitSHA and
+// Tag are echoed back so the CLI layer can print a confirmation;
+// Pushed reflects whether the `git push` step actually ran (false
+// under DryRun).
+type PublishResult struct {
+	WorkspaceRoot string
+	CommitSHA     string
+	Tag           string
+	Pushed        bool
+	FilesWritten  []string
+}
+
+// Validate checks the structural invariants of a PublishRequest.
+// Empty Files, empty ModulePath, malformed Tag, empty Author, or a
+// canonical-import-path mismatch (go.mod `module X` != ModulePath)
+// surface here so callers fail fast before any git side effects.
+func (r PublishRequest) Validate() error {
+	if len(r.Files.Files) == 0 {
+		return fmt.Errorf("%w: Files is empty", ErrPublish)
+	}
+	if _, ok := r.Files.Files["go.mod"]; !ok {
+		return fmt.Errorf("%w: Files missing go.mod", ErrPublish)
+	}
+	if strings.TrimSpace(r.ModulePath) == "" {
+		return fmt.Errorf("%w: ModulePath is required", ErrPublish)
+	}
+	if !semver.IsValid(r.Tag) {
+		return fmt.Errorf("%w: Tag %q is not a valid semver tag (expected vMAJOR.MINOR.PATCH)", ErrPublish, r.Tag)
+	}
+	if strings.TrimSpace(r.RemoteURL) == "" {
+		return fmt.Errorf("%w: RemoteURL is required", ErrPublish)
+	}
+	if strings.TrimSpace(r.Author.Name) == "" {
+		return fmt.Errorf("%w: Author.Name is required", ErrPublish)
+	}
+	if strings.TrimSpace(r.Author.Email) == "" {
+		return fmt.Errorf("%w: Author.Email is required", ErrPublish)
+	}
+	declared, err := CanonicalImportPath(r.Files.Files["go.mod"])
+	if err != nil {
+		return err
+	}
+	if declared != r.ModulePath {
+		return fmt.Errorf("%w: go.mod declares module %q but PublishRequest.ModulePath is %q", ErrPublish, declared, r.ModulePath)
+	}
+	return nil
+}
+
+// CanonicalImportPath extracts the module path from a go.mod body.
+// Returns an error if the file does not begin with a `module <path>`
+// directive (per Go's go.mod grammar, that directive must precede
+// every other top-level statement).
+func CanonicalImportPath(goMod string) (string, error) {
+	for _, raw := range strings.Split(goMod, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "//") {
+			continue
+		}
+		if !strings.HasPrefix(line, "module ") {
+			return "", fmt.Errorf("%w: go.mod first non-comment line is %q; want a module directive", ErrPublish, line)
+		}
+		path := strings.TrimSpace(strings.TrimPrefix(line, "module "))
+		path = strings.Trim(path, "\"")
+		if path == "" {
+			return "", fmt.Errorf("%w: go.mod module directive has empty path", ErrPublish)
+		}
+		return path, nil
+	}
+	return "", fmt.Errorf("%w: go.mod is empty", ErrPublish)
+}
+
+// Publish runs the full publish flow. The Runner argument is the
+// command-execution boundary; pass NewExecRunner() in production
+// or a fake runner in tests. The returned PublishResult records
+// the workspace path, commit SHA, tag, and whether the push step
+// ran. On any error the partial workspace is left on disk for the
+// caller to inspect (Publish does not delete a failed working
+// tree).
+func Publish(req PublishRequest, runner Runner) (PublishResult, error) {
+	if err := req.Validate(); err != nil {
+		return PublishResult{}, err
+	}
+
+	defaultBranch := req.DefaultBranch
+	if defaultBranch == "" {
+		defaultBranch = "main"
+	}
+	commitMessage := req.CommitMessage
+	if commitMessage == "" {
+		commitMessage = "publish " + req.Tag
+	}
+
+	root := req.WorkspaceRoot
+	if root == "" {
+		tmp, err := os.MkdirTemp("", "mochi-publish-")
+		if err != nil {
+			return PublishResult{}, fmt.Errorf("%w: temp dir: %v", ErrPublish, err)
+		}
+		root = tmp
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return PublishResult{}, fmt.Errorf("%w: mkdir workspace: %v", ErrPublish, err)
+	}
+
+	written, err := materialiseFiles(root, req.Files)
+	if err != nil {
+		return PublishResult{}, err
+	}
+
+	if err := runner.Run(root, "git", "init", "--initial-branch="+defaultBranch); err != nil {
+		return PublishResult{}, fmt.Errorf("%w: git init: %v", ErrPublish, err)
+	}
+	if err := runner.Run(root, "git", "config", "user.name", req.Author.Name); err != nil {
+		return PublishResult{}, fmt.Errorf("%w: git config user.name: %v", ErrPublish, err)
+	}
+	if err := runner.Run(root, "git", "config", "user.email", req.Author.Email); err != nil {
+		return PublishResult{}, fmt.Errorf("%w: git config user.email: %v", ErrPublish, err)
+	}
+	if err := runner.Run(root, "git", "config", "commit.gpgsign", "false"); err != nil {
+		return PublishResult{}, fmt.Errorf("%w: git config commit.gpgsign: %v", ErrPublish, err)
+	}
+	if err := runner.Run(root, "git", "config", "tag.gpgsign", "false"); err != nil {
+		return PublishResult{}, fmt.Errorf("%w: git config tag.gpgsign: %v", ErrPublish, err)
+	}
+	if err := runner.Run(root, "git", "remote", "add", "origin", req.RemoteURL); err != nil {
+		return PublishResult{}, fmt.Errorf("%w: git remote add origin: %v", ErrPublish, err)
+	}
+	if err := runner.Run(root, "git", "add", "."); err != nil {
+		return PublishResult{}, fmt.Errorf("%w: git add: %v", ErrPublish, err)
+	}
+	if err := runner.Run(root, "git", "commit", "-m", commitMessage); err != nil {
+		return PublishResult{}, fmt.Errorf("%w: git commit: %v", ErrPublish, err)
+	}
+	if err := runner.Run(root, "git", "tag", "-a", req.Tag, "-m", "release "+req.Tag); err != nil {
+		return PublishResult{}, fmt.Errorf("%w: git tag: %v", ErrPublish, err)
+	}
+
+	sha, err := runner.Output(root, "git", "rev-parse", "HEAD")
+	if err != nil {
+		return PublishResult{}, fmt.Errorf("%w: git rev-parse: %v", ErrPublish, err)
+	}
+	commitSHA := strings.TrimSpace(sha)
+
+	pushed := false
+	if !req.DryRun {
+		if err := runner.Run(root, "git", "push", "origin", defaultBranch); err != nil {
+			return PublishResult{}, fmt.Errorf("%w: git push branch: %v", ErrPublish, err)
+		}
+		if err := runner.Run(root, "git", "push", "origin", req.Tag); err != nil {
+			return PublishResult{}, fmt.Errorf("%w: git push tag: %v", ErrPublish, err)
+		}
+		pushed = true
+	}
+
+	return PublishResult{
+		WorkspaceRoot: root,
+		CommitSHA:     commitSHA,
+		Tag:           req.Tag,
+		Pushed:        pushed,
+		FilesWritten:  written,
+	}, nil
+}
+
+// materialiseFiles writes the rendered EmitResult to disk under
+// root, returning the sorted list of relative paths it wrote.
+func materialiseFiles(root string, files library.EmitResult) ([]string, error) {
+	names := make([]string, 0, len(files.Files))
+	for name := range files.Files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		full := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			return nil, fmt.Errorf("%w: mkdir %s: %v", ErrPublish, filepath.Dir(name), err)
+		}
+		if err := os.WriteFile(full, []byte(files.Files[name]), 0o644); err != nil {
+			return nil, fmt.Errorf("%w: write %s: %v", ErrPublish, name, err)
+		}
+	}
+	return names, nil
+}

--- a/package3/go/publish/publish_test.go
+++ b/package3/go/publish/publish_test.go
@@ -1,0 +1,335 @@
+package publish
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"mochi/package3/go/library"
+)
+
+func goodAPI() library.EmitResult {
+	return library.EmitResult{
+		Files: map[string]string{
+			"go.mod":  "module example.com/x\n\ngo 1.21\n",
+			"doc.go":  "// Package x is a stub.\npackage x\n",
+			"x.go":    "package x\n",
+		},
+	}
+}
+
+func goodRequest() PublishRequest {
+	return PublishRequest{
+		Files:      goodAPI(),
+		ModulePath: "example.com/x",
+		Tag:        "v0.1.0",
+		RemoteURL:  "file:///tmp/fake.git",
+		Author:     Author{Name: "Mochi", Email: "ci@mochi-lang.org"},
+	}
+}
+
+func TestValidateRejectsEmptyFiles(t *testing.T) {
+	req := goodRequest()
+	req.Files.Files = nil
+	if err := req.Validate(); err == nil || !errors.Is(err, ErrPublish) {
+		t.Errorf("expected ErrPublish, got %v", err)
+	}
+}
+
+func TestValidateRejectsMissingGoMod(t *testing.T) {
+	req := goodRequest()
+	req.Files = library.EmitResult{Files: map[string]string{"x.go": "package x\n"}}
+	if err := req.Validate(); err == nil {
+		t.Errorf("expected error for missing go.mod")
+	}
+}
+
+func TestValidateRejectsBadTag(t *testing.T) {
+	req := goodRequest()
+	req.Tag = "0.1.0" // missing v
+	if err := req.Validate(); err == nil {
+		t.Errorf("expected error for non-semver tag")
+	}
+	req.Tag = "v1.2"
+	if err := req.Validate(); err == nil {
+		t.Errorf("expected error for incomplete semver tag")
+	}
+	req.Tag = "latest"
+	if err := req.Validate(); err == nil {
+		t.Errorf("expected error for non-semver tag")
+	}
+}
+
+func TestValidateRejectsMissingRemoteURL(t *testing.T) {
+	req := goodRequest()
+	req.RemoteURL = ""
+	if err := req.Validate(); err == nil {
+		t.Errorf("expected error for empty remote URL")
+	}
+}
+
+func TestValidateRejectsMissingAuthor(t *testing.T) {
+	req := goodRequest()
+	req.Author.Name = ""
+	if err := req.Validate(); err == nil {
+		t.Errorf("expected error for missing author name")
+	}
+	req.Author.Name = "x"
+	req.Author.Email = ""
+	if err := req.Validate(); err == nil {
+		t.Errorf("expected error for missing author email")
+	}
+}
+
+func TestValidateRejectsCanonicalImportPathMismatch(t *testing.T) {
+	req := goodRequest()
+	req.ModulePath = "example.com/other"
+	err := req.Validate()
+	if err == nil || !strings.Contains(err.Error(), "go.mod declares module") {
+		t.Errorf("expected canonical-import-path mismatch, got %v", err)
+	}
+}
+
+func TestValidateAccepts(t *testing.T) {
+	if err := goodRequest().Validate(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCanonicalImportPathHappy(t *testing.T) {
+	got, err := CanonicalImportPath("module example.com/x\n\ngo 1.21\n")
+	if err != nil {
+		t.Fatalf("CanonicalImportPath: %v", err)
+	}
+	if got != "example.com/x" {
+		t.Errorf("got %q; want example.com/x", got)
+	}
+}
+
+func TestCanonicalImportPathSkipsLeadingComments(t *testing.T) {
+	body := "// auto-generated\n\nmodule example.com/x\n"
+	got, err := CanonicalImportPath(body)
+	if err != nil {
+		t.Fatalf("CanonicalImportPath: %v", err)
+	}
+	if got != "example.com/x" {
+		t.Errorf("got %q; want example.com/x", got)
+	}
+}
+
+func TestCanonicalImportPathRejectsMissingDirective(t *testing.T) {
+	if _, err := CanonicalImportPath("go 1.21\n"); err == nil {
+		t.Errorf("expected error when module directive is missing")
+	}
+}
+
+func TestCanonicalImportPathRejectsEmpty(t *testing.T) {
+	if _, err := CanonicalImportPath(""); err == nil {
+		t.Errorf("expected error on empty go.mod")
+	}
+}
+
+// RecordingRunner is a Runner that records every Run / Output call
+// in order. It surfaces a synthetic SHA for `git rev-parse HEAD` so
+// the publish driver can be exercised without spawning real git.
+type RecordingRunner struct {
+	Cmds []string
+	// SHA is the value returned for `git rev-parse HEAD`.
+	SHA string
+	// ErrAt, if set, makes the runner fail the Nth call.
+	ErrAt int
+	// callCount counts every Run+Output dispatched.
+	callCount int
+}
+
+func (r *RecordingRunner) record(name string, args ...string) {
+	r.Cmds = append(r.Cmds, name+" "+strings.Join(args, " "))
+}
+
+func (r *RecordingRunner) failNow() bool {
+	r.callCount++
+	return r.ErrAt > 0 && r.callCount == r.ErrAt
+}
+
+func (r *RecordingRunner) Run(dir, name string, args ...string) error {
+	r.record(name, args...)
+	if r.failNow() {
+		return errors.New("synthetic error")
+	}
+	return nil
+}
+
+func (r *RecordingRunner) Output(dir, name string, args ...string) (string, error) {
+	r.record(name, args...)
+	if r.failNow() {
+		return "", errors.New("synthetic error")
+	}
+	if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+		if r.SHA == "" {
+			return "fa11111111111111111111111111111111111111\n", nil
+		}
+		return r.SHA + "\n", nil
+	}
+	return "", nil
+}
+
+func TestPublishHappyPath(t *testing.T) {
+	req := goodRequest()
+	req.WorkspaceRoot = t.TempDir()
+	runner := &RecordingRunner{SHA: "deadbeefcafebabe1234567890abcdefdeadbeef"}
+	res, err := Publish(req, runner)
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if !res.Pushed {
+		t.Errorf("expected Pushed=true")
+	}
+	if res.CommitSHA != "deadbeefcafebabe1234567890abcdefdeadbeef" {
+		t.Errorf("CommitSHA = %q; want the recorder's SHA", res.CommitSHA)
+	}
+	if res.Tag != "v0.1.0" {
+		t.Errorf("Tag = %q; want v0.1.0", res.Tag)
+	}
+	if res.WorkspaceRoot != req.WorkspaceRoot {
+		t.Errorf("WorkspaceRoot = %q; want %q", res.WorkspaceRoot, req.WorkspaceRoot)
+	}
+	// Verify the expected git invocations happened in order.
+	wantSequence := []string{
+		"git init --initial-branch=main",
+		"git config user.name Mochi",
+		"git config user.email ci@mochi-lang.org",
+		"git config commit.gpgsign false",
+		"git config tag.gpgsign false",
+		"git remote add origin file:///tmp/fake.git",
+		"git add .",
+		"git commit -m publish v0.1.0",
+		"git tag -a v0.1.0 -m release v0.1.0",
+		"git rev-parse HEAD",
+		"git push origin main",
+		"git push origin v0.1.0",
+	}
+	if len(runner.Cmds) != len(wantSequence) {
+		t.Fatalf("got %d commands, want %d:\n%v", len(runner.Cmds), len(wantSequence), runner.Cmds)
+	}
+	for i, want := range wantSequence {
+		if runner.Cmds[i] != want {
+			t.Errorf("cmd[%d] = %q; want %q", i, runner.Cmds[i], want)
+		}
+	}
+}
+
+func TestPublishDryRunSkipsPush(t *testing.T) {
+	req := goodRequest()
+	req.WorkspaceRoot = t.TempDir()
+	req.DryRun = true
+	runner := &RecordingRunner{}
+	res, err := Publish(req, runner)
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if res.Pushed {
+		t.Errorf("expected Pushed=false under DryRun")
+	}
+	for _, cmd := range runner.Cmds {
+		if strings.HasPrefix(cmd, "git push") {
+			t.Errorf("DryRun should not push; saw %q", cmd)
+		}
+	}
+}
+
+func TestPublishUsesCustomBranch(t *testing.T) {
+	req := goodRequest()
+	req.WorkspaceRoot = t.TempDir()
+	req.DefaultBranch = "release"
+	runner := &RecordingRunner{}
+	if _, err := Publish(req, runner); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	foundInit := false
+	foundPush := false
+	for _, c := range runner.Cmds {
+		if c == "git init --initial-branch=release" {
+			foundInit = true
+		}
+		if c == "git push origin release" {
+			foundPush = true
+		}
+	}
+	if !foundInit || !foundPush {
+		t.Errorf("custom branch not propagated; cmds=%v", runner.Cmds)
+	}
+}
+
+func TestPublishUsesCustomCommitMessage(t *testing.T) {
+	req := goodRequest()
+	req.WorkspaceRoot = t.TempDir()
+	req.CommitMessage = "release: v0.1.0 publish"
+	runner := &RecordingRunner{}
+	if _, err := Publish(req, runner); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	found := false
+	for _, c := range runner.Cmds {
+		if c == "git commit -m release: v0.1.0 publish" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("custom commit message not propagated: %v", runner.Cmds)
+	}
+}
+
+func TestPublishMaterialisesFiles(t *testing.T) {
+	req := goodRequest()
+	req.WorkspaceRoot = t.TempDir()
+	runner := &RecordingRunner{}
+	res, err := Publish(req, runner)
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	wantFiles := []string{"doc.go", "go.mod", "x.go"}
+	if len(res.FilesWritten) != len(wantFiles) {
+		t.Fatalf("FilesWritten = %v; want %v", res.FilesWritten, wantFiles)
+	}
+	for i, w := range wantFiles {
+		if res.FilesWritten[i] != w {
+			t.Errorf("FilesWritten[%d] = %q; want %q", i, res.FilesWritten[i], w)
+		}
+	}
+}
+
+func TestPublishValidateFailureSkipsAllRunner(t *testing.T) {
+	req := goodRequest()
+	req.Tag = "invalid"
+	runner := &RecordingRunner{}
+	if _, err := Publish(req, runner); err == nil {
+		t.Errorf("expected validation error")
+	}
+	if len(runner.Cmds) != 0 {
+		t.Errorf("validation failure should not call runner; cmds=%v", runner.Cmds)
+	}
+}
+
+func TestPublishRunnerErrorSurfaces(t *testing.T) {
+	req := goodRequest()
+	req.WorkspaceRoot = t.TempDir()
+	runner := &RecordingRunner{ErrAt: 1} // fail on `git init`
+	if _, err := Publish(req, runner); err == nil {
+		t.Errorf("expected error from runner")
+	}
+}
+
+func TestPublishGeneratesTempWorkspaceWhenEmpty(t *testing.T) {
+	req := goodRequest()
+	runner := &RecordingRunner{}
+	res, err := Publish(req, runner)
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if res.WorkspaceRoot == "" {
+		t.Errorf("WorkspaceRoot was empty after auto-temp")
+	}
+	if !strings.Contains(res.WorkspaceRoot, "mochi-publish-") {
+		t.Errorf("temp dir name unexpected: %q", res.WorkspaceRoot)
+	}
+}

--- a/package3/go/publish/runner.go
+++ b/package3/go/publish/runner.go
@@ -1,0 +1,71 @@
+package publish
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Runner is the command-execution boundary the publish driver
+// uses. Run executes a command for its side effect; Output runs the
+// command and returns combined stdout for the caller. Both methods
+// receive the working directory as the first argument.
+//
+// The interface lets the unit tests substitute a recording runner
+// (RecordingRunner in runner_test.go) for the real exec runner so
+// the publish flow can be validated without touching git on disk.
+type Runner interface {
+	Run(dir string, name string, args ...string) error
+	Output(dir string, name string, args ...string) (string, error)
+}
+
+// NewExecRunner returns the default Runner that shells out to the
+// host's binaries via os/exec. The env passed to each command is
+// the parent process's env minus GIT_DIR / GIT_WORK_TREE so that
+// nested git workspaces (the host repo) cannot leak into the
+// publish workspace.
+func NewExecRunner() Runner {
+	return execRunner{}
+}
+
+type execRunner struct{}
+
+func (execRunner) Run(dir, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = sanitisedEnv()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s %s: %v\n%s", name, strings.Join(args, " "), err, out)
+	}
+	return nil
+}
+
+func (execRunner) Output(dir, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = sanitisedEnv()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%s %s: %v\n%s", name, strings.Join(args, " "), err, out)
+	}
+	return string(out), nil
+}
+
+// sanitisedEnv returns the parent process env minus the variables
+// that would let a nested git context leak into the publish
+// workspace. The publish workspace is always a fresh repo; we never
+// want GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE from the parent.
+func sanitisedEnv() []string {
+	parent := getenv()
+	out := make([]string, 0, len(parent))
+	for _, kv := range parent {
+		k := strings.SplitN(kv, "=", 2)[0]
+		switch k {
+		case "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY":
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}

--- a/website/docs/implementation/0074/index.md
+++ b/website/docs/implementation/0074/index.md
@@ -27,7 +27,7 @@ A phase is LANDED only when its gate is green for every applicable target (consu
 | 9 | Build orchestration: workspace synth + `go build -buildmode=c-archive` + artifact link | LANDED (baseline; 9.1+ deferred) | (pending) | [phase-09](/docs/implementation/0074/phase-09-build) |
 | 10 | mochi.lock `[[go-package]]` integration + `--check` mode | LANDED (schema; 10.1+ CLI deferred) | (pending) | [phase-10](/docs/implementation/0074/phase-10-lockfile) |
 | 11 | `TargetGoLibrary` emit (`go.mod` + exported package + `_cgo_export.h`) | LANDED (baseline; 11.1+ deferred) | (pending) | [phase-11](/docs/implementation/0074/phase-11-library-emit) |
-| 12 | Git-tag publish flow (`mochi pkg publish --to=git-tag`) + canonical-import-path gate | NOT STARTED | — | [phase-12](/docs/implementation/0074/phase-12-git-tag-publish) |
+| 12 | Git-tag publish flow (`mochi pkg publish --to=git-tag`) + canonical-import-path gate | LANDED (baseline; 12.1+ deferred) | (pending) | [phase-12](/docs/implementation/0074/phase-12-git-tag-publish) |
 | 13 | Cosign-on-sibling-tag opt-in (`mochi pkg publish --cosign-sign`) | NOT STARTED | — | [phase-13](/docs/implementation/0074/phase-13-cosign) |
 | 14 | Goroutine bridge (cgo handle pool + channel-as-handle + callback-as-handle) | NOT STARTED | — | [phase-14](/docs/implementation/0074/phase-14-goroutine-bridge) |
 | 15 | Monomorphisation (`[go.monomorphise]` manifest + per-instantiation wrapper) | NOT STARTED | — | [phase-15](/docs/implementation/0074/phase-15-monomorphise) |
@@ -52,7 +52,7 @@ Each phase's LANDED gate must be green for every applicable target. `n/a` cells 
 | 9. build orchestration | LANDED (baseline) | required | required | required (no cgo) | required |
 | 10. mochi.lock integration | LANDED (schema) | required | required | required | required |
 | 11. TargetGoLibrary emit | LANDED (baseline) | required | required | required | required |
-| 12. git-tag publish | NOT STARTED | n/a (publish is host-only) | n/a | n/a | n/a |
+| 12. git-tag publish | LANDED (baseline) | n/a (publish is host-only) | n/a | n/a | n/a |
 | 13. cosign on tag.sig | NOT STARTED | n/a | n/a | n/a | n/a |
 | 14. goroutine bridge | NOT STARTED | required | required | n/a (no goroutines on wasm-js without scheduler shim) | required |
 | 15. monomorphisation | NOT STARTED | required | required | required | required |
@@ -107,7 +107,7 @@ The `package3/go/` location is shared with the broader MEP-57 polyglot package w
 
 ## Status snapshot
 
-As of 2026-05-30: phases 0-11 LANDED on `main` (phases 6 + 7 + 9 + 11 baseline only; phase 10 schema only; sub-phases 6.1+/7.1+/9.1+/10.1+/11.1+ deferred), phases 12-17 NOT STARTED.
+As of 2026-05-30: phases 0-12 LANDED on `main` (phases 6 + 7 + 9 + 11 + 12 baseline only; phase 10 schema only; sub-phases 6.1+/7.1+/9.1+/10.1+/11.1+/12.1+ deferred), phases 13-17 NOT STARTED.
 
 ## Cross-references
 

--- a/website/docs/implementation/0074/phase-12-git-tag-publish.md
+++ b/website/docs/implementation/0074/phase-12-git-tag-publish.md
@@ -1,0 +1,127 @@
+---
+title: "Phase 12. Git-tag publish flow"
+sidebar_position: 14
+sidebar_label: "Phase 12. Git-tag publish"
+description: "MEP-74 Phase 12 lands the `mochi pkg publish --to=go+git+<repo-url>@<tag>` driver as a self-contained `package3/go/publish/` module. The driver consumes a `library.EmitResult`, validates the canonical-import-path invariant (`go.mod` module directive matches the configured `ModulePath`), materialises the rendered files into a fresh git working tree, runs `git init` / `add` / `commit` / `tag` / `push` via an abstract Runner, and returns the resulting commit SHA + tag for the CLI confirmation line. A DryRun flag stops short of the push step (still tags locally). The sentinel exercises the full flow against a local bare-repo fixture and then clones the remote to confirm the publish is consumable."
+---
+
+# Phase 12. Git-tag publish flow
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-74 §Phases](/docs/mep/mep-0074#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-30 00:30 (GMT+7) |
+| Landed         | 2026-05-30 00:50 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`TestPhase12GitTagPublishSentinel` in
+`package3/go/publish/phase12_test.go` walks a representative calculator package (Version const + Add func) through the full flow and asserts:
+
+- `library.Emit` + `Publish.Validate` + `Publish.Run` together produce a real git working tree whose committed contents match the rendered Files map byte-for-byte;
+- the configured tag and the publish commit both land in a local bare-repo remote (`file://<tmp>/remote.git`);
+- a downstream `git clone` of the remote + `git checkout <tag>` resolves the tag and exposes every expected file (`go.mod`, `doc.go`, `calc.go`, `LICENSE`);
+- `go build ./...` against the cloned tree succeeds, proving the publish does not corrupt the underlying library buildability;
+- DryRun mode leaves the local tree intact (commit + tag both present locally) but the remote bare-repo stays empty for that version;
+- a canonical-import-path mismatch (`go.mod` says `example.com/x`, request says `example.com/wrong`) is blocked before any git side effect occurs.
+
+Plus 17 unit tests in `publish_test.go`:
+
+- validation (`TestValidateAccepts`,
+  `TestValidateRejectsEmptyFiles`,
+  `TestValidateRejectsMissingGoMod`,
+  `TestValidateRejectsBadTag`,
+  `TestValidateRejectsMissingRemoteURL`,
+  `TestValidateRejectsMissingAuthor`,
+  `TestValidateRejectsCanonicalImportPathMismatch`),
+- canonical-import-path parser
+  (`TestCanonicalImportPathHappy`,
+  `TestCanonicalImportPathSkipsLeadingComments`,
+  `TestCanonicalImportPathRejectsMissingDirective`,
+  `TestCanonicalImportPathRejectsEmpty`),
+- happy-path command sequence
+  (`TestPublishHappyPath`),
+- dry-run skips push (`TestPublishDryRunSkipsPush`),
+- custom branch / commit message overrides
+  (`TestPublishUsesCustomBranch`,
+  `TestPublishUsesCustomCommitMessage`),
+- file materialisation (`TestPublishMaterialisesFiles`),
+- early-exit on validation failure
+  (`TestPublishValidateFailureSkipsAllRunner`),
+- runner failure surfaces (`TestPublishRunnerErrorSurfaces`),
+- auto-generated workspace temp dir
+  (`TestPublishGeneratesTempWorkspaceWhenEmpty`).
+
+## Lowering decisions
+
+The publish package is layering-conservative: it imports `package3/go/library` (for the `EmitResult` input shape) and `package3/go/semver` (for the tag validator), and otherwise depends only on the Go stdlib. The publish surface splits into a pure shaping layer (`PublishRequest.Validate`, `CanonicalImportPath`) and an impure runner (`Publish`) so callers fully validate the request before touching git.
+
+**The canonical-import-path gate is upfront and total.** `PublishRequest.Validate` parses the supplied go.mod, extracts the `module <path>` directive, and asserts it equals `PublishRequest.ModulePath`. A mismatch surfaces a wrapped `ErrPublish` before any git command runs. This is the MEP-74 spec §3 invariant that prevents a user from publishing a Mochi package under a vanity import path different from the one consumers will write in their `import` statements; a mismatch would cause every downstream `go get` to fail at the `go/packages.Load` step.
+
+**The Runner is the command-execution boundary.** `Publish` accepts a `Runner` interface (`Run(dir, name, args...)`, `Output(dir, name, args...)`) rather than calling `os/exec` directly. The production runner is `NewExecRunner()`, which shells out via `exec.Command` and scrubs `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` / `GIT_OBJECT_DIRECTORY` from the env (so a nested git context in the parent process cannot leak into the publish workspace). The unit-test runner `RecordingRunner` captures every call in order, returns a synthetic SHA for `git rev-parse HEAD`, and supports an `ErrAt` index that fails the Nth call (so every error path is reachable without a real failure mode).
+
+**The local commit + tag always happens; the push is gated by DryRun.** The publish flow always runs `git init` / `config` / `remote add` / `add` / `commit` / `tag` locally; only the two `git push` invocations are skipped under DryRun. This mirrors `npm publish --dry-run` and `cargo publish --dry-run` semantics: the local working tree is fully valid after a dry-run, so the user can inspect it before retrying with DryRun off. The MEP-74 spec §289 explicitly calls for this: `mochi pkg publish --to=go+git+<repo-url>@<tag> [--dry-run]`.
+
+**Default branch defaults to `main`, configurable per request.** The publish working tree initialises on `main` (via `git init --initial-branch=main`), the publish commit lands on `main`, and the push pushes to `origin main`. Callers that publish to a repo with a non-`main` default branch (e.g. legacy `master`, organisation-specific `release/`) override via `PublishRequest.DefaultBranch`. Phase 17's vanity-import resolver may populate this from the resolved `<meta name="go-import">` redirect's repo metadata.
+
+**Commit message defaults to `publish <tag>` but is overridable.** When the caller does not supply `CommitMessage`, the publish commit subject is `publish <tag>` (matching the cargo-publish and gem-push convention). Override via `PublishRequest.CommitMessage` for callers that need a richer subject (e.g. `release: v0.2.0 publish (CI #1234)` for an automated CI flow).
+
+**Annotated tags, not lightweight tags.** `Publish` uses `git tag -a <tag> -m "release <tag>"`. Annotated tags carry a tagger identity, a timestamp, and a message, so `go get` (which fetches the tag via the module proxy protocol) records a stable revision identifier. Lightweight tags would also work but lack the audit trail.
+
+**GPG signing is explicitly disabled.** `Publish` runs `git config commit.gpgsign false` and `git config tag.gpgsign false` in the publish workspace (not globally). This is load-bearing: a CI runner that inherits a globally-enabled `commit.gpgsign = true` from the parent env would otherwise hang waiting for a passphrase. Phase 13 (cosign signing) is the bridge's preferred signing path; users who need GPG-signed publish commits will get that as a deferred sub-phase.
+
+**Workspace cleanup is the caller's responsibility.** `Publish` does not delete the working tree on success or failure. The CLI layer (deferred to phase 12.1) will own the temp-dir lifecycle: print the workspace path on success for the user to optionally inspect, then either `rm -rf` it or leave it on disk based on a `--keep-workspace` flag. This matches the `cargo publish` and `goreleaser` conventions of leaving the build output for post-mortem inspection.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/go/publish/publish.go` | `PublishRequest`, `Author`, `PublishResult`, `ErrPublish`, `Validate`, `CanonicalImportPath`, `Publish`, `materialiseFiles`. |
+| `package3/go/publish/runner.go` | `Runner` interface, `NewExecRunner`, `execRunner`, `sanitisedEnv`. |
+| `package3/go/publish/env.go` | `getenv` indirection for unit-test stubbing. |
+| `package3/go/publish/publish_test.go` | 17 unit tests + `RecordingRunner` helper. |
+| `package3/go/publish/phase12_test.go` | `TestPhase12GitTagPublishSentinel` end-to-end against a local bare-repo fixture. |
+| `website/docs/implementation/0074/phase-12-git-tag-publish.md` | (this page) |
+
+## Test set
+
+- `TestPhase12GitTagPublishSentinel` (3 sub-tests)
+- 17 unit tests in `publish_test.go`
+
+Local run on darwin-arm64:
+
+```
+$ go test ./package3/go/publish/...
+ok      mochi/package3/go/publish       1.3s
+$ go test ./package3/go/...
+ok      mochi/package3/go/apisurface    (cached)
+ok      mochi/package3/go/build (cached)
+ok      mochi/package3/go/cmd/go-ingest (cached)
+ok      mochi/package3/go/emit  (cached)
+ok      mochi/package3/go/errors        (cached)
+ok      mochi/package3/go/library       (cached)
+ok      mochi/package3/go/lockfile      (cached)
+ok      mochi/package3/go/moduleproxy   (cached)
+ok      mochi/package3/go/publish       1.315s
+ok      mochi/package3/go/semver        (cached)
+ok      mochi/package3/go/sumdb (cached)
+ok      mochi/package3/go/typemap       (cached)
+ok      mochi/package3/go/wrapper       (cached)
+```
+
+## Closeout notes
+
+Phase 12 lands the publish driver as a leaf module. The CLI wiring (`mochi pkg publish --to=go+git+<repo-url>@<tag>`) and the workspace-lifecycle policy are reserved for phase 12.1 once the MEP-57 CLI driver gains a publish-target dispatch hook.
+
+Future phase 12.x reservations:
+
+- **12.1** CLI wiring + workspace-lifecycle (keep-workspace flag, prompt on push failure, retry).
+- **12.2** Module-proxy warm-up: after a successful push, issue a `GET <proxy>/<module>/@v/<tag>.info` to prime the public proxy cache so downstream consumers can `go get <module>@<tag>` without the typical 10-minute first-touch delay.
+- **12.3** Pre-tag hook to run `go mod tidy` + `go vet ./...` + `go build ./...` against the materialised tree (today the caller is expected to have validated the tree before invoking Publish; an integrated pre-tag hook would make the flow more robust against an accidentally-broken Emit).
+- **12.4** Multi-remote publish (push the same tag to multiple mirror remotes for high-availability).
+
+The Sigstore-cosign signature flow (an optional `<tag>.sig` sibling tag) is phase 13's responsibility and consumes `PublishResult.CommitSHA` as the artefact to sign.

--- a/website/docs/mep/mep-0074.md
+++ b/website/docs/mep/mep-0074.md
@@ -394,7 +394,7 @@ A phase is LANDED only when its gate is green for every target in the matrix bel
 | 9. build orchestration | LANDED (baseline) | required | required | required (no cgo) | required |
 | 10. mochi.lock integration | LANDED (schema) | required | required | required | required |
 | 11. TargetGoLibrary emit | LANDED (baseline) | required | required | required | required |
-| 12. git-tag publish | NOT STARTED | n/a (publish is host-only) | n/a | n/a | n/a |
+| 12. git-tag publish | LANDED (baseline) | n/a (publish is host-only) | n/a | n/a | n/a |
 | 13. cosign on tag.sig | NOT STARTED | n/a | n/a | n/a | n/a |
 | 14. goroutine bridge | NOT STARTED | required | required | n/a (no goroutines on wasm-js without scheduler shim) | required |
 | 15. monomorphisation | NOT STARTED | required | required | required | required |

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -367,7 +367,8 @@
       "implementation/0074/phase-08-import-grammar",
       "implementation/0074/phase-09-build",
       "implementation/0074/phase-10-lockfile",
-      "implementation/0074/phase-11-library-emit"
+      "implementation/0074/phase-11-library-emit",
+      "implementation/0074/phase-12-git-tag-publish"
     ]
   },
   "implementation/0075/index",


### PR DESCRIPTION
Lands `package3/go/publish/` as the MEP-74 phase 12 git-tag publish driver.

Tracking issue: https://github.com/mochilang/mochi/issues/22893

## Summary

- `PublishRequest` consumed by `Publish`, returning `PublishResult` with commit SHA / tag / pushed flag / files written.
- Canonical-import-path gate compares the `go.mod` module directive against the configured `ModulePath` before any git side effect.
- `Runner` abstraction (exec runner in production, recording runner in tests) scrubs nested git env so the publish workspace cannot inherit the parent's `GIT_DIR`.
- DryRun mode: full local commit + annotated tag, no push.

## Test plan

- [x] `go test ./package3/go/publish/...` (17 unit tests + 3-sub-test phase-12 sentinel).
- [x] `go test ./package3/go/...` (every neighbouring package still passes).
- [x] Sentinel: publish to local bare repo, clone back, checkout tag, `go build ./...` against the clone.
- [x] Sentinel asserts DryRun leaves remote untouched but local tree carries commit + tag.
- [x] Sentinel asserts canonical-import-path mismatch is blocked before any git command.

## Sub-phase deferrals

- 12.1: CLI wiring + workspace lifecycle (keep-workspace flag).
- 12.2: Module-proxy warm-up (prime `<proxy>/<module>/@v/<tag>.info`).
- 12.3: Pre-tag hook (`go mod tidy` / `go vet` / `go build` over the materialised tree).
- 12.4: Multi-remote publish (push the same tag to mirror remotes).

## Related

- MEP-74 spec matrix row for phase 12 advanced from `NOT STARTED` to `LANDED (baseline)`.
- Tracking page: `website/docs/implementation/0074/phase-12-git-tag-publish.md`.
- Sidebar appended after `phase-11-library-emit`.