### PR TITLE
feat(mep-67/p7): import java grammar wiring

### DIFF
--- a/parser/java_import.go
+++ b/parser/java_import.go
@@ -1,0 +1,48 @@
+package parser
+
+import "strings"
+
+// JavaImportRef parses the path of `import java "<group>:<artifact>@<version>" as
+// <alias>` into its (group, artifact, version) triple.
+//
+// The string must have the form "<groupId>:<artifactId>@<version>". Both the
+// groupId and artifactId are validated as Maven coordinates (see isMavenCoordPart).
+// The version is required for Java imports: MEP-67 binds the generated JNI wrapper
+// to a specific JAR, so omitting it would make the build non-reproducible.
+// On success ok is true; on any structural problem ok is false.
+func JavaImportRef(path string) (group, artifact, version string, ok bool) {
+	s := strings.Trim(path, "\"")
+	if s == "" {
+		return "", "", "", false
+	}
+
+	colonIdx := strings.Index(s, ":")
+	if colonIdx <= 0 || colonIdx == len(s)-1 {
+		return "", "", "", false
+	}
+	grp := s[:colonIdx]
+	rest := s[colonIdx+1:]
+
+	atIdx := strings.Index(rest, "@")
+	if atIdx <= 0 || atIdx == len(rest)-1 {
+		return "", "", "", false
+	}
+	art := rest[:atIdx]
+	ver := rest[atIdx+1:]
+
+	if !isMavenCoordPart(grp) || !isMavenCoordPart(art) {
+		return "", "", "", false
+	}
+	if strings.ContainsAny(ver, " \t\n") {
+		return "", "", "", false
+	}
+
+	return grp, art, ver, true
+}
+
+// HasJavaMavenCoord reports whether a java import path is in Maven coordinate form
+// (contains a colon and an at-sign in the right positions).
+func HasJavaMavenCoord(path string) bool {
+	_, _, _, ok := JavaImportRef(path)
+	return ok
+}

--- a/parser/java_import_test.go
+++ b/parser/java_import_test.go
@@ -1,0 +1,102 @@
+package parser
+
+import "testing"
+
+func TestJavaImportRef(t *testing.T) {
+	cases := []struct {
+		name                       string
+		in                         string
+		wantGroup, wantArt, wantV  string
+		wantOK                     bool
+	}{
+		// standard Maven coordinate with version
+		{"basic", `com.google.guava:guava@33.0.0-jre`, "com.google.guava", "guava", "33.0.0-jre", true},
+		{"quoted", `"com.google.guava:guava@33.0.0-jre"`, "com.google.guava", "guava", "33.0.0-jre", true},
+		{"snapshot", `org.example:my-lib@1.0-SNAPSHOT`, "org.example", "my-lib", "1.0-SNAPSHOT", true},
+		{"deep group", `com.google.android.gms:play-services-auth@21.0.0`, "com.google.android.gms", "play-services-auth", "21.0.0", true},
+		{"short artifact", `io.grpc:grpc-core@1.62.0`, "io.grpc", "grpc-core", "1.62.0", true},
+		{"underscore artifact", `org.example:my_util@0.1.0`, "org.example", "my_util", "0.1.0", true},
+
+		// error cases
+		{"empty", ``, "", "", "", false},
+		{"no colon", `com.example@1.0`, "", "", "", false},
+		{"no version", `com.example:artifact`, "", "", "", false},
+		{"missing version after @", `com.example:artifact@`, "", "", "", false},
+		{"leading colon", `:artifact@1.0`, "", "", "", false},
+		{"trailing colon", `group:`, "", "", "", false},
+		{"space in version", `com.example:lib@1.0 rc`, "", "", "", false},
+		{"tab in version", "com.example:lib@1.0\t", "", "", "", false},
+		{"empty artifact", `com.example:@1.0`, "", "", "", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			grp, art, ver, ok := JavaImportRef(c.in)
+			if ok != c.wantOK {
+				t.Fatalf("JavaImportRef(%q) ok = %v; want %v", c.in, ok, c.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if grp != c.wantGroup {
+				t.Errorf("group = %q; want %q", grp, c.wantGroup)
+			}
+			if art != c.wantArt {
+				t.Errorf("artifact = %q; want %q", art, c.wantArt)
+			}
+			if ver != c.wantV {
+				t.Errorf("version = %q; want %q", ver, c.wantV)
+			}
+		})
+	}
+}
+
+func TestParseNormalize_JavaImportAccepted(t *testing.T) {
+	src := `import java "com.google.guava:guava@33.0.0-jre" as guava`
+	prog, err := ParseString(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(prog.Statements) == 0 || prog.Statements[0].Import == nil {
+		t.Fatal("expected import statement")
+	}
+	im := prog.Statements[0].Import
+	if im.Lang == nil || *im.Lang != "java" {
+		t.Errorf("Lang = %v, want java", im.Lang)
+	}
+	if im.Path != "com.google.guava:guava@33.0.0-jre" {
+		t.Errorf("Path = %q, want com.google.guava:guava@33.0.0-jre", im.Path)
+	}
+	if im.As != "guava" {
+		t.Errorf("As = %q, want guava", im.As)
+	}
+}
+
+func TestParseNormalize_JavaImportInvalidPath(t *testing.T) {
+	src := `import java "notacoord" as lib`
+	_, err := ParseString(src)
+	if err == nil {
+		t.Error("should reject java import path without Maven coordinate form")
+	}
+}
+
+func TestParseNormalize_JavaImportMissingAlias(t *testing.T) {
+	src := `import java "com.google.guava:guava@33.0.0-jre"`
+	_, err := ParseString(src)
+	if err == nil {
+		t.Error("should reject java import without as <alias>")
+	}
+}
+
+func TestParseNormalize_JavaLangRecognized(t *testing.T) {
+	// java must be in knownImportLangs; unknown lang produces P064.
+	src := `import java "com.google.guava:guava@33.0.0-jre"`
+	_, err := ParseString(src)
+	// May fail for other reasons (missing as) but must NOT be P064.
+	if err != nil {
+		msg := err.Error()
+		if contains(msg, "P064") {
+			t.Errorf("java should be a known import lang, got P064: %v", err)
+		}
+	}
+}

--- a/parser/normalize.go
+++ b/parser/normalize.go
@@ -25,7 +25,7 @@ var (
 	errUnknownImportLang = diagnostic.Template{
 		Code:    "P064",
 		Message: "unknown import language: %q",
-		Help:    "The supported languages are `go`, `python`, `typescript`, `zig`, `lua`, `clj`, `clojure`, `rust`, and `erlang`. Omit the language to use the Mochi default, or check the spelling.",
+		Help:    "The supported languages are `go`, `python`, `typescript`, `zig`, `lua`, `clj`, `clojure`, `rust`, `erlang`, and `java`. Omit the language to use the Mochi default, or check the spelling.",
 	}
 	errUselessExprStmt = diagnostic.Template{
 		Code:    "P065",
@@ -52,6 +52,16 @@ var (
 		Message: "erlang import path %q is not a valid Hex.pm package name (optionally with `@<semver>` pin)",
 		Help:    "An `import erlang \"...\" as <alias>` statement names a Hex.pm package, eg. `import erlang \"cowboy\" as cowboy` or `import erlang \"cowboy@2.12.0\" as cowboy`. The package name must be lowercase ASCII letters, digits, and underscores, starting with a letter.",
 	}
+	errInvalidJavaImportPath = diagnostic.Template{
+		Code:    "P070",
+		Message: "java import path %q is not in `<groupId>:<artifactId>@<version>` form",
+		Help:    "An `import java \"...\" as <alias>` statement names a Maven Central artifact with a version, eg. `import java \"com.google.guava:guava@33.0.0-jre\" as guava`. The version is required so the JNI wrapper is bound to an exact JAR.",
+	}
+	errJavaImportMissingAlias = diagnostic.Template{
+		Code:    "P071",
+		Message: "java import %q requires `as <alias>`",
+		Help:    "MEP-67 requires an explicit alias so generated JNI shims are namespaced under a single identifier. Add `as <alias>`, eg. `import java \"com.google.guava:guava@33.0.0-jre\" as guava`.",
+	}
 )
 
 // knownImportLangs is the set of host-language identifiers Mochi recognises
@@ -71,6 +81,7 @@ var knownImportLangs = map[string]struct{}{
 	"rust":       {},
 	"kotlin":     {},
 	"erlang":     {},
+	"java":       {},
 }
 
 // normalizeProgram performs the post-parse pass that turns the raw
@@ -202,6 +213,9 @@ func normalizeStatement(s *Statement) error {
 			return err
 		}
 		if err := validateErlangImport(s.Import); err != nil {
+			return err
+		}
+		if err := validateJavaImport(s.Import); err != nil {
 			return err
 		}
 	case s.Expr != nil:
@@ -442,6 +456,22 @@ func validateErlangImport(im *ImportStmt) error {
 	}
 	if _, _, ok := ErlangImportRef(im.Path); !ok {
 		return errInvalidErlangImportPath.New(im.Pos, im.Path)
+	}
+	return nil
+}
+
+// validateJavaImport rejects `import java "..." as <alias>` whose path is not
+// in `<groupId>:<artifactId>@<version>` form, and also rejects imports that
+// lack an `as <alias>` clause. Both constraints are required by MEP-67.
+func validateJavaImport(im *ImportStmt) error {
+	if im == nil || im.Lang == nil || *im.Lang != "java" {
+		return nil
+	}
+	if _, _, _, ok := JavaImportRef(im.Path); !ok {
+		return errInvalidJavaImportPath.New(im.Pos, im.Path)
+	}
+	if im.As == "" {
+		return errJavaImportMissingAlias.New(im.Pos, im.Path)
 	}
 	return nil
 }

--- a/tests/parser/errors/import_unknown_lang.err
+++ b/tests/parser/errors/import_unknown_lang.err
@@ -5,4 +5,4 @@ error[P064]: unknown import language: "pythn"
     | ^
 
 help:
-  The supported languages are `go`, `python`, `typescript`, `zig`, `lua`, `clj`, `clojure`, `rust`, and `erlang`. Omit the language to use the Mochi default, or check the spelling.
+  The supported languages are `go`, `python`, `typescript`, `zig`, `lua`, `clj`, `clojure`, `rust`, `erlang`, and `java`. Omit the language to use the Mochi default, or check the spelling.


### PR DESCRIPTION
Closes #22943

## Summary

- Adds `"java"` to `knownImportLangs` (parser/normalize.go) so `import java "..."` is accepted
- Adds `parser/java_import.go` with `JavaImportRef(path) (group, artifact, version string, ok bool)` and `HasJavaMavenCoord(path) bool`
- Validates Maven coordinate form (`groupId:artifactId@version`) with new diagnostic P070
- Validates presence of `as <alias>` with new diagnostic P071
- Updates golden file `tests/parser/errors/import_unknown_lang.err` to include `java` in the help text

## Test plan

- `go test ./parser/` passes, including all new `TestJavaImportRef` and `TestParseNormalize_Java*` cases
- `go test ./package3/java/...` still green