### PR TITLE
mep73: phase 13 embedded / no_std subset

### DIFF
--- a/package3/rust/embedded/embedded.go
+++ b/package3/rust/embedded/embedded.go
@@ -1,0 +1,164 @@
+// Package embedded owns the MEP-73 Phase 13 no_std subset: the
+// deterministic text shape the wrapper crate adopts when the user
+// has declared `[rust] profile = "embedded"` in mochi.toml. The
+// embedded profile narrows the wrapper to a `no_std + alloc` build
+// (suitable for thumbv7em-none-eabihf, riscv32-imc-none-elf, and
+// similar bare-metal targets), refuses async-fn surfaces because
+// tokio requires std, and pins the upstream dep to
+// `default-features = false` so std-only features cannot leak in
+// silently.
+//
+// The package intentionally only owns the bridge-side encoding of
+// the profile. It does NOT walk upstream Cargo.toml to verify
+// no_std compatibility (that lives in the lockfile drift checker)
+// and does NOT pick the target triple (the user does, via the host
+// build driver). Phase 13's contract is: given the profile flag,
+// produce the right wrapper text and refuse the right async items.
+package embedded
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Profile is the wrapper-crate build profile. The default
+// ProfileHosted produces the full-std wrapper Phases 0-12 emit;
+// ProfileEmbedded produces the no_std + alloc subset.
+type Profile int
+
+const (
+	// ProfileHosted is the default. Wrapper uses std; tokio,
+	// HashMap, HashSet, and everything else in Phases 0-12 work.
+	ProfileHosted Profile = iota
+
+	// ProfileEmbedded is the no_std + alloc subset. The wrapper
+	// crate's src/lib.rs gains `#![no_std]` plus
+	// `extern crate alloc;`, the upstream Cargo dep is pinned to
+	// `default-features = false`, and async fns are refused at
+	// synth time because tokio requires std.
+	ProfileEmbedded
+)
+
+// String reports the profile name as it appears in mochi.toml. The
+// returned name is stable and round-trips through ParseProfile.
+func (p Profile) String() string {
+	switch p {
+	case ProfileHosted:
+		return "hosted"
+	case ProfileEmbedded:
+		return "embedded"
+	}
+	return fmt.Sprintf("unknown-profile-%d", int(p))
+}
+
+// ParseProfile parses the `[rust] profile = "..."` value from
+// mochi.toml. The empty string defaults to ProfileHosted (the
+// pre-Phase-13 behaviour). Unknown values are rejected to keep the
+// surface closed.
+func ParseProfile(s string) (Profile, error) {
+	switch strings.TrimSpace(s) {
+	case "", "hosted":
+		return ProfileHosted, nil
+	case "embedded":
+		return ProfileEmbedded, nil
+	}
+	return ProfileHosted, fmt.Errorf("embedded: unknown profile %q (want \"hosted\" or \"embedded\")", s)
+}
+
+// LibRSHeader returns the prologue lines the emitter prepends to
+// src/lib.rs. ProfileHosted returns the empty string (the wrapper
+// runs under std as before). ProfileEmbedded returns the verbatim
+// no_std attribute plus `extern crate alloc;` so allocator-using
+// types (String, Vec, BTreeMap from alloc) remain available.
+//
+// The output is deterministic and ends with a trailing newline iff
+// non-empty so callers can concatenate it directly.
+func LibRSHeader(p Profile) string {
+	if p == ProfileEmbedded {
+		return "#![no_std]\nextern crate alloc;\n"
+	}
+	return ""
+}
+
+// CargoUpstreamDepRow renders the `[dependencies] <name> = ...`
+// line for the upstream crate. For ProfileEmbedded, the inline
+// table flips `default-features = false` so the wrapper does not
+// silently inherit `std` from the upstream's default feature set.
+// For ProfileHosted, the row keeps the simple `name = "=version"`
+// shape Phases 0-12 produce.
+func CargoUpstreamDepRow(profile Profile, name, version string) string {
+	if profile == ProfileEmbedded {
+		return fmt.Sprintf("%s = { version = \"=%s\", default-features = false }\n", name, version)
+	}
+	return fmt.Sprintf("%s = \"=%s\"\n", name, version)
+}
+
+// RefuseAsync reports whether async fns must be refused at synth
+// time under the given profile. ProfileEmbedded returns true: the
+// tokio runtime singleton Phase 11 prepends to the wrapper requires
+// std, so any async fn under an embedded build would fail at link
+// time with a clearer-up-front refusal.
+func RefuseAsync(p Profile) bool {
+	return p == ProfileEmbedded
+}
+
+// AsyncRefusalReason is the human-readable diagnostic the wrapper
+// uses when refusing an async fn under ProfileEmbedded. The phrase
+// is fixed so test fixtures can match it byte-stable.
+const AsyncRefusalReason = "async fn requires tokio (std); embedded profile is no_std + alloc"
+
+// ParseTOMLBody parses the body of a `[rust] profile = "..."` table
+// fragment. The accepted shapes are:
+//
+//	profile = "embedded"
+//	profile = "hosted"
+//
+// plus blank-line / whitespace tolerance. The empty body defaults
+// to ProfileHosted. The parser is intentionally narrow; it rejects
+// anything that does not match the literal shape so the manifest
+// stays a closed surface.
+func ParseTOMLBody(body string) (Profile, error) {
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			return ProfileHosted, fmt.Errorf("embedded: malformed row %q", raw)
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if k != "profile" {
+			return ProfileHosted, fmt.Errorf("embedded: unknown key %q (want \"profile\")", k)
+		}
+		if !strings.HasPrefix(v, `"`) || !strings.HasSuffix(v, `"`) {
+			return ProfileHosted, fmt.Errorf("embedded: profile value %q is not a quoted string", v)
+		}
+		return ParseProfile(v[1 : len(v)-1])
+	}
+	return ProfileHosted, nil
+}
+
+// AllowedTriples returns the closed set of target triples the
+// embedded profile is expected to compile against. The list is
+// sorted alphabetically for byte stability; callers display it in
+// diagnostics when the user picks a non-matching triple. The list
+// follows MEP-73 §13 (embedded subset target matrix).
+func AllowedTriples(p Profile) []string {
+	if p != ProfileEmbedded {
+		return nil
+	}
+	out := []string{
+		"riscv32imac-unknown-none-elf",
+		"riscv32imc-unknown-none-elf",
+		"thumbv6m-none-eabi",
+		"thumbv7em-none-eabi",
+		"thumbv7em-none-eabihf",
+		"thumbv7m-none-eabi",
+		"thumbv8m.main-none-eabihf",
+	}
+	sort.Strings(out)
+	return out
+}

--- a/package3/rust/embedded/embedded_test.go
+++ b/package3/rust/embedded/embedded_test.go
@@ -1,0 +1,222 @@
+package embedded
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseProfileDefault(t *testing.T) {
+	p, err := ParseProfile("")
+	if err != nil {
+		t.Fatalf("ParseProfile(empty): %v", err)
+	}
+	if p != ProfileHosted {
+		t.Fatalf("ParseProfile(empty) = %v; want ProfileHosted", p)
+	}
+}
+
+func TestParseProfileHosted(t *testing.T) {
+	p, err := ParseProfile("hosted")
+	if err != nil {
+		t.Fatalf("ParseProfile(hosted): %v", err)
+	}
+	if p != ProfileHosted {
+		t.Fatalf("ParseProfile(hosted) = %v; want ProfileHosted", p)
+	}
+}
+
+func TestParseProfileEmbedded(t *testing.T) {
+	p, err := ParseProfile("embedded")
+	if err != nil {
+		t.Fatalf("ParseProfile(embedded): %v", err)
+	}
+	if p != ProfileEmbedded {
+		t.Fatalf("ParseProfile(embedded) = %v; want ProfileEmbedded", p)
+	}
+}
+
+func TestParseProfileRejectsUnknown(t *testing.T) {
+	if _, err := ParseProfile("kernel"); err == nil {
+		t.Fatalf("ParseProfile(kernel): want error")
+	}
+}
+
+func TestProfileString(t *testing.T) {
+	tests := []struct {
+		p    Profile
+		want string
+	}{
+		{ProfileHosted, "hosted"},
+		{ProfileEmbedded, "embedded"},
+	}
+	for _, c := range tests {
+		if got := c.p.String(); got != c.want {
+			t.Fatalf("Profile(%d).String() = %q; want %q", int(c.p), got, c.want)
+		}
+	}
+}
+
+func TestProfileRoundTripsThroughString(t *testing.T) {
+	for _, p := range []Profile{ProfileHosted, ProfileEmbedded} {
+		got, err := ParseProfile(p.String())
+		if err != nil {
+			t.Fatalf("ParseProfile(%s): %v", p, err)
+		}
+		if got != p {
+			t.Fatalf("round trip: %v -> %q -> %v", p, p, got)
+		}
+	}
+}
+
+func TestLibRSHeaderHosted(t *testing.T) {
+	if got := LibRSHeader(ProfileHosted); got != "" {
+		t.Fatalf("LibRSHeader(hosted) = %q; want empty", got)
+	}
+}
+
+func TestLibRSHeaderEmbedded(t *testing.T) {
+	got := LibRSHeader(ProfileEmbedded)
+	if !strings.Contains(got, "#![no_std]") {
+		t.Fatalf("LibRSHeader(embedded): missing #![no_std] in %q", got)
+	}
+	if !strings.Contains(got, "extern crate alloc;") {
+		t.Fatalf("LibRSHeader(embedded): missing extern crate alloc in %q", got)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatalf("LibRSHeader(embedded): want trailing newline, got %q", got)
+	}
+}
+
+func TestCargoUpstreamDepRowHosted(t *testing.T) {
+	got := CargoUpstreamDepRow(ProfileHosted, "hex", "0.4.3")
+	want := "hex = \"=0.4.3\"\n"
+	if got != want {
+		t.Fatalf("CargoUpstreamDepRow(hosted) = %q; want %q", got, want)
+	}
+}
+
+func TestCargoUpstreamDepRowEmbedded(t *testing.T) {
+	got := CargoUpstreamDepRow(ProfileEmbedded, "hex", "0.4.3")
+	if !strings.Contains(got, "default-features = false") {
+		t.Fatalf("CargoUpstreamDepRow(embedded): missing default-features flip in %q", got)
+	}
+	if !strings.Contains(got, "version = \"=0.4.3\"") {
+		t.Fatalf("CargoUpstreamDepRow(embedded): missing pinned version in %q", got)
+	}
+	if !strings.HasPrefix(got, "hex = ") {
+		t.Fatalf("CargoUpstreamDepRow(embedded): want \"hex = ...\" prefix, got %q", got)
+	}
+}
+
+func TestRefuseAsync(t *testing.T) {
+	if RefuseAsync(ProfileHosted) {
+		t.Fatalf("RefuseAsync(hosted) = true; want false")
+	}
+	if !RefuseAsync(ProfileEmbedded) {
+		t.Fatalf("RefuseAsync(embedded) = false; want true")
+	}
+}
+
+func TestAsyncRefusalReasonStable(t *testing.T) {
+	if !strings.Contains(AsyncRefusalReason, "tokio") {
+		t.Fatalf("AsyncRefusalReason should mention tokio: %q", AsyncRefusalReason)
+	}
+	if !strings.Contains(AsyncRefusalReason, "embedded") {
+		t.Fatalf("AsyncRefusalReason should mention embedded: %q", AsyncRefusalReason)
+	}
+}
+
+func TestParseTOMLBodyEmpty(t *testing.T) {
+	p, err := ParseTOMLBody("")
+	if err != nil {
+		t.Fatalf("ParseTOMLBody(empty): %v", err)
+	}
+	if p != ProfileHosted {
+		t.Fatalf("ParseTOMLBody(empty) = %v; want ProfileHosted", p)
+	}
+}
+
+func TestParseTOMLBodyEmbedded(t *testing.T) {
+	p, err := ParseTOMLBody(`profile = "embedded"`)
+	if err != nil {
+		t.Fatalf("ParseTOMLBody: %v", err)
+	}
+	if p != ProfileEmbedded {
+		t.Fatalf("ParseTOMLBody(embedded) = %v; want ProfileEmbedded", p)
+	}
+}
+
+func TestParseTOMLBodyAllowsCommentsAndBlankLines(t *testing.T) {
+	body := `
+# the rust profile
+profile = "embedded"   # inline comments not supported, just this one
+`
+	// The "inline comments" comment after the quoted value would fail
+	// the strict parser; verify the simpler well-formed case.
+	body2 := `
+# comment
+profile = "embedded"
+`
+	p, err := ParseTOMLBody(body2)
+	if err != nil {
+		t.Fatalf("ParseTOMLBody: %v", err)
+	}
+	if p != ProfileEmbedded {
+		t.Fatalf("ParseTOMLBody = %v; want ProfileEmbedded", p)
+	}
+	if _, err := ParseTOMLBody(body); err == nil {
+		t.Fatalf("ParseTOMLBody: want error when trailing junk follows the quoted value")
+	}
+}
+
+func TestParseTOMLBodyRejectsUnknownKey(t *testing.T) {
+	if _, err := ParseTOMLBody(`target = "embedded"`); err == nil {
+		t.Fatalf("ParseTOMLBody: want error for unknown key")
+	}
+}
+
+func TestParseTOMLBodyRejectsUnquoted(t *testing.T) {
+	if _, err := ParseTOMLBody(`profile = embedded`); err == nil {
+		t.Fatalf("ParseTOMLBody: want error for unquoted value")
+	}
+}
+
+func TestAllowedTriplesHostedReturnsNil(t *testing.T) {
+	if got := AllowedTriples(ProfileHosted); got != nil {
+		t.Fatalf("AllowedTriples(hosted) = %v; want nil", got)
+	}
+}
+
+func TestAllowedTriplesEmbeddedSorted(t *testing.T) {
+	got := AllowedTriples(ProfileEmbedded)
+	if len(got) < 4 {
+		t.Fatalf("AllowedTriples(embedded): want at least 4 triples, got %d (%v)", len(got), got)
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i-1] > got[i] {
+			t.Fatalf("AllowedTriples not sorted at index %d: %v", i, got)
+		}
+	}
+	wantSome := []string{"thumbv7em-none-eabihf", "riscv32imc-unknown-none-elf"}
+	for _, w := range wantSome {
+		found := false
+		for _, g := range got {
+			if g == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("AllowedTriples(embedded): missing %q in %v", w, got)
+		}
+	}
+}
+
+func TestLibRSHeaderByteStable(t *testing.T) {
+	first := LibRSHeader(ProfileEmbedded)
+	for i := 0; i < 32; i++ {
+		if got := LibRSHeader(ProfileEmbedded); got != first {
+			t.Fatalf("LibRSHeader not byte-stable: %q vs %q", first, got)
+		}
+	}
+}

--- a/package3/rust/embedded/phase13_test.go
+++ b/package3/rust/embedded/phase13_test.go
@@ -1,0 +1,160 @@
+package embedded_test
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/rust/embedded"
+	"mochi/package3/rust/errors"
+	"mochi/package3/rust/rustdoc"
+	"mochi/package3/rust/wrapper"
+)
+
+// TestPhase13EmbeddedSubset is the umbrella sentinel for MEP-73
+// Phase 13. It exercises the end-to-end loop: a wrapper crate
+// synthesised under `[rust] profile = "embedded"` carries
+// `#![no_std]` + `extern crate alloc;`, drops `default-features` on
+// the upstream dep, refuses async fns at synth time, and produces
+// byte-identical output across runs.
+func TestPhase13EmbeddedSubset(t *testing.T) {
+	t.Run("profile_default_is_hosted", profileDefaultIsHosted)
+	t.Run("profile_parses_from_toml", profileParsesFromTOML)
+	t.Run("libRS_carries_no_std_under_embedded", libRSCarriesNoStd)
+	t.Run("libRS_omits_no_std_under_hosted", libRSOmitsNoStd)
+	t.Run("cargo_pins_default_features_off_under_embedded", cargoPinsDefaultFeaturesOff)
+	t.Run("async_fns_refused_under_embedded", asyncFnsRefused)
+	t.Run("sync_fns_kept_under_embedded", syncFnsKept)
+	t.Run("triples_list_sorted_and_nonempty", triplesListSortedAndNonempty)
+	t.Run("emit_byte_stable_under_embedded", emitByteStable)
+}
+
+func profileDefaultIsHosted(t *testing.T) {
+	p, err := embedded.ParseProfile("")
+	if err != nil || p != embedded.ProfileHosted {
+		t.Fatalf("default profile should be hosted; got %v err=%v", p, err)
+	}
+}
+
+func profileParsesFromTOML(t *testing.T) {
+	p, err := embedded.ParseTOMLBody(`profile = "embedded"`)
+	if err != nil {
+		t.Fatalf("ParseTOMLBody: %v", err)
+	}
+	if p != embedded.ProfileEmbedded {
+		t.Fatalf("profile should be embedded; got %v", p)
+	}
+}
+
+func libRSCarriesNoStd(t *testing.T) {
+	c := wrapper.SynthWithProfile("tokio_demo", "0.1.0", phase13Surface(), embedded.ProfileEmbedded)
+	got := wrapper.EmitLibRS(c)
+	if !strings.HasPrefix(got, "#![no_std]\n") {
+		t.Fatalf("embedded EmitLibRS should start with #![no_std]; got prefix:\n%s", clip(got, 100))
+	}
+	if !strings.Contains(got, "extern crate alloc;") {
+		t.Fatalf("embedded EmitLibRS should declare extern crate alloc")
+	}
+}
+
+func libRSOmitsNoStd(t *testing.T) {
+	c := wrapper.SynthWithProfile("tokio_demo", "0.1.0", phase13Surface(), embedded.ProfileHosted)
+	got := wrapper.EmitLibRS(c)
+	if strings.Contains(got, "#![no_std]") {
+		t.Fatalf("hosted EmitLibRS should NOT carry #![no_std]")
+	}
+}
+
+func cargoPinsDefaultFeaturesOff(t *testing.T) {
+	c := wrapper.SynthWithProfile("tokio_demo", "0.1.0", phase13Surface(), embedded.ProfileEmbedded)
+	got := wrapper.EmitCargoTOML(c)
+	if !strings.Contains(got, "default-features = false") {
+		t.Fatalf("embedded Cargo.toml should pin upstream default-features off:\n%s", got)
+	}
+}
+
+func asyncFnsRefused(t *testing.T) {
+	c := wrapper.SynthWithProfile("tokio_demo", "0.1.0", phase13Surface(), embedded.ProfileEmbedded)
+	for _, fn := range c.Functions {
+		if fn.IsAsync {
+			t.Fatalf("embedded profile should refuse async fn %q", fn.UpstreamPath)
+		}
+	}
+	var found bool
+	for _, s := range c.Skipped {
+		if s.Reason == errors.SkipEmbedded {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("embedded refusal should land in SkipEmbedded; reports = %+v", c.Skipped)
+	}
+}
+
+func syncFnsKept(t *testing.T) {
+	c := wrapper.SynthWithProfile("tokio_demo", "0.1.0", phase13Surface(), embedded.ProfileEmbedded)
+	if len(c.Functions) != 1 {
+		t.Fatalf("embedded should keep 1 sync fn; got %d", len(c.Functions))
+	}
+}
+
+func triplesListSortedAndNonempty(t *testing.T) {
+	got := embedded.AllowedTriples(embedded.ProfileEmbedded)
+	if len(got) == 0 {
+		t.Fatalf("embedded triples should be non-empty")
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i-1] > got[i] {
+			t.Fatalf("AllowedTriples not sorted at %d: %v", i, got)
+		}
+	}
+}
+
+func emitByteStable(t *testing.T) {
+	c := wrapper.SynthWithProfile("tokio_demo", "0.1.0", phase13Surface(), embedded.ProfileEmbedded)
+	first := wrapper.EmitLibRS(c) + "\n---\n" + wrapper.EmitCargoTOML(c)
+	for i := 0; i < 16; i++ {
+		c2 := wrapper.SynthWithProfile("tokio_demo", "0.1.0", phase13Surface(), embedded.ProfileEmbedded)
+		got := wrapper.EmitLibRS(c2) + "\n---\n" + wrapper.EmitCargoTOML(c2)
+		if got != first {
+			t.Fatalf("embedded emit not byte-stable across runs")
+		}
+	}
+}
+
+// phase13Surface mirrors a small async-and-sync mixed surface so
+// the refusal can be observed via the after-synth SynthFn list.
+func phase13Surface() *rustdoc.ApiSurface {
+	str := rustdoc.Type{Primitive: "str"}
+	strBorrow := rustdoc.Type{BorrowedRef: &rustdoc.BorrowedRefType{
+		Lifetime: "'a", Type: str,
+	}}
+	return &rustdoc.ApiSurface{
+		CrateName:    "tokio_demo",
+		CrateVersion: "0.1.0",
+		Functions: []rustdoc.FunctionEntry{
+			{
+				ID:   "fn:greet_async",
+				Path: []string{"tokio_demo", "greet_async"},
+				Inputs: []rustdoc.ParamEntry{
+					{Name: "name", Type: strBorrow},
+				},
+				Header: rustdoc.FunctionHeader{IsAsync: true},
+			},
+			{
+				ID:   "fn:greet_sync",
+				Path: []string{"tokio_demo", "greet_sync"},
+				Inputs: []rustdoc.ParamEntry{
+					{Name: "name", Type: strBorrow},
+				},
+				Header: rustdoc.FunctionHeader{IsAsync: false},
+			},
+		},
+	}
+}
+
+func clip(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/package3/rust/errors/errors.go
+++ b/package3/rust/errors/errors.go
@@ -55,6 +55,11 @@ const (
 	SkipQualifiedPath
 	// SkipOpaqueTypeAlias: type T = impl Trait.
 	SkipOpaqueTypeAlias
+	// SkipEmbedded: the item cannot be exposed under the embedded
+	// (no_std + alloc) profile. Phase 13 emits this when an async
+	// fn would otherwise reach the runtime singleton (tokio
+	// requires std).
+	SkipEmbedded
 )
 
 // String renders the SkipReason as a short token used in the SKIPPED.txt
@@ -100,6 +105,8 @@ func (r SkipReason) String() string {
 		return "SkipQualifiedPath"
 	case SkipOpaqueTypeAlias:
 		return "SkipOpaqueTypeAlias"
+	case SkipEmbedded:
+		return "SkipEmbedded"
 	default:
 		return "SkipUnknown"
 	}

--- a/package3/rust/wrapper/crate.go
+++ b/package3/rust/wrapper/crate.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	"mochi/package3/rust/asyncbridge"
+	"mochi/package3/rust/embedded"
 	"mochi/package3/rust/errors"
 	"mochi/package3/rust/monomorphise"
 	"mochi/package3/rust/rustdoc"
@@ -48,6 +49,14 @@ type Crate struct {
 	// current-thread; callers override from the `[rust.runtime]`
 	// section of mochi.toml.
 	AsyncFlavor asyncbridge.Flavor
+
+	// Profile selects the wrapper-crate build profile. Defaults to
+	// embedded.ProfileHosted (the pre-Phase-13 behaviour); callers
+	// switch to ProfileEmbedded via the `[rust] profile = "embedded"`
+	// row in mochi.toml. The embedded profile narrows the wrapper
+	// to a `no_std + alloc` build and refuses async fns at synth
+	// time because tokio requires std.
+	Profile embedded.Profile
 }
 
 // HasAsync reports whether any synthesised function is `async fn`.
@@ -103,6 +112,52 @@ type SynthParam struct {
 // by the phase-2 walker.
 func Synth(upstream, version string, surface *rustdoc.ApiSurface) *Crate {
 	return SynthWithSpec(upstream, version, surface, monomorphise.Spec{})
+}
+
+// SynthWithProfile is Synth plus an explicit embedded profile. The
+// profile threads through to Crate.Profile so EmitLibRS /
+// EmitCargoTOML produce the no_std prologue and default-features
+// flip when ProfileEmbedded is selected. Async fns are refused at
+// synth time when embedded.RefuseAsync(profile) returns true; the
+// refusal lands in c.Skipped with the canonical SkipEmbedded reason.
+func SynthWithProfile(upstream, version string, surface *rustdoc.ApiSurface, profile embedded.Profile) *Crate {
+	c := SynthWithSpec(upstream, version, surface, monomorphise.Spec{})
+	c.Profile = profile
+	return applyProfileRefusal(c)
+}
+
+// SynthFull is the most-general entry point: spec + profile. Order
+// of operations: typemap.Map (with substitution when an entry
+// matches), then the embedded async-refusal pass.
+func SynthFull(upstream, version string, surface *rustdoc.ApiSurface, spec monomorphise.Spec, profile embedded.Profile) *Crate {
+	c := SynthWithSpec(upstream, version, surface, spec)
+	c.Profile = profile
+	return applyProfileRefusal(c)
+}
+
+// applyProfileRefusal walks the synthesised function list and moves
+// every async fn into c.Skipped when the profile rejects async. The
+// refusal carries SkipEmbedded so downstream tooling can distinguish
+// it from the SkipUnknown bucket. Idempotent: re-running on an
+// already-filtered Crate is a no-op.
+func applyProfileRefusal(c *Crate) *Crate {
+	if !embedded.RefuseAsync(c.Profile) {
+		return c
+	}
+	kept := make([]SynthFn, 0, len(c.Functions))
+	for _, fn := range c.Functions {
+		if fn.IsAsync {
+			c.Skipped = append(c.Skipped, errors.SkipReport{
+				ItemPath: fn.UpstreamPath,
+				Reason:   errors.SkipEmbedded,
+				Detail:   embedded.AsyncRefusalReason,
+			})
+			continue
+		}
+		kept = append(kept, fn)
+	}
+	c.Functions = kept
+	return c
 }
 
 // SynthWithSpec is Synth plus an explicit monomorphisation spec. For

--- a/package3/rust/wrapper/embedded_test.go
+++ b/package3/rust/wrapper/embedded_test.go
@@ -1,0 +1,130 @@
+package wrapper
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/package3/rust/embedded"
+	"mochi/package3/rust/errors"
+	"mochi/package3/rust/monomorphise"
+)
+
+func TestSynthWithProfileHostedKeepsAsync(t *testing.T) {
+	c := SynthWithProfile("tokio_demo", "0.1.0", asyncSurface(), embedded.ProfileHosted)
+	if len(c.Functions) != 2 {
+		t.Fatalf("hosted profile should keep all 2 fns; got %d", len(c.Functions))
+	}
+	for _, s := range c.Skipped {
+		if s.Reason == errors.SkipEmbedded {
+			t.Fatalf("hosted profile should not produce SkipEmbedded reports; got %+v", s)
+		}
+	}
+}
+
+func TestSynthWithProfileEmbeddedRefusesAsync(t *testing.T) {
+	c := SynthWithProfile("tokio_demo", "0.1.0", asyncSurface(), embedded.ProfileEmbedded)
+	for _, fn := range c.Functions {
+		if fn.IsAsync {
+			t.Fatalf("embedded profile should refuse async fn %q", fn.UpstreamPath)
+		}
+	}
+	var found bool
+	for _, s := range c.Skipped {
+		if s.Reason == errors.SkipEmbedded {
+			found = true
+			if !strings.Contains(s.Detail, "tokio") {
+				t.Fatalf("SkipEmbedded detail should mention tokio: %q", s.Detail)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("embedded profile should emit a SkipEmbedded report for the async fn; reports = %+v", c.Skipped)
+	}
+}
+
+func TestSynthWithProfileEmbeddedKeepsSync(t *testing.T) {
+	c := SynthWithProfile("tokio_demo", "0.1.0", asyncSurface(), embedded.ProfileEmbedded)
+	if len(c.Functions) != 1 {
+		t.Fatalf("embedded profile should keep the 1 sync fn; got %d", len(c.Functions))
+	}
+	if c.Functions[0].UpstreamPath != "tokio_demo::greet_sync" {
+		t.Fatalf("expected greet_sync to remain; got %q", c.Functions[0].UpstreamPath)
+	}
+}
+
+func TestEmitLibRSEmbeddedHasNoStdHeader(t *testing.T) {
+	c := SynthWithProfile("tokio_demo", "0.1.0", asyncSurface(), embedded.ProfileEmbedded)
+	got := EmitLibRS(c)
+	if !strings.HasPrefix(got, "#![no_std]\n") {
+		t.Fatalf("embedded EmitLibRS should start with #![no_std]; got prefix:\n%s", got[:min(120, len(got))])
+	}
+	if !strings.Contains(got, "extern crate alloc;") {
+		t.Fatalf("embedded EmitLibRS should declare extern crate alloc")
+	}
+}
+
+func TestEmitLibRSHostedNoStdAbsent(t *testing.T) {
+	c := SynthWithProfile("tokio_demo", "0.1.0", asyncSurface(), embedded.ProfileHosted)
+	got := EmitLibRS(c)
+	if strings.Contains(got, "#![no_std]") {
+		t.Fatalf("hosted EmitLibRS should NOT carry #![no_std]; got:\n%s", got[:min(120, len(got))])
+	}
+}
+
+func TestEmitCargoTOMLEmbeddedFlipsDefaultFeatures(t *testing.T) {
+	c := SynthWithProfile("tokio_demo", "0.1.0", asyncSurface(), embedded.ProfileEmbedded)
+	got := EmitCargoTOML(c)
+	if !strings.Contains(got, "default-features = false") {
+		t.Fatalf("embedded Cargo.toml should pin upstream default-features = false:\n%s", got)
+	}
+}
+
+func TestEmitCargoTOMLHostedKeepsPlainRow(t *testing.T) {
+	c := SynthWithProfile("tokio_demo", "0.1.0", asyncSurface(), embedded.ProfileHosted)
+	got := EmitCargoTOML(c)
+	if strings.Contains(got, "default-features = false") {
+		t.Fatalf("hosted Cargo.toml should NOT carry default-features flip:\n%s", got)
+	}
+}
+
+func TestEmitCargoTOMLEmbeddedDropsTokioWhenAsyncRefused(t *testing.T) {
+	c := SynthWithProfile("tokio_demo", "0.1.0", asyncSurface(), embedded.ProfileEmbedded)
+	if c.HasAsync() {
+		t.Fatalf("embedded profile should have stripped async fns before emit")
+	}
+	got := EmitCargoTOML(c)
+	// The upstream is named "tokio_demo" so a plain substring match
+	// would false-positive. Look for the tokio runtime dep row shape
+	// the async bridge emits ("tokio = ").
+	if strings.Contains(got, "\ntokio = ") {
+		t.Fatalf("embedded Cargo.toml should NOT inject tokio runtime dep (async refused):\n%s", got)
+	}
+	if strings.Contains(got, "once_cell") {
+		t.Fatalf("embedded Cargo.toml should NOT inject once_cell (async refused):\n%s", got)
+	}
+}
+
+func TestSynthFullCombinesSpecAndProfile(t *testing.T) {
+	c := SynthFull("tokio_demo", "0.1.0", asyncSurface(), monomorphise.Spec{}, embedded.ProfileEmbedded)
+	if len(c.Functions) != 1 {
+		t.Fatalf("SynthFull embedded should keep sync only; got %d", len(c.Functions))
+	}
+	if c.Profile != embedded.ProfileEmbedded {
+		t.Fatalf("Profile field not threaded; got %v", c.Profile)
+	}
+}
+
+func TestEmitLibRSEmbeddedDeterministic(t *testing.T) {
+	c1 := SynthWithProfile("tokio_demo", "0.1.0", asyncSurface(), embedded.ProfileEmbedded)
+	c2 := SynthWithProfile("tokio_demo", "0.1.0", asyncSurface(), embedded.ProfileEmbedded)
+	if EmitLibRS(c1) != EmitLibRS(c2) {
+		t.Fatalf("EmitLibRS embedded not deterministic across two synths")
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/package3/rust/wrapper/emit.go
+++ b/package3/rust/wrapper/emit.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"mochi/package3/rust/asyncbridge"
+	"mochi/package3/rust/embedded"
 	"mochi/package3/rust/errors"
 	"mochi/package3/rust/typemap"
 )
@@ -22,6 +23,7 @@ import (
 // the gate here is structural correctness.
 func EmitLibRS(c *Crate) string {
 	var b strings.Builder
+	b.WriteString(embedded.LibRSHeader(c.Profile))
 	b.WriteString(runtimePrologue)
 	b.WriteString("\n")
 	b.WriteString(fmt.Sprintf("// upstream crate: %s %s\n", c.Upstream, c.UpstreamVersion))
@@ -144,7 +146,7 @@ func EmitCargoTOML(c *Crate) string {
 	b.WriteString("crate-type = [\"cdylib\", \"rlib\"]\n")
 	b.WriteString("\n")
 	b.WriteString("[dependencies]\n")
-	b.WriteString(fmt.Sprintf("%s = \"=%s\"\n", c.Upstream, c.UpstreamVersion))
+	b.WriteString(embedded.CargoUpstreamDepRow(c.Profile, c.Upstream, c.UpstreamVersion))
 	if c.HasAsync() {
 		b.WriteString(asyncbridge.CargoDepRow(c.AsyncFlavor))
 		b.WriteString("\n")

--- a/website/docs/implementation/0073/index.md
+++ b/website/docs/implementation/0073/index.md
@@ -27,8 +27,8 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | 9 | `TargetRustLibrary` emit (rlib + cdylib + Cargo.toml + cbindgen) | LANDED | [6e966397](https://github.com/mochilang/mochi/commit/6e966397) | [phase-09](/docs/implementation/0073/phase-09-rust-library-emit) |
 | 10 | Trusted publishing (`mochi pkg publish --to=crates.io`) Sigstore OIDC flow | LANDED | [003e897f](https://github.com/mochilang/mochi/commit/003e897f) | [phase-10](/docs/implementation/0073/phase-10-trusted-publish) |
 | 11 | Async bridge (tokio runtime singleton + block_on entry) | LANDED | [fce8fc5e](https://github.com/mochilang/mochi/commit/fce8fc5e) | [phase-11](/docs/implementation/0073/phase-11-async-bridge) |
-| 12 | Monomorphisation (`[rust.monomorphise]` manifest + per-instantiation wrapper) | LANDED | (pending) | [phase-12](/docs/implementation/0073/phase-12-monomorphise) |
-| 13 | Embedded / no_std subset (`profile = "embedded"` + alloc opt-in) | NOT STARTED | — | [phase-13](/docs/implementation/0073/phase-13-embedded) |
+| 12 | Monomorphisation (`[rust.monomorphise]` manifest + per-instantiation wrapper) | LANDED | [37768e85](https://github.com/mochilang/mochi/commit/37768e85) | [phase-12](/docs/implementation/0073/phase-12-monomorphise) |
+| 13 | Embedded / no_std subset (`profile = "embedded"` + alloc opt-in) | LANDED | (pending) | [phase-13](/docs/implementation/0073/phase-13-embedded) |
 
 ## Per-phase fields
 
@@ -71,7 +71,7 @@ The `package3/rust/` location is shared with the broader MEP-57 polyglot package
 
 ## Status snapshot
 
-As of 2026-05-30 00:32 (GMT+7): phases 0-12 LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest + closed type-mapping table + extern-C wrapper synthesiser + Mochi extern-fn emitter + `import rust` grammar + build orchestration pipeline + mochi.lock `[[rust-package]]` schema + drift checker + TargetRustLibrary publish-direction emit with cbindgen header + trusted-publishing flow with Sigstore-keyless attestation bundle and crates.io upload wire-format + async-fn bridge with lazy tokio runtime singleton and `block_on` wrapper bodies + monomorphisation pipeline with `[rust.monomorphise]` manifest parsing, per-instantiation symbol mangling, and turbofish call-site rendering). Phase 13 pending. The MEP spec and research bundle are landed; implementation is progressing one phase per PR with auto-merge.
+As of 2026-05-30 00:41 (GMT+7): all 14 phases (0-13) LANDED (skeleton + sparse-index client + cargo semver + rustdoc-JSON ingest + closed type-mapping table + extern-C wrapper synthesiser + Mochi extern-fn emitter + `import rust` grammar + build orchestration pipeline + mochi.lock `[[rust-package]]` schema + drift checker + TargetRustLibrary publish-direction emit with cbindgen header + trusted-publishing flow with Sigstore-keyless attestation bundle and crates.io upload wire-format + async-fn bridge with lazy tokio runtime singleton and `block_on` wrapper bodies + monomorphisation pipeline with `[rust.monomorphise]` manifest parsing + per-instantiation symbol mangling + turbofish call-site rendering + embedded `no_std + alloc` profile with async refusal and `default-features = false` upstream pin). The MEP spec, research bundle, and implementation are all landed; the bridge is ready for integration with MEP-53's build driver.
 
 ## Cross-references
 

--- a/website/docs/implementation/0073/phase-13-embedded.md
+++ b/website/docs/implementation/0073/phase-13-embedded.md
@@ -1,0 +1,200 @@
+---
+sidebar_label: "Phase 13: Embedded / no_std subset"
+sidebar_position: 14
+---
+
+# MEP-73 Phase 13: Embedded / no_std subset (`profile = "embedded"` + alloc opt-in)
+
+**Status:** LANDED (2026-05-30)
+**Spec section:** [MEP-73 §3 — Embedded subset](/docs/mep/mep-0073)
+**Worktree:** `/Users/apple/mochi-mep73-p13`
+
+## Gate
+
+Land the embedded build profile: when the user sets `[rust] profile =
+"embedded"` in `mochi.toml`, the wrapper crate the bridge synthesises
+compiles for bare-metal targets (`thumbv7em-none-eabihf` and
+friends). The wrapper carries `#![no_std]` + `extern crate alloc;`,
+pins the upstream Cargo dep to `default-features = false`, and
+refuses every `async fn` at synth time (tokio requires std).
+
+## Why it matters
+
+Phases 0-12 produced wrappers that always linked against `std`.
+Embedded Rust users (firmware authors, RTOS integrators, anyone
+shipping to thumbv7em / riscv32imc / similar bare-metal targets)
+cannot include those wrappers because `std` is unavailable on those
+triples. Bringing Mochi to embedded Rust without Phase 13 would
+require hand-editing every generated `src/lib.rs` after the bridge
+runs.
+
+Phase 13 closes that gap. The wrapper synth grows a profile field,
+the emit prepends the no_std header, the Cargo.toml row flips
+`default-features = false` so the upstream cannot leak `std` in
+silently, and async fns get a clear up-front `SkipEmbedded` refusal
+instead of a confusing link-time tokio missing-`std` error.
+
+Pure-hosted builds pay zero cost: `LibRSHeader(ProfileHosted)` is
+empty, the Cargo row falls back to the plain `name = "=version"` form,
+and async fns continue to route through Phase 11's tokio runtime
+singleton. The embedded profile is purely additive.
+
+## What landed
+
+### `package3/rust/embedded/embedded.go`
+
+The new package owning the deterministic text shape of the embedded
+profile and the closed parser for the `[rust] profile = "..."` row.
+
+- `Profile` enum (`ProfileHosted`, `ProfileEmbedded`) with `String()`
+  and `ParseProfile(s)` round-tripping through the manifest spelling.
+- `ParseTOMLBody(body)` parses the `profile = "..."` row from a
+  table fragment. Accepts blank lines + `#` comments; rejects
+  unquoted values, unknown keys, and trailing junk after the closing
+  quote.
+- `LibRSHeader(profile)` returns the `src/lib.rs` prologue.
+  ProfileHosted returns the empty string; ProfileEmbedded returns
+  `#![no_std]\nextern crate alloc;\n` (terminating newline so callers
+  concatenate cleanly).
+- `CargoUpstreamDepRow(profile, name, version)` renders the upstream
+  dep row. ProfileEmbedded emits the inline-table form with
+  `default-features = false`; ProfileHosted emits the existing
+  `name = "=version"` shape unchanged.
+- `RefuseAsync(profile)` reports whether async fns must be skipped
+  at synth time (true iff ProfileEmbedded).
+- `AsyncRefusalReason` is the canonical detail string so test
+  fixtures and downstream tooling can match it byte-stable.
+- `AllowedTriples(profile)` lists the embedded target triples the
+  bridge expects to compile against (sorted; thumbv6m / thumbv7em /
+  thumbv7m / thumbv8m / riscv32imc / riscv32imac).
+
+### `package3/rust/errors/errors.go`
+
+New `SkipEmbedded` reason. Renders as `SkipEmbedded` in
+`SKIPPED.txt` so it sorts and groups predictably alongside the
+existing reasons.
+
+### `package3/rust/wrapper/crate.go`
+
+- New `Crate.Profile embedded.Profile` field. Defaults to
+  ProfileHosted (the pre-Phase-13 behaviour).
+- `SynthWithProfile(upstream, version, surface, profile)` extends
+  `Synth` with the profile. Plumbs the profile and runs the
+  async-refusal pass.
+- `SynthFull(...)` combines monomorphisation spec + profile for the
+  most-general path the build driver will use.
+- `applyProfileRefusal(c)` walks `c.Functions` and moves every async
+  fn into `c.Skipped` with `errors.SkipEmbedded` +
+  `embedded.AsyncRefusalReason` when `embedded.RefuseAsync(profile)`
+  is true. Idempotent.
+
+### `package3/rust/wrapper/emit.go`
+
+- `EmitLibRS` prepends `embedded.LibRSHeader(c.Profile)` before the
+  runtime prologue.
+- `EmitCargoTOML` uses `embedded.CargoUpstreamDepRow` for the
+  upstream dep row instead of the inline `name = "=version"` literal.
+  When the profile is embedded and async refusal stripped every
+  async fn, `c.HasAsync()` returns false and the tokio + once_cell
+  rows are omitted.
+
+### Tests
+
+- `embedded_test.go` (20 cases): ParseProfile (default / hosted /
+  embedded / rejects unknown), Profile.String + round-trip,
+  LibRSHeader (hosted / embedded / trailing newline / byte-stable),
+  CargoUpstreamDepRow (hosted plain / embedded default-features
+  flip), RefuseAsync, AsyncRefusalReason stable, ParseTOMLBody
+  (empty / embedded / comments + blank lines / rejects unknown key /
+  rejects unquoted / rejects trailing junk), AllowedTriples (hosted
+  returns nil / embedded sorted + nonempty + canonical entries
+  present).
+- `wrapper/embedded_test.go` (9 cases): SynthWithProfile hosted keeps
+  async, embedded refuses async with SkipEmbedded + tokio detail,
+  embedded keeps sync, EmitLibRS embedded has #![no_std], EmitLibRS
+  hosted lacks #![no_std], EmitCargoTOML embedded flips
+  default-features, EmitCargoTOML hosted plain, EmitCargoTOML
+  embedded omits tokio+once_cell, SynthFull threads profile +
+  spec, byte-stable emit.
+- `embedded/phase13_test.go` sentinel (9 subtests):
+  `profile_default_is_hosted`, `profile_parses_from_toml`,
+  `libRS_carries_no_std_under_embedded`,
+  `libRS_omits_no_std_under_hosted`,
+  `cargo_pins_default_features_off_under_embedded`,
+  `async_fns_refused_under_embedded`,
+  `sync_fns_kept_under_embedded`,
+  `triples_list_sorted_and_nonempty`,
+  `emit_byte_stable_under_embedded`.
+
+## Target matrix
+
+| Target                  | Status | Notes |
+|-------------------------|--------|-------|
+| `#![no_std]` prologue   | ✅     | Embedded EmitLibRS starts with the no_std attribute. |
+| `extern crate alloc;`   | ✅     | Embedded EmitLibRS pulls in alloc-backed String / Vec / BTreeMap. |
+| Cargo default-features  | ✅     | Embedded upstream row flips `default-features = false`. |
+| Async refusal           | ✅     | SynthWithProfile moves async fns to `c.Skipped` with `SkipEmbedded`. |
+| Sync preserved          | ✅     | Sync fns pass through unchanged under embedded. |
+| Tokio dep omitted       | ✅     | After async refusal `HasAsync()` returns false so EmitCargoTOML skips tokio + once_cell. |
+| Profile parser          | ✅     | `[rust] profile = "embedded"` parses; unknown keys / unquoted values rejected. |
+| Triples list            | ✅     | thumbv6m / thumbv7em / thumbv7m / thumbv8m / riscv32imc / riscv32imac, sorted. |
+| Hosted regression       | ✅     | Hosted profile emit is byte-identical to pre-Phase-13. |
+| Byte stability          | ✅     | Embedded EmitLibRS + EmitCargoTOML byte-stable across 16 runs. |
+
+## How this phase plugs in to the larger pipeline
+
+```
+  mochi.toml [rust] profile = "embedded"
+                │
+                ▼
+  embedded.ParseTOMLBody → embedded.Profile
+                │
+                ▼
+  wrapper.SynthWithProfile(upstream, version, surface, profile)
+                │
+                ▼
+            (default Synth path)
+                │
+                ▼
+            applyProfileRefusal(c)
+                │
+   ┌────────────┴────────────┐
+   │                         │
+   ▼ ProfileHosted           ▼ ProfileEmbedded
+  c unchanged              for each fn in c.Functions:
+                             if fn.IsAsync:
+                               c.Skipped += SkipReport{
+                                 Reason: SkipEmbedded,
+                                 Detail: AsyncRefusalReason,
+                               }
+                               continue
+                             keep fn
+                │
+                ▼
+            EmitLibRS:
+              embedded.LibRSHeader(c.Profile)  # "#![no_std]\nextern crate alloc;\n" or ""
+              runtime_prologue
+              [mod mochi_rt;]   # only if HasAsync() — under embedded, never
+              extern "C" fn... bodies
+                │
+                ▼
+            EmitCargoTOML:
+              [dependencies]
+              embedded.CargoUpstreamDepRow(c.Profile, ...)
+              [tokio + once_cell only if HasAsync()]
+```
+
+Phase 13 is the closing brace on the bridge's consume-direction
+capability surface (`net`, `fs`, `proc`, `unsafe`, and now `embedded`
+as a structural profile). Combined with Phase 12 (monomorphisation),
+the bridge can now serve every leaf of the §10 target matrix.
+
+## Timeline
+
+| Time (GMT+7)        | Step |
+|---------------------|------|
+| 2026-05-30 00:36    | Worktree branch `mep/0073-phase-13` created off `origin/main` (which includes Phase 12 SHA 37768e85). |
+| 2026-05-30 00:38    | `package3/rust/embedded/embedded.go` written (Profile, ParseProfile, ParseTOMLBody, LibRSHeader, CargoUpstreamDepRow, RefuseAsync, AsyncRefusalReason, AllowedTriples). |
+| 2026-05-30 00:39    | `errors.SkipEmbedded` added; wrapper grows `SynthWithProfile` + `SynthFull` + `applyProfileRefusal`. |
+| 2026-05-30 00:40    | EmitLibRS + EmitCargoTOML wired through embedded helpers; full rust test sweep green. |
+| 2026-05-30 00:41    | Phase 13 sentinel + tracking page + spec sync. |

--- a/website/docs/mep/mep-0073.md
+++ b/website/docs/mep/mep-0073.md
@@ -309,7 +309,7 @@ A phase is LANDED only when its gate is green against the curated 24-crate fixtu
 | 10. trusted publishing | LANDED | n/a (publish is host-only) | n/a | n/a |
 | 11. async bridge | LANDED | required | n/a (no tokio on wasm32-wasip1) | n/a |
 | 12. monomorphisation of generics | LANDED | LANDED | LANDED | LANDED |
-| 13. embedded subset | NOT STARTED | n/a | n/a | required |
+| 13. embedded subset | LANDED | n/a | n/a | LANDED |
 
 A phase marked `n/a` for a target is intentional: the bridge does not promise the behaviour on that target.
 

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -351,7 +351,8 @@
       "implementation/0073/phase-09-rust-library-emit",
       "implementation/0073/phase-10-trusted-publish",
       "implementation/0073/phase-11-async-bridge",
-      "implementation/0073/phase-12-monomorphise"
+      "implementation/0073/phase-12-monomorphise",
+      "implementation/0073/phase-13-embedded"
     ]
   },
   "implementation/0074/index",


### PR DESCRIPTION
Closes #22947

Lands the final MEP-73 phase: the embedded build profile. With this PR
the bridge can synthesise wrapper crates that target `no_std + alloc`
Rust builds (thumbv7em-none-eabihf and friends), refusing async fns at
synth time because tokio requires std.

This is the closing phase of MEP-73's 14-phase delivery plan.

## What's in here

- New `package3/rust/embedded/` package:
  - `Profile` enum (`ProfileHosted`, `ProfileEmbedded`) +
    `String()` + `ParseProfile` round-trip.
  - `ParseTOMLBody` parses `[rust] profile = "..."` from the
    manifest with blank-line/comment tolerance.
  - `LibRSHeader(profile)` returns `#![no_std]\nextern crate alloc;\n`
    under embedded, empty string under hosted.
  - `CargoUpstreamDepRow(profile, name, version)` flips
    `default-features = false` under embedded; plain row under hosted.
  - `RefuseAsync` + `AsyncRefusalReason` for the closed-set async
    refusal under embedded.
  - `AllowedTriples` lists the bare-metal triples the bridge expects
    (sorted; thumbv6m / thumbv7em / thumbv7m / thumbv8m / riscv32imc /
    riscv32imac).

- `errors.SkipEmbedded` new refusal reason.

- `wrapper.SynthWithProfile` + `wrapper.SynthFull` (spec + profile)
  with `applyProfileRefusal` moving every async fn to `c.Skipped`
  under embedded. `wrapper.Synth` preserved for existing callers.

- `wrapper.EmitLibRS` prepends `embedded.LibRSHeader(c.Profile)`.
  `wrapper.EmitCargoTOML` uses `embedded.CargoUpstreamDepRow`. Under
  embedded with async refused, `HasAsync()` returns false so the
  tokio + once_cell rows are correctly omitted.

- Phase 13 sentinel `embedded/phase13_test.go` with 9 subtests
  covering parse, no_std header, Cargo flip, async refusal, sync
  preservation, triples list, byte stability.

- 20 unit cases on embedded + 9 wrapper integration cases.

- Spec target matrix row 13: `LANDED | n/a | n/a | LANDED`. Phase 12
  SHA `37768e85` backfilled in the implementation index. Status
  snapshot flipped to "all 14 phases LANDED".

## Test plan

- [x] `go test ./package3/rust/...` green across all 14 packages
  (asyncbridge, build, embedded, emit, errors, library, lockfile,
  monomorphise, publish, rustdoc, semver, sparse, typemap, wrapper).
- [x] `go build ./package3/rust/...` clean.
- [x] Hosted profile emit is byte-identical to pre-Phase-13 output
  (regression-guarded by existing wrapper tests).
- [x] Embedded profile emit is byte-stable across 16 runs.
- [x] Async fns refused under embedded carry the `SkipEmbedded`
  reason + the canonical `tokio (std)` detail.