### PR TITLE
feat(mep-67/p8): JNI embedding driver (CGO + java_jni build tag)

### DIFF
--- a/package3/java/jni/jni.go
+++ b/package3/java/jni/jni.go
@@ -1,0 +1,137 @@
+//go:build java_jni && cgo
+
+package jni
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/include
+#cgo LDFLAGS: -ljvm
+
+#include <jni.h>
+#include <stdlib.h>
+
+static jint createJVM(JavaVM **jvm, JNIEnv **env, char *classpath) {
+    JavaVMInitArgs args;
+    JavaVMOption opts[1];
+    opts[0].optionString = classpath;
+    args.version = JNI_VERSION_1_8;
+    args.nOptions = 1;
+    args.options = opts;
+    args.ignoreUnrecognized = JNI_FALSE;
+    return JNI_CreateJavaVM(jvm, (void**)env, &args);
+}
+
+static jclass findClass(JNIEnv *env, const char *name) {
+    return (*env)->FindClass(env, name);
+}
+
+static jmethodID getStaticMethodID(JNIEnv *env, jclass cls, const char *name, const char *sig) {
+    return (*env)->GetStaticMethodID(env, cls, name, sig);
+}
+
+static jobject callStaticObjectMethod(JNIEnv *env, jclass cls, jmethodID mid) {
+    return (*env)->CallStaticObjectMethod(env, cls, mid);
+}
+
+static const char *getStringUTF(JNIEnv *env, jstring s) {
+    return (*env)->GetStringUTFChars(env, s, NULL);
+}
+
+static void releaseStringUTF(JNIEnv *env, jstring s, const char *c) {
+    (*env)->ReleaseStringUTFChars(env, s, c);
+}
+
+static jboolean exceptionCheck(JNIEnv *env) {
+    return (*env)->ExceptionCheck(env);
+}
+
+static void exceptionDescribe(JNIEnv *env) {
+    (*env)->ExceptionDescribe(env);
+}
+
+static void exceptionClear(JNIEnv *env) {
+    (*env)->ExceptionClear(env);
+}
+
+static void destroyJVM(JavaVM *jvm) {
+    (*jvm)->DestroyJavaVM(jvm);
+}
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+// Runtime holds a live JVM instance created via JNI_CreateJavaVM.
+// Only one JVM may exist per process (JNI constraint).
+type Runtime struct {
+	jvm *C.JavaVM
+	env *C.JNIEnv
+}
+
+// New creates a JVM with the given JAR paths added to the class path.
+// The JVM is initialised with JNI version 1.8.
+func New(jarPaths []string) (*Runtime, error) {
+	cp := "-Djava.class.path="
+	for i, p := range jarPaths {
+		if i > 0 {
+			cp += ":"
+		}
+		cp += p
+	}
+	ccp := C.CString(cp)
+	defer C.free(unsafe.Pointer(ccp))
+
+	var jvm *C.JavaVM
+	var env *C.JNIEnv
+	rc := C.createJVM(&jvm, &env, ccp)
+	if rc != C.JNI_OK {
+		return nil, fmt.Errorf("jni: JNI_CreateJavaVM returned %d", int(rc))
+	}
+	return &Runtime{jvm: jvm, env: env}, nil
+}
+
+// CallStaticString invokes a public static method with the given descriptor
+// that returns a java.lang.String, and returns the UTF-8 result.
+func (r *Runtime) CallStaticString(className, methodName, descriptor string) (string, error) {
+	cname := C.CString(className)
+	defer C.free(unsafe.Pointer(cname))
+	cmeth := C.CString(methodName)
+	defer C.free(unsafe.Pointer(cmeth))
+	cdesc := C.CString(descriptor)
+	defer C.free(unsafe.Pointer(cdesc))
+
+	cls := C.findClass(r.env, cname)
+	if cls == nil {
+		return "", fmt.Errorf("jni: class not found: %s", className)
+	}
+	mid := C.getStaticMethodID(r.env, cls, cmeth, cdesc)
+	if mid == nil {
+		if C.exceptionCheck(r.env) == C.JNI_TRUE {
+			C.exceptionDescribe(r.env)
+			C.exceptionClear(r.env)
+		}
+		return "", fmt.Errorf("jni: method not found: %s.%s%s", className, methodName, descriptor)
+	}
+	obj := C.callStaticObjectMethod(r.env, cls, mid)
+	if C.exceptionCheck(r.env) == C.JNI_TRUE {
+		C.exceptionDescribe(r.env)
+		C.exceptionClear(r.env)
+		return "", fmt.Errorf("jni: exception in %s.%s", className, methodName)
+	}
+	if obj == nil {
+		return "", nil
+	}
+	cstr := C.getStringUTF(r.env, C.jstring(obj))
+	defer C.releaseStringUTF(r.env, C.jstring(obj), cstr)
+	return C.GoString(cstr), nil
+}
+
+// Close destroys the JVM. After Close the Runtime must not be used.
+func (r *Runtime) Close() {
+	if r.jvm != nil {
+		C.destroyJVM(r.jvm)
+		r.jvm = nil
+		r.env = nil
+	}
+}

--- a/package3/java/jni/jni_stub.go
+++ b/package3/java/jni/jni_stub.go
@@ -1,0 +1,25 @@
+//go:build !java_jni || !cgo
+
+package jni
+
+import "errors"
+
+// ErrJNIUnavailable is returned by all Runtime methods when the package was
+// compiled without the java_jni build tag or without CGO.
+var ErrJNIUnavailable = errors.New("jni: JNI runtime not available (build with -tags java_jni and CGO enabled)")
+
+// Runtime is a placeholder type used when JNI support is compiled out.
+type Runtime struct{}
+
+// New always returns ErrJNIUnavailable in stub mode.
+func New(_ []string) (*Runtime, error) {
+	return nil, ErrJNIUnavailable
+}
+
+// CallStaticString always returns ErrJNIUnavailable in stub mode.
+func (r *Runtime) CallStaticString(_, _, _ string) (string, error) {
+	return "", ErrJNIUnavailable
+}
+
+// Close is a no-op in stub mode.
+func (r *Runtime) Close() {}

--- a/package3/java/jni/phase08_test.go
+++ b/package3/java/jni/phase08_test.go
@@ -1,0 +1,42 @@
+package jni_test
+
+import (
+	"errors"
+	"testing"
+
+	"mochi/package3/java/jni"
+)
+
+// TestJNIStub verifies that the stub (non-CGO / non-java_jni) build compiles
+// and returns ErrJNIUnavailable from every entry point.
+// When built with -tags java_jni the tests are skipped because a live JVM
+// is required and not available in CI.
+func TestNew_StubReturnsError(t *testing.T) {
+	rt, err := jni.New([]string{"/nonexistent.jar"})
+	if err == nil {
+		// Built with java_jni + cgo: we cannot test without a real JVM.
+		t.Skip("built with java_jni; live JVM required for full test")
+	}
+	if rt != nil {
+		t.Errorf("expected nil Runtime on error; got %v", rt)
+	}
+	if !errors.Is(err, jni.ErrJNIUnavailable) {
+		t.Errorf("err = %v; want ErrJNIUnavailable", err)
+	}
+}
+
+func TestCallStaticString_StubReturnsError(t *testing.T) {
+	rt := &jni.Runtime{}
+	_, err := rt.CallStaticString("java/lang/System", "lineSeparator", "()Ljava/lang/String;")
+	if err == nil {
+		t.Skip("built with java_jni; live JVM required for full test")
+	}
+	if !errors.Is(err, jni.ErrJNIUnavailable) {
+		t.Errorf("err = %v; want ErrJNIUnavailable", err)
+	}
+}
+
+func TestClose_StubIsNoop(t *testing.T) {
+	rt := &jni.Runtime{}
+	rt.Close() // must not panic
+}


### PR DESCRIPTION
Closes #22953

## Summary

- Adds `package3/java/jni/jni.go` (build tags `java_jni && cgo`) with a `Runtime` type that wraps `JNI_CreateJavaVM`, class lookup, static method dispatch returning `string`, and `Close`
- Adds `package3/java/jni/jni_stub.go` (build tags `!java_jni || !cgo`) returning `ErrJNIUnavailable` from every entry point so the package compiles in standard CI
- Adds `phase08_test.go` covering all three public entry points in stub mode

## Test plan

- `go test ./package3/java/jni/` green in stub mode (no JDK required)
- `go test ./package3/java/...` all packages still green