### PR TITLE
MEP-52 Phase 12. Wire actual tracking issue + PR numbers in the spec doc

### DIFF
--- a/website/docs/implementation/0052/phase-12-ffi.md
+++ b/website/docs/implementation/0052/phase-12-ffi.md
@@ -13,8 +13,8 @@ description: "MEP-52 Phase 12, Mochi `extern fun` to inline-translated TypeScrip
 | Status         | LANDED (Node + Deno + Bun) |
 | Started        | 2026-05-30 00:47 (GMT+7) |
 | Landed         | 2026-05-30 00:50 (GMT+7) |
-| Tracking issue | (to be filled in on merge) |
-| Tracking PR    | (to be filled in on merge) |
+| Tracking issue | [#22969](https://github.com/mochilang/mochi/issues/22969) |
+| Tracking PR    | [#22972](https://github.com/mochilang/mochi/pull/22972) |
 
 ## Gate
 


### PR DESCRIPTION
Fixup of #22972 (Phase 12 landing). The spec doc carried placeholder lines for the tracking issue and PR; this PR replaces them with the actual numbers (#22969 + #22972).