### PR TITLE
feat(mep-67): phase 04 Java-to-Mochi type mapping table

### DIFF
--- a/package3/java/typemap/kind.go
+++ b/package3/java/typemap/kind.go
@@ -1,0 +1,78 @@
+// Package typemap maps Java type names to Mochi kinds and FFI representations.
+package typemap
+
+// Kind is the Mochi type category for a mapped Java type.
+type Kind int
+
+const (
+	// KindUnknown is the zero value; it should never appear in a valid mapping.
+	KindUnknown Kind = iota
+	// KindBool: boolean / java.lang.Boolean.
+	KindBool
+	// KindInt: int, short, byte, char, and their boxed counterparts.
+	KindInt
+	// KindLong: long / java.lang.Long.
+	KindLong
+	// KindFloat: float / java.lang.Float.
+	KindFloat
+	// KindDouble: double / java.lang.Double.
+	KindDouble
+	// KindString: java.lang.String.
+	KindString
+	// KindVoid: void return type.
+	KindVoid
+	// KindBytes: byte[] (raw binary data).
+	KindBytes
+	// KindList: java.util.List<T>, java.util.ArrayList<T>, or primitive arrays.
+	KindList
+	// KindMap: java.util.Map<K,V>, java.util.HashMap<K,V>.
+	KindMap
+	// KindOptional: java.util.Optional<T>.
+	KindOptional
+	// KindFuture: java.util.concurrent.CompletableFuture<T>.
+	KindFuture
+	// KindHandle: opaque JNI handle (non-scalar class not otherwise mapped).
+	KindHandle
+	// KindEnum: Java enum class.
+	KindEnum
+	// KindRecord: Java record class (simple value object).
+	KindRecord
+)
+
+// String renders the Kind as a short token.
+func (k Kind) String() string {
+	switch k {
+	case KindBool:
+		return "bool"
+	case KindInt:
+		return "int"
+	case KindLong:
+		return "long"
+	case KindFloat:
+		return "float"
+	case KindDouble:
+		return "double"
+	case KindString:
+		return "string"
+	case KindVoid:
+		return "void"
+	case KindBytes:
+		return "bytes"
+	case KindList:
+		return "list"
+	case KindMap:
+		return "map"
+	case KindOptional:
+		return "optional"
+	case KindFuture:
+		return "future"
+	case KindHandle:
+		return "handle"
+	case KindEnum:
+		return "enum"
+	case KindRecord:
+		return "record"
+	default:
+		return "unknown"
+	}
+}

--- a/package3/java/typemap/kind_test.go
+++ b/package3/java/typemap/kind_test.go
@@ -1,0 +1,34 @@
+package typemap
+
+import (
+	"testing"
+)
+
+func TestKindString(t *testing.T) {
+	cases := []struct {
+		k    Kind
+		want string
+	}{
+		{KindBool, "bool"},
+		{KindInt, "int"},
+		{KindLong, "long"},
+		{KindFloat, "float"},
+		{KindDouble, "double"},
+		{KindString, "string"},
+		{KindVoid, "void"},
+		{KindBytes, "bytes"},
+		{KindList, "list"},
+		{KindMap, "map"},
+		{KindOptional, "optional"},
+		{KindFuture, "future"},
+		{KindHandle, "handle"},
+		{KindEnum, "enum"},
+		{KindRecord, "record"},
+		{KindUnknown, "unknown"},
+	}
+	for _, c := range cases {
+		if got := c.k.String(); got != c.want {
+			t.Errorf("Kind(%d).String() = %q; want %q", c.k, got, c.want)
+		}
+	}
+}

--- a/package3/java/typemap/map.go
+++ b/package3/java/typemap/map.go
@@ -1,0 +1,201 @@
+package typemap
+
+import (
+	"fmt"
+	"strings"
+
+	javaerrors "mochi/package3/java/errors"
+)
+
+// Map maps a Java erased type name to a Mapping or a SkipReason explaining
+// why the type cannot be mapped.
+//
+// The return convention: when SkipReason == SkipUnknown AND detail == "",
+// the Mapping is valid. Any non-zero SkipReason indicates failure.
+func Map(javaTypeName string) (*Mapping, javaerrors.SkipReason, string) {
+	// Refusal checks.
+	if sr, detail := checkRefusal(javaTypeName); sr != javaerrors.SkipUnknown {
+		return nil, sr, detail
+	}
+
+	// Direct table lookups.
+	if m, ok := primitiveTable[javaTypeName]; ok {
+		return m, javaerrors.SkipUnknown, ""
+	}
+	if m, ok := boxedTable[javaTypeName]; ok {
+		return m, javaerrors.SkipUnknown, ""
+	}
+
+	// Parametric types: look for simple suffixes. We only handle unparameterised
+	// names at this level (the wrapper synthesiser handles generic instantiations).
+	switch javaTypeName {
+	case "java.lang.String":
+		return &Mapping{Kind: KindString, JavaName: javaTypeName, MochiType: "string", FFIRepr: "String"}, javaerrors.SkipUnknown, ""
+	case "void":
+		return &Mapping{Kind: KindVoid, JavaName: javaTypeName, MochiType: "void", FFIRepr: "void"}, javaerrors.SkipUnknown, ""
+	case "byte[]":
+		return &Mapping{Kind: KindBytes, JavaName: javaTypeName, MochiType: "bytes", FFIRepr: "byte[]"}, javaerrors.SkipUnknown, ""
+	case "int[]", "long[]", "double[]", "boolean[]", "float[]":
+		return &Mapping{Kind: KindList, JavaName: javaTypeName, MochiType: "list[" + primitiveElemType(javaTypeName) + "]", FFIRepr: "String"}, javaerrors.SkipUnknown, ""
+	case "java.lang.Object":
+		return nil, javaerrors.SkipRawObject, "java.lang.Object without generic context is not mappable"
+	case "java.util.List", "java.util.ArrayList", "java.util.Collection":
+		return nil, javaerrors.SkipGeneric, fmt.Sprintf("raw (unparameterised) %s; declare monomorphisation", javaTypeName)
+	case "java.util.Map", "java.util.HashMap", "java.util.LinkedHashMap":
+		return nil, javaerrors.SkipGeneric, fmt.Sprintf("raw (unparameterised) %s; declare monomorphisation", javaTypeName)
+	case "java.util.Optional":
+		return nil, javaerrors.SkipGeneric, "raw java.util.Optional; declare monomorphisation"
+	case "java.util.concurrent.CompletableFuture":
+		return nil, javaerrors.SkipGeneric, "raw CompletableFuture; declare monomorphisation"
+	}
+
+	// Handle generic forms with parameters, e.g. "java.util.List<java.lang.String>".
+	if m, ok := mapParametric(javaTypeName); ok {
+		return m, javaerrors.SkipUnknown, ""
+	}
+
+	// Fall-through: treat unknown reference types as opaque JNI handles.
+	return &Mapping{Kind: KindHandle, JavaName: javaTypeName, MochiType: "handle<" + javaTypeName + ">", FFIRepr: "long"}, javaerrors.SkipUnknown, ""
+}
+
+// checkRefusal returns a SkipReason if the type name should be refused.
+func checkRefusal(name string) (javaerrors.SkipReason, string) {
+	// Wildcard.
+	if name == "?" || strings.HasPrefix(name, "? extends ") || strings.HasPrefix(name, "? super ") {
+		return javaerrors.SkipWildcard, "wildcard type cannot be mapped"
+	}
+	// Anonymous/inner class (name contains $).
+	if strings.Contains(name, "$") {
+		return javaerrors.SkipInnerClass, "anonymous or inner class (name contains $)"
+	}
+	// Reflective APIs.
+	if strings.HasPrefix(name, "java.lang.reflect.") || strings.HasPrefix(name, "sun.") || strings.HasPrefix(name, "com.sun.") {
+		return javaerrors.SkipReflective, "reflective API not safe to expose"
+	}
+	return javaerrors.SkipUnknown, ""
+}
+
+// mapParametric handles generic forms like "java.util.List<java.lang.String>".
+func mapParametric(name string) (*Mapping, bool) {
+	inner := func(generic, bracket string) (string, bool) {
+		if strings.HasPrefix(name, generic+"<") && strings.HasSuffix(name, ">") {
+			return name[len(generic)+1 : len(name)-1], true
+		}
+		return "", false
+	}
+
+	for _, prefix := range []string{"java.util.List", "java.util.ArrayList", "java.util.Collection"} {
+		if elem, ok := inner(prefix, "<"); ok {
+			elemM, sr, _ := Map(elem)
+			if sr != javaerrors.SkipUnknown {
+				return nil, false
+			}
+			m := &Mapping{Kind: KindList, JavaName: name, MochiType: "list[" + elemM.MochiType + "]", FFIRepr: "String", Elem: elemM}
+			return m, true
+		}
+	}
+
+	for _, prefix := range []string{"java.util.Optional"} {
+		if elem, ok := inner(prefix, "<"); ok {
+			elemM, sr, _ := Map(elem)
+			if sr != javaerrors.SkipUnknown {
+				return nil, false
+			}
+			m := &Mapping{Kind: KindOptional, JavaName: name, MochiType: elemM.MochiType + "?", FFIRepr: "String", Elem: elemM}
+			return m, true
+		}
+	}
+
+	if strings.HasPrefix(name, "java.util.concurrent.CompletableFuture<") && strings.HasSuffix(name, ">") {
+		elem := name[len("java.util.concurrent.CompletableFuture<") : len(name)-1]
+		elemM, sr, _ := Map(elem)
+		if sr != javaerrors.SkipUnknown {
+			return nil, false
+		}
+		m := &Mapping{Kind: KindFuture, JavaName: name, MochiType: "async " + elemM.MochiType, FFIRepr: "String", Elem: elemM}
+		return m, true
+	}
+
+	for _, prefix := range []string{"java.util.Map", "java.util.HashMap"} {
+		if strings.HasPrefix(name, prefix+"<") && strings.HasSuffix(name, ">") {
+			kv := name[len(prefix)+1 : len(name)-1]
+			// Split on first comma that's not inside angle brackets.
+			keyStr, valStr := splitMapKV(kv)
+			if keyStr == "" {
+				return nil, false
+			}
+			keyM, sr1, _ := Map(keyStr)
+			if sr1 != javaerrors.SkipUnknown {
+				return nil, false
+			}
+			valM, sr2, _ := Map(valStr)
+			if sr2 != javaerrors.SkipUnknown {
+				return nil, false
+			}
+			m := &Mapping{Kind: KindMap, JavaName: name, MochiType: "map[" + keyM.MochiType + "," + valM.MochiType + "]", FFIRepr: "String", Key: keyM, Value: valM}
+			return m, true
+		}
+	}
+
+	return nil, false
+}
+
+// splitMapKV splits "K,V" respecting nested angle brackets.
+func splitMapKV(s string) (string, string) {
+	depth := 0
+	for i, ch := range s {
+		switch ch {
+		case '<':
+			depth++
+		case '>':
+			depth--
+		case ',':
+			if depth == 0 {
+				return strings.TrimSpace(s[:i]), strings.TrimSpace(s[i+1:])
+			}
+		}
+	}
+	return "", ""
+}
+
+// primitiveElemType returns the Mochi element type for a primitive array.
+func primitiveElemType(name string) string {
+	switch name {
+	case "int[]":
+		return "int"
+	case "long[]":
+		return "long"
+	case "double[]":
+		return "double"
+	case "float[]":
+		return "float"
+	case "boolean[]":
+		return "bool"
+	default:
+		return "int"
+	}
+}
+
+// primitiveTable covers the Java primitive types.
+var primitiveTable = map[string]*Mapping{
+	"int":     {Kind: KindInt, JavaName: "int", MochiType: "int", FFIRepr: "int"},
+	"short":   {Kind: KindInt, JavaName: "short", MochiType: "int", FFIRepr: "int"},
+	"byte":    {Kind: KindInt, JavaName: "byte", MochiType: "int", FFIRepr: "int"},
+	"char":    {Kind: KindInt, JavaName: "char", MochiType: "int", FFIRepr: "int"},
+	"long":    {Kind: KindLong, JavaName: "long", MochiType: "long", FFIRepr: "long"},
+	"float":   {Kind: KindFloat, JavaName: "float", MochiType: "float", FFIRepr: "float"},
+	"double":  {Kind: KindDouble, JavaName: "double", MochiType: "double", FFIRepr: "double"},
+	"boolean": {Kind: KindBool, JavaName: "boolean", MochiType: "bool", FFIRepr: "boolean"},
+}
+
+// boxedTable covers the boxed equivalents of Java primitives.
+var boxedTable = map[string]*Mapping{
+	"java.lang.Integer":   {Kind: KindInt, JavaName: "java.lang.Integer", MochiType: "int", FFIRepr: "int"},
+	"java.lang.Short":     {Kind: KindInt, JavaName: "java.lang.Short", MochiType: "int", FFIRepr: "int"},
+	"java.lang.Byte":      {Kind: KindInt, JavaName: "java.lang.Byte", MochiType: "int", FFIRepr: "int"},
+	"java.lang.Character": {Kind: KindInt, JavaName: "java.lang.Character", MochiType: "int", FFIRepr: "int"},
+	"java.lang.Long":      {Kind: KindLong, JavaName: "java.lang.Long", MochiType: "long", FFIRepr: "long"},
+	"java.lang.Float":     {Kind: KindFloat, JavaName: "java.lang.Float", MochiType: "float", FFIRepr: "float"},
+	"java.lang.Double":    {Kind: KindDouble, JavaName: "java.lang.Double", MochiType: "double", FFIRepr: "double"},
+	"java.lang.Boolean":   {Kind: KindBool, JavaName: "java.lang.Boolean", MochiType: "bool", FFIRepr: "boolean"},
+}

--- a/package3/java/typemap/map_test.go
+++ b/package3/java/typemap/map_test.go
@@ -1,0 +1,197 @@
+package typemap
+
+import (
+	"testing"
+
+	javaerrors "mochi/package3/java/errors"
+)
+
+func TestMapPrimitives(t *testing.T) {
+	cases := []struct {
+		java     string
+		wantKind Kind
+	}{
+		{"int", KindInt},
+		{"long", KindLong},
+		{"short", KindInt},
+		{"byte", KindInt},
+		{"char", KindInt},
+		{"float", KindFloat},
+		{"double", KindDouble},
+		{"boolean", KindBool},
+		{"void", KindVoid},
+	}
+	for _, c := range cases {
+		m, sr, detail := Map(c.java)
+		if sr != javaerrors.SkipUnknown || detail != "" {
+			t.Errorf("Map(%q) skipped: %v %s", c.java, sr, detail)
+			continue
+		}
+		if m.Kind != c.wantKind {
+			t.Errorf("Map(%q).Kind = %v; want %v", c.java, m.Kind, c.wantKind)
+		}
+	}
+}
+
+func TestMapBoxed(t *testing.T) {
+	cases := []struct {
+		java     string
+		wantKind Kind
+	}{
+		{"java.lang.Integer", KindInt},
+		{"java.lang.Long", KindLong},
+		{"java.lang.Float", KindFloat},
+		{"java.lang.Double", KindDouble},
+		{"java.lang.Boolean", KindBool},
+		{"java.lang.Short", KindInt},
+		{"java.lang.Byte", KindInt},
+		{"java.lang.Character", KindInt},
+	}
+	for _, c := range cases {
+		m, sr, _ := Map(c.java)
+		if sr != javaerrors.SkipUnknown {
+			t.Errorf("Map(%q) skipped: %v", c.java, sr)
+			continue
+		}
+		if m.Kind != c.wantKind {
+			t.Errorf("Map(%q).Kind = %v; want %v", c.java, m.Kind, c.wantKind)
+		}
+	}
+}
+
+func TestMapString(t *testing.T) {
+	m, sr, _ := Map("java.lang.String")
+	if sr != javaerrors.SkipUnknown {
+		t.Errorf("Map(String) skipped: %v", sr)
+	}
+	if m.Kind != KindString {
+		t.Errorf("Kind = %v; want KindString", m.Kind)
+	}
+	if m.MochiType != "string" {
+		t.Errorf("MochiType = %q; want string", m.MochiType)
+	}
+}
+
+func TestMapByteArray(t *testing.T) {
+	m, sr, _ := Map("byte[]")
+	if sr != javaerrors.SkipUnknown {
+		t.Errorf("Map(byte[]) skipped: %v", sr)
+	}
+	if m.Kind != KindBytes {
+		t.Errorf("Kind = %v; want KindBytes", m.Kind)
+	}
+}
+
+func TestMapPrimitiveArrays(t *testing.T) {
+	for _, java := range []string{"int[]", "long[]", "double[]", "boolean[]"} {
+		m, sr, _ := Map(java)
+		if sr != javaerrors.SkipUnknown {
+			t.Errorf("Map(%q) skipped: %v", java, sr)
+			continue
+		}
+		if m.Kind != KindList {
+			t.Errorf("Map(%q).Kind = %v; want KindList", java, m.Kind)
+		}
+	}
+}
+
+func TestMapRefusals(t *testing.T) {
+	cases := []struct {
+		java   string
+		wantSR javaerrors.SkipReason
+	}{
+		{"java.lang.Object", javaerrors.SkipRawObject},
+		{"?", javaerrors.SkipWildcard},
+		{"? extends java.lang.Number", javaerrors.SkipWildcard},
+		{"? super java.lang.String", javaerrors.SkipWildcard},
+		{"java.util.List", javaerrors.SkipGeneric},
+		{"java.util.Map", javaerrors.SkipGeneric},
+		{"java.util.Optional", javaerrors.SkipGeneric},
+		{"com.example.Outer$Inner", javaerrors.SkipInnerClass},
+		{"java.lang.reflect.Method", javaerrors.SkipReflective},
+		{"sun.misc.Unsafe", javaerrors.SkipReflective},
+	}
+	for _, c := range cases {
+		_, sr, _ := Map(c.java)
+		if sr != c.wantSR {
+			t.Errorf("Map(%q): SkipReason = %v; want %v", c.java, sr, c.wantSR)
+		}
+	}
+}
+
+func TestMapGenericList(t *testing.T) {
+	m, sr, _ := Map("java.util.List<java.lang.String>")
+	if sr != javaerrors.SkipUnknown {
+		t.Errorf("Map(List<String>) skipped: %v", sr)
+	}
+	if m.Kind != KindList {
+		t.Errorf("Kind = %v; want KindList", m.Kind)
+	}
+	if m.Elem == nil || m.Elem.Kind != KindString {
+		t.Errorf("Elem kind = %v; want KindString", m.Elem)
+	}
+}
+
+func TestMapGenericOptional(t *testing.T) {
+	m, sr, _ := Map("java.util.Optional<java.lang.String>")
+	if sr != javaerrors.SkipUnknown {
+		t.Errorf("Map(Optional<String>) skipped: %v", sr)
+	}
+	if m.Kind != KindOptional {
+		t.Errorf("Kind = %v; want KindOptional", m.Kind)
+	}
+}
+
+func TestMapGenericFuture(t *testing.T) {
+	m, sr, _ := Map("java.util.concurrent.CompletableFuture<java.lang.String>")
+	if sr != javaerrors.SkipUnknown {
+		t.Errorf("Map(CompletableFuture<String>) skipped: %v", sr)
+	}
+	if m.Kind != KindFuture {
+		t.Errorf("Kind = %v; want KindFuture", m.Kind)
+	}
+}
+
+func TestMapGenericMap(t *testing.T) {
+	m, sr, _ := Map("java.util.Map<java.lang.String,java.lang.Integer>")
+	if sr != javaerrors.SkipUnknown {
+		t.Errorf("Map(Map<String,Integer>) skipped: %v", sr)
+	}
+	if m.Kind != KindMap {
+		t.Errorf("Kind = %v; want KindMap", m.Kind)
+	}
+}
+
+func TestMapIsScalar(t *testing.T) {
+	scalars := []string{"int", "long", "float", "double", "boolean", "void"}
+	for _, java := range scalars {
+		m, _, _ := Map(java)
+		if m != nil && !m.IsScalar() {
+			t.Errorf("Map(%q).IsScalar() = false; want true", java)
+		}
+	}
+	nonScalars := []string{"java.lang.String", "byte[]", "java.util.List<java.lang.String>"}
+	for _, java := range nonScalars {
+		m, sr, _ := Map(java)
+		if sr != javaerrors.SkipUnknown {
+			continue
+		}
+		if m.IsScalar() {
+			t.Errorf("Map(%q).IsScalar() = true; want false", java)
+		}
+	}
+}
+
+func TestMapOpaqueHandle(t *testing.T) {
+	// An unknown class should become a KindHandle.
+	m, sr, _ := Map("com.example.SomeClass")
+	if sr != javaerrors.SkipUnknown {
+		t.Errorf("Map(com.example.SomeClass) should succeed (as handle), got skip %v", sr)
+	}
+	if m.Kind != KindHandle {
+		t.Errorf("Kind = %v; want KindHandle", m.Kind)
+	}
+	if m.FFIRepr != "long" {
+		t.Errorf("FFIRepr = %q; want long", m.FFIRepr)
+	}
+}

--- a/package3/java/typemap/mapping.go
+++ b/package3/java/typemap/mapping.go
@@ -1,0 +1,30 @@
+package typemap
+
+// Mapping holds the result of successfully mapping a Java type to Mochi.
+type Mapping struct {
+	// Kind is the Mochi type category.
+	Kind Kind
+	// JavaName is the erased Java type name that was mapped.
+	JavaName string
+	// MochiType is the corresponding Mochi type expression.
+	MochiType string
+	// FFIRepr is the JNI-level representation used in wrapper method signatures.
+	FFIRepr string
+	// Elem is the element mapping for List and Optional kinds. May be nil.
+	Elem *Mapping
+	// Key is the key mapping for Map kinds. May be nil.
+	Key *Mapping
+	// Value is the value mapping for Map kinds. May be nil.
+	Value *Mapping
+}
+
+// IsScalar returns true if the mapping is a JNI primitive (no boxing needed
+// at the Java boundary).
+func (m *Mapping) IsScalar() bool {
+	switch m.Kind {
+	case KindBool, KindInt, KindLong, KindFloat, KindDouble, KindVoid:
+		return true
+	default:
+		return false
+	}
+}

--- a/package3/java/typemap/mapping_test.go
+++ b/package3/java/typemap/mapping_test.go
@@ -1,0 +1,22 @@
+package typemap
+
+import (
+	"testing"
+)
+
+func TestMappingIsScalar(t *testing.T) {
+	scalars := []Kind{KindBool, KindInt, KindLong, KindFloat, KindDouble, KindVoid}
+	for _, k := range scalars {
+		m := &Mapping{Kind: k}
+		if !m.IsScalar() {
+			t.Errorf("Kind=%v: IsScalar() = false; want true", k)
+		}
+	}
+	nonScalars := []Kind{KindString, KindBytes, KindList, KindMap, KindOptional, KindHandle}
+	for _, k := range nonScalars {
+		m := &Mapping{Kind: k}
+		if m.IsScalar() {
+			t.Errorf("Kind=%v: IsScalar() = true; want false", k)
+		}
+	}
+}

--- a/package3/java/typemap/phase04_test.go
+++ b/package3/java/typemap/phase04_test.go
@@ -1,0 +1,100 @@
+package typemap
+
+import (
+	"testing"
+
+	javaerrors "mochi/package3/java/errors"
+)
+
+// TestPhase4TypeMapping is the phase-gate sentinel test for MEP-67 phase 4.
+func TestPhase4TypeMapping(t *testing.T) {
+	t.Run("primitive_table", func(t *testing.T) {
+		for java, wantKind := range map[string]Kind{
+			"int":     KindInt,
+			"long":    KindLong,
+			"float":   KindFloat,
+			"double":  KindDouble,
+			"boolean": KindBool,
+			"void":    KindVoid,
+		} {
+			m, sr, _ := Map(java)
+			if sr != javaerrors.SkipUnknown {
+				t.Errorf("Map(%q) skipped %v", java, sr)
+				continue
+			}
+			if m.Kind != wantKind {
+				t.Errorf("Map(%q).Kind = %v; want %v", java, m.Kind, wantKind)
+			}
+		}
+	})
+
+	t.Run("boxed_equivalence", func(t *testing.T) {
+		pairs := [][2]string{
+			{"int", "java.lang.Integer"},
+			{"long", "java.lang.Long"},
+			{"float", "java.lang.Float"},
+			{"double", "java.lang.Double"},
+			{"boolean", "java.lang.Boolean"},
+		}
+		for _, p := range pairs {
+			m1, sr1, _ := Map(p[0])
+			m2, sr2, _ := Map(p[1])
+			if sr1 != javaerrors.SkipUnknown || sr2 != javaerrors.SkipUnknown {
+				t.Errorf("pair %v: skip %v %v", p, sr1, sr2)
+				continue
+			}
+			if m1.Kind != m2.Kind {
+				t.Errorf("Map(%q).Kind=%v != Map(%q).Kind=%v", p[0], m1.Kind, p[1], m2.Kind)
+			}
+		}
+	})
+
+	t.Run("refusal_table", func(t *testing.T) {
+		refusals := map[string]javaerrors.SkipReason{
+			"java.lang.Object":                javaerrors.SkipRawObject,
+			"?":                               javaerrors.SkipWildcard,
+			"java.util.List":                  javaerrors.SkipGeneric,
+			"com.example.Outer$Inner":          javaerrors.SkipInnerClass,
+			"java.lang.reflect.Method":         javaerrors.SkipReflective,
+		}
+		for java, want := range refusals {
+			_, sr, _ := Map(java)
+			if sr != want {
+				t.Errorf("Map(%q): SkipReason=%v; want %v", java, sr, want)
+			}
+		}
+	})
+
+	t.Run("generic_list", func(t *testing.T) {
+		m, sr, _ := Map("java.util.List<java.lang.String>")
+		if sr != javaerrors.SkipUnknown {
+			t.Fatalf("Map(List<String>) skipped: %v", sr)
+		}
+		if m.Kind != KindList {
+			t.Errorf("Kind = %v; want KindList", m.Kind)
+		}
+		if m.Elem == nil || m.Elem.Kind != KindString {
+			t.Errorf("Elem.Kind = %v; want KindString", m.Elem)
+		}
+	})
+
+	t.Run("generic_map", func(t *testing.T) {
+		m, sr, _ := Map("java.util.Map<java.lang.String,java.lang.Integer>")
+		if sr != javaerrors.SkipUnknown {
+			t.Fatalf("Map(Map<String,Integer>) skipped: %v", sr)
+		}
+		if m.Kind != KindMap {
+			t.Errorf("Kind = %v; want KindMap", m.Kind)
+		}
+	})
+
+	t.Run("opaque_handle", func(t *testing.T) {
+		m, sr, _ := Map("com.example.ComplexClass")
+		if sr != javaerrors.SkipUnknown {
+			t.Fatalf("unknown class should be handled, got skip %v", sr)
+		}
+		if m.Kind != KindHandle {
+			t.Errorf("Kind = %v; want KindHandle", m.Kind)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `package3/java/typemap/` package
- `kind.go`: Kind enum (KindBool, KindInt, KindLong, KindFloat, KindDouble, KindString, KindVoid, KindBytes, KindList, KindMap, KindOptional, KindFuture, KindHandle, KindEnum, KindRecord)
- `mapping.go`: Mapping struct with IsScalar()
- `map.go`: Map(javaTypeName) with full primitive/boxed table, refusal checks (SkipWildcard, SkipInnerClass, SkipReflective, SkipRawObject, SkipGeneric), generic parameterisation, opaque handle fallback

Closes $ISSUE

## Test plan

- [x] `go test ./package3/java/...` passes
- [x] TestPhase4TypeMapping all sub-tests pass