### PR TITLE
feat(mep-71 p13): abi3 wheel slimming + auditwheel-equivalent platform validator

### DIFF
--- a/package3/python/abi3/audit.go
+++ b/package3/python/abi3/audit.go
@@ -1,0 +1,131 @@
+package abi3
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// LinkedLib is one entry from a C extension's dynamic-link table: the
+// soname the linker recorded (e.g. "libc.so.6" on Linux,
+// "/usr/lib/libSystem.B.dylib" on macOS, "KERNEL32.dll" on Windows) +
+// the resolved on-disk path the loader would use (empty when not
+// resolved). External is true when the lib is provided by the host
+// system rather than vendored into the wheel; the auditor only judges
+// external libs against the profile allow-list.
+type LinkedLib struct {
+	SoName   string
+	Path     string
+	External bool
+}
+
+// SymbolReader is the IO seam the auditor uses to walk a native
+// extension's dynamic-link table. Production callers wire an ELF /
+// Mach-O / PE reader (sub-phase 13.1); tests inject a fake.
+type SymbolReader interface {
+	Read(path string) ([]LinkedLib, error)
+}
+
+// AuditOptions bundles the profile to audit against + the reader to
+// extract link information through.
+type AuditOptions struct {
+	Profile ManylinuxProfile
+	Reader  SymbolReader
+}
+
+// AuditReport is the auditor's verdict on a single C extension.
+// External holds the external lib set the auditor saw; Allowed and
+// Disallowed partition them by the profile allow-list. Violations is
+// the human-readable summary the CLI surfaces; OK is true iff
+// Disallowed is empty and the profile was recognised.
+type AuditReport struct {
+	Path       string
+	External   []LinkedLib
+	Allowed    []LinkedLib
+	Disallowed []LinkedLib
+	Violations []string
+	OK         bool
+}
+
+// AuditExtension reads the linked libs at path through opts.Reader and
+// classifies them against opts.Profile. Internal libs (External=false)
+// are recorded but never violate; external libs not in the profile's
+// allow-list become violations.
+//
+// AuditExtension never inspects the filesystem itself — that is the
+// SymbolReader's job. It returns an error only when Reader returns an
+// error (missing file, unreadable header, ...) or when the profile is
+// the zero value (caller forgot to look it up).
+func AuditExtension(path string, opts AuditOptions) (*AuditReport, error) {
+	if opts.Reader == nil {
+		return nil, fmt.Errorf("abi3: AuditExtension requires a SymbolReader")
+	}
+	if opts.Profile.Tag == "" {
+		return nil, fmt.Errorf("abi3: AuditExtension requires a non-empty profile")
+	}
+	libs, err := opts.Reader.Read(path)
+	if err != nil {
+		return nil, fmt.Errorf("abi3: read %q: %w", path, err)
+	}
+	rep := &AuditReport{Path: path}
+	for _, l := range libs {
+		if !l.External {
+			continue
+		}
+		rep.External = append(rep.External, l)
+		if opts.Profile.Allows(l.SoName) {
+			rep.Allowed = append(rep.Allowed, l)
+			continue
+		}
+		rep.Disallowed = append(rep.Disallowed, l)
+		rep.Violations = append(rep.Violations,
+			fmt.Sprintf("%s: external lib %q is not in the %s allow-list",
+				path, l.SoName, opts.Profile.Tag))
+	}
+	sortLibsByName(rep.External)
+	sortLibsByName(rep.Allowed)
+	sortLibsByName(rep.Disallowed)
+	sort.Strings(rep.Violations)
+	rep.OK = len(rep.Disallowed) == 0
+	return rep, nil
+}
+
+// AuditWheel audits every extension file in a wheel's name table. The
+// caller supplies the file list (typically from wheel RECORD), and the
+// auditor invokes AuditExtension against each .so / .dylib / .pyd. The
+// aggregate report's OK flag is true iff every per-extension report
+// was OK.
+func AuditWheel(extensions []string, opts AuditOptions) ([]*AuditReport, bool, error) {
+	reports := make([]*AuditReport, 0, len(extensions))
+	allOK := true
+	for _, ext := range extensions {
+		if !IsExtensionFilename(ext) {
+			continue
+		}
+		r, err := AuditExtension(ext, opts)
+		if err != nil {
+			return nil, false, err
+		}
+		reports = append(reports, r)
+		if !r.OK {
+			allOK = false
+		}
+	}
+	return reports, allOK, nil
+}
+
+// IsExtensionFilename reports whether name has a C-extension suffix.
+// The check is purely lexical; the auditor never opens the file.
+func IsExtensionFilename(name string) bool {
+	lower := strings.ToLower(name)
+	for _, ext := range []string{".so", ".dylib", ".pyd"} {
+		if strings.HasSuffix(lower, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+func sortLibsByName(s []LinkedLib) {
+	sort.Slice(s, func(i, j int) bool { return s[i].SoName < s[j].SoName })
+}

--- a/package3/python/abi3/audit_test.go
+++ b/package3/python/abi3/audit_test.go
@@ -1,0 +1,152 @@
+package abi3
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeReader struct {
+	libs map[string][]LinkedLib
+	err  error
+}
+
+func (f fakeReader) Read(path string) ([]LinkedLib, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.libs[path], nil
+}
+
+func TestAuditExtensionRequiresReader(t *testing.T) {
+	if _, err := AuditExtension("/x.so", AuditOptions{Profile: KnownProfiles["manylinux_2_28_x86_64"]}); err == nil {
+		t.Fatal("AuditExtension should reject nil reader")
+	}
+}
+
+func TestAuditExtensionRequiresProfile(t *testing.T) {
+	r := fakeReader{libs: map[string][]LinkedLib{}}
+	if _, err := AuditExtension("/x.so", AuditOptions{Reader: r}); err == nil {
+		t.Fatal("AuditExtension should reject zero profile")
+	}
+}
+
+func TestAuditExtensionHappyPath(t *testing.T) {
+	r := fakeReader{libs: map[string][]LinkedLib{
+		"/wheel/foo.so": {
+			{SoName: "libc.so.6", External: true},
+			{SoName: "libm.so.6", External: true},
+			{SoName: "libfoo.so.0", External: false}, // internal vendored
+		},
+	}}
+	rep, err := AuditExtension("/wheel/foo.so", AuditOptions{
+		Profile: KnownProfiles["manylinux_2_28_x86_64"],
+		Reader:  r,
+	})
+	if err != nil {
+		t.Fatalf("AuditExtension: %v", err)
+	}
+	if !rep.OK {
+		t.Fatalf("expected OK report, got violations: %v", rep.Violations)
+	}
+	if len(rep.External) != 2 {
+		t.Errorf("External count = %d", len(rep.External))
+	}
+	if len(rep.Disallowed) != 0 {
+		t.Errorf("Disallowed should be empty: %v", rep.Disallowed)
+	}
+}
+
+func TestAuditExtensionFlagsDisallowedExternal(t *testing.T) {
+	r := fakeReader{libs: map[string][]LinkedLib{
+		"/wheel/bar.so": {
+			{SoName: "libc.so.6", External: true},
+			{SoName: "libssl.so.3", External: true},
+		},
+	}}
+	rep, err := AuditExtension("/wheel/bar.so", AuditOptions{
+		Profile: KnownProfiles["manylinux_2_28_x86_64"],
+		Reader:  r,
+	})
+	if err != nil {
+		t.Fatalf("AuditExtension: %v", err)
+	}
+	if rep.OK {
+		t.Fatal("expected report to be not-OK")
+	}
+	if len(rep.Disallowed) != 1 || rep.Disallowed[0].SoName != "libssl.so.3" {
+		t.Errorf("Disallowed wrong: %+v", rep.Disallowed)
+	}
+	found := false
+	for _, v := range rep.Violations {
+		if strings.Contains(v, "libssl.so.3") && strings.Contains(v, "manylinux_2_28_x86_64") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("violation message missing: %v", rep.Violations)
+	}
+}
+
+func TestAuditExtensionPropagatesReaderError(t *testing.T) {
+	r := fakeReader{err: errors.New("not an ELF")}
+	_, err := AuditExtension("/wheel/x.so", AuditOptions{
+		Profile: KnownProfiles["manylinux_2_28_x86_64"],
+		Reader:  r,
+	})
+	if err == nil || !strings.Contains(err.Error(), "not an ELF") {
+		t.Fatalf("expected reader error, got %v", err)
+	}
+}
+
+func TestIsExtensionFilename(t *testing.T) {
+	yes := []string{"foo.so", "bar.dylib", "baz.pyd", "FOO.SO"}
+	no := []string{"foo.py", "bar.pyi", "metadata"}
+	for _, n := range yes {
+		if !IsExtensionFilename(n) {
+			t.Errorf("%q should be an extension", n)
+		}
+	}
+	for _, n := range no {
+		if IsExtensionFilename(n) {
+			t.Errorf("%q should NOT be an extension", n)
+		}
+	}
+}
+
+func TestAuditWheel(t *testing.T) {
+	r := fakeReader{libs: map[string][]LinkedLib{
+		"a.so": {{SoName: "libc.so.6", External: true}},
+		"b.so": {{SoName: "libssl.so.3", External: true}},
+	}}
+	files := []string{"a.so", "metadata.txt", "b.so", "c.py"}
+	reports, ok, err := AuditWheel(files, AuditOptions{
+		Profile: KnownProfiles["manylinux_2_28_x86_64"],
+		Reader:  r,
+	})
+	if err != nil {
+		t.Fatalf("AuditWheel: %v", err)
+	}
+	if ok {
+		t.Fatal("expected aggregate ok=false")
+	}
+	if len(reports) != 2 {
+		t.Fatalf("expected 2 reports (skip non-.so), got %d", len(reports))
+	}
+}
+
+func TestAuditWheelAllOK(t *testing.T) {
+	r := fakeReader{libs: map[string][]LinkedLib{
+		"a.so": {{SoName: "libc.so.6", External: true}},
+	}}
+	_, ok, err := AuditWheel([]string{"a.so"}, AuditOptions{
+		Profile: KnownProfiles["manylinux_2_28_x86_64"],
+		Reader:  r,
+	})
+	if err != nil {
+		t.Fatalf("AuditWheel: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected aggregate ok=true")
+	}
+}

--- a/package3/python/abi3/doc.go
+++ b/package3/python/abi3/doc.go
@@ -1,0 +1,36 @@
+// Package abi3 implements MEP-71 Phase 13: abi3 wheel slimming + the
+// auditwheel-equivalent platform tag validator.
+//
+// Two responsibilities, both pure policy with the IO mockable:
+//
+//   - Wheel tag handling per PEP 425 / PEP 600 / PEP 656. ParseWheelTag
+//     splits a wheel filename's `{python}-{abi}-{platform}` triple, and
+//     ToABI3 promotes a single-version tag (`cp312-cp312-...`) to the
+//     limited-API form (`cp32-abi3-...`) when the extension only uses
+//     Py_LIMITED_API symbols. The limited-API form ships once and
+//     resolves on every CPython ≥ 3.2, which is the slimming win.
+//
+//   - Platform tag validation, the auditwheel job. KnownProfiles maps
+//     every supported tag (manylinux_2_17 / 2_28 / 2_34, musllinux_1_2,
+//     macosx_*, win_*) to its allowed-libs list (the libc + libm
+//     baseline expected on the target platform). AuditExtension reads
+//     the linked libs of a .so / .dylib / .pyd via a SymbolReader
+//     interface, classifies each as in-policy or external, and reports
+//     violations. The SymbolReader interface is intentionally minimal
+//     (just `Read(path) ([]LinkedLib, error)`) so the bridge can swap
+//     between the real ELF / Mach-O / PE walker in production and a
+//     mock in the gate tests.
+//
+// Layout:
+//
+//   - tag.go: WheelTag + ParseWheelTag + ToABI3 + filename helpers.
+//   - manylinux.go: ManylinuxProfile + KnownProfiles + LookupProfile.
+//   - audit.go: LinkedLib + SymbolReader + AuditReport + AuditExtension.
+//   - slim.go: RenameWheelFilename + RenderWHEELMarker for the
+//     wheel-side rewrite that downstream packers apply.
+//
+// Live ELF / Mach-O / PE reading is sub-phase 13.1, not covered here.
+// abi3 promotion that walks the C extension's symbol references to
+// confirm Py_LIMITED_API discipline is sub-phase 13.2; this phase ships
+// the policy layer that the discipline check will feed into.
+package abi3

--- a/package3/python/abi3/manylinux.go
+++ b/package3/python/abi3/manylinux.go
@@ -1,0 +1,175 @@
+package abi3
+
+import "sort"
+
+// ManylinuxProfile is the policy entry for one platform tag: which
+// shared libraries the wheel may legitimately link against without
+// shipping them inside the wheel's .libs/ vendoring directory.
+//
+// The Tag matches the platform field of a WheelTag (e.g.
+// "manylinux_2_28_x86_64"). MinGlibc is the minimum glibc version
+// implied by the tag (empty for non-glibc tags like musllinux / macos /
+// windows). AllowedLibs is the sorted soname list — every external lib
+// outside this set is a violation.
+type ManylinuxProfile struct {
+	Tag         string
+	MinGlibc    string
+	AllowedLibs []string
+}
+
+// Allows reports whether soname is in the profile's allow-list.
+func (p ManylinuxProfile) Allows(soname string) bool {
+	i := sort.SearchStrings(p.AllowedLibs, soname)
+	return i < len(p.AllowedLibs) && p.AllowedLibs[i] == soname
+}
+
+// KnownProfiles is the closed table of platform tags MEP-71 ships
+// auditing rules for. The allow-lists track the upstream PEP 600
+// manylinux + PEP 656 musllinux baselines plus the macOS / Windows
+// system libraries that uv / pip / auditwheel treat as always-present.
+// Lists must remain sorted (KnownProfiles is consumed via binary
+// search through Allows).
+var KnownProfiles = map[string]ManylinuxProfile{
+	"manylinux_2_17_x86_64": {
+		Tag:      "manylinux_2_17_x86_64",
+		MinGlibc: "2.17",
+		AllowedLibs: []string{
+			"ld-linux-x86-64.so.2",
+			"libc.so.6",
+			"libdl.so.2",
+			"libm.so.6",
+			"libpthread.so.0",
+			"libresolv.so.2",
+			"librt.so.1",
+			"libutil.so.1",
+		},
+	},
+	"manylinux_2_28_x86_64": {
+		Tag:      "manylinux_2_28_x86_64",
+		MinGlibc: "2.28",
+		AllowedLibs: []string{
+			"ld-linux-x86-64.so.2",
+			"libc.so.6",
+			"libdl.so.2",
+			"libgcc_s.so.1",
+			"libm.so.6",
+			"libpthread.so.0",
+			"libresolv.so.2",
+			"librt.so.1",
+			"libstdc++.so.6",
+			"libutil.so.1",
+		},
+	},
+	"manylinux_2_34_x86_64": {
+		Tag:      "manylinux_2_34_x86_64",
+		MinGlibc: "2.34",
+		AllowedLibs: []string{
+			"ld-linux-x86-64.so.2",
+			"libc.so.6",
+			"libgcc_s.so.1",
+			"libm.so.6",
+			"libstdc++.so.6",
+		},
+	},
+	"manylinux_2_17_aarch64": {
+		Tag:      "manylinux_2_17_aarch64",
+		MinGlibc: "2.17",
+		AllowedLibs: []string{
+			"ld-linux-aarch64.so.1",
+			"libc.so.6",
+			"libdl.so.2",
+			"libm.so.6",
+			"libpthread.so.0",
+			"libresolv.so.2",
+			"librt.so.1",
+			"libutil.so.1",
+		},
+	},
+	"manylinux_2_28_aarch64": {
+		Tag:      "manylinux_2_28_aarch64",
+		MinGlibc: "2.28",
+		AllowedLibs: []string{
+			"ld-linux-aarch64.so.1",
+			"libc.so.6",
+			"libdl.so.2",
+			"libgcc_s.so.1",
+			"libm.so.6",
+			"libpthread.so.0",
+			"libstdc++.so.6",
+		},
+	},
+	"musllinux_1_2_x86_64": {
+		Tag: "musllinux_1_2_x86_64",
+		AllowedLibs: []string{
+			"ld-musl-x86_64.so.1",
+			"libc.musl-x86_64.so.1",
+		},
+	},
+	"musllinux_1_2_aarch64": {
+		Tag: "musllinux_1_2_aarch64",
+		AllowedLibs: []string{
+			"ld-musl-aarch64.so.1",
+			"libc.musl-aarch64.so.1",
+		},
+	},
+	"macosx_11_0_arm64": {
+		Tag: "macosx_11_0_arm64",
+		AllowedLibs: []string{
+			"/usr/lib/libSystem.B.dylib",
+			"/usr/lib/libc++.1.dylib",
+			"/usr/lib/libobjc.A.dylib",
+			"/usr/lib/libresolv.9.dylib",
+		},
+	},
+	"macosx_10_15_x86_64": {
+		Tag: "macosx_10_15_x86_64",
+		AllowedLibs: []string{
+			"/usr/lib/libSystem.B.dylib",
+			"/usr/lib/libc++.1.dylib",
+			"/usr/lib/libobjc.A.dylib",
+			"/usr/lib/libresolv.9.dylib",
+		},
+	},
+	"win_amd64": {
+		Tag: "win_amd64",
+		AllowedLibs: []string{
+			"ADVAPI32.dll",
+			"KERNEL32.dll",
+			"MSVCP140.dll",
+			"USER32.dll",
+			"VCRUNTIME140.dll",
+			"VCRUNTIME140_1.dll",
+			"api-ms-win-crt-runtime-l1-1-0.dll",
+		},
+	},
+	"win_arm64": {
+		Tag: "win_arm64",
+		AllowedLibs: []string{
+			"ADVAPI32.dll",
+			"KERNEL32.dll",
+			"MSVCP140.dll",
+			"USER32.dll",
+			"VCRUNTIME140.dll",
+			"api-ms-win-crt-runtime-l1-1-0.dll",
+		},
+	},
+}
+
+// LookupProfile returns the profile for tag, or ok=false when the tag
+// is unknown to the bridge. Callers should treat unknown tags as audit
+// failures rather than silently auditing against the wrong policy.
+func LookupProfile(tag string) (ManylinuxProfile, bool) {
+	p, ok := KnownProfiles[tag]
+	return p, ok
+}
+
+// ProfileTags returns the sorted slice of known tag names. Useful for
+// surfacing the supported-platform set in CLI help text.
+func ProfileTags() []string {
+	out := make([]string, 0, len(KnownProfiles))
+	for k := range KnownProfiles {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/package3/python/abi3/manylinux_test.go
+++ b/package3/python/abi3/manylinux_test.go
@@ -1,0 +1,76 @@
+package abi3
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestKnownProfilesSorted(t *testing.T) {
+	for tag, p := range KnownProfiles {
+		if p.Tag != tag {
+			t.Errorf("profile %q has Tag %q", tag, p.Tag)
+		}
+		if !sort.StringsAreSorted(p.AllowedLibs) {
+			t.Errorf("profile %q AllowedLibs is unsorted: %v", tag, p.AllowedLibs)
+		}
+	}
+}
+
+func TestLookupProfile(t *testing.T) {
+	if _, ok := LookupProfile("manylinux_2_28_x86_64"); !ok {
+		t.Fatal("manylinux_2_28_x86_64 must be known")
+	}
+	if _, ok := LookupProfile("manylinux_99_99_x86_64"); ok {
+		t.Fatal("future-dated tag must be unknown")
+	}
+}
+
+func TestProfileAllows(t *testing.T) {
+	p := KnownProfiles["manylinux_2_28_x86_64"]
+	if !p.Allows("libc.so.6") {
+		t.Error("libc.so.6 should be allowed")
+	}
+	if p.Allows("libssl.so.3") {
+		t.Error("libssl.so.3 should NOT be allowed (must be vendored)")
+	}
+}
+
+func TestProfileTagsContainsAll(t *testing.T) {
+	got := ProfileTags()
+	if !sort.StringsAreSorted(got) {
+		t.Fatalf("ProfileTags not sorted: %v", got)
+	}
+	if len(got) != len(KnownProfiles) {
+		t.Fatalf("ProfileTags returned %d, want %d", len(got), len(KnownProfiles))
+	}
+}
+
+func TestMacOSAllowsLibSystem(t *testing.T) {
+	p := KnownProfiles["macosx_11_0_arm64"]
+	if !p.Allows("/usr/lib/libSystem.B.dylib") {
+		t.Error("macOS profile must allow libSystem.B.dylib")
+	}
+	if p.Allows("/usr/local/lib/libopenssl.dylib") {
+		t.Error("macOS profile must NOT allow Homebrew libs")
+	}
+}
+
+func TestWindowsAllowsKernel32(t *testing.T) {
+	p := KnownProfiles["win_amd64"]
+	if !p.Allows("KERNEL32.dll") {
+		t.Error("win_amd64 must allow KERNEL32.dll")
+	}
+	if p.Allows("libssl-3-x64.dll") {
+		t.Error("win_amd64 must NOT allow third-party OpenSSL")
+	}
+}
+
+func TestMusllinuxAllowsMusl(t *testing.T) {
+	p := KnownProfiles["musllinux_1_2_x86_64"]
+	if !p.Allows("libc.musl-x86_64.so.1") {
+		t.Error("musllinux must allow libc.musl-x86_64.so.1")
+	}
+	if p.Allows("libc.so.6") {
+		t.Error("musllinux must NOT allow glibc libc")
+	}
+}

--- a/package3/python/abi3/phase13_test.go
+++ b/package3/python/abi3/phase13_test.go
@@ -1,0 +1,118 @@
+package abi3
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPhase13ABI3 is the Phase 13 umbrella sentinel. It walks a
+// synthetic wheel through the abi3 slimming + auditwheel pipeline and
+// asserts that the renderer + auditor together produce a coherent
+// result.
+//
+//  1. Parse a cp312 wheel filename, promote it to abi3, assert the
+//     resulting filename + tag triple shape.
+//  2. Render the WHEEL marker for the promoted wheel, assert it
+//     embeds the abi3 tag.
+//  3. Audit two extensions against the manylinux_2_28_x86_64 profile
+//     via a mock SymbolReader: a clean extension passes, an extension
+//     linking libssl violates, the aggregate report flags the wheel
+//     as not-OK with the right violation message.
+//  4. Confirm that a macOS wheel audits against the macosx_11_0_arm64
+//     profile via the same code path (cross-platform coverage).
+func TestPhase13ABI3(t *testing.T) {
+	// Step 1: promote a cp312 filename to abi3.
+	promoted, err := PromoteWheelToABI3("mochi-pkg-0.1.0-cp312-cp312-manylinux_2_28_x86_64.whl")
+	if err != nil {
+		t.Fatalf("PromoteWheelToABI3: %v", err)
+	}
+	if promoted != "mochi-pkg-0.1.0-cp32-abi3-manylinux_2_28_x86_64.whl" {
+		t.Fatalf("promoted = %q", promoted)
+	}
+
+	_, tag, err := SplitWheelFilename(promoted)
+	if err != nil {
+		t.Fatalf("SplitWheelFilename: %v", err)
+	}
+	if !tag.IsABI3() {
+		t.Fatalf("promoted tag must report IsABI3: %+v", tag)
+	}
+
+	// Step 2: WHEEL marker carries the promoted tag.
+	wheelMarker := RenderWHEELMarker("mochi-pkg/1.0", "manylinux_2_28_x86_64")
+	if !strings.Contains(wheelMarker, "Tag: cp32-abi3-manylinux_2_28_x86_64\n") {
+		t.Fatalf("WHEEL marker missing abi3 tag:\n%s", wheelMarker)
+	}
+
+	// Step 3: audit two extensions on the manylinux_2_28 profile.
+	r := fakeReader{libs: map[string][]LinkedLib{
+		"mochi_pkg/_clean.so": {
+			{SoName: "libc.so.6", External: true},
+			{SoName: "libm.so.6", External: true},
+			{SoName: "libpython3.so", External: false}, // vendored
+		},
+		"mochi_pkg/_dirty.so": {
+			{SoName: "libc.so.6", External: true},
+			{SoName: "libssl.so.3", External: true},
+		},
+	}}
+	reports, ok, err := AuditWheel(
+		[]string{"mochi_pkg/_clean.so", "mochi_pkg/__init__.py", "mochi_pkg/_dirty.so"},
+		AuditOptions{Profile: KnownProfiles["manylinux_2_28_x86_64"], Reader: r},
+	)
+	if err != nil {
+		t.Fatalf("AuditWheel: %v", err)
+	}
+	if ok {
+		t.Fatal("aggregate must be not-OK because _dirty.so violates")
+	}
+	if len(reports) != 2 {
+		t.Fatalf("expected 2 reports (skip __init__.py), got %d", len(reports))
+	}
+	var sawClean, sawDirty bool
+	for _, r := range reports {
+		switch r.Path {
+		case "mochi_pkg/_clean.so":
+			sawClean = true
+			if !r.OK {
+				t.Errorf("_clean.so should be OK: %+v", r)
+			}
+		case "mochi_pkg/_dirty.so":
+			sawDirty = true
+			if r.OK {
+				t.Errorf("_dirty.so should NOT be OK")
+			}
+			if len(r.Disallowed) != 1 || r.Disallowed[0].SoName != "libssl.so.3" {
+				t.Errorf("_dirty.so Disallowed wrong: %+v", r.Disallowed)
+			}
+			joined := strings.Join(r.Violations, "\n")
+			if !strings.Contains(joined, "libssl.so.3") || !strings.Contains(joined, "manylinux_2_28_x86_64") {
+				t.Errorf("_dirty.so violation missing details:\n%s", joined)
+			}
+		}
+	}
+	if !sawClean || !sawDirty {
+		t.Fatalf("missing per-ext reports: clean=%v dirty=%v", sawClean, sawDirty)
+	}
+
+	// Step 4: macOS profile coverage via the same code path.
+	macR := fakeReader{libs: map[string][]LinkedLib{
+		"mochi_pkg/_mac.dylib": {
+			{SoName: "/usr/lib/libSystem.B.dylib", External: true},
+			{SoName: "/opt/homebrew/lib/libpng.dylib", External: true},
+		},
+	}}
+	macRep, err := AuditExtension("mochi_pkg/_mac.dylib", AuditOptions{
+		Profile: KnownProfiles["macosx_11_0_arm64"],
+		Reader:  macR,
+	})
+	if err != nil {
+		t.Fatalf("macOS AuditExtension: %v", err)
+	}
+	if macRep.OK {
+		t.Fatal("macOS extension linking Homebrew lib must violate")
+	}
+	if len(macRep.Disallowed) != 1 || macRep.Disallowed[0].SoName != "/opt/homebrew/lib/libpng.dylib" {
+		t.Fatalf("macOS Disallowed wrong: %+v", macRep.Disallowed)
+	}
+}

--- a/package3/python/abi3/slim.go
+++ b/package3/python/abi3/slim.go
@@ -1,0 +1,60 @@
+package abi3
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RenameWheelFilename rewrites the abi field of a wheel filename in
+// place. ParseWheelTag rejects malformed inputs upstream; this helper
+// surfaces only the rename concern.
+func RenameWheelFilename(name, newABI string) (string, error) {
+	if strings.TrimSpace(newABI) == "" {
+		return "", fmt.Errorf("abi3: RenameWheelFilename requires a non-empty abi")
+	}
+	prefix, tag, err := SplitWheelFilename(name)
+	if err != nil {
+		return "", err
+	}
+	tag.ABI = newABI
+	return prefix + "-" + tag.String() + ".whl", nil
+}
+
+// PromoteWheelToABI3 rewrites a wheel filename so the interpreter +
+// abi fields claim the stable limited API (`cp32-abi3-...`). The
+// platform field is preserved; callers that also need to retag the
+// platform should pass the result through RenameWheelFilename's
+// platform-handling caller after.
+func PromoteWheelToABI3(name string) (string, error) {
+	prefix, tag, err := SplitWheelFilename(name)
+	if err != nil {
+		return "", err
+	}
+	abi3Tag, err := ToABI3(tag)
+	if err != nil {
+		return "", err
+	}
+	return prefix + "-" + abi3Tag.String() + ".whl", nil
+}
+
+// RenderWHEELMarker produces the PEP 427 WHEEL metadata stub for a
+// rendered abi3 wheel. The Tag field embeds the limited-API triple
+// (`cp32-abi3-<platform>`) so downstream installers know they can
+// resolve the wheel against any CPython ≥ 3.2.
+//
+// The caller is responsible for writing this to
+// `<dist>-<ver>.dist-info/WHEEL` inside the wheel zip.
+func RenderWHEELMarker(generator, platform string) string {
+	if strings.TrimSpace(generator) == "" {
+		generator = "mochi-pkg"
+	}
+	if strings.TrimSpace(platform) == "" {
+		platform = "any"
+	}
+	var b strings.Builder
+	b.WriteString("Wheel-Version: 1.0\n")
+	fmt.Fprintf(&b, "Generator: %s\n", generator)
+	b.WriteString("Root-Is-Purelib: false\n")
+	fmt.Fprintf(&b, "Tag: cp32-abi3-%s\n", platform)
+	return b.String()
+}

--- a/package3/python/abi3/slim_test.go
+++ b/package3/python/abi3/slim_test.go
@@ -1,0 +1,63 @@
+package abi3
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenameWheelFilename(t *testing.T) {
+	out, err := RenameWheelFilename("mochi-0.1.0-cp312-cp312-manylinux_2_28_x86_64.whl", "abi3")
+	if err != nil {
+		t.Fatalf("RenameWheelFilename: %v", err)
+	}
+	if out != "mochi-0.1.0-cp312-abi3-manylinux_2_28_x86_64.whl" {
+		t.Fatalf("got %q", out)
+	}
+}
+
+func TestRenameWheelFilenameRequiresABI(t *testing.T) {
+	if _, err := RenameWheelFilename("a-b-cp312-cp312-any.whl", ""); err == nil {
+		t.Fatal("RenameWheelFilename should reject empty abi")
+	}
+}
+
+func TestPromoteWheelToABI3(t *testing.T) {
+	out, err := PromoteWheelToABI3("mochi-0.1.0-cp312-cp312-manylinux_2_28_x86_64.whl")
+	if err != nil {
+		t.Fatalf("PromoteWheelToABI3: %v", err)
+	}
+	if out != "mochi-0.1.0-cp32-abi3-manylinux_2_28_x86_64.whl" {
+		t.Fatalf("got %q", out)
+	}
+}
+
+func TestPromoteWheelToABI3RejectsPyPy(t *testing.T) {
+	if _, err := PromoteWheelToABI3("mochi-0.1.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl"); err == nil {
+		t.Fatal("PromoteWheelToABI3 should reject PyPy")
+	}
+}
+
+func TestRenderWHEELMarker(t *testing.T) {
+	out := RenderWHEELMarker("mochi-pkg/0.1", "manylinux_2_28_x86_64")
+	wants := []string{
+		"Wheel-Version: 1.0\n",
+		"Generator: mochi-pkg/0.1\n",
+		"Root-Is-Purelib: false\n",
+		"Tag: cp32-abi3-manylinux_2_28_x86_64\n",
+	}
+	for _, w := range wants {
+		if !strings.Contains(out, w) {
+			t.Errorf("WHEEL missing %q\n%s", w, out)
+		}
+	}
+}
+
+func TestRenderWHEELMarkerDefaults(t *testing.T) {
+	out := RenderWHEELMarker("", "")
+	if !strings.Contains(out, "Generator: mochi-pkg\n") {
+		t.Errorf("default generator missing:\n%s", out)
+	}
+	if !strings.Contains(out, "Tag: cp32-abi3-any\n") {
+		t.Errorf("default platform missing:\n%s", out)
+	}
+}

--- a/package3/python/abi3/tag.go
+++ b/package3/python/abi3/tag.go
@@ -1,0 +1,86 @@
+package abi3
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// WheelTag is the (interpreter, abi, platform) triple at the tail of a
+// wheel filename per PEP 425. Compressed tag sets (multiple interpreters
+// joined with '.') are normalised by splitting them at parse time and
+// re-joining at String time, so callers can mutate one field at a time
+// without worrying about the join.
+type WheelTag struct {
+	Interpreter string
+	ABI         string
+	Platform    string
+}
+
+// ParseWheelTag splits a `{python}-{abi}-{platform}` triple. It accepts
+// the compressed form too (e.g. "cp311.cp312-abi3-manylinux_2_28_x86_64")
+// but keeps the interpreter field as the literal compressed string; the
+// caller is responsible for splitting on '.' when iterating.
+func ParseWheelTag(s string) (WheelTag, error) {
+	parts := strings.Split(s, "-")
+	if len(parts) != 3 {
+		return WheelTag{}, fmt.Errorf("abi3: wheel tag %q must have 3 hyphen-separated fields", s)
+	}
+	for i, p := range parts {
+		if strings.TrimSpace(p) == "" {
+			return WheelTag{}, fmt.Errorf("abi3: wheel tag %q field %d is empty", s, i)
+		}
+	}
+	return WheelTag{Interpreter: parts[0], ABI: parts[1], Platform: parts[2]}, nil
+}
+
+// String reassembles the triple. It does not validate; round-tripping
+// a previously-parsed tag is byte-identical.
+func (t WheelTag) String() string {
+	return t.Interpreter + "-" + t.ABI + "-" + t.Platform
+}
+
+// IsABI3 reports whether the tag claims the stable limited API. Only
+// "abi3" is honoured; "none" or interpreter-specific ABIs ("cp312") do
+// not count even if the extension happens to only use limited symbols.
+func (t WheelTag) IsABI3() bool { return t.ABI == "abi3" }
+
+// ToABI3 promotes a tag to the limited-API form. The new interpreter
+// is the floor CPython release that the limited API supports; per the
+// CPython docs that floor is 3.2 (`cp32`). The platform is preserved
+// since limited-API status does not change platform compatibility.
+//
+// ToABI3 rejects non-CPython interpreters (PyPy, GraalPy, etc.) because
+// the stable ABI is a CPython contract, and rejects tags whose
+// interpreter does not parse as a `cp<digits>` shape.
+func ToABI3(t WheelTag) (WheelTag, error) {
+	if !strings.HasPrefix(t.Interpreter, "cp") {
+		return WheelTag{}, fmt.Errorf("abi3: only CPython interpreters support the stable ABI; got %q", t.Interpreter)
+	}
+	rest := strings.TrimPrefix(t.Interpreter, "cp")
+	if _, err := strconv.Atoi(rest); err != nil {
+		return WheelTag{}, fmt.Errorf("abi3: interpreter %q does not parse as cp<digits>", t.Interpreter)
+	}
+	return WheelTag{Interpreter: "cp32", ABI: "abi3", Platform: t.Platform}, nil
+}
+
+// SplitWheelFilename pulls the trailing tag triple off a wheel filename
+// (per PEP 491 / PEP 427: `{dist}-{ver}[-{build}]-{tag}.whl`). It is
+// deliberately strict: the input must end in `.whl` and contain at
+// least four hyphen-separated fields.
+func SplitWheelFilename(name string) (prefix string, tag WheelTag, err error) {
+	if !strings.HasSuffix(name, ".whl") {
+		return "", WheelTag{}, fmt.Errorf("abi3: wheel filename %q must end in .whl", name)
+	}
+	base := strings.TrimSuffix(name, ".whl")
+	parts := strings.Split(base, "-")
+	if len(parts) < 4 {
+		return "", WheelTag{}, fmt.Errorf("abi3: wheel filename %q lacks dist-ver-...-tag fields", name)
+	}
+	tagPart := strings.Join(parts[len(parts)-3:], "-")
+	t, err := ParseWheelTag(tagPart)
+	if err != nil {
+		return "", WheelTag{}, err
+	}
+	return strings.Join(parts[:len(parts)-3], "-"), t, nil
+}

--- a/package3/python/abi3/tag_test.go
+++ b/package3/python/abi3/tag_test.go
@@ -1,0 +1,112 @@
+package abi3
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseWheelTagOK(t *testing.T) {
+	tag, err := ParseWheelTag("cp312-cp312-manylinux_2_28_x86_64")
+	if err != nil {
+		t.Fatalf("ParseWheelTag: %v", err)
+	}
+	if tag.Interpreter != "cp312" || tag.ABI != "cp312" || tag.Platform != "manylinux_2_28_x86_64" {
+		t.Fatalf("ParseWheelTag fields wrong: %+v", tag)
+	}
+}
+
+func TestParseWheelTagRejectsWrongFieldCount(t *testing.T) {
+	cases := []string{"", "cp312", "cp312-cp312", "cp312-cp312-platform-extra"}
+	for _, c := range cases {
+		if _, err := ParseWheelTag(c); err == nil {
+			t.Errorf("ParseWheelTag(%q) should error", c)
+		}
+	}
+}
+
+func TestParseWheelTagRejectsEmptyField(t *testing.T) {
+	if _, err := ParseWheelTag("cp312--manylinux_2_28_x86_64"); err == nil {
+		t.Fatal("ParseWheelTag should reject empty abi field")
+	}
+}
+
+func TestWheelTagStringRoundTrip(t *testing.T) {
+	in := "cp312-abi3-manylinux_2_28_x86_64"
+	tag, err := ParseWheelTag(in)
+	if err != nil {
+		t.Fatalf("ParseWheelTag: %v", err)
+	}
+	if tag.String() != in {
+		t.Fatalf("round-trip: got %q, want %q", tag.String(), in)
+	}
+}
+
+func TestWheelTagIsABI3(t *testing.T) {
+	cases := map[string]bool{
+		"cp312-abi3-manylinux_2_28_x86_64":  true,
+		"cp312-cp312-manylinux_2_28_x86_64": false,
+		"py3-none-any":                      false,
+	}
+	for s, want := range cases {
+		tag, err := ParseWheelTag(s)
+		if err != nil {
+			t.Fatalf("ParseWheelTag(%q): %v", s, err)
+		}
+		if got := tag.IsABI3(); got != want {
+			t.Errorf("IsABI3(%q) = %v, want %v", s, got, want)
+		}
+	}
+}
+
+func TestToABI3OK(t *testing.T) {
+	tag, err := ParseWheelTag("cp312-cp312-manylinux_2_28_x86_64")
+	if err != nil {
+		t.Fatalf("ParseWheelTag: %v", err)
+	}
+	out, err := ToABI3(tag)
+	if err != nil {
+		t.Fatalf("ToABI3: %v", err)
+	}
+	if out.Interpreter != "cp32" || out.ABI != "abi3" || out.Platform != tag.Platform {
+		t.Fatalf("ToABI3 result wrong: %+v", out)
+	}
+}
+
+func TestToABI3RejectsNonCPython(t *testing.T) {
+	tag := WheelTag{Interpreter: "pp310", ABI: "pypy310_pp73", Platform: "manylinux_2_28_x86_64"}
+	if _, err := ToABI3(tag); err == nil || !strings.Contains(err.Error(), "CPython") {
+		t.Fatalf("ToABI3 should reject PyPy, got %v", err)
+	}
+}
+
+func TestToABI3RejectsBadInterpreter(t *testing.T) {
+	tag := WheelTag{Interpreter: "cpfoo", ABI: "cpfoo", Platform: "any"}
+	if _, err := ToABI3(tag); err == nil {
+		t.Fatal("ToABI3 should reject non-numeric interpreter")
+	}
+}
+
+func TestSplitWheelFilenameOK(t *testing.T) {
+	prefix, tag, err := SplitWheelFilename("mochi-alpha-0.2.0-cp312-cp312-manylinux_2_28_x86_64.whl")
+	if err != nil {
+		t.Fatalf("SplitWheelFilename: %v", err)
+	}
+	if prefix != "mochi-alpha-0.2.0" {
+		t.Errorf("prefix = %q", prefix)
+	}
+	if tag.String() != "cp312-cp312-manylinux_2_28_x86_64" {
+		t.Errorf("tag = %q", tag.String())
+	}
+}
+
+func TestSplitWheelFilenameRejectsNonWhl(t *testing.T) {
+	if _, _, err := SplitWheelFilename("foo.tar.gz"); err == nil {
+		t.Fatal("SplitWheelFilename should reject non-.whl")
+	}
+}
+
+func TestSplitWheelFilenameRejectsTooFewFields(t *testing.T) {
+	if _, _, err := SplitWheelFilename("foo-bar-baz.whl"); err == nil {
+		t.Fatal("SplitWheelFilename should reject too-few-fields")
+	}
+}

--- a/website/docs/implementation/0071/index.md
+++ b/website/docs/implementation/0071/index.md
@@ -35,11 +35,14 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | 11.1 | Sigstore live signing harness (`sigstore-python` shell-out + Rekor log) | NOT STARTED | — | [phase-11](/docs/implementation/0071/phase-11-trusted-publish) |
 | 11.2 | Live PyPI / TestPyPI HTTP (mint endpoint contract test) | NOT STARTED | — | [phase-11](/docs/implementation/0071/phase-11-trusted-publish) |
 | 11.3 | `mochi pkg publish --to=pypi` CLI verb | NOT STARTED | — | [phase-11](/docs/implementation/0071/phase-11-trusted-publish) |
-| 12 | Async bridge (asyncio.run per-call + persistent loop opt-in + cross-loop hazard guards) | LANDED | (pending merge) | [phase-12](/docs/implementation/0071/phase-12-async-bridge) |
+| 12 | Async bridge (asyncio.run per-call + persistent loop opt-in + cross-loop hazard guards) | LANDED | `df616a89` | [phase-12](/docs/implementation/0071/phase-12-async-bridge) |
 | 12.1 | Wire asyncbridge into wrapper synthesiser so async surfaces emit sync shims end-to-end | NOT STARTED | — | [phase-12](/docs/implementation/0071/phase-12-async-bridge) |
 | 12.2 | Free-threaded GIL handling around the persistent loop cache (PyMutex on `cp3XYt`) | NOT STARTED | — | [phase-12](/docs/implementation/0071/phase-12-async-bridge) |
 | 12.3 | Cancellation + timeout propagation (`mochi_async_timeout` ContextVar -> `asyncio.wait_for`) | NOT STARTED | — | [phase-12](/docs/implementation/0071/phase-12-async-bridge) |
-| 13 | abi3 wheel slimming + auditwheel-equivalent platform tag validation | NOT STARTED | — | [phase-13](/docs/implementation/0071/phase-13-abi3) |
+| 13 | abi3 wheel slimming + auditwheel-equivalent platform tag validation | LANDED | (pending merge) | [phase-13](/docs/implementation/0071/phase-13-abi3) |
+| 13.1 | Live ELF / Mach-O / PE reader behind `SymbolReader` | NOT STARTED | — | [phase-13](/docs/implementation/0071/phase-13-abi3) |
+| 13.2 | Py_LIMITED_API discipline check before promoting to abi3 | NOT STARTED | — | [phase-13](/docs/implementation/0071/phase-13-abi3) |
+| 13.3 | `mochi pkg audit --wheel <path>` + `mochi pkg slim --abi3` CLI verbs | NOT STARTED | — | [phase-13](/docs/implementation/0071/phase-13-abi3) |
 | 14 | Subprocess runtime mode (`[python].runtime-mode = "subprocess"` with JSON-RPC protocol) | NOT STARTED | — | [phase-14](/docs/implementation/0071/phase-14-subprocess-mode) |
 | 15 | Attestation verification at install time + `--require-attestations` enforcement | NOT STARTED | — | [phase-15](/docs/implementation/0071/phase-15-attestation-verify) |
 | 16 | Pyodide / WASI target support (`wasm32-emscripten`, `wasm32-wasip2` wheel resolution + WIT interface) | NOT STARTED | — | [phase-16](/docs/implementation/0071/phase-16-pyodide-wasi) |
@@ -95,6 +98,7 @@ package3/python/
   pypackage/              # TargetPythonPackage emit: sdist + wheel + mochi_build PEP 517 backend (phase 10)
   publish/                # PyPI publish + Sigstore + PEP 740 attestations (phase 11)
   asyncbridge/            # async-fn -> sync-fn shim renderer + cross-loop guard (phase 12)
+  abi3/                   # abi3 wheel slimming + auditwheel-equivalent platform validator (phase 13)
   attest/                 # attestation verification (phase 15)
   pyodide/                # wasm32-emscripten + WASI Preview 2 target support (phase 16)
   freethread/             # free-threaded mode wrapper variants (phase 17)
@@ -105,7 +109,7 @@ The `package3/python/` location is shared with the broader MEP-57 polyglot packa
 
 ## Status snapshot
 
-As of 2026-05-30 00:45 (GMT+7): MEP-71 spec and research bundle landed; phases 0-12 LANDED (8.1, 8.2, 10.1, 10.2, 10.3, 11.1, 11.2, 11.3, 12.1, 12.2, 12.3 deferred sub-phases); phases 13-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
+As of 2026-05-30 00:51 (GMT+7): MEP-71 spec and research bundle landed; phases 0-13 LANDED (8.1, 8.2, 10.1, 10.2, 10.3, 11.1, 11.2, 11.3, 12.1, 12.2, 12.3, 13.1, 13.2, 13.3 deferred sub-phases); phases 14-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
 
 ## Cross-references
 

--- a/website/docs/implementation/0071/phase-13-abi3.md
+++ b/website/docs/implementation/0071/phase-13-abi3.md
@@ -1,0 +1,81 @@
+---
+title: MEP-71 Phase 13 (abi3 wheel slimming + auditwheel)
+sidebar_position: 14
+sidebar_label: "Phase 13. abi3 + auditwheel"
+description: "MEP-71 Phase 13: cp32-abi3 wheel slimming + the auditwheel-equivalent platform tag validator for manylinux / musllinux / macOS / Windows wheel surfaces."
+---
+
+# MEP-71 Phase 13. abi3 wheel slimming + auditwheel
+
+Status: **LANDED (pending merge)** as of 2026-05-30 00:51 (GMT+7). Implements two coupled policy layers:
+
+- **abi3 slimming.** `PromoteWheelToABI3` rewrites a wheel filename's interpreter + abi fields from `cp3XX-cp3XX-<platform>` to `cp32-abi3-<platform>` so the wheel resolves on every CPython ≥ 3.2 without rebuilding. The matching `RenderWHEELMarker` emits the PEP 427 `WHEEL` metadata stub with the abi3 `Tag:` line.
+- **auditwheel-equivalent platform validation.** `KnownProfiles` declares the closed allow-list for every supported platform tag (manylinux_2_17 / 2_28 / 2_34, musllinux_1_2, macosx_10_15 / 11_0, win_amd64 / arm64). `AuditExtension` reads a `.so` / `.dylib` / `.pyd`'s linked libs through a mockable `SymbolReader` interface and flags every external lib outside the profile's allow-list as a violation. `AuditWheel` aggregates per-extension reports for a wheel's RECORD entries.
+
+The live ELF / Mach-O / PE walker that production callers wire behind `SymbolReader` is sub-phase 13.1; the Py_LIMITED_API discipline check (refusing to promote a wheel to abi3 when its extension references symbols outside the limited API) is sub-phase 13.2; the `mochi pkg audit --wheel <path>` CLI verb is sub-phase 13.3.
+
+## Gate
+
+The umbrella sentinel `TestPhase13ABI3` in `package3/python/abi3/phase13_test.go` is green. The sentinel:
+
+- Promotes `mochi-pkg-0.1.0-cp312-cp312-manylinux_2_28_x86_64.whl` to `mochi-pkg-0.1.0-cp32-abi3-manylinux_2_28_x86_64.whl`, re-parses the result, and asserts `WheelTag.IsABI3()` reports true.
+- Renders the `WHEEL` marker for the promoted wheel and asserts the `Tag: cp32-abi3-manylinux_2_28_x86_64` line is present.
+- Audits two synthetic extensions (`mochi_pkg/_clean.so` linking only libc + libm, `mochi_pkg/_dirty.so` linking libssl.so.3) plus a non-extension file against the manylinux_2_28_x86_64 profile via a mock `SymbolReader`. Asserts the clean ext passes, the dirty ext violates with `libssl.so.3` named in the violation message, the non-extension file is skipped, and the aggregate `AuditWheel` reports ok=false.
+- Audits a macOS extension (`mochi_pkg/_mac.dylib` linking `/usr/lib/libSystem.B.dylib` + a Homebrew lib) against `macosx_11_0_arm64` and asserts the Homebrew lib violates while libSystem passes — cross-platform coverage through the same code path.
+
+Plus 31 unit tests (`go test ./package3/python/abi3/... -count=1`) covering:
+
+- `ParseWheelTag`: 3-field parse OK + rejects wrong field count + rejects empty field; `String` round-trip.
+- `WheelTag.IsABI3`: only `abi3` qualifies; `cp312` and `none` do not.
+- `ToABI3`: promotes cp312-cp312 -> cp32-abi3; rejects PyPy (`pp310`); rejects non-numeric interpreter (`cpfoo`).
+- `SplitWheelFilename`: pulls the trailing 3-field tag off `<dist>-<ver>-<interp>-<abi>-<platform>.whl`; rejects non-`.whl` and rejects too-few-fields inputs.
+- `KnownProfiles`: every entry's `Tag` matches its map key and `AllowedLibs` is sorted (binary-search invariant).
+- `LookupProfile`: returns the entry for known tags + reports ok=false for future-dated tags.
+- `ManylinuxProfile.Allows`: libc.so.6 in manylinux_2_28 yes; libssl.so.3 no; libSystem in macosx_11_0 yes; Homebrew libpng no; KERNEL32.dll in win_amd64 yes; third-party OpenSSL no; musl libc in musllinux yes; glibc libc no.
+- `ProfileTags`: sorted slice with cardinality equal to KnownProfiles.
+- `AuditExtension`: rejects nil reader + zero profile; happy path on a clean extension; flags disallowed external lib with the right violation message; propagates reader errors.
+- `IsExtensionFilename`: case-insensitive `.so` / `.dylib` / `.pyd`; rejects `.py` / `.pyi`.
+- `AuditWheel`: aggregates per-extension reports; ok=false when any extension violates; ok=true on a clean wheel; skips non-extension files.
+- `RenameWheelFilename`: swaps the abi field in place; requires a non-empty abi.
+- `PromoteWheelToABI3`: rewrites cp312-cp312-... -> cp32-abi3-...; rejects PyPy wheels.
+- `RenderWHEELMarker`: emits `Wheel-Version: 1.0` + `Generator:` + `Root-Is-Purelib: false` + `Tag: cp32-abi3-<platform>`; defaults Generator to `mochi-pkg` and platform to `any` when called with empty strings.
+
+## Files
+
+- `package3/python/abi3/doc.go` — package overview (abi3 vs interpreter-specific tags, the auditwheel parity goal, planned sub-phases).
+- `package3/python/abi3/tag.go` — `WheelTag`, `ParseWheelTag`, `String`, `IsABI3`, `ToABI3`, `SplitWheelFilename`.
+- `package3/python/abi3/manylinux.go` — `ManylinuxProfile`, `KnownProfiles` (11 profiles), `LookupProfile`, `ProfileTags`.
+- `package3/python/abi3/audit.go` — `LinkedLib`, `SymbolReader` interface, `AuditOptions`, `AuditReport`, `AuditExtension`, `AuditWheel`, `IsExtensionFilename`.
+- `package3/python/abi3/slim.go` — `RenameWheelFilename`, `PromoteWheelToABI3`, `RenderWHEELMarker`.
+- `package3/python/abi3/tag_test.go` — wheel tag parsing + filename split + abi3 promotion (12 cases).
+- `package3/python/abi3/manylinux_test.go` — profile invariants + allow-list coverage across Linux / macOS / Windows / musl (6 cases).
+- `package3/python/abi3/audit_test.go` — `AuditExtension` + `AuditWheel` happy + error paths (8 cases).
+- `package3/python/abi3/slim_test.go` — filename + WHEEL marker rendering (6 cases).
+- `package3/python/abi3/phase13_test.go` — Phase 13 umbrella sentinel.
+
+## Sub-phase decomposition
+
+Phase 13 ships the pure policy layer. Live binary inspection, abi3 discipline checking, and the user-facing CLI verb stay out of the umbrella gate so the suite remains offline + cross-platform.
+
+| Sub-phase | Title | Status | Notes |
+|-----------|-------|--------|-------|
+| 13 | Tag + profile + audit policy layer (mockable `SymbolReader`) | LANDED (pending merge) | This PR. |
+| 13.1 | Live ELF / Mach-O / PE reader behind `SymbolReader` | NOT STARTED | Real binary inspection. Plan: ELF via `debug/elf`, Mach-O via `debug/macho`, PE via `debug/pe`. |
+| 13.2 | Py_LIMITED_API discipline check before promoting to abi3 | NOT STARTED | Scans the C extension's symbol references and refuses promotion when any references fall outside the limited API. |
+| 13.3 | `mochi pkg audit --wheel <path>` + `mochi pkg slim --abi3` CLI verbs | NOT STARTED | Wires the auditor + slimmer behind the unified `mochi pkg` CLI. |
+
+## Fixtures
+
+Phase 13 is policy-only; the fixture corpus is not exercised. Sub-phase 13.1 will audit the corpus's compiled extensions (`numpy`, `pandas`, `scipy`, `pillow`) against `manylinux_2_28_x86_64` + `macosx_11_0_arm64` + `win_amd64` and assert each violation count matches a golden number per package.
+
+## Skip count
+
+N/A. Phase 13 has no `SkipReport` surface; profile lookup miss / reader error / disallowed external lib all surface as audit failures (returned `AuditReport.Violations`, not skip reports).
+
+## Cross-references
+
+- [MEP-71 spec §8 "abi3 slimming + auditwheel"](/docs/mep/mep-0071) for the normative profile + abi3 promotion rules.
+- [Phase 10](./phase-10-python-package-emit) for the wheel emit Phase 13 audits.
+- [Phase 17](./phase-17-free-threaded) for the `cp3XYt` abi tag that future free-threaded wheels will use alongside abi3.
+- [Phase 18](./phase-18-abi2026) for the abi2026 transition that Phase 13's tag-rewrite helpers will be reused for.
+- [PEP 425 (compatibility tags)](https://peps.python.org/pep-0425/), [PEP 600 (manylinux)](https://peps.python.org/pep-0600/), [PEP 656 (musllinux)](https://peps.python.org/pep-0656/), and the [auditwheel docs](https://github.com/pypa/auditwheel) for the upstream policy spec.


### PR DESCRIPTION
Closes #22975.

## Summary

- Implements MEP-71 Phase 13: two coupled policy layers for wheel emit.
- **abi3 slimming.** `PromoteWheelToABI3` rewrites a wheel filename to `cp32-abi3-<platform>` so the wheel resolves on every CPython >= 3.2 without rebuilding. `RenderWHEELMarker` emits the matching PEP 427 `WHEEL` metadata stub.
- **Auditwheel-equivalent platform validation.** `KnownProfiles` declares closed allow-lists for 11 platform tags (manylinux_2_17 / 2_28 / 2_34, musllinux_1_2, macosx_10_15 / 11_0, win_amd64 / arm64). `AuditExtension` classifies a `.so` / `.dylib` / `.pyd` through a mockable `SymbolReader`; `AuditWheel` aggregates per-extension reports. Real binary inspection is sub-phase 13.1.

## Files

- `package3/python/abi3/doc.go` package overview.
- `package3/python/abi3/tag.go` WheelTag + ParseWheelTag + ToABI3 + SplitWheelFilename.
- `package3/python/abi3/manylinux.go` ManylinuxProfile + KnownProfiles (11 entries) + LookupProfile + ProfileTags.
- `package3/python/abi3/audit.go` LinkedLib + SymbolReader + AuditOptions + AuditReport + AuditExtension + AuditWheel + IsExtensionFilename.
- `package3/python/abi3/slim.go` RenameWheelFilename + PromoteWheelToABI3 + RenderWHEELMarker.
- `package3/python/abi3/{tag,manylinux,audit,slim,phase13}_test.go` 32 tests including the umbrella sentinel.
- `website/docs/implementation/0071/phase-13-abi3.md` tracking page with sub-phase decomposition.
- `website/docs/implementation/0071/index.md` Phase 12 commit `df616a89`, Phase 13 LANDED, abi3/ added to tree, status snapshot updated.

## Sub-phases deferred

| Sub-phase | Title |
|-----------|-------|
| 13.1 | Live ELF / Mach-O / PE reader behind `SymbolReader`. |
| 13.2 | Py_LIMITED_API discipline check before abi3 promotion. |
| 13.3 | `mochi pkg audit --wheel <path>` + `mochi pkg slim --abi3` CLI verbs. |

## Test plan

- [x] `go build ./package3/python/abi3/...`
- [x] `go test ./package3/python/abi3/... -count=1` (32 tests pass)
- [x] `go test ./package3/python/... -count=1` (no regressions across the package3/python tree)