### PR TITLE
mep-52(phase 13): wire actual tracking issue + PR numbers in the spec doc

### DIFF
--- a/website/docs/implementation/0052/phase-13-llm.md
+++ b/website/docs/implementation/0052/phase-13-llm.md
@@ -13,8 +13,8 @@ description: "MEP-52 Phase 13, Mochi `generate <provider> { ... }` as cassette-r
 | Status         | LANDED (Node + Deno + Bun) |
 | Started        | 2026-05-30 00:55 (GMT+7) |
 | Landed         | 2026-05-30 01:01 (GMT+7) |
-| Tracking issue | (pending) |
-| Tracking PR    | (pending) |
+| Tracking issue | [#22992](https://github.com/mochilang/mochi/issues/22992) |
+| Tracking PR    | [#22995](https://github.com/mochilang/mochi/pull/22995) |
 
 ## Gate
 


### PR DESCRIPTION
Tracking issue: #22992
Original PR: #22995

## Summary

Auto-ship fixup so the published Phase 13 spec stops saying \`(pending)\` for issue / PR references. One-line edit to the table at the top of the doc.