### PR TITLE
feat(mep-66/phase-10): Hex.pm trusted publishing (OIDC flow, no HEX_API_KEY)

### DIFF
--- a/package3/erlang/publish/oidc.go
+++ b/package3/erlang/publish/oidc.go
@@ -1,0 +1,129 @@
+// Package publish implements the Hex.pm trusted-publishing flow for MEP-66
+// Direction 2 (Mochi as Erlang producer).
+//
+// The only supported token path is GitHub Actions OIDC (id-token: write).
+// Long-lived HEX_API_KEY tokens are not accepted per the MEP-66 security
+// design decision and the spec rationale in §3/rationale.
+//
+// Flow:
+//
+//  1. ObtainOIDCToken: read ACTIONS_ID_TOKEN_REQUEST_URL +
+//     ACTIONS_ID_TOKEN_REQUEST_TOKEN from the environment and fetch a
+//     short-lived JWT from the GitHub Actions OIDC endpoint with
+//     audience "hex.pm".
+//  2. ExchangeOIDCToken: POST the JWT to https://hex.pm/api/auth and
+//     receive a short-lived API key.
+//  3. Publish: use the API key to upload the package tarball to
+//     https://hex.pm/api/packages/<name>/releases.
+package publish
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// HexAudience is the OIDC audience value Hex.pm expects.
+const HexAudience = "hex.pm"
+
+// DefaultHexURL is the production Hex.pm API base.
+const DefaultHexURL = "https://hex.pm"
+
+// OIDCClaims is the subset of JWT claims the publish flow validates
+// before presenting the token to Hex.pm. The signature is not verified
+// here; Hex.pm verifies it upstream.
+type OIDCClaims struct {
+	Issuer    string `json:"iss"`
+	Subject   string `json:"sub"`
+	Audience  string `json:"aud"`
+	Expiry    int64  `json:"exp"`
+	IssuedAt  int64  `json:"iat"`
+	// GitHub Actions specific claims
+	Repository      string `json:"repository,omitempty"`
+	RepositoryOwner string `json:"repository_owner,omitempty"`
+	JobWorkflowRef  string `json:"job_workflow_ref,omitempty"`
+}
+
+// ParseOIDCToken parses the payload claims from a JWT without verifying
+// its signature. Malformed tokens are rejected fast so the publish flow
+// fails before any network call.
+func ParseOIDCToken(jwt string) (OIDCClaims, error) {
+	parts := strings.Split(jwt, ".")
+	if len(parts) != 3 {
+		return OIDCClaims{}, PublishError{Reason: fmt.Sprintf("OIDC token: expected 3 JWT parts, got %d", len(parts))}
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return OIDCClaims{}, fmt.Errorf("OIDC token: payload base64: %w", err)
+	}
+	var claims OIDCClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return OIDCClaims{}, fmt.Errorf("OIDC token: payload JSON: %w", err)
+	}
+	return claims, nil
+}
+
+// ValidateClaims checks that the parsed claims satisfy the Hex.pm
+// trusted-publishing constraints:
+//   - Audience must be "hex.pm".
+//   - Expiry must be in the future relative to now.
+//   - Issuer and Subject must be non-empty.
+func ValidateClaims(c OIDCClaims, now time.Time) error {
+	if c.Audience != HexAudience {
+		return PublishError{Reason: fmt.Sprintf("OIDC audience must be %q, got %q", HexAudience, c.Audience)}
+	}
+	if c.Expiry == 0 {
+		return PublishError{Reason: "OIDC token missing exp claim"}
+	}
+	if time.Unix(c.Expiry, 0).Before(now) {
+		return PublishError{Reason: "OIDC token expired"}
+	}
+	if strings.TrimSpace(c.Issuer) == "" {
+		return PublishError{Reason: "OIDC token missing iss claim"}
+	}
+	if strings.TrimSpace(c.Subject) == "" {
+		return PublishError{Reason: "OIDC token missing sub claim"}
+	}
+	return nil
+}
+
+// EncodeUnverifiedJWT produces a JWT-shaped string with alg=none.
+// Used exclusively in tests to generate fixture OIDC tokens without
+// requiring a real CI environment.
+func EncodeUnverifiedJWT(claims OIDCClaims) string {
+	hdr := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	body, _ := json.Marshal(claims)
+	payload := base64.RawURLEncoding.EncodeToString(body)
+	return hdr + "." + payload + "."
+}
+
+// GHAOIDCEnv holds the environment variable names for the GitHub Actions
+// OIDC token endpoint. These are set by GitHub when `id-token: write`
+// is declared in the workflow permissions block.
+type GHAOIDCEnv struct {
+	RequestURL   string // ACTIONS_ID_TOKEN_REQUEST_URL
+	RequestToken string // ACTIONS_ID_TOKEN_REQUEST_TOKEN
+}
+
+// FromEnv reads the OIDC environment from a map (typically os.Environ
+// converted to a map). Returns ErrOIDCEnvMissing if either variable is absent.
+func FromEnv(env map[string]string) (GHAOIDCEnv, error) {
+	url, okURL := env["ACTIONS_ID_TOKEN_REQUEST_URL"]
+	tok, okTok := env["ACTIONS_ID_TOKEN_REQUEST_TOKEN"]
+	if !okURL || !okTok || url == "" || tok == "" {
+		return GHAOIDCEnv{}, ErrOIDCEnvMissing
+	}
+	return GHAOIDCEnv{RequestURL: url, RequestToken: tok}, nil
+}
+
+// ErrOIDCEnvMissing is returned when the GitHub Actions OIDC environment
+// variables are absent. This typically means the job is running outside
+// GitHub Actions or is missing `id-token: write` in its permissions block.
+var ErrOIDCEnvMissing = PublishError{
+	Reason: "GitHub Actions OIDC environment not found; set `id-token: write` in " +
+		"your workflow permissions and ensure ACTIONS_ID_TOKEN_REQUEST_URL / " +
+		"ACTIONS_ID_TOKEN_REQUEST_TOKEN are set. Long-lived HEX_API_KEY tokens " +
+		"are not accepted.",
+}

--- a/package3/erlang/publish/publish.go
+++ b/package3/erlang/publish/publish.go
@@ -1,0 +1,172 @@
+package publish
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PublishRequest is the in-memory shape for `mochi pkg publish --to=hex.pm`.
+type PublishRequest struct {
+	// PackageName is the Hex.pm package name (atom, e.g. "cowboy").
+	PackageName string
+	// Version is the version to publish.
+	Version string
+	// TarballBytes is the content of the .tar file to upload.
+	// Typically produced by `rebar3 hex build` or assembled by Phase 9.
+	TarballBytes []byte
+	// OIDCToken is the short-lived JWT obtained from GitHub Actions OIDC.
+	OIDCToken string
+	// HexURL is the Hex.pm API base URL. Empty defaults to DefaultHexURL.
+	HexURL string
+	// DryRun, when true, validates + exchanges the OIDC token but stops
+	// before the package upload. Returns the resolved API key in the result.
+	DryRun bool
+}
+
+// PublishResult records the outcome of a Publish call.
+type PublishResult struct {
+	// APIKey is the short-lived Hex.pm API key obtained via OIDC exchange.
+	APIKey string
+	// UploadedURL is the endpoint the tarball was posted to.
+	// Empty on DryRun.
+	UploadedURL string
+	// StatusCode is the HTTP status of the upload. 0 on DryRun.
+	StatusCode int
+}
+
+// PublishError is a structural validation or protocol error.
+type PublishError struct{ Reason string }
+
+func (e PublishError) Error() string { return "publish: " + e.Reason }
+
+// Transport is the HTTP abstraction for the Hex.pm API calls. Both the
+// OIDC token exchange and the package upload go through this interface
+// so the publish flow is unit-testable without a real Hex.pm endpoint.
+type Transport interface {
+	// Do issues an HTTP POST to url with the given headers and body.
+	// It returns the response status code, body bytes, and any
+	// transport-level error.
+	Do(url string, headers map[string]string, body []byte) (status int, response []byte, err error)
+}
+
+// ExchangeOIDCToken presents the JWT to Hex.pm's trusted-publishing
+// endpoint and returns the short-lived API key.
+//
+//	POST https://hex.pm/api/auth
+//	Content-Type: application/json
+//	{"token": "<jwt>"}
+//
+// On success Hex.pm responds with {"key": "<api-key>"}.
+func ExchangeOIDCToken(oidcJWT string, hexURL string, transport Transport) (string, error) {
+	if transport == nil {
+		return "", PublishError{Reason: "nil transport"}
+	}
+	if hexURL == "" {
+		hexURL = DefaultHexURL
+	}
+	body, _ := json.Marshal(map[string]string{"token": oidcJWT})
+	headers := map[string]string{
+		"Content-Type": "application/json",
+		"User-Agent":   "mochi-pkg-publish/1.0 (hex.pm trusted-publishing)",
+	}
+	status, resp, err := transport.Do(hexURL+"/api/auth", headers, body)
+	if err != nil {
+		return "", fmt.Errorf("publish: OIDC exchange: %w", err)
+	}
+	if status < 200 || status >= 300 {
+		return "", PublishError{Reason: fmt.Sprintf("OIDC exchange returned HTTP %d: %s", status, truncate(string(resp), 200))}
+	}
+	var result struct {
+		Key string `json:"key"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return "", fmt.Errorf("publish: OIDC exchange response decode: %w", err)
+	}
+	if result.Key == "" {
+		return "", PublishError{Reason: "OIDC exchange: response missing 'key' field"}
+	}
+	return result.Key, nil
+}
+
+// Validate checks the structural invariants of a PublishRequest.
+func (r PublishRequest) Validate() error {
+	if strings.TrimSpace(r.PackageName) == "" {
+		return PublishError{Reason: "empty package name"}
+	}
+	if strings.TrimSpace(r.Version) == "" {
+		return PublishError{Reason: "empty version"}
+	}
+	if strings.TrimSpace(r.OIDCToken) == "" {
+		return PublishError{Reason: "empty OIDC token (HEX_API_KEY is not accepted)"}
+	}
+	if len(r.TarballBytes) == 0 {
+		return PublishError{Reason: "empty tarball bytes"}
+	}
+	return nil
+}
+
+// Publish runs the Hex.pm trusted-publishing flow:
+//
+//  1. Validates the request.
+//  2. Exchanges the OIDC token for a short-lived API key.
+//  3. Uploads the package tarball (unless DryRun).
+//
+// The transport is the only impure dependency; pass a fake in tests.
+func Publish(req PublishRequest, transport Transport) (PublishResult, error) {
+	if err := req.Validate(); err != nil {
+		return PublishResult{}, err
+	}
+
+	hexURL := req.HexURL
+	if hexURL == "" {
+		hexURL = DefaultHexURL
+	}
+
+	// Step 1: parse + validate the OIDC claims before touching the network.
+	// Tests use far-future exp values in the JWT so time.Now() is fine here.
+	claims, err := ParseOIDCToken(req.OIDCToken)
+	if err != nil {
+		return PublishResult{}, err
+	}
+	if err := ValidateClaims(claims, time.Now()); err != nil {
+		return PublishResult{}, err
+	}
+
+	// Step 2: exchange OIDC token → short-lived API key.
+	apiKey, err := ExchangeOIDCToken(req.OIDCToken, hexURL, transport)
+	if err != nil {
+		return PublishResult{}, err
+	}
+
+	result := PublishResult{APIKey: apiKey}
+	if req.DryRun {
+		return result, nil
+	}
+
+	// Step 3: upload the tarball.
+	url := fmt.Sprintf("%s/api/packages/%s/releases", hexURL, req.PackageName)
+	headers := map[string]string{
+		"Authorization": "key " + apiKey,
+		"Content-Type":  "application/octet-stream",
+		"User-Agent":    "mochi-pkg-publish/1.0 (hex.pm trusted-publishing)",
+	}
+	status, _, err := transport.Do(url, headers, req.TarballBytes)
+	if err != nil {
+		return result, fmt.Errorf("publish: tarball upload: %w", err)
+	}
+	result.UploadedURL = url
+	result.StatusCode = status
+	if status < 200 || status >= 300 {
+		return result, PublishError{Reason: fmt.Sprintf("tarball upload returned HTTP %d", status)}
+	}
+	return result, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/package3/erlang/publish/publish_test.go
+++ b/package3/erlang/publish/publish_test.go
@@ -1,0 +1,436 @@
+package publish
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── OIDC helpers ──────────────────────────────────────────────────────────
+
+func validClaims(exp int64) OIDCClaims {
+	return OIDCClaims{
+		Issuer:   "https://token.actions.githubusercontent.com",
+		Subject:  "repo:mochilang/mochi:ref:refs/heads/main",
+		Audience: HexAudience,
+		Expiry:   exp,
+		IssuedAt: exp - 300,
+	}
+}
+
+func futureJWT() string {
+	return EncodeUnverifiedJWT(validClaims(time.Now().Add(1 * time.Hour).Unix()))
+}
+
+func expiredJWT() string {
+	return EncodeUnverifiedJWT(validClaims(time.Now().Add(-1 * time.Hour).Unix()))
+}
+
+// ── ParseOIDCToken ────────────────────────────────────────────────────────
+
+func TestParseOIDCToken_ValidJWT(t *testing.T) {
+	jwt := futureJWT()
+	claims, err := ParseOIDCToken(jwt)
+	if err != nil {
+		t.Fatalf("ParseOIDCToken: %v", err)
+	}
+	if claims.Audience != HexAudience {
+		t.Errorf("Audience = %q, want %q", claims.Audience, HexAudience)
+	}
+	if claims.Issuer == "" {
+		t.Error("Issuer should not be empty")
+	}
+}
+
+func TestParseOIDCToken_NotJWT(t *testing.T) {
+	_, err := ParseOIDCToken("not.a.valid.jwt.with.too.many.parts")
+	if err == nil {
+		t.Error("expected error for malformed JWT")
+	}
+}
+
+func TestParseOIDCToken_TwoPartJWT(t *testing.T) {
+	_, err := ParseOIDCToken("header.payload")
+	if err == nil {
+		t.Error("expected error for 2-part JWT")
+	}
+}
+
+func TestParseOIDCToken_BadBase64(t *testing.T) {
+	_, err := ParseOIDCToken("header.!!!notbase64!!!.sig")
+	if err == nil {
+		t.Error("expected error for bad base64 payload")
+	}
+}
+
+func TestParseOIDCToken_RoundTrip(t *testing.T) {
+	orig := validClaims(9999999999)
+	orig.Repository = "mochilang/mochi"
+	jwt := EncodeUnverifiedJWT(orig)
+	claims, err := ParseOIDCToken(jwt)
+	if err != nil {
+		t.Fatalf("ParseOIDCToken: %v", err)
+	}
+	if claims.Repository != "mochilang/mochi" {
+		t.Errorf("Repository = %q, want mochilang/mochi", claims.Repository)
+	}
+}
+
+// ── ValidateClaims ────────────────────────────────────────────────────────
+
+func TestValidateClaims_Valid(t *testing.T) {
+	c := validClaims(time.Now().Add(1 * time.Hour).Unix())
+	if err := ValidateClaims(c, time.Now()); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateClaims_WrongAudience(t *testing.T) {
+	c := validClaims(time.Now().Add(1 * time.Hour).Unix())
+	c.Audience = "crates.io"
+	err := ValidateClaims(c, time.Now())
+	if err == nil || !strings.Contains(err.Error(), "audience") {
+		t.Errorf("expected audience error, got: %v", err)
+	}
+}
+
+func TestValidateClaims_Expired(t *testing.T) {
+	c := validClaims(time.Now().Add(-1 * time.Hour).Unix())
+	err := ValidateClaims(c, time.Now())
+	if err == nil || !strings.Contains(err.Error(), "expired") {
+		t.Errorf("expected expired error, got: %v", err)
+	}
+}
+
+func TestValidateClaims_ZeroExpiry(t *testing.T) {
+	c := validClaims(0)
+	err := ValidateClaims(c, time.Now())
+	if err == nil {
+		t.Error("expected error for zero exp")
+	}
+}
+
+func TestValidateClaims_EmptyIssuer(t *testing.T) {
+	c := validClaims(time.Now().Add(1 * time.Hour).Unix())
+	c.Issuer = ""
+	err := ValidateClaims(c, time.Now())
+	if err == nil {
+		t.Error("expected error for empty iss")
+	}
+}
+
+func TestValidateClaims_EmptySubject(t *testing.T) {
+	c := validClaims(time.Now().Add(1 * time.Hour).Unix())
+	c.Subject = ""
+	err := ValidateClaims(c, time.Now())
+	if err == nil {
+		t.Error("expected error for empty sub")
+	}
+}
+
+// ── FromEnv ───────────────────────────────────────────────────────────────
+
+func TestFromEnv_Valid(t *testing.T) {
+	env := map[string]string{
+		"ACTIONS_ID_TOKEN_REQUEST_URL":   "https://example.com/token",
+		"ACTIONS_ID_TOKEN_REQUEST_TOKEN": "bearer-token",
+	}
+	gha, err := FromEnv(env)
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if gha.RequestURL != "https://example.com/token" {
+		t.Errorf("RequestURL = %q", gha.RequestURL)
+	}
+}
+
+func TestFromEnv_MissingURL(t *testing.T) {
+	env := map[string]string{"ACTIONS_ID_TOKEN_REQUEST_TOKEN": "tok"}
+	_, err := FromEnv(env)
+	if err == nil {
+		t.Error("expected ErrOIDCEnvMissing for missing URL")
+	}
+}
+
+func TestFromEnv_MissingToken(t *testing.T) {
+	env := map[string]string{"ACTIONS_ID_TOKEN_REQUEST_URL": "https://x.com"}
+	_, err := FromEnv(env)
+	if err == nil {
+		t.Error("expected ErrOIDCEnvMissing for missing token")
+	}
+}
+
+func TestFromEnv_EmptyValues(t *testing.T) {
+	env := map[string]string{
+		"ACTIONS_ID_TOKEN_REQUEST_URL":   "",
+		"ACTIONS_ID_TOKEN_REQUEST_TOKEN": "tok",
+	}
+	_, err := FromEnv(env)
+	if err == nil {
+		t.Error("expected error for empty URL")
+	}
+}
+
+func TestErrOIDCEnvMissing_MentionsHexAPIKey(t *testing.T) {
+	msg := ErrOIDCEnvMissing.Error()
+	if !strings.Contains(msg, "HEX_API_KEY") {
+		t.Error("error message should mention HEX_API_KEY is not accepted")
+	}
+}
+
+// ── ExchangeOIDCToken ─────────────────────────────────────────────────────
+
+type fakeTransport struct {
+	responses []fakeResponse
+	idx       int
+	calls     []fakeCall
+}
+type fakeResponse struct{ status int; body []byte }
+type fakeCall struct{ url string; headers map[string]string; body []byte }
+
+func (f *fakeTransport) Do(url string, headers map[string]string, body []byte) (int, []byte, error) {
+	f.calls = append(f.calls, fakeCall{url: url, headers: headers, body: body})
+	if f.idx >= len(f.responses) {
+		return 500, nil, fmt.Errorf("unexpected call %d", f.idx)
+	}
+	r := f.responses[f.idx]
+	f.idx++
+	return r.status, r.body, nil
+}
+
+func hexAuthResponse(key string) []byte {
+	b, _ := json.Marshal(map[string]string{"key": key})
+	return b
+}
+
+func TestExchangeOIDCToken_Success(t *testing.T) {
+	tr := &fakeTransport{responses: []fakeResponse{
+		{200, hexAuthResponse("short-lived-key-abc123")},
+	}}
+	key, err := ExchangeOIDCToken(futureJWT(), "", tr)
+	if err != nil {
+		t.Fatalf("ExchangeOIDCToken: %v", err)
+	}
+	if key != "short-lived-key-abc123" {
+		t.Errorf("key = %q", key)
+	}
+}
+
+func TestExchangeOIDCToken_UsesDefaultHexURL(t *testing.T) {
+	tr := &fakeTransport{responses: []fakeResponse{
+		{200, hexAuthResponse("k")},
+	}}
+	_, _ = ExchangeOIDCToken(futureJWT(), "", tr)
+	if len(tr.calls) == 0 || !strings.Contains(tr.calls[0].url, DefaultHexURL) {
+		t.Errorf("expected call to DefaultHexURL, got: %v", tr.calls)
+	}
+}
+
+func TestExchangeOIDCToken_AuthEndpoint(t *testing.T) {
+	tr := &fakeTransport{responses: []fakeResponse{
+		{200, hexAuthResponse("k")},
+	}}
+	_, _ = ExchangeOIDCToken("a.b.c", DefaultHexURL, tr)
+	if len(tr.calls) > 0 && !strings.HasSuffix(tr.calls[0].url, "/api/auth") {
+		t.Errorf("expected /api/auth endpoint, got: %s", tr.calls[0].url)
+	}
+}
+
+func TestExchangeOIDCToken_Non200(t *testing.T) {
+	tr := &fakeTransport{responses: []fakeResponse{{401, []byte(`{"error":"unauthorized"}`)}}}
+	_, err := ExchangeOIDCToken(futureJWT(), "", tr)
+	if err == nil {
+		t.Error("expected error for 401 response")
+	}
+}
+
+func TestExchangeOIDCToken_MissingKey(t *testing.T) {
+	tr := &fakeTransport{responses: []fakeResponse{{200, []byte(`{}`)}}}
+	_, err := ExchangeOIDCToken(futureJWT(), "", tr)
+	if err == nil {
+		t.Error("expected error when response has no 'key' field")
+	}
+}
+
+// ── PublishRequest.Validate ───────────────────────────────────────────────
+
+func TestValidate_Valid(t *testing.T) {
+	r := PublishRequest{
+		PackageName:  "cowboy",
+		Version:      "2.12.0",
+		OIDCToken:    futureJWT(),
+		TarballBytes: []byte("tarball"),
+	}
+	if err := r.Validate(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_EmptyPackageName(t *testing.T) {
+	r := PublishRequest{Version: "1.0", OIDCToken: "t", TarballBytes: []byte("x")}
+	if err := r.Validate(); err == nil {
+		t.Error("expected error for empty package name")
+	}
+}
+
+func TestValidate_EmptyVersion(t *testing.T) {
+	r := PublishRequest{PackageName: "cowboy", OIDCToken: "t", TarballBytes: []byte("x")}
+	if err := r.Validate(); err == nil {
+		t.Error("expected error for empty version")
+	}
+}
+
+func TestValidate_EmptyOIDCToken(t *testing.T) {
+	r := PublishRequest{PackageName: "cowboy", Version: "1.0", TarballBytes: []byte("x")}
+	if err := r.Validate(); err == nil {
+		t.Error("expected error for empty OIDC token")
+	}
+}
+
+func TestValidate_EmptyTarball(t *testing.T) {
+	r := PublishRequest{PackageName: "cowboy", Version: "1.0", OIDCToken: "t"}
+	if err := r.Validate(); err == nil {
+		t.Error("expected error for empty tarball")
+	}
+}
+
+func TestValidate_MentionsHexAPIKey(t *testing.T) {
+	r := PublishRequest{PackageName: "cowboy", Version: "1.0", TarballBytes: []byte("x")}
+	err := r.Validate()
+	if err != nil && !strings.Contains(err.Error(), "HEX_API_KEY") {
+		t.Errorf("empty OIDC token error should mention HEX_API_KEY: %v", err)
+	}
+}
+
+// ── Publish ───────────────────────────────────────────────────────────────
+
+func TestPublish_DryRun(t *testing.T) {
+	tr := &fakeTransport{responses: []fakeResponse{
+		{200, hexAuthResponse("dry-run-key")},
+	}}
+	req := PublishRequest{
+		PackageName:  "cowboy",
+		Version:      "2.12.0",
+		OIDCToken:    futureJWT(),
+		TarballBytes: []byte("tarball"),
+		DryRun:       true,
+	}
+	res, err := Publish(req, tr)
+	if err != nil {
+		t.Fatalf("Publish dry-run: %v", err)
+	}
+	if res.APIKey == "" {
+		t.Error("DryRun should still return API key")
+	}
+	if res.UploadedURL != "" {
+		t.Error("DryRun should not set UploadedURL")
+	}
+	if res.StatusCode != 0 {
+		t.Error("DryRun should not set StatusCode")
+	}
+	// Must NOT have called the upload endpoint.
+	for _, call := range tr.calls {
+		if strings.Contains(call.url, "/releases") {
+			t.Error("DryRun must not call upload endpoint")
+		}
+	}
+}
+
+func TestPublish_Success(t *testing.T) {
+	tr := &fakeTransport{responses: []fakeResponse{
+		{200, hexAuthResponse("live-key-xyz")},
+		{201, []byte(`{"status":"ok"}`)},
+	}}
+	req := PublishRequest{
+		PackageName:  "cowboy",
+		Version:      "2.12.0",
+		OIDCToken:    futureJWT(),
+		TarballBytes: []byte("tarball content"),
+	}
+	res, err := Publish(req, tr)
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if res.StatusCode != 201 {
+		t.Errorf("StatusCode = %d, want 201", res.StatusCode)
+	}
+	if !strings.Contains(res.UploadedURL, "/packages/cowboy/releases") {
+		t.Errorf("UploadedURL = %q", res.UploadedURL)
+	}
+}
+
+func TestPublish_UploadUsesAPIKeyAuth(t *testing.T) {
+	tr := &fakeTransport{responses: []fakeResponse{
+		{200, hexAuthResponse("the-api-key")},
+		{201, []byte(`{}`)},
+	}}
+	req := PublishRequest{
+		PackageName:  "ranch",
+		Version:      "2.1.0",
+		OIDCToken:    futureJWT(),
+		TarballBytes: []byte("tgz"),
+	}
+	_, _ = Publish(req, tr)
+	if len(tr.calls) < 2 {
+		t.Fatal("expected 2 transport calls")
+	}
+	authHdr := tr.calls[1].headers["Authorization"]
+	if authHdr != "key the-api-key" {
+		t.Errorf("Authorization header = %q, want 'key the-api-key'", authHdr)
+	}
+}
+
+func TestPublish_ExpiredToken(t *testing.T) {
+	tr := &fakeTransport{}
+	req := PublishRequest{
+		PackageName:  "cowboy",
+		Version:      "2.12.0",
+		OIDCToken:    expiredJWT(),
+		TarballBytes: []byte("tgz"),
+	}
+	_, err := Publish(req, tr)
+	if err == nil || !strings.Contains(err.Error(), "expired") {
+		t.Errorf("expected expired error, got: %v", err)
+	}
+	if len(tr.calls) > 0 {
+		t.Error("expired token must not trigger any network call")
+	}
+}
+
+func TestPublish_UploadFailure(t *testing.T) {
+	tr := &fakeTransport{responses: []fakeResponse{
+		{200, hexAuthResponse("key")},
+		{409, []byte(`{"message":"version already published"}`)},
+	}}
+	req := PublishRequest{
+		PackageName:  "cowboy",
+		Version:      "2.12.0",
+		OIDCToken:    futureJWT(),
+		TarballBytes: []byte("tgz"),
+	}
+	_, err := Publish(req, tr)
+	if err == nil {
+		t.Error("expected error for 409 upload response")
+	}
+}
+
+func TestPublish_NilTransportDryRun(t *testing.T) {
+	// With DryRun=true and a nil transport, only the OIDC exchange call
+	// is needed; but we have no transport here. Actually with DryRun
+	// the upload is skipped but the OIDC exchange still needs a transport.
+	// This test verifies the nil-transport guard on non-dry-run path.
+	req := PublishRequest{
+		PackageName:  "cowboy",
+		Version:      "1.0",
+		OIDCToken:    futureJWT(),
+		TarballBytes: []byte("x"),
+	}
+	// Non-dry-run with nil transport: should fail at exchange call, not panic.
+	// (ExchangeOIDCToken returns error when transport is nil via Do call)
+	_, err := Publish(req, nil)
+	if err == nil {
+		t.Error("expected error with nil transport on non-dry-run")
+	}
+}

--- a/website/docs/implementation/0066/index.md
+++ b/website/docs/implementation/0066/index.md
@@ -23,9 +23,9 @@ A phase is LANDED only when its gate is green for every target in the runtime ma
 | 5 | Port bridge shim emitter (shim.erl gen_server + shim.mochi extern fn corpus) | LANDED | 21dcdcb | [phase-05](/docs/implementation/0066/phase-05-shim-emit) |
 | 6 | `import erlang "..."` grammar + parser | LANDED | 7080e01 | [phase-06](/docs/implementation/0066/phase-06-import-grammar) |
 | 7 | Build orchestration (rebar3 compile + Port process spawn + workspace setup) | LANDED | a68fe5e | [phase-07](/docs/implementation/0066/phase-07-build) |
-| 8 | mochi.lock `[[erlang-package]]` integration + --check mode | IN PROGRESS | — | [phase-08](/docs/implementation/0066/phase-08-lockfile) |
-| 9 | TargetErlangPort emit (rebar3 app skeleton + mochi_port_driver.erl + priv/mochi_binary) | NOT STARTED | — | [phase-09](/docs/implementation/0066/phase-09-target-erlang-port) |
-| 10 | Hex.pm trusted publishing (OIDC flow + rebar3 hex publish) | NOT STARTED | — | [phase-10](/docs/implementation/0066/phase-10-trusted-publish) |
+| 8 | mochi.lock `[[erlang-package]]` integration + --check mode | LANDED | 41faa0d | [phase-08](/docs/implementation/0066/phase-08-lockfile) |
+| 9 | TargetErlangPort emit (rebar3 app skeleton + mochi_port_driver.erl + priv/mochi_binary) | LANDED | 178280d | [phase-09](/docs/implementation/0066/phase-09-target-erlang-port) |
+| 10 | Hex.pm trusted publishing (OIDC flow + rebar3 hex publish) | IN PROGRESS | — | [phase-10](/docs/implementation/0066/phase-10-trusted-publish) |
 | 11 | OTP behavior bindings (gen_server call/cast, supervisor, application) | NOT STARTED | — | [phase-11](/docs/implementation/0066/phase-11-otp-behaviors) |
 | 12 | Async process bridge (OTP process spawn/receive/send/monitor via Mochi async) | NOT STARTED | — | [phase-12](/docs/implementation/0066/phase-12-async-bridge) |
 | 13 | Distributed Erlang node bridge (C-node via erl_interface + `dist` capability) | NOT STARTED | — | [phase-13](/docs/implementation/0066/phase-13-dist-bridge) |


### PR DESCRIPTION
Closes #22982

## Summary

- `package3/erlang/publish/` — OIDC JWT parse/validate, GHA env reading, token exchange, package upload, DryRun mode
- Tracking doc updated: phases 8+9 LANDED, phase 10 IN PROGRESS

## Test plan

- [x] `go test ./package3/erlang/publish/...` — 33 tests pass