### PR TITLE
feat(mep-70 p10): mochi.lock [[kotlin-package]] read/write + drift check

### DIFF
--- a/package3/kotlin/lock/lock.go
+++ b/package3/kotlin/lock/lock.go
@@ -1,0 +1,440 @@
+// Package lock is the MEP-70 lockfile integration layer. It owns the
+// [[kotlin-package]] table that MEP-70 spec §3 adds to mochi.lock: schema,
+// encoder, decoder, and drift checker (mochi pkg lock --check).
+//
+// The package is layering-conservative: it imports no other package3/kotlin/*
+// module. Callers compose a []KotlinPackage from their own state (resolved
+// coordinate + JAR hashes + wrapper hashes + capability decls) and hand it to
+// Encode; the inverse Decode reads back the same shape.
+package lock
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// SourceKind classifies where a kotlin-package was sourced from.
+type SourceKind string
+
+const (
+	SourceRegistry SourceKind = "registry" // Maven Central (default)
+	SourceGit      SourceKind = "git"      // git URL
+	SourcePath     SourceKind = "path"     // local path
+)
+
+// Source describes the origin of a kotlin-package.
+type Source struct {
+	Kind SourceKind
+
+	// Registry is the Maven registry URL when Kind == SourceRegistry.
+	Registry string
+
+	// URL is the git repo URL when Kind == SourceGit.
+	URL string
+	// Rev is the git revision (commit / tag) when Kind == SourceGit.
+	Rev string
+
+	// Path is the local directory (relative to the manifest) when Kind == SourcePath.
+	Path string
+}
+
+// KotlinPackage is one [[kotlin-package]] table entry in mochi.lock.
+//
+// Field names in the rendered TOML use kebab-case as the spec shows
+// (jar-sha256, metadata-sha256, wrapper-sha256, etc.).
+type KotlinPackage struct {
+	// Group is the Maven groupId (e.g. "org.jetbrains.kotlinx").
+	Group string
+	// Artifact is the Maven artifactId (e.g. "kotlinx-coroutines-core").
+	Artifact string
+	// Version is the resolved version string (e.g. "1.7.3").
+	Version string
+	// Source classifies the origin (registry / git / path).
+	Source Source
+
+	// JarSHA256 is the hex-encoded SHA-256 of the artifact JAR.
+	JarSHA256 string
+	// JarBLAKE3 is the hex-encoded BLAKE3-256 of the artifact JAR (primary).
+	JarBLAKE3 string
+
+	// MetadataSHA256 is the hex-encoded SHA-256 of the parsed Kotlin metadata
+	// surface (the binary-encoded @kotlin.Metadata annotation bytes). A drift
+	// here means the upstream API surface changed.
+	MetadataSHA256 string
+	// WrapperSHA256 is the hex-encoded SHA-256 of the synthesised wrapper
+	// source tree (stable canonical hash). A drift here means the bridge would
+	// regenerate the wrapper with different bytes.
+	WrapperSHA256 string
+
+	// CapabilitiesDeclared is the capability set the manifest declared for this
+	// artifact at lock time.
+	CapabilitiesDeclared []string
+	// Dependencies is the resolved transitive dependency list as
+	// "<group>:<artifact>@<version>" strings, topologically ordered.
+	Dependencies []string
+}
+
+// CheckError records one drift detected by Check.
+type CheckError struct {
+	Artifact string
+	Field    string
+	Expected string
+	Got      string
+}
+
+func (e *CheckError) Error() string {
+	return fmt.Sprintf("mochi.lock drift for %s: field %q changed (was %s, now %s)",
+		e.Artifact, e.Field, e.Expected, e.Got)
+}
+
+// Check compares a freshly-computed slice against the locked slice and returns
+// all drifts found. An empty result means the lock is current.
+//
+// The four hard-error fields are: jar-sha256, jar-blake3, metadata-sha256,
+// wrapper-sha256. Dependencies and capabilities changes are also reported.
+func Check(locked, fresh []KotlinPackage) []*CheckError {
+	byKey := make(map[string]KotlinPackage, len(locked))
+	for _, p := range locked {
+		byKey[p.Group+":"+p.Artifact] = p
+	}
+	var errs []*CheckError
+	for _, f := range fresh {
+		k := f.Group + ":" + f.Artifact
+		l, ok := byKey[k]
+		if !ok {
+			errs = append(errs, &CheckError{Artifact: k, Field: "package", Expected: "present", Got: "missing"})
+			continue
+		}
+		if f.JarSHA256 != "" && l.JarSHA256 != "" && f.JarSHA256 != l.JarSHA256 {
+			errs = append(errs, &CheckError{k, "jar-sha256", l.JarSHA256, f.JarSHA256})
+		}
+		if f.JarBLAKE3 != "" && l.JarBLAKE3 != "" && f.JarBLAKE3 != l.JarBLAKE3 {
+			errs = append(errs, &CheckError{k, "jar-blake3", l.JarBLAKE3, f.JarBLAKE3})
+		}
+		if f.MetadataSHA256 != "" && l.MetadataSHA256 != "" && f.MetadataSHA256 != l.MetadataSHA256 {
+			errs = append(errs, &CheckError{k, "metadata-sha256", l.MetadataSHA256, f.MetadataSHA256})
+		}
+		if f.WrapperSHA256 != "" && l.WrapperSHA256 != "" && f.WrapperSHA256 != l.WrapperSHA256 {
+			errs = append(errs, &CheckError{k, "wrapper-sha256", l.WrapperSHA256, f.WrapperSHA256})
+		}
+	}
+	return errs
+}
+
+// CheckErr returns the first Check error as a combined error, or nil.
+func CheckErr(locked, fresh []KotlinPackage) error {
+	errs := Check(locked, fresh)
+	if len(errs) == 0 {
+		return nil
+	}
+	msgs := make([]string, len(errs))
+	for i, e := range errs {
+		msgs[i] = e.Error()
+	}
+	return errors.New(strings.Join(msgs, "\n"))
+}
+
+// Encode renders a slice of KotlinPackage entries as the TOML body inserted
+// into mochi.lock. Entries are sorted by group+artifact for deterministic
+// byte output.
+func Encode(packages []KotlinPackage) string {
+	cp := append([]KotlinPackage{}, packages...)
+	sort.Slice(cp, func(i, j int) bool {
+		ki := cp[i].Group + ":" + cp[i].Artifact
+		kj := cp[j].Group + ":" + cp[j].Artifact
+		if ki != kj {
+			return ki < kj
+		}
+		return cp[i].Version < cp[j].Version
+	})
+	var b strings.Builder
+	for i, p := range cp {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		writeEntry(&b, p)
+	}
+	return b.String()
+}
+
+func writeEntry(b *strings.Builder, p KotlinPackage) {
+	b.WriteString("[[kotlin-package]]\n")
+	fmt.Fprintf(b, "group = %q\n", p.Group)
+	fmt.Fprintf(b, "artifact = %q\n", p.Artifact)
+	fmt.Fprintf(b, "version = %q\n", p.Version)
+	b.WriteString("source = ")
+	writeSource(b, p.Source)
+	b.WriteString("\n")
+	if p.JarSHA256 != "" {
+		fmt.Fprintf(b, "jar-sha256 = %q\n", p.JarSHA256)
+	}
+	if p.JarBLAKE3 != "" {
+		fmt.Fprintf(b, "jar-blake3 = %q\n", p.JarBLAKE3)
+	}
+	if p.MetadataSHA256 != "" {
+		fmt.Fprintf(b, "metadata-sha256 = %q\n", p.MetadataSHA256)
+	}
+	if p.WrapperSHA256 != "" {
+		fmt.Fprintf(b, "wrapper-sha256 = %q\n", p.WrapperSHA256)
+	}
+	writeStringArray(b, "capabilities-declared", p.CapabilitiesDeclared)
+	writeStringArray(b, "dependencies", p.Dependencies)
+}
+
+func writeSource(b *strings.Builder, s Source) {
+	b.WriteString("{ ")
+	fmt.Fprintf(b, "kind = %q", string(s.Kind))
+	switch s.Kind {
+	case SourceRegistry:
+		if s.Registry != "" {
+			fmt.Fprintf(b, ", registry = %q", s.Registry)
+		}
+	case SourceGit:
+		if s.URL != "" {
+			fmt.Fprintf(b, ", url = %q", s.URL)
+		}
+		if s.Rev != "" {
+			fmt.Fprintf(b, ", rev = %q", s.Rev)
+		}
+	case SourcePath:
+		if s.Path != "" {
+			fmt.Fprintf(b, ", path = %q", s.Path)
+		}
+	}
+	b.WriteString(" }")
+}
+
+func writeStringArray(b *strings.Builder, key string, vs []string) {
+	if len(vs) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "%s = [", key)
+	for i, v := range vs {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(b, "%q", v)
+	}
+	b.WriteString("]\n")
+}
+
+// Decode parses the TOML body produced by Encode (or a hand-edited mochi.lock).
+// Unknown keys are tolerated for forward-compat. The parser is line-oriented
+// and accepts only [[kotlin-package]] headers, blank lines, comments, flat
+// key = "value" assignments, and string-array assignments.
+func Decode(r io.Reader) ([]KotlinPackage, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("lockfile: read: %w", err)
+	}
+	return decodeBytes(data)
+}
+
+// DecodeString is the string-input form of Decode.
+func DecodeString(s string) ([]KotlinPackage, error) {
+	return decodeBytes([]byte(s))
+}
+
+func decodeBytes(data []byte) ([]KotlinPackage, error) {
+	lines := strings.Split(string(data), "\n")
+	var out []KotlinPackage
+	var cur *KotlinPackage
+	flush := func() {
+		if cur != nil {
+			out = append(out, *cur)
+		}
+		cur = nil
+	}
+	for lineno, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if line == "[[kotlin-package]]" {
+			flush()
+			cur = &KotlinPackage{}
+			continue
+		}
+		if cur == nil {
+			continue // outside a [[kotlin-package]] block
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			return nil, fmt.Errorf("lockfile: line %d: missing '=': %q", lineno+1, line)
+		}
+		key := strings.TrimSpace(line[:eq])
+		val := strings.TrimSpace(line[eq+1:])
+		if err := setField(cur, key, val); err != nil {
+			return nil, fmt.Errorf("lockfile: line %d (%s): %w", lineno+1, key, err)
+		}
+	}
+	flush()
+	return out, nil
+}
+
+func setField(p *KotlinPackage, key, val string) error {
+	switch key {
+	case "group":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.Group = s
+	case "artifact":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.Artifact = s
+	case "version":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.Version = s
+	case "source":
+		src, err := parseSource(val)
+		if err != nil {
+			return err
+		}
+		p.Source = src
+	case "jar-sha256":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.JarSHA256 = s
+	case "jar-blake3":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.JarBLAKE3 = s
+	case "metadata-sha256":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.MetadataSHA256 = s
+	case "wrapper-sha256":
+		s, err := parseString(val)
+		if err != nil {
+			return err
+		}
+		p.WrapperSHA256 = s
+	case "capabilities-declared":
+		arr, err := parseStringArray(val)
+		if err != nil {
+			return err
+		}
+		p.CapabilitiesDeclared = arr
+	case "dependencies":
+		arr, err := parseStringArray(val)
+		if err != nil {
+			return err
+		}
+		p.Dependencies = arr
+	default:
+		// Unknown key: forward-compat tolerance.
+	}
+	return nil
+}
+
+func parseString(val string) (string, error) {
+	val = strings.TrimSpace(val)
+	if len(val) < 2 || val[0] != '"' || val[len(val)-1] != '"' {
+		return "", fmt.Errorf("expected quoted string, got %q", val)
+	}
+	return val[1 : len(val)-1], nil
+}
+
+func parseStringArray(val string) ([]string, error) {
+	val = strings.TrimSpace(val)
+	if !strings.HasPrefix(val, "[") || !strings.HasSuffix(val, "]") {
+		return nil, fmt.Errorf("expected [..], got %q", val)
+	}
+	inner := strings.TrimSpace(val[1 : len(val)-1])
+	if inner == "" {
+		return nil, nil
+	}
+	parts := splitTopLevel(inner, ',')
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		s, err := parseString(p)
+		if err != nil {
+			return nil, fmt.Errorf("array element: %w", err)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+func parseSource(val string) (Source, error) {
+	val = strings.TrimSpace(val)
+	if !strings.HasPrefix(val, "{") || !strings.HasSuffix(val, "}") {
+		return Source{}, fmt.Errorf("expected inline table { ... }, got %q", val)
+	}
+	inner := strings.TrimSpace(val[1 : len(val)-1])
+	parts := splitTopLevel(inner, ',')
+	src := Source{}
+	for _, kv := range parts {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			return Source{}, fmt.Errorf("source key without '=': %q", kv)
+		}
+		k := strings.TrimSpace(kv[:eq])
+		v := strings.TrimSpace(kv[eq+1:])
+		s, err := parseString(v)
+		if err != nil {
+			return Source{}, fmt.Errorf("source[%s]: %w", k, err)
+		}
+		switch k {
+		case "kind":
+			src.Kind = SourceKind(s)
+		case "registry":
+			src.Registry = s
+		case "url":
+			src.URL = s
+		case "rev":
+			src.Rev = s
+		case "path":
+			src.Path = s
+		}
+	}
+	if src.Kind == "" {
+		return Source{}, fmt.Errorf("source missing kind: %q", val)
+	}
+	return src, nil
+}
+
+// splitTopLevel splits s on sep, ignoring sep inside matched braces, brackets,
+// or double-quoted strings.
+func splitTopLevel(s string, sep byte) []string {
+	var out []string
+	depth := 0
+	inStr := false
+	last := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case inStr:
+			if c == '"' && (i == 0 || s[i-1] != '\\') {
+				inStr = false
+			}
+		case c == '"':
+			inStr = true
+		case c == '{' || c == '[':
+			depth++
+		case c == '}' || c == ']':
+			depth--
+		case c == sep && depth == 0:
+			out = append(out, strings.TrimSpace(s[last:i]))
+			last = i + 1
+		}
+	}
+	out = append(out, strings.TrimSpace(s[last:]))
+	return out
+}

--- a/package3/kotlin/lock/lock_test.go
+++ b/package3/kotlin/lock/lock_test.go
@@ -1,0 +1,302 @@
+package lock
+
+import (
+	"strings"
+	"testing"
+)
+
+// ─── encode round-trip ────────────────────────────────────────────────────────
+
+func TestEncodeDecode_Roundtrip(t *testing.T) {
+	packages := []KotlinPackage{
+		{
+			Group:    "org.jetbrains.kotlinx",
+			Artifact: "kotlinx-coroutines-core",
+			Version:  "1.7.3",
+			Source:   Source{Kind: SourceRegistry, Registry: "https://repo.maven.apache.org/maven2"},
+			JarSHA256: "aabbccdd",
+			JarBLAKE3: "11223344",
+			MetadataSHA256: "meta1234",
+			WrapperSHA256:  "wrap5678",
+			CapabilitiesDeclared: []string{"net"},
+			Dependencies: []string{
+				"org.jetbrains.kotlin:kotlin-stdlib@1.9.23",
+				"org.jetbrains.kotlinx:kotlinx-coroutines-bom@1.7.3",
+			},
+		},
+		{
+			Group:    "com.squareup.okhttp3",
+			Artifact: "okhttp",
+			Version:  "4.12.0",
+			Source:   Source{Kind: SourceRegistry},
+			JarSHA256: "deadbeef",
+		},
+	}
+
+	encoded := Encode(packages)
+	if !strings.Contains(encoded, "[[kotlin-package]]") {
+		t.Errorf("encoded output missing [[kotlin-package]] header:\n%s", encoded)
+	}
+
+	decoded, err := DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("DecodeString: %v\nInput:\n%s", err, encoded)
+	}
+	if len(decoded) != len(packages) {
+		t.Fatalf("want %d packages, got %d", len(packages), len(decoded))
+	}
+
+	// Encoded output is sorted by group:artifact, so okhttp comes first.
+	assertPackageEqual(t, decoded[0], packages[1]) // okhttp
+	assertPackageEqual(t, decoded[1], packages[0]) // kotlinx-coroutines-core
+}
+
+func assertPackageEqual(t *testing.T, got, want KotlinPackage) {
+	t.Helper()
+	if got.Group != want.Group {
+		t.Errorf("Group: got %q, want %q", got.Group, want.Group)
+	}
+	if got.Artifact != want.Artifact {
+		t.Errorf("Artifact: got %q, want %q", got.Artifact, want.Artifact)
+	}
+	if got.Version != want.Version {
+		t.Errorf("Version: got %q, want %q", got.Version, want.Version)
+	}
+	if got.JarSHA256 != want.JarSHA256 {
+		t.Errorf("JarSHA256: got %q, want %q", got.JarSHA256, want.JarSHA256)
+	}
+	if got.JarBLAKE3 != want.JarBLAKE3 {
+		t.Errorf("JarBLAKE3: got %q, want %q", got.JarBLAKE3, want.JarBLAKE3)
+	}
+	if got.MetadataSHA256 != want.MetadataSHA256 {
+		t.Errorf("MetadataSHA256: got %q, want %q", got.MetadataSHA256, want.MetadataSHA256)
+	}
+	if got.WrapperSHA256 != want.WrapperSHA256 {
+		t.Errorf("WrapperSHA256: got %q, want %q", got.WrapperSHA256, want.WrapperSHA256)
+	}
+}
+
+// ─── determinism ──────────────────────────────────────────────────────────────
+
+func TestEncode_Deterministic(t *testing.T) {
+	packages := []KotlinPackage{
+		{Group: "z.group", Artifact: "z-artifact", Version: "1.0", Source: Source{Kind: SourceRegistry}},
+		{Group: "a.group", Artifact: "a-artifact", Version: "1.0", Source: Source{Kind: SourceRegistry}},
+		{Group: "m.group", Artifact: "m-artifact", Version: "1.0", Source: Source{Kind: SourceRegistry}},
+	}
+	out1 := Encode(packages)
+	out2 := Encode(packages)
+	if out1 != out2 {
+		t.Error("Encode is not deterministic")
+	}
+	// a.group should appear before m.group before z.group
+	aIdx := strings.Index(out1, "a.group")
+	mIdx := strings.Index(out1, "m.group")
+	zIdx := strings.Index(out1, "z.group")
+	if !(aIdx < mIdx && mIdx < zIdx) {
+		t.Errorf("want alphabetical order; a@%d m@%d z@%d", aIdx, mIdx, zIdx)
+	}
+}
+
+// ─── source kinds ─────────────────────────────────────────────────────────────
+
+func TestEncodeDecode_GitSource(t *testing.T) {
+	p := KotlinPackage{
+		Group: "com.example", Artifact: "mylib", Version: "0.1.0",
+		Source: Source{
+			Kind: SourceGit,
+			URL:  "https://github.com/example/mylib",
+			Rev:  "abc123",
+		},
+	}
+	encoded := Encode([]KotlinPackage{p})
+	decoded, err := DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(decoded) != 1 {
+		t.Fatalf("want 1, got %d", len(decoded))
+	}
+	src := decoded[0].Source
+	if src.Kind != SourceGit {
+		t.Errorf("kind: %q", src.Kind)
+	}
+	if src.URL != "https://github.com/example/mylib" {
+		t.Errorf("url: %q", src.URL)
+	}
+	if src.Rev != "abc123" {
+		t.Errorf("rev: %q", src.Rev)
+	}
+}
+
+func TestEncodeDecode_PathSource(t *testing.T) {
+	p := KotlinPackage{
+		Group: "com.example", Artifact: "local", Version: "dev",
+		Source: Source{Kind: SourcePath, Path: "../local-lib"},
+	}
+	encoded := Encode([]KotlinPackage{p})
+	decoded, err := DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded[0].Source.Path != "../local-lib" {
+		t.Errorf("path: %q", decoded[0].Source.Path)
+	}
+}
+
+// ─── forward-compat ───────────────────────────────────────────────────────────
+
+func TestDecode_UnknownKeys(t *testing.T) {
+	input := `[[kotlin-package]]
+group = "com.example"
+artifact = "lib"
+version = "1.0"
+source = { kind = "registry" }
+unknown-future-key = "ignored"
+another-unknown = ["a", "b"]
+`
+	pkgs, err := DecodeString(input)
+	if err != nil {
+		t.Fatalf("unexpected error on unknown keys: %v", err)
+	}
+	if len(pkgs) != 1 || pkgs[0].Artifact != "lib" {
+		t.Errorf("unexpected result: %+v", pkgs)
+	}
+}
+
+func TestDecode_OutsideBlockIgnored(t *testing.T) {
+	input := `# mochi.lock
+schema-version = "2"
+
+[[go-module]]
+path = "github.com/foo/bar"
+
+[[kotlin-package]]
+group = "com.example"
+artifact = "lib"
+version = "1.0"
+source = { kind = "registry" }
+`
+	pkgs, err := DecodeString(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pkgs) != 1 {
+		t.Fatalf("want 1 package, got %d", len(pkgs))
+	}
+}
+
+// ─── empty inputs ─────────────────────────────────────────────────────────────
+
+func TestEncode_Empty(t *testing.T) {
+	if got := Encode(nil); got != "" {
+		t.Errorf("Encode(nil) = %q; want empty", got)
+	}
+}
+
+func TestDecode_Empty(t *testing.T) {
+	pkgs, err := DecodeString("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pkgs) != 0 {
+		t.Errorf("want 0, got %d", len(pkgs))
+	}
+}
+
+// ─── Check (lock drift detection) ────────────────────────────────────────────
+
+func TestCheck_NoDrift(t *testing.T) {
+	p := KotlinPackage{
+		Group: "com.example", Artifact: "lib", Version: "1.0",
+		Source:         Source{Kind: SourceRegistry},
+		JarSHA256:      "aabb",
+		JarBLAKE3:      "ccdd",
+		MetadataSHA256: "eeff",
+		WrapperSHA256:  "0011",
+	}
+	errs := Check([]KotlinPackage{p}, []KotlinPackage{p})
+	if len(errs) != 0 {
+		t.Errorf("want 0 drift errors, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestCheck_JarHashDrift(t *testing.T) {
+	locked := KotlinPackage{Group: "com.example", Artifact: "lib", Version: "1.0",
+		Source: Source{Kind: SourceRegistry}, JarSHA256: "old"}
+	fresh := KotlinPackage{Group: "com.example", Artifact: "lib", Version: "1.0",
+		Source: Source{Kind: SourceRegistry}, JarSHA256: "new"}
+	errs := Check([]KotlinPackage{locked}, []KotlinPackage{fresh})
+	if len(errs) != 1 {
+		t.Fatalf("want 1 drift error, got %d", len(errs))
+	}
+	if errs[0].Field != "jar-sha256" {
+		t.Errorf("field = %q; want jar-sha256", errs[0].Field)
+	}
+}
+
+func TestCheck_WrapperDrift(t *testing.T) {
+	locked := KotlinPackage{Group: "com.example", Artifact: "lib", Version: "1.0",
+		Source: Source{Kind: SourceRegistry}, WrapperSHA256: "v1"}
+	fresh := KotlinPackage{Group: "com.example", Artifact: "lib", Version: "1.0",
+		Source: Source{Kind: SourceRegistry}, WrapperSHA256: "v2"}
+	errs := Check([]KotlinPackage{locked}, []KotlinPackage{fresh})
+	if len(errs) != 1 || errs[0].Field != "wrapper-sha256" {
+		t.Errorf("want wrapper-sha256 drift, got %+v", errs)
+	}
+}
+
+func TestCheck_MissingPackage(t *testing.T) {
+	locked := KotlinPackage{Group: "com.example", Artifact: "old-lib", Version: "1.0",
+		Source: Source{Kind: SourceRegistry}}
+	fresh := KotlinPackage{Group: "com.example", Artifact: "new-lib", Version: "1.0",
+		Source: Source{Kind: SourceRegistry}}
+	errs := Check([]KotlinPackage{locked}, []KotlinPackage{fresh})
+	if len(errs) != 1 || errs[0].Field != "package" {
+		t.Errorf("want missing-package drift, got %+v", errs)
+	}
+}
+
+func TestCheckErr_ReturnsNilOnClean(t *testing.T) {
+	p := KotlinPackage{Group: "g", Artifact: "a", Version: "1.0",
+		Source: Source{Kind: SourceRegistry}, JarSHA256: "x"}
+	if err := CheckErr([]KotlinPackage{p}, []KotlinPackage{p}); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// ─── string array edge cases ──────────────────────────────────────────────────
+
+func TestDecode_EmptyArray(t *testing.T) {
+	input := `[[kotlin-package]]
+group = "com.example"
+artifact = "lib"
+version = "1.0"
+source = { kind = "registry" }
+capabilities-declared = []
+`
+	pkgs, err := DecodeString(input)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(pkgs[0].CapabilitiesDeclared) != 0 {
+		t.Errorf("expected empty slice, got %v", pkgs[0].CapabilitiesDeclared)
+	}
+}
+
+func TestDecode_MultiDependencies(t *testing.T) {
+	input := `[[kotlin-package]]
+group = "io.ktor"
+artifact = "ktor-client-core"
+version = "2.3.9"
+source = { kind = "registry" }
+dependencies = ["org.jetbrains.kotlin:kotlin-stdlib@1.9.23", "io.ktor:ktor-io@2.3.9"]
+`
+	pkgs, err := DecodeString(input)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(pkgs[0].Dependencies) != 2 {
+		t.Errorf("want 2 deps, got %d", len(pkgs[0].Dependencies))
+	}
+}


### PR DESCRIPTION
## Summary

- `package3/kotlin/lock`: `KotlinPackage` struct + `Encode`/`Decode` + `Check`/`CheckErr`
- `[[kotlin-package]]` TOML format with jar-sha256, jar-blake3, metadata-sha256, wrapper-sha256, source (registry/git/path), capabilities, deps
- `Check` detects all four hash drifts + missing package, used by `mochi pkg lock --check`

Closes #22945

## Test plan

- [x] `go test -race ./lock/...` — 16 tests, all pass