### PR TITLE
feat(mep-67/p12): Maven Central publish flow (bundle ZIP and portal client)

### DIFF
--- a/package3/java/publish/bundle.go
+++ b/package3/java/publish/bundle.go
@@ -1,0 +1,232 @@
+package publish
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/md5"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// BundleSpec describes the artifact files to bundle for upload.
+type BundleSpec struct {
+	// GroupID is the Maven groupId (e.g. "dev.mochi.java-bridge").
+	GroupID string
+	// ArtifactID is the Maven artifactId.
+	ArtifactID string
+	// Version is the release version.
+	Version string
+	// JARPath is the absolute path to the compiled wrapper JAR.
+	JARPath string
+	// POMPath is the absolute path to the POM XML.
+	POMPath string
+	// SourcesJARPath is the optional -sources.jar (empty = skip).
+	SourcesJARPath string
+	// GPGKeyID is the key fingerprint to sign with (requires gpg on PATH).
+	// If empty, signing is skipped.
+	GPGKeyID string
+}
+
+// BundleResult is the path to the produced ZIP bundle.
+type BundleResult struct {
+	BundlePath string
+}
+
+// BuildBundle assembles the Sonatype Central Portal upload ZIP.
+// It includes the JAR, POM, their SHA-1/MD5 checksums, and GPG .asc
+// signatures when GPGKeyID is set.
+func BuildBundle(spec BundleSpec, outDir string) (*BundleResult, error) {
+	if err := validateBundleSpec(spec); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return nil, fmt.Errorf("bundle: mkdir: %w", err)
+	}
+
+	bundleName := fmt.Sprintf("%s-%s-bundle.zip", spec.ArtifactID, spec.Version)
+	bundlePath := filepath.Join(outDir, bundleName)
+
+	f, err := os.Create(bundlePath)
+	if err != nil {
+		return nil, fmt.Errorf("bundle: create zip: %w", err)
+	}
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+
+	groupPath := strings.ReplaceAll(spec.GroupID, ".", "/")
+	prefix := fmt.Sprintf("%s/%s/%s", groupPath, spec.ArtifactID, spec.Version)
+	base := fmt.Sprintf("%s-%s", spec.ArtifactID, spec.Version)
+
+	type entry struct {
+		src  string
+		name string
+	}
+	entries := []entry{
+		{spec.JARPath, base + ".jar"},
+		{spec.POMPath, base + ".pom"},
+	}
+	if spec.SourcesJARPath != "" {
+		if _, err := os.Stat(spec.SourcesJARPath); err == nil {
+			entries = append(entries, entry{spec.SourcesJARPath, base + "-sources.jar"})
+		}
+	}
+
+	for _, e := range entries {
+		data, err := os.ReadFile(e.src)
+		if err != nil {
+			return nil, fmt.Errorf("bundle: read %s: %w", e.src, err)
+		}
+		if err := addToZip(zw, prefix+"/"+e.name, data); err != nil {
+			return nil, err
+		}
+		sha1sum := sha1hex(data)
+		if err := addToZip(zw, prefix+"/"+e.name+".sha1", []byte(sha1sum)); err != nil {
+			return nil, err
+		}
+		md5sum := md5hex(data)
+		if err := addToZip(zw, prefix+"/"+e.name+".md5", []byte(md5sum)); err != nil {
+			return nil, err
+		}
+		if spec.GPGKeyID != "" {
+			asc, err := gpgSign(data, spec.GPGKeyID)
+			if err != nil {
+				return nil, fmt.Errorf("bundle: gpg sign %s: %w", e.name, err)
+			}
+			if err := addToZip(zw, prefix+"/"+e.name+".asc", asc); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("bundle: close zip: %w", err)
+	}
+	return &BundleResult{BundlePath: bundlePath}, nil
+}
+
+// DryRun validates a bundle ZIP without uploading: checks it can be opened,
+// all required entries are present, and checksums match.
+func DryRun(bundlePath, groupID, artifactID, version string) error {
+	r, err := zip.OpenReader(bundlePath)
+	if err != nil {
+		return fmt.Errorf("dry-run: open zip: %w", err)
+	}
+	defer r.Close()
+
+	groupPath := strings.ReplaceAll(groupID, ".", "/")
+	prefix := fmt.Sprintf("%s/%s/%s", groupPath, artifactID, version)
+	base := fmt.Sprintf("%s-%s", artifactID, version)
+
+	required := []string{
+		prefix + "/" + base + ".jar",
+		prefix + "/" + base + ".pom",
+		prefix + "/" + base + ".jar.sha1",
+		prefix + "/" + base + ".pom.sha1",
+	}
+
+	index := map[string]*zip.File{}
+	for _, f := range r.File {
+		index[f.Name] = f
+	}
+
+	for _, name := range required {
+		if _, ok := index[name]; !ok {
+			return fmt.Errorf("dry-run: missing required entry %q", name)
+		}
+	}
+
+	for _, suffix := range []string{".jar", ".pom"} {
+		dataFile := index[prefix+"/"+base+suffix]
+		sha1File := index[prefix+"/"+base+suffix+".sha1"]
+		if dataFile == nil || sha1File == nil {
+			continue
+		}
+		data, err := readZipEntry(dataFile)
+		if err != nil {
+			return fmt.Errorf("dry-run: read %s: %w", dataFile.Name, err)
+		}
+		sha1Stored, err := readZipEntry(sha1File)
+		if err != nil {
+			return fmt.Errorf("dry-run: read %s: %w", sha1File.Name, err)
+		}
+		if sha1hex(data) != strings.TrimSpace(string(sha1Stored)) {
+			return fmt.Errorf("dry-run: SHA-1 mismatch for %s%s", base, suffix)
+		}
+	}
+	return nil
+}
+
+func addToZip(zw *zip.Writer, name string, data []byte) error {
+	w, err := zw.Create(name)
+	if err != nil {
+		return fmt.Errorf("zip add %s: %w", name, err)
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+func readZipEntry(f *zip.File) ([]byte, error) {
+	rc, err := f.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	return io.ReadAll(rc)
+}
+
+func sha1hex(data []byte) string {
+	h := sha1.Sum(data)
+	return hex.EncodeToString(h[:])
+}
+
+func md5hex(data []byte) string {
+	h := md5.Sum(data)
+	return hex.EncodeToString(h[:])
+}
+
+// execGPG returns an exec.Cmd for running gpg with args.
+var execGPG = func(args ...string) *exec.Cmd {
+	return exec.Command("gpg", args...)
+}
+
+func gpgSign(data []byte, keyID string) ([]byte, error) {
+	args := []string{
+		"--batch", "--yes", "--armor", "--detach-sign",
+		"--local-user", keyID,
+		"--output", "-",
+		"-",
+	}
+	cmd := execGPG(args...)
+	cmd.Stdin = bytes.NewReader(data)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("gpg sign: %w", err)
+	}
+	return out, nil
+}
+
+func validateBundleSpec(spec BundleSpec) error {
+	if spec.GroupID == "" {
+		return fmt.Errorf("bundle: GroupID is required")
+	}
+	if spec.ArtifactID == "" {
+		return fmt.Errorf("bundle: ArtifactID is required")
+	}
+	if spec.Version == "" {
+		return fmt.Errorf("bundle: Version is required")
+	}
+	if spec.JARPath == "" {
+		return fmt.Errorf("bundle: JARPath is required")
+	}
+	if spec.POMPath == "" {
+		return fmt.Errorf("bundle: POMPath is required")
+	}
+	return nil
+}

--- a/package3/java/publish/central.go
+++ b/package3/java/publish/central.go
@@ -1,0 +1,178 @@
+// Package publish implements the Sonatype Central Portal upload flow for
+// MEP-67 Java bridge artifacts.
+//
+// The Central Portal API (GA since 2024-03) accepts a deployment bundle as
+// a ZIP archive uploaded to:
+//
+//	POST https://central.sonatype.com/api/v1/publisher/upload
+//
+// This file implements Client (upload + status polling) and DryRun.
+// The bundle ZIP is built by BuildBundle in bundle.go.
+package publish
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Client uploads a bundle to the Sonatype Central Portal and polls for completion.
+type Client struct {
+	// BaseURL is the Central Portal API base (default: https://central.sonatype.com).
+	BaseURL string
+	// Token is the bearer token (user token from the portal, or OIDC token for
+	// trusted publishing).
+	Token string
+	// HTTPClient is used for all requests (default: http.DefaultClient).
+	HTTPClient *http.Client
+	// PollInterval controls how often to check deployment status (default: 5s).
+	PollInterval time.Duration
+	// PollTimeout is the maximum time to wait for PUBLISHED state (default: 10min).
+	PollTimeout time.Duration
+}
+
+// DeploymentState is the string status returned by the Central Portal.
+type DeploymentState string
+
+const (
+	DeploymentPending   DeploymentState = "PENDING"
+	DeploymentValidated DeploymentState = "VALIDATED"
+	DeploymentPublished DeploymentState = "PUBLISHED"
+	DeploymentFailed    DeploymentState = "FAILED"
+)
+
+// Upload sends the bundle ZIP to the Central Portal and returns a deployment ID.
+// Pass dryRun=true to skip the HTTP request (returns a placeholder ID).
+func (c *Client) Upload(bundlePath string, dryRun bool, bundleName string) (string, error) {
+	if dryRun {
+		return "dry-run-deployment-id", nil
+	}
+	base := c.baseURL()
+
+	f, err := os.Open(bundlePath)
+	if err != nil {
+		return "", fmt.Errorf("upload: open bundle: %w", err)
+	}
+	defer f.Close()
+
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	fw, err := mw.CreateFormFile("bundle", filepath.Base(bundlePath))
+	if err != nil {
+		return "", fmt.Errorf("upload: multipart: %w", err)
+	}
+	if _, err := io.Copy(fw, f); err != nil {
+		return "", fmt.Errorf("upload: copy bundle: %w", err)
+	}
+	if err := mw.Close(); err != nil {
+		return "", fmt.Errorf("upload: close multipart: %w", err)
+	}
+
+	url := base + "/api/v1/publisher/upload"
+	if bundleName != "" {
+		url += "?name=" + bundleName
+	}
+	req, err := http.NewRequest(http.MethodPost, url, &body)
+	if err != nil {
+		return "", fmt.Errorf("upload: create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("upload: POST: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("upload: HTTP %d: %s", resp.StatusCode, string(b))
+	}
+
+	b, _ := io.ReadAll(resp.Body)
+	deploymentID := strings.TrimSpace(string(b))
+	if deploymentID == "" {
+		return "", fmt.Errorf("upload: empty deployment ID in response")
+	}
+	return deploymentID, nil
+}
+
+// PollUntilPublished polls the deployment status until PUBLISHED or FAILED.
+func (c *Client) PollUntilPublished(deploymentID string) (DeploymentState, error) {
+	interval := c.PollInterval
+	if interval == 0 {
+		interval = 5 * time.Second
+	}
+	timeout := c.PollTimeout
+	if timeout == 0 {
+		timeout = 10 * time.Minute
+	}
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		state, err := c.checkStatus(deploymentID)
+		if err != nil {
+			return "", err
+		}
+		switch state {
+		case DeploymentPublished:
+			return DeploymentPublished, nil
+		case DeploymentFailed:
+			return DeploymentFailed, fmt.Errorf("deployment %s failed", deploymentID)
+		}
+		time.Sleep(interval)
+	}
+	return "", fmt.Errorf("deployment %s timed out after %s", deploymentID, timeout)
+}
+
+type statusResponse struct {
+	DeploymentState DeploymentState `json:"deploymentState"`
+}
+
+func (c *Client) checkStatus(deploymentID string) (DeploymentState, error) {
+	url := c.baseURL() + "/api/v1/publisher/status?id=" + deploymentID
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("status poll: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("status poll: HTTP %d: %s", resp.StatusCode, string(b))
+	}
+
+	var sr statusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		return "", fmt.Errorf("status poll: decode: %w", err)
+	}
+	return sr.DeploymentState, nil
+}
+
+func (c *Client) baseURL() string {
+	if c.BaseURL != "" {
+		return strings.TrimRight(c.BaseURL, "/")
+	}
+	return "https://central.sonatype.com"
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return http.DefaultClient
+}

--- a/package3/java/publish/phase12_test.go
+++ b/package3/java/publish/phase12_test.go
@@ -1,0 +1,169 @@
+package publish_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"mochi/package3/java/publish"
+)
+
+func buildFakeArtifacts(t *testing.T, dir string) (jarPath, pomPath string) {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	_ = zw.Close()
+	jarPath = filepath.Join(dir, "mylib-jni-wrapper-1.0.0.jar")
+	if err := os.WriteFile(jarPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write jar: %v", err)
+	}
+	pomPath = filepath.Join(dir, "mylib-jni-wrapper-1.0.0.pom")
+	pom := `<?xml version="1.0"?><project><groupId>dev.mochi.java-bridge</groupId><artifactId>mylib-jni-wrapper</artifactId><version>1.0.0</version></project>`
+	if err := os.WriteFile(pomPath, []byte(pom), 0o644); err != nil {
+		t.Fatalf("write pom: %v", err)
+	}
+	return
+}
+
+func TestBuildBundle_ValidSpec(t *testing.T) {
+	dir := t.TempDir()
+	jar, pom := buildFakeArtifacts(t, dir)
+	spec := publish.BundleSpec{
+		GroupID:    "dev.mochi.java-bridge",
+		ArtifactID: "mylib-jni-wrapper",
+		Version:    "1.0.0",
+		JARPath:    jar,
+		POMPath:    pom,
+	}
+	res, err := publish.BuildBundle(spec, filepath.Join(dir, "out"))
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	if _, err := os.Stat(res.BundlePath); err != nil {
+		t.Errorf("bundle not on disk: %v", err)
+	}
+}
+
+func TestBuildBundle_MissingGroup(t *testing.T) {
+	_, err := publish.BuildBundle(publish.BundleSpec{
+		ArtifactID: "mylib", Version: "1.0", JARPath: "j", POMPath: "p",
+	}, t.TempDir())
+	if err == nil {
+		t.Error("expected error for missing GroupID")
+	}
+}
+
+func TestDryRun_ValidBundle(t *testing.T) {
+	dir := t.TempDir()
+	jar, pom := buildFakeArtifacts(t, dir)
+	spec := publish.BundleSpec{
+		GroupID:    "dev.mochi.java-bridge",
+		ArtifactID: "mylib-jni-wrapper",
+		Version:    "1.0.0",
+		JARPath:    jar,
+		POMPath:    pom,
+	}
+	res, err := publish.BuildBundle(spec, filepath.Join(dir, "out"))
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	if err := publish.DryRun(res.BundlePath, spec.GroupID, spec.ArtifactID, spec.Version); err != nil {
+		t.Errorf("DryRun: %v", err)
+	}
+}
+
+func TestClientUpload_DryRun(t *testing.T) {
+	client := &publish.Client{Token: "test-token"}
+	id, err := client.Upload("irrelevant.zip", true, "test-bundle")
+	if err != nil {
+		t.Fatalf("Upload dry-run: %v", err)
+	}
+	if id == "" {
+		t.Error("expected non-empty deployment ID for dry-run")
+	}
+}
+
+func TestClientUpload_MockServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method %q", r.Method)
+		}
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte("deploy-abc-123"))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	jar, pom := buildFakeArtifacts(t, dir)
+	spec := publish.BundleSpec{
+		GroupID:    "dev.mochi.java-bridge",
+		ArtifactID: "mylib-jni-wrapper",
+		Version:    "1.0.0",
+		JARPath:    jar,
+		POMPath:    pom,
+	}
+	res, err := publish.BuildBundle(spec, filepath.Join(dir, "out"))
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+
+	client := &publish.Client{
+		BaseURL: srv.URL,
+		Token:   "test-token",
+	}
+	id, err := client.Upload(res.BundlePath, false, "test-bundle")
+	if err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if id != "deploy-abc-123" {
+		t.Errorf("id = %q; want deploy-abc-123", id)
+	}
+}
+
+func TestClientPollUntilPublished_Mock(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		state := "PENDING"
+		if calls >= 2 {
+			state = "PUBLISHED"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"deploymentState": state})
+	}))
+	defer srv.Close()
+
+	client := &publish.Client{
+		BaseURL:      srv.URL,
+		Token:        "t",
+		PollInterval: 1 * time.Millisecond,
+		PollTimeout:  5 * time.Second,
+	}
+	state, err := client.PollUntilPublished("dep-xyz")
+	if err != nil {
+		t.Fatalf("PollUntilPublished: %v", err)
+	}
+	if state != publish.DeploymentPublished {
+		t.Errorf("state = %q; want PUBLISHED", state)
+	}
+}
+
+func TestDeploymentStateConstants(t *testing.T) {
+	for _, s := range []publish.DeploymentState{
+		publish.DeploymentPending,
+		publish.DeploymentValidated,
+		publish.DeploymentPublished,
+		publish.DeploymentFailed,
+	} {
+		if strings.TrimSpace(string(s)) == "" {
+			t.Errorf("empty deployment state constant: %q", s)
+		}
+	}
+}


### PR DESCRIPTION
Closes #22990

## Summary

- Adds `publish/bundle.go` with `BuildBundle` (produces a Sonatype Central Portal upload ZIP) and `DryRun` (validates bundle entries and checksums)
- Adds `publish/central.go` with `Client.Upload` (multipart POST to Central Portal) and `Client.PollUntilPublished` (polls status until PUBLISHED or FAILED)
- GPG signing is optional (skipped when `GPGKeyID` is empty)

## Test plan

- `go test ./package3/java/publish/` all 7 tests pass without GPG or network
- `go test ./package3/java/...` all packages green