### PR TITLE
feat(mep-75/p12): async PHP bridge for ReactPHP / Revolt / Amp promise types

### DIFF
--- a/package3/php/asyncemit/asyncemit.go
+++ b/package3/php/asyncemit/asyncemit.go
@@ -1,0 +1,176 @@
+// Package asyncemit emits async extern declarations for PHP methods that
+// return ReactPHP / Amp / Revolt promise types.
+//
+// PHP async patterns supported:
+//   - React\Promise\PromiseInterface (ReactPHP)
+//   - React\Promise\Promise (ReactPHP concrete)
+//   - Amp\Promise (Amp v2)
+//   - Amp\Future (Amp v3 / Revolt)
+//   - GuzzleHttp\Promise\PromiseInterface (Guzzle)
+//   - GuzzleHttp\Promise\Promise (Guzzle)
+//
+// For each detected async method the emitter produces:
+//
+//	async extern fn handle_method_name(self: Handle, ...) -> unit
+//
+// The inner type of the promise is not recoverable from PHP's reflection
+// surface (PHP lacks generic reification), so all async return types map to
+// unit. Callers that need typed results should annotate via overlay files.
+//
+// Usage:
+//
+//	cfg := asyncemit.Config{LoopDriver: asyncemit.LoopRevolt}
+//	result := asyncemit.Emit(surface, cfg)
+package asyncemit
+
+import (
+	"strings"
+
+	"mochi/package3/php/externemit"
+	"mochi/package3/php/reflect"
+)
+
+// LoopDriver identifies the PHP async event-loop backend.
+type LoopDriver int
+
+const (
+	// LoopRevolt uses Revolt PHP fiber-based event loop (recommended for PHP 8.1+).
+	LoopRevolt LoopDriver = iota
+	// LoopReactPHP uses the ReactPHP event loop.
+	LoopReactPHP
+	// LoopAmp uses the Amp v3 event loop.
+	LoopAmp
+)
+
+// Config controls async extern emission.
+type Config struct {
+	// LoopDriver is the async runtime to target. Default: LoopRevolt.
+	LoopDriver LoopDriver
+	// ExtraPromiseTypes adds additional fully-qualified PHP type names that
+	// should be treated as promise/future types.
+	ExtraPromiseTypes []string
+}
+
+// EmitResult holds the Mochi source produced by Emit.
+type EmitResult struct {
+	// MochiSource is the emitted async extern declarations.
+	MochiSource string
+	// AsyncMethodCount is the number of async methods detected.
+	AsyncMethodCount int
+}
+
+// knownPromiseTypes is the set of FQCN suffixes (without leading backslash)
+// that indicate an async return type.
+var knownPromiseTypes = []string{
+	`React\Promise\PromiseInterface`,
+	`React\Promise\Promise`,
+	`Amp\Promise`,
+	`Amp\Future`,
+	`GuzzleHttp\Promise\PromiseInterface`,
+	`GuzzleHttp\Promise\Promise`,
+}
+
+// IsPromiseType reports whether the given PHP return type string (as it appears
+// in a ReflectionSurface) is a known async promise/future type.
+func IsPromiseType(phpType string, extra []string) bool {
+	t := strings.TrimPrefix(phpType, "\\")
+	for _, known := range knownPromiseTypes {
+		if t == known || strings.HasSuffix(t, known) {
+			return true
+		}
+	}
+	for _, e := range extra {
+		et := strings.TrimPrefix(e, "\\")
+		if t == et || strings.HasSuffix(t, et) {
+			return true
+		}
+	}
+	return false
+}
+
+// Emit scans the surface for methods whose return type is a known promise/
+// future type, and emits async extern fn declarations.
+func Emit(surface *reflect.ReflectionSurface, cfg Config) *EmitResult {
+	e := &emitter{extra: cfg.ExtraPromiseTypes}
+
+	for _, cls := range surface.Classes {
+		handle := classHandle(cls.FQCN)
+		for _, m := range cls.Methods {
+			if strings.HasPrefix(m.Name, "__") {
+				continue
+			}
+			if !IsPromiseType(m.ReturnType, cfg.ExtraPromiseTypes) {
+				continue
+			}
+			e.emitAsyncMethod(handle, m, false)
+		}
+	}
+	for _, iface := range surface.Interfaces {
+		handle := classHandle(iface.FQCN)
+		for _, m := range iface.Methods {
+			if strings.HasPrefix(m.Name, "__") {
+				continue
+			}
+			if !IsPromiseType(m.ReturnType, cfg.ExtraPromiseTypes) {
+				continue
+			}
+			e.emitAsyncMethod(handle, m, false)
+		}
+	}
+
+	return &EmitResult{
+		MochiSource:      e.render(),
+		AsyncMethodCount: e.count,
+	}
+}
+
+type emitter struct {
+	extra []string
+	lines []string
+	count int
+}
+
+func (e *emitter) addLine(s string) {
+	e.lines = append(e.lines, s)
+}
+
+func (e *emitter) render() string {
+	if len(e.lines) == 0 {
+		return ""
+	}
+	return strings.Join(e.lines, "\n") + "\n"
+}
+
+func (e *emitter) emitAsyncMethod(handle string, m reflect.MethodSurface, static bool) {
+	fnName := toSnakeCase(handle) + "_" + toSnakeCase(m.Name)
+	var params []string
+	if !static {
+		params = append(params, "self: "+handle)
+	}
+	for _, p := range m.Parameters {
+		if p.Variadic {
+			continue
+		}
+		params = append(params, toSnakeCase(p.Name)+": unit")
+	}
+	e.addLine("async extern fn " + fnName + "(" + strings.Join(params, ", ") + ") -> unit")
+	e.count++
+}
+
+// classHandle converts a FQCN like "GuzzleHttp\\Client" to "GuzzleHttpClient".
+func classHandle(fqcn string) string {
+	fqcn = strings.TrimPrefix(fqcn, "\\")
+	parts := strings.Split(fqcn, "\\")
+	var sb strings.Builder
+	for _, p := range parts {
+		if len(p) > 0 {
+			sb.WriteString(strings.ToUpper(p[:1]) + p[1:])
+		}
+	}
+	return sb.String()
+}
+
+// toSnakeCase converts PascalCase or camelCase to snake_case.
+func toSnakeCase(s string) string {
+	return externemit.ToSnakeCase(s)
+}

--- a/package3/php/asyncemit/asyncemit_test.go
+++ b/package3/php/asyncemit/asyncemit_test.go
@@ -1,0 +1,186 @@
+package asyncemit
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/php/reflect"
+)
+
+func TestIsPromiseTypeReact(t *testing.T) {
+	cases := []struct {
+		t    string
+		want bool
+	}{
+		{`React\Promise\PromiseInterface`, true},
+		{`React\Promise\Promise`, true},
+		{`\React\Promise\PromiseInterface`, true},
+		{`Amp\Promise`, true},
+		{`Amp\Future`, true},
+		{`GuzzleHttp\Promise\PromiseInterface`, true},
+		{`GuzzleHttp\Promise\Promise`, true},
+		{`string`, false},
+		{`void`, false},
+		{`bool`, false},
+		{``, false},
+	}
+	for _, tc := range cases {
+		got := IsPromiseType(tc.t, nil)
+		if got != tc.want {
+			t.Errorf("IsPromiseType(%q) = %v; want %v", tc.t, got, tc.want)
+		}
+	}
+}
+
+func TestIsPromiseTypeExtra(t *testing.T) {
+	extra := []string{`My\Custom\Thenable`}
+	if !IsPromiseType(`My\Custom\Thenable`, extra) {
+		t.Error("expected custom type to be detected")
+	}
+	if IsPromiseType(`My\Custom\Other`, extra) {
+		t.Error("expected non-promise type not to be detected")
+	}
+}
+
+func buildAsyncSurface() *reflect.ReflectionSurface {
+	return &reflect.ReflectionSurface{
+		PackageName: "acme/async",
+		Classes: []reflect.ClassSurface{
+			{
+				FQCN: `Acme\Async\Client`,
+				Methods: []reflect.MethodSurface{
+					{Name: "sendAsync", ReturnType: `React\Promise\PromiseInterface`},
+					{Name: "send", ReturnType: `string`},
+					{Name: "__construct"},
+					{Name: "fetchAsync", ReturnType: `Amp\Future`},
+				},
+			},
+		},
+		Interfaces: []reflect.InterfaceSurface{
+			{
+				FQCN: `Acme\Async\AsyncClientInterface`,
+				Methods: []reflect.MethodSurface{
+					{Name: "postAsync", ReturnType: `GuzzleHttp\Promise\PromiseInterface`},
+					{Name: "get", ReturnType: `int`},
+				},
+			},
+		},
+	}
+}
+
+func TestEmitDetectsAsyncMethods(t *testing.T) {
+	result := Emit(buildAsyncSurface(), Config{})
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	// sendAsync and fetchAsync are async; send is not; __construct skipped
+	if result.AsyncMethodCount != 3 {
+		t.Errorf("expected 3 async methods; got %d", result.AsyncMethodCount)
+	}
+}
+
+func TestEmitAsyncExternFnSyntax(t *testing.T) {
+	result := Emit(buildAsyncSurface(), Config{})
+	src := result.MochiSource
+	if !strings.Contains(src, "async extern fn") {
+		t.Errorf("expected async extern fn; got:\n%s", src)
+	}
+	if !strings.Contains(src, "acme_async_client_send_async") {
+		t.Errorf("expected acme_async_client_send_async; got:\n%s", src)
+	}
+	if !strings.Contains(src, "acme_async_client_fetch_async") {
+		t.Errorf("expected acme_async_client_fetch_async; got:\n%s", src)
+	}
+}
+
+func TestEmitSkipsMagicMethods(t *testing.T) {
+	surface := &reflect.ReflectionSurface{
+		PackageName: "x/y",
+		Classes: []reflect.ClassSurface{
+			{
+				FQCN: `X\Y\Obj`,
+				Methods: []reflect.MethodSurface{
+					{Name: "__invoke", ReturnType: `React\Promise\PromiseInterface`},
+					{Name: "doAsync", ReturnType: `Amp\Future`},
+				},
+			},
+		},
+	}
+	result := Emit(surface, Config{})
+	if result.AsyncMethodCount != 1 {
+		t.Errorf("expected 1 async method (magic skipped); got %d", result.AsyncMethodCount)
+	}
+	if strings.Contains(result.MochiSource, "__invoke") {
+		t.Errorf("__invoke should be skipped; got:\n%s", result.MochiSource)
+	}
+}
+
+func TestEmitNonAsyncSurface(t *testing.T) {
+	surface := &reflect.ReflectionSurface{
+		PackageName: "sync/pkg",
+		Classes: []reflect.ClassSurface{
+			{
+				FQCN: `Sync\Client`,
+				Methods: []reflect.MethodSurface{
+					{Name: "get", ReturnType: "string"},
+					{Name: "post", ReturnType: "bool"},
+				},
+			},
+		},
+	}
+	result := Emit(surface, Config{})
+	if result.AsyncMethodCount != 0 {
+		t.Errorf("expected 0 async methods; got %d", result.AsyncMethodCount)
+	}
+	if result.MochiSource != "" {
+		t.Errorf("expected empty source for non-async surface; got:\n%s", result.MochiSource)
+	}
+}
+
+func TestEmitExtraPromiseTypes(t *testing.T) {
+	surface := &reflect.ReflectionSurface{
+		PackageName: "custom/async",
+		Classes: []reflect.ClassSurface{
+			{
+				FQCN: `Custom\Worker`,
+				Methods: []reflect.MethodSurface{
+					{Name: "run", ReturnType: `My\Thenable`},
+				},
+			},
+		},
+	}
+	cfg := Config{ExtraPromiseTypes: []string{`My\Thenable`}}
+	result := Emit(surface, cfg)
+	if result.AsyncMethodCount != 1 {
+		t.Errorf("expected 1 async method; got %d", result.AsyncMethodCount)
+	}
+}
+
+func TestEmitReturnTypeIsUnit(t *testing.T) {
+	result := Emit(buildAsyncSurface(), Config{})
+	src := result.MochiSource
+	// All async methods must return unit.
+	for line := range strings.SplitSeq(src, "\n") {
+		if strings.HasPrefix(line, "async extern fn") {
+			if !strings.HasSuffix(strings.TrimSpace(line), "-> unit") {
+				t.Errorf("expected -> unit return type; got: %s", line)
+			}
+		}
+	}
+}
+
+func TestEmitSelfParam(t *testing.T) {
+	result := Emit(buildAsyncSurface(), Config{})
+	src := result.MochiSource
+	// Instance methods must have self parameter.
+	if !strings.Contains(src, "self: AcmeAsyncClient") {
+		t.Errorf("expected self: AcmeAsyncClient param; got:\n%s", src)
+	}
+}
+
+func TestLoopDriverField(t *testing.T) {
+	// LoopDriver values should be distinct.
+	if LoopRevolt == LoopReactPHP || LoopReactPHP == LoopAmp {
+		t.Error("LoopDriver constants must be distinct")
+	}
+}

--- a/package3/php/externemit/externemit.go
+++ b/package3/php/externemit/externemit.go
@@ -264,9 +264,13 @@ func classHandle(fqcn string) string {
 	return name
 }
 
-// toSnakeCase converts a PascalCase or camelCase identifier to snake_case.
+// ToSnakeCase converts a PascalCase or camelCase identifier to snake_case.
 // "GuzzleHttpClient" -> "guzzle_http_client"
 // "send" -> "send"
+func ToSnakeCase(s string) string {
+	return toSnakeCase(s)
+}
+
 func toSnakeCase(s string) string {
 	var sb strings.Builder
 	for i, r := range s {

--- a/website/docs/implementation/0075/phase-12-async.md
+++ b/website/docs/implementation/0075/phase-12-async.md
@@ -1,0 +1,51 @@
+# MEP-75 Phase 12: Async PHP Bridge (ReactPHP / Revolt / Amp)
+
+**Status**: LANDED 2026-05-30 00:36 (GMT+7)
+
+## Goal
+
+Implement async-aware extern emission for PHP methods that return promise/future types from the major PHP async runtimes: ReactPHP, RevoltPHP, Amp, and Guzzle. The emitter produces `async extern fn` declarations so Mochi callers can await PHP async operations.
+
+## Supported Promise Types
+
+| FQCN | Runtime |
+|---|---|
+| `React\Promise\PromiseInterface` | ReactPHP |
+| `React\Promise\Promise` | ReactPHP |
+| `Amp\Promise` | Amp v2 |
+| `Amp\Future` | Amp v3 / Revolt |
+| `GuzzleHttp\Promise\PromiseInterface` | Guzzle HTTP |
+| `GuzzleHttp\Promise\Promise` | Guzzle HTTP |
+
+Extra promise types can be injected via `Config.ExtraPromiseTypes`.
+
+## Design
+
+`IsPromiseType(phpType, extra)` detects async return types by matching against the known FQCN table plus any caller-supplied extra types. Leading backslash is stripped before comparison.
+
+`Emit(surface, cfg)` scans all class and interface methods. Methods are emitted as `async extern fn` if their return type is a promise type. Magic methods (`__`-prefixed) are always skipped.
+
+Return type is always `unit` because PHP's reflection surface does not expose generic type parameters.
+
+`LoopDriver` enum (`LoopRevolt`, `LoopReactPHP`, `LoopAmp`) is reserved for future glue-code generation targeting a specific event loop backend.
+
+`ToSnakeCase` was exported from `package3/php/externemit` to allow reuse.
+
+## Files Landed
+
+- `package3/php/asyncemit/asyncemit.go` -- IsPromiseType + Emit + emitter
+- `package3/php/asyncemit/asyncemit_test.go` -- 10 test functions
+- `package3/php/externemit/externemit.go` -- exported ToSnakeCase wrapper
+
+## Test Coverage
+
+- IsPromiseType for all known promise FQCN variants
+- IsPromiseType with leading backslash normalisation
+- IsPromiseType with extra custom types
+- Emit counts async methods correctly
+- Emit emits async extern fn syntax
+- Emit skips magic methods
+- Emit produces empty output for non-async surface
+- Emit respects ExtraPromiseTypes config
+- All async methods return unit
+- Instance methods have self parameter


### PR DESCRIPTION
Closes #22933

## Summary

- New `package3/php/asyncemit` package with `IsPromiseType` and `Emit`
- Detects methods returning `React\Promise\PromiseInterface`, `Amp\Future`, `GuzzleHttp\Promise\PromiseInterface`, and 4 other known promise/future FQCNs
- Emits `async extern fn` declarations with `self` param and `-> unit` return type
- `ExtraPromiseTypes` in `Config` allows caller-supplied custom promise types
- `LoopDriver` enum for future event-loop glue generation
- Exports `ToSnakeCase` from `externemit` for reuse
- 10 tests covering all detection and emission paths

## Test plan

- `go test ./package3/php/asyncemit/... -count=1` passes locally
- `go test ./package3/php/externemit/... -count=1` still passes