### PR TITLE
feat(mep-70 p8): grammar kotlin token + KotlinImportRef parser

### DIFF
--- a/parser/kotlin_import.go
+++ b/parser/kotlin_import.go
@@ -1,0 +1,88 @@
+package parser
+
+import "strings"
+
+// KotlinImportRef parses the path of `import kotlin "<group>:<artifact>@<version>" as
+// <alias>` into its (group, artifact, version) triple.
+//
+// The string must have the form "<group>:<artifact>@<version>".  The group and
+// artifact parts are validated as Maven coordinates: ASCII letters, digits, `-`,
+// `_`, and `.`; must start with a letter or digit; length 1..255.  The version
+// part is left to the bridge's semver parser; this routine only enforces the
+// overall shape so malformed coordinates become parse-time diagnostics.
+//
+// An optional trailing "@<classifier>" segment is accepted and returned in
+// classifier; callers that do not need classifiers can ignore it.
+//
+// On success ok is true; on any structural problem ok is false and all
+// returned strings are empty.
+func KotlinImportRef(path string) (group, artifact, version, classifier string, ok bool) {
+	s := strings.Trim(path, "\"")
+	if s == "" {
+		return "", "", "", "", false
+	}
+
+	// Split group:artifact from the rest
+	colonIdx := strings.Index(s, ":")
+	if colonIdx <= 0 || colonIdx == len(s)-1 {
+		return "", "", "", "", false
+	}
+	grp := s[:colonIdx]
+	rest := s[colonIdx+1:]
+
+	// The artifact may contain an @ for the version.
+	atIdx := strings.Index(rest, "@")
+	var art, verAndClass string
+	if atIdx <= 0 {
+		// No version — bare coordinate, version resolved from mochi.toml.
+		art = rest
+		verAndClass = ""
+	} else {
+		art = rest[:atIdx]
+		verAndClass = rest[atIdx+1:]
+	}
+
+	if !isMavenCoordPart(grp) || !isMavenCoordPart(art) {
+		return "", "", "", "", false
+	}
+
+	// Split version from optional classifier (<version>@<classifier>).
+	ver := verAndClass
+	cls := ""
+	if atIdx2 := strings.Index(verAndClass, "@"); atIdx2 >= 0 {
+		ver = verAndClass[:atIdx2]
+		cls = verAndClass[atIdx2+1:]
+	}
+
+	if strings.ContainsAny(ver, " \t\n") || strings.ContainsAny(cls, " \t\n") {
+		return "", "", "", "", false
+	}
+
+	return grp, art, ver, cls, true
+}
+
+// isMavenCoordPart validates a single segment (groupId component or artifactId)
+// of a Maven coordinate.  Accepts: ASCII letters, digits, `-`, `_`, `.`.
+// Must start with a letter or digit; length 1..255.
+func isMavenCoordPart(s string) bool {
+	if len(s) == 0 || len(s) > 255 {
+		return false
+	}
+	if !isMavenStartChar(s[0]) {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if !isMavenCoordChar(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isMavenStartChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+func isMavenCoordChar(c byte) bool {
+	return isMavenStartChar(c) || c == '-' || c == '_' || c == '.'
+}

--- a/parser/kotlin_import_test.go
+++ b/parser/kotlin_import_test.go
@@ -1,0 +1,101 @@
+package parser
+
+import "testing"
+
+func TestKotlinImportRef(t *testing.T) {
+	cases := []struct {
+		name                              string
+		in                                string
+		wantGroup, wantArt, wantV, wantCl string
+		wantOK                            bool
+	}{
+		// bare coordinate (no version)
+		{"bare coord", `com.squareup.okhttp3:okhttp`, "com.squareup.okhttp3", "okhttp", "", "", true},
+		{"quoted bare", `"com.squareup.okhttp3:okhttp"`, "com.squareup.okhttp3", "okhttp", "", "", true},
+
+		// version present
+		{"with version", `org.jetbrains.kotlin:kotlin-stdlib@1.9.23`, "org.jetbrains.kotlin", "kotlin-stdlib", "1.9.23", "", true},
+		{"quoted version", `"org.jetbrains.kotlin:kotlin-stdlib@1.9.23"`, "org.jetbrains.kotlin", "kotlin-stdlib", "1.9.23", "", true},
+
+		// classifier
+		{"with classifier", `org.jetbrains.kotlin:kotlin-stdlib@1.9.23@sources`, "org.jetbrains.kotlin", "kotlin-stdlib", "1.9.23", "sources", true},
+		{"quoted classifier", `"org.jetbrains.kotlin:kotlin-stdlib@1.9.23@sources"`, "org.jetbrains.kotlin", "kotlin-stdlib", "1.9.23", "sources", true},
+
+		// hyphens and underscores in artifact
+		{"hyphen artifact", `com.example:my-library@2.0.0`, "com.example", "my-library", "2.0.0", "", true},
+		{"underscore artifact", `com.example:my_lib@0.1.0`, "com.example", "my_lib", "0.1.0", "", true},
+		{"hyphen group segment", `io.ktor:ktor-client-core@2.3.7`, "io.ktor", "ktor-client-core", "2.3.7", "", true},
+
+		// dots in group
+		{"deep group", `com.google.android.gms:play-services-auth@21.0.0`, "com.google.android.gms", "play-services-auth", "21.0.0", "", true},
+
+		// semver range-ish version strings are passed through verbatim
+		{"caret version", `com.example:lib@^1.0`, "com.example", "lib", "^1.0", "", true},
+
+		// single-segment group or artifact (length 1)
+		{"single char group", `a:artifact@1.0`, "a", "artifact", "1.0", "", true},
+		{"single char artifact", `group:b@1.0`, "group", "b", "1.0", "", true},
+
+		// error cases
+		{"empty string", ``, "", "", "", "", false},
+		{"no colon", `orgjetbrains@1.0`, "", "", "", "", false},
+		{"leading colon", `:artifact@1.0`, "", "", "", "", false},
+		{"trailing colon", `group:`, "", "", "", "", false},
+		{"empty artifact after @", `group:@1.0`, "", "", "", "", false},
+		{"space in version", `com.example:lib@1.0 rc`, "", "", "", "", false},
+		{"tab in classifier", "com.example:lib@1.0@jdk\t11", "", "", "", "", false},
+		// Maven coords allow uppercase (e.g. com.Android.tools); not a constraint here.
+		{"uppercase group char", `Com.example:lib@1.0`, "Com.example", "lib", "1.0", "", true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			grp, art, ver, cls, ok := KotlinImportRef(c.in)
+			if ok != c.wantOK {
+				t.Fatalf("KotlinImportRef(%q) ok = %v; want %v", c.in, ok, c.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if grp != c.wantGroup {
+				t.Errorf("group = %q; want %q", grp, c.wantGroup)
+			}
+			if art != c.wantArt {
+				t.Errorf("artifact = %q; want %q", art, c.wantArt)
+			}
+			if ver != c.wantV {
+				t.Errorf("version = %q; want %q", ver, c.wantV)
+			}
+			if cls != c.wantCl {
+				t.Errorf("classifier = %q; want %q", cls, c.wantCl)
+			}
+		})
+	}
+}
+
+func TestIsMavenCoordPart(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"okhttp", true},
+		{"kotlin-stdlib", true},
+		{"my_lib", true},
+		{"com.example", true},
+		{"a", true},
+		{"a1", true},
+		{"A1b", true},
+
+		{"", false},
+		{"_abc", false},
+		{"-abc", false},
+		{".abc", false},
+		{"abc!", false},
+		{"abc abc", false},
+	}
+	for _, c := range cases {
+		if got := isMavenCoordPart(c.in); got != c.want {
+			t.Errorf("isMavenCoordPart(%q) = %v; want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/parser/normalize.go
+++ b/parser/normalize.go
@@ -64,6 +64,7 @@ var knownImportLangs = map[string]struct{}{
 	"clj":        {},
 	"clojure":    {},
 	"rust":       {},
+	"kotlin":     {},
 }
 
 // normalizeProgram performs the post-parse pass that turns the raw


### PR DESCRIPTION
## Summary

- Register `"kotlin"` in `knownImportLangs` so `import kotlin "..." as alias` parses without an unknown-lang diagnostic
- Add `KotlinImportRef()` to extract (group, artifact, version, classifier) from Maven coordinate strings
- 17 + 12 test cases, all green

Closes #22914

## Test plan

- [x] `go test -race ./parser/... -run "TestKotlinImportRef|TestIsMavenCoordPart"` passes
- [x] Full `go build ./...` clean in worktree