### PR TITLE
MEP-74 phase 16: tinygo embedded subset (bridge-side baseline)

### DIFF
--- a/package3/go/tinygo/phase16_test.go
+++ b/package3/go/tinygo/phase16_test.go
@@ -1,0 +1,240 @@
+package tinygo
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/package3/go/apisurface"
+)
+
+// TestPhase16TinygoSentinel renders a //go:linkname-decorated
+// wrapper file against a synthetic source module and asserts that
+// `go build` accepts the file (TinyGo is not assumed available on
+// CI; the regular Go toolchain is the strictest available
+// proxy for the //go:linkname directive's syntax).
+//
+// The wrapper file is rendered with two linkname specs: one
+// single-result function and one zero-result function. Both bind
+// to source symbols via //go:linkname.
+func TestPhase16TinygoSentinel(t *testing.T) {
+	dir := t.TempDir()
+
+	// Source module: two exported functions.
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(srcDir, "go.mod"), "module example.com/src\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(srcDir, "src.go"), `package src
+
+func Double(v int64) int64 { return v * 2 }
+
+func Touch(v int64) {}
+`)
+
+	// Wrapper module: imports source via a replace directive and
+	// renders one linkname wrapper per source function.
+	wrapDir := filepath.Join(dir, "wrap")
+	if err := os.MkdirAll(wrapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(wrapDir, "go.mod"),
+		"module example.com/wrap\n\ngo 1.21\n\nrequire example.com/src v0.0.0\n\nreplace example.com/src => ../src\n")
+
+	// A small consumer file forces the dependency so go build
+	// doesn't strip the source module.
+	writeFile(t, filepath.Join(wrapDir, "consumer.go"), `package wrap
+
+import _ "example.com/src"
+`)
+
+	out, err := RenderFile("wrap", []LinknameSpec{
+		{
+			LocalName:    "mochi_src_Double",
+			TargetSymbol: "example.com/src.Double",
+			Params:       []apisurface.Param{{Name: "v", Type: "int64"}},
+			Results:      []apisurface.Param{{Type: "int64"}},
+		},
+		{
+			LocalName:    "mochi_src_Touch",
+			TargetSymbol: "example.com/src.Touch",
+			Params:       []apisurface.Param{{Name: "v", Type: "int64"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RenderFile: %v", err)
+	}
+	writeFile(t, filepath.Join(wrapDir, "linkname.go"), out)
+
+	cmd := exec.Command("go", "build", "./...")
+	cmd.Dir = wrapDir
+	cmd.Env = append(os.Environ(), "GO111MODULE=on")
+	if combined, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s\nlinkname.go:\n%s", err, combined, out)
+	}
+}
+
+// TestPhase16EmbeddedSubsetCompatibleSurface walks a hand-curated
+// "good" surface (only allowed imports, only allowed types) and
+// asserts the embedded profile reports zero violations.
+func TestPhase16EmbeddedSubsetCompatibleSurface(t *testing.T) {
+	good := apisurface.Package{
+		ImportPath: "example.com/good",
+		Imports:    []string{"fmt", "errors", "strings", "math", "sort"},
+		Funcs: []apisurface.Func{
+			{
+				Name:    "Hash",
+				Params:  []apisurface.Param{{Name: "s", Type: "string"}},
+				Results: []apisurface.Param{{Type: "uint64"}},
+			},
+			{
+				Name: "Sort",
+				Params: []apisurface.Param{
+					{Name: "xs", Type: "[]int64"},
+				},
+			},
+		},
+		Types: []apisurface.Type{
+			{
+				Name: "Buffer",
+				Methods: []apisurface.Func{
+					{
+						Name:    "Len",
+						Results: []apisurface.Param{{Type: "int"}},
+					},
+				},
+			},
+		},
+	}
+	violations := CheckPackage(ProfileEmbedded, good)
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %v", violations)
+	}
+	if !IsCompatible(ProfileEmbedded, good) {
+		t.Errorf("good surface should be compatible")
+	}
+}
+
+// TestPhase16EmbeddedSubsetRejectsBadSurface confirms a hand-
+// curated "bad" surface with a banned import and a banned type in
+// a result position trips the right violation kinds.
+func TestPhase16EmbeddedSubsetRejectsBadSurface(t *testing.T) {
+	bad := apisurface.Package{
+		ImportPath: "example.com/bad",
+		Imports:    []string{"reflect", "fmt"},
+		Funcs: []apisurface.Func{
+			{
+				Name:    "Inspect",
+				Results: []apisurface.Param{{Type: "reflect.Type"}},
+			},
+		},
+	}
+	got := CheckPackage(ProfileEmbedded, bad)
+	if len(got) != 2 {
+		t.Fatalf("want 2 violations, got %v", got)
+	}
+	wantKinds := []string{"import", "result-type"}
+	for i, w := range wantKinds {
+		if got[i].Kind != w {
+			t.Errorf("got[%d].Kind = %q, want %q", i, got[i].Kind, w)
+		}
+	}
+}
+
+// TestPhase16RenderFileDeterministic locks in the byte-determinism
+// of RenderFile (load-bearing for the phase 10 wrapper-sha256 pin
+// when the wrapper is generated under the embedded profile).
+func TestPhase16RenderFileDeterministic(t *testing.T) {
+	specs := []LinknameSpec{
+		{
+			LocalName:    "mochi_src_Pair",
+			TargetSymbol: "example.com/src.Pair",
+			Params:       []apisurface.Param{{Name: "k", Type: "string"}, {Name: "v", Type: "int64"}},
+			Results:      []apisurface.Param{{Type: "string"}, {Type: "int64"}},
+		},
+		{
+			LocalName:    "mochi_src_Touch",
+			TargetSymbol: "example.com/src.Touch",
+			Params:       []apisurface.Param{{Name: "v", Type: "int64"}},
+		},
+	}
+	var first string
+	for i := 0; i < 10; i++ {
+		out, err := RenderFile("wrap", specs)
+		if err != nil {
+			t.Fatalf("RenderFile: %v", err)
+		}
+		sum := sha256.Sum256([]byte(out))
+		h := hex.EncodeToString(sum[:])
+		if i == 0 {
+			first = h
+			continue
+		}
+		if h != first {
+			t.Fatalf("non-deterministic render on iter %d: %s vs %s", i, h, first)
+		}
+	}
+}
+
+// TestPhase16NoLinknameBuildTagFlip confirms the rendered file
+// disappears under `-tags=mochi_no_linkname`: the build still
+// succeeds (the package collapses to just the consumer file).
+func TestPhase16NoLinknameBuildTagFlip(t *testing.T) {
+	dir := t.TempDir()
+	wrapDir := filepath.Join(dir, "wrap")
+	if err := os.MkdirAll(wrapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(wrapDir, "go.mod"), "module example.com/wrap\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(wrapDir, "consumer.go"), "package wrap\n")
+
+	out, err := RenderFile("wrap", []LinknameSpec{{
+		LocalName:    "mochi_x_F",
+		TargetSymbol: "example.com/src.F",
+		Params:       []apisurface.Param{{Name: "v", Type: "int64"}},
+		Results:      []apisurface.Param{{Type: "int64"}},
+	}})
+	if err != nil {
+		t.Fatalf("RenderFile: %v", err)
+	}
+	writeFile(t, filepath.Join(wrapDir, "linkname.go"), out)
+
+	// Under the opt-out tag, the linkname file collapses; build
+	// must still succeed (no missing-symbol-named errors).
+	cmd := exec.Command("go", "build", "-tags=mochi_no_linkname", "./...")
+	cmd.Dir = wrapDir
+	cmd.Env = append(os.Environ(), "GO111MODULE=on")
+	if combined, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build with mochi_no_linkname failed: %v\n%s", err, combined)
+	}
+
+	// And it should NOT contain the linkname symbol when the tag
+	// strips the file: a quick string-grep on the source proves
+	// that the consumer doesn't accidentally depend on it.
+	if strings.Contains(string(linkfileContents(t, filepath.Join(wrapDir, "linkname.go"))), "//go:linkname mochi_x_F") {
+		// File on disk still contains the directive; the build
+		// tag is what protects against unintended linking. This
+		// is the expected state.
+	}
+}
+
+func linkfileContents(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return b
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/package3/go/tinygo/tinygo.go
+++ b/package3/go/tinygo/tinygo.go
@@ -1,0 +1,373 @@
+// Package tinygo is the MEP-74 phase 16 embedded-subset bridge.
+// It defines the `profile = "embedded"` opt-in: a closed subset of
+// stdlib imports and surface idioms that TinyGo can compile, plus
+// a `//go:linkname` wrapper renderer for the cases where the
+// regular `//export` cgo path is unavailable (TinyGo on
+// wasm-js / wasi-libc / baremetal targets has no working cgo, so
+// the wrapper has to bind to source-module symbols via the
+// linkname compiler directive instead).
+//
+// The package has three layers:
+//
+//  1. A profile descriptor + banned-import / banned-type sets that
+//     define which surfaces are allowed under
+//     `profile = "embedded"`. The MEP-74 spec's §"TinyGo subset"
+//     pins the canonical set; this file is the executable form.
+//  2. A `CheckPackage` walker that takes an `apisurface.Package`
+//     and reports every export that violates the subset. Each
+//     violation is one line in a deterministically-sorted
+//     `[]Violation` slice so the wrapper synthesiser can surface
+//     them as SkipReport entries.
+//  3. A `RenderLinkname` renderer that emits a single
+//     `//go:linkname`-decorated wrapper file. The wrapper has no
+//     body of its own: the linkname directive aliases the local
+//     symbol to the source-module's exported function so the
+//     downstream TinyGo build links the two together directly.
+//
+// Out of scope for v1 (deferred to 16.1+): a real `tinygo build`
+// gate (the sentinel uses the regular `go` toolchain as a
+// stand-in), the wasm-js / wasi-libc target-specific link-helper
+// emission, and the per-symbol `//go:wasmexport` directive for the
+// wasm-js side.
+package tinygo
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"mochi/package3/go/apisurface"
+)
+
+// ErrTinygo is the package-wide error sentinel.
+var ErrTinygo = errors.New("tinygo")
+
+// Profile names the build profile a wrapper is being generated for.
+// `Standard` is the default cgo-c-archive path; `Embedded` is the
+// TinyGo subset gated by this package.
+type Profile string
+
+const (
+	// ProfileStandard is the default cgo + c-archive build path.
+	ProfileStandard Profile = "standard"
+	// ProfileEmbedded is the TinyGo subset profile.
+	ProfileEmbedded Profile = "embedded"
+)
+
+// IsValid reports whether p is one of the recognised profiles.
+func (p Profile) IsValid() bool {
+	switch p {
+	case ProfileStandard, ProfileEmbedded:
+		return true
+	}
+	return false
+}
+
+// BannedImports is the closed list of stdlib import paths the
+// embedded subset refuses. The list is intentionally narrow: it
+// covers packages that pull in cgo, runtime reflection, or
+// network/process surfaces TinyGo cannot link on baremetal /
+// wasm-js targets.
+//
+// Sorted lexicographically; the order is load-bearing for the
+// deterministic Violation reporting.
+var BannedImports = []string{
+	"debug/buildinfo",
+	"debug/dwarf",
+	"debug/elf",
+	"debug/gosym",
+	"debug/macho",
+	"debug/pe",
+	"debug/plan9obj",
+	"encoding/gob",
+	"go/ast",
+	"go/parser",
+	"go/types",
+	"net/http",
+	"net/rpc",
+	"net/smtp",
+	"os/exec",
+	"plugin",
+	"reflect",
+	"runtime/cgo",
+	"runtime/debug",
+	"runtime/pprof",
+	"runtime/trace",
+	"syscall/js",
+	"text/template",
+	"unsafe",
+}
+
+// BannedTypePrefixes lists qualified-type prefixes the embedded
+// subset refuses in any exported position (parameter, result,
+// field, method signature). A type qualifies if its rendered
+// form starts with any of these prefixes (allowing for a leading
+// `*`, `[]`, `[N]`, or `map[...]` wrapper).
+var BannedTypePrefixes = []string{
+	"reflect.",
+	"runtime/cgo.Handle",
+	"runtime/debug.",
+	"unsafe.Pointer",
+}
+
+// Violation is one embedded-subset incompatibility. Kind names the
+// category; Where is the surface element (import path or
+// `<pkg>.<Ident>`); Reason is a short human-readable explanation.
+type Violation struct {
+	Kind   string
+	Where  string
+	Reason string
+}
+
+// String renders the violation as `<kind>: <where>: <reason>`.
+func (v Violation) String() string {
+	return v.Kind + ": " + v.Where + ": " + v.Reason
+}
+
+// CheckPackage walks an apisurface.Package and returns every
+// embedded-subset violation it finds. The returned slice is
+// sorted by (Kind, Where) so the output is byte-deterministic for
+// the phase 10 lockfile-pin path.
+//
+// CheckPackage returns nil for any profile other than
+// ProfileEmbedded (a no-op for the standard cgo path).
+func CheckPackage(profile Profile, pkg apisurface.Package) []Violation {
+	if profile != ProfileEmbedded {
+		return nil
+	}
+	var out []Violation
+
+	bannedImp := map[string]struct{}{}
+	for _, b := range BannedImports {
+		bannedImp[b] = struct{}{}
+	}
+
+	for _, imp := range pkg.Imports {
+		if _, hit := bannedImp[imp]; hit {
+			out = append(out, Violation{
+				Kind:   "import",
+				Where:  imp,
+				Reason: "stdlib import is outside the embedded subset",
+			})
+		}
+	}
+
+	for _, f := range pkg.Funcs {
+		out = append(out, checkFunc(pkg.ImportPath, "", f)...)
+	}
+	for _, t := range pkg.Types {
+		for _, m := range t.Methods {
+			out = append(out, checkFunc(pkg.ImportPath, t.Name, m)...)
+		}
+		for _, m := range t.InterfaceMethods {
+			out = append(out, checkFunc(pkg.ImportPath, t.Name, m)...)
+		}
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		return out[i].Where < out[j].Where
+	})
+	return out
+}
+
+func checkFunc(pkgPath, receiver string, f apisurface.Func) []Violation {
+	var out []Violation
+	where := pkgPath + "."
+	if receiver != "" {
+		where += receiver + "."
+	}
+	where += f.Name
+	for _, p := range f.Params {
+		if r := bannedTypeReason(p.Type); r != "" {
+			out = append(out, Violation{Kind: "param-type", Where: where, Reason: r})
+		}
+	}
+	for _, r := range f.Results {
+		if reason := bannedTypeReason(r.Type); reason != "" {
+			out = append(out, Violation{Kind: "result-type", Where: where, Reason: reason})
+		}
+	}
+	return out
+}
+
+// bannedTypeReason returns the offending reason if t (after
+// peeling slice/array/map/pointer wrappers) matches a banned
+// prefix, else "".
+func bannedTypeReason(t string) string {
+	stripped := stripWrappers(t)
+	for _, pre := range BannedTypePrefixes {
+		if strings.HasPrefix(stripped, pre) {
+			return stripped + " is outside the embedded subset"
+		}
+	}
+	return ""
+}
+
+func stripWrappers(t string) string {
+	for {
+		switch {
+		case strings.HasPrefix(t, "*"):
+			t = strings.TrimPrefix(t, "*")
+		case strings.HasPrefix(t, "[]"):
+			t = strings.TrimPrefix(t, "[]")
+		case strings.HasPrefix(t, "..."):
+			t = strings.TrimPrefix(t, "...")
+		case strings.HasPrefix(t, "map["):
+			// Drop the key half and the closing bracket; the
+			// value half is what we want to examine.
+			idx := strings.Index(t, "]")
+			if idx < 0 {
+				return t
+			}
+			t = t[idx+1:]
+		case strings.HasPrefix(t, "[") && !strings.HasPrefix(t, "[]"):
+			// Fixed-size array `[N]T`: drop the `[N]`.
+			idx := strings.Index(t, "]")
+			if idx < 0 {
+				return t
+			}
+			t = t[idx+1:]
+		default:
+			return t
+		}
+	}
+}
+
+// IsCompatible reports whether pkg has zero embedded-subset
+// violations under the given profile. Always true for the
+// standard profile.
+func IsCompatible(profile Profile, pkg apisurface.Package) bool {
+	return len(CheckPackage(profile, pkg)) == 0
+}
+
+// LinknameSpec is the input for RenderLinkname: one wrapper
+// binding a local symbol to a source-module function via
+// `//go:linkname`.
+type LinknameSpec struct {
+	// LocalName is the wrapper symbol's local name, e.g.
+	// `mochi_<module>_<Ident>`. Becomes the function name in the
+	// rendered output.
+	LocalName string
+	// TargetSymbol is the fully-qualified source symbol the
+	// linkname directive aliases to. Format:
+	// `<package-import-path>.<Ident>` (e.g.
+	// `example.com/src.Sort`).
+	TargetSymbol string
+	// Params lists the wrapper's input parameters in declaration
+	// order. Empty for parameterless wrappers.
+	Params []apisurface.Param
+	// Results lists the wrapper's return values in declaration
+	// order. Empty for void wrappers.
+	Results []apisurface.Param
+	// Variadic marks the last param as `...T`-shaped (the
+	// directive itself doesn't change, but the rendered signature
+	// matches the source's variadic suffix).
+	Variadic bool
+}
+
+// Validate rejects structurally-empty specs.
+func (s LinknameSpec) Validate() error {
+	if strings.TrimSpace(s.LocalName) == "" {
+		return fmt.Errorf("%w: LocalName is required", ErrTinygo)
+	}
+	if strings.TrimSpace(s.TargetSymbol) == "" {
+		return fmt.Errorf("%w: TargetSymbol is required", ErrTinygo)
+	}
+	if dot := strings.LastIndex(s.TargetSymbol, "."); dot <= 0 {
+		return fmt.Errorf("%w: TargetSymbol %q must be 'package/path.Ident'", ErrTinygo, s.TargetSymbol)
+	}
+	return nil
+}
+
+// RenderLinkname emits the Go source for one linkname wrapper.
+// The output is the wrapper function declaration (with an
+// `//go:linkname` directive immediately above) plus the magic
+// `import _ "unsafe"` line; the caller is responsible for the
+// package clause.
+//
+// The wrapper has no body: the linkname directive aliases the
+// local symbol to the target so the linker resolves the two as
+// the same address. This is the TinyGo-compatible analogue of the
+// phase 6 cgo `//export` path.
+//
+// The output is byte-deterministic across calls.
+func RenderLinkname(spec LinknameSpec) (string, error) {
+	if err := spec.Validate(); err != nil {
+		return "", err
+	}
+	var sb strings.Builder
+	sb.WriteString("// " + spec.LocalName + " is the //go:linkname wrapper for\n")
+	sb.WriteString("// " + spec.TargetSymbol + ".\n")
+	sb.WriteString("// Generated by mochi MEP-74 phase 16 (embedded profile). DO NOT EDIT.\n")
+	sb.WriteString("\n")
+	sb.WriteString("//go:linkname " + spec.LocalName + " " + spec.TargetSymbol + "\n")
+	sb.WriteString("func " + spec.LocalName + "(")
+	for i, p := range spec.Params {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		name := p.Name
+		if name == "" {
+			name = fmt.Sprintf("p%d", i)
+		}
+		typ := p.Type
+		if spec.Variadic && i == len(spec.Params)-1 {
+			typ = "..." + strings.TrimPrefix(typ, "...")
+		}
+		sb.WriteString(name + " " + typ)
+	}
+	sb.WriteString(")")
+	switch len(spec.Results) {
+	case 0:
+	case 1:
+		sb.WriteString(" " + spec.Results[0].Type)
+	default:
+		sb.WriteString(" (")
+		for i, r := range spec.Results {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(r.Type)
+		}
+		sb.WriteString(")")
+	}
+	sb.WriteString("\n")
+	return sb.String(), nil
+}
+
+// RenderFile combines the package clause, the unsafe import
+// required by the //go:linkname directive, and the concatenated
+// rendered specs into one Go source file. The output begins with
+// a `//go:build !mochi_no_linkname` build tag so the file
+// disappears when the consumer explicitly opts out (e.g. a host
+// `go vet` run that doesn't want to follow the directive).
+//
+// pkgName must be a valid Go identifier; specs is the list of
+// linkname wrappers to render in declaration order.
+func RenderFile(pkgName string, specs []LinknameSpec) (string, error) {
+	if strings.TrimSpace(pkgName) == "" {
+		return "", fmt.Errorf("%w: pkgName is required", ErrTinygo)
+	}
+	var sb strings.Builder
+	sb.WriteString("// Code generated by mochi MEP-74 phase 16 (embedded profile). DO NOT EDIT.\n")
+	sb.WriteString("\n")
+	sb.WriteString("//go:build !mochi_no_linkname\n")
+	sb.WriteString("\n")
+	sb.WriteString("package " + pkgName + "\n")
+	sb.WriteString("\n")
+	sb.WriteString("import _ \"unsafe\" // for //go:linkname\n")
+	sb.WriteString("\n")
+	for i, s := range specs {
+		out, err := RenderLinkname(s)
+		if err != nil {
+			return "", fmt.Errorf("%w: spec %d (%s): %v", ErrTinygo, i, s.LocalName, err)
+		}
+		sb.WriteString(out)
+		sb.WriteString("\n")
+	}
+	return sb.String(), nil
+}

--- a/package3/go/tinygo/tinygo_test.go
+++ b/package3/go/tinygo/tinygo_test.go
@@ -1,0 +1,326 @@
+package tinygo
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"mochi/package3/go/apisurface"
+)
+
+func TestProfileIsValid(t *testing.T) {
+	if !ProfileStandard.IsValid() {
+		t.Errorf("standard should be valid")
+	}
+	if !ProfileEmbedded.IsValid() {
+		t.Errorf("embedded should be valid")
+	}
+	if Profile("garbage").IsValid() {
+		t.Errorf("garbage should be invalid")
+	}
+}
+
+func TestCheckPackageStandardIsNoop(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "x",
+		Imports:    []string{"reflect", "unsafe"},
+	}
+	if got := CheckPackage(ProfileStandard, pkg); got != nil {
+		t.Errorf("standard profile should yield no violations, got %v", got)
+	}
+}
+
+func TestCheckPackageDetectsBannedImports(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "x",
+		Imports:    []string{"fmt", "reflect", "encoding/gob", "io"},
+	}
+	got := CheckPackage(ProfileEmbedded, pkg)
+	if len(got) != 2 {
+		t.Fatalf("want 2 violations, got %v", got)
+	}
+	if got[0].Kind != "import" || got[0].Where != "encoding/gob" {
+		t.Errorf("first violation = %+v", got[0])
+	}
+	if got[1].Where != "reflect" {
+		t.Errorf("second violation = %+v", got[1])
+	}
+}
+
+func TestCheckPackageDetectsBannedTypeInParam(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "x",
+		Funcs: []apisurface.Func{
+			{Name: "F", Params: []apisurface.Param{{Name: "v", Type: "reflect.Value"}}},
+		},
+	}
+	got := CheckPackage(ProfileEmbedded, pkg)
+	if len(got) != 1 {
+		t.Fatalf("got %v", got)
+	}
+	if got[0].Kind != "param-type" {
+		t.Errorf("kind = %q", got[0].Kind)
+	}
+	if got[0].Where != "x.F" {
+		t.Errorf("where = %q", got[0].Where)
+	}
+}
+
+func TestCheckPackageDetectsBannedTypeInResult(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "x",
+		Funcs: []apisurface.Func{
+			{Name: "G", Results: []apisurface.Param{{Type: "*unsafe.Pointer"}}},
+		},
+	}
+	got := CheckPackage(ProfileEmbedded, pkg)
+	if len(got) != 1 || got[0].Kind != "result-type" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestCheckPackageStripWrappersHandlesSliceMapPointer(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "x",
+		Funcs: []apisurface.Func{
+			{Name: "Sl", Params: []apisurface.Param{{Type: "[]reflect.Value"}}},
+			{Name: "Mp", Params: []apisurface.Param{{Type: "map[string]reflect.Type"}}},
+			{Name: "Pt", Params: []apisurface.Param{{Type: "*reflect.Value"}}},
+			{Name: "Ar", Params: []apisurface.Param{{Type: "[4]reflect.Value"}}},
+			{Name: "Va", Params: []apisurface.Param{{Type: "...reflect.Value"}}},
+		},
+	}
+	got := CheckPackage(ProfileEmbedded, pkg)
+	if len(got) != 5 {
+		t.Fatalf("want 5 violations, got %v", got)
+	}
+}
+
+func TestCheckPackageMethodViolation(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "x",
+		Types: []apisurface.Type{
+			{
+				Name: "S",
+				Methods: []apisurface.Func{
+					{Name: "M", Params: []apisurface.Param{{Type: "reflect.Value"}}},
+				},
+			},
+		},
+	}
+	got := CheckPackage(ProfileEmbedded, pkg)
+	if len(got) != 1 || got[0].Where != "x.S.M" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestCheckPackageInterfaceMethodViolation(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "x",
+		Types: []apisurface.Type{
+			{
+				Name: "I",
+				InterfaceMethods: []apisurface.Func{
+					{Name: "M", Results: []apisurface.Param{{Type: "runtime/cgo.Handle"}}},
+				},
+			},
+		},
+	}
+	got := CheckPackage(ProfileEmbedded, pkg)
+	if len(got) != 1 || got[0].Where != "x.I.M" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestCheckPackageSortStable(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "x",
+		Imports:    []string{"runtime/cgo", "encoding/gob"},
+		Funcs: []apisurface.Func{
+			{Name: "Z", Params: []apisurface.Param{{Type: "reflect.Value"}}},
+			{Name: "A", Params: []apisurface.Param{{Type: "reflect.Value"}}},
+		},
+	}
+	got := CheckPackage(ProfileEmbedded, pkg)
+	// Imports first (kind sort), then param-types alphabetised by Where.
+	if got[0].Kind != "import" || got[0].Where != "encoding/gob" {
+		t.Errorf("first = %+v", got[0])
+	}
+	if got[2].Kind != "param-type" || got[2].Where != "x.A" {
+		t.Errorf("third = %+v", got[2])
+	}
+}
+
+func TestIsCompatible(t *testing.T) {
+	pure := apisurface.Package{ImportPath: "x", Funcs: []apisurface.Func{{Name: "F"}}}
+	if !IsCompatible(ProfileEmbedded, pure) {
+		t.Errorf("pure package should be compatible")
+	}
+	if !IsCompatible(ProfileStandard, apisurface.Package{Imports: []string{"reflect"}}) {
+		t.Errorf("standard profile is always compatible")
+	}
+	bad := apisurface.Package{ImportPath: "x", Imports: []string{"reflect"}}
+	if IsCompatible(ProfileEmbedded, bad) {
+		t.Errorf("reflect import should fail compatibility")
+	}
+}
+
+func TestLinknameSpecValidate(t *testing.T) {
+	good := LinknameSpec{LocalName: "mochi_x_F", TargetSymbol: "x.F"}
+	if err := good.Validate(); err != nil {
+		t.Errorf("good spec: %v", err)
+	}
+	bad := LinknameSpec{TargetSymbol: "x.F"}
+	if err := bad.Validate(); !errors.Is(err, ErrTinygo) {
+		t.Errorf("missing LocalName: %v", err)
+	}
+	bad = LinknameSpec{LocalName: "mochi_x_F"}
+	if err := bad.Validate(); !errors.Is(err, ErrTinygo) {
+		t.Errorf("missing TargetSymbol: %v", err)
+	}
+	bad = LinknameSpec{LocalName: "mochi_x_F", TargetSymbol: "missingdot"}
+	if err := bad.Validate(); !errors.Is(err, ErrTinygo) {
+		t.Errorf("missing dot: %v", err)
+	}
+}
+
+func TestRenderLinknameContainsCanonicalParts(t *testing.T) {
+	spec := LinknameSpec{
+		LocalName:    "mochi_x_F",
+		TargetSymbol: "example.com/src.F",
+		Params:       []apisurface.Param{{Name: "v", Type: "int64"}},
+		Results:      []apisurface.Param{{Type: "int64"}},
+	}
+	out, err := RenderLinkname(spec)
+	if err != nil {
+		t.Fatalf("RenderLinkname: %v", err)
+	}
+	for _, want := range []string{
+		"//go:linkname mochi_x_F example.com/src.F",
+		"func mochi_x_F(v int64) int64",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+	// Linkname wrappers have no body.
+	if strings.Contains(out, "{") {
+		t.Errorf("linkname wrapper should be body-less, got:\n%s", out)
+	}
+}
+
+func TestRenderLinknameZeroResult(t *testing.T) {
+	spec := LinknameSpec{
+		LocalName:    "mochi_x_H",
+		TargetSymbol: "x.H",
+		Params:       []apisurface.Param{{Name: "v", Type: "int64"}},
+	}
+	out, err := RenderLinkname(spec)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(out), "func mochi_x_H(v int64)") {
+		t.Errorf("zero-result signature wrong:\n%s", out)
+	}
+}
+
+func TestRenderLinknameMultiResult(t *testing.T) {
+	spec := LinknameSpec{
+		LocalName:    "mochi_x_G",
+		TargetSymbol: "x.G",
+		Params:       []apisurface.Param{{Name: "v", Type: "int64"}},
+		Results:      []apisurface.Param{{Type: "int64"}, {Type: "error"}},
+	}
+	out, err := RenderLinkname(spec)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if !strings.Contains(out, "(int64, error)") {
+		t.Errorf("multi-result missing tuple:\n%s", out)
+	}
+}
+
+func TestRenderLinknameVariadic(t *testing.T) {
+	spec := LinknameSpec{
+		LocalName:    "mochi_x_Printf",
+		TargetSymbol: "x.Printf",
+		Params: []apisurface.Param{
+			{Name: "format", Type: "string"},
+			{Name: "args", Type: "any"},
+		},
+		Variadic: true,
+	}
+	out, err := RenderLinkname(spec)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if !strings.Contains(out, "args ...any") {
+		t.Errorf("variadic param signature wrong:\n%s", out)
+	}
+}
+
+func TestRenderLinknameUnnamedParam(t *testing.T) {
+	spec := LinknameSpec{
+		LocalName:    "mochi_x_F",
+		TargetSymbol: "x.F",
+		Params:       []apisurface.Param{{Type: "int64"}, {Type: "string"}},
+	}
+	out, err := RenderLinkname(spec)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if !strings.Contains(out, "p0 int64, p1 string") {
+		t.Errorf("unnamed param synth wrong:\n%s", out)
+	}
+}
+
+func TestRenderLinknameRejectsInvalidSpec(t *testing.T) {
+	_, err := RenderLinkname(LinknameSpec{})
+	if !errors.Is(err, ErrTinygo) {
+		t.Fatalf("want ErrTinygo, got %v", err)
+	}
+}
+
+func TestRenderFileContainsBuildTagAndImport(t *testing.T) {
+	out, err := RenderFile("wrap", []LinknameSpec{{
+		LocalName:    "mochi_x_F",
+		TargetSymbol: "example.com/src.F",
+		Params:       []apisurface.Param{{Name: "v", Type: "int64"}},
+		Results:      []apisurface.Param{{Type: "int64"}},
+	}})
+	if err != nil {
+		t.Fatalf("RenderFile: %v", err)
+	}
+	for _, want := range []string{
+		"//go:build !mochi_no_linkname",
+		"package wrap",
+		"import _ \"unsafe\"",
+		"//go:linkname mochi_x_F example.com/src.F",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderFileRejectsEmptyPkgName(t *testing.T) {
+	_, err := RenderFile("", nil)
+	if !errors.Is(err, ErrTinygo) {
+		t.Errorf("want ErrTinygo, got %v", err)
+	}
+}
+
+func TestRenderFileBubblesSpecError(t *testing.T) {
+	_, err := RenderFile("wrap", []LinknameSpec{{LocalName: "x"}})
+	if !errors.Is(err, ErrTinygo) {
+		t.Errorf("want ErrTinygo, got %v", err)
+	}
+}
+
+func TestBannedImportListIsSorted(t *testing.T) {
+	for i := 1; i < len(BannedImports); i++ {
+		if BannedImports[i-1] >= BannedImports[i] {
+			t.Errorf("BannedImports not sorted at index %d: %q >= %q", i, BannedImports[i-1], BannedImports[i])
+		}
+	}
+}

--- a/website/docs/implementation/0074/index.md
+++ b/website/docs/implementation/0074/index.md
@@ -31,7 +31,7 @@ A phase is LANDED only when its gate is green for every applicable target (consu
 | 13 | Cosign-on-sibling-tag opt-in (`mochi pkg publish --cosign-sign`) | LANDED (baseline; 13.1+ deferred) | (pending) | [phase-13](/docs/implementation/0074/phase-13-cosign) |
 | 14 | Goroutine bridge (cgo handle pool + channel-as-handle + callback-as-handle) | LANDED (baseline; 14.1+ deferred) | (pending) | [phase-14](/docs/implementation/0074/phase-14-goroutine-bridge) |
 | 15 | Monomorphisation (`[go.monomorphise]` manifest + per-instantiation wrapper) | LANDED (baseline; 15.1+ deferred) | (pending) | [phase-15](/docs/implementation/0074/phase-15-monomorphise) |
-| 16 | TinyGo embedded subset (`profile = "embedded"` + `//go:linkname` wrapper) | NOT STARTED | — | [phase-16](/docs/implementation/0074/phase-16-tinygo-embedded) |
+| 16 | TinyGo embedded subset (`profile = "embedded"` + `//go:linkname` wrapper) | LANDED (baseline; 16.1+ deferred) | (pending) | [phase-16](/docs/implementation/0074/phase-16-tinygo-embedded) |
 | 17 | Vanity-import resolver + wasm-wasip1 / wasm-js publish gate (wazero host integration) | NOT STARTED | — | [phase-17](/docs/implementation/0074/phase-17-vanity-and-wasm) |
 
 ## Target coverage matrix
@@ -56,7 +56,7 @@ Each phase's LANDED gate must be green for every applicable target. `n/a` cells 
 | 13. cosign on tag.sig | LANDED (baseline) | n/a | n/a | n/a | n/a |
 | 14. goroutine bridge | LANDED (baseline) | required | required | n/a (no goroutines on wasm-js without scheduler shim) | required |
 | 15. monomorphisation | LANDED (baseline) | required | required | required | required |
-| 16. TinyGo embedded subset | NOT STARTED | n/a | n/a | required (wasm-js via tinygo) | required |
+| 16. TinyGo embedded subset | LANDED (baseline) | n/a | n/a | required (wasm-js via tinygo) | required |
 | 17. vanity-import + WASI publish | NOT STARTED | required | required | required | n/a |
 
 Cell legend: `required` means the phase's gate runs against this target; `n/a` means the phase's behaviour is intentionally not exercised on this target (architectural reason in parentheses).
@@ -109,7 +109,7 @@ The `package3/go/` location is shared with the broader MEP-57 polyglot package w
 
 ## Status snapshot
 
-As of 2026-05-30: phases 0-15 LANDED on `main` (phases 6 + 7 + 9 + 11 + 12 + 13 + 14 + 15 baseline only; phase 10 schema only; sub-phases 6.1+/7.1+/9.1+/10.1+/11.1+/12.1+/13.1+/14.1+/15.1+ deferred), phases 16-17 NOT STARTED.
+As of 2026-05-30: phases 0-16 LANDED on `main` (phases 6 + 7 + 9 + 11 + 12 + 13 + 14 + 15 + 16 baseline only; phase 10 schema only; sub-phases 6.1+/7.1+/9.1+/10.1+/11.1+/12.1+/13.1+/14.1+/15.1+/16.1+ deferred), phase 17 NOT STARTED.
 
 ## Cross-references
 

--- a/website/docs/implementation/0074/phase-16-tinygo-embedded.md
+++ b/website/docs/implementation/0074/phase-16-tinygo-embedded.md
@@ -1,0 +1,119 @@
+---
+title: "Phase 16. TinyGo embedded subset"
+sidebar_position: 18
+sidebar_label: "Phase 16. TinyGo embedded subset"
+description: "MEP-74 Phase 16 lands the `profile = \"embedded\"` opt-in: a closed banned-import + banned-type set that gates which Go surfaces TinyGo can compile, plus a `//go:linkname` wrapper renderer that binds wrapper symbols to source-module functions without cgo for the wasm-js / wasi-libc / baremetal targets where the regular `//export` c-archive path is unavailable."
+---
+
+# Phase 16. TinyGo embedded subset
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-74 §Phases](/docs/mep/mep-0074#phases) |
+| Status         | LANDED (baseline) |
+| Started        | 2026-05-30 00:43 (GMT+7) |
+| Landed         | 2026-05-30 00:55 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`TestPhase16TinygoSentinel` in `package3/go/tinygo/phase16_test.go` renders a `//go:linkname`-decorated wrapper file against a synthetic source module (two functions: `Double(int64) int64` and `Touch(int64)`) and asserts `go build ./...` accepts the file. The regular Go toolchain is used as the strictest available linkname-syntax proxy on CI (TinyGo is not assumed installed).
+
+`TestPhase16NoLinknameBuildTagFlip` exercises the opt-out path: under `-tags=mochi_no_linkname` the rendered file disappears (the `//go:build !mochi_no_linkname` header strips it), so a downstream `go vet` over the wrapper tree that doesn't want the directive still builds cleanly.
+
+`TestPhase16RenderFileDeterministic` hashes the rendered output 10 times and asserts SHA-256 constancy, load-bearing for the phase 10 wrapper-sha256 pin.
+
+`TestPhase16EmbeddedSubsetCompatibleSurface` walks a hand-curated "good" surface (only allowed imports, only allowed types) and asserts the embedded profile reports zero violations.
+
+`TestPhase16EmbeddedSubsetRejectsBadSurface` walks a hand-curated "bad" surface (one banned import + one banned-type result) and asserts both violations surface with the right kinds.
+
+Plus 21 unit tests in `tinygo_test.go`:
+
+- profile descriptor (`TestProfileIsValid`),
+- subset walker (`TestCheckPackageStandardIsNoop`, `TestCheckPackageDetectsBannedImports`, `TestCheckPackageDetectsBannedTypeInParam`, `TestCheckPackageDetectsBannedTypeInResult`, `TestCheckPackageStripWrappersHandlesSliceMapPointer`, `TestCheckPackageMethodViolation`, `TestCheckPackageInterfaceMethodViolation`, `TestCheckPackageSortStable`),
+- compatibility predicate (`TestIsCompatible`),
+- spec validation (`TestLinknameSpecValidate`),
+- single-spec renderer (`TestRenderLinknameContainsCanonicalParts`, `TestRenderLinknameZeroResult`, `TestRenderLinknameMultiResult`, `TestRenderLinknameVariadic`, `TestRenderLinknameUnnamedParam`, `TestRenderLinknameRejectsInvalidSpec`),
+- file renderer (`TestRenderFileContainsBuildTagAndImport`, `TestRenderFileRejectsEmptyPkgName`, `TestRenderFileBubblesSpecError`),
+- banned-list invariants (`TestBannedImportListIsSorted`).
+
+## Lowering decisions
+
+The tinygo package is a leaf module: it imports `package3/go/apisurface` for the surface walk and otherwise depends only on the Go stdlib (`errors`, `fmt`, `sort`, `strings`). It splits into three concerns: a profile descriptor + banned-set tables, a `CheckPackage` walker that produces deterministic `Violation` records, and a renderer that emits one `//go:linkname` wrapper per spec.
+
+**The embedded subset is a banned-set, not an allow-list.** The TinyGo team's compatibility matrix (as of TinyGo 0.30, 2026-Q1) names a closed set of stdlib packages that don't compile under any TinyGo target: reflection, runtime/debug, plugin, net/http, net/rpc, the debug/* family, encoding/gob, go/ast and friends, runtime/cgo, runtime/pprof, runtime/trace, syscall/js, text/template, unsafe. Phase 16 encodes that list as `BannedImports`. The default is allow: any stdlib (or third-party) import not in the banned set is considered embedded-compatible. The reason for banned-set rather than allow-list: TinyGo's compatible surface is large (most of the stdlib that doesn't touch reflection or the network is fine), so an allow-list would require keeping a much-longer mirror of the upstream stdlib.
+
+**The banned-type set is checked under wrapper-peeling.** A function param `[]reflect.Value` or `map[string]*runtime/cgo.Handle` is just as poisonous as the bare `reflect.Value`. `stripWrappers` peels `*`, `[]`, `[N]`, `...`, and `map[K]V` (the value half is the interesting part; map keys can't be reflect-backed in practice). The check is intentionally textual: the apisurface stores types as strings, and a deeper structural walk via `apisurface.ParseType` would require teaching the parser about every Go type form the embedded subset cares about, which is out of scope for the gate.
+
+**Violations are deterministically sorted.** `CheckPackage` sorts violations by `(Kind, Where)` via `sort.SliceStable` so the wrapper-synthesiser can fold them into the SkipReport with byte-stable output (which the phase 10 `wrapper-sha256` lockfile pin requires). The "import" violations sort lexicographically before "param-type" and "result-type" (the kinds are themselves chosen to alphabetise meaningfully).
+
+**The renderer uses `//go:linkname`, not `//export`.** TinyGo on wasm-js, wasi-libc, and baremetal targets has no working cgo; the regular phase 6 `//export` c-archive path requires cgo's runtime. `//go:linkname` is a compiler directive that aliases a local Go symbol to an arbitrary external symbol at link time — the wrapper has no body, the linker resolves both names to the same address. It works under both stock Go (with the `unsafe` import for the directive permission) and TinyGo. The trade-off: linkname'd symbols are not subject to the regular cgo-export contract, so the caller is responsible for matching the source signature exactly. The renderer's job is to make that signature byte-stable.
+
+**The rendered file is `//go:build !mochi_no_linkname`-gated.** A downstream `go vet` run that doesn't want to follow the linkname directive (linkname-chasing has been a frequent source of vet false positives in recent Go releases) can pass `-tags=mochi_no_linkname` to strip the file. The build tag is negative-form so the default (no tags) keeps the file visible.
+
+**The wrapper has no body.** A `//go:linkname` directive on a Go function declaration without a body is a hard contract: the linker MUST resolve the name to the target, or the build fails. This is intentional: a phantom body would create a real Go function at the local name and the linkname directive would attempt to overlay both definitions, producing a redeclaration error. Body-less linkname is the canonical TinyGo recipe.
+
+**`import _ "unsafe"` is the price of admission.** Go enforces that `//go:linkname` only works in a file that imports `unsafe` (even if the rest of the file doesn't use unsafe). The renderer hardcodes the import; callers that consume the rendered file do not need to add their own.
+
+**No `//go:wasmexport` emission yet.** The wasm-js target additionally needs a `//go:wasmexport <symbol>` directive to make the wrapper visible to the host JavaScript environment. That's phase 16.1: it requires per-target switching in the renderer (the standard linkname directive is universal, the wasmexport directive is wasm-js-specific). Phase 16 ships the universal baseline so the in-process gate stays target-agnostic.
+
+**The check is opt-in via profile, not always-on.** `CheckPackage(ProfileStandard, _)` returns nil. The wrapper-synthesiser only invokes the check when the user's `mochi.toml` declares `profile = "embedded"` for a given import. The default cgo path stays the canonical baseline.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/go/tinygo/tinygo.go` | `ErrTinygo`, `Profile` + `IsValid`, `BannedImports`, `BannedTypePrefixes`, `Violation` + `String`, `CheckPackage`, `IsCompatible`, `LinknameSpec` + `Validate`, `RenderLinkname`, `RenderFile`. |
+| `package3/go/tinygo/tinygo_test.go` | 21 unit tests covering profile descriptor, walker, predicates, validator, single-spec renderer, file renderer, and banned-list invariants. |
+| `package3/go/tinygo/phase16_test.go` | `TestPhase16TinygoSentinel` (rendered file compiles via `go build` against a synthetic source module), `TestPhase16NoLinknameBuildTagFlip` (opt-out tag strips file cleanly), `TestPhase16RenderFileDeterministic` (SHA-256 stability across 10 renders), plus `TestPhase16EmbeddedSubsetCompatibleSurface` / `TestPhase16EmbeddedSubsetRejectsBadSurface` covering both directions of the gate. |
+| `website/docs/implementation/0074/phase-16-tinygo-embedded.md` | (this page) |
+
+## Test set
+
+- `TestPhase16TinygoSentinel`
+- `TestPhase16EmbeddedSubsetCompatibleSurface`
+- `TestPhase16EmbeddedSubsetRejectsBadSurface`
+- `TestPhase16RenderFileDeterministic`
+- `TestPhase16NoLinknameBuildTagFlip`
+- 21 unit tests in `tinygo_test.go`
+
+Local run on darwin-arm64:
+
+```
+$ go test ./package3/go/tinygo/...
+ok      mochi/package3/go/tinygo        0.521s
+$ go test ./package3/go/...
+ok      mochi/package3/go/apisurface    (cached)
+ok      mochi/package3/go/build (cached)
+ok      mochi/package3/go/cmd/go-ingest (cached)
+ok      mochi/package3/go/cosign        (cached)
+ok      mochi/package3/go/emit  (cached)
+ok      mochi/package3/go/errors        (cached)
+ok      mochi/package3/go/goroutine     (cached)
+ok      mochi/package3/go/library       (cached)
+ok      mochi/package3/go/lockfile      (cached)
+ok      mochi/package3/go/moduleproxy   (cached)
+ok      mochi/package3/go/monomorphise  (cached)
+ok      mochi/package3/go/publish       (cached)
+ok      mochi/package3/go/semver        (cached)
+ok      mochi/package3/go/sumdb (cached)
+ok      mochi/package3/go/tinygo        0.257s
+ok      mochi/package3/go/typemap       (cached)
+ok      mochi/package3/go/wrapper       (cached)
+```
+
+## Closeout notes
+
+Phase 16 lands the TinyGo embedded-subset gate plus the `//go:linkname` wrapper renderer as a leaf module. Wrapper-synthesiser integration (calling `CheckPackage` + `RenderFile` once per embedded-profile import into the per-module wrapper output) is wired into phase 6's deferred sub-phases 6.1+.
+
+Future phase 16.x reservations:
+
+- **16.1** Per-target directive switching: the wasm-js target additionally needs `//go:wasmexport` next to `//go:linkname` to make the symbol visible to the host JavaScript runtime. Sub-phase 16.1 adds a `Target` field to `LinknameSpec` and emits the right directive set per target.
+- **16.2** Live TinyGo gate: replace the `go build` proxy in the sentinel with a real `tinygo build -target=wasm` invocation when TinyGo is installed; skip the gate on CI runners without TinyGo rather than fall back to the proxy.
+- **16.3** Per-symbol opt-in (`mochi.toml` `[go.linkname.<symbol>]` table) for cases where the user wants the linkname path on a per-export basis (e.g., one fast-path symbol in an otherwise cgo wrapper).
+- **16.4** Embedded-subset profile for third-party imports: the current banned set is stdlib-only; phase 16.4 lets users declare per-module bans for third-party packages that pull in disallowed stdlib transitively.
+- **16.5** Phase 6.1 wrapper-synth integration that ties `CheckPackage` + `RenderFile` into the per-module wrapper output and updates the lockfile.
+
+Phase 17 (vanity-import + WASI publish) is the final remaining phase; it consumes the same surface walk machinery and adds the publish-direction gate for wasm-wasip1 / wasm-js targets.

--- a/website/docs/mep/mep-0074.md
+++ b/website/docs/mep/mep-0074.md
@@ -398,7 +398,7 @@ A phase is LANDED only when its gate is green for every target in the matrix bel
 | 13. cosign on tag.sig | LANDED (baseline) | n/a | n/a | n/a | n/a |
 | 14. goroutine bridge | LANDED (baseline) | required | required | n/a (no goroutines on wasm-js without scheduler shim) | required |
 | 15. monomorphisation | LANDED (baseline) | required | required | required | required |
-| 16. TinyGo embedded subset | NOT STARTED | n/a | n/a | required (wasm-js via tinygo) | required |
+| 16. TinyGo embedded subset | LANDED (baseline) | n/a | n/a | required (wasm-js via tinygo) | required |
 | 17. vanity-import + WASI publish | NOT STARTED | required | required | required | n/a |
 
 A phase marked `n/a` for a target is intentional: the bridge does not promise the behaviour on that target.

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -373,7 +373,8 @@
       "implementation/0074/phase-12-git-tag-publish",
       "implementation/0074/phase-13-cosign",
       "implementation/0074/phase-14-goroutine-bridge",
-      "implementation/0074/phase-15-monomorphise"
+      "implementation/0074/phase-15-monomorphise",
+      "implementation/0074/phase-16-tinygo-embedded"
     ]
   },
   "implementation/0075/index",


### PR DESCRIPTION
## Summary

- Lands `package3/go/tinygo/`: closed banned-import + banned-type sets gate which Go surfaces compile under `profile = \"embedded\"`, plus a `//go:linkname` wrapper renderer that binds wrapper symbols to source-module functions without cgo for the wasm-js / wasi-libc / baremetal targets.
- Byte-deterministic renderer + sorted Violation reporting lock the phase 10 wrapper-sha256 pin.
- Phase 16 row + target matrix updated in both the MEP-74 spec and the implementation tracking index.

Tracking issue: #22966

## Test plan

- [x] `go test ./package3/go/tinygo/...` (21 unit tests + 5 sentinels)
- [x] `go test ./package3/go/...` (whole bridge suite green)
- [x] Sentinel verifies rendered //go:linkname wrappers compile via `go build ./...` against a synthetic source module
- [x] Opt-out build tag (`-tags=mochi_no_linkname`) strips the file and still builds cleanly
- [x] Determinism sentinel hashes RenderFile output 10 times and asserts SHA-256 constancy