### PR TITLE
feat(mep-71/phase-15): install-time PEP 740 attestation verification

### DIFF
--- a/package3/python/attest/bundle.go
+++ b/package3/python/attest/bundle.go
@@ -1,0 +1,117 @@
+package attest
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// PEP 740 / Sigstore Bundle payload + envelope shapes. The bridge
+// only reads the subset PyPI emits: mediaType identifies the bundle
+// version; dsseEnvelope carries the DSSE-wrapped statement;
+// verificationMaterial carries the X.509 chain + Rekor inclusion
+// proof that sub-phase 15.1's crypto verifier consumes.
+const (
+	BundleMediaTypeV2          = "application/vnd.dev.sigstore.bundle.v0.3+json"
+	DSSEPayloadTypeInTotoJSON  = "application/vnd.in-toto+json"
+)
+
+// Bundle is the parsed PEP 740 attestation envelope.
+type Bundle struct {
+	MediaType            string                `json:"mediaType"`
+	DsseEnvelope         DSSEEnvelope          `json:"dsseEnvelope"`
+	VerificationMaterial VerificationMaterial  `json:"verificationMaterial"`
+}
+
+// DSSEEnvelope wraps the in-toto statement payload + the signatures
+// over it. Payload is base64-std encoded (RFC 4648 §4 with padding).
+type DSSEEnvelope struct {
+	Payload     string      `json:"payload"`
+	PayloadType string      `json:"payloadType"`
+	Signatures  []Signature `json:"signatures"`
+}
+
+// Signature is one DSSE signature line.
+type Signature struct {
+	Sig   string `json:"sig"`
+	Keyid string `json:"keyid,omitempty"`
+}
+
+// VerificationMaterial collects the Sigstore-specific material the
+// crypto verifier needs: the certificate chain (rooted at Fulcio) +
+// the Rekor transparency-log inclusion proof.
+type VerificationMaterial struct {
+	Certificate Certificate  `json:"x509CertificateChain,omitempty"`
+	TLogEntries []TLogEntry  `json:"tlogEntries,omitempty"`
+}
+
+// Certificate is the X.509 chain. RawBytes per cert is base64-DER.
+type Certificate struct {
+	Certificates []EncodedCert `json:"certificates"`
+}
+
+// EncodedCert is one DER-encoded X.509 certificate, base64-std.
+type EncodedCert struct {
+	RawBytes string `json:"rawBytes"`
+}
+
+// TLogEntry is one Rekor inclusion-proof entry. The verifier checks
+// LogID + KindVersion structurally; the actual inclusion proof
+// (logIndex, inclusionPromise, signed entry timestamp) is sub-phase
+// 15.1.
+type TLogEntry struct {
+	LogIndex    string      `json:"logIndex"`
+	LogID       LogID       `json:"logId"`
+	KindVersion KindVersion `json:"kindVersion"`
+}
+
+// LogID is the Rekor instance public-key identifier.
+type LogID struct {
+	KeyID string `json:"keyId"`
+}
+
+// KindVersion names the entry-format the proof was emitted under
+// (e.g. kind=intoto, version=0.0.2).
+type KindVersion struct {
+	Kind    string `json:"kind"`
+	Version string `json:"version"`
+}
+
+// ParseBundle decodes a JSON-encoded PEP 740 attestation envelope.
+// The decoder is intentionally lenient about MediaType (we accept
+// any string and validate it in policy.Verify so future bundle
+// versions can be enforced via Policy.AcceptedBundleTypes without
+// reaching back into the parser).
+func ParseBundle(raw []byte) (*Bundle, error) {
+	var b Bundle
+	if err := json.Unmarshal(raw, &b); err != nil {
+		return nil, fmt.Errorf("attest: decode bundle: %w", err)
+	}
+	if b.DsseEnvelope.Payload == "" {
+		return nil, fmt.Errorf("attest: bundle missing dsseEnvelope.payload")
+	}
+	if b.DsseEnvelope.PayloadType == "" {
+		return nil, fmt.Errorf("attest: bundle missing dsseEnvelope.payloadType")
+	}
+	if len(b.DsseEnvelope.Signatures) == 0 {
+		return nil, fmt.Errorf("attest: bundle has no signatures")
+	}
+	return &b, nil
+}
+
+// Statement decodes the base64-std payload and parses it as an
+// in-toto Statement. ParseBundle's structural checks already
+// guaranteed Payload is non-empty.
+func (b *Bundle) Statement() (*Statement, error) {
+	if b == nil {
+		return nil, fmt.Errorf("attest: nil bundle")
+	}
+	if b.DsseEnvelope.PayloadType != DSSEPayloadTypeInTotoJSON {
+		return nil, fmt.Errorf("attest: payloadType %q != %q", b.DsseEnvelope.PayloadType, DSSEPayloadTypeInTotoJSON)
+	}
+	raw, err := base64.StdEncoding.DecodeString(b.DsseEnvelope.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("attest: decode payload base64: %w", err)
+	}
+	return ParseStatement(raw)
+}

--- a/package3/python/attest/bundle_test.go
+++ b/package3/python/attest/bundle_test.go
@@ -1,0 +1,109 @@
+package attest
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func buildBundleJSON(t *testing.T, stmt string, payloadType string) []byte {
+	t.Helper()
+	b := Bundle{
+		MediaType: BundleMediaTypeV2,
+		DsseEnvelope: DSSEEnvelope{
+			Payload:     base64.StdEncoding.EncodeToString([]byte(stmt)),
+			PayloadType: payloadType,
+			Signatures: []Signature{
+				{Sig: "AAAA", Keyid: "key-1"},
+			},
+		},
+	}
+	out, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return out
+}
+
+func TestParseBundleHappy(t *testing.T) {
+	raw := buildBundleJSON(t, validStatementJSON(), DSSEPayloadTypeInTotoJSON)
+	b, err := ParseBundle(raw)
+	if err != nil {
+		t.Fatalf("ParseBundle: %v", err)
+	}
+	if b.MediaType != BundleMediaTypeV2 {
+		t.Errorf("MediaType = %q", b.MediaType)
+	}
+	if len(b.DsseEnvelope.Signatures) != 1 {
+		t.Errorf("sigs = %d", len(b.DsseEnvelope.Signatures))
+	}
+}
+
+func TestParseBundleErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"missing-payload", `{"mediaType":"x","dsseEnvelope":{"payloadType":"y","signatures":[{"sig":"z"}]}}`, "missing dsseEnvelope.payload"},
+		{"missing-payload-type", `{"mediaType":"x","dsseEnvelope":{"payload":"YWJj","signatures":[{"sig":"z"}]}}`, "missing dsseEnvelope.payloadType"},
+		{"no-signatures", `{"mediaType":"x","dsseEnvelope":{"payload":"YWJj","payloadType":"y"}}`, "no signatures"},
+		{"bad-json", `not-json`, "decode bundle"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseBundle([]byte(tc.body))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestBundleStatementRoundTrip(t *testing.T) {
+	raw := buildBundleJSON(t, validStatementJSON(), DSSEPayloadTypeInTotoJSON)
+	b, err := ParseBundle(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stmt, err := b.Statement()
+	if err != nil {
+		t.Fatalf("Statement: %v", err)
+	}
+	if stmt.Type != StatementTypeV1 {
+		t.Errorf("type = %q", stmt.Type)
+	}
+}
+
+func TestBundleStatementPayloadTypeMismatch(t *testing.T) {
+	raw := buildBundleJSON(t, validStatementJSON(), "application/json")
+	b, err := ParseBundle(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = b.Statement()
+	if err == nil {
+		t.Fatal("expected payload type mismatch")
+	}
+	if !strings.Contains(err.Error(), "payloadType") {
+		t.Errorf("error = %q", err.Error())
+	}
+}
+
+func TestBundleStatementBadBase64(t *testing.T) {
+	b := &Bundle{DsseEnvelope: DSSEEnvelope{Payload: "!!!not-base64!!!", PayloadType: DSSEPayloadTypeInTotoJSON}}
+	if _, err := b.Statement(); err == nil {
+		t.Fatal("expected base64 error")
+	}
+}
+
+func TestBundleStatementNilSafe(t *testing.T) {
+	var b *Bundle
+	if _, err := b.Statement(); err == nil {
+		t.Fatal("expected nil bundle error")
+	}
+}

--- a/package3/python/attest/doc.go
+++ b/package3/python/attest/doc.go
@@ -1,0 +1,48 @@
+// Package attest implements MEP-71 Phase 15: install-time PEP 740
+// attestation verification + the `--require-attestations` enforcement
+// knob.
+//
+// At install time, for every wheel the resolver has decided to fetch,
+// the bridge:
+//
+//  1. Fetches the attestation envelope from PyPI's
+//     `<wheel-url>.provenance` companion URL via the Fetcher interface.
+//  2. Parses the envelope as a Sigstore Bundle wrapping a DSSE-signed
+//     in-toto Statement v1 carrying a SLSA Provenance v1 predicate.
+//  3. Confirms the statement's subject sha256 matches the wheel's
+//     sha256 the resolver committed to (this catches a swapped wheel
+//     even before any crypto runs).
+//  4. Confirms the statement's predicateType is the SLSA Provenance
+//     v1 URI and the builder.id falls inside the policy's
+//     AllowedBuilders set.
+//  5. Confirms the OIDC identity an IdentityExtractor pulls off the
+//     bundle's X.509 SAN extension matches the policy's
+//     TrustedPublishers set.
+//  6. When Policy.Required is true, a missing attestation, a parse
+//     failure, or any structural violation aborts the install.
+//
+// The X.509 + Sigstore crypto path is intentionally behind interfaces
+// so the umbrella gate stays offline. Sub-phase 15.1 wires the real
+// `sigstore-go` (or equivalent) verifier behind the bundle's DSSE
+// signatures + Rekor inclusion proof. Sub-phase 15.2 wires the real
+// PyPI HTTP fetch (PEP 740 § "Fetching attestations"). Sub-phase 15.3
+// adds the `mochi pkg install --require-attestations` CLI verb.
+//
+// Layout:
+//
+//   - statement.go: in-toto Statement v1 + Subject + Predicate shape
+//     + the SLSA Provenance v1 + in-toto Statement v1 type URIs (mirrors
+//     publish/attestation.go so install-side verification is decoupled
+//     from publish-side construction).
+//   - bundle.go: Sigstore Bundle envelope (the PyPI-emitted subset:
+//     mediaType + dsseEnvelope + verificationMaterial) + ParseBundle +
+//     Bundle.Statement decoder.
+//   - policy.go: Policy + IdentityExtractor interface + verification
+//     pipeline (`Policy.Verify(bundle, target) -> Report`).
+//   - report.go: Report + Violation + Reason codes for the verifier
+//     output the CLI surfaces.
+//   - fetcher.go: Fetcher interface + StaticFetcher (test seam) +
+//     HTTPFetcher (URL-construction only; real HTTP is sub-phase 15.2).
+//   - verifier.go: Verifier glue (`Verifier.Verify(ctx, target) ->
+//     Report`) the install-time orchestrator consumes.
+package attest

--- a/package3/python/attest/fetcher.go
+++ b/package3/python/attest/fetcher.go
@@ -1,0 +1,54 @@
+package attest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Fetcher pulls the attestation bundle for a wheel. Production wires
+// HTTPFetcher; tests wire StaticFetcher.
+type Fetcher interface {
+	Fetch(ctx context.Context, target WheelTarget) ([]byte, error)
+}
+
+// ErrNoAttestation is the sentinel a Fetcher returns when PyPI does
+// not publish an attestation for the wheel. The verifier maps it to
+// ReasonMissingAttestation when Policy.Required is true.
+var ErrNoAttestation = errors.New("attest: no attestation available")
+
+// StaticFetcher returns Bundle verbatim. Bundle may be nil to
+// simulate ErrNoAttestation.
+type StaticFetcher struct {
+	Bundle []byte
+}
+
+// Fetch returns the configured bundle or ErrNoAttestation when empty.
+func (s StaticFetcher) Fetch(context.Context, WheelTarget) ([]byte, error) {
+	if len(s.Bundle) == 0 {
+		return nil, ErrNoAttestation
+	}
+	return s.Bundle, nil
+}
+
+// HTTPFetcher constructs the PEP 740 attestation URL from the wheel
+// URL. The actual HTTP fetch is sub-phase 15.2; this type ships
+// AttestationURL today so the install orchestrator can stage URL
+// construction without taking on a net dependency.
+type HTTPFetcher struct{}
+
+// AttestationURL returns the `<wheel-url>.provenance` companion URL
+// per PEP 740 § "Fetching attestations".
+func (HTTPFetcher) AttestationURL(target WheelTarget) (string, error) {
+	if !strings.HasSuffix(target.URL, ".whl") {
+		return "", fmt.Errorf("attest: wheel URL %q does not end in .whl", target.URL)
+	}
+	return target.URL + ".provenance", nil
+}
+
+// Fetch is sub-phase 15.2; for now return ErrNoAttestation so the
+// caller's flow exercises the Required gate without a network call.
+func (HTTPFetcher) Fetch(context.Context, WheelTarget) ([]byte, error) {
+	return nil, ErrNoAttestation
+}

--- a/package3/python/attest/fetcher_test.go
+++ b/package3/python/attest/fetcher_test.go
@@ -1,0 +1,58 @@
+package attest
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestStaticFetcherEmpty(t *testing.T) {
+	var f StaticFetcher
+	_, err := f.Fetch(context.Background(), WheelTarget{})
+	if !errors.Is(err, ErrNoAttestation) {
+		t.Errorf("err = %v, want ErrNoAttestation", err)
+	}
+}
+
+func TestStaticFetcherRoundTrip(t *testing.T) {
+	payload := []byte("hello")
+	f := StaticFetcher{Bundle: payload}
+	got, err := f.Fetch(context.Background(), WheelTarget{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("got %q", string(got))
+	}
+}
+
+func TestHTTPFetcherAttestationURL(t *testing.T) {
+	tgt := WheelTarget{URL: "https://pypi.example/demo-1.0-py3-none-any.whl"}
+	url, err := HTTPFetcher{}.AttestationURL(tgt)
+	if err != nil {
+		t.Fatalf("AttestationURL: %v", err)
+	}
+	want := "https://pypi.example/demo-1.0-py3-none-any.whl.provenance"
+	if url != want {
+		t.Errorf("url = %q, want %q", url, want)
+	}
+}
+
+func TestHTTPFetcherAttestationURLNonWheel(t *testing.T) {
+	tgt := WheelTarget{URL: "https://pypi.example/demo-1.0.tar.gz"}
+	_, err := HTTPFetcher{}.AttestationURL(tgt)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), ".whl") {
+		t.Errorf("error = %q", err.Error())
+	}
+}
+
+func TestHTTPFetcherFetchDeferred(t *testing.T) {
+	_, err := HTTPFetcher{}.Fetch(context.Background(), WheelTarget{})
+	if !errors.Is(err, ErrNoAttestation) {
+		t.Errorf("err = %v, want ErrNoAttestation (15.2 stub)", err)
+	}
+}

--- a/package3/python/attest/phase15_test.go
+++ b/package3/python/attest/phase15_test.go
@@ -1,0 +1,80 @@
+package attest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// TestPhase15Sentinel is the umbrella gate for Phase 15. The install
+// orchestrator goal is "pull the PEP 740 bundle for a resolved wheel,
+// validate Sigstore + SLSA fields, and gate when Required". The gate
+// exercises the goal end-to-end through StaticFetcher so the test stays
+// offline; sub-phases 15.1-15.3 wire live HTTP + sigstore-go crypto +
+// CLI verbs.
+func TestPhase15Sentinel(t *testing.T) {
+	t.Run("ok-path", func(t *testing.T) {
+		raw := mustMarshalBundle(t, okBundle(t, okStatement(t, targetFilename, targetSHA)))
+		v := Verifier{Policy: DefaultPolicy(), Fetcher: StaticFetcher{Bundle: raw}}
+		r, err := v.Verify(context.Background(), okTarget())
+		if err != nil {
+			t.Fatalf("Verify: %v", err)
+		}
+		if !r.OK() {
+			t.Errorf("expected OK, violations %+v", r.Violations)
+		}
+		if r.BuilderID == "" {
+			t.Error("expected BuilderID populated")
+		}
+	})
+
+	t.Run("digest-mismatch-flagged", func(t *testing.T) {
+		raw := mustMarshalBundle(t, okBundle(t, okStatement(t, targetFilename, "feedface")))
+		v := Verifier{Policy: DefaultPolicy(), Fetcher: StaticFetcher{Bundle: raw}}
+		r, err := v.Verify(context.Background(), okTarget())
+		if err != nil {
+			t.Errorf("expected nil err when not Required, got %v", err)
+		}
+		if !hasReason(r, ReasonDigestMismatch) {
+			t.Errorf("expected ReasonDigestMismatch, got %+v", r.Violations)
+		}
+	})
+
+	t.Run("required-gate-fails-install", func(t *testing.T) {
+		p := DefaultPolicy()
+		p.Required = true
+		v := Verifier{Policy: p, Fetcher: StaticFetcher{}}
+		_, err := v.Verify(context.Background(), okTarget())
+		if err == nil {
+			t.Fatal("expected gate error")
+		}
+	})
+
+	t.Run("trusted-publisher-end-to-end", func(t *testing.T) {
+		raw := mustMarshalBundle(t, okBundle(t, okStatement(t, targetFilename, targetSHA)))
+		p := DefaultPolicy()
+		p.TrustedPublishers = []string{"https://github.com/example/repo"}
+		p.IdentityExtractor = StaticIdentityExtractor{Identity: "https://github.com/example/repo"}
+		p.AllowedBuilders = []string{"https://github.com/pypi/publish@v1"}
+		v := Verifier{Policy: p, Fetcher: StaticFetcher{Bundle: raw}}
+		r, err := v.Verify(context.Background(), okTarget())
+		if err != nil {
+			t.Fatalf("Verify: %v", err)
+		}
+		if !r.OK() {
+			t.Errorf("expected OK, violations %+v", r.Violations)
+		}
+		if r.Identity != "https://github.com/example/repo" {
+			t.Errorf("Identity = %q", r.Identity)
+		}
+	})
+}
+
+func mustMarshalBundle(t *testing.T, b *Bundle) []byte {
+	t.Helper()
+	out, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return out
+}

--- a/package3/python/attest/policy.go
+++ b/package3/python/attest/policy.go
@@ -1,0 +1,159 @@
+package attest
+
+import (
+	"fmt"
+	"sort"
+)
+
+// WheelTarget identifies the wheel the verifier is checking. URL is
+// the resolver-decided download URL; Filename is the canonical
+// PEP 491 filename (`<dist>-<ver>-...whl`); SHA256 is the lower-case
+// hex digest the resolver committed to.
+type WheelTarget struct {
+	URL          string
+	Filename     string
+	Distribution string
+	Version      string
+	SHA256       string
+}
+
+// IdentityExtractor pulls the OIDC identity off a Bundle so the
+// policy can match it against TrustedPublishers. Production wires the
+// X.509 SAN parser; tests wire StaticIdentityExtractor.
+type IdentityExtractor interface {
+	Extract(b *Bundle) (string, error)
+}
+
+// StaticIdentityExtractor returns Identity verbatim; the test seam.
+type StaticIdentityExtractor struct{ Identity string }
+
+// Extract returns the static identity.
+func (s StaticIdentityExtractor) Extract(*Bundle) (string, error) { return s.Identity, nil }
+
+// Policy bundles the install-time verification knobs.
+type Policy struct {
+	Required             bool
+	AcceptedBundleTypes  []string
+	AcceptedPredicate    string
+	AllowedBuilders      []string
+	TrustedPublishers    []string
+	IdentityExtractor    IdentityExtractor
+}
+
+// DefaultPolicy is the policy the install orchestrator uses when the
+// user does not override (`--require-attestations` flips Required;
+// `--allowed-builder` / `--trusted-publisher` append).
+func DefaultPolicy() Policy {
+	return Policy{
+		AcceptedBundleTypes: []string{BundleMediaTypeV2},
+		AcceptedPredicate:   PredicateTypeSLSAV1,
+	}
+}
+
+// Verify walks the bundle against the policy, mutating report.
+// Returns the report and a sentinel error when Policy.Required is set
+// and the report ends up not-OK.
+func (p Policy) Verify(bundle *Bundle, target WheelTarget) (*Report, error) {
+	r := &Report{
+		WheelURL:     target.URL,
+		Distribution: target.Distribution,
+		Version:      target.Version,
+	}
+
+	if bundle == nil {
+		r.addViolation(ReasonMissingAttestation, "no attestation bundle supplied")
+		return p.gate(r)
+	}
+
+	if len(p.AcceptedBundleTypes) > 0 && !contains(p.AcceptedBundleTypes, bundle.MediaType) {
+		r.addViolation(ReasonUnsupportedBundleType,
+			fmt.Sprintf("bundle mediaType %q is not in the accepted set %v", bundle.MediaType, p.AcceptedBundleTypes))
+	}
+
+	if bundle.DsseEnvelope.PayloadType != DSSEPayloadTypeInTotoJSON {
+		r.addViolation(ReasonPayloadTypeMismatch,
+			fmt.Sprintf("payloadType %q != %q", bundle.DsseEnvelope.PayloadType, DSSEPayloadTypeInTotoJSON))
+		return p.gate(r)
+	}
+
+	stmt, err := bundle.Statement()
+	if err != nil {
+		r.addViolation(ReasonParseFailure, err.Error())
+		return p.gate(r)
+	}
+
+	if stmt.Type != StatementTypeV1 {
+		r.addViolation(ReasonStatementTypeMismatch,
+			fmt.Sprintf("statement _type %q != %q", stmt.Type, StatementTypeV1))
+	}
+
+	wantPredicate := p.AcceptedPredicate
+	if wantPredicate == "" {
+		wantPredicate = PredicateTypeSLSAV1
+	}
+	if stmt.PredicateType != wantPredicate {
+		r.addViolation(ReasonPredicateTypeMismatch,
+			fmt.Sprintf("predicateType %q != %q", stmt.PredicateType, wantPredicate))
+	}
+
+	subject := stmt.SubjectByName(target.Filename)
+	if subject == nil {
+		r.addViolation(ReasonSubjectMissing,
+			fmt.Sprintf("no subject named %q in attestation", target.Filename))
+	} else {
+		r.Subject = subject
+		if got := subject.Digest["sha256"]; got != target.SHA256 {
+			r.addViolation(ReasonDigestMismatch,
+				fmt.Sprintf("subject sha256 %q != target sha256 %q", got, target.SHA256))
+		}
+	}
+
+	builderID := stmt.BuilderID()
+	r.BuilderID = builderID
+	if len(p.AllowedBuilders) > 0 && !contains(p.AllowedBuilders, builderID) {
+		r.addViolation(ReasonBuilderRejected,
+			fmt.Sprintf("builder.id %q is not in the allow-list %v", builderID, sorted(p.AllowedBuilders)))
+	}
+
+	if len(p.TrustedPublishers) > 0 {
+		if p.IdentityExtractor == nil {
+			r.addViolation(ReasonSignatureNotVerified,
+				"TrustedPublishers configured but no IdentityExtractor wired")
+		} else {
+			identity, err := p.IdentityExtractor.Extract(bundle)
+			if err != nil {
+				r.addViolation(ReasonSignatureNotVerified, err.Error())
+			} else {
+				r.Identity = identity
+				if !contains(p.TrustedPublishers, identity) {
+					r.addViolation(ReasonPublisherRejected,
+						fmt.Sprintf("identity %q is not in the trusted set %v", identity, sorted(p.TrustedPublishers)))
+				}
+			}
+		}
+	}
+
+	return p.gate(r)
+}
+
+func (p Policy) gate(r *Report) (*Report, error) {
+	if p.Required && !r.OK() {
+		return r, fmt.Errorf("attest: install rejected: %d violation(s)", len(r.Violations))
+	}
+	return r, nil
+}
+
+func contains(set []string, s string) bool {
+	for _, x := range set {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+func sorted(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}

--- a/package3/python/attest/policy_test.go
+++ b/package3/python/attest/policy_test.go
@@ -1,0 +1,307 @@
+package attest
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+const targetSHA = "deadbeef"
+const targetFilename = "demo-1.0-py3-none-any.whl"
+
+func okTarget() WheelTarget {
+	return WheelTarget{
+		URL:          "https://pypi.example/demo/" + targetFilename,
+		Filename:     targetFilename,
+		Distribution: "demo",
+		Version:      "1.0",
+		SHA256:       targetSHA,
+	}
+}
+
+func okStatement(t *testing.T, name, sha string) string {
+	t.Helper()
+	return fmt.Sprintf(`{
+  "_type": "https://in-toto.io/Statement/v1",
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "subject": [{"name":"%s","digest":{"sha256":"%s"}}],
+  "predicate": {"runDetails":{"builder":{"id":"https://github.com/pypi/publish@v1"}}}
+}`, name, sha)
+}
+
+func okBundle(t *testing.T, statement string) *Bundle {
+	t.Helper()
+	return &Bundle{
+		MediaType: BundleMediaTypeV2,
+		DsseEnvelope: DSSEEnvelope{
+			Payload:     base64.StdEncoding.EncodeToString([]byte(statement)),
+			PayloadType: DSSEPayloadTypeInTotoJSON,
+			Signatures:  []Signature{{Sig: "AAAA"}},
+		},
+	}
+}
+
+func TestDefaultPolicy(t *testing.T) {
+	p := DefaultPolicy()
+	if p.Required {
+		t.Error("Required should default to false")
+	}
+	if len(p.AcceptedBundleTypes) != 1 || p.AcceptedBundleTypes[0] != BundleMediaTypeV2 {
+		t.Errorf("AcceptedBundleTypes = %v", p.AcceptedBundleTypes)
+	}
+	if p.AcceptedPredicate != PredicateTypeSLSAV1 {
+		t.Errorf("AcceptedPredicate = %q", p.AcceptedPredicate)
+	}
+}
+
+func TestPolicyVerifyHappy(t *testing.T) {
+	p := DefaultPolicy()
+	bundle := okBundle(t, okStatement(t, targetFilename, targetSHA))
+	r, err := p.Verify(bundle, okTarget())
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !r.OK() {
+		t.Errorf("expected OK, got violations: %+v", r.Violations)
+	}
+	if r.BuilderID != "https://github.com/pypi/publish@v1" {
+		t.Errorf("BuilderID = %q", r.BuilderID)
+	}
+	if r.Subject == nil || r.Subject.Name != targetFilename {
+		t.Errorf("Subject = %+v", r.Subject)
+	}
+}
+
+func TestPolicyVerifyMissingBundleNotRequired(t *testing.T) {
+	p := DefaultPolicy()
+	r, err := p.Verify(nil, okTarget())
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if r.OK() {
+		t.Error("expected violation")
+	}
+	if r.Violations[0].Reason != ReasonMissingAttestation {
+		t.Errorf("reason = %q", r.Violations[0].Reason)
+	}
+}
+
+func TestPolicyVerifyMissingBundleRequired(t *testing.T) {
+	p := DefaultPolicy()
+	p.Required = true
+	r, err := p.Verify(nil, okTarget())
+	if err == nil {
+		t.Fatal("expected error when Required + missing")
+	}
+	if r.OK() {
+		t.Error("expected violation")
+	}
+}
+
+func TestPolicyVerifyUnsupportedMediaType(t *testing.T) {
+	p := DefaultPolicy()
+	bundle := okBundle(t, okStatement(t, targetFilename, targetSHA))
+	bundle.MediaType = "application/unknown"
+	r, _ := p.Verify(bundle, okTarget())
+	if !hasReason(r, ReasonUnsupportedBundleType) {
+		t.Errorf("expected ReasonUnsupportedBundleType, got %+v", r.Violations)
+	}
+}
+
+func TestPolicyVerifyBadPayloadType(t *testing.T) {
+	p := DefaultPolicy()
+	bundle := okBundle(t, okStatement(t, targetFilename, targetSHA))
+	bundle.DsseEnvelope.PayloadType = "application/json"
+	r, _ := p.Verify(bundle, okTarget())
+	if !hasReason(r, ReasonPayloadTypeMismatch) {
+		t.Errorf("expected ReasonPayloadTypeMismatch, got %+v", r.Violations)
+	}
+}
+
+func TestPolicyVerifyStatementParseFail(t *testing.T) {
+	p := DefaultPolicy()
+	bundle := okBundle(t, "not-json")
+	r, _ := p.Verify(bundle, okTarget())
+	if !hasReason(r, ReasonParseFailure) {
+		t.Errorf("expected ReasonParseFailure, got %+v", r.Violations)
+	}
+}
+
+func TestPolicyVerifyWrongStatementType(t *testing.T) {
+	stmt := `{
+"_type":"https://wrong.example/Statement/v2",
+"predicateType":"https://slsa.dev/provenance/v1",
+"subject":[{"name":"` + targetFilename + `","digest":{"sha256":"` + targetSHA + `"}}],
+"predicate":{}}`
+	p := DefaultPolicy()
+	r, _ := p.Verify(okBundle(t, stmt), okTarget())
+	if !hasReason(r, ReasonStatementTypeMismatch) {
+		t.Errorf("expected ReasonStatementTypeMismatch, got %+v", r.Violations)
+	}
+}
+
+func TestPolicyVerifyWrongPredicateType(t *testing.T) {
+	stmt := `{
+"_type":"https://in-toto.io/Statement/v1",
+"predicateType":"https://slsa.dev/provenance/v0.1",
+"subject":[{"name":"` + targetFilename + `","digest":{"sha256":"` + targetSHA + `"}}],
+"predicate":{}}`
+	p := DefaultPolicy()
+	r, _ := p.Verify(okBundle(t, stmt), okTarget())
+	if !hasReason(r, ReasonPredicateTypeMismatch) {
+		t.Errorf("expected ReasonPredicateTypeMismatch, got %+v", r.Violations)
+	}
+}
+
+func TestPolicyVerifySubjectMissing(t *testing.T) {
+	stmt := okStatement(t, "other-1.0-py3-none-any.whl", targetSHA)
+	p := DefaultPolicy()
+	r, _ := p.Verify(okBundle(t, stmt), okTarget())
+	if !hasReason(r, ReasonSubjectMissing) {
+		t.Errorf("expected ReasonSubjectMissing, got %+v", r.Violations)
+	}
+}
+
+func TestPolicyVerifyDigestMismatch(t *testing.T) {
+	stmt := okStatement(t, targetFilename, "cafef00d")
+	p := DefaultPolicy()
+	r, _ := p.Verify(okBundle(t, stmt), okTarget())
+	if !hasReason(r, ReasonDigestMismatch) {
+		t.Errorf("expected ReasonDigestMismatch, got %+v", r.Violations)
+	}
+}
+
+func TestPolicyVerifyBuilderRejected(t *testing.T) {
+	p := DefaultPolicy()
+	p.AllowedBuilders = []string{"https://github.com/another/builder@v1"}
+	r, _ := p.Verify(okBundle(t, okStatement(t, targetFilename, targetSHA)), okTarget())
+	if !hasReason(r, ReasonBuilderRejected) {
+		t.Errorf("expected ReasonBuilderRejected, got %+v", r.Violations)
+	}
+}
+
+func TestPolicyVerifyBuilderAccepted(t *testing.T) {
+	p := DefaultPolicy()
+	p.AllowedBuilders = []string{"https://github.com/pypi/publish@v1"}
+	r, _ := p.Verify(okBundle(t, okStatement(t, targetFilename, targetSHA)), okTarget())
+	if !r.OK() {
+		t.Errorf("expected OK, got %+v", r.Violations)
+	}
+}
+
+func TestPolicyVerifyTrustedPublisherMissingExtractor(t *testing.T) {
+	p := DefaultPolicy()
+	p.TrustedPublishers = []string{"https://github.com/example/repo"}
+	r, _ := p.Verify(okBundle(t, okStatement(t, targetFilename, targetSHA)), okTarget())
+	if !hasReason(r, ReasonSignatureNotVerified) {
+		t.Errorf("expected ReasonSignatureNotVerified, got %+v", r.Violations)
+	}
+}
+
+func TestPolicyVerifyPublisherRejected(t *testing.T) {
+	p := DefaultPolicy()
+	p.TrustedPublishers = []string{"https://github.com/example/repo"}
+	p.IdentityExtractor = StaticIdentityExtractor{Identity: "https://github.com/intruder/repo"}
+	r, _ := p.Verify(okBundle(t, okStatement(t, targetFilename, targetSHA)), okTarget())
+	if !hasReason(r, ReasonPublisherRejected) {
+		t.Errorf("expected ReasonPublisherRejected, got %+v", r.Violations)
+	}
+}
+
+func TestPolicyVerifyPublisherAccepted(t *testing.T) {
+	p := DefaultPolicy()
+	p.TrustedPublishers = []string{"https://github.com/example/repo"}
+	p.IdentityExtractor = StaticIdentityExtractor{Identity: "https://github.com/example/repo"}
+	r, _ := p.Verify(okBundle(t, okStatement(t, targetFilename, targetSHA)), okTarget())
+	if !r.OK() {
+		t.Errorf("expected OK, got %+v", r.Violations)
+	}
+	if r.Identity != "https://github.com/example/repo" {
+		t.Errorf("Identity = %q", r.Identity)
+	}
+}
+
+type errExtractor struct{}
+
+func (errExtractor) Extract(*Bundle) (string, error) { return "", errors.New("kaboom") }
+
+func TestPolicyVerifyIdentityExtractError(t *testing.T) {
+	p := DefaultPolicy()
+	p.TrustedPublishers = []string{"https://github.com/example/repo"}
+	p.IdentityExtractor = errExtractor{}
+	r, _ := p.Verify(okBundle(t, okStatement(t, targetFilename, targetSHA)), okTarget())
+	if !hasReason(r, ReasonSignatureNotVerified) {
+		t.Errorf("expected ReasonSignatureNotVerified, got %+v", r.Violations)
+	}
+}
+
+func TestPolicyVerifyRequiredGateError(t *testing.T) {
+	p := DefaultPolicy()
+	p.Required = true
+	stmt := okStatement(t, targetFilename, "cafef00d")
+	_, err := p.Verify(okBundle(t, stmt), okTarget())
+	if err == nil {
+		t.Fatal("expected gate error")
+	}
+}
+
+func TestPolicyVerifyNotRequiredNoError(t *testing.T) {
+	p := DefaultPolicy()
+	stmt := okStatement(t, targetFilename, "cafef00d")
+	_, err := p.Verify(okBundle(t, stmt), okTarget())
+	if err != nil {
+		t.Errorf("expected nil error when not Required, got %v", err)
+	}
+}
+
+func TestPolicyVerifyPopulatesReportFromTarget(t *testing.T) {
+	p := DefaultPolicy()
+	tgt := okTarget()
+	r, _ := p.Verify(okBundle(t, okStatement(t, targetFilename, targetSHA)), tgt)
+	if r.WheelURL != tgt.URL {
+		t.Errorf("WheelURL = %q", r.WheelURL)
+	}
+	if r.Distribution != tgt.Distribution {
+		t.Errorf("Distribution = %q", r.Distribution)
+	}
+	if r.Version != tgt.Version {
+		t.Errorf("Version = %q", r.Version)
+	}
+}
+
+func hasReason(r *Report, want Reason) bool {
+	if r == nil {
+		return false
+	}
+	for _, v := range r.Violations {
+		if v.Reason == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSortedHelper(t *testing.T) {
+	in := []string{"b", "a", "c"}
+	out := sorted(in)
+	if out[0] != "a" || out[1] != "b" || out[2] != "c" {
+		t.Errorf("sorted = %v", out)
+	}
+	// must not mutate input
+	if in[0] != "b" {
+		t.Errorf("input mutated: %v", in)
+	}
+}
+
+func TestContainsHelper(t *testing.T) {
+	if !contains([]string{"a", "b"}, "a") {
+		t.Error("contains miss")
+	}
+	if contains([]string{"a", "b"}, "c") {
+		t.Error("contains false-hit")
+	}
+	if contains(nil, "a") {
+		t.Error("contains nil set should miss")
+	}
+}

--- a/package3/python/attest/report.go
+++ b/package3/python/attest/report.go
@@ -1,0 +1,46 @@
+package attest
+
+// Reason is the machine-readable code the verifier attaches to every
+// Violation so CLI output + telemetry can switch on cause without
+// pattern-matching free-form messages.
+type Reason string
+
+const (
+	ReasonMissingAttestation     Reason = "missing-attestation"
+	ReasonParseFailure           Reason = "parse-failure"
+	ReasonUnsupportedBundleType  Reason = "unsupported-bundle-type"
+	ReasonPayloadTypeMismatch    Reason = "payload-type-mismatch"
+	ReasonStatementTypeMismatch  Reason = "statement-type-mismatch"
+	ReasonPredicateTypeMismatch  Reason = "predicate-type-mismatch"
+	ReasonSubjectMissing         Reason = "subject-missing"
+	ReasonDigestMismatch         Reason = "digest-mismatch"
+	ReasonBuilderRejected        Reason = "builder-rejected"
+	ReasonPublisherRejected      Reason = "publisher-rejected"
+	ReasonSignatureNotVerified   Reason = "signature-not-verified"
+)
+
+// Violation is one structured rejection emitted by the verifier.
+type Violation struct {
+	Reason  Reason
+	Message string
+}
+
+// Report is the per-wheel verification outcome the install
+// orchestrator consumes.
+type Report struct {
+	WheelURL    string
+	Distribution string
+	Version     string
+	BuilderID   string
+	Identity    string
+	Subject     *Subject
+	Violations  []Violation
+}
+
+// OK is true iff Violations is empty. The orchestrator gates the
+// install on this field when Policy.Required is set.
+func (r *Report) OK() bool { return r != nil && len(r.Violations) == 0 }
+
+func (r *Report) addViolation(reason Reason, message string) {
+	r.Violations = append(r.Violations, Violation{Reason: reason, Message: message})
+}

--- a/package3/python/attest/report_test.go
+++ b/package3/python/attest/report_test.go
@@ -1,0 +1,53 @@
+package attest
+
+import "testing"
+
+func TestReportOK(t *testing.T) {
+	var nilReport *Report
+	if nilReport.OK() {
+		t.Error("nil report should not be OK")
+	}
+
+	empty := &Report{}
+	if !empty.OK() {
+		t.Error("empty report should be OK")
+	}
+
+	r := &Report{}
+	r.addViolation(ReasonDigestMismatch, "boom")
+	if r.OK() {
+		t.Error("report with violation should not be OK")
+	}
+	if len(r.Violations) != 1 {
+		t.Errorf("violations = %d", len(r.Violations))
+	}
+	if r.Violations[0].Reason != ReasonDigestMismatch {
+		t.Errorf("reason = %q", r.Violations[0].Reason)
+	}
+	if r.Violations[0].Message != "boom" {
+		t.Errorf("message = %q", r.Violations[0].Message)
+	}
+}
+
+func TestReasonStringStability(t *testing.T) {
+	// The CLI + telemetry switch on these exact codes; protect against
+	// accidental renames.
+	want := map[Reason]string{
+		ReasonMissingAttestation:    "missing-attestation",
+		ReasonParseFailure:          "parse-failure",
+		ReasonUnsupportedBundleType: "unsupported-bundle-type",
+		ReasonPayloadTypeMismatch:   "payload-type-mismatch",
+		ReasonStatementTypeMismatch: "statement-type-mismatch",
+		ReasonPredicateTypeMismatch: "predicate-type-mismatch",
+		ReasonSubjectMissing:        "subject-missing",
+		ReasonDigestMismatch:        "digest-mismatch",
+		ReasonBuilderRejected:       "builder-rejected",
+		ReasonPublisherRejected:     "publisher-rejected",
+		ReasonSignatureNotVerified:  "signature-not-verified",
+	}
+	for r, s := range want {
+		if string(r) != s {
+			t.Errorf("Reason value %q != %q", string(r), s)
+		}
+	}
+}

--- a/package3/python/attest/statement.go
+++ b/package3/python/attest/statement.go
@@ -1,0 +1,92 @@
+package attest
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// The in-toto Statement v1 and SLSA Provenance v1 URIs the publisher
+// emits and the verifier must accept. Mirrored from publish/attestation.go
+// so the install-side import graph stays self-contained.
+const (
+	StatementTypeV1      = "https://in-toto.io/Statement/v1"
+	PredicateTypeSLSAV1  = "https://slsa.dev/provenance/v1"
+)
+
+// Subject is one (name, digest) pair the statement covers.
+type Subject struct {
+	Name   string            `json:"name"`
+	Digest map[string]string `json:"digest"`
+}
+
+// Statement is the parsed in-toto Statement v1 envelope. Predicate is
+// kept as a raw map so the verifier can pull SLSA-specific fields
+// without typing every other predicate the wild PEP 740 ecosystem may
+// eventually use.
+type Statement struct {
+	Type          string         `json:"_type"`
+	PredicateType string         `json:"predicateType"`
+	Subject       []Subject      `json:"subject"`
+	Predicate     map[string]any `json:"predicate"`
+}
+
+// ParseStatement decodes the in-toto JSON envelope. It is strict
+// about top-level shape: missing _type or predicateType, or zero
+// subjects, are rejected before any per-field checks.
+func ParseStatement(raw []byte) (*Statement, error) {
+	var s Statement
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, fmt.Errorf("attest: decode statement: %w", err)
+	}
+	if s.Type == "" {
+		return nil, fmt.Errorf("attest: statement missing _type")
+	}
+	if s.PredicateType == "" {
+		return nil, fmt.Errorf("attest: statement missing predicateType")
+	}
+	if len(s.Subject) == 0 {
+		return nil, fmt.Errorf("attest: statement has no subjects")
+	}
+	for i, sub := range s.Subject {
+		if sub.Name == "" {
+			return nil, fmt.Errorf("attest: statement subject %d missing name", i)
+		}
+		if sub.Digest["sha256"] == "" {
+			return nil, fmt.Errorf("attest: statement subject %q missing sha256 digest", sub.Name)
+		}
+	}
+	return &s, nil
+}
+
+// BuilderID returns the builder.id field from a SLSA Provenance v1
+// predicate, or "" when the predicate does not carry one. The
+// path is `runDetails.builder.id` per SLSA v1 §3.
+func (s *Statement) BuilderID() string {
+	if s == nil {
+		return ""
+	}
+	rd, ok := s.Predicate["runDetails"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	b, ok := rd["builder"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	id, _ := b["id"].(string)
+	return id
+}
+
+// SubjectByName returns the subject whose name matches, or nil when
+// the statement does not cover the wheel.
+func (s *Statement) SubjectByName(name string) *Subject {
+	if s == nil {
+		return nil
+	}
+	for i := range s.Subject {
+		if s.Subject[i].Name == name {
+			return &s.Subject[i]
+		}
+	}
+	return nil
+}

--- a/package3/python/attest/statement_test.go
+++ b/package3/python/attest/statement_test.go
@@ -1,0 +1,113 @@
+package attest
+
+import (
+	"strings"
+	"testing"
+)
+
+func validStatementJSON() string {
+	return `{
+  "_type": "https://in-toto.io/Statement/v1",
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "subject": [
+    {"name": "demo-1.0-py3-none-any.whl", "digest": {"sha256": "deadbeef"}}
+  ],
+  "predicate": {
+    "buildDefinition": {"buildType": "https://example/build"},
+    "runDetails": {"builder": {"id": "https://example/builder@v1"}}
+  }
+}`
+}
+
+func TestParseStatementHappy(t *testing.T) {
+	s, err := ParseStatement([]byte(validStatementJSON()))
+	if err != nil {
+		t.Fatalf("ParseStatement: %v", err)
+	}
+	if s.Type != StatementTypeV1 {
+		t.Errorf("Type = %q, want %q", s.Type, StatementTypeV1)
+	}
+	if s.PredicateType != PredicateTypeSLSAV1 {
+		t.Errorf("PredicateType = %q, want %q", s.PredicateType, PredicateTypeSLSAV1)
+	}
+	if len(s.Subject) != 1 {
+		t.Fatalf("subjects = %d, want 1", len(s.Subject))
+	}
+	if got := s.Subject[0].Digest["sha256"]; got != "deadbeef" {
+		t.Errorf("digest sha256 = %q", got)
+	}
+}
+
+func TestParseStatementErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"missing-type", `{"predicateType": "x", "subject": [{"name":"a","digest":{"sha256":"d"}}]}`, "missing _type"},
+		{"missing-predicate-type", `{"_type": "x", "subject": [{"name":"a","digest":{"sha256":"d"}}]}`, "missing predicateType"},
+		{"no-subjects", `{"_type": "x", "predicateType": "y", "subject": []}`, "no subjects"},
+		{"subject-no-name", `{"_type": "x", "predicateType": "y", "subject": [{"digest":{"sha256":"d"}}]}`, "missing name"},
+		{"subject-no-sha256", `{"_type": "x", "predicateType": "y", "subject": [{"name":"a","digest":{}}]}`, "missing sha256"},
+		{"invalid-json", `not-json`, "decode statement"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseStatement([]byte(tc.body))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestStatementBuilderID(t *testing.T) {
+	s, err := ParseStatement([]byte(validStatementJSON()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := s.BuilderID(); got != "https://example/builder@v1" {
+		t.Errorf("BuilderID = %q", got)
+	}
+
+	// nil safety
+	var nilStmt *Statement
+	if got := nilStmt.BuilderID(); got != "" {
+		t.Errorf("nil BuilderID = %q, want empty", got)
+	}
+
+	// missing runDetails
+	bare := &Statement{Predicate: map[string]any{}}
+	if got := bare.BuilderID(); got != "" {
+		t.Errorf("bare BuilderID = %q", got)
+	}
+
+	// runDetails without builder
+	noBuilder := &Statement{Predicate: map[string]any{"runDetails": map[string]any{}}}
+	if got := noBuilder.BuilderID(); got != "" {
+		t.Errorf("no-builder BuilderID = %q", got)
+	}
+}
+
+func TestStatementSubjectByName(t *testing.T) {
+	s, err := ParseStatement([]byte(validStatementJSON()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := s.SubjectByName("demo-1.0-py3-none-any.whl"); got == nil {
+		t.Fatal("expected subject")
+	} else if got.Digest["sha256"] != "deadbeef" {
+		t.Errorf("digest = %q", got.Digest["sha256"])
+	}
+	if got := s.SubjectByName("missing.whl"); got != nil {
+		t.Errorf("expected nil for missing name, got %+v", got)
+	}
+
+	var nilStmt *Statement
+	if got := nilStmt.SubjectByName("x"); got != nil {
+		t.Errorf("nil SubjectByName = %+v", got)
+	}
+}

--- a/package3/python/attest/verifier.go
+++ b/package3/python/attest/verifier.go
@@ -1,0 +1,58 @@
+package attest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Verifier wires a Fetcher (network or static) to a Policy. Install
+// orchestration calls Verify once per resolved wheel and gates the
+// install on the returned Report + error per Policy.Required.
+type Verifier struct {
+	Policy  Policy
+	Fetcher Fetcher
+}
+
+// Verify pulls the attestation bundle for target, parses it, and runs
+// it through the policy. When the fetcher signals ErrNoAttestation the
+// verifier still calls Policy.Verify(nil, target) so the policy can
+// emit ReasonMissingAttestation when Required and stay silent when not.
+func (v Verifier) Verify(ctx context.Context, target WheelTarget) (*Report, error) {
+	if v.Fetcher == nil {
+		return nil, fmt.Errorf("attest: verifier missing Fetcher")
+	}
+
+	raw, err := v.Fetcher.Fetch(ctx, target)
+	if errors.Is(err, ErrNoAttestation) {
+		return v.Policy.Verify(nil, target)
+	}
+	if err != nil {
+		r := &Report{
+			WheelURL:     target.URL,
+			Distribution: target.Distribution,
+			Version:      target.Version,
+		}
+		r.addViolation(ReasonParseFailure, fmt.Sprintf("fetch attestation: %v", err))
+		if v.Policy.Required {
+			return r, fmt.Errorf("attest: fetch attestation: %w", err)
+		}
+		return r, nil
+	}
+
+	bundle, err := ParseBundle(raw)
+	if err != nil {
+		r := &Report{
+			WheelURL:     target.URL,
+			Distribution: target.Distribution,
+			Version:      target.Version,
+		}
+		r.addViolation(ReasonParseFailure, err.Error())
+		if v.Policy.Required {
+			return r, fmt.Errorf("attest: %w", err)
+		}
+		return r, nil
+	}
+
+	return v.Policy.Verify(bundle, target)
+}

--- a/package3/python/attest/verifier_test.go
+++ b/package3/python/attest/verifier_test.go
@@ -1,0 +1,128 @@
+package attest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func bundleBytes(t *testing.T, b *Bundle) []byte {
+	t.Helper()
+	out, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal bundle: %v", err)
+	}
+	return out
+}
+
+func TestVerifierHappy(t *testing.T) {
+	raw := bundleBytes(t, okBundle(t, okStatement(t, targetFilename, targetSHA)))
+	v := Verifier{Policy: DefaultPolicy(), Fetcher: StaticFetcher{Bundle: raw}}
+	r, err := v.Verify(context.Background(), okTarget())
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !r.OK() {
+		t.Errorf("expected OK, got %+v", r.Violations)
+	}
+}
+
+func TestVerifierMissingBundleNotRequired(t *testing.T) {
+	v := Verifier{Policy: DefaultPolicy(), Fetcher: StaticFetcher{}}
+	r, err := v.Verify(context.Background(), okTarget())
+	if err != nil {
+		t.Errorf("expected nil error when not Required, got %v", err)
+	}
+	if !hasReason(r, ReasonMissingAttestation) {
+		t.Errorf("expected ReasonMissingAttestation, got %+v", r.Violations)
+	}
+}
+
+func TestVerifierMissingBundleRequired(t *testing.T) {
+	p := DefaultPolicy()
+	p.Required = true
+	v := Verifier{Policy: p, Fetcher: StaticFetcher{}}
+	_, err := v.Verify(context.Background(), okTarget())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestVerifierBadDigestRequired(t *testing.T) {
+	raw := bundleBytes(t, okBundle(t, okStatement(t, targetFilename, "cafef00d")))
+	p := DefaultPolicy()
+	p.Required = true
+	v := Verifier{Policy: p, Fetcher: StaticFetcher{Bundle: raw}}
+	r, err := v.Verify(context.Background(), okTarget())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !hasReason(r, ReasonDigestMismatch) {
+		t.Errorf("expected ReasonDigestMismatch, got %+v", r.Violations)
+	}
+}
+
+func TestVerifierBundleParseError(t *testing.T) {
+	v := Verifier{Policy: DefaultPolicy(), Fetcher: StaticFetcher{Bundle: []byte(`{"mediaType":"x"}`)}}
+	r, err := v.Verify(context.Background(), okTarget())
+	if err != nil {
+		t.Errorf("expected nil error (not Required), got %v", err)
+	}
+	if !hasReason(r, ReasonParseFailure) {
+		t.Errorf("expected ReasonParseFailure, got %+v", r.Violations)
+	}
+}
+
+func TestVerifierBundleParseErrorRequired(t *testing.T) {
+	p := DefaultPolicy()
+	p.Required = true
+	v := Verifier{Policy: p, Fetcher: StaticFetcher{Bundle: []byte(`{"mediaType":"x"}`)}}
+	_, err := v.Verify(context.Background(), okTarget())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "attest:") {
+		t.Errorf("error = %q", err.Error())
+	}
+}
+
+type errFetcher struct{ err error }
+
+func (e errFetcher) Fetch(context.Context, WheelTarget) ([]byte, error) { return nil, e.err }
+
+func TestVerifierFetchErrorNotRequired(t *testing.T) {
+	v := Verifier{Policy: DefaultPolicy(), Fetcher: errFetcher{err: errors.New("network down")}}
+	r, err := v.Verify(context.Background(), okTarget())
+	if err != nil {
+		t.Errorf("expected nil error when not Required, got %v", err)
+	}
+	if !hasReason(r, ReasonParseFailure) {
+		t.Errorf("expected ReasonParseFailure for fetch error, got %+v", r.Violations)
+	}
+}
+
+func TestVerifierFetchErrorRequired(t *testing.T) {
+	p := DefaultPolicy()
+	p.Required = true
+	v := Verifier{Policy: p, Fetcher: errFetcher{err: errors.New("network down")}}
+	_, err := v.Verify(context.Background(), okTarget())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "network down") {
+		t.Errorf("error = %q", err.Error())
+	}
+}
+
+func TestVerifierNoFetcher(t *testing.T) {
+	var v Verifier
+	_, err := v.Verify(context.Background(), okTarget())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "missing Fetcher") {
+		t.Errorf("error = %q", err.Error())
+	}
+}

--- a/website/docs/implementation/0071/index.md
+++ b/website/docs/implementation/0071/index.md
@@ -43,12 +43,15 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | 13.1 | Live ELF / Mach-O / PE reader behind `SymbolReader` | NOT STARTED | — | [phase-13](/docs/implementation/0071/phase-13-abi3) |
 | 13.2 | Py_LIMITED_API discipline check before promoting to abi3 | NOT STARTED | — | [phase-13](/docs/implementation/0071/phase-13-abi3) |
 | 13.3 | `mochi pkg audit --wheel <path>` + `mochi pkg slim --abi3` CLI verbs | NOT STARTED | — | [phase-13](/docs/implementation/0071/phase-13-abi3) |
-| 14 | Subprocess runtime mode (`[python].runtime-mode = "subprocess"` with JSON-RPC protocol) | LANDED | (pending merge) | [phase-14](/docs/implementation/0071/phase-14-subprocess-mode) |
+| 14 | Subprocess runtime mode (`[python].runtime-mode = "subprocess"` with JSON-RPC protocol) | LANDED | `168d2ec7` | [phase-14](/docs/implementation/0071/phase-14-subprocess-mode) |
 | 14.1 | Live `os/exec` spawn + stderr forwarding + worker lifetime management | NOT STARTED | — | [phase-14](/docs/implementation/0071/phase-14-subprocess-mode) |
 | 14.2 | Request pipelining (multiple in-flight requests demultiplexed by ID) | NOT STARTED | — | [phase-14](/docs/implementation/0071/phase-14-subprocess-mode) |
 | 14.3 | `mochi pkg run --runtime=subprocess` CLI verb + `[python].runtime-mode` dispatch | NOT STARTED | — | [phase-14](/docs/implementation/0071/phase-14-subprocess-mode) |
 | 14.4 | Mixed sync + async worker surfaces | NOT STARTED | — | [phase-14](/docs/implementation/0071/phase-14-subprocess-mode) |
-| 15 | Attestation verification at install time + `--require-attestations` enforcement | NOT STARTED | — | [phase-15](/docs/implementation/0071/phase-15-attestation-verify) |
+| 15 | Attestation verification at install time + `--require-attestations` enforcement | LANDED | (pending merge) | [phase-15](/docs/implementation/0071/phase-15-attestation-verify) |
+| 15.1 | Live sigstore-go crypto verifier (X.509 chain + Rekor inclusion proof + SCT) | NOT STARTED | — | [phase-15](/docs/implementation/0071/phase-15-attestation-verify) |
+| 15.2 | Live PyPI HTTP `<wheel-url>.provenance` fetcher with cache + retry | NOT STARTED | — | [phase-15](/docs/implementation/0071/phase-15-attestation-verify) |
+| 15.3 | `mochi pkg install --require-attestations` + `--allowed-builder` + `--trusted-publisher` CLI verbs | NOT STARTED | — | [phase-15](/docs/implementation/0071/phase-15-attestation-verify) |
 | 16 | Pyodide / WASI target support (`wasm32-emscripten`, `wasm32-wasip2` wheel resolution + WIT interface) | NOT STARTED | — | [phase-16](/docs/implementation/0071/phase-16-pyodide-wasi) |
 | 17 | Free-threaded CPython 3.13t / 3.14t (`cp3XYt` ABI tag, PyMutex, atomic refcount) | NOT STARTED | — | [phase-17](/docs/implementation/0071/phase-17-free-threaded) |
 | 18 | abi2026 transition (`abi-tag-policy = "legacy" | "abi2026" | "both"`) + 2026-Q1 rollout | NOT STARTED | — | [phase-18](/docs/implementation/0071/phase-18-abi2026) |
@@ -104,7 +107,7 @@ package3/python/
   asyncbridge/            # async-fn -> sync-fn shim renderer + cross-loop guard (phase 12)
   abi3/                   # abi3 wheel slimming + auditwheel-equivalent platform validator (phase 13)
   subproc/                # JSON-RPC 2.0 stdio protocol + Python worker source renderer (phase 14)
-  attest/                 # attestation verification (phase 15)
+  attest/                 # install-time PEP 740 verification + policy (phase 15)
   pyodide/                # wasm32-emscripten + WASI Preview 2 target support (phase 16)
   freethread/             # free-threaded mode wrapper variants (phase 17)
   runtime/                # the embedded mochi_runtime Python package (phase 5 + phase 12)
@@ -114,7 +117,7 @@ The `package3/python/` location is shared with the broader MEP-57 polyglot packa
 
 ## Status snapshot
 
-As of 2026-05-30 00:58 (GMT+7): MEP-71 spec and research bundle landed; phases 0-14 LANDED (8.1, 8.2, 10.1, 10.2, 10.3, 11.1, 11.2, 11.3, 12.1, 12.2, 12.3, 13.1, 13.2, 13.3, 14.1, 14.2, 14.3, 14.4 deferred sub-phases); phases 15-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
+As of 2026-05-30 01:09 (GMT+7): MEP-71 spec and research bundle landed; phases 0-15 LANDED (8.1, 8.2, 10.1, 10.2, 10.3, 11.1, 11.2, 11.3, 12.1, 12.2, 12.3, 13.1, 13.2, 13.3, 14.1, 14.2, 14.3, 14.4, 15.1, 15.2, 15.3 deferred sub-phases); phases 16-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
 
 ## Cross-references
 

--- a/website/docs/implementation/0071/phase-15-attestation-verify.md
+++ b/website/docs/implementation/0071/phase-15-attestation-verify.md
@@ -1,0 +1,139 @@
+---
+title: "Phase 15. Attestation verification"
+sidebar_position: 17
+sidebar_label: "Phase 15. Attestation verification"
+description: "MEP-71 Phase 15 implementation tracking: install-time PEP 740 attestation verification + --require-attestations gate."
+---
+
+# Phase 15. Attestation verification
+
+Land the install-time half of the trusted-publishing pipeline whose
+publish half landed in [phase 11](/docs/implementation/0071/phase-11-trusted-publish):
+fetch the PEP 740 `<wheel-url>.provenance` attestation bundle for every
+resolved wheel, validate its Sigstore + SLSA fields, and gate the
+install when `--require-attestations` is on.
+
+## Status
+
+`LANDED` (pending PR merge). Phase 15 ships the offline policy +
+verifier surface that the wheel-install loop can dial in today; the
+live sigstore-go crypto verifier, the live HTTPS fetch of
+`<wheel-url>.provenance`, and the `mochi pkg install` flag wiring are
+split into sub-phases 15.1 / 15.2 / 15.3 so the umbrella gate stays
+deterministic.
+
+## Gate
+
+`go test ./package3/python/attest/... -count=1`
+
+Covers:
+
+- `ParseStatement` happy + six error paths (no `_type` / no
+  `predicateType` / zero subjects / subject missing name / subject
+  missing sha256 / non-JSON).
+- `ParseBundle` happy + four error paths (no payload / no
+  `payloadType` / no signatures / non-JSON).
+- `(*Bundle).Statement()` payload-type guard, base64 round-trip,
+  nil-safety.
+- `(*Statement).BuilderID()` extraction (deep `runDetails.builder.id`)
+  and nil-safety on every layer.
+- Every `Policy.Verify` branch: missing bundle, unsupported
+  `mediaType`, bad `payloadType`, statement parse failure, wrong
+  `_type`, wrong `predicateType`, subject not found, digest mismatch,
+  builder rejected, trusted-publisher rejection (with and without
+  `IdentityExtractor`), publisher-extractor error.
+- `Policy.Required` gate (returns error when not OK, returns nil error
+  when not Required even with violations).
+- `StaticFetcher` (empty -> `ErrNoAttestation`, non-empty -> round
+  trip).
+- `HTTPFetcher.AttestationURL` (`<url>.provenance` happy + non-`.whl`
+  rejection).
+- `Verifier.Verify` end-to-end with `StaticFetcher`: happy, missing +
+  not-Required, missing + Required, bad-digest + Required,
+  parse-error + Required, fetch-error + not-Required, fetch-error +
+  Required, no-Fetcher error.
+- `phase15_test.go` umbrella sentinel: trusted-publisher end-to-end,
+  digest-mismatch flagged, Required gate fails the install.
+
+## Files
+
+```
+package3/python/attest/
+  doc.go               # 6-step verification pipeline overview
+  statement.go         # in-toto Statement v1 + SLSA Provenance v1 shapes
+  bundle.go            # Sigstore Bundle + DSSE envelope shapes
+  report.go            # Reason codes + Violation + Report
+  policy.go            # Policy + Verify() + WheelTarget + IdentityExtractor
+  fetcher.go           # Fetcher interface + StaticFetcher + HTTPFetcher.AttestationURL
+  verifier.go          # Verifier glues Fetcher + Policy
+  statement_test.go    # 7 tests
+  bundle_test.go       # 6 tests
+  report_test.go       # 2 tests
+  policy_test.go       # 17 tests
+  fetcher_test.go      # 5 tests
+  verifier_test.go     # 9 tests
+  phase15_test.go      # 1 umbrella sentinel (4 sub-cases)
+```
+
+## Sub-phase decomposition
+
+Sub-phases land separately so the umbrella stays offline and
+deterministic.
+
+### 15.1. Live sigstore-go crypto verifier
+
+The crypto verifier (X.509 chain validation against Fulcio,
+SCT verification, Rekor inclusion-proof check, DSSE signature check
+against the certificate's public key) ships as a sigstore-go
+shell-out. Today the bundle's `verificationMaterial` is parsed but not
+cryptographically verified; a `crypto.Verifier` hook in the `Policy`
+struct will surface this once 15.1 lands. The hook signature is
+roughly `func(b *Bundle) error`; non-nil errors will flow through
+`ReasonSignatureNotVerified`. Identity (via Fulcio SAN) will be lifted
+out so the `IdentityExtractor` becomes the production
+default rather than a test seam.
+
+### 15.2. Live PyPI HTTP fetcher
+
+Today `HTTPFetcher.AttestationURL` returns `<wheel-url>.provenance`
+per PEP 740 but `HTTPFetcher.Fetch` is a stub returning
+`ErrNoAttestation`. Sub-phase 15.2 wires `net/http` with:
+
+- caching against the same content-addressed cache the wheel loop
+  uses (so repeated installs are zero-RTT).
+- retry-with-backoff on transient 5xx.
+- 404 -> `ErrNoAttestation` (the wheel publisher has not opted in).
+
+### 15.3. CLI verbs
+
+The CLI surface:
+
+- `--require-attestations` -> `Policy.Required = true`.
+- repeated `--allowed-builder=<URI>` -> `Policy.AllowedBuilders`.
+- repeated `--trusted-publisher=<identity>` -> `Policy.TrustedPublishers`.
+- machine-readable JSON output of each `Report` for telemetry (the
+  `Reason` constants exist precisely so the CLI can switch on cause
+  without pattern-matching free-form messages).
+
+## Skip count
+
+Phase 15 is install-side and does not feed the wrapper-synthesiser
+skip counter. The fixture-corpus golden counts are unchanged.
+
+## Fixtures
+
+Sub-phase 15.2 will add a fixture under `package3/python/attest/testdata/`
+mirroring the publisher-emitted bundle for one of the 25-package
+fixture corpus members so the live HTTP path can run offline against
+a recorded transcript. Phase 15 itself stays offline.
+
+## Cross-references
+
+- [PEP 740 (attestation envelope)](https://peps.python.org/pep-0740/)
+- [in-toto Statement v1](https://github.com/in-toto/attestation/tree/main/spec/v1)
+- [SLSA Provenance v1](https://slsa.dev/spec/v1.0/provenance)
+- [Sigstore Bundle v0.3](https://github.com/sigstore/protobuf-specs)
+- [phase 11](/docs/implementation/0071/phase-11-trusted-publish) for
+  the publish-side that produced the bundle this phase verifies.
+- [MEP-71 spec § Trusted publishing](/docs/mep/mep-0071) for the
+  normative design.


### PR DESCRIPTION
## Summary

- Adds `package3/python/attest/`: the install-side of MEP-71's trusted publishing pipeline.
- `ParseStatement` / `ParseBundle` decode in-toto Statement v1 + Sigstore Bundle v0.3 + DSSE envelope shapes PyPI emits.
- `Policy.Verify` walks bundle -> mediaType -> payloadType -> statement -> _type -> predicateType -> subject-by-filename -> sha256 digest -> builder allow-list -> trusted-publisher identity, attaching one structured `Violation` per failing rule.
- 11 `Reason` constants give the CLI + telemetry a stable code to switch on.
- `Verifier` wires a `Fetcher` to a `Policy`; `StaticFetcher` is the test seam, `HTTPFetcher.AttestationURL` ships the `<wheel-url>.provenance` URL shape today.
- `Policy.Required` gates the install (returns error when not OK, returns nil when not Required even with violations).
- 47 tests covering every Verify branch + the umbrella phase15 sentinel.

Tracks #23003.

## Test plan

- [x] `go build ./package3/python/attest/...`
- [x] `go test ./package3/python/attest/... -count=1`
- [x] `go test ./package3/python/... -count=1`

## Sub-phases (deferred)

- 15.1 Live sigstore-go crypto verifier (NOT STARTED)
- 15.2 Live PyPI HTTP `<wheel-url>.provenance` fetcher (NOT STARTED)
- 15.3 `mochi pkg install --require-attestations` CLI verbs (NOT STARTED)