### PR TITLE
mep73: phase 12 monomorphisation pipeline

### DIFF
--- a/package3/rust/monomorphise/monomorphise.go
+++ b/package3/rust/monomorphise/monomorphise.go
@@ -1,0 +1,383 @@
+// Package monomorphise owns the MEP-73 Phase 12 generic-instantiation
+// pipeline. Phase 3's type-mapping table refuses any function whose
+// signature contains a generic parameter (`fn from_str<T>(s: &str)`)
+// because the bridge cannot synthesise a wrapper without a concrete
+// substitution for `T`. Phase 12 unlocks this case via an explicit
+// `[rust.monomorphise]` table in `mochi.toml`: the user enumerates the
+// concretisations they need, and the bridge emits one extern "C"
+// wrapper per (item, type-args) pair.
+//
+// This package owns:
+//
+//   - The on-wire shape of the `[rust.monomorphise]` table (Spec, Entry).
+//   - The TOML parser that reads it.
+//   - The per-instantiation symbol mangler (extern name + Rust call
+//     site path).
+//   - The lookup index from "<item-path>" + sorted type-args to the
+//     matching Entry, so wrapper.Synth can decide whether a generic
+//     fn was monomorphised or should be refused.
+//
+// The package intentionally only sees the user's enumerated set: no
+// inference, no auto-monomorphisation. The combinatorial-explosion
+// risk called out in MEP-73 §Risks is hard-bounded by the manifest's
+// own length.
+package monomorphise
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"mochi/package3/rust/rustdoc"
+)
+
+// Spec is the parsed `[rust.monomorphise]` table.
+type Spec struct {
+	// Entries is the list in declaration order. Iteration order
+	// matches the user's manifest layout for deterministic emit.
+	Entries []Entry
+}
+
+// Entry is one explicit instantiation. Item is the upstream Rust
+// path of the generic item (e.g. "serde_json::from_str" or
+// "Vec::new"). TypeArgs is the per-type-parameter substitution,
+// keyed by the type-parameter name as it appears in the rustdoc
+// surface (e.g. "T", "K", "V").
+//
+// Example manifest line:
+//
+//	monomorphise = [
+//	    { item = "serde_json::from_str", T = "MyStruct" },
+//	    { item = "Vec::new", T = "i64" },
+//	]
+//
+// becomes:
+//
+//	Entry{Item: "serde_json::from_str", TypeArgs: {"T": "MyStruct"}}
+//	Entry{Item: "Vec::new",              TypeArgs: {"T": "i64"}}
+type Entry struct {
+	Item     string
+	TypeArgs map[string]string
+}
+
+// ErrInvalid is returned when an Entry is structurally bad. The
+// Reason field carries the human-readable diagnostic.
+type ErrInvalid struct{ Reason string }
+
+// Error implements error.
+func (e ErrInvalid) Error() string { return "monomorphise: " + e.Reason }
+
+// Validate checks that every Entry has a non-empty Item and at least
+// one TypeArg. Empty items would mangle to ambiguous symbols; empty
+// TypeArgs would defeat the point of an instantiation entry (the
+// generic refusal would still fire).
+func (s Spec) Validate() error {
+	for i, e := range s.Entries {
+		if strings.TrimSpace(e.Item) == "" {
+			return ErrInvalid{Reason: fmt.Sprintf("entry %d: empty item path", i)}
+		}
+		if len(e.TypeArgs) == 0 {
+			return ErrInvalid{Reason: fmt.Sprintf("entry %d (%s): no type-args", i, e.Item)}
+		}
+		for k, v := range e.TypeArgs {
+			if strings.TrimSpace(k) == "" {
+				return ErrInvalid{Reason: fmt.Sprintf("entry %d (%s): empty type-parameter name", i, e.Item)}
+			}
+			if strings.TrimSpace(v) == "" {
+				return ErrInvalid{Reason: fmt.Sprintf("entry %d (%s): empty substitution for %s", i, e.Item, k)}
+			}
+		}
+	}
+	return nil
+}
+
+// Lookup finds an Entry by Item path. Returns nil if no monomorphise
+// entry was declared for the path. The Spec is intentionally a flat
+// slice (small N, manifest-bounded); a linear scan is faster than
+// any map for the expected sizes (a-few-tens of entries).
+func (s Spec) Lookup(item string) []Entry {
+	out := make([]Entry, 0, len(s.Entries))
+	for _, e := range s.Entries {
+		if e.Item == item {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// ExternName mangles an (item, type-args) pair into a stable
+// extern "C" symbol. The shape mirrors wrapper.externName for sync
+// fns and appends a `_of_` suffix carrying the type-args in sorted
+// (type-param-name) order. Sorting keeps the symbol byte-stable
+// across runs even though TypeArgs is a map.
+//
+// Example: ("serde_json::from_str", {"T": "MyStruct"}) becomes
+// "mochi_serde_json_from_str_of_t_my_struct".
+func ExternName(upstream, item string, typeArgs map[string]string) string {
+	out := "mochi_" + sanitize(upstream)
+	for _, seg := range itemSegments(upstream, item) {
+		out += "_" + sanitize(seg)
+	}
+	if len(typeArgs) == 0 {
+		return out
+	}
+	out += "_of"
+	keys := sortedKeys(typeArgs)
+	for _, k := range keys {
+		out += "_" + sanitize(k) + "_" + sanitize(typeArgs[k])
+	}
+	return out
+}
+
+// CallSite renders the concretised Rust path the wrapper body calls
+// for an Entry. For "serde_json::from_str" with T=MyStruct this is
+// "serde_json::from_str::<MyStruct>"; the turbofish ordering matches
+// the rustdoc-types declaration order via sortedKeys.
+//
+// Multi-arg substitutions render as "<A, B>" with the type-parameter
+// names sorted for byte stability.
+func CallSite(item string, typeArgs map[string]string) string {
+	if len(typeArgs) == 0 {
+		return item
+	}
+	keys := sortedKeys(typeArgs)
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = typeArgs[k]
+	}
+	return item + "::<" + strings.Join(parts, ", ") + ">"
+}
+
+// Substitute recursively walks a rustdoc.Type and replaces every
+// Generic node whose name appears in `subs` with a concrete type
+// derived from the substitution string. Substitutions that match a
+// known Rust primitive (e.g. "i64", "bool") become primitive types;
+// anything else becomes a resolved_path with the substitution as the
+// path text. Non-generic positions are returned unchanged, so the
+// caller can run typemap.Map on the result without further dispatch.
+//
+// Substitute is intentionally a shallow lowering: it does not parse
+// nested turbofish (`Vec<i64>` substitutions remain a single
+// resolved_path string) because typemap rejects such constructs at
+// the path-name layer anyway. Phase 12's contract is one-level
+// concretisation.
+func Substitute(t rustdoc.Type, subs map[string]string) rustdoc.Type {
+	if t.Generic != "" {
+		if sub, ok := subs[t.Generic]; ok {
+			return concretise(sub)
+		}
+		return t
+	}
+	if t.Tuple != nil {
+		out := make([]rustdoc.Type, len(t.Tuple))
+		for i, e := range t.Tuple {
+			out[i] = Substitute(e, subs)
+		}
+		t.Tuple = out
+	}
+	if t.Slice != nil {
+		s := Substitute(*t.Slice, subs)
+		t.Slice = &s
+	}
+	if t.Array != nil {
+		a := Substitute(t.Array.Type, subs)
+		t.Array.Type = a
+	}
+	if t.BorrowedRef != nil {
+		b := Substitute(t.BorrowedRef.Type, subs)
+		t.BorrowedRef.Type = b
+	}
+	if t.ResolvedPath != nil && t.ResolvedPath.Args != nil && t.ResolvedPath.Args.AngleBracketed != nil {
+		args := t.ResolvedPath.Args.AngleBracketed.Args
+		out := make([]rustdoc.GenericArg, len(args))
+		for i, a := range args {
+			if a.Type != nil {
+				sub := Substitute(*a.Type, subs)
+				a.Type = &sub
+			}
+			out[i] = a
+		}
+		t.ResolvedPath.Args.AngleBracketed.Args = out
+	}
+	return t
+}
+
+func concretise(sub string) rustdoc.Type {
+	if isKnownPrimitive(sub) {
+		return rustdoc.Type{Primitive: sub}
+	}
+	return rustdoc.Type{ResolvedPath: &rustdoc.PathType{Path: sub}}
+}
+
+func isKnownPrimitive(s string) bool {
+	switch s {
+	case "bool",
+		"i8", "i16", "i32", "i64", "i128", "isize",
+		"u8", "u16", "u32", "u64", "u128", "usize",
+		"f32", "f64",
+		"char", "str":
+		return true
+	}
+	return false
+}
+
+// ParseTOMLEntries parses the inline-array body of a `monomorphise`
+// manifest row. The accepted shape is the verbatim Cargo-style
+// inline array of inline tables:
+//
+//	[
+//	    { item = "serde_json::from_str", T = "MyStruct" },
+//	    { item = "Vec::new", T = "i64" },
+//	]
+//
+// The leading `[` and trailing `]` may be present or stripped. Each
+// inline table must have an `item` key plus at least one capitalised
+// type-parameter key. The parser is intentionally narrow; it rejects
+// anything that does not match the literal shape so the manifest
+// stays a closed surface.
+//
+// This parser is hand-rolled (no third-party TOML dep) to keep the
+// package layering-conservative.
+func ParseTOMLEntries(body string) (Spec, error) {
+	body = strings.TrimSpace(body)
+	body = strings.TrimPrefix(body, "[")
+	body = strings.TrimSuffix(body, "]")
+	tables, err := splitTables(body)
+	if err != nil {
+		return Spec{}, err
+	}
+	out := Spec{Entries: make([]Entry, 0, len(tables))}
+	for i, tbl := range tables {
+		entry, err := parseTable(tbl)
+		if err != nil {
+			return Spec{}, ErrInvalid{Reason: fmt.Sprintf("entry %d: %s", i, err.Error())}
+		}
+		out.Entries = append(out.Entries, entry)
+	}
+	return out, nil
+}
+
+func splitTables(body string) ([]string, error) {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return nil, nil
+	}
+	var out []string
+	depth := 0
+	start := -1
+	for i := 0; i < len(body); i++ {
+		c := body[i]
+		switch c {
+		case '{':
+			if depth == 0 {
+				start = i + 1
+			}
+			depth++
+		case '}':
+			depth--
+			if depth == 0 && start >= 0 {
+				out = append(out, body[start:i])
+				start = -1
+			}
+		}
+	}
+	if depth != 0 {
+		return nil, ErrInvalid{Reason: "unbalanced braces"}
+	}
+	return out, nil
+}
+
+func parseTable(body string) (Entry, error) {
+	e := Entry{TypeArgs: map[string]string{}}
+	for _, part := range splitKVs(body) {
+		k, v, ok := strings.Cut(part, "=")
+		if !ok {
+			return Entry{}, fmt.Errorf("missing `=` in %q", part)
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if strings.HasPrefix(v, `"`) && strings.HasSuffix(v, `"`) {
+			v = v[1 : len(v)-1]
+		} else {
+			return Entry{}, fmt.Errorf("value %q is not a quoted string", v)
+		}
+		if k == "item" {
+			e.Item = v
+		} else {
+			e.TypeArgs[k] = v
+		}
+	}
+	return e, nil
+}
+
+func splitKVs(body string) []string {
+	var out []string
+	depth := 0
+	start := 0
+	inStr := false
+	for i := 0; i < len(body); i++ {
+		c := body[i]
+		switch c {
+		case '"':
+			inStr = !inStr
+		case '{', '[':
+			if !inStr {
+				depth++
+			}
+		case '}', ']':
+			if !inStr {
+				depth--
+			}
+		case ',':
+			if !inStr && depth == 0 {
+				chunk := strings.TrimSpace(body[start:i])
+				if chunk != "" {
+					out = append(out, chunk)
+				}
+				start = i + 1
+			}
+		}
+	}
+	tail := strings.TrimSpace(body[start:])
+	if tail != "" {
+		out = append(out, tail)
+	}
+	return out
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sanitize(s string) string {
+	b := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '_':
+			b = append(b, c)
+		case c >= 'A' && c <= 'Z':
+			b = append(b, c-'A'+'a')
+		default:
+			b = append(b, '_')
+		}
+	}
+	return string(b)
+}
+
+// itemSegments splits the upstream-relative tail of `item`. When
+// `item` does not start with `<upstream>::`, the whole path is
+// treated as the tail (e.g. "Vec::new" inside the "smallvec"
+// upstream is just ["Vec", "new"]).
+func itemSegments(upstream, item string) []string {
+	prefix := upstream + "::"
+	if strings.HasPrefix(item, prefix) {
+		item = item[len(prefix):]
+	}
+	return strings.Split(item, "::")
+}

--- a/package3/rust/monomorphise/monomorphise_test.go
+++ b/package3/rust/monomorphise/monomorphise_test.go
@@ -1,0 +1,301 @@
+package monomorphise
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/rust/rustdoc"
+)
+
+func TestValidateAcceptsWellFormed(t *testing.T) {
+	s := Spec{Entries: []Entry{
+		{Item: "serde_json::from_str", TypeArgs: map[string]string{"T": "MyStruct"}},
+		{Item: "Vec::new", TypeArgs: map[string]string{"T": "i64"}},
+	}}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestValidateRejectsEmptyItem(t *testing.T) {
+	s := Spec{Entries: []Entry{
+		{Item: "", TypeArgs: map[string]string{"T": "i64"}},
+	}}
+	err := s.Validate()
+	if err == nil {
+		t.Fatalf("Validate: want error for empty item")
+	}
+	if !strings.Contains(err.Error(), "empty item") {
+		t.Fatalf("Validate: error %q does not mention empty item", err.Error())
+	}
+}
+
+func TestValidateRejectsNoTypeArgs(t *testing.T) {
+	s := Spec{Entries: []Entry{
+		{Item: "Vec::new", TypeArgs: map[string]string{}},
+	}}
+	err := s.Validate()
+	if err == nil {
+		t.Fatalf("Validate: want error for empty type-args")
+	}
+	if !strings.Contains(err.Error(), "no type-args") {
+		t.Fatalf("Validate: error %q does not mention no type-args", err.Error())
+	}
+}
+
+func TestValidateRejectsEmptyKey(t *testing.T) {
+	s := Spec{Entries: []Entry{
+		{Item: "Vec::new", TypeArgs: map[string]string{"   ": "i64"}},
+	}}
+	if err := s.Validate(); err == nil {
+		t.Fatalf("Validate: want error for empty type-parameter name")
+	}
+}
+
+func TestValidateRejectsEmptyValue(t *testing.T) {
+	s := Spec{Entries: []Entry{
+		{Item: "Vec::new", TypeArgs: map[string]string{"T": "   "}},
+	}}
+	if err := s.Validate(); err == nil {
+		t.Fatalf("Validate: want error for empty substitution")
+	}
+}
+
+func TestLookupReturnsAllMatches(t *testing.T) {
+	s := Spec{Entries: []Entry{
+		{Item: "serde_json::from_str", TypeArgs: map[string]string{"T": "A"}},
+		{Item: "Vec::new", TypeArgs: map[string]string{"T": "i64"}},
+		{Item: "serde_json::from_str", TypeArgs: map[string]string{"T": "B"}},
+	}}
+	got := s.Lookup("serde_json::from_str")
+	if len(got) != 2 {
+		t.Fatalf("Lookup: want 2 entries, got %d", len(got))
+	}
+	if got[0].TypeArgs["T"] != "A" || got[1].TypeArgs["T"] != "B" {
+		t.Fatalf("Lookup: want [A,B] iteration order, got [%s,%s]", got[0].TypeArgs["T"], got[1].TypeArgs["T"])
+	}
+}
+
+func TestLookupMiss(t *testing.T) {
+	s := Spec{Entries: []Entry{
+		{Item: "Vec::new", TypeArgs: map[string]string{"T": "i64"}},
+	}}
+	got := s.Lookup("HashMap::new")
+	if len(got) != 0 {
+		t.Fatalf("Lookup: want empty, got %v", got)
+	}
+}
+
+func TestExternNameSingleArg(t *testing.T) {
+	got := ExternName("serde_json", "serde_json::from_str", map[string]string{"T": "MyStruct"})
+	want := "mochi_serde_json_from_str_of_t_mystruct"
+	if got != want {
+		t.Fatalf("ExternName:\n  got  %q\n  want %q", got, want)
+	}
+}
+
+func TestExternNameMultiArgSorted(t *testing.T) {
+	a := ExternName("collections", "HashMap::new", map[string]string{"K": "String", "V": "i64"})
+	b := ExternName("collections", "HashMap::new", map[string]string{"V": "i64", "K": "String"})
+	if a != b {
+		t.Fatalf("ExternName: map insertion order leaked\n  a=%q\n  b=%q", a, b)
+	}
+	if !strings.Contains(a, "_of_k_string_v_i64") {
+		t.Fatalf("ExternName: want sorted suffix, got %q", a)
+	}
+}
+
+func TestExternNameSanitisesNonAlphanumeric(t *testing.T) {
+	got := ExternName("smallvec", "Vec::new", map[string]string{"T": "Box<i64>"})
+	if strings.ContainsAny(got, "<>:") {
+		t.Fatalf("ExternName: unsanitised symbol %q", got)
+	}
+}
+
+func TestExternNameNoTypeArgs(t *testing.T) {
+	got := ExternName("smallvec", "Vec::new", nil)
+	if strings.Contains(got, "_of") {
+		t.Fatalf("ExternName: empty type-args should not emit _of suffix, got %q", got)
+	}
+}
+
+func TestCallSiteTurbofishSingle(t *testing.T) {
+	got := CallSite("serde_json::from_str", map[string]string{"T": "MyStruct"})
+	want := "serde_json::from_str::<MyStruct>"
+	if got != want {
+		t.Fatalf("CallSite:\n  got  %q\n  want %q", got, want)
+	}
+}
+
+func TestCallSiteTurbofishMultiSortedByKey(t *testing.T) {
+	got := CallSite("collections::HashMap::new", map[string]string{"V": "i64", "K": "String"})
+	want := "collections::HashMap::new::<String, i64>"
+	if got != want {
+		t.Fatalf("CallSite:\n  got  %q\n  want %q", got, want)
+	}
+}
+
+func TestCallSiteNoTypeArgsReturnsPlain(t *testing.T) {
+	got := CallSite("serde_json::from_str", nil)
+	if got != "serde_json::from_str" {
+		t.Fatalf("CallSite: want plain path, got %q", got)
+	}
+}
+
+func TestParseTOMLEntriesSingleEntry(t *testing.T) {
+	body := `[ { item = "serde_json::from_str", T = "MyStruct" } ]`
+	spec, err := ParseTOMLEntries(body)
+	if err != nil {
+		t.Fatalf("ParseTOMLEntries: %v", err)
+	}
+	if len(spec.Entries) != 1 {
+		t.Fatalf("ParseTOMLEntries: want 1 entry, got %d", len(spec.Entries))
+	}
+	e := spec.Entries[0]
+	if e.Item != "serde_json::from_str" {
+		t.Fatalf("ParseTOMLEntries: item = %q", e.Item)
+	}
+	if e.TypeArgs["T"] != "MyStruct" {
+		t.Fatalf("ParseTOMLEntries: T = %q", e.TypeArgs["T"])
+	}
+}
+
+func TestParseTOMLEntriesMultiple(t *testing.T) {
+	body := `[
+        { item = "serde_json::from_str", T = "MyStruct" },
+        { item = "Vec::new", T = "i64" },
+    ]`
+	spec, err := ParseTOMLEntries(body)
+	if err != nil {
+		t.Fatalf("ParseTOMLEntries: %v", err)
+	}
+	if len(spec.Entries) != 2 {
+		t.Fatalf("ParseTOMLEntries: want 2 entries, got %d", len(spec.Entries))
+	}
+	if spec.Entries[0].Item != "serde_json::from_str" {
+		t.Fatalf("ParseTOMLEntries[0]: %q", spec.Entries[0].Item)
+	}
+	if spec.Entries[1].Item != "Vec::new" {
+		t.Fatalf("ParseTOMLEntries[1]: %q", spec.Entries[1].Item)
+	}
+}
+
+func TestParseTOMLEntriesAcceptsStrippedBrackets(t *testing.T) {
+	body := `{ item = "Vec::new", T = "i64" }`
+	spec, err := ParseTOMLEntries(body)
+	if err != nil {
+		t.Fatalf("ParseTOMLEntries: %v", err)
+	}
+	if len(spec.Entries) != 1 {
+		t.Fatalf("ParseTOMLEntries: want 1 entry, got %d", len(spec.Entries))
+	}
+}
+
+func TestParseTOMLEntriesRejectsUnquoted(t *testing.T) {
+	body := `[ { item = serde_json, T = "MyStruct" } ]`
+	if _, err := ParseTOMLEntries(body); err == nil {
+		t.Fatalf("ParseTOMLEntries: want error for unquoted value")
+	}
+}
+
+func TestParseTOMLEntriesRejectsUnbalanced(t *testing.T) {
+	body := `[ { item = "Vec::new", T = "i64" ]`
+	if _, err := ParseTOMLEntries(body); err == nil {
+		t.Fatalf("ParseTOMLEntries: want error for unbalanced braces")
+	}
+}
+
+func TestParseTOMLEntriesEmpty(t *testing.T) {
+	spec, err := ParseTOMLEntries("[]")
+	if err != nil {
+		t.Fatalf("ParseTOMLEntries(empty): %v", err)
+	}
+	if len(spec.Entries) != 0 {
+		t.Fatalf("ParseTOMLEntries(empty): want 0 entries, got %d", len(spec.Entries))
+	}
+}
+
+func TestExternNameByteStableAcrossRuns(t *testing.T) {
+	args := map[string]string{"K": "String", "V": "i64", "T": "MyStruct"}
+	first := ExternName("crate", "Module::fn", args)
+	for i := 0; i < 64; i++ {
+		got := ExternName("crate", "Module::fn", args)
+		if got != first {
+			t.Fatalf("ExternName not byte-stable: %q vs %q", first, got)
+		}
+	}
+}
+
+func TestSubstituteReplacesGenericWithPrimitive(t *testing.T) {
+	in := rustdoc.Type{Generic: "T"}
+	out := Substitute(in, map[string]string{"T": "i64"})
+	if out.Primitive != "i64" {
+		t.Fatalf("Substitute: want primitive i64, got %+v", out)
+	}
+}
+
+func TestSubstituteReplacesGenericWithPath(t *testing.T) {
+	in := rustdoc.Type{Generic: "T"}
+	out := Substitute(in, map[string]string{"T": "my_crate::MyStruct"})
+	if out.ResolvedPath == nil || out.ResolvedPath.Path != "my_crate::MyStruct" {
+		t.Fatalf("Substitute: want resolved_path, got %+v", out)
+	}
+}
+
+func TestSubstituteWalksTuple(t *testing.T) {
+	in := rustdoc.Type{Tuple: []rustdoc.Type{
+		{Generic: "T"},
+		{Primitive: "bool"},
+	}}
+	out := Substitute(in, map[string]string{"T": "i64"})
+	if out.Tuple[0].Primitive != "i64" {
+		t.Fatalf("Substitute tuple[0]: %+v", out.Tuple[0])
+	}
+	if out.Tuple[1].Primitive != "bool" {
+		t.Fatalf("Substitute tuple[1] mutated: %+v", out.Tuple[1])
+	}
+}
+
+func TestSubstituteWalksVecArg(t *testing.T) {
+	tArg := rustdoc.Type{Generic: "T"}
+	in := rustdoc.Type{ResolvedPath: &rustdoc.PathType{
+		Path: "Vec",
+		Args: &rustdoc.GenericArgs{AngleBracketed: &rustdoc.AngleBracketedArgs{
+			Args: []rustdoc.GenericArg{{Type: &tArg}},
+		}},
+	}}
+	out := Substitute(in, map[string]string{"T": "i64"})
+	got := out.ResolvedPath.Args.AngleBracketed.Args[0].Type
+	if got == nil || got.Primitive != "i64" {
+		t.Fatalf("Substitute Vec<T>: arg = %+v", got)
+	}
+}
+
+func TestSubstituteWalksBorrowedRef(t *testing.T) {
+	in := rustdoc.Type{BorrowedRef: &rustdoc.BorrowedRefType{
+		Type: rustdoc.Type{Generic: "T"},
+	}}
+	out := Substitute(in, map[string]string{"T": "str"})
+	if out.BorrowedRef.Type.Primitive != "str" {
+		t.Fatalf("Substitute &T: %+v", out.BorrowedRef.Type)
+	}
+}
+
+func TestSubstituteLeavesUnknownGenericIntact(t *testing.T) {
+	in := rustdoc.Type{Generic: "U"}
+	out := Substitute(in, map[string]string{"T": "i64"})
+	if out.Generic != "U" {
+		t.Fatalf("Substitute: unknown generic should remain, got %+v", out)
+	}
+}
+
+func TestCallSiteByteStableAcrossRuns(t *testing.T) {
+	args := map[string]string{"K": "String", "V": "i64", "T": "MyStruct"}
+	first := CallSite("Module::fn", args)
+	for i := 0; i < 64; i++ {
+		got := CallSite("Module::fn", args)
+		if got != first {
+			t.Fatalf("CallSite not byte-stable: %q vs %q", first, got)
+		}
+	}
+}

--- a/package3/rust/monomorphise/phase12_test.go
+++ b/package3/rust/monomorphise/phase12_test.go
@@ -1,0 +1,146 @@
+package monomorphise_test
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/rust/monomorphise"
+	"mochi/package3/rust/rustdoc"
+	"mochi/package3/rust/wrapper"
+)
+
+// TestPhase12Monomorphisation is the umbrella sentinel for MEP-73
+// Phase 12. It exercises the end-to-end loop: a manifest declares
+// two instantiations of one generic fn; the wrapper synthesises two
+// extern symbols (one per substitution), each with a turbofish call
+// site. Failure modes (empty Spec, unmatched fn, validation errors)
+// must keep the wrapper in its closed-typemap behaviour.
+func TestPhase12Monomorphisation(t *testing.T) {
+	t.Run("parses_spec_from_manifest", parsesSpecFromManifest)
+	t.Run("lookup_returns_entries_for_item", lookupReturnsEntries)
+	t.Run("extern_name_byte_stable", externNameByteStable)
+	t.Run("call_site_turbofish_rendering", callSiteTurbofish)
+	t.Run("validate_rejects_empty_item", validateRejectsEmptyItem)
+	t.Run("validate_rejects_no_type_args", validateRejectsNoTypeArgs)
+	t.Run("wrapper_emits_one_fn_per_entry", wrapperEmitsOneFnPerEntry)
+	t.Run("wrapper_skips_generic_when_no_spec", wrapperSkipsGenericWhenNoSpec)
+}
+
+func parsesSpecFromManifest(t *testing.T) {
+	body := `[
+        { item = "smallvec::push", T = "i64" },
+        { item = "smallvec::push", T = "u8" },
+    ]`
+	spec, err := monomorphise.ParseTOMLEntries(body)
+	if err != nil {
+		t.Fatalf("ParseTOMLEntries: %v", err)
+	}
+	if len(spec.Entries) != 2 {
+		t.Fatalf("entries = %d; want 2", len(spec.Entries))
+	}
+	if err := spec.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func lookupReturnsEntries(t *testing.T) {
+	spec := monomorphise.Spec{Entries: []monomorphise.Entry{
+		{Item: "smallvec::push", TypeArgs: map[string]string{"T": "i64"}},
+		{Item: "smallvec::push", TypeArgs: map[string]string{"T": "u8"}},
+	}}
+	got := spec.Lookup("smallvec::push")
+	if len(got) != 2 {
+		t.Fatalf("Lookup returned %d entries; want 2", len(got))
+	}
+}
+
+func externNameByteStable(t *testing.T) {
+	a := monomorphise.ExternName("smallvec", "smallvec::push", map[string]string{"T": "i64"})
+	b := monomorphise.ExternName("smallvec", "smallvec::push", map[string]string{"T": "i64"})
+	if a != b {
+		t.Fatalf("ExternName not byte-stable: %q vs %q", a, b)
+	}
+	if !strings.HasSuffix(a, "_of_t_i64") {
+		t.Fatalf("ExternName: missing _of suffix in %q", a)
+	}
+}
+
+func callSiteTurbofish(t *testing.T) {
+	got := monomorphise.CallSite("serde_json::from_str", map[string]string{"T": "MyStruct"})
+	want := "serde_json::from_str::<MyStruct>"
+	if got != want {
+		t.Fatalf("CallSite: got %q want %q", got, want)
+	}
+}
+
+func validateRejectsEmptyItem(t *testing.T) {
+	s := monomorphise.Spec{Entries: []monomorphise.Entry{
+		{Item: "", TypeArgs: map[string]string{"T": "i64"}},
+	}}
+	if err := s.Validate(); err == nil {
+		t.Fatalf("Validate: want error for empty item")
+	}
+}
+
+func validateRejectsNoTypeArgs(t *testing.T) {
+	s := monomorphise.Spec{Entries: []monomorphise.Entry{
+		{Item: "Vec::new", TypeArgs: nil},
+	}}
+	if err := s.Validate(); err == nil {
+		t.Fatalf("Validate: want error for no type-args")
+	}
+}
+
+// genericPushFn is a synthetic FunctionEntry mirroring a generic
+// upstream fn `smallvec::push<T>(v: T) -> ()`. It's deliberately
+// minimal so the test does not have to depend on rustdoc-types JSON
+// fixtures.
+func genericPushFn() rustdoc.FunctionEntry {
+	return rustdoc.FunctionEntry{
+		Path: []string{"smallvec", "push"},
+		Inputs: []rustdoc.ParamEntry{
+			{Name: "v", Type: rustdoc.Type{Generic: "T"}},
+		},
+		Output: nil,
+		Generics: rustdoc.Generics{
+			Params: []rustdoc.GenericParamDef{{Name: "T"}},
+		},
+	}
+}
+
+func wrapperEmitsOneFnPerEntry(t *testing.T) {
+	surface := &rustdoc.ApiSurface{
+		Functions: []rustdoc.FunctionEntry{genericPushFn()},
+	}
+	spec := monomorphise.Spec{Entries: []monomorphise.Entry{
+		{Item: "smallvec::push", TypeArgs: map[string]string{"T": "i64"}},
+		{Item: "smallvec::push", TypeArgs: map[string]string{"T": "u8"}},
+	}}
+	c := wrapper.SynthWithSpec("smallvec", "0.1.0", surface, spec)
+	if len(c.Functions) != 2 {
+		t.Fatalf("SynthWithSpec emitted %d fns; want 2 (one per entry)", len(c.Functions))
+	}
+	seen := map[string]bool{}
+	for _, fn := range c.Functions {
+		if seen[fn.ExternName] {
+			t.Fatalf("duplicate extern name %q", fn.ExternName)
+		}
+		seen[fn.ExternName] = true
+		if !strings.Contains(fn.UpstreamPath, "::<") {
+			t.Fatalf("call site missing turbofish: %q", fn.UpstreamPath)
+		}
+	}
+}
+
+func wrapperSkipsGenericWhenNoSpec(t *testing.T) {
+	surface := &rustdoc.ApiSurface{
+		Functions: []rustdoc.FunctionEntry{genericPushFn()},
+	}
+	c := wrapper.Synth("smallvec", "0.1.0", surface)
+	if len(c.Functions) != 0 {
+		t.Fatalf("default Synth should not emit unconcretised generic fn; got %d", len(c.Functions))
+	}
+	if len(c.Skipped) == 0 {
+		t.Fatalf("default Synth: want SkipReport for generic fn, got none")
+	}
+}

--- a/package3/rust/wrapper/crate.go
+++ b/package3/rust/wrapper/crate.go
@@ -16,6 +16,7 @@ import (
 
 	"mochi/package3/rust/asyncbridge"
 	"mochi/package3/rust/errors"
+	"mochi/package3/rust/monomorphise"
 	"mochi/package3/rust/rustdoc"
 	"mochi/package3/rust/typemap"
 )
@@ -101,12 +102,40 @@ type SynthParam struct {
 // Synth assumes the surface has already been filtered for visibility
 // by the phase-2 walker.
 func Synth(upstream, version string, surface *rustdoc.ApiSurface) *Crate {
+	return SynthWithSpec(upstream, version, surface, monomorphise.Spec{})
+}
+
+// SynthWithSpec is Synth plus an explicit monomorphisation spec. For
+// each fn whose path matches a Spec entry, SynthWithSpec emits one
+// SynthFn per Entry with a substituted signature (every Generic of
+// matching name swapped for its concrete type) and a mangled
+// extern-C symbol that carries the substitution suffix. Functions
+// without matching Spec entries take the default Synth path, which
+// will still SkipGeneric if the signature carries unconcretised
+// parameters; the Spec is the only escape hatch.
+func SynthWithSpec(upstream, version string, surface *rustdoc.ApiSurface, spec monomorphise.Spec) *Crate {
 	c := &Crate{
 		Name:            crateName(upstream),
 		Upstream:        upstream,
 		UpstreamVersion: version,
 	}
 	for _, fn := range surface.Functions {
+		entries := spec.Lookup(joinPath(fn.Path))
+		if len(entries) > 0 {
+			for _, e := range entries {
+				sf, sr, detail := synthFnMonomorphised(upstream, fn, e)
+				if sr != errors.SkipUnknown || detail != "" {
+					c.Skipped = append(c.Skipped, errors.SkipReport{
+						ItemPath: joinPath(fn.Path),
+						Reason:   sr,
+						Detail:   detail,
+					})
+					continue
+				}
+				c.Functions = append(c.Functions, *sf)
+			}
+			continue
+		}
 		sf, sr, detail := synthFn(upstream, fn)
 		if sr != errors.SkipUnknown || detail != "" {
 			c.Skipped = append(c.Skipped, errors.SkipReport{
@@ -149,6 +178,46 @@ func synthFn(upstream string, fn rustdoc.FunctionEntry) (*SynthFn, errors.SkipRe
 	return &SynthFn{
 		ExternName:   externName(upstream, fn.Path),
 		UpstreamPath: joinPath(fn.Path),
+		Params:       params,
+		Return:       ret,
+		IsAsync:      fn.Header.IsAsync,
+	}, errors.SkipUnknown, ""
+}
+
+// synthFnMonomorphised is synthFn with a substitution lens applied
+// to the inputs and output. The extern symbol and call-site path
+// come from monomorphise.ExternName / CallSite so multiple
+// instantiations of the same upstream item produce distinct,
+// byte-stable symbols.
+func synthFnMonomorphised(upstream string, fn rustdoc.FunctionEntry, e monomorphise.Entry) (*SynthFn, errors.SkipReason, string) {
+	params := make([]SynthParam, 0, len(fn.Inputs))
+	for i, in := range fn.Inputs {
+		subbed := monomorphise.Substitute(in.Type, e.TypeArgs)
+		m, sr, det := typemap.Map(subbed, typemap.DirectionIn)
+		if sr != errors.SkipUnknown || det != "" {
+			return nil, sr, fmt.Sprintf("param %d (%s): %s", i, in.Name, det)
+		}
+		name := in.Name
+		if name == "" {
+			name = fmt.Sprintf("arg%d", i)
+		}
+		params = append(params, SynthParam{Name: name, Mapping: *m})
+	}
+	var ret *typemap.Mapping
+	if fn.Output != nil {
+		subbed := monomorphise.Substitute(*fn.Output, e.TypeArgs)
+		m, sr, det := typemap.Map(subbed, typemap.DirectionOut)
+		if sr != errors.SkipUnknown || det != "" {
+			return nil, sr, fmt.Sprintf("return: %s", det)
+		}
+		if m.Kind != typemap.KindUnit {
+			ret = m
+		}
+	}
+	item := joinPath(fn.Path)
+	return &SynthFn{
+		ExternName:   monomorphise.ExternName(upstream, item, e.TypeArgs),
+		UpstreamPath: monomorphise.CallSite(item, e.TypeArgs),
 		Params:       params,
 		Return:       ret,
 		IsAsync:      fn.Header.IsAsync,

--- a/website/docs/implementation/0073/index.md
+++ b/website/docs/implementation/0073/index.md
@@ -26,8 +26,8 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | 8 | mochi.lock `[[rust-package]]` integration + `--check` mode | LANDED | [d50fc563](https://github.com/mochilang/mochi/commit/d50fc563) | [phase-08](/docs/implementation/0073/phase-08-lockfile) |
 | 9 | `TargetRustLibrary` emit (rlib + cdylib + Cargo.toml + cbindgen) | LANDED | [6e966397](https://github.com/mochilang/mochi/commit/6e966397) | [phase-09](/docs/implementation/0073/phase-09-rust-library-emit) |
 | 10 | Trusted publishing (`mochi pkg publish --to=crates.io`) Sigstore OIDC flow | LANDED | [003e897f](https://github.com/mochilang/mochi/commit/003e897f) | [phase-10](/docs/implementation/0073/phase-10-trusted-publish) |
-| 11 | Async bridge (tokio runtime singleton + block_on entry) | LANDED | (pending) | [phase-11](/docs/implementation/0073/phase-11-async-bridge) |
-| 12 | Monomorphisation (`[rust.monomorphise]` manifest + per-instantiation wrapper) | NOT STARTED | — | [phase-12](/docs/implementation/0073/phase-12-monomorphise) |
+| 11 | Async bridge (tokio runtime singleton + block_on entry) | LANDED | [fce8fc5e](https://github.com/mochilang/mochi/commit/fce8fc5e) | [phase-11](/docs/implementation/0073/phase-11-async-bridge) |
+| 12 | Monomorphisation (`[rust.monomorphise]` manifest + per-instantiation wrapper) | LANDED | (pending) | [phase-12](/docs/implementation/0073/phase-12-monomorphise) |
 | 13 | Embedded / no_std subset (`profile = "embedded"` + alloc opt-in) | NOT STARTED | — | [phase-13](/docs/implementation/0073/phase-13-embedded) |
 
 ## Per-phase fields
@@ -71,7 +71,7 @@ The `package3/rust/` location is shared with the broader MEP-57 polyglot package
 
 ## Status snapshot
 
-As of 2026-05-30 00:18 (GMT+7): phases 0-11 LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest + closed type-mapping table + extern-C wrapper synthesiser + Mochi extern-fn emitter + `import rust` grammar + build orchestration pipeline + mochi.lock `[[rust-package]]` schema + drift checker + TargetRustLibrary publish-direction emit with cbindgen header + trusted-publishing flow with Sigstore-keyless attestation bundle and crates.io upload wire-format + async-fn bridge with lazy tokio runtime singleton and `block_on` wrapper bodies). Phases 12-13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
+As of 2026-05-30 00:32 (GMT+7): phases 0-12 LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest + closed type-mapping table + extern-C wrapper synthesiser + Mochi extern-fn emitter + `import rust` grammar + build orchestration pipeline + mochi.lock `[[rust-package]]` schema + drift checker + TargetRustLibrary publish-direction emit with cbindgen header + trusted-publishing flow with Sigstore-keyless attestation bundle and crates.io upload wire-format + async-fn bridge with lazy tokio runtime singleton and `block_on` wrapper bodies + monomorphisation pipeline with `[rust.monomorphise]` manifest parsing, per-instantiation symbol mangling, and turbofish call-site rendering). Phase 13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
 
 ## Cross-references
 

--- a/website/docs/implementation/0073/phase-12-monomorphise.md
+++ b/website/docs/implementation/0073/phase-12-monomorphise.md
@@ -1,0 +1,174 @@
+---
+sidebar_label: "Phase 12: Monomorphisation"
+sidebar_position: 13
+---
+
+# MEP-73 Phase 12: Monomorphisation (`[rust.monomorphise]` manifest + per-instantiation wrapper)
+
+**Status:** LANDED (2026-05-30)
+**Spec section:** [MEP-73 §3 — Generics and monomorphisation](/docs/mep/mep-0073)
+**Worktree:** `/Users/apple/mochi-mep73-p12`
+
+## Gate
+
+Land the manifest-driven monomorphisation pipeline: when an upstream
+crate exposes a generic fn like `fn from_str<T: DeserializeOwned>(s:
+&str) -> Result<T, Error>`, Phase 3's typemap refuses it with
+`SkipGeneric`. Phase 12 unlocks the case via an explicit
+`[rust.monomorphise]` table in `mochi.toml`; the bridge synthesises one
+extern "C" wrapper per `(item, type-args)` pair, with a mangled symbol
+and a turbofish call-site path.
+
+## Why it matters
+
+Phases 4-5 produced wrappers only for fns whose every type was in the
+closed type-mapping table. Generic fns (especially serde's
+`from_str<T>`, `from_value<T>`, `to_string<T>` and the `Vec::new`
+/ `HashMap::new` constructors) hit `SkipGeneric` and never produce a
+SynthFn, so a Mochi user importing serde_json today cannot deserialise
+into a concrete `MyStruct` type. The auto-monomorphisation alternative
+(walk every Mochi call site and synthesise the matching instantiation)
+risks the combinatorial-explosion failure mode MEP-73 §Risks calls out.
+
+Phase 12 follows the spec's "closed surface" principle: the user
+declares exactly which instantiations they need, the bridge emits
+exactly those, and the manifest's length hard-bounds the combinatorial
+risk. No inference; no auto-monomorphisation.
+
+## What landed
+
+### `package3/rust/monomorphise/monomorphise.go`
+
+A new package owning the manifest's on-wire shape, the symbol mangler,
+the turbofish renderer, the substitution lens, and the hand-rolled
+TOML parser. No third-party TOML dep — the parser is narrow enough
+that the layering-conservative path is the right tradeoff.
+
+- `Spec` and `Entry` types. `Entry{Item, TypeArgs}` carries the
+  upstream Rust path (e.g. `"serde_json::from_str"`) plus the
+  per-type-parameter substitution map (e.g. `{"T": "MyStruct"}`).
+- `Spec.Validate()` rejects empty item paths, empty type-args, empty
+  parameter names, and empty substitutions. Bad entries would mangle
+  to ambiguous symbols.
+- `Spec.Lookup(item)` returns every Entry matching an upstream path
+  (the same generic can be instantiated multiple times). Linear scan
+  because the manifest is bounded at a few tens of entries.
+- `ExternName(upstream, item, typeArgs)` mangles to a stable extern-C
+  symbol with an `_of_<sorted-key>_<value>...` suffix. Sorting keeps
+  the symbol byte-stable across runs even though `TypeArgs` is a map.
+- `CallSite(item, typeArgs)` renders the turbofish call expression
+  (e.g. `"serde_json::from_str::<MyStruct>"`). Multi-arg
+  substitutions render as `<A, B>` with parameter names sorted for
+  byte stability.
+- `Substitute(t, subs)` recursively walks a `rustdoc.Type`, replacing
+  every `Generic` node whose name is in `subs` with a concrete type
+  (primitive when the substitution names a known Rust primitive,
+  resolved_path otherwise). Tuples, slices, arrays, borrowed-refs and
+  generic-arg lists are walked through.
+- `ParseTOMLEntries(body)` parses the inline-array body of the
+  `monomorphise` row. Accepts both bracket-wrapped and stripped
+  forms. Rejects unquoted values and unbalanced braces.
+
+### `package3/rust/wrapper/crate.go`
+
+A new `SynthWithSpec(upstream, version, surface, spec)` entry point
+extends `Synth` with a monomorphisation lens. For each fn whose path
+matches a Spec entry, the wrapper emits one SynthFn per Entry with
+substituted types, a mangled `ExternName`, and a turbofish
+`UpstreamPath` from `monomorphise.CallSite`. Functions without
+matching Spec entries take the default Synth path, which still
+SkipGenerics for unconcretised parameters — the Spec is the only
+escape hatch.
+
+`Synth` is preserved as a thin wrapper over `SynthWithSpec(...,
+monomorphise.Spec{})` so all existing callers compile unchanged.
+
+### Tests
+
+- `monomorphise_test.go` (24 cases): `Spec.Validate` (well-formed,
+  empty-item, no-type-args, empty-key, empty-value); `Spec.Lookup`
+  (multi-match preserves order, miss returns empty); `ExternName`
+  (single arg, multi-arg sorted, non-alphanumeric sanitisation, no-
+  type-args path, byte stable across 64 runs); `CallSite` (turbofish
+  single, multi sorted by key, no-args returns plain, byte stable);
+  `ParseTOMLEntries` (single entry, multiple entries, stripped
+  brackets, rejects unquoted, rejects unbalanced, empty array);
+  `Substitute` (primitive substitution, path substitution, tuple
+  walk, Vec arg walk, borrowed-ref walk, unknown generic preserved).
+- `phase12_test.go` (sentinel) with subtests:
+  `parses_spec_from_manifest`, `lookup_returns_entries_for_item`,
+  `extern_name_byte_stable`, `call_site_turbofish_rendering`,
+  `validate_rejects_empty_item`, `validate_rejects_no_type_args`,
+  `wrapper_emits_one_fn_per_entry`,
+  `wrapper_skips_generic_when_no_spec`.
+
+## Target matrix
+
+| Target               | Status | Notes |
+|----------------------|--------|-------|
+| Manifest shape       | ✅     | Inline-array of inline-tables. `item` plus N capitalised type-param keys. |
+| Parser               | ✅     | Hand-rolled; no third-party TOML dep. Rejects unquoted / unbalanced. |
+| Spec validation      | ✅     | Empty item / type-args / key / value all rejected pre-emit. |
+| Symbol mangling      | ✅     | `_of_<sorted-key>_<value>...` suffix; sanitises `<>:` to `_`. |
+| Turbofish rendering  | ✅     | `::<A, B>` with parameter names sorted by key. |
+| Substitution lens    | ✅     | Walks tuple / slice / array / borrowed-ref / Vec args. |
+| Multi-instantiation  | ✅     | One SynthFn per Entry; no duplicate extern names. |
+| Default closed-table | ✅     | Generic fns without Spec entries still SkipGeneric. |
+| Async + generic combo| ✅     | `SynthFn.IsAsync` carries through; Phase 11 `block_on` body wraps the turbofish call. |
+| Byte stability       | ✅     | ExternName + CallSite byte-stable across 64 runs (sort-by-key). |
+| Embedded interaction | ⚠️     | Out of scope for Phase 12. Phase 13 may add an `embedded` profile that further restricts which substitutions resolve. |
+
+## How this phase plugs in to the larger pipeline
+
+```
+  mochi.toml [rust.monomorphise]
+    [
+      { item = "serde_json::from_str", T = "MyStruct" },
+      { item = "Vec::new", T = "i64" },
+    ]
+                │
+                ▼
+  monomorphise.ParseTOMLEntries
+                │
+                ▼
+  monomorphise.Spec.Validate
+                │
+                ▼
+  wrapper.SynthWithSpec(upstream, version, surface, spec)
+                │
+                ▼   (for each fn in surface.Functions)
+                │
+            entries := spec.Lookup(joinPath(fn.Path))
+                │
+   ┌────────────┴────────────┐
+   │                         │
+   ▼ entries empty           ▼ entries non-empty
+  synthFn(...)              for each Entry e in entries:
+   │                          synthFnMonomorphised(upstream, fn, e)
+   │                          │
+   │                          ▼
+   │                        Inputs / Output run through
+   │                        monomorphise.Substitute then typemap.Map
+   │                          │
+   │                          ▼
+   │                        SynthFn{
+   │                          ExternName: monomorphise.ExternName(...),
+   │                          UpstreamPath: monomorphise.CallSite(...),
+   │                        }
+   ▼                          │
+  Crate.Functions ◄───────────┘
+```
+
+The bridge sees only the user's enumerated set. Auto-monomorphisation
+remains unsupported by design (MEP-73 §Risks).
+
+## Timeline
+
+| Time (GMT+7)        | Step |
+|---------------------|------|
+| 2026-05-30 00:20    | Worktree branch `mep/0073-phase-12` created off `origin/main`. |
+| 2026-05-30 00:24    | `package3/rust/monomorphise/monomorphise.go` written (Spec, Entry, Validate, Lookup, ExternName, CallSite, ParseTOMLEntries). |
+| 2026-05-30 00:27    | `Substitute` lens added to monomorphise; tests for primitive / path / tuple / Vec-arg / borrowed-ref walks. |
+| 2026-05-30 00:29    | `wrapper.SynthWithSpec` + `synthFnMonomorphised` plumbed; `wrapper.Synth` preserved for callers. |
+| 2026-05-30 00:31    | Phase 12 sentinel added (8 subtests). `go test ./package3/rust/...` green. |
+| 2026-05-30 00:32    | Tracking page + spec sync. |

--- a/website/docs/mep/mep-0073.md
+++ b/website/docs/mep/mep-0073.md
@@ -308,7 +308,7 @@ A phase is LANDED only when its gate is green against the curated 24-crate fixtu
 | 9. TargetRustLibrary emit | LANDED | LANDED | n/a (lib is rlib + cdylib for native) | n/a |
 | 10. trusted publishing | LANDED | n/a (publish is host-only) | n/a | n/a |
 | 11. async bridge | LANDED | required | n/a (no tokio on wasm32-wasip1) | n/a |
-| 12. monomorphisation of generics | NOT STARTED | required | required | required |
+| 12. monomorphisation of generics | LANDED | LANDED | LANDED | LANDED |
 | 13. embedded subset | NOT STARTED | n/a | n/a | required |
 
 A phase marked `n/a` for a target is intentional: the bridge does not promise the behaviour on that target.

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -350,7 +350,8 @@
       "implementation/0073/phase-08-lockfile",
       "implementation/0073/phase-09-rust-library-emit",
       "implementation/0073/phase-10-trusted-publish",
-      "implementation/0073/phase-11-async-bridge"
+      "implementation/0073/phase-11-async-bridge",
+      "implementation/0073/phase-12-monomorphise"
     ]
   },
   "implementation/0074/index",


### PR DESCRIPTION
Closes #22926

Lands the manifest-driven generic instantiation layer so the bridge
can emit wrappers for generic upstream items the user explicitly
concretises in `mochi.toml`'s `[rust.monomorphise]` table.

## What's in here

- New `package3/rust/monomorphise/` package:
  - `Spec` / `Entry` on-wire types + `Validate` (rejects empty
    item / type-args / param-name / substitution).
  - `Lookup(item)` returns every Entry matching an upstream path; one
    generic may be instantiated multiple times.
  - `ExternName` mangler with a byte-stable
    `_of_<sorted-key>_<value>...` suffix.
  - `CallSite` turbofish renderer: `::<A, B>` with parameter names
    sorted by key.
  - `Substitute(t, subs)` walks `rustdoc.Type` recursively (tuple,
    slice, array, borrowed-ref, Vec/HashMap arg lists) replacing
    `Generic` nodes with primitive or resolved-path concretisations
    based on the substitution string.
  - Hand-rolled inline-array-of-inline-tables TOML parser (no
    third-party dep; layering-conservative).

- `wrapper.SynthWithSpec` extends `Synth` with a monomorphisation
  pass: fns whose path matches a Spec entry produce one SynthFn per
  Entry with substituted signatures, a mangled `ExternName`, and a
  turbofish `UpstreamPath`. `wrapper.Synth` preserved as a thin
  wrapper for existing callers.

- Phase 12 sentinel (`package3/rust/monomorphise/phase12_test.go`)
  with 8 subtests covering the end-to-end loop, plus 24 unit cases.

- Spec target matrix row 12 (host / musl / wasm32 / embedded) → LANDED.
- Phase 11 SHA `fce8fc5e` backfilled in the implementation index.
- Tracking page `phase-12-monomorphise.md` + sidebar wired.

## Test plan

- [x] `go test ./package3/rust/...` green (all 13 packages).
- [x] `go build ./package3/rust/...` green.
- [x] `wrapper.Synth` regression-guarded: pure-sync, non-monomorphised
  surfaces produce byte-identical wrappers (existing wrapper tests pass).
- [x] Generic fns without a Spec entry still SkipGeneric in the
  default Synth path.
- [x] Multi-instantiation produces distinct extern names.
- [x] Sentinel covers parse + lookup + extern-name byte stability +
  turbofish + validation rejections + wrapper emit + default skip.