### PR TITLE
MEP-74 phase 17: vanity-import + wasm publish gate (final baseline)

### DIFF
--- a/package3/go/vanity/phase17_test.go
+++ b/package3/go/vanity/phase17_test.go
@@ -1,0 +1,156 @@
+package vanity
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"mochi/package3/go/apisurface"
+)
+
+// TestPhase17VanityResolverSentinel exercises the full vanity-resolver
+// path against a real httptest.Server: a simulated vanity host serves
+// the `<meta name="go-import">` redirect at `/x/sync?go-get=1`, the
+// HTTPFetcher fetches it, ParseGoImport extracts the resolution, and
+// the test asserts the resulting Module/VCS/RepoURL match the
+// expected canonical record. This is the closest reproduction of
+// the live golang.org/x/* path without making a real network call.
+func TestPhase17VanityResolverSentinel(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/x/sync", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("go-get") != "1" {
+			http.Error(w, "expected go-get=1 probe", http.StatusBadRequest)
+			return
+		}
+		fmt.Fprintln(w, `<!doctype html><html><head>
+<meta name="go-import" content="vanity.test/x/sync git https://repo.test/sync">
+</head></html>`)
+	})
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	// Rewrite the host so the fetcher hits the local server. The
+	// HTTPFetcher itself takes the URL verbatim, so we use a
+	// rewriting fetcher that maps vanity.test → the live test
+	// server's URL.
+	transport := &rewriteTransport{
+		Base:   srv.Client().Transport,
+		Target: srv.URL,
+		From:   "https://vanity.test",
+	}
+	fetcher := &HTTPFetcher{Client: &http.Client{Transport: transport}}
+
+	res, err := Resolve("vanity.test/x/sync", fetcher)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Module != "vanity.test/x/sync" {
+		t.Errorf("Module = %q", res.Module)
+	}
+	if res.VCS != "git" {
+		t.Errorf("VCS = %q", res.VCS)
+	}
+	if res.RepoURL != "https://repo.test/sync" {
+		t.Errorf("RepoURL = %q", res.RepoURL)
+	}
+}
+
+// TestPhase17VanityResolverServer404Surfaces verifies the resolver
+// wraps a non-2xx response in ErrVanity rather than masking it as
+// a "no go-import meta" parse failure.
+func TestPhase17VanityResolverServer404Surfaces(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	transport := &rewriteTransport{
+		Base:   srv.Client().Transport,
+		Target: srv.URL,
+		From:   "https://vanity.test",
+	}
+	fetcher := &HTTPFetcher{Client: &http.Client{Transport: transport}}
+
+	_, err := Resolve("vanity.test/x/sync", fetcher)
+	if err == nil {
+		t.Fatalf("expected error for 404")
+	}
+	if !strings.Contains(err.Error(), "status 404") {
+		t.Errorf("error should name the status code: %v", err)
+	}
+}
+
+// TestPhase17WasmPublishGateRejectsCgoSurface walks a hand-curated
+// apisurface that imports runtime/cgo and asserts the wasm-wasip1
+// publish gate reports the violation. Mirrors the closeout
+// invariant for the publish-direction matrix.
+func TestPhase17WasmPublishGateRejectsCgoSurface(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "example.com/cgo-using",
+		Imports:    []string{"fmt", "runtime/cgo", "syscall/js"},
+	}
+	got := CheckPublish(WasmTargetWasip1, pkg)
+	if len(got) != 2 {
+		t.Fatalf("want 2 violations, got %v", got)
+	}
+	// wasip1 bans both runtime/cgo and syscall/js.
+	wantWheres := []string{"runtime/cgo", "syscall/js"}
+	for i, w := range wantWheres {
+		if got[i].Where != w {
+			t.Errorf("got[%d].Where = %q, want %q", i, got[i].Where, w)
+		}
+	}
+
+	// On wasm-js only runtime/cgo trips.
+	gotJS := CheckPublish(WasmTargetJS, pkg)
+	if len(gotJS) != 1 || gotJS[0].Where != "runtime/cgo" {
+		t.Fatalf("wasm-js: want 1 cgo violation, got %v", gotJS)
+	}
+}
+
+// TestPhase17WasmPublishGatePassesPureSurface confirms a pure-go
+// surface (no cgo, no syscall/js) publishes cleanly to both wasm
+// targets — the green-path of the matrix.
+func TestPhase17WasmPublishGatePassesPureSurface(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "example.com/pure",
+		Imports:    []string{"fmt", "errors", "strings", "math"},
+		Funcs: []apisurface.Func{
+			{
+				Name:    "Hash",
+				Params:  []apisurface.Param{{Name: "s", Type: "string"}},
+				Results: []apisurface.Param{{Type: "uint64"}},
+			},
+		},
+	}
+	for _, target := range []WasmTarget{WasmTargetWasip1, WasmTargetJS} {
+		if !IsPublishable(target, pkg) {
+			t.Errorf("%s: pure surface should be publishable, got %v", target, CheckPublish(target, pkg))
+		}
+	}
+}
+
+// rewriteTransport rewrites a fixed URL prefix (`From`) to the
+// httptest server's URL before delegating to the base RoundTripper.
+// Used so the in-test HTTPFetcher can hit a "vanity.test" host name
+// without DNS.
+type rewriteTransport struct {
+	Base   http.RoundTripper
+	From   string
+	Target string
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.HasPrefix(req.URL.String(), t.From) {
+		newURL := t.Target + strings.TrimPrefix(req.URL.String(), t.From)
+		newReq, err := http.NewRequestWithContext(req.Context(), req.Method, newURL, req.Body)
+		if err != nil {
+			return nil, err
+		}
+		newReq.Header = req.Header
+		req = newReq
+	}
+	return t.Base.RoundTrip(req)
+}

--- a/package3/go/vanity/vanity.go
+++ b/package3/go/vanity/vanity.go
@@ -1,0 +1,378 @@
+// Package vanity is the MEP-74 phase 17 vanity-import path
+// resolver plus the wasm-wasip1 / wasm-js publish gate.
+//
+// The Go ecosystem distinguishes two kinds of import paths:
+//
+//  1. Direct paths whose first segment is a known VCS host
+//     (github.com, gitlab.com, bitbucket.org, etc.) where the
+//     module proxy can fetch the source directly from the host.
+//  2. Vanity paths (golang.org/x/*, gopkg.in/*, k8s.io/*,
+//     google.golang.org/*, sigs.k8s.io/*, and any user-controlled
+//     domain) that delegate to a real VCS via the `<meta
+//     name="go-import" content="<root> <vcs> <repo-url>">` HTML
+//     redirect tag served at the path-prefix URL.
+//
+// MEP-74's `import go "<module>@<semver>"` form needs to resolve
+// vanity paths before the phase 1 module-proxy client can fetch
+// the source. This package owns that resolution: a single
+// `Resolve(path)` call that, for a vanity path, fetches the
+// go-get probe URL, parses the meta tag, and returns the
+// `Resolution{Module, VCS, RepoURL}` the proxy client can use.
+//
+// The wasm publish-direction gate is a separate concern that
+// happens to live in the same package: the
+// `WasmTarget` profile constants name wasm-wasip1, wasm-js, and a
+// `CheckPublish(target, pkg)` walker reports violations for any
+// surface that cannot be published under the given target (e.g.,
+// cgo-using packages cannot be published as wasm-wasip1; packages
+// importing `syscall/js` cannot be published as wasm-wasip1
+// either).
+//
+// Out of scope for v1 (deferred to 17.1+): a real HTTP transport
+// against live vanity hosts (the unit tests use an in-memory
+// transport), a per-mochi.toml override table for vendored
+// vanity paths, and the wazero-host smoke run that actually
+// instantiates the published wasm module.
+package vanity
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+
+	"mochi/package3/go/apisurface"
+)
+
+// ErrVanity is the package-wide error sentinel.
+var ErrVanity = errors.New("vanity")
+
+// KnownVCSHosts is the closed list of import-path first-segments
+// that the proxy fetches from directly (no vanity redirect needed).
+// Anything else is treated as a vanity path and goes through the
+// go-import meta-tag resolver.
+//
+// Sorted lexicographically; the order is load-bearing for the
+// `IsVanity` predicate's stability.
+var KnownVCSHosts = []string{
+	"bitbucket.org",
+	"github.com",
+	"gitlab.com",
+}
+
+// Resolution is the result of resolving a vanity path: the canonical
+// module root, the VCS system ("git", "hg", "svn", "fossil"), and
+// the real VCS repository URL.
+type Resolution struct {
+	// Module is the canonical module root from the meta tag's
+	// first field (e.g., "golang.org/x/sync").
+	Module string
+	// VCS is the version-control system the meta tag's second
+	// field names. The Go convention restricts this to "git", "hg",
+	// "svn", or "fossil"; the resolver does not further validate
+	// (the proxy client owns that check).
+	VCS string
+	// RepoURL is the meta tag's third field, the real VCS-clonable
+	// URL (e.g., "https://go.googlesource.com/sync").
+	RepoURL string
+}
+
+// IsVanity reports whether path's first segment is NOT a known VCS
+// host (and so requires meta-tag resolution).
+func IsVanity(path string) bool {
+	if path == "" {
+		return false
+	}
+	first := path
+	if slash := strings.Index(path, "/"); slash >= 0 {
+		first = path[:slash]
+	}
+	for _, host := range KnownVCSHosts {
+		if first == host {
+			return false
+		}
+	}
+	return true
+}
+
+// Fetcher is the minimal HTTP-fetch interface the resolver needs.
+// Implementations: the default `http.DefaultClient`-backed fetcher,
+// or a unit-test in-memory map keyed by URL.
+type Fetcher interface {
+	// Fetch returns the body of `https://<host>/<path>?go-get=1`
+	// as a string. Returns ErrVanity-wrapped errors on transport
+	// failure or non-2xx status.
+	Fetch(url string) (string, error)
+}
+
+// HTTPFetcher is the default Fetcher implementation backed by
+// `net/http`. It uses the supplied client (or `http.DefaultClient`
+// if nil) and follows redirects per stdlib defaults.
+type HTTPFetcher struct {
+	Client *http.Client
+}
+
+// Fetch implements Fetcher.
+func (f *HTTPFetcher) Fetch(url string) (string, error) {
+	client := f.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("%w: GET %s: %v", ErrVanity, url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return "", fmt.Errorf("%w: GET %s: status %d", ErrVanity, url, resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("%w: read %s: %v", ErrVanity, url, err)
+	}
+	return string(body), nil
+}
+
+// MapFetcher is a hermetic Fetcher backed by an in-memory map keyed
+// by URL. Used by the package's own tests; consumers can also wrap
+// it for offline reproducibility.
+type MapFetcher map[string]string
+
+// Fetch implements Fetcher; returns ErrVanity if the URL is not
+// in the map.
+func (m MapFetcher) Fetch(url string) (string, error) {
+	body, ok := m[url]
+	if !ok {
+		return "", fmt.Errorf("%w: MapFetcher: no entry for %s", ErrVanity, url)
+	}
+	return body, nil
+}
+
+// Resolve takes an import path, decides whether it's a vanity path,
+// and either returns a direct-VCS Resolution (no fetch) or fetches
+// the go-import meta tag from the path's `?go-get=1` URL and
+// returns the parsed Resolution.
+//
+// For direct paths (github.com/..., gitlab.com/..., etc.) the
+// returned Resolution has VCS="git" and RepoURL="https://<path>"
+// (truncated to the module root, i.e., the first three segments
+// for hosted git providers); the resolver does not fetch.
+func Resolve(path string, fetcher Fetcher) (Resolution, error) {
+	if strings.TrimSpace(path) == "" {
+		return Resolution{}, fmt.Errorf("%w: empty path", ErrVanity)
+	}
+	if !IsVanity(path) {
+		return directResolution(path), nil
+	}
+	if fetcher == nil {
+		return Resolution{}, fmt.Errorf("%w: vanity path %q needs a Fetcher", ErrVanity, path)
+	}
+	url := "https://" + path + "?go-get=1"
+	body, err := fetcher.Fetch(url)
+	if err != nil {
+		return Resolution{}, err
+	}
+	res, err := ParseGoImport(body, path)
+	if err != nil {
+		return Resolution{}, fmt.Errorf("%w: %s: %v", ErrVanity, path, err)
+	}
+	return res, nil
+}
+
+// directResolution builds a Resolution for a non-vanity path. The
+// module root for a hosted-git provider is the first three
+// segments (host + owner + repo); deeper paths are sub-packages
+// inside the same module.
+func directResolution(path string) Resolution {
+	parts := strings.Split(path, "/")
+	root := path
+	if len(parts) >= 3 {
+		root = strings.Join(parts[:3], "/")
+	}
+	return Resolution{
+		Module:  root,
+		VCS:     "git",
+		RepoURL: "https://" + root,
+	}
+}
+
+// ParseGoImport scans HTML body for `<meta name="go-import"
+// content="<root> <vcs> <repo>">` and returns the Resolution whose
+// Module is the import-path-most-specific prefix of `wantPrefix`.
+// If multiple meta tags match, the longest matching Module wins
+// (so `golang.org/x/sync` picks the `x/sync`-rooted tag, not a
+// `golang.org`-wide fallback). Returns an error if no go-import
+// meta matches `wantPrefix`.
+func ParseGoImport(body, wantPrefix string) (Resolution, error) {
+	tags := scanGoImportTags(body)
+	if len(tags) == 0 {
+		return Resolution{}, fmt.Errorf("no go-import meta tag found")
+	}
+	var best Resolution
+	bestLen := -1
+	for _, t := range tags {
+		if t.Module == wantPrefix || strings.HasPrefix(wantPrefix+"/", t.Module+"/") {
+			if len(t.Module) > bestLen {
+				best = t
+				bestLen = len(t.Module)
+			}
+		}
+	}
+	if bestLen < 0 {
+		return Resolution{}, fmt.Errorf("no go-import meta tag covers %q", wantPrefix)
+	}
+	return best, nil
+}
+
+// scanGoImportTags returns every well-formed
+// `<meta name="go-import" content="<root> <vcs> <repo>">`
+// occurrence in body. The scanner is intentionally tag-level (not
+// a full HTML parser): it handles single- and double-quoted
+// attribute values and is tolerant of whitespace and the `name` /
+// `content` attribute order.
+func scanGoImportTags(body string) []Resolution {
+	var out []Resolution
+	lower := strings.ToLower(body)
+	i := 0
+	for {
+		idx := strings.Index(lower[i:], "<meta")
+		if idx < 0 {
+			break
+		}
+		start := i + idx
+		end := strings.Index(body[start:], ">")
+		if end < 0 {
+			break
+		}
+		tag := body[start : start+end+1]
+		i = start + end + 1
+		nameVal := extractAttr(tag, "name")
+		if !strings.EqualFold(nameVal, "go-import") {
+			continue
+		}
+		contentVal := extractAttr(tag, "content")
+		if contentVal == "" {
+			continue
+		}
+		fields := strings.Fields(contentVal)
+		if len(fields) != 3 {
+			continue
+		}
+		out = append(out, Resolution{Module: fields[0], VCS: fields[1], RepoURL: fields[2]})
+	}
+	return out
+}
+
+// extractAttr returns the value of the named attribute in tag, or
+// "" if absent. Handles single- and double-quoted values.
+func extractAttr(tag, name string) string {
+	lower := strings.ToLower(tag)
+	key := strings.ToLower(name) + "="
+	idx := strings.Index(lower, key)
+	if idx < 0 {
+		return ""
+	}
+	rest := tag[idx+len(key):]
+	if rest == "" {
+		return ""
+	}
+	quote := rest[0]
+	if quote != '"' && quote != '\'' {
+		return ""
+	}
+	end := strings.IndexByte(rest[1:], quote)
+	if end < 0 {
+		return ""
+	}
+	return rest[1 : 1+end]
+}
+
+// WasmTarget names the publish-direction wasm target. The
+// `CheckPublish` walker uses it to decide which import + type
+// bans apply.
+type WasmTarget string
+
+const (
+	// WasmTargetWasip1 is the WASI Preview 1 target. Has no JS host;
+	// `syscall/js` is banned. cgo is banned (no wasm cgo runtime).
+	WasmTargetWasip1 WasmTarget = "wasm-wasip1"
+	// WasmTargetJS is the wasm-js / `js/wasm` target. Has the JS
+	// host; `syscall/js` is allowed. cgo is still banned.
+	WasmTargetJS WasmTarget = "wasm-js"
+)
+
+// IsValid reports whether t is a recognised wasm target.
+func (t WasmTarget) IsValid() bool {
+	switch t {
+	case WasmTargetWasip1, WasmTargetJS:
+		return true
+	}
+	return false
+}
+
+// wasmBanned returns the closed banned-import set for target t.
+// Both wasm targets ban runtime/cgo and the C-toolchain-coupled
+// debug packages; wasip1 additionally bans `syscall/js`.
+func wasmBanned(t WasmTarget) map[string]struct{} {
+	base := map[string]struct{}{
+		"runtime/cgo": {},
+		"debug/elf":   {},
+		"debug/macho": {},
+		"debug/pe":    {},
+		"os/exec":     {},
+		"plugin":      {},
+	}
+	if t == WasmTargetWasip1 {
+		base["syscall/js"] = struct{}{}
+	}
+	return base
+}
+
+// Violation is one wasm-publish incompatibility. Mirrors the shape
+// of `tinygo.Violation` so a consumer can fold both gates' output
+// into a single SkipReport stream.
+type Violation struct {
+	Kind   string
+	Where  string
+	Reason string
+}
+
+// String renders the violation as `<kind>: <where>: <reason>`.
+func (v Violation) String() string {
+	return v.Kind + ": " + v.Where + ": " + v.Reason
+}
+
+// CheckPublish walks pkg and reports every import or surface element
+// that would prevent publishing to wasm target t. Sorted by
+// (Kind, Where) for byte-deterministic output.
+func CheckPublish(t WasmTarget, pkg apisurface.Package) []Violation {
+	if !t.IsValid() {
+		return nil
+	}
+	banned := wasmBanned(t)
+	var out []Violation
+	for _, imp := range pkg.Imports {
+		if _, hit := banned[imp]; hit {
+			out = append(out, Violation{
+				Kind:   "import",
+				Where:  imp,
+				Reason: fmt.Sprintf("import is unavailable on %s", t),
+			})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		return out[i].Where < out[j].Where
+	})
+	return out
+}
+
+// IsPublishable reports whether pkg has zero violations under
+// target t.
+func IsPublishable(t WasmTarget, pkg apisurface.Package) bool {
+	return len(CheckPublish(t, pkg)) == 0
+}

--- a/package3/go/vanity/vanity_test.go
+++ b/package3/go/vanity/vanity_test.go
@@ -1,0 +1,286 @@
+package vanity
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"mochi/package3/go/apisurface"
+)
+
+func TestIsVanity(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"github.com/spf13/cobra", false},
+		{"gitlab.com/foo/bar", false},
+		{"bitbucket.org/foo/bar", false},
+		{"golang.org/x/sync", true},
+		{"gopkg.in/yaml.v3", true},
+		{"k8s.io/api", true},
+		{"google.golang.org/protobuf", true},
+		{"sigs.k8s.io/yaml", true},
+		{"example.com/foo/bar", true},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsVanity(c.path); got != c.want {
+			t.Errorf("IsVanity(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+func TestKnownVCSHostsIsSorted(t *testing.T) {
+	for i := 1; i < len(KnownVCSHosts); i++ {
+		if KnownVCSHosts[i-1] >= KnownVCSHosts[i] {
+			t.Errorf("not sorted at %d: %q >= %q", i, KnownVCSHosts[i-1], KnownVCSHosts[i])
+		}
+	}
+}
+
+func TestResolveDirectGithub(t *testing.T) {
+	res, err := Resolve("github.com/spf13/cobra", nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Module != "github.com/spf13/cobra" {
+		t.Errorf("Module = %q", res.Module)
+	}
+	if res.VCS != "git" {
+		t.Errorf("VCS = %q", res.VCS)
+	}
+	if res.RepoURL != "https://github.com/spf13/cobra" {
+		t.Errorf("RepoURL = %q", res.RepoURL)
+	}
+}
+
+func TestResolveDirectGithubSubpackage(t *testing.T) {
+	// A subpackage path resolves to the module root, not the
+	// deeper path.
+	res, err := Resolve("github.com/spf13/cobra/internal/util", nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Module != "github.com/spf13/cobra" {
+		t.Errorf("Module = %q (subpackage should yield root)", res.Module)
+	}
+}
+
+func TestResolveEmptyPath(t *testing.T) {
+	_, err := Resolve("", nil)
+	if !errors.Is(err, ErrVanity) {
+		t.Fatalf("want ErrVanity, got %v", err)
+	}
+}
+
+func TestResolveVanityNoFetcher(t *testing.T) {
+	_, err := Resolve("golang.org/x/sync", nil)
+	if !errors.Is(err, ErrVanity) {
+		t.Fatalf("want ErrVanity, got %v", err)
+	}
+}
+
+func TestResolveVanityViaMapFetcher(t *testing.T) {
+	fetcher := MapFetcher{
+		"https://golang.org/x/sync?go-get=1": `<!doctype html>
+<html><head>
+<meta name="go-import" content="golang.org/x/sync git https://go.googlesource.com/sync">
+</head></html>`,
+	}
+	res, err := Resolve("golang.org/x/sync", fetcher)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Module != "golang.org/x/sync" {
+		t.Errorf("Module = %q", res.Module)
+	}
+	if res.VCS != "git" {
+		t.Errorf("VCS = %q", res.VCS)
+	}
+	if res.RepoURL != "https://go.googlesource.com/sync" {
+		t.Errorf("RepoURL = %q", res.RepoURL)
+	}
+}
+
+func TestResolveVanityLongestPrefixWins(t *testing.T) {
+	// Two meta tags; the more-specific one should win.
+	body := `<meta name="go-import" content="example.com git https://git.example.com/main">
+<meta name="go-import" content="example.com/x/sync git https://git.example.com/sync">`
+	res, err := ParseGoImport(body, "example.com/x/sync/internal")
+	if err != nil {
+		t.Fatalf("ParseGoImport: %v", err)
+	}
+	if res.Module != "example.com/x/sync" {
+		t.Errorf("Module = %q, want longest prefix", res.Module)
+	}
+}
+
+func TestResolveVanityRejectsNoMeta(t *testing.T) {
+	fetcher := MapFetcher{
+		"https://golang.org/x/sync?go-get=1": `<html><head><title>no meta</title></head></html>`,
+	}
+	_, err := Resolve("golang.org/x/sync", fetcher)
+	if !errors.Is(err, ErrVanity) {
+		t.Fatalf("want ErrVanity, got %v", err)
+	}
+}
+
+func TestResolveVanityRejectsNonCoveringMeta(t *testing.T) {
+	fetcher := MapFetcher{
+		"https://golang.org/x/sync?go-get=1": `<meta name="go-import" content="completely.different git https://elsewhere">`,
+	}
+	_, err := Resolve("golang.org/x/sync", fetcher)
+	if !errors.Is(err, ErrVanity) {
+		t.Fatalf("want ErrVanity, got %v", err)
+	}
+}
+
+func TestParseGoImportSingleQuoted(t *testing.T) {
+	body := `<meta name='go-import' content='golang.org/x/sync git https://go.googlesource.com/sync'>`
+	res, err := ParseGoImport(body, "golang.org/x/sync")
+	if err != nil {
+		t.Fatalf("ParseGoImport: %v", err)
+	}
+	if res.RepoURL != "https://go.googlesource.com/sync" {
+		t.Errorf("RepoURL = %q", res.RepoURL)
+	}
+}
+
+func TestParseGoImportAttrOrderIndependent(t *testing.T) {
+	body := `<meta content="golang.org/x/sync git https://go.googlesource.com/sync" name="go-import">`
+	res, err := ParseGoImport(body, "golang.org/x/sync")
+	if err != nil {
+		t.Fatalf("ParseGoImport: %v", err)
+	}
+	if res.Module != "golang.org/x/sync" {
+		t.Errorf("Module = %q", res.Module)
+	}
+}
+
+func TestParseGoImportIgnoresMalformedContent(t *testing.T) {
+	body := `<meta name="go-import" content="onlytwo fields">
+<meta name="go-import" content="golang.org/x/sync git https://go.googlesource.com/sync">`
+	res, err := ParseGoImport(body, "golang.org/x/sync")
+	if err != nil {
+		t.Fatalf("ParseGoImport: %v", err)
+	}
+	if res.Module != "golang.org/x/sync" {
+		t.Errorf("Module = %q", res.Module)
+	}
+}
+
+func TestParseGoImportIgnoresOtherMetas(t *testing.T) {
+	body := `<meta name="generator" content="hugo">
+<meta name="description" content="some module">
+<meta name="go-import" content="golang.org/x/sync git https://go.googlesource.com/sync">`
+	res, err := ParseGoImport(body, "golang.org/x/sync")
+	if err != nil {
+		t.Fatalf("ParseGoImport: %v", err)
+	}
+	if res.VCS != "git" {
+		t.Errorf("VCS = %q", res.VCS)
+	}
+}
+
+func TestExtractAttrUnquoted(t *testing.T) {
+	if got := extractAttr(`<meta name=go-import>`, "name"); got != "" {
+		t.Errorf("unquoted attr should be ignored, got %q", got)
+	}
+}
+
+func TestMapFetcherMiss(t *testing.T) {
+	_, err := MapFetcher{}.Fetch("http://example.com")
+	if !errors.Is(err, ErrVanity) {
+		t.Fatalf("want ErrVanity, got %v", err)
+	}
+}
+
+func TestWasmTargetIsValid(t *testing.T) {
+	if !WasmTargetWasip1.IsValid() {
+		t.Errorf("wasip1 should be valid")
+	}
+	if !WasmTargetJS.IsValid() {
+		t.Errorf("wasm-js should be valid")
+	}
+	if WasmTarget("garbage").IsValid() {
+		t.Errorf("garbage should be invalid")
+	}
+}
+
+func TestCheckPublishWasip1BansSyscallJS(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "x",
+		Imports:    []string{"fmt", "syscall/js"},
+	}
+	got := CheckPublish(WasmTargetWasip1, pkg)
+	if len(got) != 1 || got[0].Where != "syscall/js" {
+		t.Fatalf("want syscall/js banned on wasip1, got %v", got)
+	}
+}
+
+func TestCheckPublishJSAllowsSyscallJS(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "x",
+		Imports:    []string{"fmt", "syscall/js"},
+	}
+	got := CheckPublish(WasmTargetJS, pkg)
+	if len(got) != 0 {
+		t.Fatalf("syscall/js should be OK on wasm-js, got %v", got)
+	}
+}
+
+func TestCheckPublishBansCgo(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "x",
+		Imports:    []string{"runtime/cgo"},
+	}
+	for _, target := range []WasmTarget{WasmTargetWasip1, WasmTargetJS} {
+		got := CheckPublish(target, pkg)
+		if len(got) != 1 || got[0].Where != "runtime/cgo" {
+			t.Errorf("%s: want cgo banned, got %v", target, got)
+		}
+	}
+}
+
+func TestCheckPublishBansDebugFamily(t *testing.T) {
+	pkg := apisurface.Package{
+		ImportPath: "x",
+		Imports:    []string{"debug/elf", "debug/macho", "debug/pe"},
+	}
+	got := CheckPublish(WasmTargetWasip1, pkg)
+	if len(got) != 3 {
+		t.Fatalf("want 3 violations, got %v", got)
+	}
+	want := []string{"debug/elf", "debug/macho", "debug/pe"}
+	for i, w := range want {
+		if got[i].Where != w {
+			t.Errorf("got[%d].Where = %q, want %q", i, got[i].Where, w)
+		}
+	}
+}
+
+func TestCheckPublishInvalidTargetIsNoop(t *testing.T) {
+	if got := CheckPublish("garbage", apisurface.Package{Imports: []string{"runtime/cgo"}}); got != nil {
+		t.Errorf("invalid target should yield no violations, got %v", got)
+	}
+}
+
+func TestIsPublishable(t *testing.T) {
+	pure := apisurface.Package{ImportPath: "x", Imports: []string{"fmt"}}
+	if !IsPublishable(WasmTargetWasip1, pure) {
+		t.Errorf("pure pkg should be publishable")
+	}
+	bad := apisurface.Package{ImportPath: "x", Imports: []string{"runtime/cgo"}}
+	if IsPublishable(WasmTargetWasip1, bad) {
+		t.Errorf("cgo pkg should not be publishable")
+	}
+}
+
+func TestViolationString(t *testing.T) {
+	v := Violation{Kind: "import", Where: "runtime/cgo", Reason: "no cgo on wasm"}
+	got := v.String()
+	if !strings.Contains(got, "import:") || !strings.Contains(got, "runtime/cgo") {
+		t.Errorf("violation string = %q", got)
+	}
+}

--- a/website/docs/implementation/0074/index.md
+++ b/website/docs/implementation/0074/index.md
@@ -32,7 +32,7 @@ A phase is LANDED only when its gate is green for every applicable target (consu
 | 14 | Goroutine bridge (cgo handle pool + channel-as-handle + callback-as-handle) | LANDED (baseline; 14.1+ deferred) | (pending) | [phase-14](/docs/implementation/0074/phase-14-goroutine-bridge) |
 | 15 | Monomorphisation (`[go.monomorphise]` manifest + per-instantiation wrapper) | LANDED (baseline; 15.1+ deferred) | (pending) | [phase-15](/docs/implementation/0074/phase-15-monomorphise) |
 | 16 | TinyGo embedded subset (`profile = "embedded"` + `//go:linkname` wrapper) | LANDED (baseline; 16.1+ deferred) | (pending) | [phase-16](/docs/implementation/0074/phase-16-tinygo-embedded) |
-| 17 | Vanity-import resolver + wasm-wasip1 / wasm-js publish gate (wazero host integration) | NOT STARTED | — | [phase-17](/docs/implementation/0074/phase-17-vanity-and-wasm) |
+| 17 | Vanity-import resolver + wasm-wasip1 / wasm-js publish gate (wazero host integration) | LANDED (baseline; 17.1+ deferred) | (pending) | [phase-17](/docs/implementation/0074/phase-17-vanity-and-wasm) |
 
 ## Target coverage matrix
 
@@ -57,7 +57,7 @@ Each phase's LANDED gate must be green for every applicable target. `n/a` cells 
 | 14. goroutine bridge | LANDED (baseline) | required | required | n/a (no goroutines on wasm-js without scheduler shim) | required |
 | 15. monomorphisation | LANDED (baseline) | required | required | required | required |
 | 16. TinyGo embedded subset | LANDED (baseline) | n/a | n/a | required (wasm-js via tinygo) | required |
-| 17. vanity-import + WASI publish | NOT STARTED | required | required | required | n/a |
+| 17. vanity-import + WASI publish | LANDED (baseline) | required | required | required | n/a |
 
 Cell legend: `required` means the phase's gate runs against this target; `n/a` means the phase's behaviour is intentionally not exercised on this target (architectural reason in parentheses).
 
@@ -109,7 +109,7 @@ The `package3/go/` location is shared with the broader MEP-57 polyglot package w
 
 ## Status snapshot
 
-As of 2026-05-30: phases 0-16 LANDED on `main` (phases 6 + 7 + 9 + 11 + 12 + 13 + 14 + 15 + 16 baseline only; phase 10 schema only; sub-phases 6.1+/7.1+/9.1+/10.1+/11.1+/12.1+/13.1+/14.1+/15.1+/16.1+ deferred), phase 17 NOT STARTED.
+As of 2026-05-30: all 18 phases (0-17) LANDED on `main` (phases 6 + 7 + 9 + 11 + 12 + 13 + 14 + 15 + 16 + 17 baseline only; phase 10 schema only; sub-phases 6.1+/7.1+/9.1+/10.1+/11.1+/12.1+/13.1+/14.1+/15.1+/16.1+/17.1+ deferred). The MEP-74 umbrella plan is complete at the baseline level; remaining work is per-phase sub-phase integration (wrapper-synth wiring, MEP-54 driver wiring, mochi.lock CLI, live-target gates).
 
 ## Cross-references
 

--- a/website/docs/implementation/0074/phase-17-vanity-and-wasm.md
+++ b/website/docs/implementation/0074/phase-17-vanity-and-wasm.md
@@ -1,0 +1,120 @@
+---
+title: "Phase 17. Vanity-import resolver + WASI publish gate"
+sidebar_position: 19
+sidebar_label: "Phase 17. Vanity-import + WASI publish"
+description: "MEP-74 Phase 17 lands the final two consume + publish-direction bits: a vanity-import resolver that fetches the `<meta name=\"go-import\">` HTML redirect tag the Go ecosystem uses to delegate non-VCS-rooted import paths (golang.org/x/*, gopkg.in/*, k8s.io/*) to a real git repo, plus a wasm-wasip1 / wasm-js publish gate that walks an ApiSurface and reports every import that would break on the target wasm runtime."
+---
+
+# Phase 17. Vanity-import resolver + WASI publish gate
+
+| Field          | Value |
+|----------------|-------|
+| MEP            | [MEP-74 §Phases](/docs/mep/mep-0074#phases) |
+| Status         | LANDED (baseline) |
+| Started        | 2026-05-30 00:50 (GMT+7) |
+| Landed         | 2026-05-30 00:58 (GMT+7) |
+| Tracking issue | (pending) |
+| Tracking PR    | (pending) |
+| Commit         | (pending) |
+
+## Gate
+
+`TestPhase17VanityResolverSentinel` in `package3/go/vanity/phase17_test.go` stands up an in-process `httptest.NewTLSServer`, serves a `<meta name="go-import" content="vanity.test/x/sync git https://repo.test/sync">` redirect on the `/x/sync?go-get=1` URL, points an `HTTPFetcher` at the test server via a `rewriteTransport` (so the production-shaped `https://vanity.test/x/sync?go-get=1` request hits the local server without DNS), and asserts the resolved `Resolution{Module, VCS, RepoURL}` triple matches the served meta tag. This is the closest reproduction of the live golang.org/x/* path the unit-test suite can stage without making a real network call.
+
+`TestPhase17VanityResolverServer404Surfaces` confirms the resolver wraps a non-2xx status in `ErrVanity` (with the status code in the error message) rather than masking it as a "no go-import meta" parse failure.
+
+`TestPhase17WasmPublishGateRejectsCgoSurface` walks a hand-curated surface that imports both `runtime/cgo` and `syscall/js`, then asserts wasm-wasip1 reports both as violations and wasm-js reports only the cgo one (since wasm-js does have a JS host).
+
+`TestPhase17WasmPublishGatePassesPureSurface` walks a pure-go surface (no cgo, no syscall/js) and asserts both wasm targets accept it cleanly.
+
+Plus 24 unit tests in `vanity_test.go`:
+
+- vanity predicate (`TestIsVanity`, `TestKnownVCSHostsIsSorted`),
+- direct + vanity resolver (`TestResolveDirectGithub`, `TestResolveDirectGithubSubpackage`, `TestResolveEmptyPath`, `TestResolveVanityNoFetcher`, `TestResolveVanityViaMapFetcher`, `TestResolveVanityLongestPrefixWins`, `TestResolveVanityRejectsNoMeta`, `TestResolveVanityRejectsNonCoveringMeta`),
+- HTML meta-tag scanner (`TestParseGoImportSingleQuoted`, `TestParseGoImportAttrOrderIndependent`, `TestParseGoImportIgnoresMalformedContent`, `TestParseGoImportIgnoresOtherMetas`, `TestExtractAttrUnquoted`),
+- in-memory Fetcher (`TestMapFetcherMiss`),
+- wasm publish gate (`TestWasmTargetIsValid`, `TestCheckPublishWasip1BansSyscallJS`, `TestCheckPublishJSAllowsSyscallJS`, `TestCheckPublishBansCgo`, `TestCheckPublishBansDebugFamily`, `TestCheckPublishInvalidTargetIsNoop`, `TestIsPublishable`, `TestViolationString`).
+
+## Lowering decisions
+
+The vanity package is a near-leaf module: it imports `package3/go/apisurface` for the wasm publish-gate's surface walk, plus stdlib `net/http`, `io`, `sort`, `strings`. Two distinct concerns share the same directory because they share the same delivery phase (consume-direction vanity + publish-direction wasm gate are both spec'd as phase 17), but the package boundary keeps them as separate top-level surfaces (`Resolve(...)` / `IsVanity(...)` vs `CheckPublish(...)` / `IsPublishable(...)`).
+
+**Vanity detection is a banned-host-set check, not an allow-list.** The Go ecosystem's vanity convention works by delegation: any import path whose first segment is NOT a known VCS host (github.com / gitlab.com / bitbucket.org) is assumed to delegate via the meta tag. Phase 17 hardcodes the closed VCS-host set as `KnownVCSHosts`; everything else is a vanity path. The reason for banned-host rather than allow-list is the same as the tinygo subset's banned-import: the vanity universe is open-ended (any user-controlled domain), but the direct-VCS universe is small and well-known.
+
+**Direct paths skip the fetch.** When a path resolves directly (`github.com/spf13/cobra`), `Resolve` synthesises a `Resolution{Module, VCS: "git", RepoURL: "https://" + module-root}` without making any HTTP call. The module root is the first three segments (host + owner + repo) for hosted-git providers; deeper paths like `github.com/spf13/cobra/internal/util` resolve to the same `github.com/spf13/cobra` module root. This matches the canonical Go module-resolution algorithm and lets the phase 1 proxy client treat both vanity and direct paths through a single Resolution interface.
+
+**Longest-prefix wins on meta-tag matching.** When the fetched HTML body has multiple `<meta name="go-import">` tags (the `golang.org` root vs `golang.org/x/sync` subroot pattern), `ParseGoImport` picks the one whose Module is the longest prefix of `wantPrefix`. The check is `t.Module == wantPrefix || strings.HasPrefix(wantPrefix+"/", t.Module+"/")` so a tag for `example.com/x/sync` covers `example.com/x/sync/internal` (a sub-path) but a tag for `example.com` does NOT cover `example.com/x/sync` if a more-specific tag is also present. This matches the upstream `cmd/go` resolver's behaviour and avoids the "fallback tag eats a more-specific tag" foot-gun.
+
+**The HTML scanner is tag-level, not a full HTML parser.** The Go ecosystem's vanity meta tags are deliberately simple: `<meta name="go-import" content="<root> <vcs> <repo>">` with single or double-quoted values, optional whitespace, free attribute order. A full `golang.org/x/net/html` parser would be heavier and pull in another dep; the tag-level scanner is enough for the fixed grammar. Malformed tags (wrong field count, missing attribute, unquoted value) are silently dropped, mirroring the cmd/go resolver's tolerance.
+
+**The Fetcher interface is the hermetic seam.** `Resolve` takes a `Fetcher` parameter so the unit tests pass a `MapFetcher` (in-memory map) and the production wiring passes an `HTTPFetcher` (real `net/http`-backed). The sentinel uses `httptest.NewTLSServer` plus a `rewriteTransport` to exercise the full HTTP roundtrip path without leaving the test process. The interface is one method (`Fetch(url string) (string, error)`) so a future custom transport (offline cache, vendored mirror, signing-aware fetcher) drops in without touching the resolver.
+
+**Wasm publish gate is per-target.** wasm-wasip1 and wasm-js share most banned imports (`runtime/cgo` is universal because wasm has no working cgo runtime; `debug/elf`, `debug/macho`, `debug/pe` are universal because they're toolchain-coupled; `os/exec` is universal because wasm has no exec; `plugin` is universal because wasm has no plugin loader). Wasm-wasip1 additionally bans `syscall/js` (no JS host); wasm-js does not. The split lives in `wasmBanned(t)` so adding a third wasm target later (e.g., wasm-baremetal) is a one-line case-add.
+
+**Violations are sorted, kind-prefixed, deterministic.** Same shape as the phase 16 tinygo gate: `(Kind, Where)` sort via `sort.SliceStable`, so the wrapper-synthesiser can fold both gates' output into a single deterministic SkipReport stream for the phase 10 wrapper-sha256 pin.
+
+**No live wazero smoke run yet.** A real wazero-host smoke (instantiate the published wasm module, call one export, assert the call succeeds) is phase 17.1: it requires a wazero dependency, a Mochi-side test that emits a wasm module, and a CI runner that can host the wazero instance. The current gate is import-level only; the wazero validation is the next-step verification.
+
+**No live golang.org/x/* fetch in CI.** The sentinel uses an in-process `httptest.NewTLSServer` and rewrites the URL via a custom `RoundTripper` rather than fetching live vanity hosts. The reasons: CI flakiness, network-dependency in the test suite, and the brittleness of pinning a specific meta-tag wording from an upstream host the bridge does not control. Phase 17.2 will add an opt-in `--vanity-live` build tag that exercises a curated set of stable vanity hosts (`golang.org/x/sync`, `gopkg.in/yaml.v3`, `google.golang.org/protobuf`) once a CI runner with reliable outbound HTTPS lands.
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `package3/go/vanity/vanity.go` | `ErrVanity`, `KnownVCSHosts`, `Resolution`, `IsVanity`, `Fetcher` interface, `HTTPFetcher`, `MapFetcher`, `Resolve`, `ParseGoImport`, internal tag scanner; plus `WasmTarget`, `Violation`, `CheckPublish`, `IsPublishable`. |
+| `package3/go/vanity/vanity_test.go` | 24 unit tests covering vanity predicate, direct + meta-redirect resolver, HTML scanner edge cases, wasm publish gate per-target. |
+| `package3/go/vanity/phase17_test.go` | `TestPhase17VanityResolverSentinel` (full HTTP roundtrip via httptest.TLSServer + rewriteTransport), `TestPhase17VanityResolverServer404Surfaces`, `TestPhase17WasmPublishGateRejectsCgoSurface`, `TestPhase17WasmPublishGatePassesPureSurface`. |
+| `website/docs/implementation/0074/phase-17-vanity-and-wasm.md` | (this page) |
+
+## Test set
+
+- `TestPhase17VanityResolverSentinel`
+- `TestPhase17VanityResolverServer404Surfaces`
+- `TestPhase17WasmPublishGateRejectsCgoSurface`
+- `TestPhase17WasmPublishGatePassesPureSurface`
+- 24 unit tests in `vanity_test.go`
+
+Local run on darwin-arm64:
+
+```
+$ go test ./package3/go/vanity/...
+ok      mochi/package3/go/vanity        0.330s
+$ go test ./package3/go/...
+ok      mochi/package3/go/apisurface    (cached)
+ok      mochi/package3/go/build (cached)
+ok      mochi/package3/go/cmd/go-ingest (cached)
+ok      mochi/package3/go/cosign        (cached)
+ok      mochi/package3/go/emit  (cached)
+ok      mochi/package3/go/errors        (cached)
+ok      mochi/package3/go/goroutine     (cached)
+ok      mochi/package3/go/library       (cached)
+ok      mochi/package3/go/lockfile      (cached)
+ok      mochi/package3/go/moduleproxy   (cached)
+ok      mochi/package3/go/monomorphise  (cached)
+ok      mochi/package3/go/publish       (cached)
+ok      mochi/package3/go/semver        (cached)
+ok      mochi/package3/go/sumdb (cached)
+ok      mochi/package3/go/tinygo        (cached)
+ok      mochi/package3/go/typemap       (cached)
+ok      mochi/package3/go/vanity        0.197s
+ok      mochi/package3/go/wrapper       (cached)
+```
+
+## Closeout notes
+
+Phase 17 is the final umbrella phase of MEP-74. With this landing, every phase 0-17 has its baseline implementation and test gate green. The remaining work is per-phase sub-phase integration (the N.1+ deferred slots tracked in the phase 0-17 closeouts):
+
+- consumed-direction wrapper-synth integration (phase 6.1+) that wires `tinygo.CheckPackage`, `tinygo.RenderFile`, `monomorphise.Resolve`, `monomorphise.RenderInstance`, `goroutine.NeedsRuntime`, `goroutine.RenderRuntime`, and the channel + callback shim renderers into the per-module wrapper output;
+- publish-direction MEP-54 driver integration (phase 11.1+) that calls `library.Emit`, `publish.Publish`, `cosign.Sign`, and the new `vanity.CheckPublish` per target;
+- mochi.lock CLI surface (phase 10.1+) that pins per-instance wrapper-sha256 + per-publish target-spec via the manifest tables;
+- live-target integration gates (phase 14.5 live cgo, phase 17.1 live wazero, phase 17.2 live vanity fetch) that move the in-process sentinels onto real runtimes.
+
+Future phase 17.x reservations:
+
+- **17.1** wazero host smoke: instantiate the published wasm module via `embedded "github.com/tetratelabs/wazero"`, call one export, assert the round-trip succeeds.
+- **17.2** Live vanity fetch via opt-in build tag (`-tags=mochi_vanity_live`) against a curated stable host set.
+- **17.3** Per-mochi.toml vanity override table (`[go.vanity.<path>] vcs = "git" repo = "..."`) for offline / vendored vanity bypass.
+- **17.4** Negative-cache for failed vanity lookups (so a CI run that hits one bad vanity host does not retry on every subsequent build).
+- **17.5** wasm-baremetal target case in `wasmBanned`.
+
+The MEP-74 phase plan is complete; subsequent work moves under the per-phase sub-phase closeouts and the wider MEP-57 polyglot package work that depends on MEP-74's surfaces.

--- a/website/docs/mep/mep-0074.md
+++ b/website/docs/mep/mep-0074.md
@@ -399,7 +399,7 @@ A phase is LANDED only when its gate is green for every target in the matrix bel
 | 14. goroutine bridge | LANDED (baseline) | required | required | n/a (no goroutines on wasm-js without scheduler shim) | required |
 | 15. monomorphisation | LANDED (baseline) | required | required | required | required |
 | 16. TinyGo embedded subset | LANDED (baseline) | n/a | n/a | required (wasm-js via tinygo) | required |
-| 17. vanity-import + WASI publish | NOT STARTED | required | required | required | n/a |
+| 17. vanity-import + WASI publish | LANDED (baseline) | required | required | required | n/a |
 
 A phase marked `n/a` for a target is intentional: the bridge does not promise the behaviour on that target.
 

--- a/website/src/data/implementation-sidebar.json
+++ b/website/src/data/implementation-sidebar.json
@@ -375,7 +375,8 @@
       "implementation/0074/phase-13-cosign",
       "implementation/0074/phase-14-goroutine-bridge",
       "implementation/0074/phase-15-monomorphise",
-      "implementation/0074/phase-16-tinygo-embedded"
+      "implementation/0074/phase-16-tinygo-embedded",
+      "implementation/0074/phase-17-vanity-and-wasm"
     ]
   },
   "implementation/0075/index",


### PR DESCRIPTION
## Summary

- Lands `package3/go/vanity/`: the consume-direction vanity-import resolver (fetches the `<meta name=\"go-import\">` HTML redirect tag for non-VCS-rooted paths) plus the publish-direction wasm-wasip1 / wasm-js banned-import gate (runtime/cgo + debug/* + os/exec + plugin universally banned; syscall/js banned on wasip1).
- Hermetic Fetcher seam: production uses `HTTPFetcher`, unit tests use `MapFetcher`, the sentinel uses `httptest.NewTLSServer` plus a `rewriteTransport` so the full HTTP roundtrip path runs in process without DNS.
- Phase 17 row + target matrix updated; status snapshot flipped to \"all 18 phases LANDED at baseline\".

**This PR closes the MEP-74 phase 0-17 umbrella at the baseline level.**

Tracking issue: #22984

## Test plan

- [x] `go test ./package3/go/vanity/...` (24 unit tests + 4 sentinels)
- [x] `go test ./package3/go/...` (whole bridge suite green; 18 packages)
- [x] Vanity sentinel exercises full HTTP roundtrip via httptest.TLSServer
- [x] 404 path wraps in ErrVanity with status code in message
- [x] Wasm gate cross-checks per-target banned-import matrix