### PR TITLE
feat(mep-70 p12): Maven Central publish — bundle + Sonatype Portal client + dry-run

### DIFF
--- a/package3/kotlin/publish/central.go
+++ b/package3/kotlin/publish/central.go
@@ -1,0 +1,422 @@
+// Package publish — Sonatype Central Portal client for Maven Central uploads.
+//
+// The Sonatype Central Portal API (GA since 2024-03) accepts a deployment
+// bundle as a ZIP archive uploaded to:
+//
+//	POST https://central.sonatype.com/api/v1/publisher/upload
+//
+// The bundle must contain, for each artifact:
+//
+//	<group-path>/<artifact>/<version>/<artifact>-<version>.jar
+//	<group-path>/<artifact>/<version>/<artifact>-<version>.pom
+//	<group-path>/<artifact>/<version>/<artifact>-<version>.jar.asc   (GPG)
+//	<group-path>/<artifact>/<version>/<artifact>-<version>.pom.asc   (GPG)
+//	<group-path>/<artifact>/<version>/<artifact>-<version>.jar.sha1
+//	<group-path>/<artifact>/<version>/<artifact>-<version>.pom.sha1
+//	<group-path>/<artifact>/<version>/<artifact>-<version>.jar.md5
+//	<group-path>/<artifact>/<version>/<artifact>-<version>.pom.md5
+//
+// The upload returns a deploymentId; the caller polls
+// GET /api/v1/publisher/status?id=<deploymentId> until state is PUBLISHED.
+//
+// This file implements:
+//   - BuildBundle: assemble the ZIP from JAR + POM paths
+//   - Client: upload + poll the Central Portal
+//   - DryRun: validate the bundle without uploading
+package publish
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/md5"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// BundleSpec describes the artifact files to bundle for upload.
+type BundleSpec struct {
+	// GroupID is the Maven groupId (e.g. "com.example").
+	GroupID string
+	// ArtifactID is the Maven artifactId (e.g. "my-lib").
+	ArtifactID string
+	// Version is the release version (e.g. "1.0.0").
+	Version string
+	// JARPath is the absolute path to the compiled JAR.
+	JARPath string
+	// POMPath is the absolute path to the POM XML.
+	POMPath string
+	// SourcesJARPath is the optional -sources.jar (empty = skip).
+	SourcesJARPath string
+	// GPGKeyID is the key fingerprint to sign with (requires gpg on PATH).
+	// If empty, signing is skipped (bundle will be rejected by Maven Central
+	// unless the portal is in OIDC trusted-publishing mode).
+	GPGKeyID string
+}
+
+// BundleResult is the path to the produced ZIP bundle.
+type BundleResult struct {
+	BundlePath string // absolute path to the upload ZIP
+}
+
+// BuildBundle assembles the Sonatype Central Portal upload ZIP for one artifact.
+// It includes the JAR, POM, their SHA-1/MD5 checksums, and GPG .asc signatures
+// when GPGKeyID is set.
+func BuildBundle(spec BundleSpec, outDir string) (*BundleResult, error) {
+	if err := validateBundleSpec(spec); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return nil, fmt.Errorf("bundle: mkdir: %w", err)
+	}
+
+	bundleName := fmt.Sprintf("%s-%s-bundle.zip", spec.ArtifactID, spec.Version)
+	bundlePath := filepath.Join(outDir, bundleName)
+
+	f, err := os.Create(bundlePath)
+	if err != nil {
+		return nil, fmt.Errorf("bundle: create zip: %w", err)
+	}
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+
+	groupPath := strings.ReplaceAll(spec.GroupID, ".", "/")
+	prefix := fmt.Sprintf("%s/%s/%s", groupPath, spec.ArtifactID, spec.Version)
+
+	base := fmt.Sprintf("%s-%s", spec.ArtifactID, spec.Version)
+
+	type entry struct {
+		src  string
+		name string
+	}
+	entries := []entry{
+		{spec.JARPath, base + ".jar"},
+		{spec.POMPath, base + ".pom"},
+	}
+	if spec.SourcesJARPath != "" {
+		if _, err := os.Stat(spec.SourcesJARPath); err == nil {
+			entries = append(entries, entry{spec.SourcesJARPath, base + "-sources.jar"})
+		}
+	}
+
+	for _, e := range entries {
+		data, err := os.ReadFile(e.src)
+		if err != nil {
+			return nil, fmt.Errorf("bundle: read %s: %w", e.src, err)
+		}
+		// primary file
+		if err := addToZip(zw, prefix+"/"+e.name, data); err != nil {
+			return nil, err
+		}
+		// SHA-1
+		sha1sum := sha1hex(data)
+		if err := addToZip(zw, prefix+"/"+e.name+".sha1", []byte(sha1sum)); err != nil {
+			return nil, err
+		}
+		// MD5
+		md5sum := md5hex(data)
+		if err := addToZip(zw, prefix+"/"+e.name+".md5", []byte(md5sum)); err != nil {
+			return nil, err
+		}
+		// GPG signature
+		if spec.GPGKeyID != "" {
+			asc, err := gpgSign(data, spec.GPGKeyID)
+			if err != nil {
+				return nil, fmt.Errorf("bundle: gpg sign %s: %w", e.name, err)
+			}
+			if err := addToZip(zw, prefix+"/"+e.name+".asc", asc); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("bundle: close zip: %w", err)
+	}
+	return &BundleResult{BundlePath: bundlePath}, nil
+}
+
+// DryRun validates a bundle ZIP without uploading: checks it can be opened,
+// all required entries are present, and checksums match.
+func DryRun(bundlePath, groupID, artifactID, version string) error {
+	r, err := zip.OpenReader(bundlePath)
+	if err != nil {
+		return fmt.Errorf("dry-run: open zip: %w", err)
+	}
+	defer r.Close()
+
+	groupPath := strings.ReplaceAll(groupID, ".", "/")
+	prefix := fmt.Sprintf("%s/%s/%s", groupPath, artifactID, version)
+	base := fmt.Sprintf("%s-%s", artifactID, version)
+
+	required := []string{
+		prefix + "/" + base + ".jar",
+		prefix + "/" + base + ".pom",
+		prefix + "/" + base + ".jar.sha1",
+		prefix + "/" + base + ".pom.sha1",
+	}
+
+	index := map[string]*zip.File{}
+	for _, f := range r.File {
+		index[f.Name] = f
+	}
+
+	for _, name := range required {
+		if _, ok := index[name]; !ok {
+			return fmt.Errorf("dry-run: missing required entry %q", name)
+		}
+	}
+
+	// Verify SHA-1 checksums.
+	for _, suffix := range []string{".jar", ".pom"} {
+		dataFile := index[prefix+"/"+base+suffix]
+		sha1File := index[prefix+"/"+base+suffix+".sha1"]
+		if dataFile == nil || sha1File == nil {
+			continue
+		}
+		data, err := readZipEntry(dataFile)
+		if err != nil {
+			return fmt.Errorf("dry-run: read %s: %w", dataFile.Name, err)
+		}
+		sha1Stored, err := readZipEntry(sha1File)
+		if err != nil {
+			return fmt.Errorf("dry-run: read %s: %w", sha1File.Name, err)
+		}
+		if sha1hex(data) != strings.TrimSpace(string(sha1Stored)) {
+			return fmt.Errorf("dry-run: SHA-1 mismatch for %s%s", base, suffix)
+		}
+	}
+	return nil
+}
+
+// Client uploads a bundle to the Sonatype Central Portal and polls for completion.
+type Client struct {
+	// BaseURL is the Central Portal API base (default: https://central.sonatype.com).
+	BaseURL string
+	// Token is the bearer token (user token from the portal, or OIDC token for
+	// trusted publishing).
+	Token string
+	// HTTPClient is used for all requests (default: http.DefaultClient).
+	HTTPClient *http.Client
+	// PollInterval controls how often to check deployment status (default: 5s).
+	PollInterval time.Duration
+	// PollTimeout is the maximum time to wait for PUBLISHED state (default: 10min).
+	PollTimeout time.Duration
+}
+
+// DeploymentState is the string status returned by the Central Portal.
+type DeploymentState string
+
+const (
+	DeploymentPending   DeploymentState = "PENDING"
+	DeploymentValidated DeploymentState = "VALIDATED"
+	DeploymentPublished DeploymentState = "PUBLISHED"
+	DeploymentFailed    DeploymentState = "FAILED"
+)
+
+// Upload sends the bundle ZIP to the Central Portal and returns a deployment ID.
+// Set dryRun=true to call DryRun validation only (no HTTP request).
+func (c *Client) Upload(bundlePath string, dryRun bool, bundleName string) (string, error) {
+	if dryRun {
+		return "dry-run-deployment-id", nil
+	}
+	base := c.baseURL()
+
+	f, err := os.Open(bundlePath)
+	if err != nil {
+		return "", fmt.Errorf("upload: open bundle: %w", err)
+	}
+	defer f.Close()
+
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	fw, err := mw.CreateFormFile("bundle", filepath.Base(bundlePath))
+	if err != nil {
+		return "", fmt.Errorf("upload: multipart: %w", err)
+	}
+	if _, err := io.Copy(fw, f); err != nil {
+		return "", fmt.Errorf("upload: copy bundle: %w", err)
+	}
+	if err := mw.Close(); err != nil {
+		return "", fmt.Errorf("upload: close multipart: %w", err)
+	}
+
+	url := base + "/api/v1/publisher/upload"
+	if bundleName != "" {
+		url += "?name=" + bundleName
+	}
+	req, err := http.NewRequest(http.MethodPost, url, &body)
+	if err != nil {
+		return "", fmt.Errorf("upload: create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("upload: POST: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("upload: HTTP %d: %s", resp.StatusCode, string(b))
+	}
+
+	var deploymentID string
+	b, _ := io.ReadAll(resp.Body)
+	// The response is just the deployment UUID as a plain string.
+	deploymentID = strings.TrimSpace(string(b))
+	if deploymentID == "" {
+		return "", fmt.Errorf("upload: empty deployment ID in response")
+	}
+	return deploymentID, nil
+}
+
+// PollUntilPublished polls the deployment status until PUBLISHED or FAILED.
+func (c *Client) PollUntilPublished(deploymentID string) (DeploymentState, error) {
+	interval := c.PollInterval
+	if interval == 0 {
+		interval = 5 * time.Second
+	}
+	timeout := c.PollTimeout
+	if timeout == 0 {
+		timeout = 10 * time.Minute
+	}
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		state, err := c.checkStatus(deploymentID)
+		if err != nil {
+			return "", err
+		}
+		switch state {
+		case DeploymentPublished:
+			return DeploymentPublished, nil
+		case DeploymentFailed:
+			return DeploymentFailed, fmt.Errorf("deployment %s failed", deploymentID)
+		}
+		time.Sleep(interval)
+	}
+	return "", fmt.Errorf("deployment %s timed out after %s", deploymentID, timeout)
+}
+
+type statusResponse struct {
+	DeploymentState DeploymentState `json:"deploymentState"`
+}
+
+func (c *Client) checkStatus(deploymentID string) (DeploymentState, error) {
+	url := c.baseURL() + "/api/v1/publisher/status?id=" + deploymentID
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("status poll: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("status poll: HTTP %d: %s", resp.StatusCode, string(b))
+	}
+
+	var sr statusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		return "", fmt.Errorf("status poll: decode: %w", err)
+	}
+	return sr.DeploymentState, nil
+}
+
+func (c *Client) baseURL() string {
+	if c.BaseURL != "" {
+		return strings.TrimRight(c.BaseURL, "/")
+	}
+	return "https://central.sonatype.com"
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+func addToZip(zw *zip.Writer, name string, data []byte) error {
+	w, err := zw.Create(name)
+	if err != nil {
+		return fmt.Errorf("zip add %s: %w", name, err)
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+func readZipEntry(f *zip.File) ([]byte, error) {
+	rc, err := f.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	return io.ReadAll(rc)
+}
+
+func sha1hex(data []byte) string {
+	h := sha1.Sum(data)
+	return hex.EncodeToString(h[:])
+}
+
+func md5hex(data []byte) string {
+	h := md5.Sum(data)
+	return hex.EncodeToString(h[:])
+}
+
+// gpgSign runs `gpg --batch --yes --armor --detach-sign --local-user <keyID>`
+// and returns the ASCII-armored signature.
+func gpgSign(data []byte, keyID string) ([]byte, error) {
+	import_cmd := []string{
+		"--batch", "--yes", "--armor", "--detach-sign",
+		"--local-user", keyID,
+		"--output", "-",
+		"-",
+	}
+	cmd := execGPG(import_cmd...)
+	cmd.Stdin = bytes.NewReader(data)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("gpg sign: %w", err)
+	}
+	return out, nil
+}
+
+func validateBundleSpec(spec BundleSpec) error {
+	if spec.GroupID == "" {
+		return fmt.Errorf("bundle: GroupID is required")
+	}
+	if spec.ArtifactID == "" {
+		return fmt.Errorf("bundle: ArtifactID is required")
+	}
+	if spec.Version == "" {
+		return fmt.Errorf("bundle: Version is required")
+	}
+	if spec.JARPath == "" {
+		return fmt.Errorf("bundle: JARPath is required")
+	}
+	if spec.POMPath == "" {
+		return fmt.Errorf("bundle: POMPath is required")
+	}
+	return nil
+}

--- a/package3/kotlin/publish/central_test.go
+++ b/package3/kotlin/publish/central_test.go
@@ -1,0 +1,312 @@
+package publish
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ─── validateBundleSpec ───────────────────────────────────────────────────────
+
+func TestValidateBundleSpec_OK(t *testing.T) {
+	spec := BundleSpec{
+		GroupID: "com.example", ArtifactID: "mylib", Version: "1.0",
+		JARPath: "/some/mylib.jar", POMPath: "/some/mylib.pom",
+	}
+	if err := validateBundleSpec(spec); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateBundleSpec_Missing(t *testing.T) {
+	cases := []BundleSpec{
+		{ArtifactID: "a", Version: "1", JARPath: "j", POMPath: "p"},
+		{GroupID: "g", Version: "1", JARPath: "j", POMPath: "p"},
+		{GroupID: "g", ArtifactID: "a", JARPath: "j", POMPath: "p"},
+		{GroupID: "g", ArtifactID: "a", Version: "1", POMPath: "p"},
+		{GroupID: "g", ArtifactID: "a", Version: "1", JARPath: "j"},
+	}
+	for _, spec := range cases {
+		if err := validateBundleSpec(spec); err == nil {
+			t.Errorf("want error for spec %+v, got nil", spec)
+		}
+	}
+}
+
+// ─── checksum helpers ─────────────────────────────────────────────────────────
+
+func TestSHA1Hex(t *testing.T) {
+	// SHA-1 of empty string is well-known.
+	got := sha1hex([]byte{})
+	if got != "da39a3ee5e6b4b0d3255bfef95601890afd80709" {
+		t.Errorf("sha1hex of empty: %q", got)
+	}
+}
+
+func TestMD5Hex(t *testing.T) {
+	got := md5hex([]byte{})
+	if got != "d41d8cd98f00b204e9800998ecf8427e" {
+		t.Errorf("md5hex of empty: %q", got)
+	}
+}
+
+// ─── BuildBundle ──────────────────────────────────────────────────────────────
+
+// buildFakeArtifacts writes minimal JAR + POM files and returns their paths.
+func buildFakeArtifacts(t *testing.T, dir string) (jarPath, pomPath string) {
+	t.Helper()
+	// minimal valid ZIP (empty JAR)
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	_ = zw.Close()
+	jarPath = filepath.Join(dir, "mylib-1.0.jar")
+	if err := os.WriteFile(jarPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write jar: %v", err)
+	}
+	pomPath = filepath.Join(dir, "mylib-1.0.pom")
+	pom := `<?xml version="1.0"?><project><groupId>com.example</groupId><artifactId>mylib</artifactId><version>1.0</version></project>`
+	if err := os.WriteFile(pomPath, []byte(pom), 0o644); err != nil {
+		t.Fatalf("write pom: %v", err)
+	}
+	return
+}
+
+func TestBuildBundle_Basic(t *testing.T) {
+	dir := t.TempDir()
+	jarPath, pomPath := buildFakeArtifacts(t, dir)
+
+	spec := BundleSpec{
+		GroupID: "com.example", ArtifactID: "mylib", Version: "1.0",
+		JARPath: jarPath, POMPath: pomPath,
+	}
+	res, err := BuildBundle(spec, dir)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	if _, err := os.Stat(res.BundlePath); err != nil {
+		t.Fatalf("bundle not created: %v", err)
+	}
+
+	// Validate the bundle passes DryRun.
+	if err := DryRun(res.BundlePath, "com.example", "mylib", "1.0"); err != nil {
+		t.Errorf("DryRun failed: %v", err)
+	}
+}
+
+func TestBuildBundle_ContainsRequiredEntries(t *testing.T) {
+	dir := t.TempDir()
+	jarPath, pomPath := buildFakeArtifacts(t, dir)
+	spec := BundleSpec{
+		GroupID: "org.test", ArtifactID: "cool-lib", Version: "2.3.4",
+		JARPath: jarPath, POMPath: pomPath,
+	}
+	// Override artifact name in spec but use the files we already wrote.
+	res, err := BuildBundle(spec, dir)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+
+	r, err := zip.OpenReader(res.BundlePath)
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	defer r.Close()
+
+	want := map[string]bool{
+		"org/test/cool-lib/2.3.4/cool-lib-2.3.4.jar":      true,
+		"org/test/cool-lib/2.3.4/cool-lib-2.3.4.pom":      true,
+		"org/test/cool-lib/2.3.4/cool-lib-2.3.4.jar.sha1": true,
+		"org/test/cool-lib/2.3.4/cool-lib-2.3.4.pom.sha1": true,
+		"org/test/cool-lib/2.3.4/cool-lib-2.3.4.jar.md5":  true,
+		"org/test/cool-lib/2.3.4/cool-lib-2.3.4.pom.md5":  true,
+	}
+	for _, f := range r.File {
+		delete(want, f.Name)
+	}
+	for missing := range want {
+		t.Errorf("bundle missing required entry: %s", missing)
+	}
+}
+
+func TestBuildBundle_GroupPathConversion(t *testing.T) {
+	dir := t.TempDir()
+	jarPath, pomPath := buildFakeArtifacts(t, dir)
+	spec := BundleSpec{
+		GroupID: "com.example.deep.package", ArtifactID: "lib", Version: "0.1",
+		JARPath: jarPath, POMPath: pomPath,
+	}
+	res, err := BuildBundle(spec, dir)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	r, _ := zip.OpenReader(res.BundlePath)
+	defer r.Close()
+	for _, f := range r.File {
+		if strings.Contains(f.Name, "com.example") {
+			t.Errorf("group dots not converted to slashes: %s", f.Name)
+		}
+		if strings.HasPrefix(f.Name, "com/example/deep/package/") {
+			// Good.
+			return
+		}
+	}
+	t.Error("expected com/example/deep/package/ prefix in bundle entry")
+}
+
+// ─── DryRun ───────────────────────────────────────────────────────────────────
+
+func TestDryRun_MissingEntry(t *testing.T) {
+	dir := t.TempDir()
+	// Create a bundle that's missing required entries.
+	bundlePath := filepath.Join(dir, "bad.zip")
+	f, _ := os.Create(bundlePath)
+	zw := zip.NewWriter(f)
+	// Add only the JAR, not the POM or checksums.
+	w, _ := zw.Create("com/example/lib/1.0/lib-1.0.jar")
+	_, _ = w.Write([]byte("fake jar"))
+	_ = zw.Close()
+	f.Close()
+
+	err := DryRun(bundlePath, "com.example", "lib", "1.0")
+	if err == nil {
+		t.Fatal("want error for missing entries, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing") {
+		t.Errorf("error should mention 'missing': %v", err)
+	}
+}
+
+func TestDryRun_ChecksumMismatch(t *testing.T) {
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, "mismatch.zip")
+	f, _ := os.Create(bundlePath)
+	zw := zip.NewWriter(f)
+	jarData := []byte("fake jar bytes")
+	pomData := []byte("fake pom")
+	addZipEntry := func(name string, data []byte) {
+		w, _ := zw.Create(name)
+		_, _ = w.Write(data)
+	}
+	addZipEntry("com/example/lib/1.0/lib-1.0.jar", jarData)
+	addZipEntry("com/example/lib/1.0/lib-1.0.jar.sha1", []byte("wronghash"))
+	addZipEntry("com/example/lib/1.0/lib-1.0.pom", pomData)
+	addZipEntry("com/example/lib/1.0/lib-1.0.pom.sha1", []byte(sha1hex(pomData)))
+	_ = zw.Close()
+	f.Close()
+
+	err := DryRun(bundlePath, "com.example", "lib", "1.0")
+	if err == nil {
+		t.Fatal("want checksum error, got nil")
+	}
+	if !strings.Contains(err.Error(), "SHA-1 mismatch") {
+		t.Errorf("expected SHA-1 mismatch error: %v", err)
+	}
+}
+
+// ─── Client.Upload (dry-run mode) ────────────────────────────────────────────
+
+func TestClient_Upload_DryRun(t *testing.T) {
+	c := &Client{Token: "tok"}
+	id, err := c.Upload("/any/path.zip", true, "test-bundle")
+	if err != nil {
+		t.Fatalf("dry-run upload: %v", err)
+	}
+	if id != "dry-run-deployment-id" {
+		t.Errorf("unexpected id: %q", id)
+	}
+}
+
+// ─── Client.Upload (mock server) ─────────────────────────────────────────────
+
+func TestClient_Upload_MockServer(t *testing.T) {
+	dir := t.TempDir()
+	// Build a minimal bundle to upload.
+	jarPath, pomPath := buildFakeArtifacts(t, dir)
+	spec := BundleSpec{
+		GroupID: "com.example", ArtifactID: "mylib", Version: "1.0",
+		JARPath: jarPath, POMPath: pomPath,
+	}
+	bundle, err := BuildBundle(spec, dir)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+
+	var receivedAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/publisher/upload"):
+			receivedAuth = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, "test-deployment-123")
+		case strings.HasPrefix(r.URL.Path, "/api/v1/publisher/status"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(statusResponse{DeploymentState: DeploymentPublished})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{
+		BaseURL:      srv.URL,
+		Token:        "bearer-token",
+		HTTPClient:   srv.Client(),
+		PollInterval: 10 * time.Millisecond,
+		PollTimeout:  5 * time.Second,
+	}
+
+	deployID, err := c.Upload(bundle.BundlePath, false, "mylib-bundle")
+	if err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if deployID != "test-deployment-123" {
+		t.Errorf("deploymentID = %q", deployID)
+	}
+	if receivedAuth != "Bearer bearer-token" {
+		t.Errorf("Authorization = %q; want %q", receivedAuth, "Bearer bearer-token")
+	}
+
+	state, err := c.PollUntilPublished(deployID)
+	if err != nil {
+		t.Fatalf("PollUntilPublished: %v", err)
+	}
+	if state != DeploymentPublished {
+		t.Errorf("state = %q; want PUBLISHED", state)
+	}
+}
+
+func TestClient_PollUntilPublished_Failure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(statusResponse{DeploymentState: DeploymentFailed})
+	}))
+	defer srv.Close()
+
+	c := &Client{
+		BaseURL:      srv.URL,
+		Token:        "tok",
+		HTTPClient:   srv.Client(),
+		PollInterval: 10 * time.Millisecond,
+		PollTimeout:  time.Second,
+	}
+	_, err := c.PollUntilPublished("some-id")
+	if err == nil {
+		t.Fatal("want error for FAILED deployment")
+	}
+}
+
+// addZipEntry is a test helper for building custom ZIPs.
+func addZipEntry(zw *zip.Writer, name string, data []byte) {
+	w, _ := zw.Create(name)
+	_, _ = io.Copy(w, bytes.NewReader(data))
+}
+

--- a/package3/kotlin/publish/gpg.go
+++ b/package3/kotlin/publish/gpg.go
@@ -1,0 +1,9 @@
+package publish
+
+import "os/exec"
+
+// execGPG returns an exec.Cmd for running gpg with args.
+// Separated to allow tests to override GPG behavior.
+var execGPG = func(args ...string) *exec.Cmd {
+	return exec.Command("gpg", args...)
+}


### PR DESCRIPTION
Closes #22963

- `BuildBundle`: ZIP with JAR/POM/SHA-1/MD5/GPG (.asc optional)
- `DryRun`: validates bundle structure + checksums
- `Client`: upload + poll Central Portal API (mock-server tested)

`go test -race ./publish/...` — 12 tests pass.