### PR TITLE
feat(mep-67/p15): generics and type-erasure utilities (typemap, reflect)

### DIFF
--- a/package3/java/reflect/erasure.go
+++ b/package3/java/reflect/erasure.go
@@ -1,0 +1,74 @@
+package reflect
+
+import "strings"
+
+// EraseType returns the type-erased (raw) form of a Java type name. For
+// generic types (e.g. "java.util.List<java.lang.String>") it strips the
+// angle-bracket parameters and returns the base class name. Non-generic
+// types are returned unchanged.
+//
+// This matches the JVM's type-erasure semantics: at runtime all generic
+// information is removed and the JVM operates on the raw class.
+func EraseType(javaTypeName string) string {
+	idx := strings.IndexByte(javaTypeName, '<')
+	if idx < 0 {
+		return javaTypeName
+	}
+	return javaTypeName[:idx]
+}
+
+// IsErased reports whether a type name contains no generic parameters.
+func IsErased(javaTypeName string) bool {
+	return !strings.ContainsAny(javaTypeName, "<>")
+}
+
+// ErasedParams extracts the type parameters from a generic type name.
+// For "java.util.Map<K,V>" it returns ["K", "V"]. For raw types it returns nil.
+// This is the counterpart to EraseType for callers that need the parameter list.
+func ErasedParams(javaTypeName string) []string {
+	lt := strings.IndexByte(javaTypeName, '<')
+	if lt < 0 {
+		return nil
+	}
+	if !strings.HasSuffix(javaTypeName, ">") {
+		return nil
+	}
+	inner := javaTypeName[lt+1 : len(javaTypeName)-1]
+	return splitParams(inner)
+}
+
+// NormaliseTypeName applies a standard set of transformations to a raw type
+// name extracted from bytecode metadata (as seen in the reflection surface):
+//
+//   - Replaces '$' inner-class separators with '.' for consistency.
+//   - Strips array suffixes "[]" (returns the element type only).
+//   - Strips leading/trailing whitespace.
+func NormaliseTypeName(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.ReplaceAll(name, "$", ".")
+	name = strings.TrimSuffix(name, "[]")
+	return name
+}
+
+// splitParams splits a comma-separated list of type parameters, respecting
+// nested angle brackets.
+func splitParams(s string) []string {
+	var out []string
+	depth := 0
+	last := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '<':
+			depth++
+		case '>':
+			depth--
+		case ',':
+			if depth == 0 {
+				out = append(out, strings.TrimSpace(s[last:i]))
+				last = i + 1
+			}
+		}
+	}
+	out = append(out, strings.TrimSpace(s[last:]))
+	return out
+}

--- a/package3/java/reflect/erasure_test.go
+++ b/package3/java/reflect/erasure_test.go
@@ -1,0 +1,76 @@
+package reflect_test
+
+import (
+	"testing"
+
+	javareflect "mochi/package3/java/reflect"
+)
+
+func TestEraseType_Raw(t *testing.T) {
+	if got := javareflect.EraseType("java.lang.String"); got != "java.lang.String" {
+		t.Errorf("EraseType(%q) = %q; want same", "java.lang.String", got)
+	}
+}
+
+func TestEraseType_Generic(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"java.util.List<java.lang.String>", "java.util.List"},
+		{"java.util.Map<K,V>", "java.util.Map"},
+		{"java.util.concurrent.CompletableFuture<java.lang.Integer>", "java.util.concurrent.CompletableFuture"},
+	}
+	for _, c := range cases {
+		got := javareflect.EraseType(c.in)
+		if got != c.want {
+			t.Errorf("EraseType(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestIsErased(t *testing.T) {
+	if !javareflect.IsErased("java.lang.String") {
+		t.Error("IsErased should be true for raw type")
+	}
+	if javareflect.IsErased("java.util.List<java.lang.String>") {
+		t.Error("IsErased should be false for generic type")
+	}
+}
+
+func TestErasedParams(t *testing.T) {
+	params := javareflect.ErasedParams("java.util.Map<java.lang.String,java.lang.Integer>")
+	if len(params) != 2 {
+		t.Fatalf("want 2 params; got %d: %v", len(params), params)
+	}
+	if params[0] != "java.lang.String" {
+		t.Errorf("params[0] = %q; want java.lang.String", params[0])
+	}
+	if params[1] != "java.lang.Integer" {
+		t.Errorf("params[1] = %q; want java.lang.Integer", params[1])
+	}
+}
+
+func TestErasedParams_Raw(t *testing.T) {
+	if p := javareflect.ErasedParams("java.lang.String"); p != nil {
+		t.Errorf("ErasedParams of raw type should be nil; got %v", p)
+	}
+}
+
+func TestNormaliseTypeName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"java.util.Map$Entry", "java.util.Map.Entry"},
+		{"int[]", "int"},
+		{"  java.lang.String  ", "java.lang.String"},
+		{"java.lang.String[]", "java.lang.String"},
+	}
+	for _, c := range cases {
+		got := javareflect.NormaliseTypeName(c.in)
+		if got != c.want {
+			t.Errorf("NormaliseTypeName(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/package3/java/typemap/generic.go
+++ b/package3/java/typemap/generic.go
@@ -1,0 +1,87 @@
+package typemap
+
+import "strings"
+
+// GenericSignature holds a parsed Java generic type signature.
+// It covers the common cases the bridge needs: raw class, single-param
+// generics (List<T>, Optional<T>, CompletableFuture<T>), and two-param
+// generics (Map<K,V>).
+type GenericSignature struct {
+	// Base is the fully-qualified class name without type parameters.
+	Base string
+	// Params are the type parameter strings (possibly themselves generic).
+	Params []string
+}
+
+// ParseGenericSignature parses a Java generic type name like
+// "java.util.List<java.lang.String>" into its base class and type params.
+// On success ok is true. Raw (non-generic) types return the name as Base
+// with an empty Params slice.
+func ParseGenericSignature(name string) (sig GenericSignature, ok bool) {
+	name = strings.TrimSpace(name)
+	lt := strings.Index(name, "<")
+	if lt < 0 {
+		return GenericSignature{Base: name}, true
+	}
+	if !strings.HasSuffix(name, ">") {
+		return GenericSignature{}, false
+	}
+	base := name[:lt]
+	inner := name[lt+1 : len(name)-1]
+	params := splitTopLevelParams(inner)
+	return GenericSignature{Base: base, Params: params}, true
+}
+
+// IsRaw reports whether the signature has no type parameters.
+func (s GenericSignature) IsRaw() bool { return len(s.Params) == 0 }
+
+// Arity returns the number of type parameters.
+func (s GenericSignature) Arity() int { return len(s.Params) }
+
+// String reconstructs the full Java type name from the signature.
+func (s GenericSignature) String() string {
+	if s.IsRaw() {
+		return s.Base
+	}
+	return s.Base + "<" + strings.Join(s.Params, ",") + ">"
+}
+
+// EraseParams returns the raw (erased) form of the signature.
+func (s GenericSignature) EraseParams() GenericSignature {
+	return GenericSignature{Base: s.Base}
+}
+
+// WildcardErased reports whether any parameter is a wildcard ("?", "? extends ...",
+// "? super ..."). Such types cannot be safely bridged.
+func (s GenericSignature) WildcardErased() bool {
+	for _, p := range s.Params {
+		tp := strings.TrimSpace(p)
+		if tp == "?" || strings.HasPrefix(tp, "? ") {
+			return true
+		}
+	}
+	return false
+}
+
+// splitTopLevelParams splits a comma-separated list of type parameters,
+// ignoring commas nested inside angle brackets.
+func splitTopLevelParams(s string) []string {
+	var out []string
+	depth := 0
+	last := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '<':
+			depth++
+		case '>':
+			depth--
+		case ',':
+			if depth == 0 {
+				out = append(out, strings.TrimSpace(s[last:i]))
+				last = i + 1
+			}
+		}
+	}
+	out = append(out, strings.TrimSpace(s[last:]))
+	return out
+}

--- a/package3/java/typemap/generic_test.go
+++ b/package3/java/typemap/generic_test.go
@@ -1,0 +1,95 @@
+package typemap_test
+
+import (
+	"testing"
+
+	"mochi/package3/java/typemap"
+)
+
+func TestParseGenericSignature_Raw(t *testing.T) {
+	sig, ok := typemap.ParseGenericSignature("java.lang.String")
+	if !ok {
+		t.Fatal("expected ok for raw type")
+	}
+	if sig.Base != "java.lang.String" {
+		t.Errorf("Base = %q; want java.lang.String", sig.Base)
+	}
+	if !sig.IsRaw() {
+		t.Error("IsRaw() should be true for non-generic type")
+	}
+}
+
+func TestParseGenericSignature_SingleParam(t *testing.T) {
+	sig, ok := typemap.ParseGenericSignature("java.util.List<java.lang.String>")
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if sig.Base != "java.util.List" {
+		t.Errorf("Base = %q; want java.util.List", sig.Base)
+	}
+	if sig.Arity() != 1 {
+		t.Errorf("Arity = %d; want 1", sig.Arity())
+	}
+	if sig.Params[0] != "java.lang.String" {
+		t.Errorf("Params[0] = %q; want java.lang.String", sig.Params[0])
+	}
+}
+
+func TestParseGenericSignature_TwoParams(t *testing.T) {
+	sig, ok := typemap.ParseGenericSignature("java.util.Map<java.lang.String,java.lang.Integer>")
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if sig.Arity() != 2 {
+		t.Errorf("Arity = %d; want 2", sig.Arity())
+	}
+}
+
+func TestParseGenericSignature_Nested(t *testing.T) {
+	sig, ok := typemap.ParseGenericSignature("java.util.List<java.util.List<java.lang.String>>")
+	if !ok {
+		t.Fatal("expected ok for nested generic")
+	}
+	if sig.Arity() != 1 {
+		t.Errorf("Arity = %d; want 1", sig.Arity())
+	}
+	if sig.Params[0] != "java.util.List<java.lang.String>" {
+		t.Errorf("Params[0] = %q", sig.Params[0])
+	}
+}
+
+func TestParseGenericSignature_Malformed(t *testing.T) {
+	_, ok := typemap.ParseGenericSignature("java.util.List<incomplete")
+	if ok {
+		t.Error("expected !ok for malformed generic")
+	}
+}
+
+func TestGenericSignature_String(t *testing.T) {
+	sig, _ := typemap.ParseGenericSignature("java.util.List<java.lang.String>")
+	if got := sig.String(); got != "java.util.List<java.lang.String>" {
+		t.Errorf("String() = %q; want java.util.List<java.lang.String>", got)
+	}
+}
+
+func TestGenericSignature_EraseParams(t *testing.T) {
+	sig, _ := typemap.ParseGenericSignature("java.util.List<java.lang.String>")
+	erased := sig.EraseParams()
+	if !erased.IsRaw() {
+		t.Error("EraseParams() result should be raw")
+	}
+	if erased.Base != "java.util.List" {
+		t.Errorf("erased.Base = %q; want java.util.List", erased.Base)
+	}
+}
+
+func TestGenericSignature_WildcardErased(t *testing.T) {
+	sig, _ := typemap.ParseGenericSignature("java.util.List<?>")
+	if !sig.WildcardErased() {
+		t.Error("WildcardErased should be true for List<?>")
+	}
+	sig2, _ := typemap.ParseGenericSignature("java.util.List<java.lang.String>")
+	if sig2.WildcardErased() {
+		t.Error("WildcardErased should be false for List<String>")
+	}
+}


### PR DESCRIPTION
Closes #23001

## Summary

- Adds `typemap/generic.go` with `GenericSignature`, `ParseGenericSignature` (handles raw, single-param, two-param, nested generics), and helpers `IsRaw`, `Arity`, `String`, `EraseParams`, `WildcardErased`
- Adds `reflect/erasure.go` with `EraseType`, `IsErased`, `ErasedParams`, `NormaliseTypeName`

## Test plan

- 8 tests in `typemap/generic_test.go`, 6 tests in `reflect/erasure_test.go`
- `go test ./package3/java/...` all packages green