### PR TITLE
MEP-52 Phase 11. Wire actual tracking issue + PR numbers in the spec doc

### DIFF
--- a/website/docs/implementation/0052/phase-11-async.md
+++ b/website/docs/implementation/0052/phase-11-async.md
@@ -13,8 +13,8 @@ description: "MEP-52 Phase 11, panic + try-catch lowered to native JS throw with
 | Status         | LANDED (Node + Deno + Bun) |
 | Started        | 2026-05-30 00:05 (GMT+7) |
 | Landed         | 2026-05-30 00:35 (GMT+7) |
-| Tracking issue | (pending PR) |
-| Tracking PR    | (pending PR) |
+| Tracking issue | [#22922](https://github.com/mochilang/mochi/issues/22922) |
+| Tracking PR    | [#22924](https://github.com/mochilang/mochi/pull/22924) |
 
 ## Gate
 


### PR DESCRIPTION
Phase 11 doc fixup. Replaces the `(pending PR)` placeholders in `website/docs/implementation/0052/phase-11-async.md` with the actual tracking issue #22922 and tracking PR #22924 (already merged into worktree-mep52-phase10 as part of the daisy-chain).

Tracking issue: #22922

## Test plan

- [x] Trivial doc fixup; no code changes.