### PR TITLE
feat(mep-75 p9): TargetPhpLibrary emit (PSR-4 src/ + composer.json + README)

### DIFF
--- a/package3/php/library/library.go
+++ b/package3/php/library/library.go
@@ -1,5 +1,214 @@
 // Package library implements the TargetPhpLibrary build target that emits a
 // PSR-4 src/ tree, composer.json, README.md, and LICENSE from a Mochi source
-// module. Phase 0 ships the package stub; the full implementation arrives in
-// phase 9.
+// module.
+//
+// The emitted library structure:
+//
+//	composer.json          # Composer metadata
+//	README.md              # generated documentation stub
+//	LICENSE                # MIT license text
+//	src/
+//	  <Vendor>/<Pkg>/      # PSR-4 root directory
+//	    <ClassName>.php    # one file per class/interface/enum
+//
+// Usage:
+//
+//	result, err := library.Emit(config)
+//	if err != nil { ... }
+//	// result.Files maps file path -> content
 package library
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"strings"
+	"time"
+)
+
+// Config holds the metadata needed to emit a PHP library.
+type Config struct {
+	// ComposerName is the Composer package name, e.g. "acme/my-lib".
+	ComposerName string
+	// Description is a short package description for composer.json.
+	Description string
+	// Version is the semver version string, e.g. "1.0.0".
+	Version string
+	// License is the SPDX license identifier, e.g. "MIT".
+	License string
+	// Authors is a list of author name/email pairs.
+	Authors []Author
+	// PSR4Namespace is the PHP namespace root, e.g. "Acme\\MyLib\\".
+	// Must end with a backslash.
+	PSR4Namespace string
+	// PHPRequire is the minimum PHP version constraint, e.g. "^8.4".
+	PHPRequire string
+	// Require is the additional composer require entries (beyond php).
+	Require map[string]string
+	// Keywords is the list of Packagist search keywords.
+	Keywords []string
+	// Homepage is the project URL for composer.json.
+	Homepage string
+}
+
+// Author is a composer.json author entry.
+type Author struct {
+	Name  string `json:"name"`
+	Email string `json:"email,omitempty"`
+}
+
+// ClassFile is one PHP source file to emit under src/.
+type ClassFile struct {
+	// FQCN is the fully-qualified class name, e.g. "Acme\\MyLib\\Client".
+	FQCN string
+	// Source is the PHP source text.
+	Source string
+}
+
+// EmitResult holds the file set produced by Emit.
+type EmitResult struct {
+	// Files maps relative file path -> file content.
+	Files map[string]string
+}
+
+// Emit generates the complete PHP library file set.
+func Emit(cfg Config, classes []ClassFile) (*EmitResult, error) {
+	if cfg.ComposerName == "" {
+		return nil, fmt.Errorf("library: ComposerName is required")
+	}
+	if cfg.PSR4Namespace == "" {
+		return nil, fmt.Errorf("library: PSR4Namespace is required")
+	}
+
+	result := &EmitResult{Files: make(map[string]string)}
+
+	// composer.json
+	cj, err := renderComposerJSON(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("library: composer.json: %w", err)
+	}
+	result.Files["composer.json"] = cj
+
+	// README.md
+	result.Files["README.md"] = renderREADME(cfg)
+
+	// LICENSE
+	if cfg.License == "" || strings.EqualFold(cfg.License, "MIT") {
+		result.Files["LICENSE"] = renderMITLicense(cfg)
+	}
+
+	// src/ tree
+	ns := strings.TrimSuffix(cfg.PSR4Namespace, "\\")
+	for _, cls := range classes {
+		path := classFilePath(ns, cls.FQCN)
+		result.Files["src/"+path] = cls.Source
+	}
+
+	return result, nil
+}
+
+// classFilePath converts a FQCN to a PSR-4 relative file path.
+// Given namespace root "Acme\\MyLib" and FQCN "Acme\\MyLib\\Client",
+// returns "Acme/MyLib/Client.php".
+func classFilePath(_ string, fqcn string) string {
+	fqcn = strings.TrimPrefix(fqcn, "\\")
+	path := strings.ReplaceAll(fqcn, "\\", "/")
+	return path + ".php"
+}
+
+// composerJSONFields is the ordered composer.json structure for JSON encoding.
+type composerJSONFields struct {
+	Name             string            `json:"name"`
+	Description      string            `json:"description"`
+	Type             string            `json:"type"`
+	License          string            `json:"license"`
+	Authors          []Author          `json:"authors,omitempty"`
+	Keywords         []string          `json:"keywords,omitempty"`
+	Homepage         string            `json:"homepage,omitempty"`
+	Require          map[string]string `json:"require"`
+	Autoload         map[string]any    `json:"autoload"`
+	MinimumStability string            `json:"minimum-stability"`
+}
+
+func renderComposerJSON(cfg Config) (string, error) {
+	phpReq := cfg.PHPRequire
+	if phpReq == "" {
+		phpReq = "^8.4"
+	}
+	ns := cfg.PSR4Namespace
+	if !strings.HasSuffix(ns, "\\") {
+		ns = ns + "\\"
+	}
+
+	require := map[string]string{
+		"php": phpReq,
+	}
+	maps.Copy(require, cfg.Require)
+
+	license := cfg.License
+	if license == "" {
+		license = "MIT"
+	}
+
+	fields := composerJSONFields{
+		Name:        cfg.ComposerName,
+		Description: cfg.Description,
+		Type:        "library",
+		License:     license,
+		Authors:     cfg.Authors,
+		Keywords:    cfg.Keywords,
+		Homepage:    cfg.Homepage,
+		Require:     require,
+		Autoload: map[string]any{
+			"psr-4": map[string]string{
+				ns: "src/",
+			},
+		},
+		MinimumStability: "stable",
+	}
+
+	data, err := json.MarshalIndent(fields, "", "    ")
+	if err != nil {
+		return "", err
+	}
+	return string(data) + "\n", nil
+}
+
+func renderREADME(cfg Config) string {
+	name := cfg.ComposerName
+	desc := cfg.Description
+	if desc == "" {
+		desc = "A PHP library generated by Mochi."
+	}
+	return fmt.Sprintf("# %s\n\n%s\n\n## Installation\n\n```bash\ncomposer require %s\n```\n", name, desc, name)
+}
+
+func renderMITLicense(cfg Config) string {
+	year := time.Now().Year()
+	author := "Contributors"
+	if len(cfg.Authors) > 0 {
+		author = cfg.Authors[0].Name
+	}
+	return fmt.Sprintf(`MIT License
+
+Copyright (c) %d %s
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`, year, author)
+}

--- a/package3/php/library/library_test.go
+++ b/package3/php/library/library_test.go
@@ -1,0 +1,223 @@
+package library
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func defaultConfig() Config {
+	return Config{
+		ComposerName:  "acme/my-lib",
+		Description:   "Test library",
+		Version:       "1.0.0",
+		License:       "MIT",
+		PSR4Namespace: `Acme\MyLib`,
+		PHPRequire:    "^8.4",
+	}
+}
+
+func TestEmitRequiredFields(t *testing.T) {
+	_, err := Emit(Config{}, nil)
+	if err == nil {
+		t.Error("expected error for empty ComposerName")
+	}
+	_, err = Emit(Config{ComposerName: "a/b"}, nil)
+	if err == nil {
+		t.Error("expected error for empty PSR4Namespace")
+	}
+}
+
+func TestEmitProducesExpectedFiles(t *testing.T) {
+	result, err := Emit(defaultConfig(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, expect := range []string{"composer.json", "README.md", "LICENSE"} {
+		if _, ok := result.Files[expect]; !ok {
+			t.Errorf("expected file %q; got %v", expect, fileKeys(result.Files))
+		}
+	}
+}
+
+func TestEmitComposerJSON(t *testing.T) {
+	result, err := Emit(defaultConfig(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src := result.Files["composer.json"]
+	// Must parse as valid JSON.
+	var m map[string]any
+	if err := json.Unmarshal([]byte(src), &m); err != nil {
+		t.Fatalf("composer.json is not valid JSON: %v\n%s", err, src)
+	}
+	if m["name"] != "acme/my-lib" {
+		t.Errorf("name = %v; want acme/my-lib", m["name"])
+	}
+	if m["type"] != "library" {
+		t.Errorf("type = %v; want library", m["type"])
+	}
+	if m["minimum-stability"] != "stable" {
+		t.Errorf("minimum-stability = %v; want stable", m["minimum-stability"])
+	}
+}
+
+func TestEmitComposerJSONPSR4(t *testing.T) {
+	result, err := Emit(defaultConfig(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src := result.Files["composer.json"]
+	// PSR-4 namespace must have trailing backslash in JSON.
+	if !strings.Contains(src, `"Acme\\MyLib\\"`) {
+		t.Errorf("expected PSR-4 namespace with trailing backslash; got:\n%s", src)
+	}
+	if !strings.Contains(src, `"src/"`) {
+		t.Errorf("expected src/ directory; got:\n%s", src)
+	}
+}
+
+func TestEmitComposerJSONRequire(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Require = map[string]string{"monolog/monolog": "^3.0"}
+	result, err := Emit(cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src := result.Files["composer.json"]
+	if !strings.Contains(src, `"php"`) {
+		t.Errorf("expected php in require; got:\n%s", src)
+	}
+	if !strings.Contains(src, `"monolog/monolog"`) {
+		t.Errorf("expected monolog/monolog in require; got:\n%s", src)
+	}
+}
+
+func TestEmitComposerJSONAuthors(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Authors = []Author{{Name: "Alice", Email: "alice@example.com"}}
+	result, err := Emit(cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src := result.Files["composer.json"]
+	if !strings.Contains(src, "Alice") {
+		t.Errorf("expected author Alice; got:\n%s", src)
+	}
+}
+
+func TestEmitREADME(t *testing.T) {
+	result, err := Emit(defaultConfig(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src := result.Files["README.md"]
+	if !strings.Contains(src, "acme/my-lib") {
+		t.Errorf("expected package name in README; got:\n%s", src)
+	}
+	if !strings.Contains(src, "composer require") {
+		t.Errorf("expected installation instructions; got:\n%s", src)
+	}
+}
+
+func TestEmitLicense(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Authors = []Author{{Name: "Acme Corp"}}
+	result, err := Emit(cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src := result.Files["LICENSE"]
+	if !strings.Contains(src, "MIT License") {
+		t.Errorf("expected MIT License; got:\n%s", src)
+	}
+	if !strings.Contains(src, "Acme Corp") {
+		t.Errorf("expected author in LICENSE; got:\n%s", src)
+	}
+}
+
+func TestEmitClassFile(t *testing.T) {
+	cfg := defaultConfig()
+	classes := []ClassFile{
+		{
+			FQCN:   `Acme\MyLib\Client`,
+			Source: "<?php\ndeclare(strict_types=1);\nnamespace Acme\\MyLib;\nclass Client {}\n",
+		},
+	}
+	result, err := Emit(cfg, classes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	path := "src/Acme/MyLib/Client.php"
+	src, ok := result.Files[path]
+	if !ok {
+		t.Fatalf("expected %q; got files: %v", path, fileKeys(result.Files))
+	}
+	if !strings.Contains(src, "class Client") {
+		t.Errorf("expected class Client in file; got:\n%s", src)
+	}
+}
+
+func TestEmitMultipleClasses(t *testing.T) {
+	cfg := defaultConfig()
+	classes := []ClassFile{
+		{FQCN: `Acme\MyLib\Client`, Source: "<?php class Client {}"},
+		{FQCN: `Acme\MyLib\Response`, Source: "<?php class Response {}"},
+		{FQCN: `Acme\MyLib\Http\Request`, Source: "<?php class Request {}"},
+	}
+	result, err := Emit(cfg, classes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []string{
+		"src/Acme/MyLib/Client.php",
+		"src/Acme/MyLib/Response.php",
+		"src/Acme/MyLib/Http/Request.php",
+	}
+	for _, path := range expected {
+		if _, ok := result.Files[path]; !ok {
+			t.Errorf("expected file %q; got: %v", path, fileKeys(result.Files))
+		}
+	}
+}
+
+func TestClassFilePath(t *testing.T) {
+	cases := []struct {
+		nsRoot, fqcn, want string
+	}{
+		{`Acme\MyLib`, `Acme\MyLib\Client`, "Acme/MyLib/Client.php"},
+		{`Acme\MyLib`, `Acme\MyLib\Http\Request`, "Acme/MyLib/Http/Request.php"},
+		{`Foo`, `Foo\Bar`, "Foo/Bar.php"},
+		{`Foo`, `\Foo\Bar`, "Foo/Bar.php"},
+	}
+	for _, tc := range cases {
+		got := classFilePath(tc.nsRoot, tc.fqcn)
+		if got != tc.want {
+			t.Errorf("classFilePath(%q, %q) = %q; want %q", tc.nsRoot, tc.fqcn, got, tc.want)
+		}
+	}
+}
+
+func TestDefaultPHPRequire(t *testing.T) {
+	cfg := Config{
+		ComposerName:  "x/y",
+		PSR4Namespace: `X\Y`,
+		// PHPRequire intentionally empty
+	}
+	result, err := Emit(cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src := result.Files["composer.json"]
+	if !strings.Contains(src, "^8.4") {
+		t.Errorf("expected default ^8.4 PHP require; got:\n%s", src)
+	}
+}
+
+func fileKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/website/docs/implementation/0075/phase-09-library.md
+++ b/website/docs/implementation/0075/phase-09-library.md
@@ -1,0 +1,47 @@
+# MEP-75 Phase 9: TargetPhpLibrary (PSR-4 src/ + composer.json + README)
+
+**Status**: LANDED 2026-05-30 00:00 (GMT+7)
+
+## Goal
+
+Implement the `TargetPhpLibrary` build target under `package3/php/library`. Given a `Config` (package metadata) and a list of `ClassFile` entries, the emitter produces the complete PHP library file set ready for git tag and Packagist publish.
+
+## Emitted files
+
+| File | Description |
+|---|---|
+| `composer.json` | Composer metadata with PSR-4 autoload, require, authors, keywords |
+| `README.md` | Generated documentation stub with installation instructions |
+| `LICENSE` | MIT license text with year and first author |
+| `src/<FQCN>.php` | One PHP file per class/interface/enum (one class per file, PSR-4 layout) |
+
+## Design
+
+`Emit(Config, []ClassFile)` is the main entry point. It:
+1. Validates required fields (`ComposerName`, `PSR4Namespace`)
+2. Renders `composer.json` via `json.MarshalIndent` with PSR-4 namespace
+3. Renders `README.md` with package name and `composer require` instructions
+4. Renders MIT `LICENSE` with current year and first author name
+5. For each `ClassFile`, converts FQCN to a PSR-4 file path and writes to `src/`
+
+The PSR-4 namespace in `composer.json` always has a trailing backslash: `"Acme\\MyLib\\"`.
+
+## Files Landed
+
+- `package3/php/library/library.go` -- Emit() + helpers
+- `package3/php/library/library_test.go` -- 12 test functions
+
+## Test Coverage
+
+- Required field validation (ComposerName and PSR4Namespace)
+- Expected output files: composer.json, README.md, LICENSE
+- composer.json valid JSON with correct fields
+- PSR-4 namespace with trailing backslash in composer.json
+- require entries: php + additional packages
+- Authors in composer.json
+- README.md content with composer require command
+- LICENSE MIT text with author name
+- Class file PSR-4 path generation
+- Multiple classes at different namespace depths
+- classFilePath unit tests
+- Default ^8.4 PHP require when PHPRequire is empty


### PR DESCRIPTION
## Summary

- Implements `TargetPhpLibrary` build target under `package3/php/library`
- `Emit(Config, []ClassFile)` produces `composer.json`, `README.md`, `LICENSE`, and `src/<FQCN>.php` one-class-per-file PSR-4 layout
- `composer.json` uses `json.MarshalIndent` with PSR-4 namespace (trailing backslash), require map, authors, keywords
- Default PHP constraint `^8.4` when not specified
- 12 test functions

## Test plan

- [x] `go test ./package3/php/library/...` -- 12 tests pass
- [x] `go test ./package3/php/...` -- all packages green
- [x] `go vet ./package3/php/library/...` -- clean