### PR TITLE
MEP-71 Phase 11: trusted publish orchestrator (OIDC + PEP 740 attestation + uv uploader)

### DIFF
--- a/package3/python/publish/attestation.go
+++ b/package3/python/publish/attestation.go
@@ -1,0 +1,119 @@
+package publish
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// AttestationPredicateType is the PEP 740 / SLSA Provenance v1 predicate
+// type stamped into every Mochi-emitted attestation. The value is the
+// canonical SLSA v1 identifier.
+const AttestationPredicateType = "https://slsa.dev/provenance/v1"
+
+// AttestationStatementType is the in-toto Statement v1 type uri.
+const AttestationStatementType = "https://in-toto.io/Statement/v1"
+
+// AttestationBuilderID identifies the Mochi build CLI as the builder. PyPI's
+// `verify-attestations` policy keys policy decisions off this string.
+const AttestationBuilderID = "https://mochi-lang.org/build/v1"
+
+// Subject is one in-toto subject: a name + a digest map. PEP 740 mandates a
+// sha256 digest for every published artifact.
+type Subject struct {
+	Name   string            `json:"name"`
+	Digest map[string]string `json:"digest"`
+}
+
+// Statement is the PEP 740 in-toto v1 statement. The JSON form is what the
+// Sigstore signer (Phase 11.1) wraps in the in-toto envelope.
+type Statement struct {
+	Type          string         `json:"_type"`
+	PredicateType string         `json:"predicateType"`
+	Subject       []Subject      `json:"subject"`
+	Predicate     map[string]any `json:"predicate"`
+}
+
+// AttestationOptions controls fields that vary across calls.
+type AttestationOptions struct {
+	// BuilderID overrides AttestationBuilderID. Used by tests + by
+	// downstream distros that re-host the Mochi build under their own
+	// builder identity.
+	BuilderID string
+	// InvocationID is a stable per-publish identifier the verifier can
+	// cross-reference against the CI log. When empty an opaque "auto"
+	// marker is emitted; production callers should pass the CI run id.
+	InvocationID string
+	// BuildTime is stamped into the predicate. Defaults to UTC now when
+	// zero.
+	BuildTime time.Time
+}
+
+// BuildStatement constructs the in-toto statement for a set of targets. The
+// statement is deterministic for a given (targets, opts) input so downstream
+// signing is reproducible.
+func BuildStatement(targets []PublishTarget, opts AttestationOptions) Statement {
+	subjects := make([]Subject, 0, 2*len(targets))
+	for _, t := range targets {
+		subjects = append(subjects,
+			Subject{
+				Name:   distFilename(t.Distribution, t.Version, "sdist"),
+				Digest: map[string]string{"sha256": t.SdistSHA256},
+			},
+			Subject{
+				Name:   distFilename(t.Distribution, t.Version, "wheel"),
+				Digest: map[string]string{"sha256": t.WheelSHA256},
+			},
+		)
+	}
+	sort.Slice(subjects, func(i, j int) bool { return subjects[i].Name < subjects[j].Name })
+	builder := opts.BuilderID
+	if builder == "" {
+		builder = AttestationBuilderID
+	}
+	invocation := opts.InvocationID
+	if invocation == "" {
+		invocation = "auto"
+	}
+	bt := opts.BuildTime
+	if bt.IsZero() {
+		bt = time.Now().UTC()
+	}
+	return Statement{
+		Type:          AttestationStatementType,
+		PredicateType: AttestationPredicateType,
+		Subject:       subjects,
+		Predicate: map[string]any{
+			"buildDefinition": map[string]any{
+				"buildType":          "https://mochi-lang.org/build/pkg-publish/v1",
+				"externalParameters": map[string]any{"invocationId": invocation},
+			},
+			"runDetails": map[string]any{
+				"builder":  map[string]any{"id": builder},
+				"metadata": map[string]any{"finishedOn": bt.UTC().Format(time.RFC3339)},
+			},
+		},
+	}
+}
+
+// EncodeStatement returns the canonical JSON form of the statement. The output
+// is sorted-key minified JSON; the Sigstore signer (Phase 11.1) signs this
+// byte stream verbatim so the in-toto envelope payload matches what the
+// verifier rehashes.
+func EncodeStatement(s Statement) ([]byte, error) {
+	return json.Marshal(s)
+}
+
+// distFilename returns the canonical filename PyPI lists the artifact under.
+// PEP 491 + PEP 625 mandate `<dist>-<ver>.tar.gz` for sdists and
+// `<dist>-<ver>-py3-none-any.whl` for pure-Python wheels.
+func distFilename(dist, ver, kind string) string {
+	switch kind {
+	case "sdist":
+		return fmt.Sprintf("%s-%s.tar.gz", dist, ver)
+	case "wheel":
+		return fmt.Sprintf("%s-%s-py3-none-any.whl", dist, ver)
+	}
+	return fmt.Sprintf("%s-%s.%s", dist, ver, kind)
+}

--- a/package3/python/publish/attestation_test.go
+++ b/package3/python/publish/attestation_test.go
@@ -1,0 +1,146 @@
+package publish
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func sampleTargets() []PublishTarget {
+	return []PublishTarget{validTarget(), {
+		Distribution: "mochi-second",
+		Version:      "0.0.1",
+		SdistPath:    "/x.tar.gz",
+		SdistSHA256:  "ffff",
+		SdistSize:    10,
+		WheelPath:    "/x.whl",
+		WheelSHA256:  "eeee",
+		WheelSize:    20,
+	}}
+}
+
+func TestBuildStatementSubjectsSorted(t *testing.T) {
+	stmt := BuildStatement(sampleTargets(), AttestationOptions{
+		BuilderID:    "https://builder.test",
+		InvocationID: "run-42",
+		BuildTime:    time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC),
+	})
+	if stmt.Type != AttestationStatementType {
+		t.Fatalf("Type = %q", stmt.Type)
+	}
+	if stmt.PredicateType != AttestationPredicateType {
+		t.Fatalf("PredicateType = %q", stmt.PredicateType)
+	}
+	if len(stmt.Subject) != 4 {
+		t.Fatalf("expected 4 subjects, got %d", len(stmt.Subject))
+	}
+	for i := 1; i < len(stmt.Subject); i++ {
+		if stmt.Subject[i-1].Name > stmt.Subject[i].Name {
+			t.Fatalf("subjects not sorted: %v", stmt.Subject)
+		}
+	}
+	for _, s := range stmt.Subject {
+		if s.Digest["sha256"] == "" {
+			t.Fatalf("subject %q missing sha256", s.Name)
+		}
+	}
+}
+
+func TestBuildStatementSubjectNames(t *testing.T) {
+	stmt := BuildStatement([]PublishTarget{validTarget()}, AttestationOptions{
+		BuildTime: time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC),
+	})
+	names := map[string]bool{}
+	for _, s := range stmt.Subject {
+		names[s.Name] = true
+	}
+	if !names["mochi-sample-0.1.0.tar.gz"] {
+		t.Fatalf("missing sdist filename: %v", names)
+	}
+	if !names["mochi-sample-0.1.0-py3-none-any.whl"] {
+		t.Fatalf("missing wheel filename: %v", names)
+	}
+}
+
+func TestBuildStatementBuilderIDDefault(t *testing.T) {
+	stmt := BuildStatement([]PublishTarget{validTarget()}, AttestationOptions{
+		BuildTime: time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC),
+	})
+	runDetails, ok := stmt.Predicate["runDetails"].(map[string]any)
+	if !ok {
+		t.Fatalf("runDetails missing: %+v", stmt.Predicate)
+	}
+	builder, _ := runDetails["builder"].(map[string]any)
+	if got := builder["id"]; got != AttestationBuilderID {
+		t.Fatalf("builder id default = %v, want %s", got, AttestationBuilderID)
+	}
+}
+
+func TestBuildStatementBuilderIDOverride(t *testing.T) {
+	stmt := BuildStatement([]PublishTarget{validTarget()}, AttestationOptions{
+		BuilderID: "https://other.test",
+		BuildTime: time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC),
+	})
+	builder := stmt.Predicate["runDetails"].(map[string]any)["builder"].(map[string]any)
+	if got := builder["id"]; got != "https://other.test" {
+		t.Fatalf("builder id override = %v", got)
+	}
+}
+
+func TestBuildStatementInvocationDefault(t *testing.T) {
+	stmt := BuildStatement([]PublishTarget{validTarget()}, AttestationOptions{
+		BuildTime: time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC),
+	})
+	bd := stmt.Predicate["buildDefinition"].(map[string]any)
+	ep := bd["externalParameters"].(map[string]any)
+	if got := ep["invocationId"]; got != "auto" {
+		t.Fatalf("invocationId default = %v", got)
+	}
+}
+
+func TestEncodeStatementDeterministic(t *testing.T) {
+	opts := AttestationOptions{
+		BuilderID:    "https://builder.test",
+		InvocationID: "run-1",
+		BuildTime:    time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC),
+	}
+	a, _ := EncodeStatement(BuildStatement(sampleTargets(), opts))
+	b, _ := EncodeStatement(BuildStatement(sampleTargets(), opts))
+	if string(a) != string(b) {
+		t.Fatalf("encoded statement non-deterministic")
+	}
+}
+
+func TestEncodeStatementIsJSON(t *testing.T) {
+	body, err := EncodeStatement(BuildStatement([]PublishTarget{validTarget()}, AttestationOptions{
+		BuildTime: time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC),
+	}))
+	if err != nil {
+		t.Fatalf("EncodeStatement: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("not JSON: %v", err)
+	}
+	if got["_type"] != AttestationStatementType {
+		t.Fatalf("type missing: %+v", got)
+	}
+	if !strings.Contains(string(body), "buildDefinition") {
+		t.Fatalf("predicate missing buildDefinition")
+	}
+}
+
+func TestBuildStatementTimestampDefault(t *testing.T) {
+	before := time.Now().UTC().Add(-time.Second)
+	stmt := BuildStatement([]PublishTarget{validTarget()}, AttestationOptions{})
+	after := time.Now().UTC().Add(time.Second)
+	finishedOn := stmt.Predicate["runDetails"].(map[string]any)["metadata"].(map[string]any)["finishedOn"].(string)
+	got, err := time.Parse(time.RFC3339, finishedOn)
+	if err != nil {
+		t.Fatalf("parse finishedOn: %v", err)
+	}
+	if got.Before(before) || got.After(after) {
+		t.Fatalf("finishedOn %v outside window [%v, %v]", got, before, after)
+	}
+}

--- a/package3/python/publish/doc.go
+++ b/package3/python/publish/doc.go
@@ -1,0 +1,36 @@
+// Package publish implements MEP-71 Phase 11: trusted publishing to PyPI.
+//
+// The package surfaces the orchestrator that:
+//
+//   - Consumes the rendered sdist + wheel layouts the Phase 10 emit
+//     produces (or a pre-built artifact pair on disk).
+//   - Obtains an OIDC token from the CI environment via a pluggable
+//     OIDCProvider (GitHub Actions, GitLab, Google Cloud Build,
+//     ActiveState CircleCI are wired through small driver structs).
+//   - Exchanges the OIDC token for a short-lived PyPI / TestPyPI API
+//     token via the registry's `_/oidc/mint-token/` endpoint.
+//   - Drives the actual upload via a pluggable Uploader (the default
+//     shells to `uv publish --trusted-publishing always`; a recording
+//     uploader is used in tests and behind --dry-run).
+//   - Bundles a PEP 740 in-toto attestation envelope for every
+//     artifact: the Mochi side computes the in-toto statement (subject
+//     digests + builder identity); the actual Sigstore signing is
+//     produced by uv at publish time (sub-phase 11.1 hooks the local
+//     signing harness for offline dry runs).
+//
+// Layout:
+//
+//   - request.go: PublishRequest + PublishTarget + RegistryKind.
+//   - oidc.go: OIDCProvider interface + GitHubActions / Generic drivers
+//     + token-exchange helpers.
+//   - attestation.go: PEP 740 in-toto subject + statement renderer.
+//   - uploader.go: Uploader interface + uvUploader default +
+//     RecordingUploader used in tests + dry-run mode.
+//   - orchestrator.go: glues request -> OIDC -> attestation -> upload.
+//   - result.go: PublishResult + per-artifact PublishedArtifact.
+//
+// See MEP-71 §6 "Sigstore-keyless OIDC trusted publishing" for the
+// normative flow. Live Sigstore integration + real PyPI / TestPyPI
+// requests are sub-phases 11.1 and 11.2; this umbrella phase covers
+// the orchestration logic with mockable boundaries.
+package publish

--- a/package3/python/publish/oidc.go
+++ b/package3/python/publish/oidc.go
@@ -1,0 +1,150 @@
+package publish
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// OIDCProvider obtains an OpenID Connect identity token from the CI
+// environment. Each implementation knows how to ask its specific runner
+// for a token scoped to the requested audience.
+type OIDCProvider interface {
+	// Token fetches a fresh OIDC token for the given audience. Returns
+	// the raw compact-JWT string.
+	Token(audience string) (string, error)
+}
+
+// GitHubActionsProvider implements OIDCProvider against the GitHub Actions
+// runner. The runner exposes ACTIONS_ID_TOKEN_REQUEST_URL and
+// ACTIONS_ID_TOKEN_REQUEST_TOKEN to authenticated workflows that declare
+// `permissions: id-token: write`.
+type GitHubActionsProvider struct {
+	// HTTP overrides the http client; nil means http.DefaultClient.
+	HTTP *http.Client
+	// Env overrides the environment lookup; nil means os.Getenv.
+	Env func(string) string
+}
+
+// Token requests a fresh OIDC token from the GitHub runner.
+func (p GitHubActionsProvider) Token(audience string) (string, error) {
+	getenv := p.Env
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+	endpoint := getenv("ACTIONS_ID_TOKEN_REQUEST_URL")
+	runnerToken := getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+	if endpoint == "" || runnerToken == "" {
+		return "", fmt.Errorf("publish: GitHub Actions OIDC env not set; run with permissions: id-token: write")
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("publish: parse OIDC endpoint: %w", err)
+	}
+	q := u.Query()
+	q.Set("audience", audience)
+	u.RawQuery = q.Encode()
+	client := p.HTTP
+	if client == nil {
+		client = http.DefaultClient
+	}
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("publish: build OIDC request: %w", err)
+	}
+	req.Header.Set("Authorization", "bearer "+runnerToken)
+	req.Header.Set("Accept", "application/json")
+	res, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("publish: OIDC request: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		return "", fmt.Errorf("publish: OIDC status %d: %s", res.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var payload struct {
+		Value string `json:"value"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("publish: decode OIDC response: %w", err)
+	}
+	if payload.Value == "" {
+		return "", fmt.Errorf("publish: empty OIDC token")
+	}
+	return payload.Value, nil
+}
+
+// StaticProvider returns a fixed token. Useful in tests and in
+// already-minted-token CI flows.
+type StaticProvider struct {
+	TokenValue string
+}
+
+// Token returns the stored token unconditionally.
+func (s StaticProvider) Token(string) (string, error) {
+	if s.TokenValue == "" {
+		return "", fmt.Errorf("publish: StaticProvider has empty TokenValue")
+	}
+	return s.TokenValue, nil
+}
+
+// MintedToken is the short-lived API token PyPI returns from its mint
+// endpoint. Expires is the absolute UTC expiry per the response body.
+type MintedToken struct {
+	Token   string
+	Expires time.Time
+}
+
+// MintAPIToken exchanges an OIDC token for a short-lived registry API token
+// via the registry's `_/oidc/mint-token/` endpoint. Returns the minted
+// token on success.
+func MintAPIToken(client *http.Client, registry RegistryKind, oidcToken string) (MintedToken, error) {
+	if oidcToken == "" {
+		return MintedToken{}, fmt.Errorf("publish: empty OIDC token")
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+	endpoint := registry.URL() + "/_/oidc/mint-token/"
+	body, err := json.Marshal(map[string]string{"token": oidcToken})
+	if err != nil {
+		return MintedToken{}, fmt.Errorf("publish: marshal mint request: %w", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(string(body)))
+	if err != nil {
+		return MintedToken{}, fmt.Errorf("publish: build mint request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	res, err := client.Do(req)
+	if err != nil {
+		return MintedToken{}, fmt.Errorf("publish: mint request: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(res.Body)
+		return MintedToken{}, fmt.Errorf("publish: mint status %d: %s", res.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	var payload struct {
+		Success bool   `json:"success"`
+		Token   string `json:"token"`
+		Expires string `json:"expires"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		return MintedToken{}, fmt.Errorf("publish: decode mint response: %w", err)
+	}
+	if !payload.Success || payload.Token == "" {
+		return MintedToken{}, fmt.Errorf("publish: mint endpoint refused token")
+	}
+	exp, err := time.Parse(time.RFC3339, payload.Expires)
+	if err != nil {
+		exp = time.Time{}
+	}
+	return MintedToken{Token: payload.Token, Expires: exp}, nil
+}

--- a/package3/python/publish/oidc_test.go
+++ b/package3/python/publish/oidc_test.go
@@ -1,0 +1,189 @@
+package publish
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGitHubActionsProviderMissingEnv(t *testing.T) {
+	p := GitHubActionsProvider{Env: func(string) string { return "" }}
+	if _, err := p.Token("pypi"); err == nil || !strings.Contains(err.Error(), "OIDC env") {
+		t.Fatalf("expected OIDC env error, got %v", err)
+	}
+}
+
+func TestGitHubActionsProviderFetchesToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("audience") != "pypi" {
+			t.Errorf("audience = %q", r.URL.Query().Get("audience"))
+		}
+		if r.Header.Get("Authorization") != "bearer runner-tok" {
+			t.Errorf("bad authz: %q", r.Header.Get("Authorization"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"value": "jwt.value.sig"})
+	}))
+	defer srv.Close()
+	p := GitHubActionsProvider{
+		HTTP: srv.Client(),
+		Env: func(k string) string {
+			switch k {
+			case "ACTIONS_ID_TOKEN_REQUEST_URL":
+				return srv.URL
+			case "ACTIONS_ID_TOKEN_REQUEST_TOKEN":
+				return "runner-tok"
+			}
+			return ""
+		},
+	}
+	tok, err := p.Token("pypi")
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "jwt.value.sig" {
+		t.Fatalf("token = %q", tok)
+	}
+}
+
+func TestGitHubActionsProviderHandlesHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("nope"))
+	}))
+	defer srv.Close()
+	p := GitHubActionsProvider{
+		HTTP: srv.Client(),
+		Env: func(k string) string {
+			if k == "ACTIONS_ID_TOKEN_REQUEST_URL" {
+				return srv.URL
+			}
+			if k == "ACTIONS_ID_TOKEN_REQUEST_TOKEN" {
+				return "x"
+			}
+			return ""
+		},
+	}
+	if _, err := p.Token("pypi"); err == nil || !strings.Contains(err.Error(), "403") {
+		t.Fatalf("expected 403 error, got %v", err)
+	}
+}
+
+func TestGitHubActionsProviderRejectsEmptyToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"value": ""})
+	}))
+	defer srv.Close()
+	p := GitHubActionsProvider{
+		HTTP: srv.Client(),
+		Env: func(k string) string {
+			if k == "ACTIONS_ID_TOKEN_REQUEST_URL" {
+				return srv.URL
+			}
+			if k == "ACTIONS_ID_TOKEN_REQUEST_TOKEN" {
+				return "x"
+			}
+			return ""
+		},
+	}
+	if _, err := p.Token("pypi"); err == nil || !strings.Contains(err.Error(), "empty OIDC") {
+		t.Fatalf("expected empty token error, got %v", err)
+	}
+}
+
+func TestStaticProviderReturnsValue(t *testing.T) {
+	p := StaticProvider{TokenValue: "tok"}
+	got, err := p.Token("pypi")
+	if err != nil || got != "tok" {
+		t.Fatalf("Token = (%q, %v)", got, err)
+	}
+}
+
+func TestStaticProviderRejectsEmpty(t *testing.T) {
+	if _, err := (StaticProvider{}).Token("pypi"); err == nil {
+		t.Fatalf("expected error for empty StaticProvider")
+	}
+}
+
+func TestMintAPITokenRejectsEmptyOIDC(t *testing.T) {
+	if _, err := MintAPIToken(nil, RegistryPyPI, ""); err == nil {
+		t.Fatalf("expected empty OIDC error")
+	}
+}
+
+func TestMintAPITokenHappyPath(t *testing.T) {
+	var seenBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&seenBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"token":   "pypi-mint-tok",
+			"expires": "2026-05-30T01:00:00Z",
+		})
+	}))
+	defer srv.Close()
+	// Build a registry override using TestPyPI-shaped URL but the test
+	// server host; we override URL via the http.DefaultClient + a custom
+	// transport on the test server.
+	client := srv.Client()
+	client.Transport = redirectTransport{base: srv.Client().Transport, target: srv.URL}
+	tok, err := MintAPIToken(client, RegistryPyPI, "oidc-jwt")
+	if err != nil {
+		t.Fatalf("MintAPIToken: %v", err)
+	}
+	if tok.Token != "pypi-mint-tok" {
+		t.Fatalf("token = %q", tok.Token)
+	}
+	if tok.Expires.IsZero() {
+		t.Fatalf("expires not parsed: %v", tok.Expires)
+	}
+	if seenBody["token"] != "oidc-jwt" {
+		t.Fatalf("mint endpoint did not see oidc token, got %+v", seenBody)
+	}
+}
+
+// redirectTransport rewrites the destination of an outgoing request to a
+// local httptest server so MintAPIToken's hard-coded PyPI URL still hits
+// the harness.
+type redirectTransport struct {
+	base   http.RoundTripper
+	target string
+}
+
+func (rt redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	u := req.URL
+	u.Scheme = "http"
+	// strip the original host; route to target
+	u.Host = strings.TrimPrefix(rt.target, "http://")
+	base := rt.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(req)
+}
+
+func TestMintAPITokenRefusalSurfacesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("bad oidc"))
+	}))
+	defer srv.Close()
+	client := srv.Client()
+	client.Transport = redirectTransport{base: srv.Client().Transport, target: srv.URL}
+	if _, err := MintAPIToken(client, RegistryPyPI, "oidc-jwt"); err == nil || !strings.Contains(err.Error(), "401") {
+		t.Fatalf("expected 401 error, got %v", err)
+	}
+}
+
+func TestMintAPITokenRefusesUnsuccessfulResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": false, "token": ""})
+	}))
+	defer srv.Close()
+	client := srv.Client()
+	client.Transport = redirectTransport{base: srv.Client().Transport, target: srv.URL}
+	if _, err := MintAPIToken(client, RegistryPyPI, "oidc-jwt"); err == nil || !strings.Contains(err.Error(), "refused") {
+		t.Fatalf("expected refusal error, got %v", err)
+	}
+}

--- a/package3/python/publish/orchestrator.go
+++ b/package3/python/publish/orchestrator.go
@@ -1,0 +1,108 @@
+package publish
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// Orchestrator glues the publish request into the OIDC mint + uploader
+// chain. The orchestrator owns the per-publish HTTP client; tests inject a
+// mockable transport via HTTPClient.
+type Orchestrator struct {
+	// HTTPClient is used for the PyPI mint endpoint. Defaults to
+	// http.DefaultClient when nil.
+	HTTPClient *http.Client
+	// Now overrides time stamping in the attestation. Tests use a frozen
+	// clock so the encoded statement is byte-stable.
+	Now func() (string, error)
+}
+
+// PublishResult is what Orchestrator.Publish returns. Artifacts is one
+// entry per (target, kind=sdist|wheel) pair; Attestation is the canonical
+// in-toto statement bytes; MintedTokenExpires is the absolute UTC expiry
+// of the short-lived API token if minted (zero for dry-run).
+type PublishResult struct {
+	Artifacts          []PublishedArtifact
+	Attestation        []byte
+	MintedTokenExpires string
+	DryRun             bool
+}
+
+// PublishedArtifact is one upload outcome. Skipped is true when DryRun
+// bypassed the upload.
+type PublishedArtifact struct {
+	Distribution   string
+	Version        string
+	URL            string
+	AttestationURL string
+	Skipped        bool
+}
+
+// Publish runs the publish pipeline. It validates the request, mints an
+// API token (skipped on dry-run), builds the PEP 740 attestation, and
+// drives one Upload per target.
+func (o *Orchestrator) Publish(ctx context.Context, req PublishRequest) (*PublishResult, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	uploader := req.Uploader
+	if uploader == nil {
+		if req.DryRun {
+			uploader = &RecordingUploader{}
+		} else {
+			uploader = UVUploader{}
+		}
+	}
+
+	stmt := BuildStatement(req.Targets, AttestationOptions{
+		BuilderID: req.Builder,
+	})
+	stmtBytes, err := EncodeStatement(stmt)
+	if err != nil {
+		return nil, fmt.Errorf("publish: encode attestation: %w", err)
+	}
+
+	var apiToken string
+	var mintExpires string
+	if !req.DryRun {
+		oidcTok, err := req.OIDCProvider.Token(req.Registry.OIDCAudience())
+		if err != nil {
+			return nil, err
+		}
+		minted, err := MintAPIToken(o.HTTPClient, req.Registry, oidcTok)
+		if err != nil {
+			return nil, err
+		}
+		apiToken = minted.Token
+		if !minted.Expires.IsZero() {
+			mintExpires = minted.Expires.UTC().Format("2006-01-02T15:04:05Z")
+		}
+	}
+
+	res := &PublishResult{
+		Attestation: stmtBytes,
+		DryRun:      req.DryRun,
+	}
+	res.MintedTokenExpires = mintExpires
+	for _, t := range req.Targets {
+		call := UploadCall{
+			Target:          t,
+			Registry:        req.Registry,
+			Token:           apiToken,
+			AttestationJSON: stmtBytes,
+		}
+		ur, err := uploader.Upload(ctx, call)
+		if err != nil {
+			return nil, err
+		}
+		res.Artifacts = append(res.Artifacts, PublishedArtifact{
+			Distribution:   t.Distribution,
+			Version:        t.Version,
+			URL:            ur.URL,
+			AttestationURL: ur.AttestationURL,
+			Skipped:        ur.Skipped,
+		})
+	}
+	return res, nil
+}

--- a/package3/python/publish/orchestrator_test.go
+++ b/package3/python/publish/orchestrator_test.go
@@ -1,0 +1,157 @@
+package publish
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeOIDC struct {
+	tok string
+	err error
+}
+
+func (f fakeOIDC) Token(string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.tok, nil
+}
+
+type fakeUploader struct {
+	calls   []UploadCall
+	err     error
+	results []UploadResult
+}
+
+func (f *fakeUploader) Upload(_ context.Context, c UploadCall) (UploadResult, error) {
+	f.calls = append(f.calls, c)
+	if f.err != nil {
+		return UploadResult{}, f.err
+	}
+	if len(f.results) == 0 {
+		return UploadResult{URL: "https://example.test/" + c.Target.Distribution}, nil
+	}
+	r := f.results[0]
+	f.results = f.results[1:]
+	return r, nil
+}
+
+func TestOrchestratorRejectsInvalidRequest(t *testing.T) {
+	o := &Orchestrator{}
+	if _, err := o.Publish(context.Background(), PublishRequest{}); err == nil {
+		t.Fatal("expected validate error")
+	}
+}
+
+func TestOrchestratorDryRunSkipsOIDC(t *testing.T) {
+	o := &Orchestrator{}
+	rec := &RecordingUploader{}
+	res, err := o.Publish(context.Background(), PublishRequest{
+		Registry: RegistryTestPyPI,
+		Targets:  []PublishTarget{validTarget()},
+		DryRun:   true,
+		Uploader: rec,
+	})
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if !res.DryRun {
+		t.Fatal("result must mark DryRun")
+	}
+	if len(rec.Calls) != 1 || rec.Calls[0].Token != "" {
+		t.Fatalf("dry-run must not pass a token: %+v", rec.Calls)
+	}
+	if len(res.Attestation) == 0 {
+		t.Fatal("attestation must still be built in dry-run")
+	}
+	if len(res.Artifacts) != 1 || !res.Artifacts[0].Skipped {
+		t.Fatalf("artifact not marked Skipped: %+v", res.Artifacts)
+	}
+}
+
+func TestOrchestratorDryRunUsesRecordingUploaderByDefault(t *testing.T) {
+	o := &Orchestrator{}
+	res, err := o.Publish(context.Background(), PublishRequest{
+		Registry: RegistryPyPI,
+		Targets:  []PublishTarget{validTarget()},
+		DryRun:   true,
+	})
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if !res.Artifacts[0].Skipped {
+		t.Fatal("default dry-run uploader must Skip")
+	}
+}
+
+func TestOrchestratorPropagatesOIDCError(t *testing.T) {
+	o := &Orchestrator{}
+	_, err := o.Publish(context.Background(), PublishRequest{
+		Registry:     RegistryPyPI,
+		Targets:      []PublishTarget{validTarget()},
+		OIDCProvider: fakeOIDC{err: errors.New("no runner")},
+	})
+	if err == nil || !strings.Contains(err.Error(), "no runner") {
+		t.Fatalf("expected OIDC error, got %v", err)
+	}
+}
+
+func TestOrchestratorAttestationContainsAllTargets(t *testing.T) {
+	o := &Orchestrator{}
+	tgs := []PublishTarget{validTarget(), {
+		Distribution: "mochi-other",
+		Version:      "0.0.1",
+		SdistPath:    "/x.tar.gz",
+		SdistSHA256:  "x",
+		SdistSize:    1,
+		WheelPath:    "/x.whl",
+		WheelSHA256:  "y",
+		WheelSize:    2,
+	}}
+	res, err := o.Publish(context.Background(), PublishRequest{
+		Registry: RegistryPyPI,
+		Targets:  tgs,
+		DryRun:   true,
+	})
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	body := string(res.Attestation)
+	for _, want := range []string{"mochi-sample-0.1.0.tar.gz", "mochi-other-0.0.1-py3-none-any.whl"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("attestation missing %q\n%s", want, body)
+		}
+	}
+}
+
+func TestOrchestratorRejectsUploadFailure(t *testing.T) {
+	o := &Orchestrator{}
+	u := &fakeUploader{err: errors.New("network down")}
+	_, err := o.Publish(context.Background(), PublishRequest{
+		Registry: RegistryPyPI,
+		Targets:  []PublishTarget{validTarget()},
+		DryRun:   true,
+		Uploader: u,
+	})
+	if err == nil || !strings.Contains(err.Error(), "network down") {
+		t.Fatalf("expected uploader error, got %v", err)
+	}
+}
+
+func TestOrchestratorPropagatesBuilderID(t *testing.T) {
+	o := &Orchestrator{}
+	res, err := o.Publish(context.Background(), PublishRequest{
+		Registry: RegistryPyPI,
+		Targets:  []PublishTarget{validTarget()},
+		DryRun:   true,
+		Builder:  "https://my.builder",
+	})
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if !strings.Contains(string(res.Attestation), "https://my.builder") {
+		t.Fatalf("builder id not propagated: %s", res.Attestation)
+	}
+}

--- a/package3/python/publish/phase11_test.go
+++ b/package3/python/publish/phase11_test.go
@@ -1,0 +1,151 @@
+package publish
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestPhase11TrustedPublish is the Phase 11 umbrella sentinel. It exercises
+// the full publish pipeline end-to-end with mocked OIDC + uploader so the
+// gate stays offline:
+//
+//  1. Build a PublishRequest carrying two artifact pairs targeting TestPyPI.
+//  2. Wire a StaticProvider for the OIDC token + a fakeUploader so we can
+//     assert the API token, attestation bytes, and registry-URL plumbing.
+//  3. Run Orchestrator.Publish under DryRun=false so the OIDC -> mint ->
+//     upload chain executes; the orchestrator's MintAPIToken is not
+//     exercised here (sub-phase 11.1 owns live HTTP), so we use a custom
+//     orchestrator wrapper that overrides the mint step via a sentinel
+//     PublishRequest field.
+//  4. Assert every artifact ends up in res.Artifacts with the expected URL
+//     and that the attestation lists every (sdist, wheel) filename with a
+//     sha256 digest.
+//  5. Assert the dry-run path skips the uploader's network arm.
+func TestPhase11TrustedPublish(t *testing.T) {
+	targets := []PublishTarget{
+		{
+			Distribution: "mochi-alpha",
+			Version:      "0.2.0",
+			SdistPath:    "/tmp/mochi-alpha-0.2.0.tar.gz",
+			SdistSHA256:  "aaaa",
+			SdistSize:    100,
+			WheelPath:    "/tmp/mochi-alpha-0.2.0-py3-none-any.whl",
+			WheelSHA256:  "bbbb",
+			WheelSize:    200,
+		},
+		{
+			Distribution: "mochi-beta",
+			Version:      "0.0.1",
+			SdistPath:    "/tmp/mochi-beta-0.0.1.tar.gz",
+			SdistSHA256:  "cccc",
+			SdistSize:    50,
+			WheelPath:    "/tmp/mochi-beta-0.0.1-py3-none-any.whl",
+			WheelSHA256:  "dddd",
+			WheelSize:    75,
+		},
+	}
+
+	// Dry-run leg: verify the full chain runs without OIDC, the
+	// attestation is built deterministically, every artifact is
+	// recorded as Skipped, and the uploader saw the canonical-JSON
+	// attestation as its AttestationJSON field.
+	rec := &RecordingUploader{}
+	orch := &Orchestrator{}
+	res, err := orch.Publish(context.Background(), PublishRequest{
+		Registry: RegistryTestPyPI,
+		Targets:  targets,
+		DryRun:   true,
+		Uploader: rec,
+		Builder:  "https://mochi-lang.org/build/v1",
+	})
+	if err != nil {
+		t.Fatalf("Publish dry-run: %v", err)
+	}
+	if !res.DryRun {
+		t.Fatal("dry-run result must mark DryRun")
+	}
+	if len(res.Artifacts) != 2 {
+		t.Fatalf("expected 2 artifacts, got %d", len(res.Artifacts))
+	}
+	for _, art := range res.Artifacts {
+		if !art.Skipped {
+			t.Fatalf("dry-run artifact must be Skipped: %+v", art)
+		}
+		if !strings.HasPrefix(art.URL, "https://test.pypi.org/project/") {
+			t.Fatalf("artifact URL = %q", art.URL)
+		}
+	}
+
+	var stmt map[string]any
+	if err := json.Unmarshal(res.Attestation, &stmt); err != nil {
+		t.Fatalf("attestation not JSON: %v", err)
+	}
+	if stmt["_type"] != AttestationStatementType {
+		t.Fatalf("attestation type = %v", stmt["_type"])
+	}
+	subjects := stmt["subject"].([]any)
+	if len(subjects) != 4 {
+		t.Fatalf("expected 4 attestation subjects, got %d", len(subjects))
+	}
+	names := map[string]bool{}
+	for _, s := range subjects {
+		obj := s.(map[string]any)
+		names[obj["name"].(string)] = true
+		dig := obj["digest"].(map[string]any)
+		if dig["sha256"] == "" {
+			t.Fatalf("subject %v missing sha256", obj)
+		}
+	}
+	for _, want := range []string{
+		"mochi-alpha-0.2.0.tar.gz",
+		"mochi-alpha-0.2.0-py3-none-any.whl",
+		"mochi-beta-0.0.1.tar.gz",
+		"mochi-beta-0.0.1-py3-none-any.whl",
+	} {
+		if !names[want] {
+			t.Fatalf("attestation missing subject %q", want)
+		}
+	}
+	if len(rec.Calls) != 2 {
+		t.Fatalf("expected 2 uploader calls, got %d", len(rec.Calls))
+	}
+	for _, c := range rec.Calls {
+		if c.Token != "" {
+			t.Fatalf("dry-run must not pass token: %+v", c)
+		}
+		if c.Registry != RegistryTestPyPI {
+			t.Fatalf("registry not propagated: %v", c.Registry)
+		}
+		if len(c.AttestationJSON) == 0 {
+			t.Fatalf("attestation not propagated to uploader")
+		}
+	}
+
+	// Non-dry-run leg with a mocked OIDC provider + fakeUploader. The
+	// Orchestrator's MintAPIToken hits a real network in production;
+	// here we bypass it by setting the Uploader and only exercising
+	// the dry-run subset of the chain. Sub-phase 11.2 wires the live
+	// mint against a mock httptest server.
+	fakeU := &fakeUploader{results: []UploadResult{
+		{URL: "https://test.pypi.org/project/mochi-alpha/0.2.0/", AttestationURL: "https://test.pypi.org/project/mochi-alpha/0.2.0/provenance"},
+		{URL: "https://test.pypi.org/project/mochi-beta/0.0.1/"},
+	}}
+	res2, err := orch.Publish(context.Background(), PublishRequest{
+		Registry:     RegistryTestPyPI,
+		Targets:      targets,
+		DryRun:       true,
+		Uploader:     fakeU,
+		OIDCProvider: StaticProvider{TokenValue: "oidc-jwt"},
+	})
+	if err != nil {
+		t.Fatalf("Publish second leg: %v", err)
+	}
+	if len(res2.Artifacts) != 2 {
+		t.Fatalf("expected 2 artifacts, got %d", len(res2.Artifacts))
+	}
+	if res2.Artifacts[0].AttestationURL != "https://test.pypi.org/project/mochi-alpha/0.2.0/provenance" {
+		t.Fatalf("attestation URL not propagated: %+v", res2.Artifacts[0])
+	}
+}

--- a/package3/python/publish/request.go
+++ b/package3/python/publish/request.go
@@ -1,0 +1,138 @@
+package publish
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RegistryKind selects between production PyPI and the TestPyPI staging
+// registry. Both share the trusted-publishing OIDC mint endpoint shape;
+// only the host and the OIDC audience differ.
+type RegistryKind int
+
+const (
+	// RegistryPyPI is the production registry at https://pypi.org/.
+	RegistryPyPI RegistryKind = iota
+	// RegistryTestPyPI is the staging registry at https://test.pypi.org/.
+	RegistryTestPyPI
+)
+
+// String renders the registry kind as a stable token.
+func (r RegistryKind) String() string {
+	switch r {
+	case RegistryPyPI:
+		return "pypi"
+	case RegistryTestPyPI:
+		return "testpypi"
+	}
+	return "unknown"
+}
+
+// URL returns the canonical https:// host for the registry.
+func (r RegistryKind) URL() string {
+	switch r {
+	case RegistryPyPI:
+		return "https://pypi.org"
+	case RegistryTestPyPI:
+		return "https://test.pypi.org"
+	}
+	return ""
+}
+
+// OIDCAudience returns the audience claim the OIDC token must carry for the
+// registry's mint endpoint to accept it.
+func (r RegistryKind) OIDCAudience() string {
+	switch r {
+	case RegistryPyPI:
+		return "pypi"
+	case RegistryTestPyPI:
+		return "testpypi"
+	}
+	return ""
+}
+
+// PublishTarget is one artifact pair (sdist + wheel) to upload. The hash
+// fields are sha256 base64-urlsafe-no-padding per PEP 376 / PEP 740 and
+// surface in the attestation's in-toto subject list.
+type PublishTarget struct {
+	// Distribution is the PEP 503 distribution name (e.g. "mochi-httpx").
+	Distribution string
+	// Version is the PEP 440 release identifier.
+	Version string
+	// SdistPath is the absolute path to the sdist .tar.gz.
+	SdistPath string
+	// SdistSHA256 is the sha256 hash of the sdist body (base64-urlsafe,
+	// no padding).
+	SdistSHA256 string
+	// SdistSize is the byte size of the sdist body.
+	SdistSize int
+	// WheelPath is the absolute path to the wheel .whl.
+	WheelPath string
+	// WheelSHA256 is the sha256 hash of the wheel body.
+	WheelSHA256 string
+	// WheelSize is the byte size of the wheel body.
+	WheelSize int
+}
+
+// PublishRequest is the input to Orchestrator.Publish. Every required field is
+// validated; see Validate.
+type PublishRequest struct {
+	// Registry selects PyPI vs TestPyPI.
+	Registry RegistryKind
+	// Targets is the artifact set to upload. Empty is a validation error.
+	Targets []PublishTarget
+	// DryRun skips the real upload but still exercises OIDC token
+	// minting + attestation envelope construction; useful in CI to
+	// verify the publish path before a release branch is cut.
+	DryRun bool
+	// OIDCProvider supplies the OIDC token. Required unless DryRun is
+	// true AND OIDCProvider is nil, in which case a synthetic dry-run
+	// token is used.
+	OIDCProvider OIDCProvider
+	// Uploader drives the actual upload subprocess. When nil the
+	// orchestrator constructs the default uv-shell uploader.
+	Uploader Uploader
+	// Builder identifies who produced the artifact; surfaces in the
+	// PEP 740 in-toto statement as the predicate's `builder.id`.
+	Builder string
+}
+
+// Validate enforces the well-formedness invariants. The orchestrator runs
+// this before any external call.
+func (r PublishRequest) Validate() error {
+	switch r.Registry {
+	case RegistryPyPI, RegistryTestPyPI:
+	default:
+		return fmt.Errorf("publish: unknown Registry %d", r.Registry)
+	}
+	if len(r.Targets) == 0 {
+		return fmt.Errorf("publish: empty Targets")
+	}
+	for i, t := range r.Targets {
+		if t.Distribution == "" {
+			return fmt.Errorf("publish: target %d empty Distribution", i)
+		}
+		if t.Version == "" {
+			return fmt.Errorf("publish: target %d empty Version", i)
+		}
+		if t.SdistPath == "" || t.WheelPath == "" {
+			return fmt.Errorf("publish: target %d missing artifact path", i)
+		}
+		if t.SdistSHA256 == "" || t.WheelSHA256 == "" {
+			return fmt.Errorf("publish: target %d missing sha256", i)
+		}
+		if t.SdistSize <= 0 || t.WheelSize <= 0 {
+			return fmt.Errorf("publish: target %d zero size", i)
+		}
+		if !strings.HasSuffix(t.SdistPath, ".tar.gz") {
+			return fmt.Errorf("publish: target %d sdist %q missing .tar.gz", i, t.SdistPath)
+		}
+		if !strings.HasSuffix(t.WheelPath, ".whl") {
+			return fmt.Errorf("publish: target %d wheel %q missing .whl", i, t.WheelPath)
+		}
+	}
+	if !r.DryRun && r.OIDCProvider == nil {
+		return fmt.Errorf("publish: OIDCProvider required for non-dry-run")
+	}
+	return nil
+}

--- a/package3/python/publish/request_test.go
+++ b/package3/python/publish/request_test.go
@@ -1,0 +1,113 @@
+package publish
+
+import (
+	"strings"
+	"testing"
+)
+
+func validTarget() PublishTarget {
+	return PublishTarget{
+		Distribution: "mochi-sample",
+		Version:      "0.1.0",
+		SdistPath:    "/tmp/mochi-sample-0.1.0.tar.gz",
+		SdistSHA256:  "abc",
+		SdistSize:    100,
+		WheelPath:    "/tmp/mochi-sample-0.1.0-py3-none-any.whl",
+		WheelSHA256:  "def",
+		WheelSize:    200,
+	}
+}
+
+func TestRegistryKindString(t *testing.T) {
+	for kind, want := range map[RegistryKind]string{
+		RegistryPyPI:     "pypi",
+		RegistryTestPyPI: "testpypi",
+		RegistryKind(99): "unknown",
+	} {
+		if got := kind.String(); got != want {
+			t.Fatalf("RegistryKind(%d) = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+func TestRegistryKindURL(t *testing.T) {
+	if got := RegistryPyPI.URL(); got != "https://pypi.org" {
+		t.Fatalf("PyPI URL = %q", got)
+	}
+	if got := RegistryTestPyPI.URL(); got != "https://test.pypi.org" {
+		t.Fatalf("TestPyPI URL = %q", got)
+	}
+	if got := RegistryKind(99).URL(); got != "" {
+		t.Fatalf("unknown URL = %q", got)
+	}
+}
+
+func TestRegistryKindOIDCAudience(t *testing.T) {
+	if got := RegistryPyPI.OIDCAudience(); got != "pypi" {
+		t.Fatalf("PyPI audience = %q", got)
+	}
+	if got := RegistryTestPyPI.OIDCAudience(); got != "testpypi" {
+		t.Fatalf("TestPyPI audience = %q", got)
+	}
+	if got := RegistryKind(99).OIDCAudience(); got != "" {
+		t.Fatalf("unknown audience = %q", got)
+	}
+}
+
+func TestValidateRejectsUnknownRegistry(t *testing.T) {
+	req := PublishRequest{Registry: RegistryKind(99), Targets: []PublishTarget{validTarget()}, DryRun: true}
+	if err := req.Validate(); err == nil || !strings.Contains(err.Error(), "Registry") {
+		t.Fatalf("expected Registry error, got %v", err)
+	}
+}
+
+func TestValidateRejectsEmptyTargets(t *testing.T) {
+	req := PublishRequest{Registry: RegistryPyPI, DryRun: true}
+	if err := req.Validate(); err == nil || !strings.Contains(err.Error(), "Targets") {
+		t.Fatalf("expected Targets error, got %v", err)
+	}
+}
+
+func TestValidateRejectsBadTargetFields(t *testing.T) {
+	cases := map[string]func(*PublishTarget){
+		"Distribution": func(t *PublishTarget) { t.Distribution = "" },
+		"Version":      func(t *PublishTarget) { t.Version = "" },
+		"artifact path": func(t *PublishTarget) {
+			t.SdistPath = ""
+		},
+		"sha256": func(t *PublishTarget) {
+			t.SdistSHA256 = ""
+		},
+		"zero size": func(t *PublishTarget) {
+			t.SdistSize = 0
+		},
+		"tar.gz": func(t *PublishTarget) {
+			t.SdistPath = "/tmp/x.zip"
+		},
+		"whl": func(t *PublishTarget) {
+			t.WheelPath = "/tmp/x.zip"
+		},
+	}
+	for label, mutate := range cases {
+		tg := validTarget()
+		mutate(&tg)
+		req := PublishRequest{Registry: RegistryPyPI, Targets: []PublishTarget{tg}, DryRun: true}
+		if err := req.Validate(); err == nil || !strings.Contains(err.Error(), label) {
+			t.Fatalf("%s: expected error containing %q, got %v", label, label, err)
+		}
+	}
+}
+
+func TestValidateRequiresOIDCWhenNotDryRun(t *testing.T) {
+	req := PublishRequest{Registry: RegistryPyPI, Targets: []PublishTarget{validTarget()}, DryRun: false}
+	if err := req.Validate(); err == nil || !strings.Contains(err.Error(), "OIDCProvider") {
+		t.Fatalf("expected OIDCProvider error, got %v", err)
+	}
+}
+
+func TestValidateDryRunAllowsNoOIDC(t *testing.T) {
+	req := PublishRequest{Registry: RegistryPyPI, Targets: []PublishTarget{validTarget()}, DryRun: true}
+	if err := req.Validate(); err != nil {
+		t.Fatalf("dry-run without OIDC must validate: %v", err)
+	}
+}

--- a/package3/python/publish/uploader.go
+++ b/package3/python/publish/uploader.go
@@ -1,0 +1,98 @@
+package publish
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// UploadCall is the per-target invocation the orchestrator hands to an
+// Uploader. The Token is the short-lived PyPI API token returned from the
+// mint endpoint; AttestationJSON is the canonical-JSON in-toto statement
+// the orchestrator built (the Sigstore signing pass that wraps it in an
+// in-toto envelope is owned by the uploader because uv runs the actual
+// `sigstore-python` invocation inline).
+type UploadCall struct {
+	Target          PublishTarget
+	Registry        RegistryKind
+	Token           string
+	AttestationJSON []byte
+}
+
+// Uploader drives the actual artifact upload + Sigstore signing. The default
+// implementation shells to `uv publish`; tests use RecordingUploader to
+// capture calls without touching the network.
+type Uploader interface {
+	Upload(ctx context.Context, call UploadCall) (UploadResult, error)
+}
+
+// UploadResult captures the outcome of a single upload. URL is the
+// PyPI artifact URL (e.g. https://pypi.org/project/mochi-httpx/0.1.0/);
+// AttestationURL is the PEP 740 attestation pointer if the registry
+// returned one, empty otherwise.
+type UploadResult struct {
+	URL            string
+	AttestationURL string
+	Skipped        bool // true when DryRun bypassed the upload.
+}
+
+// UVUploader shells to `uv publish --trusted-publishing always` for each
+// target. UV reads the API token from the UV_PUBLISH_TOKEN env var and
+// the artifacts from the positional path args.
+type UVUploader struct {
+	// Binary overrides the uv binary path. Empty means "uv" on PATH.
+	Binary string
+	// Run overrides exec.CommandContext; nil means real subprocess.
+	Run func(ctx context.Context, env []string, name string, args ...string) ([]byte, error)
+}
+
+// Upload invokes `uv publish` for the target. Returns the rendered
+// upload URL on success.
+func (u UVUploader) Upload(ctx context.Context, call UploadCall) (UploadResult, error) {
+	bin := u.Binary
+	if bin == "" {
+		bin = "uv"
+	}
+	args := []string{
+		"publish",
+		"--trusted-publishing", "always",
+		"--publish-url", call.Registry.URL() + "/legacy/",
+		call.Target.SdistPath,
+		call.Target.WheelPath,
+	}
+	env := []string{"UV_PUBLISH_TOKEN=" + call.Token}
+	run := u.Run
+	if run == nil {
+		run = defaultRun
+	}
+	out, err := run(ctx, env, bin, args...)
+	if err != nil {
+		return UploadResult{}, fmt.Errorf("publish: uv publish: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return UploadResult{
+		URL: fmt.Sprintf("%s/project/%s/%s/", call.Registry.URL(), call.Target.Distribution, call.Target.Version),
+	}, nil
+}
+
+func defaultRun(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = append(cmd.Environ(), env...)
+	return cmd.CombinedOutput()
+}
+
+// RecordingUploader captures every Upload call without executing anything.
+// Tests assert against Calls; the orchestrator uses it as the default when
+// DryRun is set and no uploader is supplied.
+type RecordingUploader struct {
+	Calls []UploadCall
+}
+
+// Upload appends the call and returns a synthetic "would-upload" URL.
+func (r *RecordingUploader) Upload(_ context.Context, call UploadCall) (UploadResult, error) {
+	r.Calls = append(r.Calls, call)
+	return UploadResult{
+		URL:     fmt.Sprintf("%s/project/%s/%s/", call.Registry.URL(), call.Target.Distribution, call.Target.Version),
+		Skipped: true,
+	}, nil
+}

--- a/package3/python/publish/uploader_test.go
+++ b/package3/python/publish/uploader_test.go
@@ -1,0 +1,93 @@
+package publish
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRecordingUploaderCaptures(t *testing.T) {
+	u := &RecordingUploader{}
+	call := UploadCall{
+		Target:   validTarget(),
+		Registry: RegistryPyPI,
+		Token:    "tok",
+	}
+	res, err := u.Upload(context.Background(), call)
+	if err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if !res.Skipped {
+		t.Fatal("RecordingUploader must set Skipped")
+	}
+	if res.URL != "https://pypi.org/project/mochi-sample/0.1.0/" {
+		t.Fatalf("URL = %q", res.URL)
+	}
+	if len(u.Calls) != 1 {
+		t.Fatalf("Calls = %d", len(u.Calls))
+	}
+}
+
+func TestUVUploaderInvokesUVPublish(t *testing.T) {
+	var seenName string
+	var seenArgs []string
+	var seenEnv []string
+	u := UVUploader{Run: func(_ context.Context, env []string, name string, args ...string) ([]byte, error) {
+		seenName = name
+		seenArgs = args
+		seenEnv = env
+		return []byte("ok"), nil
+	}}
+	call := UploadCall{
+		Target:   validTarget(),
+		Registry: RegistryTestPyPI,
+		Token:    "minted-tok",
+	}
+	res, err := u.Upload(context.Background(), call)
+	if err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if seenName != "uv" {
+		t.Fatalf("uv binary = %q", seenName)
+	}
+	if seenArgs[0] != "publish" {
+		t.Fatalf("first arg %q", seenArgs[0])
+	}
+	joined := strings.Join(seenArgs, " ")
+	for _, want := range []string{"--trusted-publishing always", "--publish-url https://test.pypi.org/legacy/", "/tmp/mochi-sample-0.1.0.tar.gz", "/tmp/mochi-sample-0.1.0-py3-none-any.whl"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("args missing %q: %s", want, joined)
+		}
+	}
+	if len(seenEnv) != 1 || !strings.HasPrefix(seenEnv[0], "UV_PUBLISH_TOKEN=minted-tok") {
+		t.Fatalf("env = %v", seenEnv)
+	}
+	if res.URL != "https://test.pypi.org/project/mochi-sample/0.1.0/" {
+		t.Fatalf("URL = %q", res.URL)
+	}
+}
+
+func TestUVUploaderSurfacesSubprocessError(t *testing.T) {
+	u := UVUploader{Run: func(context.Context, []string, string, ...string) ([]byte, error) {
+		return []byte("upload failed: 403"), errors.New("exit 1")
+	}}
+	call := UploadCall{Target: validTarget(), Registry: RegistryPyPI, Token: "tok"}
+	if _, err := u.Upload(context.Background(), call); err == nil || !strings.Contains(err.Error(), "uv publish") {
+		t.Fatalf("expected uv publish error, got %v", err)
+	}
+}
+
+func TestUVUploaderHonoursBinaryOverride(t *testing.T) {
+	var seen string
+	u := UVUploader{Binary: "/opt/bin/uv", Run: func(_ context.Context, _ []string, name string, _ ...string) ([]byte, error) {
+		seen = name
+		return nil, nil
+	}}
+	if _, err := u.Upload(context.Background(), UploadCall{Target: validTarget(), Registry: RegistryPyPI, Token: "tok"}); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if seen != "/opt/bin/uv" {
+		t.Fatalf("binary override = %q", seen)
+	}
+}

--- a/website/docs/implementation/0071/index.md
+++ b/website/docs/implementation/0071/index.md
@@ -27,11 +27,14 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | 8.1 | Wheel install loop: drive uv against rendered pyproject.toml | NOT STARTED | — | [phase-08](/docs/implementation/0071/phase-08-build) |
 | 8.2 | libpython link: cgo embed for `runtime-mode = "embedded"` | NOT STARTED | — | [phase-08](/docs/implementation/0071/phase-08-build) |
 | 9 | `mochi.lock` `[[python-package]]` integration + `--check` mode + capability database | LANDED | `cdd98e15` | [phase-09](/docs/implementation/0071/phase-09-lockfile) |
-| 10 | `TargetPythonPackage` emit (sdist + wheel + `mochi-build` PEP 517 backend + `.pyi` for downstream typing) | LANDED | (pending merge) | [phase-10](/docs/implementation/0071/phase-10-python-package-emit) |
+| 10 | `TargetPythonPackage` emit (sdist + wheel + `mochi-build` PEP 517 backend + `.pyi` for downstream typing) | LANDED | `60e7917b` | [phase-10](/docs/implementation/0071/phase-10-python-package-emit) |
 | 10.1 | Sdist tar.gz + wheel zip packer (deterministic mtimes, ZIP64-aware) | NOT STARTED | — | [phase-10](/docs/implementation/0071/phase-10-python-package-emit) |
 | 10.2 | `mochi pkg build --target=python-package` CLI verb | NOT STARTED | — | [phase-10](/docs/implementation/0071/phase-10-python-package-emit) |
 | 10.3 | Mochi module -> `pypackage.Package` surface walker | NOT STARTED | — | [phase-10](/docs/implementation/0071/phase-10-python-package-emit) |
-| 11 | Trusted publishing (`mochi pkg publish --to=pypi`) Sigstore OIDC + PEP 740 attestations | NOT STARTED | — | [phase-11](/docs/implementation/0071/phase-11-trusted-publish) |
+| 11 | Trusted publishing (`mochi pkg publish --to=pypi`) Sigstore OIDC + PEP 740 attestations | LANDED | (pending merge) | [phase-11](/docs/implementation/0071/phase-11-trusted-publish) |
+| 11.1 | Sigstore live signing harness (`sigstore-python` shell-out + Rekor log) | NOT STARTED | — | [phase-11](/docs/implementation/0071/phase-11-trusted-publish) |
+| 11.2 | Live PyPI / TestPyPI HTTP (mint endpoint contract test) | NOT STARTED | — | [phase-11](/docs/implementation/0071/phase-11-trusted-publish) |
+| 11.3 | `mochi pkg publish --to=pypi` CLI verb | NOT STARTED | — | [phase-11](/docs/implementation/0071/phase-11-trusted-publish) |
 | 12 | Async bridge (asyncio.run per-call + persistent loop opt-in + cross-loop hazard guards) | NOT STARTED | — | [phase-12](/docs/implementation/0071/phase-12-async-bridge) |
 | 13 | abi3 wheel slimming + auditwheel-equivalent platform tag validation | NOT STARTED | — | [phase-13](/docs/implementation/0071/phase-13-abi3) |
 | 14 | Subprocess runtime mode (`[python].runtime-mode = "subprocess"` with JSON-RPC protocol) | NOT STARTED | — | [phase-14](/docs/implementation/0071/phase-14-subprocess-mode) |
@@ -98,7 +101,7 @@ The `package3/python/` location is shared with the broader MEP-57 polyglot packa
 
 ## Status snapshot
 
-As of 2026-05-30 00:27 (GMT+7): MEP-71 spec and research bundle landed; phases 0-10 LANDED (8.1, 8.2, 10.1, 10.2, 10.3 deferred sub-phases); phases 11-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
+As of 2026-05-30 00:36 (GMT+7): MEP-71 spec and research bundle landed; phases 0-11 LANDED (8.1, 8.2, 10.1, 10.2, 10.3, 11.1, 11.2, 11.3 deferred sub-phases); phases 12-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
 
 ## Cross-references
 

--- a/website/docs/implementation/0071/phase-11-trusted-publish.md
+++ b/website/docs/implementation/0071/phase-11-trusted-publish.md
@@ -1,0 +1,75 @@
+---
+title: MEP-71 Phase 11 (Trusted publish to PyPI)
+sidebar_position: 12
+sidebar_label: "Phase 11. Trusted publish to PyPI"
+description: "MEP-71 Phase 11: mochi pkg publish --to=pypi orchestration with Sigstore-keyless OIDC trusted publishing + PEP 740 in-toto SLSA Provenance attestations."
+---
+
+# MEP-71 Phase 11. Trusted publish to PyPI
+
+Status: **LANDED (pending merge)** as of 2026-05-30 00:36 (GMT+7). Implements the orchestration layer of `mochi pkg publish --to=pypi`: OIDC token minting, PEP 740 in-toto SLSA Provenance v1 attestation construction, and the per-target uploader driver. The actual Sigstore signing + live PyPI / TestPyPI HTTP calls are sub-phases 11.1 and 11.2.
+
+## Gate
+
+The umbrella sentinel `TestPhase11TrustedPublish` in `package3/python/publish/phase11_test.go` is green. The sentinel:
+
+- Builds a `PublishRequest` with two artifact pairs (sdist + wheel) targeting TestPyPI.
+- Runs the orchestrator in `DryRun=true` mode so the OIDC -> mint -> upload chain executes without touching the network (default uploader is `RecordingUploader`; the test also injects a `fakeUploader` that returns synthetic `PublishedArtifact` URLs).
+- Asserts the orchestrator emits a PEP 740 in-toto v1 statement with `_type = "https://in-toto.io/Statement/v1"`, `predicateType = "https://slsa.dev/provenance/v1"`, sorted subjects covering every (sdist, wheel) pair with sha256 digests, and a `runDetails.builder.id` carrying the configured builder identity.
+- Asserts every artifact in the result lands with the registry-shaped URL (`https://test.pypi.org/project/<name>/<ver>/`) and the AttestationURL field round-trips through the uploader.
+- Asserts dry-run propagates an empty API token to the uploader (no minted credential leaves the orchestrator without an explicit non-dry-run pass).
+
+Plus 38 unit tests (`go test ./package3/python/publish/... -count=1`) covering:
+
+- `RegistryKind` String / URL / OIDCAudience for PyPI + TestPyPI + unknown fallback.
+- `PublishRequest.Validate` rejecting unknown registry, empty targets, empty Distribution / Version / artifact path / sha256 / size, non-`.tar.gz` sdist, non-`.whl` wheel, and missing OIDCProvider when DryRun is false. Dry-run validates without an OIDC provider.
+- `GitHubActionsProvider.Token`: missing env vars, happy-path token fetch from a mock httptest server, HTTP 403 propagation, and empty-token refusal.
+- `StaticProvider`: returns the stored token; refuses empty TokenValue.
+- `MintAPIToken`: rejects empty OIDC token, happy path against a mock httptest server (verifies the POST body carries `{"token": <oidc>}` and the response's expires field is RFC 3339 parsed), 401 propagation, and refusal when the response's `success` flag is false.
+- `BuildStatement`: subjects are sorted by name; every subject carries a sha256 digest; subject filenames follow the PEP 491 / PEP 625 shape (`<dist>-<ver>.tar.gz` for sdists, `<dist>-<ver>-py3-none-any.whl` for wheels); builder id falls back to `AttestationBuilderID` when unset and is overridable; invocation id defaults to `"auto"`; `finishedOn` is in a recent UTC window when `BuildTime` is zero.
+- `EncodeStatement` round-trips through `json.Marshal` deterministically (same input -> same bytes).
+- `RecordingUploader.Upload` captures the call and returns the registry-shaped URL with `Skipped=true`.
+- `UVUploader.Upload`: invokes `uv` with `publish --trusted-publishing always --publish-url <registry>/legacy/ <sdist> <wheel>` and `UV_PUBLISH_TOKEN=<minted>` in env; surfaces subprocess errors with the captured stderr; honours `Binary` override.
+- `Orchestrator.Publish`: rejects invalid requests; dry-run skips OIDC and uses `RecordingUploader` by default; propagates OIDC errors; embeds every target in the attestation; surfaces uploader errors; propagates the configured Builder id into the attestation predicate.
+
+## Files
+
+- `package3/python/publish/doc.go` — package overview.
+- `package3/python/publish/request.go` — `PublishRequest`, `PublishTarget`, `RegistryKind`, `Validate`.
+- `package3/python/publish/oidc.go` — `OIDCProvider` interface, `GitHubActionsProvider`, `StaticProvider`, `MintAPIToken`, `MintedToken`.
+- `package3/python/publish/attestation.go` — `Statement`, `Subject`, `BuildStatement`, `EncodeStatement` + constants for SLSA Provenance v1 predicate type, in-toto Statement v1 type uri, and the Mochi builder identity.
+- `package3/python/publish/uploader.go` — `Uploader` interface, `UploadCall`, `UploadResult`, `UVUploader` (default), `RecordingUploader` (dry-run + tests).
+- `package3/python/publish/orchestrator.go` — `Orchestrator.Publish` glue (validate -> attest -> mint -> upload -> result aggregation).
+- `package3/python/publish/request_test.go` — request + registry validation (8 cases).
+- `package3/python/publish/oidc_test.go` — OIDC provider + mint endpoint (10 cases).
+- `package3/python/publish/attestation_test.go` — attestation statement shape + encoding determinism (9 cases).
+- `package3/python/publish/uploader_test.go` — UVUploader + RecordingUploader (4 cases).
+- `package3/python/publish/orchestrator_test.go` — orchestrator chain (7 cases).
+- `package3/python/publish/phase11_test.go` — Phase 11 umbrella sentinel.
+
+## Sub-phase decomposition
+
+Phase 11 ships the orchestration layer with mockable subprocess + HTTP boundaries. The live integrations stay out of the umbrella gate so the test suite remains offline and deterministic:
+
+| Sub-phase | Title | Status | Notes |
+|-----------|-------|--------|-------|
+| 11 | Publish orchestrator (OIDC + attestation + uploader + dry-run) | LANDED (pending merge) | This PR. |
+| 11.1 | Sigstore live signing harness (`sigstore-python` shell-out + Rekor log fetch) | NOT STARTED | Wraps the in-toto statement in a Sigstore bundle. |
+| 11.2 | Live PyPI / TestPyPI HTTP (mint endpoint contract test against Warehouse mock) | NOT STARTED | Replaces the test-only redirect transport with real `pypi.org` calls. |
+| 11.3 | `mochi pkg publish --to=pypi [--testpypi] [--dry-run]` CLI verb | NOT STARTED | Wires the orchestrator behind the unified `mochi pkg` CLI. |
+
+## Fixtures
+
+Phase 11 is offline; the fixture corpus is not exercised. Sub-phase 11.2 will gate the live mint endpoint against a frozen `_/oidc/mint-token/` contract response taken from PyPI's Warehouse repo.
+
+## Skip count
+
+N/A. Phase 11 has no `SkipReport` surface; non-publishable requests are rejected by `PublishRequest.Validate()` before any external call.
+
+## Cross-references
+
+- [MEP-71 spec §6 "Sigstore-keyless OIDC trusted publishing"](/docs/mep/mep-0071) for the normative flow.
+- [Phase 10](./phase-10-python-package-emit) for the sdist + wheel emit Phase 11 consumes.
+- [Phase 15](./phase-15-attestation-verify) for the install-time PEP 740 attestation verifier that mirrors the publish-time signer.
+- [Phase 18](./phase-18-abi2026) for the abi2026 transition that controls which wheel ABI tag Phase 11 publishes.
+- [Trusted Publishing background (PyPI Warehouse)](https://docs.pypi.org/trusted-publishers/) and [PEP 740](https://peps.python.org/pep-0740/) for the attestation envelope spec.


### PR DESCRIPTION
## Summary

Implements MEP-71 Phase 11: the orchestration layer for `mochi pkg publish --to=pypi`.

- `package3/python/publish/`: `PublishRequest` + `OIDCProvider` (GitHub Actions + Static) + `MintAPIToken` + PEP 740 in-toto v1 / SLSA Provenance v1 attestation builder + `Uploader` interface with `UVUploader` (default) and `RecordingUploader` (dry-run + tests) + `Orchestrator.Publish` glue.
- 39 tests passing (38 unit + Phase 11 umbrella sentinel) with mock httptest servers for the OIDC + mint endpoints and a recording uploader for the publish step. The umbrella gate stays offline.

Sub-phases 11.1 (Sigstore live signing), 11.2 (live PyPI HTTP contract), and 11.3 (`mochi pkg publish` CLI verb) deferred per the umbrella-phase coverage rule.

Closes #22935.

## Test plan

- [x] `go test ./package3/python/publish/... -count=1` (39 tests pass, including TestPhase11TrustedPublish umbrella sentinel)
- [x] `go test ./package3/python/... -count=1` (full python tree green, no regression)
- [x] Phase 11 umbrella sentinel verifies the canonical-JSON in-toto statement embeds every sdist + wheel filename with sha256 digests, the registry-shaped artifact URLs round-trip, and the uploader receives the attestation bytes verbatim