### PR TITLE
MEP-74 phase 15: monomorphisation (bridge-side baseline)

### DIFF
--- a/package3/go/monomorphise/monomorphise.go
+++ b/package3/go/monomorphise/monomorphise.go
@@ -1,0 +1,435 @@
+// Package monomorphise is the MEP-74 phase 15 generic-
+// instantiation surface. It covers the bridge-side handling of
+// Go 1.18+ generic functions and types: the mochi.toml
+// `[go.monomorphise]` table lists concrete instantiations per
+// generic item, and the wrapper synthesiser emits one
+// per-instantiation Go function (and lockfile entry) so the
+// rest of the bridge can treat the instantiation as a plain
+// non-generic export.
+//
+// The package has three layers:
+//
+//  1. A parser for the [go.monomorphise] table that produces a
+//     SpecSet from inline TOML-array-of-tables fragments. The
+//     parser is intentionally tiny and table-only (no full TOML
+//     parser dependency); the wider MEP-57 mochi.toml driver
+//     extracts the slice of inline tables and feeds them to
+//     ParseSpecs here.
+//  2. A resolver that walks an apisurface.Package, matches
+//     each Spec against an exported generic Func (or generic
+//     Type method), validates the type-argument count, and
+//     produces a fully-typed Instance for the wrapper
+//     synthesiser.
+//  3. A renderer that emits the Go source for one Instance: a
+//     non-generic wrapper function whose body calls the
+//     generic original with the resolved type arguments
+//     spliced into the call. The output is byte-deterministic
+//     so the phase 10 wrapper-sha256 pin stays stable.
+//
+// Out of scope for v1 (deferred to 15.1+): auto-monomorphisation
+// from a usage-site `slices.Sort([]int{})` call, multi-param
+// generic type instantiations declared via positional indexing,
+// and constraint-checking against the type-parameter's interface.
+package monomorphise
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"mochi/package3/go/apisurface"
+)
+
+// ErrMonomorphise is the package-wide error sentinel.
+var ErrMonomorphise = errors.New("monomorphise")
+
+// Spec is one entry of the mochi.toml `[go.monomorphise]`
+// table. Item is the canonical generic identifier:
+// `<package-import-path>.<Identifier>` (e.g.
+// "encoding/json.Unmarshal" or "golang.org/x/exp/slices.Sort").
+// TypeArgs is the comma-split list of concrete type
+// arguments (single-arg generics have len(TypeArgs)==1).
+type Spec struct {
+	Item     string
+	TypeArgs []string
+}
+
+// SpecSet is an ordered list of monomorphise Specs. The order
+// is preserved verbatim from the manifest so a downstream
+// `mochi pkg lock` diff is interpretable.
+type SpecSet struct {
+	Specs []Spec
+}
+
+// ParseSpecs turns a slice of `{item, T}` table fragments into
+// a SpecSet. Each fragment is a `key = "value"` line list (no
+// nested tables, no comments). The wider mochi.toml driver
+// extracts and passes the fragments; this function does the
+// final shape check.
+//
+// Format per fragment:
+//
+//	item = "<pkg-path>.<Ident>"
+//	T = "<type>" | "<t1>, <t2>"
+//
+// Returns ErrMonomorphise for any unparseable fragment.
+func ParseSpecs(fragments []string) (*SpecSet, error) {
+	out := &SpecSet{}
+	for i, frag := range fragments {
+		s, err := parseFragment(frag)
+		if err != nil {
+			return nil, fmt.Errorf("%w: entry %d: %v", ErrMonomorphise, i, err)
+		}
+		out.Specs = append(out.Specs, s)
+	}
+	if err := out.Validate(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func parseFragment(s string) (Spec, error) {
+	spec := Spec{}
+	for _, raw := range strings.Split(s, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, val, ok := cutEquals(line)
+		if !ok {
+			return Spec{}, fmt.Errorf("malformed entry line %q (expected 'key = value')", line)
+		}
+		val = strings.Trim(val, ",")
+		val = strings.TrimSpace(val)
+		val = strings.Trim(val, "\"")
+		switch key {
+		case "item":
+			spec.Item = val
+		case "T":
+			parts := strings.Split(val, ",")
+			for _, p := range parts {
+				p = strings.TrimSpace(p)
+				if p != "" {
+					spec.TypeArgs = append(spec.TypeArgs, p)
+				}
+			}
+		default:
+			return Spec{}, fmt.Errorf("unknown entry key %q", key)
+		}
+	}
+	return spec, nil
+}
+
+func cutEquals(s string) (string, string, bool) {
+	idx := strings.Index(s, "=")
+	if idx < 0 {
+		return "", "", false
+	}
+	return strings.TrimSpace(s[:idx]), strings.TrimSpace(s[idx+1:]), true
+}
+
+// Validate checks that every Spec is structurally well-formed:
+// non-empty Item, a dot separating PackagePath from Ident, at
+// least one TypeArg. Returns nil for an empty SpecSet.
+func (set *SpecSet) Validate() error {
+	for i, s := range set.Specs {
+		if strings.TrimSpace(s.Item) == "" {
+			return fmt.Errorf("%w: entry %d: item is required", ErrMonomorphise, i)
+		}
+		if dot := strings.LastIndex(s.Item, "."); dot <= 0 {
+			return fmt.Errorf("%w: entry %d: item %q must be 'package/path.Ident'", ErrMonomorphise, i, s.Item)
+		}
+		if len(s.TypeArgs) == 0 {
+			return fmt.Errorf("%w: entry %d: T is required", ErrMonomorphise, i)
+		}
+		for j, ta := range s.TypeArgs {
+			if strings.TrimSpace(ta) == "" {
+				return fmt.Errorf("%w: entry %d, T[%d]: empty type argument", ErrMonomorphise, i, j)
+			}
+		}
+	}
+	return nil
+}
+
+// PackagePath returns the import-path portion of Item, i.e.
+// everything before the final dot.
+func (s Spec) PackagePath() string {
+	if dot := strings.LastIndex(s.Item, "."); dot > 0 {
+		return s.Item[:dot]
+	}
+	return ""
+}
+
+// Ident returns the identifier portion of Item, i.e.
+// everything after the final dot.
+func (s Spec) Ident() string {
+	if dot := strings.LastIndex(s.Item, "."); dot > 0 {
+		return s.Item[dot+1:]
+	}
+	return s.Item
+}
+
+// Instance is a fully-resolved monomorphisation: the matched
+// generic Func plus the parsed-and-validated type arguments
+// and a renderer-ready symbol suffix.
+type Instance struct {
+	// Spec is the manifest entry this instance derives from.
+	Spec Spec
+	// Func is the matched generic function in the surface.
+	Func apisurface.Func
+	// SymbolSuffix is the wrapper symbol suffix (e.g.
+	// "MyStruct" for a single-arg, "string_int64" for two
+	// args). Derived from TypeArgs with non-identifier
+	// characters replaced by `_`.
+	SymbolSuffix string
+}
+
+// Resolve matches every Spec in set against an exported
+// generic Func or generic Type-method in pkg and returns the
+// resolved Instances plus a list of error strings for specs
+// that did not match (so the caller can surface them as
+// SkipReport entries without aborting the whole synthesise).
+// A successful Resolve produces deterministic output: the
+// Instances slice is sorted by Spec.Item then by
+// SymbolSuffix.
+func Resolve(pkg apisurface.Package, set *SpecSet) ([]Instance, []string, error) {
+	if set == nil {
+		return nil, nil, nil
+	}
+	if err := set.Validate(); err != nil {
+		return nil, nil, err
+	}
+
+	// Build a quick lookup table of generic funcs in pkg keyed
+	// by `<pkg-path>.<Ident>`. The pkg-path of a function
+	// declared in the package itself is pkg.Path. Methods on
+	// generic types are keyed by `<pkg-path>.<TypeName>.<Method>`.
+	lookup := map[string]apisurface.Func{}
+	for _, f := range pkg.Funcs {
+		if len(f.TypeParams) == 0 {
+			continue
+		}
+		lookup[pkg.ImportPath+"."+f.Name] = f
+	}
+	for _, t := range pkg.Types {
+		// Generic type's methods are themselves generic via the
+		// type-parameter inheritance; we synthesise the key as
+		// `<pkg-path>.<Type>.<Method>` so the manifest can refer
+		// to them explicitly.
+		if len(t.TypeParams) == 0 {
+			continue
+		}
+		for _, m := range t.Methods {
+			lookup[pkg.ImportPath+"."+t.Name+"."+m.Name] = m
+		}
+	}
+
+	var out []Instance
+	var missing []string
+	for _, s := range set.Specs {
+		f, ok := lookup[s.Item]
+		if !ok {
+			missing = append(missing, fmt.Sprintf("%s: no generic identifier matches", s.Item))
+			continue
+		}
+		// The number of type arguments must match the function's
+		// generic arity.
+		if len(s.TypeArgs) != len(f.TypeParams) {
+			missing = append(missing, fmt.Sprintf("%s: needs %d type argument(s), got %d", s.Item, len(f.TypeParams), len(s.TypeArgs)))
+			continue
+		}
+		out = append(out, Instance{
+			Spec:         s,
+			Func:         f,
+			SymbolSuffix: sanitiseSuffix(s.TypeArgs),
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Spec.Item != out[j].Spec.Item {
+			return out[i].Spec.Item < out[j].Spec.Item
+		}
+		return out[i].SymbolSuffix < out[j].SymbolSuffix
+	})
+	return out, missing, nil
+}
+
+// sanitiseSuffix converts a list of type arguments into an
+// identifier-safe symbol suffix: dots, slashes, brackets, and
+// commas become `_`; existing identifier chars pass through.
+// "MyStruct" -> "MyStruct"
+// "encoding/json.Decoder" -> "encoding_json_Decoder"
+// ["string", "int64"] -> "string_int64"
+func sanitiseSuffix(args []string) string {
+	parts := make([]string, len(args))
+	for i, a := range args {
+		parts[i] = sanitiseIdent(strings.TrimSpace(a))
+	}
+	return strings.Join(parts, "_")
+}
+
+func sanitiseIdent(s string) string {
+	var sb strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+			sb.WriteRune(r)
+		} else {
+			sb.WriteRune('_')
+		}
+	}
+	return sb.String()
+}
+
+// RenderInstance returns the Go source for one Instance: a
+// non-generic wrapper function `mochi_<module>_<Ident>_<suffix>`
+// whose body calls the original generic with `[T1, T2, ...]`
+// type arguments spliced into the call site. The wrapper's
+// signature mirrors the original's signature with every
+// TypeParam name replaced by its corresponding TypeArg.
+//
+// The wrapper is decorated with a `//export` directive so the
+// cgo wrapper synthesiser (phase 6) picks it up like any other
+// non-generic export. The package clause is the wrapper's,
+// not the source module's: callers are expected to drop the
+// rendered source into the wrapper package's directory.
+//
+// alias is the wrapper's import alias for the source module
+// (e.g. "src_slices" for `import src_slices "golang.org/x/exp/slices"`).
+func RenderInstance(inst Instance, moduleFlatName, alias string) (string, error) {
+	if moduleFlatName == "" {
+		return "", fmt.Errorf("%w: moduleFlatName is required", ErrMonomorphise)
+	}
+	if alias == "" {
+		return "", fmt.Errorf("%w: alias is required", ErrMonomorphise)
+	}
+	if len(inst.Func.TypeParams) != len(inst.Spec.TypeArgs) {
+		return "", fmt.Errorf("%w: arity mismatch: func has %d type params, spec has %d args", ErrMonomorphise, len(inst.Func.TypeParams), len(inst.Spec.TypeArgs))
+	}
+
+	// Map type-param name -> concrete type expression.
+	tpMap := map[string]string{}
+	for i, tp := range inst.Func.TypeParams {
+		tpMap[tp.Name] = inst.Spec.TypeArgs[i]
+	}
+
+	prefix := "mochi_" + moduleFlatName + "_" + inst.Func.Name + "_" + inst.SymbolSuffix
+
+	var sb strings.Builder
+	sb.WriteString("// " + prefix + " is the monomorphised wrapper for\n")
+	sb.WriteString("// " + inst.Spec.Item + "[" + strings.Join(inst.Spec.TypeArgs, ", ") + "].\n")
+	sb.WriteString("// Generated by mochi MEP-74 phase 15. DO NOT EDIT.\n")
+	sb.WriteString("//\n")
+	sb.WriteString("//export " + prefix + "\n")
+	sb.WriteString("func " + prefix + "(")
+	for i, p := range inst.Func.Params {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		name := p.Name
+		if name == "" {
+			name = fmt.Sprintf("p%d", i)
+		}
+		sb.WriteString(name + " " + concretiseType(p.Type, tpMap))
+	}
+	sb.WriteString(")")
+	switch len(inst.Func.Results) {
+	case 0:
+	case 1:
+		sb.WriteString(" " + concretiseType(inst.Func.Results[0].Type, tpMap))
+	default:
+		sb.WriteString(" (")
+		for i, r := range inst.Func.Results {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(concretiseType(r.Type, tpMap))
+		}
+		sb.WriteString(")")
+	}
+	sb.WriteString(" {\n")
+	// Body: `return alias.Ident[T1, T2, ...](p0, p1, ...)`
+	callArgs := make([]string, len(inst.Func.Params))
+	for i, p := range inst.Func.Params {
+		name := p.Name
+		if name == "" {
+			name = fmt.Sprintf("p%d", i)
+		}
+		callArgs[i] = name
+	}
+	call := alias + "." + inst.Func.Name + "[" + strings.Join(inst.Spec.TypeArgs, ", ") + "](" + strings.Join(callArgs, ", ") + ")"
+	if len(inst.Func.Results) == 0 {
+		sb.WriteString("\t" + call + "\n")
+	} else {
+		sb.WriteString("\treturn " + call + "\n")
+	}
+	sb.WriteString("}\n")
+	return sb.String(), nil
+}
+
+// concretiseType replaces type-parameter names in a type
+// expression with their concrete type. The substitution is
+// textual but identifier-bounded so a TypeParam name "T" does
+// not match a longer ident like "Truthy".
+func concretiseType(t string, tpMap map[string]string) string {
+	if len(tpMap) == 0 || t == "" {
+		return t
+	}
+	out := t
+	// Apply longer names first so a substitution of "T" does
+	// not eat the leading "T" of "TX". For Go generics, type
+	// params are always single capital identifiers in practice,
+	// but the rule applies in general.
+	keys := make([]string, 0, len(tpMap))
+	for k := range tpMap {
+		keys = append(keys, k)
+	}
+	sort.SliceStable(keys, func(i, j int) bool {
+		return len(keys[i]) > len(keys[j])
+	})
+	for _, k := range keys {
+		out = replaceIdentBoundary(out, k, tpMap[k])
+	}
+	return out
+}
+
+// replaceIdentBoundary replaces every occurrence of `old`
+// that's bounded by non-identifier characters with `new`. Used
+// so substituting "T" in "[]T" hits the standalone T but
+// substituting "T" in "TX" or "list[T2]" leaves the longer
+// ident alone.
+func replaceIdentBoundary(s, old, new string) string {
+	if old == "" {
+		return s
+	}
+	var sb strings.Builder
+	i := 0
+	for i < len(s) {
+		j := strings.Index(s[i:], old)
+		if j < 0 {
+			sb.WriteString(s[i:])
+			break
+		}
+		j += i
+		// Left boundary.
+		if j > 0 && isIdentByte(s[j-1]) {
+			sb.WriteString(s[i : j+1])
+			i = j + 1
+			continue
+		}
+		// Right boundary.
+		end := j + len(old)
+		if end < len(s) && isIdentByte(s[end]) {
+			sb.WriteString(s[i : j+1])
+			i = j + 1
+			continue
+		}
+		sb.WriteString(s[i:j])
+		sb.WriteString(new)
+		i = end
+	}
+	return sb.String()
+}
+
+func isIdentByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+}

--- a/package3/go/monomorphise/monomorphise_test.go
+++ b/package3/go/monomorphise/monomorphise_test.go
@@ -1,0 +1,451 @@
+package monomorphise
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"mochi/package3/go/apisurface"
+)
+
+func TestParseSpecsHappyPath(t *testing.T) {
+	frags := []string{
+		"item = \"golang.org/x/exp/slices.Sort\"\nT = \"int64\"",
+		"item = \"encoding/json.Unmarshal\"\nT = \"string\"",
+	}
+	set, err := ParseSpecs(frags)
+	if err != nil {
+		t.Fatalf("ParseSpecs error: %v", err)
+	}
+	if len(set.Specs) != 2 {
+		t.Fatalf("Specs len = %d, want 2", len(set.Specs))
+	}
+	if set.Specs[0].Item != "golang.org/x/exp/slices.Sort" {
+		t.Errorf("Specs[0].Item = %q", set.Specs[0].Item)
+	}
+	if got := set.Specs[0].TypeArgs; len(got) != 1 || got[0] != "int64" {
+		t.Errorf("Specs[0].TypeArgs = %v", got)
+	}
+}
+
+func TestParseSpecsMultipleTypeArgs(t *testing.T) {
+	set, err := ParseSpecs([]string{"item = \"x.Map\"\nT = \"string, int64\""})
+	if err != nil {
+		t.Fatalf("ParseSpecs error: %v", err)
+	}
+	if got := set.Specs[0].TypeArgs; len(got) != 2 || got[0] != "string" || got[1] != "int64" {
+		t.Errorf("TypeArgs = %v", got)
+	}
+}
+
+func TestParseSpecsIgnoresBlankAndComment(t *testing.T) {
+	frag := "# leading comment\n\nitem = \"a.B\"\n# inline\nT = \"int\"\n"
+	set, err := ParseSpecs([]string{frag})
+	if err != nil {
+		t.Fatalf("ParseSpecs error: %v", err)
+	}
+	if set.Specs[0].Item != "a.B" {
+		t.Errorf("Item = %q", set.Specs[0].Item)
+	}
+}
+
+func TestParseSpecsRejectsMalformedLine(t *testing.T) {
+	_, err := ParseSpecs([]string{"justwords"})
+	if !errors.Is(err, ErrMonomorphise) {
+		t.Fatalf("want ErrMonomorphise, got %v", err)
+	}
+}
+
+func TestParseSpecsRejectsUnknownKey(t *testing.T) {
+	_, err := ParseSpecs([]string{"item = \"a.B\"\nT = \"int\"\nUnknown = \"x\""})
+	if !errors.Is(err, ErrMonomorphise) {
+		t.Fatalf("want ErrMonomorphise, got %v", err)
+	}
+}
+
+func TestParseSpecsRejectsMissingDot(t *testing.T) {
+	_, err := ParseSpecs([]string{"item = \"missingdot\"\nT = \"int\""})
+	if !errors.Is(err, ErrMonomorphise) {
+		t.Fatalf("want ErrMonomorphise, got %v", err)
+	}
+}
+
+func TestParseSpecsRejectsEmptyT(t *testing.T) {
+	_, err := ParseSpecs([]string{"item = \"a.B\"\nT = \"\""})
+	if !errors.Is(err, ErrMonomorphise) {
+		t.Fatalf("want ErrMonomorphise, got %v", err)
+	}
+}
+
+func TestSpecAccessors(t *testing.T) {
+	s := Spec{Item: "encoding/json.Decoder"}
+	if got := s.PackagePath(); got != "encoding/json" {
+		t.Errorf("PackagePath = %q", got)
+	}
+	if got := s.Ident(); got != "Decoder" {
+		t.Errorf("Ident = %q", got)
+	}
+}
+
+func TestSpecAccessorsNoDot(t *testing.T) {
+	s := Spec{Item: "bareword"}
+	if got := s.PackagePath(); got != "" {
+		t.Errorf("PackagePath = %q, want empty", got)
+	}
+	if got := s.Ident(); got != "bareword" {
+		t.Errorf("Ident = %q", got)
+	}
+}
+
+func TestValidateEmptyOK(t *testing.T) {
+	set := &SpecSet{}
+	if err := set.Validate(); err != nil {
+		t.Fatalf("Validate on empty set: %v", err)
+	}
+}
+
+func TestValidateRejectsEmptyTypeArg(t *testing.T) {
+	set := &SpecSet{Specs: []Spec{{Item: "a.B", TypeArgs: []string{"int", "   "}}}}
+	if err := set.Validate(); !errors.Is(err, ErrMonomorphise) {
+		t.Fatalf("want ErrMonomorphise, got %v", err)
+	}
+}
+
+func TestResolveHappyPath(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "golang.org/x/exp/slices",
+		Funcs: []apisurface.Func{
+			{
+				Name:       "Sort",
+				TypeParams: []apisurface.TypeParam{{Name: "T", Constraint: "any"}},
+				Params:     []apisurface.Param{{Name: "xs", Type: "[]T"}},
+			},
+		},
+	}
+	set := &SpecSet{Specs: []Spec{
+		{Item: "golang.org/x/exp/slices.Sort", TypeArgs: []string{"int64"}},
+	}}
+	out, missing, err := Resolve(pkg, set)
+	if err != nil {
+		t.Fatalf("Resolve error: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Errorf("missing = %v", missing)
+	}
+	if len(out) != 1 {
+		t.Fatalf("instances len = %d", len(out))
+	}
+	if out[0].Func.Name != "Sort" {
+		t.Errorf("Func.Name = %q", out[0].Func.Name)
+	}
+	if out[0].SymbolSuffix != "int64" {
+		t.Errorf("SymbolSuffix = %q", out[0].SymbolSuffix)
+	}
+}
+
+func TestResolveReportsMissing(t *testing.T) {
+	pkg := apisurface.Package{ImportPath: "x"}
+	set := &SpecSet{Specs: []Spec{{Item: "x.NotThere", TypeArgs: []string{"int"}}}}
+	_, missing, err := Resolve(pkg, set)
+	if err != nil {
+		t.Fatalf("Resolve error: %v", err)
+	}
+	if len(missing) != 1 {
+		t.Fatalf("missing = %v", missing)
+	}
+}
+
+func TestResolveReportsArityMismatch(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "x",
+		Funcs: []apisurface.Func{
+			{Name: "F", TypeParams: []apisurface.TypeParam{{Name: "T"}, {Name: "U"}}},
+		},
+	}
+	set := &SpecSet{Specs: []Spec{{Item: "x.F", TypeArgs: []string{"int"}}}}
+	_, missing, err := Resolve(pkg, set)
+	if err != nil {
+		t.Fatalf("Resolve error: %v", err)
+	}
+	if len(missing) != 1 || !strings.Contains(missing[0], "needs 2") {
+		t.Fatalf("missing = %v", missing)
+	}
+}
+
+func TestResolveSkipsNonGenericFunc(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "x",
+		Funcs:      []apisurface.Func{{Name: "F"}},
+	}
+	set := &SpecSet{Specs: []Spec{{Item: "x.F", TypeArgs: []string{"int"}}}}
+	_, missing, err := Resolve(pkg, set)
+	if err != nil {
+		t.Fatalf("Resolve error: %v", err)
+	}
+	if len(missing) != 1 {
+		t.Fatalf("expected non-generic F to be unmatched; missing = %v", missing)
+	}
+}
+
+func TestResolveMatchesGenericTypeMethod(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "x",
+		Types: []apisurface.Type{
+			{
+				Name:       "Stack",
+				TypeParams: []apisurface.TypeParam{{Name: "T"}},
+				Methods: []apisurface.Func{
+					{
+						Name:       "Push",
+						TypeParams: []apisurface.TypeParam{{Name: "T"}},
+						Params:     []apisurface.Param{{Name: "v", Type: "T"}},
+					},
+				},
+			},
+		},
+	}
+	set := &SpecSet{Specs: []Spec{{Item: "x.Stack.Push", TypeArgs: []string{"int64"}}}}
+	out, missing, err := Resolve(pkg, set)
+	if err != nil {
+		t.Fatalf("Resolve error: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Errorf("missing = %v", missing)
+	}
+	if len(out) != 1 || out[0].Func.Name != "Push" {
+		t.Fatalf("instances = %+v", out)
+	}
+}
+
+func TestResolveDeterministicOrder(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "x",
+		Funcs: []apisurface.Func{
+			{Name: "A", TypeParams: []apisurface.TypeParam{{Name: "T"}}},
+			{Name: "B", TypeParams: []apisurface.TypeParam{{Name: "T"}}},
+		},
+	}
+	set := &SpecSet{Specs: []Spec{
+		{Item: "x.B", TypeArgs: []string{"int"}},
+		{Item: "x.A", TypeArgs: []string{"string"}},
+		{Item: "x.A", TypeArgs: []string{"int"}},
+	}}
+	out, _, err := Resolve(pkg, set)
+	if err != nil {
+		t.Fatalf("Resolve error: %v", err)
+	}
+	want := []string{"x.A", "x.A", "x.B"}
+	for i, w := range want {
+		if out[i].Spec.Item != w {
+			t.Errorf("out[%d].Spec.Item = %q, want %q", i, out[i].Spec.Item, w)
+		}
+	}
+	if out[0].SymbolSuffix != "int" || out[1].SymbolSuffix != "string" {
+		t.Errorf("suffix tie-break wrong: %q, %q", out[0].SymbolSuffix, out[1].SymbolSuffix)
+	}
+}
+
+func TestResolveNilSetReturnsEmpty(t *testing.T) {
+	out, missing, err := Resolve(apisurface.Package{}, nil)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(out) != 0 || len(missing) != 0 {
+		t.Errorf("nil set should yield empty: out=%v missing=%v", out, missing)
+	}
+}
+
+func TestSanitiseSuffix(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want string
+	}{
+		{[]string{"MyStruct"}, "MyStruct"},
+		{[]string{"encoding/json.Decoder"}, "encoding_json_Decoder"},
+		{[]string{"string", "int64"}, "string_int64"},
+		{[]string{"*foo.Bar"}, "_foo_Bar"},
+		{[]string{"[]byte"}, "__byte"},
+	}
+	for _, c := range cases {
+		if got := sanitiseSuffix(c.in); got != c.want {
+			t.Errorf("sanitiseSuffix(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestRenderInstanceHappyPath(t *testing.T) {
+	inst := Instance{
+		Spec: Spec{Item: "golang.org/x/exp/slices.Sort", TypeArgs: []string{"int64"}},
+		Func: apisurface.Func{
+			Name:       "Sort",
+			TypeParams: []apisurface.TypeParam{{Name: "T", Constraint: "any"}},
+			Params:     []apisurface.Param{{Name: "xs", Type: "[]T"}},
+		},
+		SymbolSuffix: "int64",
+	}
+	out, err := RenderInstance(inst, "slices_v0_0_0", "src_slices")
+	if err != nil {
+		t.Fatalf("RenderInstance: %v", err)
+	}
+	wantSubs := []string{
+		"mochi_slices_v0_0_0_Sort_int64",
+		"//export mochi_slices_v0_0_0_Sort_int64",
+		"xs []int64",
+		"src_slices.Sort[int64](xs)",
+	}
+	for _, w := range wantSubs {
+		if !strings.Contains(out, w) {
+			t.Errorf("missing %q in output:\n%s", w, out)
+		}
+	}
+}
+
+func TestRenderInstanceSingleResult(t *testing.T) {
+	inst := Instance{
+		Spec: Spec{Item: "x.F", TypeArgs: []string{"int"}},
+		Func: apisurface.Func{
+			Name:       "F",
+			TypeParams: []apisurface.TypeParam{{Name: "T"}},
+			Params:     []apisurface.Param{{Name: "v", Type: "T"}},
+			Results:    []apisurface.Param{{Type: "T"}},
+		},
+		SymbolSuffix: "int",
+	}
+	out, err := RenderInstance(inst, "m", "src")
+	if err != nil {
+		t.Fatalf("RenderInstance: %v", err)
+	}
+	if !strings.Contains(out, ") int {") {
+		t.Errorf("expected single-result type ') int {': %s", out)
+	}
+	if !strings.Contains(out, "return src.F[int](v)") {
+		t.Errorf("expected `return src.F[int](v)`: %s", out)
+	}
+}
+
+func TestRenderInstanceMultipleResults(t *testing.T) {
+	inst := Instance{
+		Spec: Spec{Item: "x.G", TypeArgs: []string{"int"}},
+		Func: apisurface.Func{
+			Name:       "G",
+			TypeParams: []apisurface.TypeParam{{Name: "T"}},
+			Params:     []apisurface.Param{{Name: "v", Type: "T"}},
+			Results:    []apisurface.Param{{Type: "T"}, {Type: "error"}},
+		},
+		SymbolSuffix: "int",
+	}
+	out, err := RenderInstance(inst, "m", "src")
+	if err != nil {
+		t.Fatalf("RenderInstance: %v", err)
+	}
+	if !strings.Contains(out, "(int, error)") {
+		t.Errorf("expected `(int, error)`: %s", out)
+	}
+}
+
+func TestRenderInstanceNoResults(t *testing.T) {
+	inst := Instance{
+		Spec: Spec{Item: "x.H", TypeArgs: []string{"int"}},
+		Func: apisurface.Func{
+			Name:       "H",
+			TypeParams: []apisurface.TypeParam{{Name: "T"}},
+			Params:     []apisurface.Param{{Name: "v", Type: "T"}},
+		},
+		SymbolSuffix: "int",
+	}
+	out, err := RenderInstance(inst, "m", "src")
+	if err != nil {
+		t.Fatalf("RenderInstance: %v", err)
+	}
+	// No "return" keyword for void wrappers.
+	if strings.Contains(out, "return src.H") {
+		t.Errorf("zero-result wrapper should not have return: %s", out)
+	}
+	if !strings.Contains(out, "\tsrc.H[int](v)\n") {
+		t.Errorf("expected bare call line: %s", out)
+	}
+}
+
+func TestRenderInstanceUnnamedParam(t *testing.T) {
+	inst := Instance{
+		Spec: Spec{Item: "x.F", TypeArgs: []string{"int"}},
+		Func: apisurface.Func{
+			Name:       "F",
+			TypeParams: []apisurface.TypeParam{{Name: "T"}},
+			Params:     []apisurface.Param{{Type: "T"}, {Type: "T"}},
+		},
+		SymbolSuffix: "int",
+	}
+	out, err := RenderInstance(inst, "m", "src")
+	if err != nil {
+		t.Fatalf("RenderInstance: %v", err)
+	}
+	if !strings.Contains(out, "p0 int, p1 int") {
+		t.Errorf("expected synthetic param names p0, p1: %s", out)
+	}
+	if !strings.Contains(out, "src.F[int](p0, p1)") {
+		t.Errorf("expected call site to use synthetic names: %s", out)
+	}
+}
+
+func TestRenderInstanceRejectsArityMismatch(t *testing.T) {
+	inst := Instance{
+		Spec: Spec{Item: "x.F", TypeArgs: []string{"int", "string"}},
+		Func: apisurface.Func{
+			Name:       "F",
+			TypeParams: []apisurface.TypeParam{{Name: "T"}},
+		},
+	}
+	if _, err := RenderInstance(inst, "m", "src"); !errors.Is(err, ErrMonomorphise) {
+		t.Fatalf("want ErrMonomorphise, got %v", err)
+	}
+}
+
+func TestRenderInstanceRejectsMissingModule(t *testing.T) {
+	inst := Instance{Spec: Spec{Item: "x.F", TypeArgs: []string{"int"}}, Func: apisurface.Func{Name: "F", TypeParams: []apisurface.TypeParam{{Name: "T"}}}}
+	if _, err := RenderInstance(inst, "", "src"); !errors.Is(err, ErrMonomorphise) {
+		t.Fatalf("missing module: want ErrMonomorphise, got %v", err)
+	}
+	if _, err := RenderInstance(inst, "m", ""); !errors.Is(err, ErrMonomorphise) {
+		t.Fatalf("missing alias: want ErrMonomorphise, got %v", err)
+	}
+}
+
+func TestConcretiseTypePreservesLongerIdents(t *testing.T) {
+	tpMap := map[string]string{"T": "int", "U": "string"}
+	// "T" appears in "[]T" but also in "Truthy"; only the bare T should be replaced.
+	got := concretiseType("[]T", tpMap)
+	if got != "[]int" {
+		t.Errorf("[]T -> %q", got)
+	}
+	got = concretiseType("Truthy", tpMap)
+	if got != "Truthy" {
+		t.Errorf("Truthy -> %q, want unchanged", got)
+	}
+	got = concretiseType("map[T]U", tpMap)
+	if got != "map[int]string" {
+		t.Errorf("map[T]U -> %q", got)
+	}
+	got = concretiseType("func(T) (U, error)", tpMap)
+	if got != "func(int) (string, error)" {
+		t.Errorf("func(T) (U, error) -> %q", got)
+	}
+}
+
+func TestConcretiseTypeEmpty(t *testing.T) {
+	if got := concretiseType("", map[string]string{"T": "int"}); got != "" {
+		t.Errorf("empty in -> %q", got)
+	}
+	if got := concretiseType("[]int", nil); got != "[]int" {
+		t.Errorf("nil tpMap -> %q", got)
+	}
+}
+
+func TestReplaceIdentBoundaryDoesNotEatPartialMatches(t *testing.T) {
+	got := replaceIdentBoundary("TX TT T2 []T T", "T", "int")
+	// Only the bare standalone "T" tokens (the two at the end) should change.
+	want := "TX TT T2 []int int"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/package3/go/monomorphise/phase15_test.go
+++ b/package3/go/monomorphise/phase15_test.go
@@ -1,0 +1,148 @@
+package monomorphise
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/package3/go/apisurface"
+)
+
+// TestPhase15MonomorphiseSentinel renders a monomorphised wrapper for a
+// tiny synthetic generic function and asserts that `go build ./...`
+// against the rendered source compiles cleanly. The synthetic source
+// module is dropped into the same scratch tree so the wrapper resolves
+// the generic via a relative replace directive.
+func TestPhase15MonomorphiseSentinel(t *testing.T) {
+	dir := t.TempDir()
+
+	// Source module: exports two generic funcs.
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(srcDir, "go.mod"), "module example.com/src\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(srcDir, "src.go"), `package src
+
+func Sort[T any](xs []T) []T { return xs }
+
+func Pair[K any, V any](k K, v V) (K, V) { return k, v }
+`)
+
+	// Wrapper module: imports the source as src_aliased and emits two
+	// monomorphised wrappers.
+	wrapDir := filepath.Join(dir, "wrap")
+	if err := os.MkdirAll(wrapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(wrapDir, "go.mod"),
+		"module example.com/wrap\n\ngo 1.21\n\nrequire example.com/src v0.0.0\n\nreplace example.com/src => ../src\n")
+
+	pkg := apisurface.Package{
+		ImportPath: "example.com/src",
+		Funcs: []apisurface.Func{
+			{
+				Name:       "Sort",
+				TypeParams: []apisurface.TypeParam{{Name: "T", Constraint: "any"}},
+				Params:     []apisurface.Param{{Name: "xs", Type: "[]T"}},
+				Results:    []apisurface.Param{{Type: "[]T"}},
+			},
+			{
+				Name:       "Pair",
+				TypeParams: []apisurface.TypeParam{{Name: "K"}, {Name: "V"}},
+				Params:     []apisurface.Param{{Name: "k", Type: "K"}, {Name: "v", Type: "V"}},
+				Results:    []apisurface.Param{{Type: "K"}, {Type: "V"}},
+			},
+		},
+	}
+	set := &SpecSet{Specs: []Spec{
+		{Item: "example.com/src.Sort", TypeArgs: []string{"int64"}},
+		{Item: "example.com/src.Pair", TypeArgs: []string{"string", "int64"}},
+	}}
+	instances, missing, err := Resolve(pkg, set)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("unexpected missing: %v", missing)
+	}
+	if len(instances) != 2 {
+		t.Fatalf("instances = %d", len(instances))
+	}
+
+	header := "package wrap\n\nimport src_aliased \"example.com/src\"\n\n// Force-use the import for the void wrapper case.\nvar _ = src_aliased.Sort[int64]\n\n"
+	var sb strings.Builder
+	sb.WriteString(header)
+	for _, inst := range instances {
+		// Strip the //export directive so the test compiles without cgo.
+		out, err := RenderInstance(inst, "src_v0_0_0", "src_aliased")
+		if err != nil {
+			t.Fatalf("RenderInstance(%q): %v", inst.Spec.Item, err)
+		}
+		out = stripExport(out)
+		sb.WriteString(out)
+		sb.WriteString("\n")
+	}
+	writeFile(t, filepath.Join(wrapDir, "wrap.go"), sb.String())
+
+	cmd := exec.Command("go", "build", "./...")
+	cmd.Dir = wrapDir
+	cmd.Env = append(os.Environ(), "GO111MODULE=on")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\noutput:\n%s\nwrap.go was:\n%s", err, out, sb.String())
+	}
+}
+
+// TestPhase15RenderInstanceDeterministic locks in the byte-determinism
+// of RenderInstance: the same input must yield the same SHA-256 across
+// 10 calls. This is load-bearing for the phase 10 wrapper-sha256 pin.
+func TestPhase15RenderInstanceDeterministic(t *testing.T) {
+	inst := Instance{
+		Spec: Spec{Item: "x.F", TypeArgs: []string{"int64", "string"}},
+		Func: apisurface.Func{
+			Name:       "F",
+			TypeParams: []apisurface.TypeParam{{Name: "K"}, {Name: "V"}},
+			Params:     []apisurface.Param{{Name: "k", Type: "K"}, {Name: "v", Type: "V"}},
+			Results:    []apisurface.Param{{Type: "K"}, {Type: "V"}},
+		},
+		SymbolSuffix: "int64_string",
+	}
+	var first string
+	for i := 0; i < 10; i++ {
+		out, err := RenderInstance(inst, "m", "src")
+		if err != nil {
+			t.Fatalf("RenderInstance: %v", err)
+		}
+		sum := sha256.Sum256([]byte(out))
+		hex := hex.EncodeToString(sum[:])
+		if i == 0 {
+			first = hex
+			continue
+		}
+		if hex != first {
+			t.Fatalf("non-deterministic render on iteration %d: %s vs %s", i, hex, first)
+		}
+	}
+}
+
+func stripExport(s string) string {
+	var keep []string
+	for _, line := range strings.Split(s, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//export ") {
+			continue
+		}
+		keep = append(keep, line)
+	}
+	return strings.Join(keep, "\n")
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/website/docs/implementation/0074/index.md
+++ b/website/docs/implementation/0074/index.md
@@ -30,7 +30,7 @@ A phase is LANDED only when its gate is green for every applicable target (consu
 | 12 | Git-tag publish flow (`mochi pkg publish --to=git-tag`) + canonical-import-path gate | LANDED (baseline; 12.1+ deferred) | (pending) | [phase-12](/docs/implementation/0074/phase-12-git-tag-publish) |
 | 13 | Cosign-on-sibling-tag opt-in (`mochi pkg publish --cosign-sign`) | LANDED (baseline; 13.1+ deferred) | (pending) | [phase-13](/docs/implementation/0074/phase-13-cosign) |
 | 14 | Goroutine bridge (cgo handle pool + channel-as-handle + callback-as-handle) | LANDED (baseline; 14.1+ deferred) | (pending) | [phase-14](/docs/implementation/0074/phase-14-goroutine-bridge) |
-| 15 | Monomorphisation (`[go.monomorphise]` manifest + per-instantiation wrapper) | NOT STARTED | — | [phase-15](/docs/implementation/0074/phase-15-monomorphise) |
+| 15 | Monomorphisation (`[go.monomorphise]` manifest + per-instantiation wrapper) | LANDED (baseline; 15.1+ deferred) | (pending) | [phase-15](/docs/implementation/0074/phase-15-monomorphise) |
 | 16 | TinyGo embedded subset (`profile = "embedded"` + `//go:linkname` wrapper) | NOT STARTED | — | [phase-16](/docs/implementation/0074/phase-16-tinygo-embedded) |
 | 17 | Vanity-import resolver + wasm-wasip1 / wasm-js publish gate (wazero host integration) | NOT STARTED | — | [phase-17](/docs/implementation/0074/phase-17-vanity-and-wasm) |
 
@@ -55,7 +55,7 @@ Each phase's LANDED gate must be green for every applicable target. `n/a` cells 
 | 12. git-tag publish | LANDED (baseline) | n/a (publish is host-only) | n/a | n/a | n/a |
 | 13. cosign on tag.sig | LANDED (baseline) | n/a | n/a | n/a | n/a |
 | 14. goroutine bridge | LANDED (baseline) | required | required | n/a (no goroutines on wasm-js without scheduler shim) | required |
-| 15. monomorphisation | NOT STARTED | required | required | required | required |
+| 15. monomorphisation | LANDED (baseline) | required | required | required | required |
 | 16. TinyGo embedded subset | NOT STARTED | n/a | n/a | required (wasm-js via tinygo) | required |
 | 17. vanity-import + WASI publish | NOT STARTED | required | required | required | n/a |
 
@@ -100,6 +100,7 @@ package3/go/
   publish/                # git-tag publish (phase 12)
   cosign/                 # cosign-on-sibling-tag signer (phase 13)
   goroutine/              # cgo handle pool + bridge runtime (phase 14)
+  monomorphise/           # `[go.monomorphise]` parser + renderer (phase 15)
   tinygo/                 # TinyGo embedded subset (phase 16)
   vanity/                 # vanity-import redirect resolver (phase 17)
 ```
@@ -108,7 +109,7 @@ The `package3/go/` location is shared with the broader MEP-57 polyglot package w
 
 ## Status snapshot
 
-As of 2026-05-30: phases 0-14 LANDED on `main` (phases 6 + 7 + 9 + 11 + 12 + 13 + 14 baseline only; phase 10 schema only; sub-phases 6.1+/7.1+/9.1+/10.1+/11.1+/12.1+/13.1+/14.1+ deferred), phases 15-17 NOT STARTED.
+As of 2026-05-30: phases 0-15 LANDED on `main` (phases 6 + 7 + 9 + 11 + 12 + 13 + 14 + 15 baseline only; phase 10 schema only; sub-phases 6.1+/7.1+/9.1+/10.1+/11.1+/12.1+/13.1+/14.1+/15.1+ deferred), phases 16-17 NOT STARTED.
 
 ## Cross-references
 

--- a/website/docs/implementation/0074/phase-15-monomorphise.md
+++ b/website/docs/implementation/0074/phase-15-monomorphise.md
@@ -1,0 +1,108 @@
+---
+title: "Phase 15. Monomorphisation"
+sidebar_position: 17
+sidebar_label: "Phase 15. Monomorphisation"
+description: "MEP-74 Phase 15 lands the bridge-side monomorphiser: a parser for the `[go.monomorphise]` mochi.toml table, a resolver that matches each spec against an exported generic Func or generic Type method in an ApiSurface, and a renderer that emits one non-generic Go wrapper per instantiation so the rest of the bridge (cgo wrapper synth, Mochi-side extern emit, lockfile pin) can treat each instantiation as a plain export."
+---
+
+# Phase 15. Monomorphisation
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-74 §Phases](/docs/mep/mep-0074#phases) |
+| Status         | LANDED (baseline) |
+| Started        | 2026-05-30 00:30 (GMT+7) |
+| Landed         | 2026-05-30 00:50 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`TestPhase15MonomorphiseSentinel` in `package3/go/monomorphise/phase15_test.go` writes a tiny synthetic source module (two generic funcs: `Sort[T any]` and `Pair[K, V any]`) plus a wrapper module that renders one monomorphised instance per spec, and asserts `go build ./...` against the rendered wrapper compiles cleanly. The wrapper module uses a relative `replace` directive so the test stays hermetic (no module-proxy fetch).
+
+`TestPhase15RenderInstanceDeterministic` hashes the output of `RenderInstance` 10 times and asserts the SHA-256 is constant, which is load-bearing for the phase 10 wrapper-sha256 lockfile pin.
+
+Plus 28 unit tests in `monomorphise_test.go`:
+
+- spec parser (`TestParseSpecsHappyPath`, `TestParseSpecsMultipleTypeArgs`, `TestParseSpecsIgnoresBlankAndComment`, `TestParseSpecsRejectsMalformedLine`, `TestParseSpecsRejectsUnknownKey`, `TestParseSpecsRejectsMissingDot`, `TestParseSpecsRejectsEmptyT`),
+- spec accessors and validation (`TestSpecAccessors`, `TestSpecAccessorsNoDot`, `TestValidateEmptyOK`, `TestValidateRejectsEmptyTypeArg`),
+- resolver (`TestResolveHappyPath`, `TestResolveReportsMissing`, `TestResolveReportsArityMismatch`, `TestResolveSkipsNonGenericFunc`, `TestResolveMatchesGenericTypeMethod`, `TestResolveDeterministicOrder`, `TestResolveNilSetReturnsEmpty`),
+- symbol naming (`TestSanitiseSuffix`),
+- renderer (`TestRenderInstanceHappyPath`, `TestRenderInstanceSingleResult`, `TestRenderInstanceMultipleResults`, `TestRenderInstanceNoResults`, `TestRenderInstanceUnnamedParam`, `TestRenderInstanceRejectsArityMismatch`, `TestRenderInstanceRejectsMissingModule`),
+- type substitution (`TestConcretiseTypePreservesLongerIdents`, `TestConcretiseTypeEmpty`, `TestReplaceIdentBoundaryDoesNotEatPartialMatches`).
+
+## Lowering decisions
+
+The monomorphise package is a leaf module: it imports `package3/go/apisurface` for the surface walk and otherwise depends only on the Go stdlib (`errors`, `fmt`, `sort`, `strings`). It splits into three concerns: a parser for `[go.monomorphise]` table fragments, a resolver that produces fully-typed `Instance` records, and a renderer that emits one wrapper function per instance.
+
+**The manifest is opt-in, not auto-detected.** MEP-74 deliberately leaves automatic monomorphisation (from a Mochi-side `slices.Sort([]int{})` call-site) to a future sub-phase. The v1 surface is explicit: every instantiation the wrapper synthesiser must emit is named in `[go.monomorphise]` in the project's `mochi.toml`. Two reasons: explicit instantiations match how Go users already think about generic bindings (one symbol per `[T1, T2, ...]` combination), and the manifest gives the lockfile a stable per-instance entry to pin a wrapper-sha256 against.
+
+**Item format is `<package-import-path>.<Identifier>`.** Each spec's `item` field is the canonical fully-qualified name. The terminal `.<Ident>` is the generic function's name; methods on generic types use the three-part form `<pkg-path>.<TypeName>.<Method>` (for example, `example.com/data.Stack.Push`). The parser does not impose this split itself: it only checks that there's at least one dot. The resolver builds a lookup table keyed by the full path so the parser doesn't need to know about packages.
+
+**Symbol suffix is identifier-sanitised type args.** `sanitiseSuffix` joins `TypeArgs` with `_` after replacing any non-identifier character (dot, slash, bracket, asterisk, comma) with `_`. So `[]string` becomes `__string`, `*foo.Bar` becomes `_foo_Bar`, and `["string", "int64"]` joins to `string_int64`. The rule is intentionally simple: the suffix is just a per-instance differentiator within the `mochi_<module>_<Ident>_<suffix>` symbol namespace, so collision avoidance dominates readability.
+
+**Type-parameter substitution is identifier-bounded, longest-first.** `concretiseType` walks the type-parameter map and applies each `<TypeParam> -> <TypeArg>` replacement using `replaceIdentBoundary`, which respects identifier boundaries (so substituting `T` in `[]T` works but does not touch `TX` or `Truthy`). When multiple type parameters share a prefix, the longer name is applied first; this keeps the substitution stable even if a future test introduces multi-character names like `T` and `T2` side by side. Go generics in practice use single capital letters, but the rule applies in general.
+
+**Deterministic output, twice.** First, the renderer is byte-deterministic: it builds output via `strings.Builder` with no map iteration, no time-of-day, no random IDs. Second, the resolver sorts its output by `Spec.Item` then `SymbolSuffix` via `sort.SliceStable`, so two manifest orderings that resolve to the same set of instances produce the same wrapper output. Both properties are load-bearing for the phase 10 wrapper-sha256 pin.
+
+**Missing specs return as strings, not errors.** A spec that doesn't match a generic identifier (typo, deleted upstream, never existed) and a spec with wrong arity both return as entries in the `missing` slice rather than aborting `Resolve`. The wrapper synthesiser surfaces these as `SkipReport` entries so a single misspelled item doesn't fail the entire `mochi pkg build`. The resolver only returns a hard error for structurally invalid input (missing dot, empty type args, etc.) that the parser already caught.
+
+**Wrappers are non-generic, `//export`-decorated.** Each instance renders to a single Go function `mochi_<moduleFlatName>_<Ident>_<suffix>(p0, p1, ...) (r0, r1, ...) { return alias.Ident[T1, T2, ...](p0, p1, ...) }` with a `//export` directive. The wrapper's parameters and results have their `TypeParam` names rewritten to the concrete `TypeArg`s. The result is a plain non-generic export that the phase 6 cgo wrapper synthesiser and phase 7 Mochi-side extern emitter can consume without any generic-aware codegen.
+
+**Method receivers are not yet rewritten.** A method on a generic type `Stack[T].Push(v T)` resolves and renders to a free function `mochi_<module>_Push_int64(v int64)`. The receiver dispatch (calling `s.Push(v)` rather than `Push(s, v)`) is a phase 15.1 reservation: it requires the wrapper to allocate or accept a receiver value, which intersects with the phase 14 handle pool. Phase 15 ships the free-function path so single-arg `slices.Sort[int64]` and friends land in v1.
+
+**No constraint-checking.** The resolver matches purely on arity (number of `TypeParam`s vs `TypeArg`s). It does not verify that the supplied `int64` satisfies the generic's `comparable` or `cmp.Ordered` constraint. Go's compile step on the rendered wrapper catches the violation; surfacing a clearer pre-compile diagnostic is phase 15.2.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/go/monomorphise/monomorphise.go` | `ErrMonomorphise`, `Spec` + `SpecSet`, `ParseSpecs`, `Validate`, accessors, `Instance`, `Resolve`, `RenderInstance`, internal helpers (`sanitiseSuffix`, `concretiseType`, `replaceIdentBoundary`). |
+| `package3/go/monomorphise/monomorphise_test.go` | 28 unit tests covering parser, validation, resolver, sanitiser, renderer, and substitution edge cases. |
+| `package3/go/monomorphise/phase15_test.go` | `TestPhase15MonomorphiseSentinel` (compiles rendered wrappers against a synthetic two-generic source module via a relative replace directive) plus `TestPhase15RenderInstanceDeterministic` (SHA-256 stability across 10 renders). |
+| `website/docs/implementation/0074/phase-15-monomorphise.md` | (this page) |
+
+## Test set
+
+- `TestPhase15MonomorphiseSentinel`
+- `TestPhase15RenderInstanceDeterministic`
+- 28 unit tests in `monomorphise_test.go`
+
+Local run on darwin-arm64:
+
+```
+$ go test ./package3/go/monomorphise/...
+ok      mochi/package3/go/monomorphise  0.289s
+$ go test ./package3/go/...
+ok      mochi/package3/go/apisurface    (cached)
+ok      mochi/package3/go/build (cached)
+ok      mochi/package3/go/cmd/go-ingest (cached)
+ok      mochi/package3/go/cosign        (cached)
+ok      mochi/package3/go/emit  (cached)
+ok      mochi/package3/go/errors        (cached)
+ok      mochi/package3/go/goroutine     (cached)
+ok      mochi/package3/go/library       (cached)
+ok      mochi/package3/go/lockfile      (cached)
+ok      mochi/package3/go/moduleproxy   (cached)
+ok      mochi/package3/go/monomorphise  0.173s
+ok      mochi/package3/go/publish       (cached)
+ok      mochi/package3/go/semver        (cached)
+ok      mochi/package3/go/sumdb (cached)
+ok      mochi/package3/go/typemap       (cached)
+ok      mochi/package3/go/wrapper       (cached)
+```
+
+## Closeout notes
+
+Phase 15 lands the bridge-side monomorphiser as a leaf module. The integration into the wrapper-synthesiser (calling `Resolve` + `RenderInstance` once per spec into the per-module wrapper output) is wired into phase 6's deferred sub-phases 6.1+. Phase 15 ships standalone so phase 10 (lockfile) can already pin a stable `wrapper-sha256` for any in-test instance that exercises the renderer.
+
+Future phase 15.x reservations:
+
+- **15.1** Method-receiver rewriting: a generic-type method `Stack[T].Push(v T)` currently renders to a free function. Sub-phase 15.1 will pair with the phase 14 handle pool so the wrapper can either resolve a `*Stack[int64]` from a handle (Mochi-owned receiver) or instantiate a fresh receiver from a constructor wrapper.
+- **15.2** Pre-compile constraint check: surface a clearer diagnostic when a `TypeArg` does not satisfy the generic's `cmp.Ordered` / `comparable` / interface constraint, rather than relying on Go's compile-step error.
+- **15.3** Auto-monomorphisation: walk Mochi call sites and synthesise a spec when a Mochi-side call binds a concrete type to an unconstrained generic. The opt-in `[go.monomorphise]` manifest stays as the explicit override.
+- **15.4** Multi-param positional spec form: today `T = "string, int64"` is the only way to encode multiple type args. Sub-phase 15.4 will accept `T = ["string", "int64"]` (TOML inline array) once the wider `mochi.toml` driver supports inline-array values inside the inline-table fragment.
+- **15.5** Wrapper-synth integration (phase 6.1) that drops the rendered instances into the per-module wrapper output and updates the lockfile.
+
+Phase 16 (TinyGo embedded subset) builds on the same renderer: a TinyGo wrapper for a generic stdlib function needs the same monomorphised non-generic export the phase 15 renderer produces.

--- a/website/docs/mep/mep-0074.md
+++ b/website/docs/mep/mep-0074.md
@@ -397,7 +397,7 @@ A phase is LANDED only when its gate is green for every target in the matrix bel
 | 12. git-tag publish | LANDED (baseline) | n/a (publish is host-only) | n/a | n/a | n/a |
 | 13. cosign on tag.sig | LANDED (baseline) | n/a | n/a | n/a | n/a |
 | 14. goroutine bridge | LANDED (baseline) | required | required | n/a (no goroutines on wasm-js without scheduler shim) | required |
-| 15. monomorphisation | NOT STARTED | required | required | required | required |
+| 15. monomorphisation | LANDED (baseline) | required | required | required | required |
 | 16. TinyGo embedded subset | NOT STARTED | n/a | n/a | required (wasm-js via tinygo) | required |
 | 17. vanity-import + WASI publish | NOT STARTED | required | required | required | n/a |
 

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -372,7 +372,8 @@
       "implementation/0074/phase-11-library-emit",
       "implementation/0074/phase-12-git-tag-publish",
       "implementation/0074/phase-13-cosign",
-      "implementation/0074/phase-14-goroutine-bridge"
+      "implementation/0074/phase-14-goroutine-bridge",
+      "implementation/0074/phase-15-monomorphise"
     ]
   },
   "implementation/0075/index",


### PR DESCRIPTION
## Summary

- Lands `package3/go/monomorphise/`: parses the `[go.monomorphise]` manifest, resolves each spec against an exported generic Func or generic-type method in an ApiSurface, and renders one `//export`-decorated non-generic wrapper per instantiation so the rest of the bridge treats each instance as a plain export.
- Byte-deterministic renderer + stable Resolve sort lock down the phase 10 `wrapper-sha256` pin.
- Phase 15 row + target matrix updated in both the MEP-74 spec and the implementation tracking index.

Tracking issue: #22950

## Test plan

- [x] `go test ./package3/go/monomorphise/...` (28 unit tests + 2 sentinels)
- [x] `go test ./package3/go/...` (whole bridge suite green)
- [x] Sentinel verifies rendered wrappers compile via `go build ./...` against a synthetic two-generic source module
- [x] Determinism sentinel hashes RenderInstance output 10 times and asserts SHA-256 constancy