### PR TITLE
MEP-68 phases 10-13: OIDC publish, async bridge, generics, NativeAOT

### DIFF
--- a/package3/dotnet/asyncbridge/async_test.go
+++ b/package3/dotnet/asyncbridge/async_test.go
@@ -1,0 +1,327 @@
+package asyncbridge_test
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/dotnet/asyncbridge"
+	"mochi/package3/dotnet/shimgen"
+	"mochi/package3/dotnet/typemap"
+)
+
+// ---------- DefaultConfig ----------
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := asyncbridge.DefaultConfig()
+	if cfg.Mode != asyncbridge.DispatchGetAwaiter {
+		t.Errorf("expected DispatchGetAwaiter, got %s", cfg.Mode)
+	}
+}
+
+// ---------- EmitAsyncWrapper: DispatchGetAwaiter ----------
+
+func TestEmitAsyncWrapper_GetAwaiter_string(t *testing.T) {
+	got := asyncbridge.EmitAsyncWrapper("MyClass.Method(arg)", typemap.KindString, asyncbridge.DispatchGetAwaiter)
+	if !strings.Contains(got, "return") {
+		t.Errorf("expected return in body, got: %s", got)
+	}
+	if !strings.Contains(got, ".GetAwaiter().GetResult()") {
+		t.Errorf("expected .GetAwaiter().GetResult(), got: %s", got)
+	}
+	if !strings.Contains(got, "MyClass.Method(arg)") {
+		t.Errorf("expected call expr in body, got: %s", got)
+	}
+}
+
+func TestEmitAsyncWrapper_GetAwaiter_unit(t *testing.T) {
+	got := asyncbridge.EmitAsyncWrapper("MyClass.DoVoid()", typemap.KindUnit, asyncbridge.DispatchGetAwaiter)
+	if strings.HasPrefix(strings.TrimSpace(got), "return") {
+		t.Errorf("expected no return for void, got: %s", got)
+	}
+	if !strings.Contains(got, ".GetAwaiter().GetResult()") {
+		t.Errorf("expected .GetAwaiter().GetResult(), got: %s", got)
+	}
+}
+
+// ---------- EmitAsyncWrapper: DispatchManualReset ----------
+
+func TestEmitAsyncWrapper_ManualReset_string(t *testing.T) {
+	got := asyncbridge.EmitAsyncWrapper("Svc.GetData(x)", typemap.KindString, asyncbridge.DispatchManualReset)
+	if !strings.Contains(got, "ManualResetEventSlim") {
+		t.Errorf("expected ManualResetEventSlim, got: %s", got)
+	}
+	if !strings.Contains(got, "ConfigureAwait(false)") {
+		t.Errorf("expected ConfigureAwait(false), got: %s", got)
+	}
+	if !strings.Contains(got, "return __result") {
+		t.Errorf("expected return __result, got: %s", got)
+	}
+	if !strings.Contains(got, "ExceptionDispatchInfo") {
+		t.Errorf("expected ExceptionDispatchInfo, got: %s", got)
+	}
+}
+
+func TestEmitAsyncWrapper_ManualReset_unit(t *testing.T) {
+	got := asyncbridge.EmitAsyncWrapper("Svc.DoAsync()", typemap.KindUnit, asyncbridge.DispatchManualReset)
+	if !strings.Contains(got, "ManualResetEventSlim") {
+		t.Errorf("expected ManualResetEventSlim, got: %s", got)
+	}
+	if strings.Contains(got, "return __result") {
+		t.Errorf("should not have return __result for void, got: %s", got)
+	}
+	if !strings.Contains(got, "__mre.Wait()") {
+		t.Errorf("expected __mre.Wait(), got: %s", got)
+	}
+}
+
+func TestEmitAsyncWrapper_ManualReset_int(t *testing.T) {
+	got := asyncbridge.EmitAsyncWrapper("Counter.GetAsync()", typemap.KindInt, asyncbridge.DispatchManualReset)
+	if !strings.Contains(got, "int __result") {
+		t.Errorf("expected int __result declaration, got: %s", got)
+	}
+}
+
+func TestEmitAsyncWrapper_ManualReset_bool(t *testing.T) {
+	got := asyncbridge.EmitAsyncWrapper("Checker.IsValid()", typemap.KindBool, asyncbridge.DispatchManualReset)
+	if !strings.Contains(got, "bool __result") {
+		t.Errorf("expected bool __result declaration, got: %s", got)
+	}
+}
+
+// ---------- EmitAsyncWrapper: DispatchTaskRun ----------
+
+func TestEmitAsyncWrapper_TaskRun_string(t *testing.T) {
+	got := asyncbridge.EmitAsyncWrapper("Api.FetchAsync(id)", typemap.KindString, asyncbridge.DispatchTaskRun)
+	if !strings.Contains(got, "Task.Run") {
+		t.Errorf("expected Task.Run, got: %s", got)
+	}
+	if !strings.Contains(got, ".GetAwaiter().GetResult()") {
+		t.Errorf("expected .GetAwaiter().GetResult(), got: %s", got)
+	}
+	if !strings.Contains(got, "return") {
+		t.Errorf("expected return, got: %s", got)
+	}
+}
+
+func TestEmitAsyncWrapper_TaskRun_unit(t *testing.T) {
+	got := asyncbridge.EmitAsyncWrapper("Api.FireAndForget()", typemap.KindUnit, asyncbridge.DispatchTaskRun)
+	if strings.HasPrefix(strings.TrimSpace(got), "return") {
+		t.Errorf("expected no return for void, got: %s", got)
+	}
+	if !strings.Contains(got, "Task.Run") {
+		t.Errorf("expected Task.Run, got: %s", got)
+	}
+}
+
+// ---------- IsAsyncMethod ----------
+
+func TestIsAsyncMethod_nil(t *testing.T) {
+	if asyncbridge.IsAsyncMethod(nil) {
+		t.Error("expected false for nil")
+	}
+}
+
+func TestIsAsyncMethod_async(t *testing.T) {
+	m := &shimgen.ShimMethod{IsAsync: true}
+	if !asyncbridge.IsAsyncMethod(m) {
+		t.Error("expected true for IsAsync=true")
+	}
+}
+
+func TestIsAsyncMethod_sync(t *testing.T) {
+	m := &shimgen.ShimMethod{IsAsync: false}
+	if asyncbridge.IsAsyncMethod(m) {
+		t.Error("expected false for IsAsync=false")
+	}
+}
+
+// ---------- AsyncMethodCount ----------
+
+func TestAsyncMethodCount_nil(t *testing.T) {
+	if asyncbridge.AsyncMethodCount(nil) != 0 {
+		t.Error("expected 0 for nil shim")
+	}
+}
+
+func TestAsyncMethodCount_empty(t *testing.T) {
+	s := &shimgen.Shim{}
+	if asyncbridge.AsyncMethodCount(s) != 0 {
+		t.Error("expected 0 for empty shim")
+	}
+}
+
+func TestAsyncMethodCount_mixed(t *testing.T) {
+	s := &shimgen.Shim{
+		Methods: []shimgen.ShimMethod{
+			{IsAsync: true},
+			{IsAsync: false},
+			{IsAsync: true},
+			{IsAsync: false},
+			{IsAsync: true},
+		},
+	}
+	if got := asyncbridge.AsyncMethodCount(s); got != 3 {
+		t.Errorf("expected 3, got %d", got)
+	}
+}
+
+func TestAsyncMethodCount_allAsync(t *testing.T) {
+	s := &shimgen.Shim{
+		Methods: []shimgen.ShimMethod{
+			{IsAsync: true},
+			{IsAsync: true},
+		},
+	}
+	if got := asyncbridge.AsyncMethodCount(s); got != 2 {
+		t.Errorf("expected 2, got %d", got)
+	}
+}
+
+func TestAsyncMethodCount_noneAsync(t *testing.T) {
+	s := &shimgen.Shim{
+		Methods: []shimgen.ShimMethod{
+			{IsAsync: false},
+			{IsAsync: false},
+		},
+	}
+	if got := asyncbridge.AsyncMethodCount(s); got != 0 {
+		t.Errorf("expected 0, got %d", got)
+	}
+}
+
+// ---------- RewriteForMode ----------
+
+func makeTestShim() *shimgen.Shim {
+	strMapping := typemap.Mapping{Kind: typemap.KindString, MochiType: "string"}
+	return &shimgen.Shim{
+		Package: "TestPkg",
+		Methods: []shimgen.ShimMethod{
+			{
+				IsAsync:      true,
+				CSMethodName: "MyClass_GetAsync",
+				UpstreamCall: "TestPkg.MyClass.GetAsync",
+				Return:       &strMapping,
+				Params: []shimgen.ShimParam{
+					{Name: "id", Mapping: typemap.Mapping{Kind: typemap.KindInt}},
+				},
+			},
+			{
+				IsAsync:      false,
+				CSMethodName: "MyClass_Sync",
+				UpstreamCall: "TestPkg.MyClass.Sync",
+				Return:       &strMapping,
+			},
+			{
+				IsAsync:      true,
+				CSMethodName: "MyClass_DoAsync",
+				UpstreamCall: "TestPkg.MyClass.DoAsync",
+				Return:       nil, // void
+			},
+		},
+	}
+}
+
+func TestRewriteForMode_nil(t *testing.T) {
+	result := asyncbridge.RewriteForMode(nil, asyncbridge.DispatchManualReset)
+	if result != nil {
+		t.Error("expected nil for nil shim")
+	}
+}
+
+func TestRewriteForMode_GetAwaiter(t *testing.T) {
+	s := makeTestShim()
+	result := asyncbridge.RewriteForMode(s, asyncbridge.DispatchGetAwaiter)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 rewrites (async only), got %d", len(result))
+	}
+	for _, r := range result {
+		if !strings.Contains(r.CSharpBody, ".GetAwaiter().GetResult()") {
+			t.Errorf("expected GetAwaiter in body for %s, got: %s", r.Method.CSMethodName, r.CSharpBody)
+		}
+	}
+}
+
+func TestRewriteForMode_ManualReset(t *testing.T) {
+	s := makeTestShim()
+	result := asyncbridge.RewriteForMode(s, asyncbridge.DispatchManualReset)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 rewrites, got %d", len(result))
+	}
+	for _, r := range result {
+		if !strings.Contains(r.CSharpBody, "ManualResetEventSlim") {
+			t.Errorf("expected ManualResetEventSlim for %s", r.Method.CSMethodName)
+		}
+	}
+}
+
+func TestRewriteForMode_TaskRun(t *testing.T) {
+	s := makeTestShim()
+	result := asyncbridge.RewriteForMode(s, asyncbridge.DispatchTaskRun)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 rewrites, got %d", len(result))
+	}
+	for _, r := range result {
+		if !strings.Contains(r.CSharpBody, "Task.Run") {
+			t.Errorf("expected Task.Run for %s", r.Method.CSMethodName)
+		}
+	}
+}
+
+func TestRewriteForMode_preservesMethod(t *testing.T) {
+	s := makeTestShim()
+	result := asyncbridge.RewriteForMode(s, asyncbridge.DispatchGetAwaiter)
+	if result[0].Method.CSMethodName != "MyClass_GetAsync" {
+		t.Errorf("expected MyClass_GetAsync, got %s", result[0].Method.CSMethodName)
+	}
+}
+
+func TestRewriteForMode_includesCallExpr(t *testing.T) {
+	s := makeTestShim()
+	result := asyncbridge.RewriteForMode(s, asyncbridge.DispatchGetAwaiter)
+	// First async method has param "id", so call expr includes "id".
+	if !strings.Contains(result[0].CSharpBody, "GetAsync(id)") {
+		t.Errorf("expected GetAsync(id) in body, got: %s", result[0].CSharpBody)
+	}
+}
+
+// ---------- EmitAsyncRuntimeCS ----------
+
+func TestEmitAsyncRuntimeCS_GetAwaiter_empty(t *testing.T) {
+	got := asyncbridge.EmitAsyncRuntimeCS(asyncbridge.DispatchGetAwaiter)
+	if got != "" {
+		t.Errorf("expected empty string for GetAwaiter, got: %s", got)
+	}
+}
+
+func TestEmitAsyncRuntimeCS_ManualReset_nonEmpty(t *testing.T) {
+	got := asyncbridge.EmitAsyncRuntimeCS(asyncbridge.DispatchManualReset)
+	if got == "" {
+		t.Error("expected non-empty for ManualReset")
+	}
+	if !strings.Contains(got, "ManualResetEventSlim") {
+		t.Errorf("expected ManualResetEventSlim in helper, got: %s", got)
+	}
+	if !strings.Contains(got, "AsyncRuntime") {
+		t.Errorf("expected AsyncRuntime class in helper")
+	}
+}
+
+func TestEmitAsyncRuntimeCS_TaskRun_nonEmpty(t *testing.T) {
+	got := asyncbridge.EmitAsyncRuntimeCS(asyncbridge.DispatchTaskRun)
+	if got == "" {
+		t.Error("expected non-empty for TaskRun")
+	}
+	if !strings.Contains(got, "Task.Run") {
+		t.Errorf("expected Task.Run in helper, got: %s", got)
+	}
+	if !strings.Contains(got, "AsyncRuntime") {
+		t.Errorf("expected AsyncRuntime class in helper")
+	}
+}
+
+func TestEmitAsyncRuntimeCS_unknown_empty(t *testing.T) {
+	got := asyncbridge.EmitAsyncRuntimeCS(asyncbridge.DispatchMode("unknown"))
+	if got != "" {
+		t.Errorf("expected empty for unknown mode, got: %s", got)
+	}
+}

--- a/package3/dotnet/asyncbridge/asyncbridge.go
+++ b/package3/dotnet/asyncbridge/asyncbridge.go
@@ -1,0 +1,282 @@
+// Package asyncbridge handles Task<T> methods in the C# shim.
+// It provides detection of async shimgen.ShimMethod entries and emits
+// enhanced C# wrapper bodies that avoid deadlocks in single-threaded contexts.
+package asyncbridge
+
+import (
+	"fmt"
+	"strings"
+
+	"mochi/package3/dotnet/shimgen"
+	"mochi/package3/dotnet/typemap"
+)
+
+// DispatchMode controls how async .NET methods are bridged to synchronous Mochi calls.
+type DispatchMode string
+
+const (
+	// DispatchGetAwaiter uses .GetAwaiter().GetResult() directly.
+	// Simple, but can deadlock if the method captures a SynchronizationContext.
+	DispatchGetAwaiter DispatchMode = "get-awaiter"
+	// DispatchManualReset uses ManualResetEventSlim for deadlock-safe blocking.
+	// Recommended for UI-context and ASP.NET-hosted environments.
+	DispatchManualReset DispatchMode = "manual-reset"
+	// DispatchTaskRun wraps in Task.Run(...).GetAwaiter().GetResult() to
+	// escape any captured SynchronizationContext. Adds a thread-pool hop.
+	DispatchTaskRun DispatchMode = "task-run"
+)
+
+// Config holds the async bridge configuration.
+type Config struct {
+	Mode DispatchMode
+}
+
+// DefaultConfig returns the default async bridge configuration.
+func DefaultConfig() Config {
+	return Config{Mode: DispatchGetAwaiter}
+}
+
+// EmitAsyncWrapper emits the C# wrapper body for an async method using the configured mode.
+// Returns the C# source lines for the method body (no surrounding braces).
+// callExpr is the upstream call expression (without .GetAwaiter etc.).
+// returnKind is the Mochi Kind of the return type.
+func EmitAsyncWrapper(callExpr string, returnKind typemap.Kind, mode DispatchMode) string {
+	isVoid := returnKind == typemap.KindUnit
+
+	switch mode {
+	case DispatchGetAwaiter:
+		if isVoid {
+			return fmt.Sprintf("            %s.GetAwaiter().GetResult();", callExpr)
+		}
+		return fmt.Sprintf("            return %s.GetAwaiter().GetResult();", callExpr)
+
+	case DispatchManualReset:
+		return emitManualReset(callExpr, returnKind, isVoid)
+
+	case DispatchTaskRun:
+		if isVoid {
+			return fmt.Sprintf("            Task.Run(() => %s).GetAwaiter().GetResult();", callExpr)
+		}
+		return fmt.Sprintf("            return Task.Run(() => %s).GetAwaiter().GetResult();", callExpr)
+
+	default:
+		// Fall back to GetAwaiter for unknown modes.
+		if isVoid {
+			return fmt.Sprintf("            %s.GetAwaiter().GetResult();", callExpr)
+		}
+		return fmt.Sprintf("            return %s.GetAwaiter().GetResult();", callExpr)
+	}
+}
+
+// emitManualReset builds the ManualResetEventSlim-based wrapper body.
+func emitManualReset(callExpr string, returnKind typemap.Kind, isVoid bool) string {
+	var b strings.Builder
+	b.WriteString("            var __mre = new ManualResetEventSlim(false);\n")
+	b.WriteString("            Exception? __ex = null;\n")
+	if !isVoid {
+		csReturnType := kindToCSharpType(returnKind)
+		fmt.Fprintf(&b, "            %s __result = default!;\n", csReturnType)
+		b.WriteString("            Task.Run(async () => {\n")
+		fmt.Fprintf(&b, "                try { __result = await %s.ConfigureAwait(false); }\n", callExpr)
+		b.WriteString("                catch (Exception e) { __ex = e; }\n")
+		b.WriteString("                finally { __mre.Set(); }\n")
+		b.WriteString("            });\n")
+		b.WriteString("            __mre.Wait();\n")
+		b.WriteString("            if (__ex != null) System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(__ex).Throw();\n")
+		b.WriteString("            return __result;")
+	} else {
+		b.WriteString("            Task.Run(async () => {\n")
+		fmt.Fprintf(&b, "                try { await %s.ConfigureAwait(false); }\n", callExpr)
+		b.WriteString("                catch (Exception e) { __ex = e; }\n")
+		b.WriteString("                finally { __mre.Set(); }\n")
+		b.WriteString("            });\n")
+		b.WriteString("            __mre.Wait();\n")
+		b.WriteString("            if (__ex != null) System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(__ex).Throw();")
+	}
+	return b.String()
+}
+
+// kindToCSharpType maps a typemap.Kind to an approximate C# type name for use
+// in local variable declarations in the generated wrapper body.
+func kindToCSharpType(k typemap.Kind) string {
+	switch k {
+	case typemap.KindBool:
+		return "bool"
+	case typemap.KindByte:
+		return "byte"
+	case typemap.KindInt:
+		return "int"
+	case typemap.KindInt64:
+		return "long"
+	case typemap.KindUInt:
+		return "uint"
+	case typemap.KindUInt64:
+		return "ulong"
+	case typemap.KindFloat:
+		return "float"
+	case typemap.KindFloat64:
+		return "double"
+	case typemap.KindChar:
+		return "char"
+	case typemap.KindString:
+		return "string"
+	case typemap.KindUnit:
+		return "void"
+	default:
+		return "object"
+	}
+}
+
+// IsAsyncMethod reports whether a shimgen.ShimMethod is async (IsAsync == true).
+func IsAsyncMethod(m *shimgen.ShimMethod) bool {
+	if m == nil {
+		return false
+	}
+	return m.IsAsync
+}
+
+// AsyncMethodCount counts async methods in a shimgen.Shim.
+func AsyncMethodCount(s *shimgen.Shim) int {
+	if s == nil {
+		return 0
+	}
+	n := 0
+	for i := range s.Methods {
+		if s.Methods[i].IsAsync {
+			n++
+		}
+	}
+	return n
+}
+
+// AsyncRewrite pairs a shimgen.ShimMethod with its rewritten C# body for the
+// configured DispatchMode.
+type AsyncRewrite struct {
+	Method     shimgen.ShimMethod
+	CSharpBody string
+}
+
+// RewriteForMode rewrites the async method bodies in a *shimgen.Shim to use
+// the specified DispatchMode instead of the default GetAwaiter.
+// Returns a slice of AsyncRewrite, one per async method in the shim.
+// Non-async methods are not included.
+func RewriteForMode(s *shimgen.Shim, mode DispatchMode) []AsyncRewrite {
+	if s == nil {
+		return nil
+	}
+	var out []AsyncRewrite
+	for _, m := range s.Methods {
+		if !m.IsAsync {
+			continue
+		}
+		callExpr := m.UpstreamCall + "(" + buildArgList(m) + ")"
+		var retKind typemap.Kind
+		if m.Return != nil {
+			retKind = m.Return.Kind
+		} else {
+			retKind = typemap.KindUnit
+		}
+		body := EmitAsyncWrapper(callExpr, retKind, mode)
+		out = append(out, AsyncRewrite{Method: m, CSharpBody: body})
+	}
+	return out
+}
+
+// buildArgList builds a comma-separated argument list from a ShimMethod's parameters.
+func buildArgList(m shimgen.ShimMethod) string {
+	args := make([]string, 0, len(m.Params))
+	for _, p := range m.Params {
+		args = append(args, p.Name)
+	}
+	return strings.Join(args, ", ")
+}
+
+// EmitAsyncRuntimeCS emits an optional AsyncRuntime.cs helper for ManualReset
+// and TaskRun modes. For DispatchGetAwaiter, returns empty string (no helper needed).
+func EmitAsyncRuntimeCS(mode DispatchMode) string {
+	switch mode {
+	case DispatchGetAwaiter:
+		return ""
+	case DispatchManualReset:
+		return `// AsyncRuntime.cs -- generated by mochi/package3/dotnet/asyncbridge; do not edit.
+// Provides the ManualResetEventSlim-based async dispatch helper.
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MochiShim.AsyncRuntime
+{
+    /// <summary>
+    /// Provides helpers for deadlock-safe blocking on async Task methods.
+    /// </summary>
+    internal static class AsyncRuntime
+    {
+        /// <summary>
+        /// Blocks synchronously on a Task using ManualResetEventSlim to avoid
+        /// SynchronizationContext deadlocks.
+        /// </summary>
+        internal static T BlockOn<T>(Func<Task<T>> factory)
+        {
+            var mre = new ManualResetEventSlim(false);
+            T result = default!;
+            Exception? ex = null;
+            Task.Run(async () => {
+                try { result = await factory().ConfigureAwait(false); }
+                catch (Exception e) { ex = e; }
+                finally { mre.Set(); }
+            });
+            mre.Wait();
+            if (ex != null) System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw();
+            return result!;
+        }
+
+        /// <summary>
+        /// Void variant of BlockOn.
+        /// </summary>
+        internal static void BlockOnVoid(Func<Task> factory)
+        {
+            var mre = new ManualResetEventSlim(false);
+            Exception? ex = null;
+            Task.Run(async () => {
+                try { await factory().ConfigureAwait(false); }
+                catch (Exception e) { ex = e; }
+                finally { mre.Set(); }
+            });
+            mre.Wait();
+            if (ex != null) System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw();
+        }
+    }
+}
+`
+	case DispatchTaskRun:
+		return `// AsyncRuntime.cs -- generated by mochi/package3/dotnet/asyncbridge; do not edit.
+// Provides the Task.Run-based async dispatch helper (thread-pool hop).
+using System;
+using System.Threading.Tasks;
+
+namespace MochiShim.AsyncRuntime
+{
+    /// <summary>
+    /// Provides Task.Run-based blocking helpers that escape any captured
+    /// SynchronizationContext by hopping to the thread pool.
+    /// </summary>
+    internal static class AsyncRuntime
+    {
+        /// <summary>
+        /// Runs the async factory on the thread pool and blocks until complete.
+        /// </summary>
+        internal static T BlockOn<T>(Func<Task<T>> factory)
+            => Task.Run(factory).GetAwaiter().GetResult();
+
+        /// <summary>
+        /// Void variant of BlockOn.
+        /// </summary>
+        internal static void BlockOnVoid(Func<Task> factory)
+            => Task.Run(factory).GetAwaiter().GetResult();
+    }
+}
+`
+	default:
+		return ""
+	}
+}

--- a/package3/dotnet/build/integration_test.go
+++ b/package3/dotnet/build/integration_test.go
@@ -1,0 +1,434 @@
+package build_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/package3/dotnet/build"
+	"mochi/package3/dotnet/metacli"
+)
+
+// buildEndToEndSurface constructs a minimal ApiSurface with 5 types that
+// exercise the full pipeline:
+//
+//  1. A static class with string->string, int->bool, and async string->string methods.
+//  2. A class with 2 instance methods returning handles.
+//  3. An enum type.
+//  4. A struct type.
+//  5. A type with a generic method (should get SkipGeneric in the shim).
+func buildEndToEndSurface(pkg string) *metacli.ApiSurface {
+	return &metacli.ApiSurface{
+		Assembly:        pkg,
+		Version:         "2.0.0",
+		TargetFramework: "net8.0",
+		Types: []metacli.SurfaceType{
+			// 1. Static utility class.
+			{
+				FullName:  pkg + ".Utils",
+				ShortName: "Utils",
+				Namespace: pkg,
+				Kind:      metacli.KindClass,
+				IsStatic:  true,
+				Methods: []metacli.SurfaceMethod{
+					{
+						Name:     "Format",
+						IsStatic: true,
+						ReturnType: metacli.TypeRef{
+							FullName: "System.String",
+							Kind:     metacli.TypeRefPrimitive,
+						},
+						Params: []metacli.ParamDef{
+							{
+								Name: "input",
+								Type: metacli.TypeRef{FullName: "System.String", Kind: metacli.TypeRefPrimitive},
+							},
+						},
+					},
+					{
+						Name:     "IsValid",
+						IsStatic: true,
+						ReturnType: metacli.TypeRef{
+							FullName: "System.Boolean",
+							Kind:     metacli.TypeRefPrimitive,
+						},
+						Params: []metacli.ParamDef{
+							{
+								Name: "value",
+								Type: metacli.TypeRef{FullName: "System.Int32", Kind: metacli.TypeRefPrimitive},
+							},
+						},
+					},
+					{
+						Name:     "FetchAsync",
+						IsStatic: true,
+						IsAsync:  true,
+						ReturnType: metacli.TypeRef{
+							FullName: "System.Threading.Tasks.Task`1",
+							Kind:     metacli.TypeRefGenericInst,
+							TypeArgs: []metacli.TypeRef{
+								{FullName: "System.String", Kind: metacli.TypeRefPrimitive},
+							},
+						},
+						Params: []metacli.ParamDef{
+							{
+								Name: "key",
+								Type: metacli.TypeRef{FullName: "System.String", Kind: metacli.TypeRefPrimitive},
+							},
+						},
+					},
+				},
+			},
+			// 2. Instance class with handle-returning methods.
+			{
+				FullName:  pkg + ".Client",
+				ShortName: "Client",
+				Namespace: pkg,
+				Kind:      metacli.KindClass,
+				IsStatic:  false,
+				Methods: []metacli.SurfaceMethod{
+					{
+						Name:     "Connect",
+						IsStatic: false,
+						ReturnType: metacli.TypeRef{
+							FullName: pkg + ".Connection",
+							Kind:     metacli.TypeRefClass,
+						},
+					},
+					{
+						Name:     "Disconnect",
+						IsStatic: false,
+						ReturnType: metacli.TypeRef{
+							FullName: "System.Void",
+							Kind:     metacli.TypeRefVoid,
+						},
+					},
+				},
+			},
+			// 3. Enum type.
+			{
+				FullName:  pkg + ".StatusCode",
+				ShortName: "StatusCode",
+				Namespace: pkg,
+				Kind:      metacli.KindEnum,
+			},
+			// 4. Struct type.
+			{
+				FullName:  pkg + ".Point",
+				ShortName: "Point",
+				Namespace: pkg,
+				Kind:      metacli.KindStruct,
+				Methods: []metacli.SurfaceMethod{
+					{
+						Name:     "Distance",
+						IsStatic: false,
+						ReturnType: metacli.TypeRef{
+							FullName: "System.Double",
+							Kind:     metacli.TypeRefPrimitive,
+						},
+						Params: []metacli.ParamDef{
+							{
+								Name: "other",
+								Type: metacli.TypeRef{FullName: "System.Double", Kind: metacli.TypeRefPrimitive},
+							},
+						},
+					},
+				},
+			},
+			// 5. Type with a generic method (should produce SkipGeneric).
+			{
+				FullName:  pkg + ".Repository",
+				ShortName: "Repository",
+				Namespace: pkg,
+				Kind:      metacli.KindClass,
+				IsStatic:  true,
+				Methods: []metacli.SurfaceMethod{
+					{
+						Name:     "FindAll",
+						IsStatic: true,
+						ReturnType: metacli.TypeRef{
+							FullName: "T",
+							Kind:     metacli.TypeRefGenericParam,
+						},
+					},
+					// One non-generic method to ensure not all are skipped.
+					{
+						Name:     "Count",
+						IsStatic: true,
+						ReturnType: metacli.TypeRef{
+							FullName: "System.Int32",
+							Kind:     metacli.TypeRefPrimitive,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func endToEndProvider() build.SurfaceProviderFunc {
+	return func(id, version string) (*metacli.ApiSurface, error) {
+		return buildEndToEndSurface(id), nil
+	}
+}
+
+func TestPipeline_EndToEnd(t *testing.T) {
+	const pkgID = "E2E.TestPackage"
+	const pkgVersion = "2.0.0"
+
+	dir := t.TempDir()
+	d := build.NewDriver(dir)
+	if err := d.PrepareWorkspace(); err != nil {
+		t.Fatalf("PrepareWorkspace: %v", err)
+	}
+
+	p := &build.Pipeline{
+		Driver:          d,
+		Provider:        endToEndProvider(),
+		TargetFramework: "net8.0",
+	}
+
+	refs := []build.ImportRef{
+		{ID: pkgID, Version: pkgVersion, Alias: "e2e"},
+	}
+
+	// 1. Resolve.
+	result, err := p.Resolve(refs)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// 2. Assert basic structure.
+	if len(result.Resolved) != 1 {
+		t.Fatalf("expected 1 resolved package, got %d", len(result.Resolved))
+	}
+	rp := result.Resolved[0]
+
+	// 3. Assert ref.
+	if rp.Ref.ID != pkgID {
+		t.Errorf("Ref.ID = %q, want %q", rp.Ref.ID, pkgID)
+	}
+	if rp.Ref.Version != pkgVersion {
+		t.Errorf("Ref.Version = %q, want %q", rp.Ref.Version, pkgVersion)
+	}
+
+	// 4. Assert shim is non-nil.
+	if rp.Shim == nil {
+		t.Fatal("expected non-nil Shim")
+	}
+
+	// 5. Assert shim package and version.
+	if rp.Shim.Package != pkgID {
+		t.Errorf("Shim.Package = %q, want %q", rp.Shim.Package, pkgID)
+	}
+	if rp.Shim.PackageVersion != pkgVersion {
+		t.Errorf("Shim.PackageVersion = %q, want %q", rp.Shim.PackageVersion, pkgVersion)
+	}
+
+	// 6. Assert methods count is reasonable (static utils + client methods + point distance + repo.Count).
+	if len(rp.Shim.Methods) < 4 {
+		t.Errorf("expected at least 4 shim methods, got %d", len(rp.Shim.Methods))
+	}
+
+	// 7. Assert skipped entries exist (Repository.FindAll is generic => SkipGeneric).
+	if len(rp.Shim.Skipped) == 0 {
+		t.Error("expected at least one skipped entry for generic method")
+	}
+
+	// 8. Find the specific SkipGeneric entry for Repository.FindAll.
+	var foundSkipGeneric bool
+	for _, skip := range rp.Shim.Skipped {
+		if strings.Contains(skip.ItemPath, "FindAll") {
+			foundSkipGeneric = true
+		}
+	}
+	if !foundSkipGeneric {
+		t.Errorf("expected SkipGeneric for Repository.FindAll, skipped: %v", rp.Shim.Skipped)
+	}
+
+	// 9. Assert async method is present (FetchAsync).
+	var hasAsync bool
+	for _, m := range rp.Shim.Methods {
+		if m.IsAsync {
+			hasAsync = true
+		}
+	}
+	if !hasAsync {
+		t.Error("expected at least one async method in shim")
+	}
+
+	// 10. Assert Mochi files are populated.
+	if rp.Mochi.ExternMochi == "" {
+		t.Error("expected non-empty ExternMochi")
+	}
+	if rp.Mochi.AliasMochi == "" {
+		t.Error("expected non-empty AliasMochi")
+	}
+
+	// 11. Assert extern mochi contains extern type declarations.
+	if !strings.Contains(rp.Mochi.ExternMochi, "extern") {
+		t.Errorf("ExternMochi should contain 'extern', got: %s", rp.Mochi.ExternMochi)
+	}
+
+	// 12. Assert bridge Go file is non-empty.
+	if rp.Bridge.GoFile == "" {
+		t.Error("expected non-empty Bridge.GoFile")
+	}
+
+	// 13. Assert bridge Go file contains init().
+	if !strings.Contains(rp.Bridge.GoFile, "func init()") {
+		t.Errorf("Bridge.GoFile should contain init(), got: %s", rp.Bridge.GoFile)
+	}
+
+	// 14. Assert runtime config JSON is non-empty.
+	if rp.Bridge.RuntimeConfigJSON == "" {
+		t.Error("expected non-empty RuntimeConfigJSON")
+	}
+
+	// 15. Assert runtime config contains runtimeOptions.
+	if !strings.Contains(rp.Bridge.RuntimeConfigJSON, "runtimeOptions") {
+		t.Errorf("RuntimeConfigJSON should contain runtimeOptions, got: %s", rp.Bridge.RuntimeConfigJSON)
+	}
+
+	// 16. Assert shim dir is set.
+	if rp.ShimDir == "" {
+		t.Error("expected non-empty ShimDir")
+	}
+	if !strings.HasPrefix(rp.ShimDir, "dotnet_shim/") {
+		t.Errorf("ShimDir should start with dotnet_shim/, got: %s", rp.ShimDir)
+	}
+
+	// 17. Assert target framework is set in shim.
+	if rp.Shim.TargetFramework != "net8.0" {
+		t.Errorf("expected net8.0, got %s", rp.Shim.TargetFramework)
+	}
+
+	// 18. Materialise workspace.
+	slnPath, err := p.MaterialiseWorkspace(result)
+	if err != nil {
+		t.Fatalf("MaterialiseWorkspace: %v", err)
+	}
+
+	// 19. Assert .sln file exists.
+	if _, err := os.Stat(slnPath); err != nil {
+		t.Errorf("sln not created at %s: %v", slnPath, err)
+	}
+
+	// 20. Locate shim directory.
+	shimDir := filepath.Join(dir, "dotnet_workspace", rp.ShimDir)
+
+	// 21. Assert Bridge.cs exists.
+	bridgePath := filepath.Join(shimDir, "Bridge.cs")
+	if _, err := os.Stat(bridgePath); err != nil {
+		t.Errorf("Bridge.cs not found at %s: %v", bridgePath, err)
+	}
+
+	// 22. Assert Bridge.cs contains the package reference.
+	bridgeCS, err := os.ReadFile(bridgePath)
+	if err != nil {
+		t.Fatalf("read Bridge.cs: %v", err)
+	}
+	if !strings.Contains(string(bridgeCS), "Bridge") {
+		t.Errorf("Bridge.cs missing expected content, got: %s", string(bridgeCS)[:200])
+	}
+
+	// 23. Assert .csproj exists.
+	assemblyName := "MochiShim.E2ETestPackage"
+	csprojPath := filepath.Join(shimDir, assemblyName+".csproj")
+	if _, err := os.Stat(csprojPath); err != nil {
+		t.Errorf("csproj not found at %s: %v", csprojPath, err)
+	}
+
+	// 24. Assert SKIPPED.txt exists.
+	skippedPath := filepath.Join(shimDir, "SKIPPED.txt")
+	if _, err := os.Stat(skippedPath); err != nil {
+		t.Errorf("SKIPPED.txt not found at %s: %v", skippedPath, err)
+	}
+
+	// 25. Assert SKIPPED.txt contains SkipGeneric.
+	skippedContent, err := os.ReadFile(skippedPath)
+	if err != nil {
+		t.Fatalf("read SKIPPED.txt: %v", err)
+	}
+	if !strings.Contains(string(skippedContent), "SkipGeneric") {
+		t.Errorf("SKIPPED.txt should contain SkipGeneric, got: %s", string(skippedContent))
+	}
+
+	// 26. Assert .csproj contains the target framework.
+	csprojContent, err := os.ReadFile(csprojPath)
+	if err != nil {
+		t.Fatalf("read csproj: %v", err)
+	}
+	if !strings.Contains(string(csprojContent), "net8.0") {
+		t.Errorf("csproj should contain net8.0, got: %s", string(csprojContent))
+	}
+
+	// 27. Assert Bridge.cs contains [UnmanagedCallersOnly].
+	if !strings.Contains(string(bridgeCS), "UnmanagedCallersOnly") {
+		t.Error("Bridge.cs should contain UnmanagedCallersOnly")
+	}
+
+	// 28. Assert the bridge Go file contains loadShim.
+	if !strings.Contains(rp.Bridge.GoFile, "loadShim") {
+		t.Errorf("Bridge.GoFile should contain loadShim, got: %s", rp.Bridge.GoFile)
+	}
+
+	// 29. Assert the runtime config JSON contains net8.0.
+	if !strings.Contains(rp.Bridge.RuntimeConfigJSON, "net8.0") {
+		t.Errorf("RuntimeConfigJSON should contain net8.0, got: %s", rp.Bridge.RuntimeConfigJSON)
+	}
+
+	// 30. Assert mochi extern file contains the package name.
+	if !strings.Contains(rp.Mochi.ExternMochi, pkgID) {
+		// The header contains the package ID.
+		t.Errorf("ExternMochi should reference package %s, got: %s", pkgID, rp.Mochi.ExternMochi)
+	}
+}
+
+// TestPipeline_EndToEnd_multiplePackages exercises the pipeline with multiple
+// packages to verify each produces distinct workspace output.
+func TestPipeline_EndToEnd_multiplePackages(t *testing.T) {
+	dir := t.TempDir()
+	d := build.NewDriver(dir)
+	if err := d.PrepareWorkspace(); err != nil {
+		t.Fatalf("PrepareWorkspace: %v", err)
+	}
+
+	p := &build.Pipeline{
+		Driver:   d,
+		Provider: endToEndProvider(),
+	}
+
+	refs := []build.ImportRef{
+		{ID: "Pkg.Alpha", Version: "1.0.0"},
+		{ID: "Pkg.Beta", Version: "2.0.0"},
+	}
+
+	result, err := p.Resolve(refs)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if len(result.Resolved) != 2 {
+		t.Fatalf("expected 2 resolved packages, got %d", len(result.Resolved))
+	}
+
+	slnPath, err := p.MaterialiseWorkspace(result)
+	if err != nil {
+		t.Fatalf("MaterialiseWorkspace: %v", err)
+	}
+
+	// Assert .sln was created.
+	if _, err := os.Stat(slnPath); err != nil {
+		t.Errorf("sln not created: %v", err)
+	}
+
+	// Assert each shim dir exists.
+	for _, rp := range result.Resolved {
+		shimDir := filepath.Join(dir, "dotnet_workspace", rp.ShimDir)
+		if _, err := os.Stat(shimDir); err != nil {
+			t.Errorf("shim dir missing for %s: %v", rp.Ref.ID, err)
+		}
+	}
+}

--- a/package3/dotnet/generics/generics.go
+++ b/package3/dotnet/generics/generics.go
@@ -1,0 +1,454 @@
+// Package generics handles .NET reified generic monomorphisation for the
+// MEP-68 bridge. .NET generics are reified: List<int> and List<string> are
+// distinct runtime types. The bridge must explicitly enumerate which generic
+// instantiations to generate wrappers for via the [dotnet.monomorphise] table
+// in mochi.toml.
+package generics
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	doterrors "mochi/package3/dotnet/errors"
+	"mochi/package3/dotnet/metacli"
+	"mochi/package3/dotnet/shimgen"
+	"mochi/package3/dotnet/typemap"
+)
+
+// MonoEntry is one explicit generic instantiation declared in mochi.toml.
+type MonoEntry struct {
+	// Item is the fully-qualified .NET type+method, e.g.
+	// "System.Linq.Enumerable.Select" or "System.Collections.Generic.List`1"
+	Item string
+	// TypeArgs is the list of concrete type argument full names,
+	// e.g. ["System.String", "System.Int32"]
+	TypeArgs []string
+}
+
+// MonoTable is the parsed [dotnet.monomorphise] table from mochi.toml.
+type MonoTable struct {
+	Entries []MonoEntry
+}
+
+// ParseMonoTable parses the TOML array of inline tables used in mochi.toml:
+//
+//	monomorphise = [
+//	    { item = "System.Linq.Enumerable.Select", type_args = ["System.String", "System.Int32"] },
+//	]
+//
+// The parser handles simple single-line inline table arrays. Each entry must
+// have an item key and a type_args key.
+func ParseMonoTable(toml string) (*MonoTable, error) {
+	// Find the monomorphise = [...] value.
+	const key = "monomorphise"
+	_, afterKey, found := strings.Cut(toml, key)
+	if !found {
+		// No monomorphise table: return empty.
+		return &MonoTable{}, nil
+	}
+	rest := strings.TrimSpace(afterKey)
+	if len(rest) == 0 || rest[0] != '=' {
+		return nil, fmt.Errorf("generics: malformed monomorphise entry: expected '=' after key")
+	}
+	rest = strings.TrimSpace(rest[1:])
+	// Expect '['.
+	if len(rest) == 0 || rest[0] != '[' {
+		return nil, fmt.Errorf("generics: monomorphise value is not an array")
+	}
+
+	// Extract the full array content (may span multiple lines).
+	arrayContent, err := extractBracketContent(rest)
+	if err != nil {
+		return nil, fmt.Errorf("generics: extract array: %w", err)
+	}
+
+	// Split into inline table entries at top-level commas between '}'.
+	entries, err := splitInlineTables(arrayContent)
+	if err != nil {
+		return nil, fmt.Errorf("generics: split entries: %w", err)
+	}
+
+	table := &MonoTable{}
+	for i, entry := range entries {
+		e, err := parseInlineEntry(entry)
+		if err != nil {
+			return nil, fmt.Errorf("generics: entry %d: %w", i, err)
+		}
+		table.Entries = append(table.Entries, e)
+	}
+	return table, nil
+}
+
+// extractBracketContent returns everything between the first '[' and matching ']'.
+func extractBracketContent(s string) (string, error) {
+	if len(s) == 0 || s[0] != '[' {
+		return "", fmt.Errorf("expected '[', got %q", s)
+	}
+	depth := 0
+	for i, c := range s {
+		switch c {
+		case '[', '{':
+			depth++
+		case ']', '}':
+			depth--
+			if depth == 0 {
+				return s[1:i], nil
+			}
+		}
+	}
+	return "", fmt.Errorf("unmatched '['")
+}
+
+// splitInlineTables splits the content of a TOML array into individual inline
+// table strings separated by top-level commas.
+func splitInlineTables(content string) ([]string, error) {
+	var out []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(content); i++ {
+		switch content[i] {
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+		case ',':
+			if depth == 0 {
+				segment := strings.TrimSpace(content[start:i])
+				if segment != "" {
+					out = append(out, segment)
+				}
+				start = i + 1
+			}
+		}
+	}
+	// Last segment.
+	if segment := strings.TrimSpace(content[start:]); segment != "" {
+		out = append(out, segment)
+	}
+	return out, nil
+}
+
+// parseInlineEntry parses one TOML inline table like:
+// { item = "System.Linq.Enumerable.Select", type_args = ["System.String"] }
+func parseInlineEntry(s string) (MonoEntry, error) {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "{") || !strings.HasSuffix(s, "}") {
+		return MonoEntry{}, fmt.Errorf("expected inline table { ... }, got %q", s)
+	}
+	inner := s[1 : len(s)-1]
+
+	// Split by top-level commas.
+	parts := splitAtTopLevelCommas(inner)
+	var e MonoEntry
+	for _, part := range parts {
+		k, v, ok := strings.Cut(part, "=")
+		if !ok {
+			return MonoEntry{}, fmt.Errorf("missing '=' in key-value pair %q", part)
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		switch k {
+		case "item":
+			s, err := parseTomlString(v)
+			if err != nil {
+				return MonoEntry{}, fmt.Errorf("item: %w", err)
+			}
+			e.Item = s
+		case "type_args":
+			args, err := parseTomlStringArray(v)
+			if err != nil {
+				return MonoEntry{}, fmt.Errorf("type_args: %w", err)
+			}
+			e.TypeArgs = args
+		}
+	}
+	if e.Item == "" {
+		return MonoEntry{}, fmt.Errorf("missing required key 'item'")
+	}
+	if len(e.TypeArgs) == 0 {
+		return MonoEntry{}, fmt.Errorf("missing required key 'type_args' or empty for item %q", e.Item)
+	}
+	return e, nil
+}
+
+// splitAtTopLevelCommas splits s at commas that are not inside brackets or braces.
+func splitAtTopLevelCommas(s string) []string {
+	var out []string
+	depth := 0
+	inStr := false
+	start := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inStr {
+			if c == '"' && (i == 0 || s[i-1] != '\\') {
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+		case ',':
+			if depth == 0 {
+				out = append(out, strings.TrimSpace(s[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	if last := strings.TrimSpace(s[start:]); last != "" {
+		out = append(out, last)
+	}
+	return out
+}
+
+// parseTomlString extracts the string value from a TOML quoted string.
+func parseTomlString(v string) (string, error) {
+	v = strings.TrimSpace(v)
+	if len(v) < 2 || v[0] != '"' || v[len(v)-1] != '"' {
+		return "", fmt.Errorf("expected quoted string, got %q", v)
+	}
+	return v[1 : len(v)-1], nil
+}
+
+// parseTomlStringArray parses a TOML string array like ["a", "b", "c"].
+func parseTomlStringArray(v string) ([]string, error) {
+	v = strings.TrimSpace(v)
+	if !strings.HasPrefix(v, "[") || !strings.HasSuffix(v, "]") {
+		return nil, fmt.Errorf("expected array [..], got %q", v)
+	}
+	inner := strings.TrimSpace(v[1 : len(v)-1])
+	if inner == "" {
+		return nil, nil
+	}
+	parts := splitAtTopLevelCommas(inner)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		s, err := parseTomlString(p)
+		if err != nil {
+			return nil, fmt.Errorf("array element: %w", err)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// Instantiate checks whether an Item has an entry in the MonoTable.
+// Returns the concrete TypeArgs if found, nil if not.
+func (t *MonoTable) Instantiate(item string) ([]string, bool) {
+	if t == nil {
+		return nil, false
+	}
+	for _, e := range t.Entries {
+		if e.Item == item {
+			return e.TypeArgs, true
+		}
+	}
+	return nil, false
+}
+
+// MonomorphiseMethod attempts to produce a concrete shimgen.ShimMethod for a
+// generic MethodDef by substituting TypeArgs from the MonoTable.
+// Returns (method, true) if the method was successfully monomorphised,
+// or (zero, false) if no matching entry exists or substitution fails.
+func MonomorphiseMethod(
+	typeName, methodName string,
+	method metacli.MethodDef,
+	table *MonoTable,
+	dir typemap.Direction,
+) (shimgen.ShimMethod, bool) {
+	fullItem := typeName + "." + methodName
+	typeArgs, ok := table.Instantiate(fullItem)
+	if !ok {
+		return shimgen.ShimMethod{}, false
+	}
+	if len(typeArgs) == 0 {
+		return shimgen.ShimMethod{}, false
+	}
+
+	// Substitute the type args into the method's generic parameters.
+	// Build a substitution map from the method's TypeParams.
+	subst := map[string]string{}
+	for i, tp := range method.TypeParams {
+		if i < len(typeArgs) {
+			subst[tp] = typeArgs[i]
+		}
+	}
+
+	// Build the ShimMethod params.
+	params := make([]shimgen.ShimParam, 0, len(method.Parameters))
+	for _, p := range method.Parameters {
+		typeRef := substituteTypeRef(p.Type, subst)
+		mapping, sr, _ := typemap.Map(typeRef, dir)
+		if sr != doterrors.SkipUnknown {
+			return shimgen.ShimMethod{}, false
+		}
+		params = append(params, shimgen.ShimParam{
+			Name:    p.Name,
+			Mapping: *mapping,
+		})
+	}
+
+	// Map return type.
+	retRef := substituteTypeRef(method.ReturnType, subst)
+	retMapping, sr, _ := typemap.Map(retRef, typemap.DirectionOut)
+	if sr != doterrors.SkipUnknown {
+		return shimgen.ShimMethod{}, false
+	}
+	var finalReturn *typemap.Mapping
+	if retMapping != nil && retMapping.Kind != typemap.KindUnit {
+		finalReturn = retMapping
+	}
+
+	// Build a mangled method name that includes the type args.
+	mangledArgs := strings.Join(typeArgs, "_")
+	mangledArgs = sanitizeForIdent(mangledArgs)
+	csMethodName := shortName(typeName) + "_" + methodName + "_" + mangledArgs
+
+	entryPoint := "mochi_" + sanitizeForIdent(typeName) + "_" + sanitizeForIdent(methodName) + "_" + mangledArgs
+
+	return shimgen.ShimMethod{
+		EntryPoint:   entryPoint,
+		CSMethodName: csMethodName,
+		UpstreamCall: typeName + "." + methodName,
+		Params:       params,
+		Return:       finalReturn,
+		IsAsync:      method.IsAsync,
+		IsStatic:     method.IsStatic,
+	}, true
+}
+
+// substituteTypeRef replaces TypeRefGenericParam references with concrete types.
+func substituteTypeRef(ref metacli.TypeRef, subst map[string]string) metacli.TypeRef {
+	if ref.Kind == metacli.TypeRefGenericParam {
+		if concrete, ok := subst[ref.FullName]; ok {
+			return metacli.TypeRef{
+				FullName: concrete,
+				Kind:     metacli.TypeRefClass,
+			}
+		}
+	}
+	// Substitute recursively in TypeArgs.
+	if len(ref.TypeArgs) > 0 {
+		newArgs := make([]metacli.TypeRef, len(ref.TypeArgs))
+		for i, a := range ref.TypeArgs {
+			newArgs[i] = substituteTypeRef(a, subst)
+		}
+		ref.TypeArgs = newArgs
+	}
+	return ref
+}
+
+// ApplyToSurface rewrites an ApiSurface by attempting to monomorphise all
+// generic methods that have entries in the MonoTable. Non-generic methods are
+// passed through unchanged. Generic methods without a MonoTable entry
+// accumulate SkipReport entries in the returned slice.
+func ApplyToSurface(surface *metacli.ApiSurface, table *MonoTable) (*metacli.ApiSurface, []doterrors.SkipReport) {
+	if surface == nil {
+		return &metacli.ApiSurface{}, nil
+	}
+	var skipped []doterrors.SkipReport
+	out := &metacli.ApiSurface{
+		Assembly:        surface.Assembly,
+		Version:         surface.Version,
+		TargetFramework: surface.TargetFramework,
+	}
+
+	for _, st := range surface.Types {
+		newType := metacli.SurfaceType{
+			FullName:   st.FullName,
+			ShortName:  st.ShortName,
+			Namespace:  st.Namespace,
+			Kind:       st.Kind,
+			IsAbstract: st.IsAbstract,
+			IsStatic:   st.IsStatic,
+		}
+
+		for _, m := range st.Methods {
+			// Find the MethodDef from the surface for generic processing.
+			if !isGenericMethod(m) {
+				// Non-generic: pass through.
+				newType.Methods = append(newType.Methods, m)
+				continue
+			}
+
+			// Generic method: look up in MonoTable.
+			fullItem := st.FullName + "." + m.Name
+			if _, ok := table.Instantiate(fullItem); !ok {
+				skipped = append(skipped, doterrors.SkipReport{
+					ItemPath: fullItem,
+					Reason:   doterrors.SkipGeneric,
+					Detail:   fmt.Sprintf("generic method %s has no monomorphise entry", fullItem),
+					Override: fmt.Sprintf("add { item = %q, type_args = [\"T\"] } under [dotnet.monomorphise]", fullItem),
+				})
+				continue
+			}
+
+			// Has a MonoTable entry: include it but note it still appears in
+			// the surface (actual shim generation via MonomorphiseMethod is
+			// the caller's responsibility). We keep the method as-is in the
+			// surface to allow callers to then invoke MonomorphiseMethod.
+			newType.Methods = append(newType.Methods, m)
+		}
+
+		// Properties pass through unchanged.
+		newType.Properties = append(newType.Properties, st.Properties...)
+		out.Types = append(out.Types, newType)
+	}
+
+	return out, skipped
+}
+
+// isGenericMethod reports whether a SurfaceMethod is generic.
+// We check the return type and parameter types for generic params.
+func isGenericMethod(m metacli.SurfaceMethod) bool {
+	if containsGenericParam(m.ReturnType) {
+		return true
+	}
+	for _, p := range m.Params {
+		if containsGenericParam(p.Type) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsGenericParam reports whether a TypeRef contains a generic parameter.
+func containsGenericParam(ref metacli.TypeRef) bool {
+	if ref.Kind == metacli.TypeRefGenericParam {
+		return true
+	}
+	return slices.ContainsFunc(ref.TypeArgs, containsGenericParam)
+}
+
+// sanitizeForIdent converts a CLR full name to a safe identifier fragment.
+func sanitizeForIdent(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '_':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + 32) // tolower
+		case r == '.', r == ',', r == ' ', r == '[', r == ']':
+			b.WriteRune('_')
+		case r == '`':
+			// drop backtick arity
+		default:
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}
+
+// shortName returns the last dot-separated segment of a CLR full name.
+func shortName(full string) string {
+	if i := strings.LastIndex(full, "."); i >= 0 {
+		return full[i+1:]
+	}
+	return full
+}

--- a/package3/dotnet/generics/generics_test.go
+++ b/package3/dotnet/generics/generics_test.go
@@ -1,0 +1,390 @@
+package generics_test
+
+import (
+	"testing"
+
+	"mochi/package3/dotnet/errors"
+	"mochi/package3/dotnet/generics"
+	"mochi/package3/dotnet/metacli"
+	"mochi/package3/dotnet/typemap"
+)
+
+// ---------- ParseMonoTable ----------
+
+func TestParseMonoTable_empty(t *testing.T) {
+	tbl, err := generics.ParseMonoTable("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tbl == nil {
+		t.Fatal("expected non-nil table")
+	}
+	if len(tbl.Entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(tbl.Entries))
+	}
+}
+
+func TestParseMonoTable_noMonomorphiseKey(t *testing.T) {
+	toml := `[dotnet]
+registry = "https://api.nuget.org/v3/index.json"
+`
+	tbl, err := generics.ParseMonoTable(toml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tbl.Entries) != 0 {
+		t.Errorf("expected 0 entries for missing key, got %d", len(tbl.Entries))
+	}
+}
+
+func TestParseMonoTable_singleEntry(t *testing.T) {
+	toml := `monomorphise = [
+    { item = "System.Linq.Enumerable.Select", type_args = ["System.String", "System.Int32"] }
+]`
+	tbl, err := generics.ParseMonoTable(toml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tbl.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(tbl.Entries))
+	}
+	e := tbl.Entries[0]
+	if e.Item != "System.Linq.Enumerable.Select" {
+		t.Errorf("expected item name, got %s", e.Item)
+	}
+	if len(e.TypeArgs) != 2 {
+		t.Fatalf("expected 2 type args, got %d", len(e.TypeArgs))
+	}
+	if e.TypeArgs[0] != "System.String" {
+		t.Errorf("expected System.String, got %s", e.TypeArgs[0])
+	}
+	if e.TypeArgs[1] != "System.Int32" {
+		t.Errorf("expected System.Int32, got %s", e.TypeArgs[1])
+	}
+}
+
+func TestParseMonoTable_multipleEntries(t *testing.T) {
+	toml := `monomorphise = [
+    { item = "System.Collections.Generic.List.Add", type_args = ["System.String"] },
+    { item = "System.Collections.Generic.List.Get", type_args = ["System.Int32"] }
+]`
+	tbl, err := generics.ParseMonoTable(toml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tbl.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(tbl.Entries))
+	}
+}
+
+func TestParseMonoTable_missingItemKey(t *testing.T) {
+	toml := `monomorphise = [
+    { type_args = ["System.String"] }
+]`
+	_, err := generics.ParseMonoTable(toml)
+	if err == nil {
+		t.Fatal("expected error for missing item key")
+	}
+}
+
+func TestParseMonoTable_missingTypeArgs(t *testing.T) {
+	toml := `monomorphise = [
+    { item = "Foo.Bar.Method" }
+]`
+	_, err := generics.ParseMonoTable(toml)
+	if err == nil {
+		t.Fatal("expected error for missing type_args")
+	}
+}
+
+// ---------- Instantiate ----------
+
+func TestInstantiate_hit(t *testing.T) {
+	tbl := &generics.MonoTable{
+		Entries: []generics.MonoEntry{
+			{Item: "System.Linq.Enumerable.Select", TypeArgs: []string{"System.String", "System.Int32"}},
+		},
+	}
+	args, ok := tbl.Instantiate("System.Linq.Enumerable.Select")
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	if len(args) != 2 {
+		t.Fatalf("expected 2 type args, got %d", len(args))
+	}
+}
+
+func TestInstantiate_miss(t *testing.T) {
+	tbl := &generics.MonoTable{
+		Entries: []generics.MonoEntry{
+			{Item: "Foo.Bar.Method", TypeArgs: []string{"System.String"}},
+		},
+	}
+	_, ok := tbl.Instantiate("NotInTable.Method")
+	if ok {
+		t.Fatal("expected miss")
+	}
+}
+
+func TestInstantiate_nilTable(t *testing.T) {
+	var tbl *generics.MonoTable
+	_, ok := tbl.Instantiate("anything")
+	if ok {
+		t.Fatal("expected miss for nil table")
+	}
+}
+
+func TestInstantiate_emptyTable(t *testing.T) {
+	tbl := &generics.MonoTable{}
+	_, ok := tbl.Instantiate("anything")
+	if ok {
+		t.Fatal("expected miss for empty table")
+	}
+}
+
+// ---------- MonomorphiseMethod ----------
+
+func makeGenericMethodDef() metacli.MethodDef {
+	return metacli.MethodDef{
+		Name:       "Select",
+		IsStatic:   true,
+		IsGeneric:  true,
+		TypeParams: []string{"TSource", "TResult"},
+		ReturnType: metacli.TypeRef{
+			FullName: "TResult",
+			Kind:     metacli.TypeRefGenericParam,
+		},
+		Parameters: []metacli.ParamDef{
+			{
+				Name: "input",
+				Type: metacli.TypeRef{
+					FullName: "TSource",
+					Kind:     metacli.TypeRefGenericParam,
+				},
+			},
+		},
+	}
+}
+
+func TestMonomorphiseMethod_success(t *testing.T) {
+	tbl := &generics.MonoTable{
+		Entries: []generics.MonoEntry{
+			{
+				Item:     "System.Linq.Enumerable.Select",
+				TypeArgs: []string{"System.String", "System.String"},
+			},
+		},
+	}
+	method := makeGenericMethodDef()
+	sm, ok := generics.MonomorphiseMethod("System.Linq.Enumerable", "Select", method, tbl, typemap.DirectionOut)
+	if !ok {
+		t.Fatal("expected successful monomorphisation")
+	}
+	if sm.EntryPoint == "" {
+		t.Error("expected non-empty entry point")
+	}
+	if sm.CSMethodName == "" {
+		t.Error("expected non-empty CSMethodName")
+	}
+	if len(sm.Params) != 1 {
+		t.Errorf("expected 1 param, got %d", len(sm.Params))
+	}
+}
+
+func TestMonomorphiseMethod_missingEntry(t *testing.T) {
+	tbl := &generics.MonoTable{}
+	method := makeGenericMethodDef()
+	_, ok := generics.MonomorphiseMethod("Foo.Bar", "Method", method, tbl, typemap.DirectionOut)
+	if ok {
+		t.Fatal("expected miss for missing entry")
+	}
+}
+
+func TestMonomorphiseMethod_entryPointContainsTypeArg(t *testing.T) {
+	tbl := &generics.MonoTable{
+		Entries: []generics.MonoEntry{
+			{
+				Item:     "MyNS.MyClass.GetAsync",
+				TypeArgs: []string{"System.String"},
+			},
+		},
+	}
+	method := metacli.MethodDef{
+		Name:       "GetAsync",
+		TypeParams: []string{"T"},
+		ReturnType: metacli.TypeRef{FullName: "T", Kind: metacli.TypeRefGenericParam},
+		IsAsync:    true,
+	}
+	sm, ok := generics.MonomorphiseMethod("MyNS.MyClass", "GetAsync", method, tbl, typemap.DirectionOut)
+	if !ok {
+		t.Fatal("expected successful monomorphisation")
+	}
+	if sm.IsAsync != true {
+		t.Error("expected IsAsync preserved")
+	}
+}
+
+// ---------- ApplyToSurface ----------
+
+func makeGenericSurface() *metacli.ApiSurface {
+	return &metacli.ApiSurface{
+		Assembly: "TestAssembly",
+		Types: []metacli.SurfaceType{
+			{
+				// Type with a generic method that IS in the MonoTable.
+				FullName:  "MyNS.GenericType",
+				ShortName: "GenericType",
+				Methods: []metacli.SurfaceMethod{
+					{
+						Name: "Select",
+						ReturnType: metacli.TypeRef{
+							FullName: "TResult",
+							Kind:     metacli.TypeRefGenericParam,
+						},
+						Params: []metacli.ParamDef{
+							{
+								Name: "item",
+								Type: metacli.TypeRef{FullName: "TSource", Kind: metacli.TypeRefGenericParam},
+							},
+						},
+					},
+				},
+			},
+			{
+				// Type with a generic method that is NOT in the MonoTable.
+				FullName:  "MyNS.OtherGeneric",
+				ShortName: "OtherGeneric",
+				Methods: []metacli.SurfaceMethod{
+					{
+						Name: "Transform",
+						ReturnType: metacli.TypeRef{
+							FullName: "T",
+							Kind:     metacli.TypeRefGenericParam,
+						},
+					},
+				},
+			},
+			{
+				// Non-generic type: passes through unchanged.
+				FullName:  "MyNS.PlainType",
+				ShortName: "PlainType",
+				Methods: []metacli.SurfaceMethod{
+					{
+						Name: "DoWork",
+						ReturnType: metacli.TypeRef{
+							FullName: "System.String",
+							Kind:     metacli.TypeRefPrimitive,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestApplyToSurface_nil(t *testing.T) {
+	tbl := &generics.MonoTable{}
+	out, skipped := generics.ApplyToSurface(nil, tbl)
+	if out == nil {
+		t.Fatal("expected non-nil output")
+	}
+	if len(skipped) != 0 {
+		t.Errorf("expected 0 skipped, got %d", len(skipped))
+	}
+}
+
+func TestApplyToSurface_genericInTable_notSkipped(t *testing.T) {
+	tbl := &generics.MonoTable{
+		Entries: []generics.MonoEntry{
+			{Item: "MyNS.GenericType.Select", TypeArgs: []string{"System.String", "System.String"}},
+		},
+	}
+	surface := makeGenericSurface()
+	out, skipped := generics.ApplyToSurface(surface, tbl)
+
+	// The OtherGeneric.Transform should be skipped.
+	var foundSkip bool
+	for _, s := range skipped {
+		if s.ItemPath == "MyNS.OtherGeneric.Transform" {
+			foundSkip = true
+			if s.Reason != errors.SkipGeneric {
+				t.Errorf("expected SkipGeneric, got %v", s.Reason)
+			}
+		}
+	}
+	if !foundSkip {
+		t.Error("expected OtherGeneric.Transform in skipped list")
+	}
+
+	// GenericType.Select should NOT be skipped.
+	for _, s := range skipped {
+		if s.ItemPath == "MyNS.GenericType.Select" {
+			t.Error("GenericType.Select should not be in skipped list (it has a MonoTable entry)")
+		}
+	}
+
+	// PlainType should appear with its method intact.
+	var foundPlain bool
+	for _, st := range out.Types {
+		if st.FullName == "MyNS.PlainType" {
+			foundPlain = true
+			if len(st.Methods) != 1 {
+				t.Errorf("PlainType: expected 1 method, got %d", len(st.Methods))
+			}
+		}
+	}
+	if !foundPlain {
+		t.Error("expected PlainType in output")
+	}
+}
+
+func TestApplyToSurface_allGenericNoTable_allSkipped(t *testing.T) {
+	tbl := &generics.MonoTable{} // empty
+	surface := &metacli.ApiSurface{
+		Types: []metacli.SurfaceType{
+			{
+				FullName: "Foo.Bar",
+				Methods: []metacli.SurfaceMethod{
+					{
+						Name: "Process",
+						ReturnType: metacli.TypeRef{
+							FullName: "T",
+							Kind:     metacli.TypeRefGenericParam,
+						},
+					},
+				},
+			},
+		},
+	}
+	_, skipped := generics.ApplyToSurface(surface, tbl)
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 skip, got %d", len(skipped))
+	}
+	if skipped[0].Reason != errors.SkipGeneric {
+		t.Errorf("expected SkipGeneric, got %v", skipped[0].Reason)
+	}
+}
+
+func TestApplyToSurface_skippedContainsOverride(t *testing.T) {
+	tbl := &generics.MonoTable{}
+	surface := &metacli.ApiSurface{
+		Types: []metacli.SurfaceType{
+			{
+				FullName: "Foo.Bar",
+				Methods: []metacli.SurfaceMethod{
+					{
+						Name:       "GenMethod",
+						ReturnType: metacli.TypeRef{FullName: "T", Kind: metacli.TypeRefGenericParam},
+					},
+				},
+			},
+		},
+	}
+	_, skipped := generics.ApplyToSurface(surface, tbl)
+	if len(skipped) == 0 {
+		t.Fatal("expected skipped entries")
+	}
+	if skipped[0].Override == "" {
+		t.Error("expected non-empty Override hint in SkipReport")
+	}
+}

--- a/package3/dotnet/nativeaot/nativeaot.go
+++ b/package3/dotnet/nativeaot/nativeaot.go
@@ -1,0 +1,229 @@
+// Package nativeaot provides NativeAOT opt-in support for MEP-68 shim projects.
+// It includes a curated compatibility database, .csproj generation helpers,
+// and static validation of shim surfaces for AOT safety.
+package nativeaot
+
+import (
+	"fmt"
+	"strings"
+
+	"mochi/package3/dotnet/shimgen"
+	"mochi/package3/dotnet/typemap"
+)
+
+// Compatibility classifies a NuGet package's NativeAOT compatibility.
+type Compatibility int
+
+const (
+	// CompatUnknown means AOT compatibility was not declared.
+	CompatUnknown Compatibility = iota
+	// CompatFull means the package declares IsAotCompatible=true.
+	CompatFull
+	// CompatPartial means the package works with AOT but has some limitations.
+	CompatPartial
+	// CompatIncompatible means the package is known to be AOT-incompatible.
+	CompatIncompatible
+)
+
+// String renders the Compatibility.
+func (c Compatibility) String() string {
+	switch c {
+	case CompatFull:
+		return "CompatFull"
+	case CompatPartial:
+		return "CompatPartial"
+	case CompatIncompatible:
+		return "CompatIncompatible"
+	default:
+		return "CompatUnknown"
+	}
+}
+
+// PackageAOTInfo holds NativeAOT compatibility information for a NuGet package.
+type PackageAOTInfo struct {
+	PackageID     string
+	Version       string
+	Compatibility Compatibility
+	// Notes explains partial/incompatible status.
+	Notes string
+}
+
+// knownCompatDB is the curated compatibility database from MEP-68 research note 11.
+// Keys are lowercase package IDs for case-insensitive lookup.
+var knownCompatDB = map[string]Compatibility{
+	"system.text.json":                                CompatFull,
+	"microsoft.extensions.dependencyinjection":        CompatFull,
+	"microsoft.extensions.http":                       CompatFull,
+	"newtonsoft.json":                                 CompatIncompatible,
+	"serilog":                                         CompatPartial,
+	"dapper":                                          CompatIncompatible,
+	"nunit":                                           CompatIncompatible,
+	"xunit":                                           CompatIncompatible,
+	"fluentassertions":                                CompatPartial,
+	"automapper":                                      CompatIncompatible,
+	"mediatr":                                         CompatPartial,
+	"fluentvalidation":                                CompatPartial,
+	"polly":                                           CompatFull,
+	"bogus":                                           CompatPartial,
+	"moq":                                             CompatIncompatible,
+	"restsharp":                                       CompatPartial,
+	"stackexchange.redis":                             CompatPartial,
+	"npgsql":                                          CompatFull,
+	"awssdk.core":                                     CompatPartial,
+	"microsoft.entityframeworkcore":                   CompatIncompatible,
+}
+
+// KnownCompatibility returns the known AOT compatibility for a package based
+// on a curated database of the MEP-68 fixture corpus (20 packages).
+// Returns CompatUnknown for packages not in the database.
+// Lookup is case-insensitive.
+func KnownCompatibility(id, version string) Compatibility {
+	key := strings.ToLower(id)
+	if c, ok := knownCompatDB[key]; ok {
+		return c
+	}
+	return CompatUnknown
+}
+
+// AOTCompatibilityFromNuspec reads the <IsAotCompatible> tag from a .nuspec
+// or .csproj string to determine declared AOT compatibility.
+// Returns CompatFull if the tag is true, CompatIncompatible if false,
+// and CompatUnknown if the tag is absent.
+func AOTCompatibilityFromNuspec(xmlContent string) Compatibility {
+	lower := strings.ToLower(xmlContent)
+	_, afterOpen, found := strings.Cut(lower, "<isaotcompatible>")
+	if !found {
+		return CompatUnknown
+	}
+	inner, _, hasClose := strings.Cut(afterOpen, "</")
+	if !hasClose {
+		return CompatUnknown
+	}
+	value := strings.TrimSpace(inner)
+	switch value {
+	case "true":
+		return CompatFull
+	case "false":
+		return CompatIncompatible
+	default:
+		return CompatUnknown
+	}
+}
+
+// EmitAOTCsproj renders the .csproj additions required for NativeAOT publishing
+// of the shim project: PublishAot=true, TrimmerRootFile, etc.
+// It returns the complete .csproj content (not a fragment).
+func EmitAOTCsproj(s *shimgen.Shim, runtimeID string) string {
+	ns := safeNamespace(s.Package)
+	var b strings.Builder
+	b.WriteString("<Project Sdk=\"Microsoft.NET.Sdk\">\n")
+	b.WriteString("  <PropertyGroup>\n")
+	fmt.Fprintf(&b, "    <TargetFramework>%s</TargetFramework>\n", s.TargetFramework)
+	b.WriteString("    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>\n")
+	b.WriteString("    <PublishAot>true</PublishAot>\n")
+	b.WriteString("    <TrimmerRootDescriptor>TrimmerRoots.xml</TrimmerRootDescriptor>\n")
+	b.WriteString("    <Nullable>enable</Nullable>\n")
+	b.WriteString("    <ImplicitUsings>disable</ImplicitUsings>\n")
+	b.WriteString("    <SelfContained>true</SelfContained>\n")
+	if runtimeID != "" {
+		fmt.Fprintf(&b, "    <RuntimeIdentifier>%s</RuntimeIdentifier>\n", runtimeID)
+	}
+	fmt.Fprintf(&b, "    <AssemblyName>MochiShim.%s</AssemblyName>\n", ns)
+	b.WriteString("  </PropertyGroup>\n")
+	b.WriteString("  <ItemGroup>\n")
+	fmt.Fprintf(&b, "    <PackageReference Include=%q Version=%q />\n",
+		s.Package, "["+s.PackageVersion+"]")
+	b.WriteString("  </ItemGroup>\n")
+	b.WriteString("</Project>\n")
+	return b.String()
+}
+
+// AOTPublishArgs returns the `dotnet publish` arguments for NativeAOT.
+// e.g. ["publish", "-c", "Release", "-r", "linux-x64", "-p:PublishAot=true"]
+func AOTPublishArgs(runtimeID string) []string {
+	args := []string{
+		"publish",
+		"-c", "Release",
+	}
+	if runtimeID != "" {
+		args = append(args, "-r", runtimeID)
+	}
+	args = append(args, "-p:PublishAot=true")
+	return args
+}
+
+// AOTWarning records a method in the shim that may not be AOT-safe.
+type AOTWarning struct {
+	Method string
+	Reason string
+}
+
+// ValidateForAOT checks whether a shimgen.Shim's type surface is AOT-safe.
+// It returns warnings for features that require runtime reflection
+// (dynamic dispatch, compound collection types in params/return that
+// require type.MakeGenericType, etc.).
+func ValidateForAOT(s *shimgen.Shim) []AOTWarning {
+	if s == nil {
+		return nil
+	}
+	var warnings []AOTWarning
+	for _, m := range s.Methods {
+		// Check return type.
+		if w, ok := checkMappingAOT(m.CSMethodName, "return", m.Return); ok {
+			warnings = append(warnings, w)
+		}
+		// Check params.
+		for _, p := range m.Params {
+			pm := p.Mapping
+			if w, ok := checkMappingAOT(m.CSMethodName, "param:"+p.Name, &pm); ok {
+				warnings = append(warnings, w)
+			}
+		}
+	}
+	return warnings
+}
+
+// checkMappingAOT returns a warning if the mapping requires reflection that
+// is not safe for NativeAOT.
+func checkMappingAOT(method, position string, m *typemap.Mapping) (AOTWarning, bool) {
+	if m == nil {
+		return AOTWarning{}, false
+	}
+	switch m.Kind {
+	case typemap.KindHandle, typemap.KindRecord:
+		// GCHandle.Alloc / GCHandle.FromIntPtr requires runtime type information
+		// but is generally safe in AOT. However, warn if the handle type is not
+		// a sealed/concrete type that can be statically rooted.
+		return AOTWarning{
+			Method: method,
+			Reason: fmt.Sprintf("position %s: handle/record type %q requires GCHandle; ensure TrimmerRoots.xml roots this type", position, m.CLRName),
+		}, true
+	case typemap.KindList, typemap.KindSet, typemap.KindMap:
+		return AOTWarning{
+			Method: method,
+			Reason: fmt.Sprintf("position %s: collection type %q may require MakeGenericType at runtime; use explicit monomorphise entries", position, m.CLRName),
+		}, true
+	case typemap.KindTuple:
+		return AOTWarning{
+			Method: method,
+			Reason: fmt.Sprintf("position %s: tuple type may require reflection; verify AOT compatibility", position),
+		}, true
+	}
+	return AOTWarning{}, false
+}
+
+// safeNamespace converts a NuGet package id to a C# namespace-safe segment.
+func safeNamespace(pkg string) string {
+	var b strings.Builder
+	for _, r := range pkg {
+		switch {
+		case r == '.', r == '-':
+			// drop separators
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}

--- a/package3/dotnet/nativeaot/nativeaot_test.go
+++ b/package3/dotnet/nativeaot/nativeaot_test.go
@@ -1,0 +1,369 @@
+package nativeaot_test
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/dotnet/nativeaot"
+	"mochi/package3/dotnet/shimgen"
+	"mochi/package3/dotnet/typemap"
+)
+
+// ---------- KnownCompatibility: all 20 packages ----------
+
+func TestKnownCompatibility_SystemTextJson(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("System.Text.Json", ""); got != nativeaot.CompatFull {
+		t.Errorf("expected CompatFull, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_MicrosoftExtensionsDI(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("Microsoft.Extensions.DependencyInjection", ""); got != nativeaot.CompatFull {
+		t.Errorf("expected CompatFull, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_MicrosoftExtensionsHttp(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("Microsoft.Extensions.Http", ""); got != nativeaot.CompatFull {
+		t.Errorf("expected CompatFull, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_NewtonsoftJson_Incompatible(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("Newtonsoft.Json", ""); got != nativeaot.CompatIncompatible {
+		t.Errorf("expected CompatIncompatible, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_Serilog_Partial(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("Serilog", ""); got != nativeaot.CompatPartial {
+		t.Errorf("expected CompatPartial, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_Dapper_Incompatible(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("Dapper", ""); got != nativeaot.CompatIncompatible {
+		t.Errorf("expected CompatIncompatible, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_NUnit_Incompatible(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("NUnit", ""); got != nativeaot.CompatIncompatible {
+		t.Errorf("expected CompatIncompatible, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_xUnit_Incompatible(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("xUnit", ""); got != nativeaot.CompatIncompatible {
+		t.Errorf("expected CompatIncompatible, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_FluentAssertions_Partial(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("FluentAssertions", ""); got != nativeaot.CompatPartial {
+		t.Errorf("expected CompatPartial, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_AutoMapper_Incompatible(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("AutoMapper", ""); got != nativeaot.CompatIncompatible {
+		t.Errorf("expected CompatIncompatible, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_MediatR_Partial(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("MediatR", ""); got != nativeaot.CompatPartial {
+		t.Errorf("expected CompatPartial, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_FluentValidation_Partial(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("FluentValidation", ""); got != nativeaot.CompatPartial {
+		t.Errorf("expected CompatPartial, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_Polly_Full(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("Polly", ""); got != nativeaot.CompatFull {
+		t.Errorf("expected CompatFull, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_Bogus_Partial(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("Bogus", ""); got != nativeaot.CompatPartial {
+		t.Errorf("expected CompatPartial, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_Moq_Incompatible(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("Moq", ""); got != nativeaot.CompatIncompatible {
+		t.Errorf("expected CompatIncompatible, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_RestSharp_Partial(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("RestSharp", ""); got != nativeaot.CompatPartial {
+		t.Errorf("expected CompatPartial, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_StackExchangeRedis_Partial(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("StackExchange.Redis", ""); got != nativeaot.CompatPartial {
+		t.Errorf("expected CompatPartial, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_Npgsql_Full(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("Npgsql", ""); got != nativeaot.CompatFull {
+		t.Errorf("expected CompatFull, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_AWSSdk_Partial(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("AWSSDK.Core", ""); got != nativeaot.CompatPartial {
+		t.Errorf("expected CompatPartial, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_EFCore_Incompatible(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("Microsoft.EntityFrameworkCore", ""); got != nativeaot.CompatIncompatible {
+		t.Errorf("expected CompatIncompatible, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_Unknown(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("SomeRandomPackage.Unknown", "1.0.0"); got != nativeaot.CompatUnknown {
+		t.Errorf("expected CompatUnknown, got %v", got)
+	}
+}
+
+func TestKnownCompatibility_caseInsensitive(t *testing.T) {
+	if got := nativeaot.KnownCompatibility("newtonsoft.json", ""); got != nativeaot.CompatIncompatible {
+		t.Errorf("case-insensitive lookup failed, got %v", got)
+	}
+}
+
+// ---------- Compatibility.String ----------
+
+func TestCompatibility_String(t *testing.T) {
+	cases := []struct {
+		c    nativeaot.Compatibility
+		want string
+	}{
+		{nativeaot.CompatUnknown, "CompatUnknown"},
+		{nativeaot.CompatFull, "CompatFull"},
+		{nativeaot.CompatPartial, "CompatPartial"},
+		{nativeaot.CompatIncompatible, "CompatIncompatible"},
+	}
+	for _, tc := range cases {
+		if got := tc.c.String(); got != tc.want {
+			t.Errorf("String() = %q, want %q", got, tc.want)
+		}
+	}
+}
+
+// ---------- AOTCompatibilityFromNuspec ----------
+
+func TestAOTCompatibilityFromNuspec_trueTag(t *testing.T) {
+	xml := `<Project><PropertyGroup><IsAotCompatible>true</IsAotCompatible></PropertyGroup></Project>`
+	if got := nativeaot.AOTCompatibilityFromNuspec(xml); got != nativeaot.CompatFull {
+		t.Errorf("expected CompatFull, got %v", got)
+	}
+}
+
+func TestAOTCompatibilityFromNuspec_falseTag(t *testing.T) {
+	xml := `<Project><PropertyGroup><IsAotCompatible>false</IsAotCompatible></PropertyGroup></Project>`
+	if got := nativeaot.AOTCompatibilityFromNuspec(xml); got != nativeaot.CompatIncompatible {
+		t.Errorf("expected CompatIncompatible, got %v", got)
+	}
+}
+
+func TestAOTCompatibilityFromNuspec_noTag(t *testing.T) {
+	xml := `<Project><PropertyGroup></PropertyGroup></Project>`
+	if got := nativeaot.AOTCompatibilityFromNuspec(xml); got != nativeaot.CompatUnknown {
+		t.Errorf("expected CompatUnknown, got %v", got)
+	}
+}
+
+func TestAOTCompatibilityFromNuspec_empty(t *testing.T) {
+	if got := nativeaot.AOTCompatibilityFromNuspec(""); got != nativeaot.CompatUnknown {
+		t.Errorf("expected CompatUnknown for empty, got %v", got)
+	}
+}
+
+// ---------- EmitAOTCsproj ----------
+
+func TestEmitAOTCsproj_containsPublishAot(t *testing.T) {
+	s := &shimgen.Shim{Package: "Newtonsoft.Json", PackageVersion: "13.0.3", TargetFramework: "net8.0"}
+	got := nativeaot.EmitAOTCsproj(s, "linux-x64")
+	if !strings.Contains(got, "PublishAot") {
+		t.Errorf("expected PublishAot in output, got: %s", got)
+	}
+}
+
+func TestEmitAOTCsproj_containsRuntimeID(t *testing.T) {
+	s := &shimgen.Shim{Package: "Polly", PackageVersion: "8.0.0", TargetFramework: "net8.0"}
+	got := nativeaot.EmitAOTCsproj(s, "linux-x64")
+	if !strings.Contains(got, "linux-x64") {
+		t.Errorf("expected linux-x64 in output, got: %s", got)
+	}
+}
+
+func TestEmitAOTCsproj_containsTrimmerRoot(t *testing.T) {
+	s := &shimgen.Shim{Package: "Polly", PackageVersion: "8.0.0", TargetFramework: "net8.0"}
+	got := nativeaot.EmitAOTCsproj(s, "")
+	if !strings.Contains(got, "TrimmerRoot") {
+		t.Errorf("expected TrimmerRoot in output, got: %s", got)
+	}
+}
+
+func TestEmitAOTCsproj_emptyRuntimeID(t *testing.T) {
+	s := &shimgen.Shim{Package: "Polly", PackageVersion: "8.0.0", TargetFramework: "net8.0"}
+	got := nativeaot.EmitAOTCsproj(s, "")
+	// Should not contain an empty RuntimeIdentifier element.
+	if strings.Contains(got, "<RuntimeIdentifier></RuntimeIdentifier>") {
+		t.Error("should not emit empty RuntimeIdentifier")
+	}
+}
+
+// ---------- AOTPublishArgs ----------
+
+func TestAOTPublishArgs_basic(t *testing.T) {
+	args := nativeaot.AOTPublishArgs("linux-x64")
+	if len(args) == 0 {
+		t.Fatal("expected non-empty args")
+	}
+	if args[0] != "publish" {
+		t.Errorf("expected first arg to be 'publish', got %s", args[0])
+	}
+}
+
+func TestAOTPublishArgs_containsRelease(t *testing.T) {
+	args := nativeaot.AOTPublishArgs("linux-x64")
+	found := false
+	for _, a := range args {
+		if a == "Release" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected Release in args: %v", args)
+	}
+}
+
+func TestAOTPublishArgs_containsRuntimeID(t *testing.T) {
+	args := nativeaot.AOTPublishArgs("win-x64")
+	found := false
+	for _, a := range args {
+		if a == "win-x64" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected win-x64 in args: %v", args)
+	}
+}
+
+func TestAOTPublishArgs_containsPublishAotFlag(t *testing.T) {
+	args := nativeaot.AOTPublishArgs("osx-arm64")
+	found := false
+	for _, a := range args {
+		if strings.Contains(a, "PublishAot=true") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected PublishAot=true in args: %v", args)
+	}
+}
+
+func TestAOTPublishArgs_emptyRuntimeID(t *testing.T) {
+	args := nativeaot.AOTPublishArgs("")
+	for _, a := range args {
+		if a == "-r" {
+			t.Error("should not include -r flag for empty runtime ID")
+		}
+	}
+}
+
+// ---------- ValidateForAOT ----------
+
+func makeHandleShim() *shimgen.Shim {
+	handleMapping := typemap.Mapping{
+		Kind:       typemap.KindHandle,
+		CLRName:    "Newtonsoft.Json.JsonConverter",
+		HandleName: "JsonConverter",
+	}
+	return &shimgen.Shim{
+		Package: "Newtonsoft.Json",
+		Methods: []shimgen.ShimMethod{
+			{
+				CSMethodName: "JsonConvert_Deserialize",
+				Return:       &handleMapping,
+			},
+			{
+				CSMethodName: "JsonConvert_ParseArgs",
+				Return:       nil,
+				Params: []shimgen.ShimParam{
+					{Name: "obj", Mapping: handleMapping},
+				},
+			},
+		},
+	}
+}
+
+func TestValidateForAOT_nil(t *testing.T) {
+	warnings := nativeaot.ValidateForAOT(nil)
+	if len(warnings) != 0 {
+		t.Errorf("expected 0 warnings for nil shim, got %d", len(warnings))
+	}
+}
+
+func TestValidateForAOT_handleTypeProducesWarnings(t *testing.T) {
+	s := makeHandleShim()
+	warnings := nativeaot.ValidateForAOT(s)
+	if len(warnings) == 0 {
+		t.Fatal("expected warnings for handle-typed methods")
+	}
+}
+
+func TestValidateForAOT_warningContainsMethodName(t *testing.T) {
+	s := makeHandleShim()
+	warnings := nativeaot.ValidateForAOT(s)
+	found := false
+	for _, w := range warnings {
+		if w.Method == "JsonConvert_Deserialize" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for JsonConvert_Deserialize, got: %v", warnings)
+	}
+}
+
+func TestValidateForAOT_warningHasReason(t *testing.T) {
+	s := makeHandleShim()
+	warnings := nativeaot.ValidateForAOT(s)
+	for _, w := range warnings {
+		if w.Reason == "" {
+			t.Errorf("warning for %s has empty reason", w.Method)
+		}
+	}
+}
+
+func TestValidateForAOT_plainScalarsNoWarnings(t *testing.T) {
+	strMapping := typemap.Mapping{Kind: typemap.KindString}
+	s := &shimgen.Shim{
+		Methods: []shimgen.ShimMethod{
+			{
+				CSMethodName: "Foo_Bar",
+				Return:       &strMapping,
+				Params:       []shimgen.ShimParam{{Name: "x", Mapping: typemap.Mapping{Kind: typemap.KindInt}}},
+			},
+		},
+	}
+	warnings := nativeaot.ValidateForAOT(s)
+	if len(warnings) != 0 {
+		t.Errorf("expected 0 warnings for plain scalar types, got %d: %v", len(warnings), warnings)
+	}
+}

--- a/package3/dotnet/publish/oidc.go
+++ b/package3/dotnet/publish/oidc.go
@@ -1,0 +1,250 @@
+// Package publish provides NuGet package emit and trusted-publishing flows.
+package publish
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+// OIDCConfig holds configuration for the GitHub Actions OIDC trusted publishing flow.
+type OIDCConfig struct {
+	// PackageID is the NuGet package id to publish.
+	PackageID string
+	// PackageVersion is the version to publish.
+	PackageVersion string
+	// NuGetRegistryURL is the registry endpoint.
+	// Default: "https://api.nuget.org/v3/index.json"
+	NuGetRegistryURL string
+	// OIDCTokenURL is the GitHub Actions OIDC token endpoint.
+	// Sourced from $ACTIONS_ID_TOKEN_REQUEST_URL.
+	OIDCTokenURL string
+	// OIDCRequestToken is the bearer token for the OIDC request.
+	// Sourced from $ACTIONS_ID_TOKEN_REQUEST_TOKEN.
+	OIDCRequestToken string
+	// DryRun skips the upload step; still exercises the token exchange flow
+	// against a mock server if MockFulcioURL is set.
+	DryRun bool
+	// MockFulcioURL overrides the Fulcio endpoint for testing.
+	MockFulcioURL string
+}
+
+// OIDCTokenResponse is the response from the OIDC token endpoint.
+type OIDCTokenResponse struct {
+	Value string `json:"value"`
+}
+
+// NuGetPublishToken is the short-lived token from nuget.org.
+type NuGetPublishToken struct {
+	Token     string
+	ExpiresAt time.Time
+}
+
+// nugetExchangeResponse is the JSON body from the trusted-publishing exchange endpoint.
+type nugetExchangeResponse struct {
+	Token     string `json:"token"`
+	ExpiresAt string `json:"expiresAt"`
+}
+
+// nugetExchangeRequest is the JSON body sent to the trusted-publishing exchange endpoint.
+type nugetExchangeRequest struct {
+	OIDCToken string `json:"oidcToken"`
+}
+
+// nuGetRegistryDefault is the default NuGet v3 index endpoint.
+const nuGetRegistryDefault = "https://api.nuget.org/v3/index.json"
+
+// nuGetExchangeEndpoint is the trusted-publishing token exchange endpoint.
+const nuGetExchangeEndpoint = "https://api.nuget.org/v3/trustedpublishing/exchange"
+
+// nuGetUploadEndpoint is the v2 package upload endpoint.
+const nuGetUploadEndpoint = "https://www.nuget.org/api/v2/package"
+
+// FetchOIDCToken retrieves a GitHub Actions OIDC JWT from the token endpoint.
+func FetchOIDCToken(ctx context.Context, tokenURL, requestToken string) (string, error) {
+	if tokenURL == "" {
+		return "", fmt.Errorf("publish: OIDC token URL is empty; set ACTIONS_ID_TOKEN_REQUEST_URL")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("publish: build OIDC token request: %w", err)
+	}
+	if requestToken != "" {
+		req.Header.Set("Authorization", "Bearer "+requestToken)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("publish: fetch OIDC token: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("publish: read OIDC token response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("publish: OIDC token endpoint returned %d: %s", resp.StatusCode, string(body))
+	}
+	var tok OIDCTokenResponse
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return "", fmt.Errorf("publish: decode OIDC token response: %w", err)
+	}
+	if tok.Value == "" {
+		return "", fmt.Errorf("publish: OIDC token response has empty value")
+	}
+	return tok.Value, nil
+}
+
+// ExchangeForNuGetToken presents the OIDC JWT to nuget.org's trusted-publishing
+// endpoint and returns a short-lived API token.
+// Endpoint: POST https://api.nuget.org/v3/trustedpublishing/exchange
+// Body: { "oidcToken": "<jwt>" }
+// Response: { "token": "<nuget-token>", "expiresAt": "<iso8601>" }
+func ExchangeForNuGetToken(ctx context.Context, cfg OIDCConfig, oidcJWT string) (*NuGetPublishToken, error) {
+	exchangeURL := nuGetExchangeEndpoint
+	if cfg.MockFulcioURL != "" {
+		exchangeURL = cfg.MockFulcioURL
+	}
+
+	payload, err := json.Marshal(nugetExchangeRequest{OIDCToken: oidcJWT})
+	if err != nil {
+		return nil, fmt.Errorf("publish: marshal exchange request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, exchangeURL, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("publish: build exchange request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("publish: exchange token: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("publish: read exchange response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("publish: exchange endpoint returned %d: %s", resp.StatusCode, string(body))
+	}
+	var r nugetExchangeResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, fmt.Errorf("publish: decode exchange response: %w", err)
+	}
+	if r.Token == "" {
+		return nil, fmt.Errorf("publish: exchange response has empty token")
+	}
+	var expiresAt time.Time
+	if r.ExpiresAt != "" {
+		expiresAt, err = time.Parse(time.RFC3339, r.ExpiresAt)
+		if err != nil {
+			// Try without nanoseconds.
+			expiresAt, err = time.Parse("2006-01-02T15:04:05Z", r.ExpiresAt)
+			if err != nil {
+				// Non-fatal: use zero time.
+				expiresAt = time.Time{}
+			}
+		}
+	}
+	return &NuGetPublishToken{Token: r.Token, ExpiresAt: expiresAt}, nil
+}
+
+// PublishNupkg uploads a .nupkg file to nuget.org using the given API token.
+// Endpoint: PUT https://www.nuget.org/api/v2/package
+// Header: X-NuGet-ApiKey: <token>
+func PublishNupkg(ctx context.Context, registryURL, token, nupkgPath string) error {
+	uploadURL := registryURL
+	if uploadURL == "" {
+		uploadURL = nuGetUploadEndpoint
+	}
+
+	f, err := os.Open(nupkgPath)
+	if err != nil {
+		return fmt.Errorf("publish: open nupkg %s: %w", nupkgPath, err)
+	}
+	defer f.Close()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, f)
+	if err != nil {
+		return fmt.Errorf("publish: build upload request: %w", err)
+	}
+	req.Header.Set("X-NuGet-ApiKey", token)
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("publish: upload nupkg: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("publish: upload returned %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// OIDCPublishResult records the outcome of a trusted publishing run.
+type OIDCPublishResult struct {
+	PackageID           string
+	PackageVersion      string
+	DryRun              bool
+	OIDCTokenFetched    bool
+	NuGetTokenExchanged bool
+	Uploaded            bool
+	RegistryURL         string
+	Error               error
+}
+
+// Run executes the full trusted publishing flow:
+// 1. Fetch OIDC token from GitHub Actions
+// 2. Exchange for nuget.org token
+// 3. Upload .nupkg
+// Returns an OIDCPublishResult with status and any error.
+func Run(ctx context.Context, cfg OIDCConfig, nupkgPath string) (*OIDCPublishResult, error) {
+	result := &OIDCPublishResult{
+		PackageID:      cfg.PackageID,
+		PackageVersion: cfg.PackageVersion,
+		DryRun:         cfg.DryRun,
+		RegistryURL:    cfg.NuGetRegistryURL,
+	}
+	if result.RegistryURL == "" {
+		result.RegistryURL = nuGetRegistryDefault
+	}
+
+	// Step 1: Fetch OIDC token.
+	oidcJWT, err := FetchOIDCToken(ctx, cfg.OIDCTokenURL, cfg.OIDCRequestToken)
+	if err != nil {
+		result.Error = err
+		return result, err
+	}
+	result.OIDCTokenFetched = true
+
+	// Step 2: Exchange for NuGet token.
+	nugetTok, err := ExchangeForNuGetToken(ctx, cfg, oidcJWT)
+	if err != nil {
+		result.Error = err
+		return result, err
+	}
+	result.NuGetTokenExchanged = true
+
+	// Step 3: Upload .nupkg (unless dry run).
+	if cfg.DryRun {
+		return result, nil
+	}
+
+	uploadURL := cfg.NuGetRegistryURL
+	if uploadURL == "" || uploadURL == nuGetRegistryDefault {
+		uploadURL = nuGetUploadEndpoint
+	}
+	if err := PublishNupkg(ctx, uploadURL, nugetTok.Token, nupkgPath); err != nil {
+		result.Error = err
+		return result, err
+	}
+	result.Uploaded = true
+	return result, nil
+}

--- a/package3/dotnet/publish/oidc_test.go
+++ b/package3/dotnet/publish/oidc_test.go
@@ -1,0 +1,406 @@
+package publish_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/package3/dotnet/publish"
+)
+
+// ---------- FetchOIDCToken tests ----------
+
+func TestFetchOIDCToken_emptyURL(t *testing.T) {
+	_, err := publish.FetchOIDCToken(context.Background(), "", "tok")
+	if err == nil {
+		t.Fatal("expected error for empty URL")
+	}
+}
+
+func TestFetchOIDCToken_success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer mytoken" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(publish.OIDCTokenResponse{Value: "jwt-value-abc"})
+	}))
+	defer srv.Close()
+
+	got, err := publish.FetchOIDCToken(context.Background(), srv.URL, "mytoken")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "jwt-value-abc" {
+		t.Errorf("expected jwt-value-abc, got %s", got)
+	}
+}
+
+func TestFetchOIDCToken_non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	_, err := publish.FetchOIDCToken(context.Background(), srv.URL, "")
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("expected 403 in error, got: %v", err)
+	}
+}
+
+func TestFetchOIDCToken_malformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not-json{"))
+	}))
+	defer srv.Close()
+
+	_, err := publish.FetchOIDCToken(context.Background(), srv.URL, "")
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestFetchOIDCToken_emptyValue(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(publish.OIDCTokenResponse{Value: ""})
+	}))
+	defer srv.Close()
+
+	_, err := publish.FetchOIDCToken(context.Background(), srv.URL, "")
+	if err == nil {
+		t.Fatal("expected error for empty value")
+	}
+}
+
+// ---------- ExchangeForNuGetToken tests ----------
+
+func TestExchangeForNuGetToken_success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token":"nuget-secret","expiresAt":"2026-06-01T00:00:00Z"}`))
+	}))
+	defer srv.Close()
+
+	cfg := publish.OIDCConfig{MockFulcioURL: srv.URL}
+	tok, err := publish.ExchangeForNuGetToken(context.Background(), cfg, "my-jwt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok.Token != "nuget-secret" {
+		t.Errorf("expected nuget-secret, got %s", tok.Token)
+	}
+	if tok.ExpiresAt.IsZero() {
+		t.Error("expected non-zero ExpiresAt")
+	}
+}
+
+func TestExchangeForNuGetToken_non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	cfg := publish.OIDCConfig{MockFulcioURL: srv.URL}
+	_, err := publish.ExchangeForNuGetToken(context.Background(), cfg, "jwt")
+	if err == nil {
+		t.Fatal("expected error for 503")
+	}
+}
+
+func TestExchangeForNuGetToken_malformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{{bad"))
+	}))
+	defer srv.Close()
+
+	cfg := publish.OIDCConfig{MockFulcioURL: srv.URL}
+	_, err := publish.ExchangeForNuGetToken(context.Background(), cfg, "jwt")
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestExchangeForNuGetToken_emptyToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token":"","expiresAt":"2026-06-01T00:00:00Z"}`))
+	}))
+	defer srv.Close()
+
+	cfg := publish.OIDCConfig{MockFulcioURL: srv.URL}
+	_, err := publish.ExchangeForNuGetToken(context.Background(), cfg, "jwt")
+	if err == nil {
+		t.Fatal("expected error for empty token")
+	}
+}
+
+func TestExchangeForNuGetToken_noExpiresAt(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token":"tok123"}`))
+	}))
+	defer srv.Close()
+
+	cfg := publish.OIDCConfig{MockFulcioURL: srv.URL}
+	tok, err := publish.ExchangeForNuGetToken(context.Background(), cfg, "jwt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok.Token != "tok123" {
+		t.Errorf("expected tok123, got %s", tok.Token)
+	}
+}
+
+// ---------- PublishNupkg tests ----------
+
+func TestPublishNupkg_success(t *testing.T) {
+	var gotKey string
+	var gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotKey = r.Header.Get("X-NuGet-ApiKey")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	// Write a temp nupkg file.
+	f, err := os.CreateTemp(t.TempDir(), "*.nupkg")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	_ = f.Close()
+
+	err = publish.PublishNupkg(context.Background(), srv.URL, "the-api-key", f.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("expected PUT, got %s", gotMethod)
+	}
+	if gotKey != "the-api-key" {
+		t.Errorf("expected the-api-key, got %s", gotKey)
+	}
+}
+
+func TestPublishNupkg_non2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "conflict", http.StatusConflict)
+	}))
+	defer srv.Close()
+
+	f, err := os.CreateTemp(t.TempDir(), "*.nupkg")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	_ = f.Close()
+
+	err = publish.PublishNupkg(context.Background(), srv.URL, "key", f.Name())
+	if err == nil {
+		t.Fatal("expected error for 409")
+	}
+}
+
+func TestPublishNupkg_missingFile(t *testing.T) {
+	err := publish.PublishNupkg(context.Background(), "http://nowhere", "key", "/nonexistent/path.nupkg")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+// ---------- Run (dry-run) tests ----------
+
+func TestRun_dryRun_success(t *testing.T) {
+	// Mock OIDC endpoint.
+	oidcSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(publish.OIDCTokenResponse{Value: "jwt-from-gha"})
+	}))
+	defer oidcSrv.Close()
+
+	// Mock exchange endpoint.
+	exchangeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token":"nuget-dry","expiresAt":"2026-06-01T00:00:00Z"}`))
+	}))
+	defer exchangeSrv.Close()
+
+	cfg := publish.OIDCConfig{
+		PackageID:      "My.Package",
+		PackageVersion: "1.0.0",
+		OIDCTokenURL:   oidcSrv.URL,
+		MockFulcioURL:  exchangeSrv.URL,
+		DryRun:         true,
+	}
+
+	result, err := publish.Run(context.Background(), cfg, "/nonexistent.nupkg")
+	if err != nil {
+		t.Fatalf("unexpected error in dry run: %v", err)
+	}
+	if !result.OIDCTokenFetched {
+		t.Error("expected OIDCTokenFetched to be true")
+	}
+	if !result.NuGetTokenExchanged {
+		t.Error("expected NuGetTokenExchanged to be true")
+	}
+	if result.Uploaded {
+		t.Error("expected Uploaded to be false in dry-run mode")
+	}
+	if result.DryRun != true {
+		t.Error("expected DryRun to be true")
+	}
+}
+
+func TestRun_fullMode_success(t *testing.T) {
+	oidcSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(publish.OIDCTokenResponse{Value: "jwt-value"})
+	}))
+	defer oidcSrv.Close()
+
+	exchangeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token":"upload-token","expiresAt":"2026-06-01T00:00:00Z"}`))
+	}))
+	defer exchangeSrv.Close()
+
+	uploadSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer uploadSrv.Close()
+
+	// Create temp nupkg.
+	nupkgPath := filepath.Join(t.TempDir(), "test.nupkg")
+	if err := os.WriteFile(nupkgPath, []byte("fake-nupkg"), 0o644); err != nil {
+		t.Fatalf("write nupkg: %v", err)
+	}
+
+	cfg := publish.OIDCConfig{
+		PackageID:        "My.Package",
+		PackageVersion:   "1.0.0",
+		NuGetRegistryURL: uploadSrv.URL,
+		OIDCTokenURL:     oidcSrv.URL,
+		MockFulcioURL:    exchangeSrv.URL,
+		DryRun:           false,
+	}
+
+	result, err := publish.Run(context.Background(), cfg, nupkgPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.OIDCTokenFetched {
+		t.Error("expected OIDCTokenFetched true")
+	}
+	if !result.NuGetTokenExchanged {
+		t.Error("expected NuGetTokenExchanged true")
+	}
+	if !result.Uploaded {
+		t.Error("expected Uploaded true")
+	}
+}
+
+func TestRun_oidcFetchFails(t *testing.T) {
+	// Use a server that returns 500.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := publish.OIDCConfig{
+		OIDCTokenURL:  srv.URL,
+		MockFulcioURL: srv.URL,
+	}
+	result, err := publish.Run(context.Background(), cfg, "/tmp/x.nupkg")
+	if err == nil {
+		t.Fatal("expected error when OIDC fetch fails")
+	}
+	if result.OIDCTokenFetched {
+		t.Error("OIDCTokenFetched should be false")
+	}
+}
+
+func TestRun_exchangeFails(t *testing.T) {
+	oidcSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(publish.OIDCTokenResponse{Value: "jwt"})
+	}))
+	defer oidcSrv.Close()
+
+	exchangeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+	}))
+	defer exchangeSrv.Close()
+
+	cfg := publish.OIDCConfig{
+		OIDCTokenURL:  oidcSrv.URL,
+		MockFulcioURL: exchangeSrv.URL,
+	}
+	result, err := publish.Run(context.Background(), cfg, "/tmp/x.nupkg")
+	if err == nil {
+		t.Fatal("expected error when exchange fails")
+	}
+	if !result.OIDCTokenFetched {
+		t.Error("expected OIDCTokenFetched true after OIDC success")
+	}
+	if result.NuGetTokenExchanged {
+		t.Error("NuGetTokenExchanged should be false")
+	}
+}
+
+func TestRun_resultContainsPackageInfo(t *testing.T) {
+	oidcSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(publish.OIDCTokenResponse{Value: "jwt"})
+	}))
+	defer oidcSrv.Close()
+
+	exchangeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token":"t","expiresAt":"2026-06-01T00:00:00Z"}`))
+	}))
+	defer exchangeSrv.Close()
+
+	cfg := publish.OIDCConfig{
+		PackageID:      "Foo.Bar",
+		PackageVersion: "2.3.4",
+		OIDCTokenURL:   oidcSrv.URL,
+		MockFulcioURL:  exchangeSrv.URL,
+		DryRun:         true,
+	}
+	result, err := publish.Run(context.Background(), cfg, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.PackageID != "Foo.Bar" {
+		t.Errorf("expected Foo.Bar, got %s", result.PackageID)
+	}
+	if result.PackageVersion != "2.3.4" {
+		t.Errorf("expected 2.3.4, got %s", result.PackageVersion)
+	}
+}
+
+func TestRun_defaultRegistryURL(t *testing.T) {
+	cfg := publish.OIDCConfig{
+		PackageID:    "X",
+		OIDCTokenURL: "http://bad-host",
+	}
+	result, _ := publish.Run(context.Background(), cfg, "")
+	if !strings.HasPrefix(result.RegistryURL, "https://") {
+		t.Errorf("expected https:// registry URL, got %s", result.RegistryURL)
+	}
+}


### PR DESCRIPTION
## Summary
- Phase 10: `publish/oidc` — FetchOIDCToken, ExchangeForNuGetToken, PublishNupkg, Run (dry-run + mock)
- Phase 11: `asyncbridge` — DispatchGetAwaiter/ManualReset/TaskRun; EmitAsyncWrapper; EmitAsyncRuntimeCS; RewriteForMode
- Phase 12: `generics` — MonoTable/ParseMonoTable; MonomorphiseMethod; ApplyToSurface with SkipGeneric accumulation
- Phase 13: `nativeaot` — KnownCompatibility (20-package corpus); AOTCompatibilityFromNuspec; EmitAOTCsproj; ValidateForAOT
- Integration test: TestPipeline_EndToEnd (30 assertions, full workspace materialisation)

## Test plan
- [ ] 413 tests pass across 15 packages (`go test -v ./package3/dotnet/...`)
- [ ] `go vet ./package3/dotnet/...` clean