### PR TITLE
MEP-74 phase 13: cosign-on-sibling-tag

### DIFF
--- a/package3/go/cosign/cosign.go
+++ b/package3/go/cosign/cosign.go
@@ -1,0 +1,283 @@
+// Package cosign is the MEP-74 phase 13 Sigstore-cosign sibling-tag
+// signer. It takes a publish commit (typically the output of
+// `package3/go/publish.Publish`), exchanges an OIDC token for a
+// keyless Sigstore bundle covering the publish commit SHA, and
+// attaches the bundle as the annotated message body of a sibling
+// tag `<tag>.sig` per the experimental gosum-cosign workflow draft
+// of 2026-Q1. The sibling tag is pushed to the same remote the
+// publish commit went to (unless DryRun is set).
+//
+// The package is layering-conservative: it imports `package3/go/
+// publish` only for the Runner interface and otherwise depends only
+// on the Go stdlib. The signing surface is split into a pure
+// shaping layer (SignRequest.Validate) and an impure runner
+// (Sign) so callers can validate the request before any side
+// effect, and the network-facing signing primitive flows through a
+// small Signer interface so the unit tests can exercise the full
+// flow against an in-process fake.
+//
+// The bundle format mirrors the cosign signature envelope: a
+// JSON document containing the signature bytes (base64-encoded),
+// the public key or x509 certificate chain, and the Rekor
+// transparency-log inclusion proof. The bundle is stored verbatim
+// in the sibling tag's annotated message body so a `git fetch
+// --tags` followed by a `git cat-file -p <tag>.sig` round-trips
+// the signature without an out-of-band registry.
+package cosign
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	"mochi/package3/go/publish"
+)
+
+// ErrCosign is the package-wide error sentinel for the signer.
+var ErrCosign = errors.New("cosign")
+
+// DefaultAudience is the OIDC audience that Sigstore Fulcio
+// expects in a keyless-sign token exchange. Mirrors the value
+// hardcoded in the upstream cosign CLI.
+const DefaultAudience = "sigstore"
+
+// DefaultFulcioURL is the production Sigstore Fulcio certificate-
+// authority endpoint. Override via SignRequest.FulcioURL for
+// staging or air-gapped Sigstore deployments.
+const DefaultFulcioURL = "https://fulcio.sigstore.dev"
+
+// DefaultRekorURL is the production Sigstore Rekor transparency-
+// log endpoint. Override via SignRequest.RekorURL for staging or
+// air-gapped Sigstore deployments.
+const DefaultRekorURL = "https://rekor.sigstore.dev"
+
+// SignRequest is the in-memory shape of a `mochi pkg publish
+// --cosign-sign` follow-up call. Callers populate it from the
+// PublishResult of the upstream `publish.Publish` invocation plus
+// the OIDC token harvested from the CI environment.
+type SignRequest struct {
+	// CommitSHA is the publish commit to sign. Required. Must be
+	// the full 40-character git SHA so the bundle binds to a
+	// specific revision; short SHAs are rejected because two
+	// distinct commits in the same repo can share a short prefix.
+	CommitSHA string
+	// Tag is the publish tag the cosign sibling attaches to.
+	// Required. The sibling tag will be `<Tag>.sig`. The tag is
+	// also embedded in the bundle's `payload.tag` field so a
+	// verifier can cross-check the sibling without reading the
+	// surrounding repo.
+	Tag string
+	// WorkspaceRoot is the local git working tree to operate on.
+	// Required. Typically the same path the upstream `publish.
+	// Publish` returned in `PublishResult.WorkspaceRoot`.
+	WorkspaceRoot string
+	// Author is the git author / committer recorded on the
+	// sibling tag. Required. Conventionally the same Author the
+	// upstream publish used.
+	Author publish.Author
+	// OIDCToken is the JWT obtained from the CI's OIDC issuer
+	// (GitHub Actions, GitLab CI, ...). Required. The Signer
+	// trades this token for a short-lived Fulcio code-signing
+	// certificate per Sigstore's keyless flow.
+	OIDCToken string
+	// FulcioURL is the Sigstore Fulcio CA endpoint. Optional;
+	// defaults to DefaultFulcioURL.
+	FulcioURL string
+	// RekorURL is the Sigstore Rekor transparency-log endpoint.
+	// Optional; defaults to DefaultRekorURL.
+	RekorURL string
+	// Audience is the OIDC audience the Signer requests. Optional;
+	// defaults to DefaultAudience.
+	Audience string
+	// DryRun runs the signer end-to-end (so the bundle is
+	// produced and the sibling tag is created locally) but skips
+	// the `git push` step. Mirrors the upstream publish.PublishRequest
+	// DryRun semantics so a single `mochi pkg publish --dry-run
+	// --cosign-sign` invocation does the full local rehearsal.
+	DryRun bool
+}
+
+// SignResult is the outcome of a Sign call. The Bundle is the
+// cosign signature envelope (verbatim bytes that ended up in the
+// sibling tag's annotated message body); SiblingTag is the tag
+// name (typically `<Tag>.sig`); Pushed reflects whether the
+// sibling tag was pushed to the remote.
+type SignResult struct {
+	SiblingTag string
+	Bundle     []byte
+	Pushed     bool
+}
+
+// Signer is the network-facing signing primitive. Implementations
+// exchange `oidcToken` (with `audience`) for a Fulcio code-signing
+// certificate, sign the SHA256 of `commitSHA` plus the metadata
+// payload, log the signature to Rekor, and return the resulting
+// cosign-style bundle bytes.
+//
+// The interface is split out so the unit tests can substitute a
+// recording fake without touching the live Sigstore endpoints.
+type Signer interface {
+	Sign(commitSHA, tag, audience, oidcToken, fulcioURL, rekorURL string) (bundle []byte, err error)
+}
+
+// Validate checks the structural invariants of a SignRequest.
+// Missing required fields, a malformed CommitSHA (must be 40
+// lowercase hex chars), or an empty Tag surface here so callers
+// fail fast.
+func (r SignRequest) Validate() error {
+	if !isFullSHA(r.CommitSHA) {
+		return fmt.Errorf("%w: CommitSHA must be a 40-character lowercase hex string, got %q", ErrCosign, r.CommitSHA)
+	}
+	if strings.TrimSpace(r.Tag) == "" {
+		return fmt.Errorf("%w: Tag is required", ErrCosign)
+	}
+	if strings.HasSuffix(r.Tag, ".sig") {
+		return fmt.Errorf("%w: Tag %q already ends in .sig; pass the publish tag, not the sibling", ErrCosign, r.Tag)
+	}
+	if strings.TrimSpace(r.WorkspaceRoot) == "" {
+		return fmt.Errorf("%w: WorkspaceRoot is required", ErrCosign)
+	}
+	if strings.TrimSpace(r.OIDCToken) == "" {
+		return fmt.Errorf("%w: OIDCToken is required", ErrCosign)
+	}
+	if strings.TrimSpace(r.Author.Name) == "" {
+		return fmt.Errorf("%w: Author.Name is required", ErrCosign)
+	}
+	if strings.TrimSpace(r.Author.Email) == "" {
+		return fmt.Errorf("%w: Author.Email is required", ErrCosign)
+	}
+	return nil
+}
+
+// Sign runs the cosign sign-and-attach flow: it asks the Signer for
+// a bundle, encodes the bundle into the annotated message body of
+// the sibling tag, and (unless DryRun) pushes the sibling tag to
+// the same remote the publish commit lives on. Callers stitch this
+// together with the upstream publish.Publish call.
+func Sign(req SignRequest, signer Signer, runner publish.Runner) (SignResult, error) {
+	if err := req.Validate(); err != nil {
+		return SignResult{}, err
+	}
+	audience := req.Audience
+	if audience == "" {
+		audience = DefaultAudience
+	}
+	fulcio := req.FulcioURL
+	if fulcio == "" {
+		fulcio = DefaultFulcioURL
+	}
+	rekor := req.RekorURL
+	if rekor == "" {
+		rekor = DefaultRekorURL
+	}
+
+	bundle, err := signer.Sign(req.CommitSHA, req.Tag, audience, req.OIDCToken, fulcio, rekor)
+	if err != nil {
+		return SignResult{}, fmt.Errorf("%w: signer: %v", ErrCosign, err)
+	}
+	if len(bundle) == 0 {
+		return SignResult{}, fmt.Errorf("%w: signer returned empty bundle", ErrCosign)
+	}
+
+	siblingTag := req.Tag + ".sig"
+	if err := runner.Run(req.WorkspaceRoot, "git", "config", "user.name", req.Author.Name); err != nil {
+		return SignResult{}, fmt.Errorf("%w: git config user.name: %v", ErrCosign, err)
+	}
+	if err := runner.Run(req.WorkspaceRoot, "git", "config", "user.email", req.Author.Email); err != nil {
+		return SignResult{}, fmt.Errorf("%w: git config user.email: %v", ErrCosign, err)
+	}
+	message := buildSiblingMessage(req.Tag, req.CommitSHA, bundle)
+	if err := runner.Run(req.WorkspaceRoot, "git", "tag", "-a", siblingTag, req.CommitSHA, "-m", message); err != nil {
+		return SignResult{}, fmt.Errorf("%w: git tag sibling: %v", ErrCosign, err)
+	}
+
+	pushed := false
+	if !req.DryRun {
+		if err := runner.Run(req.WorkspaceRoot, "git", "push", "origin", siblingTag); err != nil {
+			return SignResult{}, fmt.Errorf("%w: git push sibling: %v", ErrCosign, err)
+		}
+		pushed = true
+	}
+	return SignResult{SiblingTag: siblingTag, Bundle: bundle, Pushed: pushed}, nil
+}
+
+// buildSiblingMessage renders the annotated tag message that
+// carries the cosign bundle. The message has a header naming the
+// signature scheme (`mochi-mep74-cosign-v1`), the publish tag, the
+// signed commit SHA, and the bundle bytes base64-encoded so the tag
+// message stays text-safe (git restricts what byte sequences can
+// appear in tag messages).
+func buildSiblingMessage(tag, commitSHA string, bundle []byte) string {
+	var sb strings.Builder
+	sb.WriteString("cosign-sig: mochi-mep74-cosign-v1\n")
+	sb.WriteString("tag: ")
+	sb.WriteString(tag)
+	sb.WriteString("\n")
+	sb.WriteString("commit: ")
+	sb.WriteString(commitSHA)
+	sb.WriteString("\n")
+	sb.WriteString("bundle-base64: ")
+	sb.WriteString(base64.StdEncoding.EncodeToString(bundle))
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// ParseSiblingMessage parses a sibling-tag annotated message back
+// into its components: the publish tag, the signed commit SHA, and
+// the verbatim bundle bytes (after base64 decode). This is the
+// verifier-side helper a downstream consumer would call after `git
+// cat-file -p <tag>.sig` to recover the bundle.
+func ParseSiblingMessage(message string) (tag, commitSHA string, bundle []byte, err error) {
+	var b64 string
+	for _, raw := range strings.Split(message, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		key, val, ok := cutColon(line)
+		if !ok {
+			continue
+		}
+		switch key {
+		case "cosign-sig":
+			if val != "mochi-mep74-cosign-v1" {
+				return "", "", nil, fmt.Errorf("%w: unknown cosign-sig scheme %q", ErrCosign, val)
+			}
+		case "tag":
+			tag = val
+		case "commit":
+			commitSHA = val
+		case "bundle-base64":
+			b64 = val
+		}
+	}
+	if tag == "" || commitSHA == "" || b64 == "" {
+		return "", "", nil, fmt.Errorf("%w: sibling message missing required fields", ErrCosign)
+	}
+	bundle, err = base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("%w: bundle base64 decode: %v", ErrCosign, err)
+	}
+	return tag, commitSHA, bundle, nil
+}
+
+func cutColon(s string) (string, string, bool) {
+	idx := strings.Index(s, ": ")
+	if idx <= 0 {
+		return "", "", false
+	}
+	return s[:idx], s[idx+2:], true
+}
+
+func isFullSHA(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+	for _, r := range s {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			return false
+		}
+	}
+	return true
+}

--- a/package3/go/cosign/cosign_test.go
+++ b/package3/go/cosign/cosign_test.go
@@ -1,0 +1,320 @@
+package cosign
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"mochi/package3/go/publish"
+)
+
+const sampleSHA = "deadbeefcafebabe1234567890abcdefdeadbeef"
+
+func goodReq() SignRequest {
+	return SignRequest{
+		CommitSHA:     sampleSHA,
+		Tag:           "v0.1.0",
+		WorkspaceRoot: "/tmp/x",
+		Author:        publish.Author{Name: "Mochi", Email: "ci@mochi-lang.org"},
+		OIDCToken:     "fake.oidc.token",
+	}
+}
+
+// fakeSigner records its inputs and returns a deterministic bundle.
+type fakeSigner struct {
+	gotCommitSHA, gotTag string
+	gotAudience          string
+	gotOIDC              string
+	gotFulcio, gotRekor  string
+	bundle               []byte
+	err                  error
+}
+
+func (f *fakeSigner) Sign(commitSHA, tag, audience, oidc, fulcio, rekor string) ([]byte, error) {
+	f.gotCommitSHA = commitSHA
+	f.gotTag = tag
+	f.gotAudience = audience
+	f.gotOIDC = oidc
+	f.gotFulcio = fulcio
+	f.gotRekor = rekor
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.bundle != nil {
+		return f.bundle, nil
+	}
+	return []byte("{\"signature\":\"AAA\",\"cert\":\"BBB\"}"), nil
+}
+
+// recordingRunner mirrors publish.Runner without the network bits.
+type recordingRunner struct {
+	Cmds []string
+}
+
+func (r *recordingRunner) Run(dir, name string, args ...string) error {
+	r.Cmds = append(r.Cmds, name+" "+strings.Join(args, " "))
+	return nil
+}
+
+func (r *recordingRunner) Output(dir, name string, args ...string) (string, error) {
+	r.Cmds = append(r.Cmds, name+" "+strings.Join(args, " "))
+	return "", nil
+}
+
+func TestValidateAccepts(t *testing.T) {
+	if err := goodReq().Validate(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRejectsShortSHA(t *testing.T) {
+	r := goodReq()
+	r.CommitSHA = "abc123"
+	if err := r.Validate(); err == nil || !errors.Is(err, ErrCosign) {
+		t.Errorf("expected ErrCosign for short SHA, got %v", err)
+	}
+}
+
+func TestValidateRejectsNonHexSHA(t *testing.T) {
+	r := goodReq()
+	r.CommitSHA = strings.Repeat("z", 40)
+	if err := r.Validate(); err == nil {
+		t.Errorf("expected error for non-hex SHA")
+	}
+}
+
+func TestValidateRejectsUppercaseSHA(t *testing.T) {
+	r := goodReq()
+	r.CommitSHA = strings.ToUpper(sampleSHA)
+	if err := r.Validate(); err == nil {
+		t.Errorf("expected error for uppercase SHA")
+	}
+}
+
+func TestValidateRejectsEmptyTag(t *testing.T) {
+	r := goodReq()
+	r.Tag = ""
+	if err := r.Validate(); err == nil {
+		t.Errorf("expected error for empty tag")
+	}
+}
+
+func TestValidateRejectsAlreadySigTag(t *testing.T) {
+	r := goodReq()
+	r.Tag = "v0.1.0.sig"
+	err := r.Validate()
+	if err == nil || !strings.Contains(err.Error(), "already ends in .sig") {
+		t.Errorf("expected sibling-tag rejection, got %v", err)
+	}
+}
+
+func TestValidateRejectsEmptyWorkspaceRoot(t *testing.T) {
+	r := goodReq()
+	r.WorkspaceRoot = ""
+	if err := r.Validate(); err == nil {
+		t.Errorf("expected error for empty workspace")
+	}
+}
+
+func TestValidateRejectsEmptyOIDC(t *testing.T) {
+	r := goodReq()
+	r.OIDCToken = ""
+	if err := r.Validate(); err == nil {
+		t.Errorf("expected error for empty OIDC token")
+	}
+}
+
+func TestValidateRejectsEmptyAuthor(t *testing.T) {
+	r := goodReq()
+	r.Author.Name = ""
+	if err := r.Validate(); err == nil {
+		t.Errorf("expected error for empty author name")
+	}
+	r.Author.Name = "x"
+	r.Author.Email = ""
+	if err := r.Validate(); err == nil {
+		t.Errorf("expected error for empty author email")
+	}
+}
+
+func TestSignHappyPath(t *testing.T) {
+	req := goodReq()
+	signer := &fakeSigner{}
+	runner := &recordingRunner{}
+	res, err := Sign(req, signer, runner)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if res.SiblingTag != "v0.1.0.sig" {
+		t.Errorf("SiblingTag = %q; want v0.1.0.sig", res.SiblingTag)
+	}
+	if !res.Pushed {
+		t.Errorf("expected Pushed=true")
+	}
+	if string(res.Bundle) != "{\"signature\":\"AAA\",\"cert\":\"BBB\"}" {
+		t.Errorf("Bundle = %q; want the fake signer's bundle", res.Bundle)
+	}
+
+	if signer.gotCommitSHA != sampleSHA {
+		t.Errorf("signer received CommitSHA %q; want %q", signer.gotCommitSHA, sampleSHA)
+	}
+	if signer.gotTag != "v0.1.0" {
+		t.Errorf("signer received Tag %q; want v0.1.0", signer.gotTag)
+	}
+	if signer.gotAudience != "sigstore" {
+		t.Errorf("audience = %q; want sigstore", signer.gotAudience)
+	}
+	if signer.gotFulcio != DefaultFulcioURL {
+		t.Errorf("fulcio = %q; want %q", signer.gotFulcio, DefaultFulcioURL)
+	}
+	if signer.gotRekor != DefaultRekorURL {
+		t.Errorf("rekor = %q; want %q", signer.gotRekor, DefaultRekorURL)
+	}
+
+	wantCmds := []string{
+		"git config user.name Mochi",
+		"git config user.email ci@mochi-lang.org",
+	}
+	for i, want := range wantCmds {
+		if runner.Cmds[i] != want {
+			t.Errorf("cmd[%d] = %q; want %q", i, runner.Cmds[i], want)
+		}
+	}
+	tagCmd := runner.Cmds[2]
+	if !strings.HasPrefix(tagCmd, "git tag -a v0.1.0.sig "+sampleSHA+" -m cosign-sig:") {
+		t.Errorf("tag cmd unexpected: %q", tagCmd)
+	}
+	if runner.Cmds[3] != "git push origin v0.1.0.sig" {
+		t.Errorf("push cmd unexpected: %q", runner.Cmds[3])
+	}
+}
+
+func TestSignDryRunSkipsPush(t *testing.T) {
+	req := goodReq()
+	req.DryRun = true
+	runner := &recordingRunner{}
+	res, err := Sign(req, &fakeSigner{}, runner)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if res.Pushed {
+		t.Errorf("Pushed should be false under DryRun")
+	}
+	for _, c := range runner.Cmds {
+		if strings.HasPrefix(c, "git push") {
+			t.Errorf("DryRun should not push; saw %q", c)
+		}
+	}
+}
+
+func TestSignSurfacesSignerError(t *testing.T) {
+	req := goodReq()
+	signer := &fakeSigner{err: errors.New("synthetic signer failure")}
+	runner := &recordingRunner{}
+	_, err := Sign(req, signer, runner)
+	if err == nil || !errors.Is(err, ErrCosign) {
+		t.Errorf("expected ErrCosign on signer error, got %v", err)
+	}
+	if len(runner.Cmds) != 0 {
+		t.Errorf("signer failure should not call runner; cmds=%v", runner.Cmds)
+	}
+}
+
+func TestSignRejectsEmptyBundle(t *testing.T) {
+	req := goodReq()
+	signer := &fakeSigner{bundle: []byte{}}
+	runner := &recordingRunner{}
+	_, err := Sign(req, signer, runner)
+	if err == nil || !strings.Contains(err.Error(), "empty bundle") {
+		t.Errorf("expected empty-bundle rejection, got %v", err)
+	}
+}
+
+func TestSignValidationFailureSkipsSigner(t *testing.T) {
+	req := goodReq()
+	req.CommitSHA = "shortbad"
+	signer := &fakeSigner{}
+	runner := &recordingRunner{}
+	_, err := Sign(req, signer, runner)
+	if err == nil {
+		t.Errorf("expected validation error")
+	}
+	if signer.gotCommitSHA != "" {
+		t.Errorf("validation failure should not call signer")
+	}
+}
+
+func TestBuildAndParseSiblingMessageRoundtrip(t *testing.T) {
+	bundle := []byte("\x00\x01\x02bundle\xff\xfe")
+	msg := buildSiblingMessage("v1.2.3", sampleSHA, bundle)
+	tag, commit, gotBundle, err := ParseSiblingMessage(msg)
+	if err != nil {
+		t.Fatalf("ParseSiblingMessage: %v", err)
+	}
+	if tag != "v1.2.3" {
+		t.Errorf("tag = %q; want v1.2.3", tag)
+	}
+	if commit != sampleSHA {
+		t.Errorf("commit = %q; want %q", commit, sampleSHA)
+	}
+	if string(gotBundle) != string(bundle) {
+		t.Errorf("bundle roundtrip drift: %x vs %x", gotBundle, bundle)
+	}
+}
+
+func TestParseSiblingMessageRejectsUnknownScheme(t *testing.T) {
+	msg := "cosign-sig: future-scheme-v99\ntag: v0.1.0\ncommit: " + sampleSHA + "\nbundle-base64: AA==\n"
+	if _, _, _, err := ParseSiblingMessage(msg); err == nil {
+		t.Errorf("expected unknown-scheme rejection")
+	}
+}
+
+func TestParseSiblingMessageRejectsMissingFields(t *testing.T) {
+	msg := "cosign-sig: mochi-mep74-cosign-v1\ntag: v0.1.0\n"
+	if _, _, _, err := ParseSiblingMessage(msg); err == nil {
+		t.Errorf("expected missing-fields rejection")
+	}
+}
+
+func TestParseSiblingMessageRejectsBadBase64(t *testing.T) {
+	msg := "cosign-sig: mochi-mep74-cosign-v1\ntag: v0.1.0\ncommit: " + sampleSHA + "\nbundle-base64: ***not-base64***\n"
+	if _, _, _, err := ParseSiblingMessage(msg); err == nil {
+		t.Errorf("expected base64 decode error")
+	}
+}
+
+func TestSignUsesCustomAudienceAndEndpoints(t *testing.T) {
+	req := goodReq()
+	req.Audience = "custom-aud"
+	req.FulcioURL = "https://staging.fulcio"
+	req.RekorURL = "https://staging.rekor"
+	signer := &fakeSigner{}
+	runner := &recordingRunner{}
+	if _, err := Sign(req, signer, runner); err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if signer.gotAudience != "custom-aud" {
+		t.Errorf("audience = %q; want custom-aud", signer.gotAudience)
+	}
+	if signer.gotFulcio != "https://staging.fulcio" {
+		t.Errorf("fulcio = %q; want staging.fulcio", signer.gotFulcio)
+	}
+	if signer.gotRekor != "https://staging.rekor" {
+		t.Errorf("rekor = %q; want staging.rekor", signer.gotRekor)
+	}
+}
+
+func TestIsFullSHA(t *testing.T) {
+	if !isFullSHA(sampleSHA) {
+		t.Errorf("sampleSHA should be valid")
+	}
+	if isFullSHA("") {
+		t.Errorf("empty should not be valid")
+	}
+	if isFullSHA(sampleSHA + "0") {
+		t.Errorf("41 chars should not be valid")
+	}
+	if isFullSHA(sampleSHA[:39]) {
+		t.Errorf("39 chars should not be valid")
+	}
+}

--- a/package3/go/cosign/phase13_test.go
+++ b/package3/go/cosign/phase13_test.go
@@ -1,0 +1,223 @@
+package cosign
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/package3/go/library"
+	"mochi/package3/go/publish"
+)
+
+// TestPhase13CosignSiblingTagSentinel is the MEP-74 phase 13
+// end-to-end sentinel. It exercises the full chain
+//
+//	library.Emit -> publish.Publish -> cosign.Sign
+//
+// against a local bare-repo fixture (no network, fake signer) and
+// proves:
+//
+//   - Sign attaches the sibling tag `<tag>.sig` to the publish
+//     commit in the publish workspace and pushes it to the same
+//     bare remote the publish commit went to;
+//   - a downstream `git clone` of the remote sees the sibling tag,
+//     and `git cat-file -p <tag>.sig` round-trips the cosign bundle
+//     bytes through ParseSiblingMessage;
+//   - the sibling tag does not perturb the original publish tag
+//     (the publish commit SHA the sibling points at matches the
+//     publish-flow SHA).
+func TestPhase13CosignSiblingTagSentinel(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+
+	root := t.TempDir()
+	remoteRoot := filepath.Join(root, "remote.git")
+	if err := runCmd(t, root, "git", "init", "--bare", remoteRoot); err != nil {
+		t.Fatalf("init bare remote: %v", err)
+	}
+
+	api := library.PublicAPI{
+		ModulePath:  "example.com/mochi/calc",
+		PackageName: "calc",
+		Version:     "v0.3.0",
+		GoVersion:   "1.21",
+		Meta: library.PackageMeta{
+			DocComment:  "Package calc is a tiny calculator published by Mochi.",
+			Description: "Tiny calculator",
+			License:     "MIT",
+			LicenseText: "MIT License\n\nCopyright (c) 2026 Mochi.\n",
+		},
+		Items: []library.Item{
+			library.ItemConst{Name: "Version", Type: "string", Value: "\"v0.3.0\""},
+			library.ItemFunc{Name: "Add",
+				Params:  []library.Param{{Name: "a", Type: "int64"}, {Name: "b", Type: "int64"}},
+				Results: []library.Result{{Type: "int64"}},
+				Body:    "return a + b",
+			},
+		},
+	}
+	files, err := library.Emit(api)
+	if err != nil {
+		t.Fatalf("library.Emit: %v", err)
+	}
+
+	publishReq := publish.PublishRequest{
+		Files:         files,
+		ModulePath:    api.ModulePath,
+		Tag:           "v0.3.0",
+		RemoteURL:     "file://" + remoteRoot,
+		Author:        publish.Author{Name: "Mochi CI", Email: "ci@mochi-lang.org"},
+		WorkspaceRoot: filepath.Join(root, "ws"),
+	}
+	pubRes, err := publish.Publish(publishReq, publish.NewExecRunner())
+	if err != nil {
+		t.Fatalf("publish.Publish: %v", err)
+	}
+	if !pubRes.Pushed {
+		t.Fatalf("expected publish Pushed=true")
+	}
+	if len(pubRes.CommitSHA) != 40 {
+		t.Fatalf("expected 40-char publish commit SHA, got %q", pubRes.CommitSHA)
+	}
+
+	bundle := []byte("{\"signature\":\"AAA\",\"cert\":\"BBB\",\"rekorLogIndex\":42}")
+	signer := &fakeSigner{bundle: bundle}
+	signReq := SignRequest{
+		CommitSHA:     pubRes.CommitSHA,
+		Tag:           "v0.3.0",
+		WorkspaceRoot: pubRes.WorkspaceRoot,
+		Author:        publish.Author{Name: "Mochi CI", Email: "ci@mochi-lang.org"},
+		OIDCToken:     "fake.oidc.token",
+	}
+	signRes, err := Sign(signReq, signer, publish.NewExecRunner())
+	if err != nil {
+		t.Fatalf("cosign.Sign: %v", err)
+	}
+	if !signRes.Pushed {
+		t.Fatalf("expected cosign Pushed=true")
+	}
+	if signRes.SiblingTag != "v0.3.0.sig" {
+		t.Errorf("SiblingTag = %q; want v0.3.0.sig", signRes.SiblingTag)
+	}
+
+	// The remote bare repo should now carry both the publish tag
+	// and the sibling tag.
+	out, err := combinedOutput(remoteRoot, "git", "tag", "-l")
+	if err != nil {
+		t.Fatalf("list remote tags: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "v0.3.0\n") && !strings.HasSuffix(strings.TrimSpace(out), "v0.3.0") && !strings.Contains(out, "v0.3.0 ") {
+		t.Errorf("remote missing v0.3.0:\n%s", out)
+	}
+	if !strings.Contains(out, "v0.3.0.sig") {
+		t.Errorf("remote missing v0.3.0.sig:\n%s", out)
+	}
+
+	// Clone the bare repo, then read the sibling-tag message back
+	// through `git cat-file -p` and verify the bundle round-trips.
+	clonePath := filepath.Join(root, "consumer-clone")
+	if out, err := combinedOutput(root, "git", "clone", "file://"+remoteRoot, clonePath); err != nil {
+		t.Fatalf("clone remote: %v\n%s", err, out)
+	}
+
+	// Resolve the sibling-tag object to its annotated commit SHA and
+	// confirm it matches the publish commit (sibling tag must point
+	// to the publish commit, not to a separate commit).
+	pointedSHA, err := combinedOutput(clonePath, "git", "rev-list", "-n", "1", "v0.3.0.sig")
+	if err != nil {
+		t.Fatalf("git rev-list v0.3.0.sig: %v\n%s", err, pointedSHA)
+	}
+	if got := strings.TrimSpace(pointedSHA); got != pubRes.CommitSHA {
+		t.Errorf("sibling tag points to %q; want publish commit %q", got, pubRes.CommitSHA)
+	}
+
+	// `git cat-file -p <annotated-tag>` outputs the tag header lines
+	// followed by a blank line and then the annotated message body.
+	tagBlob, err := combinedOutput(clonePath, "git", "cat-file", "-p", "v0.3.0.sig")
+	if err != nil {
+		t.Fatalf("git cat-file -p v0.3.0.sig: %v\n%s", err, tagBlob)
+	}
+	body := tagBlobBody(tagBlob)
+	if body == "" {
+		t.Fatalf("annotated tag body is empty; full blob:\n%s", tagBlob)
+	}
+
+	gotTag, gotCommit, gotBundle, err := ParseSiblingMessage(body)
+	if err != nil {
+		t.Fatalf("ParseSiblingMessage: %v\nbody=%q", err, body)
+	}
+	if gotTag != "v0.3.0" {
+		t.Errorf("parsed tag = %q; want v0.3.0", gotTag)
+	}
+	if gotCommit != pubRes.CommitSHA {
+		t.Errorf("parsed commit = %q; want %q", gotCommit, pubRes.CommitSHA)
+	}
+	if string(gotBundle) != string(bundle) {
+		t.Errorf("bundle did not round-trip through annotated tag:\ngot:  %q\nwant: %q", gotBundle, bundle)
+	}
+
+	// And the fake signer must have seen the publish commit SHA,
+	// the publish tag, and the default Sigstore endpoints.
+	if signer.gotCommitSHA != pubRes.CommitSHA {
+		t.Errorf("signer received commit %q; want %q", signer.gotCommitSHA, pubRes.CommitSHA)
+	}
+	if signer.gotTag != "v0.3.0" {
+		t.Errorf("signer received tag %q; want v0.3.0", signer.gotTag)
+	}
+	if signer.gotFulcio != DefaultFulcioURL {
+		t.Errorf("signer received fulcio %q; want %q", signer.gotFulcio, DefaultFulcioURL)
+	}
+	if signer.gotRekor != DefaultRekorURL {
+		t.Errorf("signer received rekor %q; want %q", signer.gotRekor, DefaultRekorURL)
+	}
+	if signer.gotAudience != DefaultAudience {
+		t.Errorf("signer received audience %q; want %q", signer.gotAudience, DefaultAudience)
+	}
+}
+
+// tagBlobBody strips the `object/type/tag/tagger` header from the
+// output of `git cat-file -p <annotated-tag>` and returns the
+// annotated message body. The header is separated from the body by
+// a blank line per the git object format.
+func tagBlobBody(blob string) string {
+	idx := strings.Index(blob, "\n\n")
+	if idx < 0 {
+		return ""
+	}
+	return blob[idx+2:]
+}
+
+func runCmd(t *testing.T, dir, name string, args ...string) error {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("%s %v failed: %v\n%s", name, args, err, out)
+	}
+	return err
+}
+
+func combinedOutput(dir, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	// Scrub GIT_* envs so a parent test harness cannot leak its
+	// index/working-tree into a child git invocation that targets
+	// a different repo.
+	clean := []string{}
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "GIT_DIR=") ||
+			strings.HasPrefix(e, "GIT_WORK_TREE=") ||
+			strings.HasPrefix(e, "GIT_INDEX_FILE=") ||
+			strings.HasPrefix(e, "GIT_OBJECT_DIRECTORY=") {
+			continue
+		}
+		clean = append(clean, e)
+	}
+	cmd.Env = clean
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}

--- a/website/docs/implementation/0074/index.md
+++ b/website/docs/implementation/0074/index.md
@@ -28,7 +28,7 @@ A phase is LANDED only when its gate is green for every applicable target (consu
 | 10 | mochi.lock `[[go-package]]` integration + `--check` mode | LANDED (schema; 10.1+ CLI deferred) | (pending) | [phase-10](/docs/implementation/0074/phase-10-lockfile) |
 | 11 | `TargetGoLibrary` emit (`go.mod` + exported package + `_cgo_export.h`) | LANDED (baseline; 11.1+ deferred) | (pending) | [phase-11](/docs/implementation/0074/phase-11-library-emit) |
 | 12 | Git-tag publish flow (`mochi pkg publish --to=git-tag`) + canonical-import-path gate | LANDED (baseline; 12.1+ deferred) | (pending) | [phase-12](/docs/implementation/0074/phase-12-git-tag-publish) |
-| 13 | Cosign-on-sibling-tag opt-in (`mochi pkg publish --cosign-sign`) | NOT STARTED | — | [phase-13](/docs/implementation/0074/phase-13-cosign) |
+| 13 | Cosign-on-sibling-tag opt-in (`mochi pkg publish --cosign-sign`) | LANDED (baseline; 13.1+ deferred) | (pending) | [phase-13](/docs/implementation/0074/phase-13-cosign) |
 | 14 | Goroutine bridge (cgo handle pool + channel-as-handle + callback-as-handle) | NOT STARTED | — | [phase-14](/docs/implementation/0074/phase-14-goroutine-bridge) |
 | 15 | Monomorphisation (`[go.monomorphise]` manifest + per-instantiation wrapper) | NOT STARTED | — | [phase-15](/docs/implementation/0074/phase-15-monomorphise) |
 | 16 | TinyGo embedded subset (`profile = "embedded"` + `//go:linkname` wrapper) | NOT STARTED | — | [phase-16](/docs/implementation/0074/phase-16-tinygo-embedded) |
@@ -53,7 +53,7 @@ Each phase's LANDED gate must be green for every applicable target. `n/a` cells 
 | 10. mochi.lock integration | LANDED (schema) | required | required | required | required |
 | 11. TargetGoLibrary emit | LANDED (baseline) | required | required | required | required |
 | 12. git-tag publish | LANDED (baseline) | n/a (publish is host-only) | n/a | n/a | n/a |
-| 13. cosign on tag.sig | NOT STARTED | n/a | n/a | n/a | n/a |
+| 13. cosign on tag.sig | LANDED (baseline) | n/a | n/a | n/a | n/a |
 | 14. goroutine bridge | NOT STARTED | required | required | n/a (no goroutines on wasm-js without scheduler shim) | required |
 | 15. monomorphisation | NOT STARTED | required | required | required | required |
 | 16. TinyGo embedded subset | NOT STARTED | n/a | n/a | required (wasm-js via tinygo) | required |
@@ -97,7 +97,8 @@ package3/go/
   build/                  # workspace + go build orchestration (phase 9)
   lockfile/               # `[[go-package]]` schema + drift check (phase 10)
   library/                # TargetGoLibrary emit (phase 11)
-  publish/                # git-tag publish + cosign (phases 12-13)
+  publish/                # git-tag publish (phase 12)
+  cosign/                 # cosign-on-sibling-tag signer (phase 13)
   goroutine/              # cgo handle pool + bridge runtime (phase 14)
   tinygo/                 # TinyGo embedded subset (phase 16)
   vanity/                 # vanity-import redirect resolver (phase 17)
@@ -107,7 +108,7 @@ The `package3/go/` location is shared with the broader MEP-57 polyglot package w
 
 ## Status snapshot
 
-As of 2026-05-30: phases 0-12 LANDED on `main` (phases 6 + 7 + 9 + 11 + 12 baseline only; phase 10 schema only; sub-phases 6.1+/7.1+/9.1+/10.1+/11.1+/12.1+ deferred), phases 13-17 NOT STARTED.
+As of 2026-05-30: phases 0-13 LANDED on `main` (phases 6 + 7 + 9 + 11 + 12 + 13 baseline only; phase 10 schema only; sub-phases 6.1+/7.1+/9.1+/10.1+/11.1+/12.1+/13.1+ deferred), phases 14-17 NOT STARTED.
 
 ## Cross-references
 

--- a/website/docs/implementation/0074/phase-13-cosign.md
+++ b/website/docs/implementation/0074/phase-13-cosign.md
@@ -1,0 +1,128 @@
+---
+title: "Phase 13. Cosign-on-sibling-tag"
+sidebar_position: 15
+sidebar_label: "Phase 13. Cosign sibling-tag"
+description: "MEP-74 Phase 13 lands the optional Sigstore-cosign signing layer as a self-contained `package3/go/cosign/` module. The signer consumes a `publish.PublishResult` plus an OIDC token, exchanges the token for a keyless Fulcio code-signing certificate, signs the publish commit SHA, logs the signature to Rekor, and attaches the resulting cosign bundle as the annotated message body of a sibling tag `<tag>.sig` that lives on the same remote the publish commit went to. A DryRun flag stops short of the push step (still tags + commits locally). The end-to-end sentinel verifies that a downstream clone of the remote can recover the cosign bundle bytes byte-for-byte via `git cat-file -p <tag>.sig`."
+---
+
+# Phase 13. Cosign-on-sibling-tag
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-74 §Phases](/docs/mep/mep-0074#phases) |
+| Status         | LANDED |
+| Started        | 2026-05-30 00:00 (GMT+7) |
+| Landed         | 2026-05-30 00:30 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`TestPhase13CosignSiblingTagSentinel` in
+`package3/go/cosign/phase13_test.go` walks a representative calculator package (Version const + Add func) through the full `library.Emit` -> `publish.Publish` -> `cosign.Sign` chain and asserts:
+
+- the sibling tag `<tag>.sig` lands in the same local bare-repo remote (`file://<tmp>/remote.git`) the publish commit was pushed to;
+- the sibling tag points to the publish commit SHA (not to a separate commit) so a verifier can resolve `<tag>.sig` and immediately know which revision is signed;
+- a downstream `git clone` of the remote followed by `git cat-file -p <tag>.sig` round-trips the cosign bundle bytes byte-for-byte through `ParseSiblingMessage`;
+- the fake signer received the publish commit SHA, the publish tag, the default Sigstore audience (`sigstore`), and the default Fulcio + Rekor endpoints.
+
+Plus 19 unit tests in `cosign_test.go`:
+
+- validation
+  (`TestValidateAccepts`,
+  `TestValidateRejectsShortSHA`,
+  `TestValidateRejectsNonHexSHA`,
+  `TestValidateRejectsUppercaseSHA`,
+  `TestValidateRejectsEmptyTag`,
+  `TestValidateRejectsAlreadySigTag`,
+  `TestValidateRejectsEmptyWorkspaceRoot`,
+  `TestValidateRejectsEmptyOIDC`,
+  `TestValidateRejectsEmptyAuthor`),
+- happy-path signer + runner sequence
+  (`TestSignHappyPath`),
+- dry-run skips push (`TestSignDryRunSkipsPush`),
+- signer error surfaces, short-circuits runner
+  (`TestSignSurfacesSignerError`),
+- empty bundle rejection
+  (`TestSignRejectsEmptyBundle`),
+- validation failure short-circuits the signer
+  (`TestSignValidationFailureSkipsSigner`),
+- sibling-tag message round-trip
+  (`TestBuildAndParseSiblingMessageRoundtrip`,
+  `TestParseSiblingMessageRejectsUnknownScheme`,
+  `TestParseSiblingMessageRejectsMissingFields`,
+  `TestParseSiblingMessageRejectsBadBase64`),
+- custom audience + endpoint overrides
+  (`TestSignUsesCustomAudienceAndEndpoints`),
+- `isFullSHA` predicate
+  (`TestIsFullSHA`).
+
+## Lowering decisions
+
+The cosign package is layering-conservative: it imports `package3/go/publish` for the `Runner` interface + `Author` shape and otherwise depends only on the Go stdlib. The signing surface splits into a pure shaping layer (`SignRequest.Validate`), a small network-facing primitive (`Signer.Sign`), and an impure runner (`Sign`) so callers fully validate the request before any side effect, and the unit tests can exercise the full flow against an in-process fake signer.
+
+**The Signer interface is the only network seam.** Production builds wire a real Sigstore client behind the `Signer` interface (OIDC token exchange with Fulcio, keyless certificate issuance, Rekor inclusion-proof log). The interface signature `Sign(commitSHA, tag, audience, oidcToken, fulcioURL, rekorURL) ([]byte, error)` returns the verbatim cosign bundle bytes; the signing package never inspects the bundle past asserting it is non-empty. This keeps the signing-side cryptography deployable as a separate runtime dependency (deferred to phase 13.1) without making the surrounding orchestrator depend on the live Sigstore stack at build time.
+
+**Sibling-tag scheme is `<tag>.sig`, annotated, with a structured message body.** The cosign bundle bytes go into the annotated message body of a sibling tag whose name is `<publish-tag>.sig`. The body has a header line `cosign-sig: mochi-mep74-cosign-v1` (the scheme name + version), the publish `tag:` and `commit:` lines, and a `bundle-base64:` line carrying the raw bundle bytes base64-encoded. Base64 keeps the message text-safe (git restricts what byte sequences can appear in tag messages). The `ParseSiblingMessage` verifier-side helper round-trips the body back to (`tag`, `commit`, `bundle`); a downstream consumer that runs `git cat-file -p <tag>.sig` can recover the bundle without an out-of-band registry.
+
+**The sibling tag points to the publish commit, not to a fresh commit.** `git tag -a <tag>.sig <publish-commit-sha> -m ...` attaches the sibling directly to the publish commit. This means a verifier who resolves `<tag>.sig` (`git rev-list -n 1 <tag>.sig`) immediately knows the signed revision; the bundle's signed payload also binds to that commit SHA so a tampered bundle that points to a different revision will fail to verify. The end-to-end sentinel asserts this round-trip explicitly.
+
+**Validation rejects `<tag>.sig` as the input tag.** `SignRequest.Validate` errors if `Tag` already ends in `.sig`: the caller should pass the publish tag (e.g. `v0.2.0`) and the package will compute the sibling name. Otherwise a typo (`mochi pkg publish --cosign-sign --tag=v0.2.0.sig`) would land a `<tag>.sig.sig` tag, which is harmless but confusing.
+
+**Default endpoints match upstream Sigstore.** `DefaultAudience = "sigstore"`, `DefaultFulcioURL = "https://fulcio.sigstore.dev"`, `DefaultRekorURL = "https://rekor.sigstore.dev"` mirror the values hardcoded in the upstream `cosign sign` CLI. Callers can override per-request via `SignRequest.Audience`, `.FulcioURL`, `.RekorURL` for staging or air-gapped Sigstore deployments.
+
+**The Runner is reused from `publish.Runner`.** The cosign signer uses the same `publish.Runner` interface as the publish driver, so the production runner (`publish.NewExecRunner()`) handles env sanitisation (scrubs `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` / `GIT_OBJECT_DIRECTORY`) consistently across publish + sign. The unit-test `recordingRunner` captures every call in order so the happy-path test asserts the exact `git config user.name` / `git config user.email` / `git tag -a <sibling> <sha> -m ...` / `git push origin <sibling>` sequence.
+
+**DryRun is a full local rehearsal.** Like `publish.PublishRequest.DryRun`, the cosign DryRun runs the signer end-to-end (the bundle is produced, the sibling tag is created locally) but skips the `git push`. A single `mochi pkg publish --dry-run --cosign-sign` invocation therefore exercises both flows end-to-end against a local working tree without touching any remote.
+
+**The signer is fail-loud on empty bundles.** If the `Signer` implementation returns a zero-length byte slice (e.g. a misconfigured Fulcio endpoint returns a 200 with no body), `Sign` short-circuits with a wrapped `ErrCosign` before invoking the runner. This is load-bearing: a silently-empty bundle would land an unsigned sibling tag that looks signed.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/go/cosign/cosign.go` | `SignRequest`, `Author` reuse from publish, `SignResult`, `ErrCosign`, `Signer` interface, `DefaultAudience` / `DefaultFulcioURL` / `DefaultRekorURL`, `Validate`, `Sign`, `buildSiblingMessage`, `ParseSiblingMessage`, `isFullSHA`. |
+| `package3/go/cosign/cosign_test.go` | 19 unit tests + `fakeSigner` + `recordingRunner` helpers. |
+| `package3/go/cosign/phase13_test.go` | `TestPhase13CosignSiblingTagSentinel` end-to-end against a local bare-repo fixture (publish then cosign-sign then clone-and-verify). |
+| `website/docs/implementation/0074/phase-13-cosign.md` | (this page) |
+
+## Test set
+
+- `TestPhase13CosignSiblingTagSentinel`
+- 19 unit tests in `cosign_test.go`
+
+Local run on darwin-arm64:
+
+```
+$ go test ./package3/go/cosign/...
+ok      mochi/package3/go/cosign        1.2s
+$ go test ./package3/go/...
+ok      mochi/package3/go/apisurface    (cached)
+ok      mochi/package3/go/build (cached)
+ok      mochi/package3/go/cmd/go-ingest (cached)
+ok      mochi/package3/go/cosign        1.120s
+ok      mochi/package3/go/emit  (cached)
+ok      mochi/package3/go/errors        (cached)
+ok      mochi/package3/go/library       (cached)
+ok      mochi/package3/go/lockfile      (cached)
+ok      mochi/package3/go/moduleproxy   (cached)
+ok      mochi/package3/go/publish       (cached)
+ok      mochi/package3/go/semver        (cached)
+ok      mochi/package3/go/sumdb (cached)
+ok      mochi/package3/go/typemap       (cached)
+ok      mochi/package3/go/wrapper       (cached)
+```
+
+## Closeout notes
+
+Phase 13 lands the cosign signer as a leaf module gated by the `Signer` interface. The production Sigstore client (live Fulcio + Rekor calls) is reserved for phase 13.1 once the bridge gains a runtime crypto dependency. The CLI wiring (`mochi pkg publish --to=go+git+<repo-url>@<tag> --cosign-sign`) is reserved for phase 13.2 alongside phase 12.1.
+
+Future phase 13.x reservations:
+
+- **13.1** Production `Signer` implementation against live Fulcio + Rekor (OIDC token exchange, certificate issuance, transparency-log inclusion proof).
+- **13.2** CLI wiring + `--cosign-sign` flag + OIDC-token-from-env discovery (GitHub Actions, GitLab CI, Buildkite).
+- **13.3** Verifier-side helper `mochi pkg verify --cosign-sign` (`git cat-file -p <tag>.sig` + `ParseSiblingMessage` + Sigstore verify).
+- **13.4** Sibling-tag delete recovery: handle the edge case where a previous publish left a stale `<tag>.sig` that the signer needs to overwrite.
+
+The goroutine bridge (phase 14) consumes `PublishResult.CommitSHA` like the cosign signer does but for a completely different purpose: phase 14 stitches the cgo handle pool into the wrapper layer so cross-tier channels and callbacks can survive a goroutine yield.

--- a/website/docs/mep/mep-0074.md
+++ b/website/docs/mep/mep-0074.md
@@ -395,7 +395,7 @@ A phase is LANDED only when its gate is green for every target in the matrix bel
 | 10. mochi.lock integration | LANDED (schema) | required | required | required | required |
 | 11. TargetGoLibrary emit | LANDED (baseline) | required | required | required | required |
 | 12. git-tag publish | LANDED (baseline) | n/a (publish is host-only) | n/a | n/a | n/a |
-| 13. cosign on tag.sig | NOT STARTED | n/a | n/a | n/a | n/a |
+| 13. cosign on tag.sig | LANDED (baseline) | n/a | n/a | n/a | n/a |
 | 14. goroutine bridge | NOT STARTED | required | required | n/a (no goroutines on wasm-js without scheduler shim) | required |
 | 15. monomorphisation | NOT STARTED | required | required | required | required |
 | 16. TinyGo embedded subset | NOT STARTED | n/a | n/a | required (wasm-js via tinygo) | required |

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -368,7 +368,8 @@
       "implementation/0074/phase-09-build",
       "implementation/0074/phase-10-lockfile",
       "implementation/0074/phase-11-library-emit",
-      "implementation/0074/phase-12-git-tag-publish"
+      "implementation/0074/phase-12-git-tag-publish",
+      "implementation/0074/phase-13-cosign"
     ]
   },
   "implementation/0075/index",


### PR DESCRIPTION
## Summary

- Lands MEP-74 phase 13 (cosign-on-sibling-tag) as a self-contained `package3/go/cosign/` module.
- Adds 19 unit tests + the end-to-end `TestPhase13CosignSiblingTagSentinel` that verifies `library.Emit` -> `publish.Publish` -> `cosign.Sign` against a local bare-repo fixture and that `git cat-file -p <tag>.sig` round-trips the cosign bundle bytes byte-for-byte.
- Marks phase 13 LANDED (baseline) in the MEP-74 spec target matrix + implementation tracking index + sidebar. Sub-phases 13.1+ (live-Sigstore Signer, CLI wiring, verifier helper) are reserved.

Tracking issue: #22910

## Test plan

- [x] `go test ./package3/go/cosign/` (20 tests including the end-to-end sentinel)
- [x] `go test ./package3/go/...` (full package3/go sweep, no regressions)