### PR TITLE
feat(mep-70 p13): coroutines bridge — suspend fn blocking + event-loop dispatchers

### DIFF
--- a/package3/kotlin/coroutines/bridge.go
+++ b/package3/kotlin/coroutines/bridge.go
@@ -1,0 +1,269 @@
+// Package coroutines implements the MEP-70 Phase-13 coroutines bridge.
+//
+// Kotlin coroutines expose functions marked `suspend` whose return type is
+// Continuation<T>. At the JVM call site, the kotlinx-coroutines runtime
+// requires a CoroutineScope to dispatch them. The bridge synthesises two
+// patterns for every suspend fn in the type-map:
+//
+//  1. BlockingDispatcher — calls runBlocking{} inside the GraalVM native
+//     image C entry point. Blocks the calling Go goroutine until the
+//     coroutine completes. Safe for low-concurrency and CLI use.
+//
+//  2. EventLoopDispatcher — maintains a per-artifact single-threaded event
+//     loop (Dispatchers.Default on a fixed-thread pool). The C entry point
+//     posts the coroutine and returns a handle; the caller polls via a
+//     separate entry point until the result is ready.
+//
+// Both patterns are emitted as @CEntryPoint Java stubs that GraalVM compiles
+// to the shared library. This file contains:
+//   - DispatchMode enum
+//   - SuspendFn descriptor (name, parameters, return type, dispatch mode)
+//   - EmitBlockingStub / EmitEventLoopStub: generate the Java source fragments
+//   - EmitCoroutinesHelper: generate the shared CoroutinesHelper.java file
+package coroutines
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DispatchMode controls how a suspend fn is bridged.
+type DispatchMode int
+
+const (
+	// Blocking dispatches via runBlocking{}: the C entry point blocks until done.
+	Blocking DispatchMode = iota
+	// EventLoop dispatches on a per-artifact event loop; C entry point returns
+	// a future handle.
+	EventLoop
+)
+
+// Param is a single function parameter.
+type Param struct {
+	Name     string
+	JavaType string // Java type string, e.g. "String", "int", "long"
+}
+
+// SuspendFn describes one Kotlin suspend function to bridge.
+type SuspendFn struct {
+	// CName is the C entry point name (e.g. "mochi_okhttp_fetch_async").
+	CName string
+	// KotlinFQN is the fully-qualified Kotlin call expression
+	// (e.g. "com.squareup.okhttp3.OkHttpClient.fetchAsync").
+	KotlinFQN string
+	// Params are the non-continuation parameters.
+	Params []Param
+	// ReturnJavaType is the Java return type (e.g. "String", "void").
+	ReturnJavaType string
+	// Mode selects the dispatch strategy.
+	Mode DispatchMode
+}
+
+// EmitBlockingStub returns the Java @CEntryPoint source for a blocking-dispatch
+// suspend function.
+func EmitBlockingStub(fn SuspendFn) string {
+	var b strings.Builder
+	b.WriteString("    @CEntryPoint(name = \"")
+	b.WriteString(fn.CName)
+	b.WriteString("\")\n")
+	b.WriteString("    @Uninterruptible(reason = \"Called from unmanaged code\")\n")
+	fmt.Fprintf(&b, "    public static %s %s(IsolateThread thread",
+		fn.ReturnJavaType, javaMethodName(fn.CName))
+	for _, p := range fn.Params {
+		fmt.Fprintf(&b, ", %s %s", p.JavaType, p.Name)
+	}
+	b.WriteString(") {\n")
+	b.WriteString("        try {\n")
+	indent := "            "
+	callArgs := make([]string, len(fn.Params))
+	for i, p := range fn.Params {
+		callArgs[i] = p.Name
+	}
+	call := fn.KotlinFQN + "(" + strings.Join(callArgs, ", ") + ")"
+	if fn.ReturnJavaType == "void" {
+		fmt.Fprintf(&b, "%skotlinx.coroutines.BuildersKt.runBlocking(\n", indent)
+		fmt.Fprintf(&b, "%s    kotlinx.coroutines.EmptyCoroutineContext.INSTANCE,\n", indent)
+		fmt.Fprintf(&b, "%s    (scope, continuation) -> { %s; return null; }\n", indent, call)
+		b.WriteString(indent + ");\n")
+	} else {
+		fmt.Fprintf(&b, "%sreturn (%s) kotlinx.coroutines.BuildersKt.runBlocking(\n", indent, fn.ReturnJavaType)
+		fmt.Fprintf(&b, "%s    kotlinx.coroutines.EmptyCoroutineContext.INSTANCE,\n", indent)
+		fmt.Fprintf(&b, "%s    (scope, continuation) -> %s\n", indent, call)
+		b.WriteString(indent + ");\n")
+	}
+	b.WriteString("        } catch (Exception e) {\n")
+	b.WriteString("            throw new RuntimeException(e);\n")
+	b.WriteString("        }\n")
+	b.WriteString("    }\n")
+	return b.String()
+}
+
+// EmitEventLoopStub returns the Java @CEntryPoint source for an event-loop-dispatch
+// suspend function.  It generates two entry points:
+//   - <cname>_submit(thread, ...params) → long handleId
+//   - <cname>_poll(thread, handleId)   → returns result or throws if pending
+func EmitEventLoopStub(fn SuspendFn) string {
+	var b strings.Builder
+	methodName := javaMethodName(fn.CName)
+	callArgs := make([]string, len(fn.Params))
+	for i, p := range fn.Params {
+		callArgs[i] = p.Name
+	}
+	call := fn.KotlinFQN + "(" + strings.Join(callArgs, ", ") + ")"
+
+	// submit entry point
+	b.WriteString("    @CEntryPoint(name = \"")
+	b.WriteString(fn.CName)
+	b.WriteString("_submit\")\n")
+	b.WriteString("    @Uninterruptible(reason = \"Called from unmanaged code\")\n")
+	fmt.Fprintf(&b, "    public static long %sSubmit(IsolateThread thread", methodName)
+	for _, p := range fn.Params {
+		fmt.Fprintf(&b, ", %s %s", p.JavaType, p.Name)
+	}
+	b.WriteString(") {\n")
+	fmt.Fprintf(&b, "        return CoroutinesHelper.submit(() -> %s);\n", call)
+	b.WriteString("    }\n\n")
+
+	// poll entry point
+	b.WriteString("    @CEntryPoint(name = \"")
+	b.WriteString(fn.CName)
+	b.WriteString("_poll\")\n")
+	b.WriteString("    @Uninterruptible(reason = \"Called from unmanaged code\")\n")
+	fmt.Fprintf(&b, "    public static %s %sPoll(IsolateThread thread, long handleId) {\n",
+		fn.ReturnJavaType, methodName)
+	b.WriteString("        return CoroutinesHelper.poll(handleId);\n")
+	b.WriteString("    }\n")
+	return b.String()
+}
+
+// EmitCoroutinesHelper generates the CoroutinesHelper.java source file that
+// implements the event-loop submit/poll mechanism.
+func EmitCoroutinesHelper(packageName string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "package %s;\n\n", packageName)
+	b.WriteString(`import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import kotlinx.coroutines.GlobalScope;
+import kotlinx.coroutines.Dispatchers;
+import kotlinx.coroutines.future.FutureKt;
+
+/**
+ * CoroutinesHelper manages an event-loop handle registry for suspend function
+ * results. Each submitted coroutine gets a unique handle ID; the caller polls
+ * until the result is ready.
+ */
+public class CoroutinesHelper {
+    private static final AtomicLong COUNTER = new AtomicLong(1);
+    private static final ConcurrentHashMap<Long, CompletableFuture<Object>> FUTURES =
+        new ConcurrentHashMap<>();
+
+    /** Submit a suspend-fn supplier to the coroutines event loop.  Returns a handle ID. */
+    @SuppressWarnings("unchecked")
+    public static <T> long submit(Supplier<T> supplier) {
+        long id = COUNTER.getAndIncrement();
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        FutureKt.future(GlobalScope.INSTANCE, Dispatchers.getDefault(), null,
+            (scope, continuation) -> {
+                try {
+                    future.complete((Object) supplier.get());
+                } catch (Exception e) {
+                    future.completeExceptionally(e);
+                }
+                return null;
+            });
+        FUTURES.put(id, future);
+        return id;
+    }
+
+    /** Poll for the result of handle ID.  Returns the result if done, or throws PendingException. */
+    @SuppressWarnings("unchecked")
+    public static <T> T poll(long id) {
+        CompletableFuture<Object> f = FUTURES.get(id);
+        if (f == null) throw new IllegalArgumentException("unknown handle: " + id);
+        if (!f.isDone()) throw new PendingException(id);
+        FUTURES.remove(id);
+        try {
+            return (T) f.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Thrown by poll() when the coroutine has not yet completed. */
+    public static class PendingException extends RuntimeException {
+        public final long handleId;
+        public PendingException(long id) {
+            super("coroutine " + id + " not yet complete");
+            this.handleId = id;
+        }
+    }
+}
+`)
+	return b.String()
+}
+
+// ShimLines returns the shim.mochi lines for a suspend fn in blocking mode:
+//
+//	extern fn <cname>(params...) : <mochiReturnType> from kotlin "<KotlinFQN>"
+func ShimLines(fn SuspendFn, mochiReturnType string) string {
+	var parts []string
+	for _, p := range fn.Params {
+		parts = append(parts, p.Name+": "+javaTypeToMochi(p.JavaType))
+	}
+	paramsStr := strings.Join(parts, ", ")
+	if fn.Mode == EventLoop {
+		// Event-loop mode exposes two extern fns per suspend fn.
+		submitLine := fmt.Sprintf("extern fn %s_submit(%s): int from kotlin %q",
+			fn.CName, paramsStr, fn.KotlinFQN)
+		pollLine := fmt.Sprintf("extern fn %s_poll(handle: int): %s from kotlin %q",
+			fn.CName, mochiReturnType, fn.KotlinFQN)
+		return submitLine + "\n" + pollLine
+	}
+	return fmt.Sprintf("extern fn %s(%s): %s from kotlin %q",
+		fn.CName, paramsStr, mochiReturnType, fn.KotlinFQN)
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+// javaMethodName converts a C-style snake_case name to camelCase Java method name.
+func javaMethodName(cname string) string {
+	parts := strings.Split(cname, "_")
+	if len(parts) == 0 {
+		return cname
+	}
+	var b strings.Builder
+	for i, p := range parts {
+		if i == 0 {
+			b.WriteString(p)
+		} else if len(p) > 0 {
+			b.WriteString(strings.ToUpper(p[:1]))
+			b.WriteString(p[1:])
+		}
+	}
+	return b.String()
+}
+
+// javaTypeToMochi converts a Java type string to its Mochi equivalent.
+func javaTypeToMochi(jt string) string {
+	switch jt {
+	case "int", "Integer":
+		return "int"
+	case "long", "Long":
+		return "int"
+	case "float", "Float":
+		return "float"
+	case "double", "Double":
+		return "float"
+	case "boolean", "Boolean":
+		return "bool"
+	case "String":
+		return "string"
+	case "void":
+		return "unit"
+	default:
+		return "any"
+	}
+}

--- a/package3/kotlin/coroutines/bridge_test.go
+++ b/package3/kotlin/coroutines/bridge_test.go
@@ -1,0 +1,172 @@
+package coroutines
+
+import (
+	"strings"
+	"testing"
+)
+
+// ─── javaMethodName ───────────────────────────────────────────────────────────
+
+func TestJavaMethodName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"fetch", "fetch"},
+		{"mochi_okhttp_fetch", "mochiOkhttpFetch"},
+		{"mochi_okhttp_fetch_async", "mochiOkhttpFetchAsync"},
+		{"a_b_c", "aBC"},
+		{"already", "already"},
+	}
+	for _, c := range cases {
+		if got := javaMethodName(c.in); got != c.want {
+			t.Errorf("javaMethodName(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// ─── javaTypeToMochi ──────────────────────────────────────────────────────────
+
+func TestJavaTypeToMochi(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"int", "int"},
+		{"Integer", "int"},
+		{"long", "int"},
+		{"float", "float"},
+		{"double", "float"},
+		{"boolean", "bool"},
+		{"String", "string"},
+		{"void", "unit"},
+		{"MyCustomType", "any"},
+	}
+	for _, c := range cases {
+		if got := javaTypeToMochi(c.in); got != c.want {
+			t.Errorf("javaTypeToMochi(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// ─── EmitBlockingStub ─────────────────────────────────────────────────────────
+
+func TestEmitBlockingStub_Void(t *testing.T) {
+	fn := SuspendFn{
+		CName:          "mochi_client_send",
+		KotlinFQN:      "com.example.Client.send",
+		Params:         []Param{{Name: "msg", JavaType: "String"}},
+		ReturnJavaType: "void",
+		Mode:           Blocking,
+	}
+	stub := EmitBlockingStub(fn)
+
+	mustContain(t, stub, "@CEntryPoint(name = \"mochi_client_send\")")
+	mustContain(t, stub, "public static void mochiClientSend(IsolateThread thread, String msg)")
+	mustContain(t, stub, "runBlocking")
+	mustContain(t, stub, "com.example.Client.send(msg)")
+}
+
+func TestEmitBlockingStub_WithReturn(t *testing.T) {
+	fn := SuspendFn{
+		CName:          "mochi_fetcher_get",
+		KotlinFQN:      "com.example.Fetcher.get",
+		Params:         []Param{{Name: "url", JavaType: "String"}},
+		ReturnJavaType: "String",
+		Mode:           Blocking,
+	}
+	stub := EmitBlockingStub(fn)
+
+	mustContain(t, stub, "public static String mochiFetcherGet(IsolateThread thread")
+	mustContain(t, stub, "return (String) kotlinx.coroutines.BuildersKt.runBlocking")
+	mustContain(t, stub, "com.example.Fetcher.get(url)")
+}
+
+func TestEmitBlockingStub_NoParams(t *testing.T) {
+	fn := SuspendFn{
+		CName:          "mochi_health_check",
+		KotlinFQN:      "com.example.Api.healthCheck",
+		ReturnJavaType: "boolean",
+		Mode:           Blocking,
+	}
+	stub := EmitBlockingStub(fn)
+	mustContain(t, stub, "public static boolean mochiHealthCheck(IsolateThread thread)")
+	mustContain(t, stub, "com.example.Api.healthCheck()")
+}
+
+// ─── EmitEventLoopStub ────────────────────────────────────────────────────────
+
+func TestEmitEventLoopStub_SubmitAndPoll(t *testing.T) {
+	fn := SuspendFn{
+		CName:          "mochi_parser_parse",
+		KotlinFQN:      "com.example.Parser.parse",
+		Params:         []Param{{Name: "input", JavaType: "String"}},
+		ReturnJavaType: "String",
+		Mode:           EventLoop,
+	}
+	stub := EmitEventLoopStub(fn)
+
+	mustContain(t, stub, "@CEntryPoint(name = \"mochi_parser_parse_submit\")")
+	mustContain(t, stub, "public static long mochiParserParseSubmit(IsolateThread thread, String input)")
+	mustContain(t, stub, "CoroutinesHelper.submit(")
+
+	mustContain(t, stub, "@CEntryPoint(name = \"mochi_parser_parse_poll\")")
+	mustContain(t, stub, "public static String mochiParserParsePoll(IsolateThread thread, long handleId)")
+	mustContain(t, stub, "CoroutinesHelper.poll(handleId)")
+}
+
+// ─── EmitCoroutinesHelper ─────────────────────────────────────────────────────
+
+func TestEmitCoroutinesHelper_Package(t *testing.T) {
+	code := EmitCoroutinesHelper("com.mochi.bridge.okhttp")
+	mustContain(t, code, "package com.mochi.bridge.okhttp;")
+	mustContain(t, code, "class CoroutinesHelper")
+	mustContain(t, code, "long submit(")
+	mustContain(t, code, "class PendingException")
+}
+
+// ─── ShimLines ────────────────────────────────────────────────────────────────
+
+func TestShimLines_Blocking(t *testing.T) {
+	fn := SuspendFn{
+		CName:          "mochi_api_call",
+		KotlinFQN:      "com.example.Api.call",
+		Params:         []Param{{Name: "req", JavaType: "String"}},
+		ReturnJavaType: "String",
+		Mode:           Blocking,
+	}
+	line := ShimLines(fn, "string")
+	if !strings.HasPrefix(line, "extern fn mochi_api_call(") {
+		t.Errorf("blocking shim line: %q", line)
+	}
+	mustContain(t, line, "): string from kotlin")
+	mustContain(t, line, "com.example.Api.call")
+	// Should be a single line (no newline in the middle).
+	if strings.Count(line, "\n") > 0 {
+		t.Errorf("blocking shim should be one line, got:\n%s", line)
+	}
+}
+
+func TestShimLines_EventLoop(t *testing.T) {
+	fn := SuspendFn{
+		CName:          "mochi_api_call",
+		KotlinFQN:      "com.example.Api.call",
+		Params:         []Param{{Name: "req", JavaType: "String"}},
+		ReturnJavaType: "String",
+		Mode:           EventLoop,
+	}
+	lines := ShimLines(fn, "string")
+	if strings.Count(lines, "\n") != 1 {
+		t.Errorf("event-loop shim should have 2 lines, got:\n%s", lines)
+	}
+	mustContain(t, lines, "mochi_api_call_submit")
+	mustContain(t, lines, "mochi_api_call_poll")
+	mustContain(t, lines, "handle: int")
+}
+
+// ─── helper ───────────────────────────────────────────────────────────────────
+
+func mustContain(t *testing.T, s, sub string) {
+	t.Helper()
+	if !strings.Contains(s, sub) {
+		t.Errorf("expected to find %q in:\n%s", sub, s)
+	}
+}


### PR DESCRIPTION
Closes #22974

- `EmitBlockingStub`: runBlocking{} wrapper as @CEntryPoint
- `EmitEventLoopStub`: submit/poll pair with handle registry
- `EmitCoroutinesHelper`: CoroutinesHelper.java generator
- `ShimLines`: shim.mochi extern fn declarations

9 tests pass.