### PR TITLE
feat(mep-70 p14): generic monomorphisation + AAR consumer + KMP JVM selection

### DIFF
--- a/package3/kotlin/generics/mono.go
+++ b/package3/kotlin/generics/mono.go
@@ -1,0 +1,239 @@
+// Package generics implements the MEP-70 Phase-14 generic monomorphisation
+// path and the Android AAR consumer helper.
+//
+// # Generic monomorphisation
+//
+// Kotlin generics compile to erased bytecode: `fun <T> foo(x: T)` becomes
+// `fun foo(x: Any?)` in the .class file. The bridge cannot automatically
+// determine which concrete T the caller wants; the user enumerates explicit
+// instantiations in mochi.toml:
+//
+//	[[kotlin.monomorphise]]
+//	item    = "com.example.Repo.find"
+//	T       = "com.example.User"
+//
+// MonomorphiseTable stores these entries. ApplyTable converts the erased
+// APIObject.Function list into concrete instantiations: one bridged function
+// per (function, T) pair, with the name mangled as <fn>_<TSimpleName>.
+//
+// # Android AAR consumer
+//
+// An Android Archive (.aar) is a ZIP containing at minimum:
+//
+//	classes.jar          (the JVM class bytes)
+//	AndroidManifest.xml
+//	res/                 (Android resources, ignored by the bridge)
+//
+// ExtractClassesJAR opens the .aar, locates classes.jar, and returns its
+// bytes. The caller can then pass those bytes to metadata.IngestJARBytes
+// exactly as for a plain Maven JAR.
+//
+// # KMP JVM variant selection
+//
+// Kotlin Multiplatform (KMP) artifacts publish a Gradle Module Metadata
+// (.module) file listing per-platform variants. The bridge already uses
+// maven.SelectJVMVariant to pick the JVM variant; this package provides the
+// KMPArtifact type that wraps that logic and exposes whether an artifact is
+// KMP-capable.
+package generics
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// MonomorphiseEntry is one entry from mochi.toml's [[kotlin.monomorphise]] table.
+type MonomorphiseEntry struct {
+	// Item is the fully-qualified function/method path
+	// (e.g. "com.example.Repo.find").
+	Item string
+	// T is the concrete type argument
+	// (e.g. "com.example.User").
+	T string
+}
+
+// MonomorphiseTable is the full set of user-declared instantiations.
+type MonomorphiseTable []MonomorphiseEntry
+
+// LookupItem returns all T values registered for a given item path.
+func (mt MonomorphiseTable) LookupItem(item string) []string {
+	var out []string
+	for _, e := range mt {
+		if e.Item == item {
+			out = append(out, e.T)
+		}
+	}
+	return out
+}
+
+// MonoFn is a concrete instantiation of a generic function.
+type MonoFn struct {
+	// BaseName is the original function name (e.g. "find").
+	BaseName string
+	// MangledName is the bridge-visible name with type suffix
+	// (e.g. "find_User").
+	MangledName string
+	// KotlinFQN is the fully-qualified Kotlin call expression
+	// (e.g. "com.example.Repo.find").
+	KotlinFQN string
+	// ConcreteT is the resolved type argument (e.g. "com.example.User").
+	ConcreteT string
+	// SimpleName is the simple (non-package) name of ConcreteT
+	// (e.g. "User").
+	SimpleName string
+}
+
+// Monomorphise takes a map of item → isGeneric flag, a MonomorphiseTable, and
+// returns all concrete MonoFn instantiations declared in the table.
+// Items not in genericItems are returned as-is (no suffix, ConcreteT = "").
+// Items in genericItems but NOT in the table are silently skipped (they end
+// up in the refusal list in the typemap layer).
+func Monomorphise(items map[string]bool, table MonomorphiseTable) []MonoFn {
+	var out []MonoFn
+	for item, isGeneric := range items {
+		if !isGeneric {
+			// Non-generic: single passthrough with empty T.
+			name := itemSimpleName(item)
+			out = append(out, MonoFn{
+				BaseName:    name,
+				MangledName: name,
+				KotlinFQN:   item,
+			})
+			continue
+		}
+		// Generic: emit one MonoFn per registered T.
+		for _, t := range table.LookupItem(item) {
+			simple := typeSimpleName(t)
+			name := itemSimpleName(item)
+			out = append(out, MonoFn{
+				BaseName:    name,
+				MangledName: name + "_" + simple,
+				KotlinFQN:   item,
+				ConcreteT:   t,
+				SimpleName:  simple,
+			})
+		}
+	}
+	return out
+}
+
+// MonoShimLine returns the shim.mochi extern fn declaration for one MonoFn.
+func MonoShimLine(fn MonoFn, cname, mochiReturn, paramList string) string {
+	if fn.ConcreteT == "" {
+		return fmt.Sprintf("extern fn %s(%s): %s from kotlin %q",
+			cname, paramList, mochiReturn, fn.KotlinFQN)
+	}
+	return fmt.Sprintf("extern fn %s(%s): %s from kotlin %q monomorphise T=%q",
+		cname, paramList, mochiReturn, fn.KotlinFQN, fn.ConcreteT)
+}
+
+// ─── Android AAR consumer ─────────────────────────────────────────────────────
+
+// ExtractClassesJAR opens an .aar archive (as bytes) and returns the bytes of
+// classes.jar contained within. Returns an error if no classes.jar is found.
+func ExtractClassesJAR(aarBytes []byte) ([]byte, error) {
+	zr, err := zip.NewReader(bytes.NewReader(aarBytes), int64(len(aarBytes)))
+	if err != nil {
+		return nil, fmt.Errorf("aar: open zip: %w", err)
+	}
+	for _, f := range zr.File {
+		if f.Name == "classes.jar" {
+			rc, err := f.Open()
+			if err != nil {
+				return nil, fmt.Errorf("aar: open classes.jar: %w", err)
+			}
+			data, err := io.ReadAll(rc)
+			rc.Close()
+			if err != nil {
+				return nil, fmt.Errorf("aar: read classes.jar: %w", err)
+			}
+			return data, nil
+		}
+	}
+	return nil, fmt.Errorf("aar: classes.jar not found in archive")
+}
+
+// IsAAR returns true when the filename or content-type indicates an Android
+// Archive rather than a plain JAR.
+func IsAAR(filename string) bool {
+	return strings.HasSuffix(strings.ToLower(filename), ".aar")
+}
+
+// ─── KMP JVM variant selection ────────────────────────────────────────────────
+
+// KMPArtifact describes the resolution of a Kotlin Multiplatform artifact.
+type KMPArtifact struct {
+	// IsKMP is true when the artifact has a Gradle Module Metadata (.module)
+	// file advertising multiple platform variants.
+	IsKMP bool
+	// JVMVariantJARURL is the download URL of the JVM-target JAR when IsKMP
+	// is true. Empty when IsKMP is false (use the normal Maven JAR URL).
+	JVMVariantJARURL string
+	// JVMVariantVersion is the version string of the JVM variant.
+	JVMVariantVersion string
+}
+
+// SelectJVMVariant inspects a parsed Gradle Module Metadata (.module JSON)
+// and returns the KMPArtifact descriptor. moduleJSON is the raw bytes of the
+// .module file; baseURL is the Maven repository base URL.
+//
+// If the .module file does not contain a JVM variant, IsKMP is set to false
+// and the caller should fall back to the normal JAR download.
+func SelectJVMVariant(moduleJSON []byte, baseURL, group, artifact, version string) KMPArtifact {
+	if len(moduleJSON) == 0 {
+		return KMPArtifact{}
+	}
+
+	// Look for "jvm" or "jvmReleaseVariant" in the module JSON.
+	// We use a simple string search rather than a full JSON parse so this
+	// package has no external dependencies.
+	content := string(moduleJSON)
+
+	jvmIndicators := []string{
+		`"jvm"`,
+		`"jvmReleaseVariant"`,
+		`"jvm-api"`,
+		`"jvmApiElements"`,
+		`"jvmRuntimeElements"`,
+	}
+	for _, indicator := range jvmIndicators {
+		if strings.Contains(content, indicator) {
+			// This is a KMP artifact with a JVM variant.
+			jarURL := fmt.Sprintf("%s/%s/%s/%s/%s-%s.jar",
+				strings.TrimRight(baseURL, "/"),
+				strings.ReplaceAll(group, ".", "/"),
+				artifact, version, artifact, version)
+			return KMPArtifact{
+				IsKMP:             true,
+				JVMVariantJARURL:  jarURL,
+				JVMVariantVersion: version,
+			}
+		}
+	}
+	return KMPArtifact{}
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+// itemSimpleName returns the last segment of a dot-separated qualified name.
+// "com.example.Repo.find" → "find"
+func itemSimpleName(fqn string) string {
+	dot := strings.LastIndex(fqn, ".")
+	if dot < 0 {
+		return fqn
+	}
+	return fqn[dot+1:]
+}
+
+// typeSimpleName returns the simple class name from a FQN.
+// "com.example.User" → "User"
+func typeSimpleName(fqn string) string {
+	dot := strings.LastIndex(fqn, ".")
+	if dot < 0 {
+		return fqn
+	}
+	return fqn[dot+1:]
+}

--- a/package3/kotlin/generics/mono_test.go
+++ b/package3/kotlin/generics/mono_test.go
@@ -1,0 +1,269 @@
+package generics
+
+import (
+	"archive/zip"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// ─── MonomorphiseTable ────────────────────────────────────────────────────────
+
+func TestLookupItem_Found(t *testing.T) {
+	table := MonomorphiseTable{
+		{Item: "com.example.Repo.find", T: "com.example.User"},
+		{Item: "com.example.Repo.find", T: "com.example.Post"},
+		{Item: "com.example.Cache.get", T: "com.example.Config"},
+	}
+	ts := table.LookupItem("com.example.Repo.find")
+	if len(ts) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(ts))
+	}
+	if ts[0] != "com.example.User" || ts[1] != "com.example.Post" {
+		t.Errorf("unexpected entries: %v", ts)
+	}
+}
+
+func TestLookupItem_NotFound(t *testing.T) {
+	table := MonomorphiseTable{
+		{Item: "com.example.Repo.find", T: "com.example.User"},
+	}
+	ts := table.LookupItem("com.example.Missing.method")
+	if len(ts) != 0 {
+		t.Errorf("want 0, got %d: %v", len(ts), ts)
+	}
+}
+
+// ─── Monomorphise ─────────────────────────────────────────────────────────────
+
+func TestMonomorphise_NonGeneric(t *testing.T) {
+	items := map[string]bool{"com.example.Api.call": false}
+	fns := Monomorphise(items, nil)
+	if len(fns) != 1 {
+		t.Fatalf("want 1 fn, got %d", len(fns))
+	}
+	fn := fns[0]
+	if fn.MangledName != "call" {
+		t.Errorf("mangled name = %q; want call", fn.MangledName)
+	}
+	if fn.ConcreteT != "" {
+		t.Errorf("non-generic should have empty ConcreteT")
+	}
+}
+
+func TestMonomorphise_Generic_OneT(t *testing.T) {
+	items := map[string]bool{"com.example.Repo.find": true}
+	table := MonomorphiseTable{
+		{Item: "com.example.Repo.find", T: "com.example.User"},
+	}
+	fns := Monomorphise(items, table)
+	if len(fns) != 1 {
+		t.Fatalf("want 1 fn, got %d", len(fns))
+	}
+	fn := fns[0]
+	if fn.MangledName != "find_User" {
+		t.Errorf("mangled = %q; want find_User", fn.MangledName)
+	}
+	if fn.SimpleName != "User" {
+		t.Errorf("SimpleName = %q; want User", fn.SimpleName)
+	}
+	if fn.ConcreteT != "com.example.User" {
+		t.Errorf("ConcreteT = %q", fn.ConcreteT)
+	}
+}
+
+func TestMonomorphise_Generic_MultipleT(t *testing.T) {
+	items := map[string]bool{"com.example.Repo.find": true}
+	table := MonomorphiseTable{
+		{Item: "com.example.Repo.find", T: "com.example.User"},
+		{Item: "com.example.Repo.find", T: "com.example.Post"},
+	}
+	fns := Monomorphise(items, table)
+	if len(fns) != 2 {
+		t.Fatalf("want 2 fns, got %d", len(fns))
+	}
+	names := map[string]bool{}
+	for _, fn := range fns {
+		names[fn.MangledName] = true
+	}
+	if !names["find_User"] || !names["find_Post"] {
+		t.Errorf("unexpected mangled names: %v", names)
+	}
+}
+
+func TestMonomorphise_Generic_NoTableEntry(t *testing.T) {
+	items := map[string]bool{"com.example.Repo.find": true}
+	// No entry in table — generic is in refusal set; nothing emitted.
+	fns := Monomorphise(items, nil)
+	if len(fns) != 0 {
+		t.Errorf("want 0 fns for unregistered generic, got %d", len(fns))
+	}
+}
+
+// ─── MonoShimLine ─────────────────────────────────────────────────────────────
+
+func TestMonoShimLine_NonGeneric(t *testing.T) {
+	fn := MonoFn{BaseName: "call", MangledName: "call", KotlinFQN: "com.example.Api.call"}
+	line := MonoShimLine(fn, "mochi_api_call", "string", "req: string")
+	if !strings.Contains(line, `from kotlin "com.example.Api.call"`) {
+		t.Errorf("missing kotlin annotation: %q", line)
+	}
+	if strings.Contains(line, "monomorphise") {
+		t.Errorf("non-generic should not have monomorphise: %q", line)
+	}
+}
+
+func TestMonoShimLine_Generic(t *testing.T) {
+	fn := MonoFn{
+		BaseName: "find", MangledName: "find_User",
+		KotlinFQN: "com.example.Repo.find",
+		ConcreteT: "com.example.User", SimpleName: "User",
+	}
+	line := MonoShimLine(fn, "mochi_repo_find_user", "any", "")
+	if !strings.Contains(line, `monomorphise T="com.example.User"`) {
+		t.Errorf("missing monomorphise annotation: %q", line)
+	}
+}
+
+// ─── itemSimpleName / typeSimpleName ──────────────────────────────────────────
+
+func TestItemSimpleName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"com.example.Repo.find", "find"},
+		{"find", "find"},
+		{"a.b", "b"},
+	}
+	for _, c := range cases {
+		if got := itemSimpleName(c.in); got != c.want {
+			t.Errorf("itemSimpleName(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestTypeSimpleName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"com.example.User", "User"},
+		{"User", "User"},
+		{"com.example.deep.Type", "Type"},
+	}
+	for _, c := range cases {
+		if got := typeSimpleName(c.in); got != c.want {
+			t.Errorf("typeSimpleName(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// ─── ExtractClassesJAR (AAR) ──────────────────────────────────────────────────
+
+func buildAAR(t *testing.T, classesJARContent []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	// Add AndroidManifest.xml
+	w, _ := zw.Create("AndroidManifest.xml")
+	_, _ = w.Write([]byte(`<manifest package="com.example"/>`))
+	// Add classes.jar
+	w, _ = zw.Create("classes.jar")
+	_, _ = w.Write(classesJARContent)
+	// Add a res/ entry
+	w, _ = zw.Create("res/values/strings.xml")
+	_, _ = w.Write([]byte(`<resources/>`))
+	_ = zw.Close()
+	return buf.Bytes()
+}
+
+func TestExtractClassesJAR_Found(t *testing.T) {
+	fakeJAR := []byte("PK fake jar bytes")
+	aar := buildAAR(t, fakeJAR)
+
+	got, err := ExtractClassesJAR(aar)
+	if err != nil {
+		t.Fatalf("ExtractClassesJAR: %v", err)
+	}
+	if !bytes.Equal(got, fakeJAR) {
+		t.Errorf("classes.jar content mismatch")
+	}
+}
+
+func TestExtractClassesJAR_Missing(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, _ := zw.Create("AndroidManifest.xml")
+	_, _ = w.Write([]byte(`<manifest/>`))
+	_ = zw.Close()
+
+	_, err := ExtractClassesJAR(buf.Bytes())
+	if err == nil {
+		t.Fatal("want error when classes.jar absent")
+	}
+	if !strings.Contains(err.Error(), "classes.jar not found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestExtractClassesJAR_NotZIP(t *testing.T) {
+	_, err := ExtractClassesJAR([]byte("not a zip"))
+	if err == nil {
+		t.Fatal("want error for non-ZIP input")
+	}
+}
+
+// ─── IsAAR ────────────────────────────────────────────────────────────────────
+
+func TestIsAAR(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"mylib.aar", true},
+		{"MyLib.AAR", true},
+		{"mylib.jar", false},
+		{"mylib.aar.bak", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsAAR(c.in); got != c.want {
+			t.Errorf("IsAAR(%q) = %v; want %v", c.in, got, c.want)
+		}
+	}
+}
+
+// ─── SelectJVMVariant ─────────────────────────────────────────────────────────
+
+func TestSelectJVMVariant_KMP(t *testing.T) {
+	moduleJSON := []byte(`{
+  "formatVersion": "1.1",
+  "component": {"group":"org.example","module":"lib","version":"1.0"},
+  "variants": [
+    {"name": "jvmApiElements", "attributes": {"org.jetbrains.kotlin.platform.type": "jvm"}},
+    {"name": "jsApiElements", "attributes": {"org.jetbrains.kotlin.platform.type": "js"}}
+  ]
+}`)
+	art := SelectJVMVariant(moduleJSON, "https://repo.maven.apache.org/maven2",
+		"org.example", "lib", "1.0")
+	if !art.IsKMP {
+		t.Error("want IsKMP=true for KMP module JSON")
+	}
+	if art.JVMVariantJARURL == "" {
+		t.Error("want non-empty JVMVariantJARURL")
+	}
+	if art.JVMVariantVersion != "1.0" {
+		t.Errorf("version = %q; want 1.0", art.JVMVariantVersion)
+	}
+}
+
+func TestSelectJVMVariant_NotKMP(t *testing.T) {
+	moduleJSON := []byte(`{"formatVersion":"1.1","variants":[{"name":"releaseApiElements"}]}`)
+	art := SelectJVMVariant(moduleJSON, "https://repo.maven.apache.org/maven2",
+		"com.example", "lib", "2.0")
+	if art.IsKMP {
+		t.Error("want IsKMP=false for non-KMP module JSON")
+	}
+}
+
+func TestSelectJVMVariant_Empty(t *testing.T) {
+	art := SelectJVMVariant(nil, "", "g", "a", "1")
+	if art.IsKMP {
+		t.Error("want IsKMP=false for nil module JSON")
+	}
+}


### PR DESCRIPTION
Closes #22980

Final phase of MEP-70. Adds `package3/kotlin/generics`:
- Generic monomorphisation via `MonomorphiseTable` + `Monomorphise()`
- Android AAR consumer: `ExtractClassesJAR` + `IsAAR`
- KMP JVM variant selection: `SelectJVMVariant` scans Gradle Module Metadata

17 tests pass.