### PR TITLE
feat(mep-66/p11): OTP behavior bindings (gen_server, supervisor, application)

### DIFF
--- a/package3/erlang/otp/application.go
+++ b/package3/erlang/otp/application.go
@@ -1,0 +1,163 @@
+package otp
+
+import (
+	"fmt"
+
+	"mochi/package3/erlang/etf"
+)
+
+// Application wraps application:start, stop, ensure_all_started, get_env,
+// and set_env for a single OTP application.
+type Application struct {
+	caller Caller
+	name   string
+}
+
+// NewApplication returns an Application wrapper for the named OTP application.
+// name is the atom name of the application, e.g. "cowboy".
+func NewApplication(caller Caller, name string) *Application {
+	return &Application{caller: caller, name: name}
+}
+
+// Start calls application:start(Name) and returns an error when the Erlang
+// side replies with {error, Reason}. The atom `already_started` is not
+// treated as an error here; callers that need to distinguish it should use
+// StartResult instead.
+func (a *Application) Start() error {
+	v, err := a.caller.Call("application:start", []interface{}{etf.Atom(a.name)})
+	if err != nil {
+		return err
+	}
+	if isAtom(v, "ok") {
+		return nil
+	}
+	if tup, ok := v.(etf.Tuple); ok && len(tup) == 2 && isAtom(tup[0], "error") {
+		// {error, {already_started, App}} is benign — normalise to nil.
+		if inner, ok := tup[1].(etf.Tuple); ok && len(inner) == 2 && isAtom(inner[0], "already_started") {
+			return nil
+		}
+		return fmt.Errorf("otp: application:start(%s): %v", a.name, tup[1])
+	}
+	return fmt.Errorf("otp: application:start(%s): unexpected reply: %v", a.name, v)
+}
+
+// StartPermanent calls application:start(Name, permanent). A permanent
+// application crashes the entire node if it terminates abnormally.
+func (a *Application) StartPermanent() error {
+	v, err := a.caller.Call("application:start", []interface{}{
+		etf.Atom(a.name), etf.Atom("permanent"),
+	})
+	if err != nil {
+		return err
+	}
+	if isAtom(v, "ok") {
+		return nil
+	}
+	if tup, ok := v.(etf.Tuple); ok && len(tup) == 2 && isAtom(tup[0], "error") {
+		if inner, ok := tup[1].(etf.Tuple); ok && len(inner) == 2 && isAtom(inner[0], "already_started") {
+			return nil
+		}
+		return fmt.Errorf("otp: application:start(%s, permanent): %v", a.name, tup[1])
+	}
+	return fmt.Errorf("otp: application:start(%s, permanent): unexpected reply: %v", a.name, v)
+}
+
+// Stop calls application:stop(Name).
+func (a *Application) Stop() error {
+	v, err := a.caller.Call("application:stop", []interface{}{etf.Atom(a.name)})
+	if err != nil {
+		return err
+	}
+	return expectOK(v)
+}
+
+// EnsureAllStarted calls application:ensure_all_started(Name) and returns
+// the list of application names that were started as a result. The Erlang
+// side returns {ok, [App]} on success.
+func (a *Application) EnsureAllStarted() ([]string, error) {
+	v, err := a.caller.Call("application:ensure_all_started", []interface{}{etf.Atom(a.name)})
+	if err != nil {
+		return nil, err
+	}
+	val, err := unwrapOKValue(v)
+	if err != nil {
+		return nil, err
+	}
+	list, ok := val.(etf.List)
+	if !ok {
+		return nil, fmt.Errorf("otp: application:ensure_all_started: expected list, got %T", val)
+	}
+	apps := make([]string, 0, len(list))
+	for _, item := range list {
+		apps = append(apps, termToString(item))
+	}
+	return apps, nil
+}
+
+// GetEnv calls application:get_env(Name, Key) and returns the value when
+// present. The Erlang side returns {ok, Val} or the atom `undefined`.
+// The second return value is true when the key is set.
+func (a *Application) GetEnv(key string) (interface{}, bool, error) {
+	v, err := a.caller.Call("application:get_env", []interface{}{
+		etf.Atom(a.name), etf.Atom(key),
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	if isAtom(v, "undefined") {
+		return nil, false, nil
+	}
+	tup, ok := v.(etf.Tuple)
+	if !ok || len(tup) != 2 || !isAtom(tup[0], "ok") {
+		return nil, false, fmt.Errorf("otp: application:get_env unexpected reply: %v", v)
+	}
+	return tup[1], true, nil
+}
+
+// SetEnv calls application:set_env(Name, Key, Val). Persistent is false.
+func (a *Application) SetEnv(key string, value interface{}) error {
+	v, err := a.caller.Call("application:set_env", []interface{}{
+		etf.Atom(a.name), etf.Atom(key), value,
+	})
+	if err != nil {
+		return err
+	}
+	return expectOK(v)
+}
+
+// LoadedApplications calls application:loaded_applications() and returns the
+// names of all currently loaded applications. The Erlang side returns
+// [{Name, Desc, Vsn}].
+func LoadedApplications(caller Caller) ([]string, error) {
+	v, err := caller.Call("application:loaded_applications", []interface{}{})
+	if err != nil {
+		return nil, err
+	}
+	return parseApplicationList(v)
+}
+
+// WhichApplications calls application:which_applications() and returns the
+// names of all currently running applications.
+func WhichApplications(caller Caller) ([]string, error) {
+	v, err := caller.Call("application:which_applications", []interface{}{})
+	if err != nil {
+		return nil, err
+	}
+	return parseApplicationList(v)
+}
+
+func parseApplicationList(v interface{}) ([]string, error) {
+	list, ok := v.(etf.List)
+	if !ok {
+		return nil, fmt.Errorf("otp: expected application list, got %T", v)
+	}
+	apps := make([]string, 0, len(list))
+	for _, item := range list {
+		tup, ok := item.(etf.Tuple)
+		if !ok || len(tup) < 1 {
+			continue
+		}
+		apps = append(apps, termToString(tup[0]))
+	}
+	return apps, nil
+}

--- a/package3/erlang/otp/genserver.go
+++ b/package3/erlang/otp/genserver.go
@@ -1,0 +1,82 @@
+package otp
+
+import (
+	"fmt"
+
+	"mochi/package3/erlang/etf"
+)
+
+// GenServer wraps gen_server:call, gen_server:cast, and gen_server:stop for
+// a single registered server name.
+//
+// The server name is passed to every Erlang call as an atom, so it must match
+// the name used in gen_server:start_link({local, Name}, ...).
+type GenServer struct {
+	caller Caller
+	name   string
+}
+
+// NewGenServer returns a GenServer bound to the registered server name.
+// name is an Erlang atom string, e.g. "my_server".
+func NewGenServer(caller Caller, name string) *GenServer {
+	return &GenServer{caller: caller, name: name}
+}
+
+// Call dispatches gen_server:call(Name, Request) and returns the raw ETF
+// reply value. Errors from the Erlang side (noproc, timeout, etc.) surface
+// as Go errors.
+func (g *GenServer) Call(request interface{}) (interface{}, error) {
+	return g.caller.Call("gen_server:call", []interface{}{etf.Atom(g.name), request})
+}
+
+// CallTimeout dispatches gen_server:call(Name, Request, TimeoutMs).
+// timeoutMs is the Erlang-side call timeout in milliseconds; pass a value
+// greater than the default 5000 for long-running handlers.
+func (g *GenServer) CallTimeout(request interface{}, timeoutMs int) (interface{}, error) {
+	return g.caller.Call("gen_server:call", []interface{}{
+		etf.Atom(g.name), request, int64(timeoutMs),
+	})
+}
+
+// Cast dispatches gen_server:cast(Name, Message). Always returns nil on
+// success; the Erlang side never replies to a cast.
+func (g *GenServer) Cast(message interface{}) error {
+	v, err := g.caller.Call("gen_server:cast", []interface{}{etf.Atom(g.name), message})
+	if err != nil {
+		return err
+	}
+	return expectOK(v)
+}
+
+// Stop calls gen_server:stop(Name) and waits for the process to terminate.
+func (g *GenServer) Stop() error {
+	v, err := g.caller.Call("gen_server:stop", []interface{}{etf.Atom(g.name)})
+	if err != nil {
+		return err
+	}
+	return expectOK(v)
+}
+
+// StartLink calls gen_server:start_link({local, Name}, Module, InitArgs, [])
+// and returns the PID of the newly started process on success.
+func StartLink(caller Caller, module, name string, initArgs []interface{}) (etf.Pid, error) {
+	localReg := etf.Tuple{etf.Atom("local"), etf.Atom(name)}
+	v, err := caller.Call("gen_server:start_link", []interface{}{
+		localReg,
+		etf.Atom(module),
+		etf.List(initArgs),
+		etf.List(nil),
+	})
+	if err != nil {
+		return etf.Pid{}, err
+	}
+	val, err := unwrapOKValue(v)
+	if err != nil {
+		return etf.Pid{}, err
+	}
+	pid, ok := val.(etf.Pid)
+	if !ok {
+		return etf.Pid{}, fmt.Errorf("otp: gen_server:start_link returned non-pid: %T", val)
+	}
+	return pid, nil
+}

--- a/package3/erlang/otp/otp.go
+++ b/package3/erlang/otp/otp.go
@@ -1,0 +1,95 @@
+// Package otp provides typed Go bindings for OTP behavior calls dispatched
+// through the MEP-66 Erlang Port bridge.
+//
+// All three standard OTP behaviors are covered:
+//
+//   - GenServer  -- gen_server:call / gen_server:cast
+//   - Supervisor -- supervisor:which_children / count_children /
+//     terminate_child / restart_child / delete_child
+//   - Application -- application:start / stop / ensure_all_started /
+//     get_env / set_env
+//
+// Every wrapper calls through the Caller interface, which is satisfied by
+// *port.Manager from package3/erlang/port. Tests inject a mock Caller so
+// no real `erl` binary is required.
+//
+// ETF term conventions (all values are returned by the Port runner after
+// evaluating the named function call):
+//
+//	ok                    → etf.Atom("ok")
+//	{ok, Term}            → etf.Tuple{etf.Atom("ok"), Term}
+//	{error, Reason}       → etf.Tuple{etf.Atom("error"), Reason}
+//	undefined             → etf.Atom("undefined")
+//	Pid                   → etf.Pid{...}
+package otp
+
+import (
+	"fmt"
+
+	"mochi/package3/erlang/etf"
+)
+
+// Caller dispatches a function call to the connected Erlang node.
+// *port.Manager satisfies this interface. Tests use mockCaller.
+type Caller interface {
+	Call(fun string, args []interface{}) (interface{}, error)
+}
+
+// isAtom reports whether v is etf.Atom(a).
+func isAtom(v interface{}, a string) bool {
+	atom, ok := v.(etf.Atom)
+	return ok && string(atom) == a
+}
+
+// expectOK returns nil when v is the atom `ok`, or an error otherwise.
+func expectOK(v interface{}) error {
+	if isAtom(v, "ok") {
+		return nil
+	}
+	if tup, ok := v.(etf.Tuple); ok && len(tup) == 2 && isAtom(tup[0], "error") {
+		return fmt.Errorf("otp: erlang error: %v", tup[1])
+	}
+	return fmt.Errorf("otp: unexpected reply: %v", v)
+}
+
+// unwrapOKValue expects either `{ok, Value}` or `{error, Reason}`.
+// Returns (Value, nil) or (nil, error).
+func unwrapOKValue(v interface{}) (interface{}, error) {
+	tup, ok := v.(etf.Tuple)
+	if !ok || len(tup) < 2 {
+		return nil, fmt.Errorf("otp: unexpected reply shape: %v", v)
+	}
+	switch etf.Atom(fmt.Sprintf("%v", tup[0])) {
+	case "ok":
+		return tup[1], nil
+	case "error":
+		return nil, fmt.Errorf("otp: erlang error: %v", tup[1])
+	default:
+		return nil, fmt.Errorf("otp: unexpected reply tag: %v", tup[0])
+	}
+}
+
+// termToString converts an ETF term to a string best-effort.
+func termToString(v interface{}) string {
+	switch t := v.(type) {
+	case etf.Atom:
+		return string(t)
+	case string:
+		return t
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// termToInt64 extracts an integer from an ETF integer term.
+func termToInt64(v interface{}) (int64, bool) {
+	switch n := v.(type) {
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	case uint32:
+		return int64(n), true
+	}
+	return 0, false
+}

--- a/package3/erlang/otp/otp_test.go
+++ b/package3/erlang/otp/otp_test.go
@@ -1,0 +1,524 @@
+package otp
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"mochi/package3/erlang/etf"
+)
+
+// mockCaller records calls and returns pre-configured responses.
+type mockCaller struct {
+	responses []interface{}
+	idx       int
+	calls     []mockCall
+}
+
+type mockCall struct {
+	fun  string
+	args []interface{}
+}
+
+func (m *mockCaller) Call(fun string, args []interface{}) (interface{}, error) {
+	m.calls = append(m.calls, mockCall{fun: fun, args: args})
+	if m.idx >= len(m.responses) {
+		return nil, fmt.Errorf("unexpected call %d to %s", m.idx, fun)
+	}
+	r := m.responses[m.idx]
+	m.idx++
+	if err, ok := r.(error); ok {
+		return nil, err
+	}
+	return r, nil
+}
+
+func newMock(responses ...interface{}) *mockCaller {
+	return &mockCaller{responses: responses}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func TestIsAtom(t *testing.T) {
+	if !isAtom(etf.Atom("ok"), "ok") {
+		t.Error("isAtom: ok should match ok")
+	}
+	if isAtom(etf.Atom("ok"), "error") {
+		t.Error("isAtom: ok should not match error")
+	}
+	if isAtom("not-an-atom", "ok") {
+		t.Error("isAtom: string should not match")
+	}
+}
+
+func TestExpectOK_OK(t *testing.T) {
+	if err := expectOK(etf.Atom("ok")); err != nil {
+		t.Errorf("unexpected: %v", err)
+	}
+}
+
+func TestExpectOK_Error(t *testing.T) {
+	err := expectOK(etf.Tuple{etf.Atom("error"), etf.Atom("noproc")})
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestExpectOK_Unknown(t *testing.T) {
+	err := expectOK(etf.Atom("something_else"))
+	if err == nil {
+		t.Error("expected error for unknown reply")
+	}
+}
+
+func TestUnwrapOKValue_Success(t *testing.T) {
+	val, err := unwrapOKValue(etf.Tuple{etf.Atom("ok"), etf.Atom("value")})
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if !isAtom(val, "value") {
+		t.Errorf("val = %v", val)
+	}
+}
+
+func TestUnwrapOKValue_Error(t *testing.T) {
+	_, err := unwrapOKValue(etf.Tuple{etf.Atom("error"), etf.Atom("badarg")})
+	if err == nil || !strings.Contains(err.Error(), "badarg") {
+		t.Errorf("expected badarg error, got: %v", err)
+	}
+}
+
+func TestUnwrapOKValue_NotTuple(t *testing.T) {
+	_, err := unwrapOKValue(etf.Atom("ok"))
+	if err == nil {
+		t.Error("expected error for bare atom")
+	}
+}
+
+// ── GenServer ─────────────────────────────────────────────────────────────────
+
+func TestGenServer_Call_Success(t *testing.T) {
+	mock := newMock(etf.Atom("pong"))
+	gs := NewGenServer(mock, "my_server")
+	v, err := gs.Call(etf.Atom("ping"))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if !isAtom(v, "pong") {
+		t.Errorf("reply = %v", v)
+	}
+	if mock.calls[0].fun != "gen_server:call" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+func TestGenServer_Call_PassesServerName(t *testing.T) {
+	mock := newMock(etf.Atom("ok"))
+	gs := NewGenServer(mock, "counter")
+	_, _ = gs.Call(etf.Atom("get"))
+	if len(mock.calls) == 0 {
+		t.Fatal("no calls recorded")
+	}
+	args := mock.calls[0].args
+	if len(args) < 1 {
+		t.Fatal("no args")
+	}
+	if !isAtom(args[0], "counter") {
+		t.Errorf("first arg = %v, want atom counter", args[0])
+	}
+}
+
+func TestGenServer_CallTimeout(t *testing.T) {
+	mock := newMock(etf.Atom("result"))
+	gs := NewGenServer(mock, "srv")
+	v, err := gs.CallTimeout(etf.Atom("req"), 10000)
+	if err != nil {
+		t.Fatalf("CallTimeout: %v", err)
+	}
+	if !isAtom(v, "result") {
+		t.Errorf("reply = %v", v)
+	}
+	args := mock.calls[0].args
+	if len(args) != 3 {
+		t.Errorf("expected 3 args (server, request, timeout), got %d", len(args))
+	}
+}
+
+func TestGenServer_Cast_Success(t *testing.T) {
+	mock := newMock(etf.Atom("ok"))
+	gs := NewGenServer(mock, "worker")
+	if err := gs.Cast(etf.Atom("do_work")); err != nil {
+		t.Errorf("Cast: %v", err)
+	}
+	if mock.calls[0].fun != "gen_server:cast" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+func TestGenServer_Cast_Error(t *testing.T) {
+	mock := newMock(fmt.Errorf("noproc"))
+	gs := NewGenServer(mock, "dead_server")
+	if err := gs.Cast(etf.Atom("msg")); err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestGenServer_Stop(t *testing.T) {
+	mock := newMock(etf.Atom("ok"))
+	gs := NewGenServer(mock, "srv")
+	if err := gs.Stop(); err != nil {
+		t.Errorf("Stop: %v", err)
+	}
+	if mock.calls[0].fun != "gen_server:stop" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+func TestStartLink_Success(t *testing.T) {
+	pid := etf.Pid{Node: "nonode@nohost", ID: 1, Serial: 0, Creation: 0}
+	mock := newMock(etf.Tuple{etf.Atom("ok"), pid})
+	got, err := StartLink(mock, "my_module", "my_server", nil)
+	if err != nil {
+		t.Fatalf("StartLink: %v", err)
+	}
+	if got.ID != pid.ID {
+		t.Errorf("pid ID = %d, want %d", got.ID, pid.ID)
+	}
+	if mock.calls[0].fun != "gen_server:start_link" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+func TestStartLink_Error(t *testing.T) {
+	mock := newMock(etf.Tuple{etf.Atom("error"), etf.Atom("already_started")})
+	_, err := StartLink(mock, "mod", "srv", nil)
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestStartLink_NonPidReply(t *testing.T) {
+	mock := newMock(etf.Tuple{etf.Atom("ok"), etf.Atom("not_a_pid")})
+	_, err := StartLink(mock, "mod", "srv", nil)
+	if err == nil {
+		t.Error("expected error for non-pid reply")
+	}
+}
+
+// ── Supervisor ────────────────────────────────────────────────────────────────
+
+func makeChildTuple(id string, pid etf.Pid, typ string) etf.Tuple {
+	return etf.Tuple{
+		etf.Atom(id),
+		pid,
+		etf.Atom(typ),
+		etf.List{etf.Atom(id + "_mod")},
+	}
+}
+
+func TestSupervisor_WhichChildren(t *testing.T) {
+	pid1 := etf.Pid{Node: "n@h", ID: 10}
+	pid2 := etf.Pid{Node: "n@h", ID: 11}
+	list := etf.List{
+		makeChildTuple("child1", pid1, "worker"),
+		makeChildTuple("child2", pid2, "supervisor"),
+	}
+	mock := newMock(list)
+	sup := NewSupervisor(mock, "my_sup")
+	children, err := sup.WhichChildren()
+	if err != nil {
+		t.Fatalf("WhichChildren: %v", err)
+	}
+	if len(children) != 2 {
+		t.Fatalf("len = %d, want 2", len(children))
+	}
+	if termToString(children[0].ID) != "child1" {
+		t.Errorf("child[0].ID = %v", children[0].ID)
+	}
+	if children[0].PID == nil || children[0].PID.ID != 10 {
+		t.Errorf("child[0].PID = %v", children[0].PID)
+	}
+	if children[0].Type != "worker" {
+		t.Errorf("child[0].Type = %q", children[0].Type)
+	}
+	if children[1].Type != "supervisor" {
+		t.Errorf("child[1].Type = %q", children[1].Type)
+	}
+}
+
+func TestSupervisor_WhichChildren_UndefinedPID(t *testing.T) {
+	item := etf.Tuple{
+		etf.Atom("child1"),
+		etf.Atom("undefined"),
+		etf.Atom("worker"),
+		etf.List{},
+	}
+	mock := newMock(etf.List{item})
+	sup := NewSupervisor(mock, "sup")
+	children, err := sup.WhichChildren()
+	if err != nil {
+		t.Fatalf("WhichChildren: %v", err)
+	}
+	if len(children) != 1 {
+		t.Fatalf("len = %d", len(children))
+	}
+	if children[0].PID != nil {
+		t.Error("PID should be nil for undefined child")
+	}
+}
+
+func TestSupervisor_WhichChildren_NonList(t *testing.T) {
+	mock := newMock(etf.Atom("badarg"))
+	sup := NewSupervisor(mock, "sup")
+	_, err := sup.WhichChildren()
+	if err == nil {
+		t.Error("expected error for non-list reply")
+	}
+}
+
+func TestSupervisor_CountChildren(t *testing.T) {
+	list := etf.List{
+		etf.Tuple{etf.Atom("specs"), int64(3)},
+		etf.Tuple{etf.Atom("active"), int64(2)},
+		etf.Tuple{etf.Atom("supervisors"), int64(1)},
+		etf.Tuple{etf.Atom("workers"), int64(1)},
+	}
+	mock := newMock(list)
+	sup := NewSupervisor(mock, "sup")
+	cc, err := sup.CountChildren()
+	if err != nil {
+		t.Fatalf("CountChildren: %v", err)
+	}
+	if cc.Specs != 3 {
+		t.Errorf("Specs = %d", cc.Specs)
+	}
+	if cc.Active != 2 {
+		t.Errorf("Active = %d", cc.Active)
+	}
+	if cc.Supervisors != 1 {
+		t.Errorf("Supervisors = %d", cc.Supervisors)
+	}
+	if cc.Workers != 1 {
+		t.Errorf("Workers = %d", cc.Workers)
+	}
+}
+
+func TestSupervisor_TerminateChild_OK(t *testing.T) {
+	mock := newMock(etf.Atom("ok"))
+	sup := NewSupervisor(mock, "sup")
+	if err := sup.TerminateChild(etf.Atom("child1")); err != nil {
+		t.Errorf("TerminateChild: %v", err)
+	}
+	if mock.calls[0].fun != "supervisor:terminate_child" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+func TestSupervisor_TerminateChild_Error(t *testing.T) {
+	mock := newMock(etf.Tuple{etf.Atom("error"), etf.Atom("not_found")})
+	sup := NewSupervisor(mock, "sup")
+	err := sup.TerminateChild(etf.Atom("ghost"))
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestSupervisor_RestartChild_OK(t *testing.T) {
+	pid := etf.Pid{Node: "n@h", ID: 42}
+	mock := newMock(etf.Tuple{etf.Atom("ok"), pid})
+	sup := NewSupervisor(mock, "sup")
+	got, err := sup.RestartChild(etf.Atom("worker1"))
+	if err != nil {
+		t.Fatalf("RestartChild: %v", err)
+	}
+	if got.ID != 42 {
+		t.Errorf("pid.ID = %d", got.ID)
+	}
+}
+
+func TestSupervisor_RestartChild_Error(t *testing.T) {
+	mock := newMock(etf.Tuple{etf.Atom("error"), etf.Atom("running")})
+	sup := NewSupervisor(mock, "sup")
+	_, err := sup.RestartChild(etf.Atom("c1"))
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestSupervisor_DeleteChild(t *testing.T) {
+	mock := newMock(etf.Atom("ok"))
+	sup := NewSupervisor(mock, "sup")
+	if err := sup.DeleteChild(etf.Atom("child1")); err != nil {
+		t.Errorf("DeleteChild: %v", err)
+	}
+	if mock.calls[0].fun != "supervisor:delete_child" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+// ── Application ──────────────────────────────────────────────────────────────
+
+func TestApplication_Start_OK(t *testing.T) {
+	mock := newMock(etf.Atom("ok"))
+	app := NewApplication(mock, "cowboy")
+	if err := app.Start(); err != nil {
+		t.Errorf("Start: %v", err)
+	}
+	if mock.calls[0].fun != "application:start" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+func TestApplication_Start_AlreadyStarted(t *testing.T) {
+	reason := etf.Tuple{etf.Atom("already_started"), etf.Atom("cowboy")}
+	mock := newMock(etf.Tuple{etf.Atom("error"), reason})
+	app := NewApplication(mock, "cowboy")
+	if err := app.Start(); err != nil {
+		t.Errorf("already_started should not be an error: %v", err)
+	}
+}
+
+func TestApplication_Start_OtherError(t *testing.T) {
+	mock := newMock(etf.Tuple{etf.Atom("error"), etf.Atom("bad_return")})
+	app := NewApplication(mock, "cowboy")
+	if err := app.Start(); err == nil {
+		t.Error("expected error for bad_return")
+	}
+}
+
+func TestApplication_StartPermanent(t *testing.T) {
+	mock := newMock(etf.Atom("ok"))
+	app := NewApplication(mock, "myapp")
+	if err := app.StartPermanent(); err != nil {
+		t.Errorf("StartPermanent: %v", err)
+	}
+	args := mock.calls[0].args
+	if len(args) < 2 || !isAtom(args[1], "permanent") {
+		t.Errorf("second arg should be atom permanent, got: %v", args)
+	}
+}
+
+func TestApplication_Stop(t *testing.T) {
+	mock := newMock(etf.Atom("ok"))
+	app := NewApplication(mock, "cowboy")
+	if err := app.Stop(); err != nil {
+		t.Errorf("Stop: %v", err)
+	}
+	if mock.calls[0].fun != "application:stop" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+func TestApplication_EnsureAllStarted(t *testing.T) {
+	list := etf.List{etf.Atom("ranch"), etf.Atom("cowlib"), etf.Atom("cowboy")}
+	mock := newMock(etf.Tuple{etf.Atom("ok"), list})
+	app := NewApplication(mock, "cowboy")
+	apps, err := app.EnsureAllStarted()
+	if err != nil {
+		t.Fatalf("EnsureAllStarted: %v", err)
+	}
+	if len(apps) != 3 {
+		t.Fatalf("len = %d", len(apps))
+	}
+	if apps[0] != "ranch" || apps[2] != "cowboy" {
+		t.Errorf("apps = %v", apps)
+	}
+}
+
+func TestApplication_EnsureAllStarted_Error(t *testing.T) {
+	mock := newMock(etf.Tuple{etf.Atom("error"), etf.Atom("missing_dep")})
+	app := NewApplication(mock, "myapp")
+	_, err := app.EnsureAllStarted()
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestApplication_GetEnv_Present(t *testing.T) {
+	mock := newMock(etf.Tuple{etf.Atom("ok"), int64(8080)})
+	app := NewApplication(mock, "myapp")
+	val, ok, err := app.GetEnv("port")
+	if err != nil {
+		t.Fatalf("GetEnv: %v", err)
+	}
+	if !ok {
+		t.Error("expected ok=true")
+	}
+	n, _ := termToInt64(val)
+	if n != 8080 {
+		t.Errorf("val = %v", val)
+	}
+}
+
+func TestApplication_GetEnv_Undefined(t *testing.T) {
+	mock := newMock(etf.Atom("undefined"))
+	app := NewApplication(mock, "myapp")
+	_, ok, err := app.GetEnv("missing_key")
+	if err != nil {
+		t.Fatalf("GetEnv: %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false for undefined")
+	}
+}
+
+func TestApplication_GetEnv_PassesAppAndKey(t *testing.T) {
+	mock := newMock(etf.Atom("undefined"))
+	app := NewApplication(mock, "ranch")
+	_, _, _ = app.GetEnv("max_connections")
+	if mock.calls[0].fun != "application:get_env" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+	args := mock.calls[0].args
+	if !isAtom(args[0], "ranch") || !isAtom(args[1], "max_connections") {
+		t.Errorf("args = %v", args)
+	}
+}
+
+func TestApplication_SetEnv(t *testing.T) {
+	mock := newMock(etf.Atom("ok"))
+	app := NewApplication(mock, "myapp")
+	if err := app.SetEnv("debug", etf.Atom("true")); err != nil {
+		t.Errorf("SetEnv: %v", err)
+	}
+	if mock.calls[0].fun != "application:set_env" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+func TestLoadedApplications(t *testing.T) {
+	list := etf.List{
+		etf.Tuple{etf.Atom("kernel"), etf.Atom("ERTS kernel"), etf.Atom("9.0")},
+		etf.Tuple{etf.Atom("stdlib"), etf.Atom("ERTS stdlib"), etf.Atom("5.0")},
+	}
+	mock := newMock(list)
+	apps, err := LoadedApplications(mock)
+	if err != nil {
+		t.Fatalf("LoadedApplications: %v", err)
+	}
+	if len(apps) != 2 || apps[0] != "kernel" {
+		t.Errorf("apps = %v", apps)
+	}
+}
+
+func TestWhichApplications(t *testing.T) {
+	list := etf.List{
+		etf.Tuple{etf.Atom("cowboy"), etf.Atom("HTTP server"), etf.Atom("2.12.0")},
+	}
+	mock := newMock(list)
+	apps, err := WhichApplications(mock)
+	if err != nil {
+		t.Fatalf("WhichApplications: %v", err)
+	}
+	if len(apps) != 1 || apps[0] != "cowboy" {
+		t.Errorf("apps = %v", apps)
+	}
+}
+
+func TestWhichApplications_UsesWhichFun(t *testing.T) {
+	mock := newMock(etf.List{})
+	_, _ = WhichApplications(mock)
+	if mock.calls[0].fun != "application:which_applications" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}

--- a/package3/erlang/otp/supervisor.go
+++ b/package3/erlang/otp/supervisor.go
@@ -1,0 +1,158 @@
+package otp
+
+import (
+	"fmt"
+
+	"mochi/package3/erlang/etf"
+)
+
+// Supervisor wraps the supervisor:* functions for a single supervisor process.
+type Supervisor struct {
+	caller Caller
+	name   string
+}
+
+// NewSupervisor returns a Supervisor bound to the registered supervisor name.
+func NewSupervisor(caller Caller, name string) *Supervisor {
+	return &Supervisor{caller: caller, name: name}
+}
+
+// ChildInfo holds the data returned by supervisor:which_children for one child.
+type ChildInfo struct {
+	// ID is the child spec identifier (any Erlang term).
+	ID interface{}
+	// PID is non-nil when the child process is running.
+	PID *etf.Pid
+	// Type is "worker" or "supervisor".
+	Type string
+	// Modules is the list of callback module names.
+	Modules []string
+}
+
+// WhichChildren calls supervisor:which_children(Name) and returns the parsed
+// child list. Each element of the Erlang list has the shape:
+//
+//	{Id, Child, Type, Modules}
+//
+// where Child is a Pid, the atom `undefined`, or the atom `restarting`.
+func (s *Supervisor) WhichChildren() ([]ChildInfo, error) {
+	v, err := s.caller.Call("supervisor:which_children", []interface{}{etf.Atom(s.name)})
+	if err != nil {
+		return nil, err
+	}
+	list, ok := v.(etf.List)
+	if !ok {
+		return nil, fmt.Errorf("otp: supervisor:which_children expected list, got %T", v)
+	}
+	children := make([]ChildInfo, 0, len(list))
+	for _, item := range list {
+		tup, ok := item.(etf.Tuple)
+		if !ok || len(tup) < 4 {
+			continue
+		}
+		ci := ChildInfo{
+			ID:   tup[0],
+			Type: termToString(tup[2]),
+		}
+		if pid, ok := tup[1].(etf.Pid); ok {
+			ci.PID = &pid
+		}
+		if mods, ok := tup[3].(etf.List); ok {
+			for _, m := range mods {
+				ci.Modules = append(ci.Modules, termToString(m))
+			}
+		}
+		children = append(children, ci)
+	}
+	return children, nil
+}
+
+// ChildCounts holds the values from supervisor:count_children.
+type ChildCounts struct {
+	// Specs is the total number of child specifications.
+	Specs int
+	// Active is the number of actively running child processes.
+	Active int
+	// Supervisors is the number of running child supervisors.
+	Supervisors int
+	// Workers is the number of running child worker processes.
+	Workers int
+}
+
+// CountChildren calls supervisor:count_children(Name) and returns the parsed
+// counts. The Erlang return value is a proplist:
+//
+//	[{specs,N},{active,N},{supervisors,N},{workers,N}]
+func (s *Supervisor) CountChildren() (ChildCounts, error) {
+	v, err := s.caller.Call("supervisor:count_children", []interface{}{etf.Atom(s.name)})
+	if err != nil {
+		return ChildCounts{}, err
+	}
+	list, ok := v.(etf.List)
+	if !ok {
+		return ChildCounts{}, fmt.Errorf("otp: supervisor:count_children expected list, got %T", v)
+	}
+	var cc ChildCounts
+	for _, item := range list {
+		tup, ok := item.(etf.Tuple)
+		if !ok || len(tup) != 2 {
+			continue
+		}
+		key := termToString(tup[0])
+		n, _ := termToInt64(tup[1])
+		switch key {
+		case "specs":
+			cc.Specs = int(n)
+		case "active":
+			cc.Active = int(n)
+		case "supervisors":
+			cc.Supervisors = int(n)
+		case "workers":
+			cc.Workers = int(n)
+		}
+	}
+	return cc, nil
+}
+
+// TerminateChild calls supervisor:terminate_child(Name, ChildID).
+func (s *Supervisor) TerminateChild(childID interface{}) error {
+	v, err := s.caller.Call("supervisor:terminate_child", []interface{}{etf.Atom(s.name), childID})
+	if err != nil {
+		return err
+	}
+	return expectOK(v)
+}
+
+// RestartChild calls supervisor:restart_child(Name, ChildID) and returns the
+// PID of the restarted child on success.
+func (s *Supervisor) RestartChild(childID interface{}) (etf.Pid, error) {
+	v, err := s.caller.Call("supervisor:restart_child", []interface{}{etf.Atom(s.name), childID})
+	if err != nil {
+		return etf.Pid{}, err
+	}
+	val, err := unwrapOKValue(v)
+	if err != nil {
+		return etf.Pid{}, err
+	}
+	// restart_child returns {ok, Child} or {ok, Child, Info}.
+	// Child may itself be a tuple if the reply is {ok, {Pid, Info}}.
+	if pid, ok := val.(etf.Pid); ok {
+		return pid, nil
+	}
+	// Some supervisors return {ok, {Pid, _Extra}} — unwrap one more level.
+	if tup, ok := val.(etf.Tuple); ok && len(tup) >= 1 {
+		if pid, ok := tup[0].(etf.Pid); ok {
+			return pid, nil
+		}
+	}
+	return etf.Pid{}, fmt.Errorf("otp: supervisor:restart_child returned unexpected child term: %v", val)
+}
+
+// DeleteChild calls supervisor:delete_child(Name, ChildID).
+func (s *Supervisor) DeleteChild(childID interface{}) error {
+	v, err := s.caller.Call("supervisor:delete_child", []interface{}{etf.Atom(s.name), childID})
+	if err != nil {
+		return err
+	}
+	return expectOK(v)
+}

--- a/website/docs/implementation/0066/index.md
+++ b/website/docs/implementation/0066/index.md
@@ -25,8 +25,8 @@ A phase is LANDED only when its gate is green for every target in the runtime ma
 | 7 | Build orchestration (rebar3 compile + Port process spawn + workspace setup) | LANDED | a68fe5e | [phase-07](/docs/implementation/0066/phase-07-build) |
 | 8 | mochi.lock `[[erlang-package]]` integration + --check mode | LANDED | 41faa0d | [phase-08](/docs/implementation/0066/phase-08-lockfile) |
 | 9 | TargetErlangPort emit (rebar3 app skeleton + mochi_port_driver.erl + priv/mochi_binary) | LANDED | 178280d | [phase-09](/docs/implementation/0066/phase-09-target-erlang-port) |
-| 10 | Hex.pm trusted publishing (OIDC flow + rebar3 hex publish) | IN PROGRESS | — | [phase-10](/docs/implementation/0066/phase-10-trusted-publish) |
-| 11 | OTP behavior bindings (gen_server call/cast, supervisor, application) | NOT STARTED | — | [phase-11](/docs/implementation/0066/phase-11-otp-behaviors) |
+| 10 | Hex.pm trusted publishing (OIDC flow + rebar3 hex publish) | LANDED | a66f1db | [phase-10](/docs/implementation/0066/phase-10-trusted-publish) |
+| 11 | OTP behavior bindings (gen_server call/cast, supervisor, application) | IN PROGRESS | — | [phase-11](/docs/implementation/0066/phase-11-otp-behaviors) |
 | 12 | Async process bridge (OTP process spawn/receive/send/monitor via Mochi async) | NOT STARTED | — | [phase-12](/docs/implementation/0066/phase-12-async-bridge) |
 | 13 | Distributed Erlang node bridge (C-node via erl_interface + `dist` capability) | NOT STARTED | — | [phase-13](/docs/implementation/0066/phase-13-dist-bridge) |
 


### PR DESCRIPTION
Closes #22997

## Summary
- Adds `package3/erlang/otp` package with typed Go wrappers for the three standard OTP behaviors
- `GenServer`: Call, CallTimeout, Cast, Stop, StartLink
- `Supervisor`: WhichChildren, CountChildren, TerminateChild, RestartChild, DeleteChild
- `Application`: Start, StartPermanent, Stop, EnsureAllStarted, GetEnv, SetEnv, plus package-level LoadedApplications/WhichApplications
- All wrappers share a `Caller` interface (`*port.Manager` satisfies it); tests use `mockCaller` with no real `erl` required

## Test plan
- [x] `go test ./package3/erlang/otp/...` — 39 tests, all green
- [x] Tracking doc updated: phase 10 LANDED (a66f1db), phase 11 IN PROGRESS