### PR TITLE
feat(mep-75/p13): Phar distribution path (stub + build script generator)

### DIFF
--- a/package3/php/pharemit/pharemit.go
+++ b/package3/php/pharemit/pharemit.go
@@ -1,0 +1,172 @@
+// Package pharemit generates the PHP build script and Phar stub for
+// distributing a Mochi-emitted PHP library as a self-contained .phar archive.
+//
+// A Phar (PHP Archive) bundles all library source files into a single
+// distributable file. The emitter produces two PHP files:
+//
+//   - stub.php    - the Phar stub (bootstrap code embedded at the archive head)
+//   - build.php   - the builder script: run with `php build.php` to produce
+//     the .phar file from the library src/ tree
+//
+// The generated build.php uses PHP's built-in Phar class and requires
+// phar.readonly = 0 in php.ini (or the -d flag). Compression is optional.
+//
+// Usage:
+//
+//	result := pharemit.Build(pharemit.Config{
+//	    PharName:      "acme-mylib",
+//	    PSR4Namespace: `Acme\MyLib`,
+//	    SrcDir:        "src",
+//	})
+//	// result.Files["stub.php"]  - embed this as the Phar stub
+//	// result.Files["build.php"] - run to create acme-mylib.phar
+package pharemit
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Compression selects Phar compression algorithm.
+type Compression int
+
+const (
+	// CompressNone leaves files uncompressed (default; no zlib/bz2 needed).
+	CompressNone Compression = iota
+	// CompressGZ uses zlib DEFLATE compression (requires zlib extension).
+	CompressGZ
+	// CompressBZ2 uses bzip2 compression (requires bz2 extension).
+	CompressBZ2
+)
+
+// Config holds parameters for Phar generation.
+type Config struct {
+	// PharName is the base name without extension, e.g. "acme-mylib".
+	// The output archive is PharName + ".phar".
+	PharName string
+	// PSR4Namespace is the PHP namespace root, e.g. "Acme\\MyLib".
+	PSR4Namespace string
+	// SrcDir is the source directory relative to the library root (default "src").
+	SrcDir string
+	// Compression selects the archive compression. Default: CompressNone.
+	Compression Compression
+	// StubPreamble is an optional PHP comment/banner to prepend to stub.php.
+	StubPreamble string
+}
+
+// BuildResult holds the generated files.
+type BuildResult struct {
+	// Files maps relative file path -> PHP source content.
+	Files map[string]string
+	// PharFileName is the output archive name, e.g. "acme-mylib.phar".
+	PharFileName string
+}
+
+// Build generates stub.php and build.php for the given config.
+func Build(cfg Config) (*BuildResult, error) {
+	if cfg.PharName == "" {
+		return nil, fmt.Errorf("pharemit: PharName is required")
+	}
+	if cfg.PSR4Namespace == "" {
+		return nil, fmt.Errorf("pharemit: PSR4Namespace is required")
+	}
+	srcDir := cfg.SrcDir
+	if srcDir == "" {
+		srcDir = "src"
+	}
+
+	pharFile := cfg.PharName + ".phar"
+	result := &BuildResult{
+		Files:        make(map[string]string),
+		PharFileName: pharFile,
+	}
+
+	result.Files["stub.php"] = renderStub(cfg, pharFile)
+	result.Files["build.php"] = renderBuild(cfg, pharFile, srcDir)
+
+	return result, nil
+}
+
+func renderStub(cfg Config, pharFile string) string {
+	ns := strings.TrimSuffix(cfg.PSR4Namespace, "\\")
+	// Normalise namespace separator to forward slash for use in PHAR paths.
+	nsPath := strings.ReplaceAll(ns, "\\", "/")
+	var sb strings.Builder
+	sb.WriteString("<?php\n")
+	if cfg.StubPreamble != "" {
+		sb.WriteString("// ")
+		sb.WriteString(strings.ReplaceAll(cfg.StubPreamble, "\n", "\n// "))
+		sb.WriteString("\n")
+	}
+	fmt.Fprintf(&sb, `
+// Auto-generated Phar stub for %s
+// Registers PSR-4 autoloader for namespace %s from within the archive.
+
+Phar::mapPhar(%q);
+
+spl_autoload_register(function (string $class) use (&$_pharFile): void {
+    $ns = %q;
+    $nsPath = %q;
+    if (strncmp($class, $ns . '\\', strlen($ns) + 1) !== 0) {
+        return;
+    }
+    $rel = substr($class, strlen($ns) + 1);
+    $rel = str_replace('\\', '/', $rel);
+    $path = 'phar://' . $_pharFile . '/src/' . $nsPath . '/' . $rel . '.php';
+    if (file_exists($path)) {
+        require $path;
+    }
+});
+
+__HALT_COMPILER();
+`, cfg.PharName, ns, pharFile, ns, nsPath) //nolint:errcheck
+	return sb.String()
+}
+
+func renderBuild(cfg Config, pharFile, srcDir string) string {
+	compressCall := ""
+	switch cfg.Compression {
+	case CompressGZ:
+		compressCall = "\n$phar->compressFiles(Phar::GZ);"
+	case CompressBZ2:
+		compressCall = "\n$phar->compressFiles(Phar::BZ2);"
+	}
+
+	return fmt.Sprintf(`<?php
+/**
+ * Build script for %s
+ *
+ * Usage: php -d phar.readonly=0 build.php
+ *
+ * Requires: PHP 8.0+, phar.readonly=0
+ */
+declare(strict_types=1);
+
+$pharFile = __DIR__ . '/' . %q;
+$srcDir   = __DIR__ . '/' . %q;
+
+if (file_exists($pharFile)) {
+    unlink($pharFile);
+}
+
+$phar = new Phar($pharFile, 0, %q);
+$phar->startBuffering();
+
+// Add all PHP files from src/ preserving directory structure.
+$iterator = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($srcDir, FilesystemIterator::SKIP_DOTS)
+);
+foreach ($iterator as $file) {
+    if ($file->getExtension() !== 'php') {
+        continue;
+    }
+    $relative = substr((string) $file, strlen(__DIR__) + 1);
+    $phar->addFile((string) $file, $relative);
+}
+%s
+$phar->setStub(file_get_contents(__DIR__ . '/stub.php'));
+$phar->stopBuffering();
+
+echo "Built: $pharFile\n";
+`, cfg.PharName, pharFile, srcDir, pharFile, compressCall)
+}

--- a/package3/php/pharemit/pharemit_test.go
+++ b/package3/php/pharemit/pharemit_test.go
@@ -1,0 +1,179 @@
+package pharemit
+
+import (
+	"strings"
+	"testing"
+)
+
+func defaultConfig() Config {
+	return Config{
+		PharName:      "acme-mylib",
+		PSR4Namespace: `Acme\MyLib`,
+	}
+}
+
+func TestBuildRequiredPharName(t *testing.T) {
+	_, err := Build(Config{PSR4Namespace: `A\B`})
+	if err == nil {
+		t.Error("expected error for empty PharName")
+	}
+}
+
+func TestBuildRequiredPSR4Namespace(t *testing.T) {
+	_, err := Build(Config{PharName: "foo"})
+	if err == nil {
+		t.Error("expected error for empty PSR4Namespace")
+	}
+}
+
+func TestBuildProducesExpectedFiles(t *testing.T) {
+	result, err := Build(defaultConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"stub.php", "build.php"} {
+		if _, ok := result.Files[want]; !ok {
+			t.Errorf("expected file %q in result", want)
+		}
+	}
+}
+
+func TestBuildPharFileName(t *testing.T) {
+	result, err := Build(defaultConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.PharFileName != "acme-mylib.phar" {
+		t.Errorf("PharFileName = %q; want acme-mylib.phar", result.PharFileName)
+	}
+}
+
+func TestStubContainsPharMapPhar(t *testing.T) {
+	result, err := Build(defaultConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	stub := result.Files["stub.php"]
+	if !strings.Contains(stub, "Phar::mapPhar") {
+		t.Errorf("expected Phar::mapPhar in stub; got:\n%s", stub)
+	}
+	if !strings.Contains(stub, "__HALT_COMPILER") {
+		t.Errorf("expected __HALT_COMPILER in stub; got:\n%s", stub)
+	}
+}
+
+func TestStubContainsPSR4Autoloader(t *testing.T) {
+	result, err := Build(defaultConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	stub := result.Files["stub.php"]
+	if !strings.Contains(stub, "spl_autoload_register") {
+		t.Errorf("expected spl_autoload_register in stub; got:\n%s", stub)
+	}
+	if !strings.Contains(stub, "Acme\\MyLib") {
+		t.Errorf("expected namespace in stub; got:\n%s", stub)
+	}
+}
+
+func TestStubContainsPharName(t *testing.T) {
+	result, err := Build(defaultConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	stub := result.Files["stub.php"]
+	if !strings.Contains(stub, "acme-mylib.phar") {
+		t.Errorf("expected phar file name in stub; got:\n%s", stub)
+	}
+}
+
+func TestBuildScriptContainsRecursiveIterator(t *testing.T) {
+	result, err := Build(defaultConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	build := result.Files["build.php"]
+	if !strings.Contains(build, "RecursiveIteratorIterator") {
+		t.Errorf("expected RecursiveIteratorIterator in build.php; got:\n%s", build)
+	}
+	if !strings.Contains(build, "addFile") {
+		t.Errorf("expected addFile in build.php; got:\n%s", build)
+	}
+	if !strings.Contains(build, "setStub") {
+		t.Errorf("expected setStub in build.php; got:\n%s", build)
+	}
+}
+
+func TestBuildScriptDefaultSrcDir(t *testing.T) {
+	result, err := Build(defaultConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	build := result.Files["build.php"]
+	if !strings.Contains(build, `"src"`) {
+		t.Errorf("expected default src/ dir in build.php; got:\n%s", build)
+	}
+}
+
+func TestBuildScriptCustomSrcDir(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.SrcDir = "lib"
+	result, err := Build(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	build := result.Files["build.php"]
+	if !strings.Contains(build, `"lib"`) {
+		t.Errorf("expected custom lib/ dir in build.php; got:\n%s", build)
+	}
+}
+
+func TestBuildCompressionGZ(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Compression = CompressGZ
+	result, err := Build(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	build := result.Files["build.php"]
+	if !strings.Contains(build, "Phar::GZ") {
+		t.Errorf("expected Phar::GZ compression; got:\n%s", build)
+	}
+}
+
+func TestBuildCompressionBZ2(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Compression = CompressBZ2
+	result, err := Build(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	build := result.Files["build.php"]
+	if !strings.Contains(build, "Phar::BZ2") {
+		t.Errorf("expected Phar::BZ2 compression; got:\n%s", build)
+	}
+}
+
+func TestBuildCompressionNoneNoCall(t *testing.T) {
+	result, err := Build(defaultConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	build := result.Files["build.php"]
+	if strings.Contains(build, "compressFiles") {
+		t.Errorf("expected no compressFiles for CompressNone; got:\n%s", build)
+	}
+}
+
+func TestStubPreamble(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.StubPreamble = "Auto-generated. Do not edit."
+	result, err := Build(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	stub := result.Files["stub.php"]
+	if !strings.Contains(stub, "Auto-generated. Do not edit.") {
+		t.Errorf("expected preamble in stub; got:\n%s", stub)
+	}
+}

--- a/website/docs/implementation/0075/phase-13-phar.md
+++ b/website/docs/implementation/0075/phase-13-phar.md
@@ -1,0 +1,47 @@
+# MEP-75 Phase 13: Phar Distribution Path
+
+**Status**: LANDED 2026-05-30 00:38 (GMT+7)
+
+## Goal
+
+Implement Phar archive generation support for the PHP library distribution path. Given a package name, PSR-4 namespace, and optional compression config, emit `stub.php` (the Phar bootstrap) and `build.php` (the builder script) so a Mochi-emitted PHP library can be distributed as a single self-contained `.phar` file.
+
+## Design
+
+`Build(cfg Config)` is the main entry point. It validates `PharName` and `PSR4Namespace`, then produces two files:
+
+**stub.php** - the Phar stub embedded at the archive head:
+- Calls `Phar::mapPhar` to register the archive
+- Registers an `spl_autoload_register` PSR-4 loader rooted at `phar://archive.phar/src/`
+- Ends with `__HALT_COMPILER()` as required by the Phar format
+
+**build.php** - the builder script run by the developer:
+- Uses `RecursiveIteratorIterator` + `RecursiveDirectoryIterator` to add all `.php` files from `src/`
+- Calls `$phar->setStub(file_get_contents('stub.php'))`
+- Optionally calls `compressFiles(Phar::GZ)` or `compressFiles(Phar::BZ2)`
+- Usage: `php -d phar.readonly=0 build.php`
+
+`Compression` enum provides `CompressNone` (default), `CompressGZ`, and `CompressBZ2` options.
+
+`Config.StubPreamble` allows injecting a banner comment into the stub.
+
+## Files Landed
+
+- `package3/php/pharemit/pharemit.go` -- Build + renderStub + renderBuild
+- `package3/php/pharemit/pharemit_test.go` -- 13 test functions
+
+## Test Coverage
+
+- Required field validation (PharName, PSR4Namespace)
+- Both expected files produced (stub.php, build.php)
+- PharFileName set correctly
+- stub.php contains Phar::mapPhar and __HALT_COMPILER
+- stub.php contains spl_autoload_register with PSR-4 namespace
+- stub.php references the phar file name
+- build.php contains RecursiveIteratorIterator, addFile, setStub
+- build.php uses default src/ dir
+- build.php respects custom SrcDir
+- CompressGZ emits Phar::GZ call
+- CompressBZ2 emits Phar::BZ2 call
+- CompressNone emits no compressFiles call
+- StubPreamble injected as comment into stub


### PR DESCRIPTION
Closes #22937

## Summary

- New `package3/php/pharemit` package with `Build(cfg Config) (*BuildResult, error)`
- Emits `stub.php`: PSR-4 `spl_autoload_register` that loads from `phar://` paths, ending with `__HALT_COMPILER()`
- Emits `build.php`: PHP script using `RecursiveDirectoryIterator` to add all `.php` files and embed the stub
- `Compression` enum: `CompressNone` (default), `CompressGZ`, `CompressBZ2`
- `Config.StubPreamble` injects a banner comment into the stub
- 13 tests covering all options and output content

## Test plan

- `go test ./package3/php/pharemit/... -count=1` passes locally