### PR TITLE
feat(mep-66/p12): async process bridge (spawn, send, monitor, mailbox)

### DIFF
--- a/package3/erlang/async/async.go
+++ b/package3/erlang/async/async.go
@@ -1,0 +1,171 @@
+// Package async provides a Go channel-based API for OTP process operations:
+// spawn, send, monitor, demonitor, link, unlink, and a polling Mailbox for
+// receiving messages from registered Erlang processes.
+//
+// All operations dispatch through the Caller interface (satisfied by
+// *port.Manager) so no real `erl` binary is needed in tests.
+//
+// # Process operations
+//
+// Spawn, SpawnLink, Send, SendNamed, Exit, IsAlive, and ProcessInfo wrap the
+// corresponding Erlang BIFs. They use synchronous Port calls and return
+// typed results.
+//
+// # Mailbox
+//
+// A Mailbox wraps a Go channel. The caller calls NewMailbox with a Caller
+// and the registered name of an Erlang mailbox gen_server (see the
+// mochi_mailbox.erl template emitted by Phase 7). A background goroutine
+// polls the Erlang mailbox at a configurable interval and pushes each
+// message onto the channel. The goroutine stops when Close is called.
+//
+// For tests: use NewMailboxFromChan to inject a pre-filled channel directly;
+// or call mailbox.Push to inject messages without polling.
+package async
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"mochi/package3/erlang/etf"
+)
+
+// Caller dispatches a synchronous function call to the Erlang node.
+// *port.Manager satisfies this interface.
+type Caller interface {
+	Call(fun string, args []interface{}) (interface{}, error)
+}
+
+// defaultPollInterval is the rate at which Mailbox.poll drains the Erlang
+// mailbox process when no custom interval is provided.
+const defaultPollInterval = 50 * time.Millisecond
+
+// pidArg converts an etf.Pid to a plain interface{} for use as a Call arg.
+func pidArg(p etf.Pid) interface{} { return p }
+
+// isAtom reports whether v is etf.Atom(a).
+func isAtom(v interface{}, a string) bool {
+	atom, ok := v.(etf.Atom)
+	return ok && string(atom) == a
+}
+
+// expectOK returns nil when v is `ok`, or an error for {error, Reason}.
+func expectOK(v interface{}) error {
+	if isAtom(v, "ok") {
+		return nil
+	}
+	if tup, ok := v.(etf.Tuple); ok && len(tup) == 2 && isAtom(tup[0], "error") {
+		return fmt.Errorf("async: erlang error: %v", tup[1])
+	}
+	return fmt.Errorf("async: unexpected reply: %v", v)
+}
+
+// Mailbox buffers messages received from an Erlang mailbox process.
+// Messages are pushed onto the channel by a background poll goroutine or
+// directly via Push (in tests).
+type Mailbox struct {
+	ch     chan interface{}
+	mu     sync.Mutex
+	closed bool
+	stop   chan struct{}
+	done   chan struct{}
+}
+
+// NewMailbox starts a Mailbox that polls erlangName at pollInterval.
+// erlangName is the registered name of the Erlang mailbox gen_server.
+// The background goroutine calls `erlang_mailbox:recv(erlangName)` at each
+// tick; the Erlang side returns {ok, Msg} or the atom `empty`.
+// Call Close() to stop the poller and close the channel.
+func NewMailbox(caller Caller, erlangName string, bufSize int, pollInterval time.Duration) *Mailbox {
+	if pollInterval <= 0 {
+		pollInterval = defaultPollInterval
+	}
+	if bufSize <= 0 {
+		bufSize = 64
+	}
+	m := &Mailbox{
+		ch:   make(chan interface{}, bufSize),
+		stop: make(chan struct{}),
+		done: make(chan struct{}),
+	}
+	go m.poll(caller, erlangName, pollInterval)
+	return m
+}
+
+// NewMailboxFromChan wraps an existing channel as a Mailbox. Used by tests
+// to inject a pre-populated channel without a live Erlang node.
+// Close() closes the channel without waiting for a background goroutine.
+func NewMailboxFromChan(ch chan interface{}) *Mailbox {
+	done := make(chan struct{})
+	close(done) // no background goroutine; Close() unblocks immediately
+	return &Mailbox{ch: ch, stop: make(chan struct{}), done: done}
+}
+
+// Chan returns the receive-only message channel.
+func (m *Mailbox) Chan() <-chan interface{} { return m.ch }
+
+// Push injects a message directly onto the channel. Used only in tests.
+func (m *Mailbox) Push(msg interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.closed {
+		m.ch <- msg
+	}
+}
+
+// Close stops the background poll goroutine (if any) and closes the channel.
+func (m *Mailbox) Close() {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return
+	}
+	m.closed = true
+	select {
+	case <-m.stop:
+	default:
+		close(m.stop)
+	}
+	m.mu.Unlock()
+	<-m.done
+	close(m.ch)
+}
+
+// poll drains messages from the Erlang mailbox process at the given interval.
+func (m *Mailbox) poll(caller Caller, erlangName string, interval time.Duration) {
+	defer close(m.done)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.stop:
+			return
+		case <-ticker.C:
+			for {
+				v, err := caller.Call("erlang_mailbox:recv", []interface{}{etf.Atom(erlangName)})
+				if err != nil {
+					return
+				}
+				if isAtom(v, "empty") {
+					break
+				}
+				tup, ok := v.(etf.Tuple)
+				if !ok || len(tup) != 2 || !isAtom(tup[0], "ok") {
+					break
+				}
+				m.mu.Lock()
+				if m.closed {
+					m.mu.Unlock()
+					return
+				}
+				select {
+				case m.ch <- tup[1]:
+				default:
+					// drop on full buffer
+				}
+				m.mu.Unlock()
+			}
+		}
+	}
+}

--- a/package3/erlang/async/async_test.go
+++ b/package3/erlang/async/async_test.go
@@ -1,0 +1,462 @@
+package async
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"mochi/package3/erlang/etf"
+)
+
+// ── mock Caller ───────────────────────────────────────────────────────────────
+
+type mockCaller struct {
+	responses []interface{}
+	idx       int
+	calls     []mockCall
+}
+
+type mockCall struct {
+	fun  string
+	args []interface{}
+}
+
+func (m *mockCaller) Call(fun string, args []interface{}) (interface{}, error) {
+	m.calls = append(m.calls, mockCall{fun: fun, args: args})
+	if m.idx >= len(m.responses) {
+		return nil, fmt.Errorf("unexpected call %d to %s", m.idx, fun)
+	}
+	r := m.responses[m.idx]
+	m.idx++
+	if err, ok := r.(error); ok {
+		return nil, err
+	}
+	return r, nil
+}
+
+func newMock(responses ...interface{}) *mockCaller {
+	return &mockCaller{responses: responses}
+}
+
+func fakePid(id uint32) etf.Pid {
+	return etf.Pid{Node: "nonode@nohost", ID: id}
+}
+
+func fakeRef() etf.Reference {
+	return etf.Reference{Node: "nonode@nohost", Creation: 1, IDs: []uint32{1, 0, 0}}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func TestIsAtom(t *testing.T) {
+	if !isAtom(etf.Atom("ok"), "ok") {
+		t.Error("expected ok match")
+	}
+	if isAtom("ok", "ok") {
+		t.Error("string should not match atom")
+	}
+}
+
+func TestExpectOK_OK(t *testing.T) {
+	if err := expectOK(etf.Atom("ok")); err != nil {
+		t.Errorf("unexpected: %v", err)
+	}
+}
+
+func TestExpectOK_Error(t *testing.T) {
+	err := expectOK(etf.Tuple{etf.Atom("error"), etf.Atom("noproc")})
+	if err == nil || !strings.Contains(err.Error(), "noproc") {
+		t.Errorf("expected noproc error, got: %v", err)
+	}
+}
+
+// ── process operations ────────────────────────────────────────────────────────
+
+func TestSpawn_Success(t *testing.T) {
+	pid := fakePid(42)
+	mock := newMock(pid)
+	got, err := Spawn(mock, "mymod", "myfun", nil)
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if got.ID != 42 {
+		t.Errorf("pid.ID = %d", got.ID)
+	}
+	if mock.calls[0].fun != "erlang:spawn" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+func TestSpawn_NonPidReply(t *testing.T) {
+	mock := newMock(etf.Atom("error"))
+	_, err := Spawn(mock, "m", "f", nil)
+	if err == nil {
+		t.Error("expected error for non-pid reply")
+	}
+}
+
+func TestSpawn_PassesModFunArgs(t *testing.T) {
+	mock := newMock(fakePid(1))
+	_, _ = Spawn(mock, "counter", "start", []interface{}{int64(0)})
+	args := mock.calls[0].args
+	if !isAtom(args[0], "counter") {
+		t.Errorf("module arg = %v", args[0])
+	}
+	if !isAtom(args[1], "start") {
+		t.Errorf("fun arg = %v", args[1])
+	}
+}
+
+func TestSpawnLink(t *testing.T) {
+	pid := fakePid(7)
+	mock := newMock(pid)
+	got, err := SpawnLink(mock, "m", "f", nil)
+	if err != nil {
+		t.Fatalf("SpawnLink: %v", err)
+	}
+	if got.ID != 7 {
+		t.Errorf("pid.ID = %d", got.ID)
+	}
+	if mock.calls[0].fun != "erlang:spawn_link" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+func TestSpawnMonitor_Success(t *testing.T) {
+	pid := fakePid(5)
+	ref := fakeRef()
+	mock := newMock(etf.Tuple{pid, ref})
+	gotPid, gotRef, err := SpawnMonitor(mock, "m", "f", nil)
+	if err != nil {
+		t.Fatalf("SpawnMonitor: %v", err)
+	}
+	if gotPid.ID != 5 {
+		t.Errorf("pid.ID = %d", gotPid.ID)
+	}
+	if gotRef.Creation != ref.Creation {
+		t.Errorf("ref mismatch")
+	}
+}
+
+func TestSpawnMonitor_BadShape(t *testing.T) {
+	mock := newMock(etf.Atom("bad"))
+	_, _, err := SpawnMonitor(mock, "m", "f", nil)
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestSend_Success(t *testing.T) {
+	mock := newMock(etf.Atom("hello"))
+	pid := fakePid(3)
+	if err := Send(mock, pid, etf.Atom("hello")); err != nil {
+		t.Errorf("Send: %v", err)
+	}
+	if mock.calls[0].fun != "erlang:send" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+func TestSend_TransportError(t *testing.T) {
+	mock := newMock(fmt.Errorf("closed"))
+	if err := Send(mock, fakePid(1), etf.Atom("msg")); err == nil {
+		t.Error("expected error on transport failure")
+	}
+}
+
+func TestSendNamed(t *testing.T) {
+	mock := newMock(etf.Atom("msg"))
+	if err := SendNamed(mock, "my_server", etf.Atom("msg")); err != nil {
+		t.Errorf("SendNamed: %v", err)
+	}
+	args := mock.calls[0].args
+	if !isAtom(args[0], "my_server") {
+		t.Errorf("first arg = %v", args[0])
+	}
+}
+
+func TestExit_OK(t *testing.T) {
+	mock := newMock(etf.Atom("ok"))
+	if err := Exit(mock, fakePid(2), etf.Atom("kill")); err != nil {
+		t.Errorf("Exit: %v", err)
+	}
+	if mock.calls[0].fun != "erlang:exit" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+func TestIsAlive_True(t *testing.T) {
+	mock := newMock(etf.Atom("true"))
+	alive, err := IsAlive(mock, fakePid(1))
+	if err != nil {
+		t.Fatalf("IsAlive: %v", err)
+	}
+	if !alive {
+		t.Error("expected alive=true")
+	}
+}
+
+func TestIsAlive_False(t *testing.T) {
+	mock := newMock(etf.Atom("false"))
+	alive, err := IsAlive(mock, fakePid(999))
+	if err != nil {
+		t.Fatalf("IsAlive: %v", err)
+	}
+	if alive {
+		t.Error("expected alive=false")
+	}
+}
+
+func TestIsAlive_UnexpectedReply(t *testing.T) {
+	mock := newMock(etf.Atom("maybe"))
+	_, err := IsAlive(mock, fakePid(1))
+	if err == nil {
+		t.Error("expected error for unexpected reply")
+	}
+}
+
+func TestProcessInfo_Present(t *testing.T) {
+	mock := newMock(etf.Tuple{etf.Atom("status"), etf.Atom("running")})
+	val, ok, err := ProcessInfo(mock, fakePid(1), "status")
+	if err != nil {
+		t.Fatalf("ProcessInfo: %v", err)
+	}
+	if !ok {
+		t.Error("expected ok=true")
+	}
+	if !isAtom(val, "running") {
+		t.Errorf("val = %v", val)
+	}
+}
+
+func TestProcessInfo_Undefined(t *testing.T) {
+	mock := newMock(etf.Atom("undefined"))
+	_, ok, err := ProcessInfo(mock, fakePid(1), "status")
+	if err != nil {
+		t.Fatalf("ProcessInfo: %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false for undefined")
+	}
+}
+
+func TestSelf(t *testing.T) {
+	pid := fakePid(99)
+	mock := newMock(pid)
+	got, err := Self(mock)
+	if err != nil {
+		t.Fatalf("Self: %v", err)
+	}
+	if got.ID != 99 {
+		t.Errorf("pid.ID = %d", got.ID)
+	}
+	if mock.calls[0].fun != "erlang:self" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+// ── monitor operations ────────────────────────────────────────────────────────
+
+func TestMonitor_Success(t *testing.T) {
+	ref := fakeRef()
+	mock := newMock(ref)
+	got, err := Monitor(mock, fakePid(5))
+	if err != nil {
+		t.Fatalf("Monitor: %v", err)
+	}
+	if got.Creation != ref.Creation {
+		t.Errorf("ref mismatch")
+	}
+	if mock.calls[0].fun != "erlang:monitor" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+func TestMonitor_PassesProcessAtom(t *testing.T) {
+	mock := newMock(fakeRef())
+	_, _ = Monitor(mock, fakePid(1))
+	args := mock.calls[0].args
+	if !isAtom(args[0], "process") {
+		t.Errorf("first arg should be atom 'process', got: %v", args[0])
+	}
+}
+
+func TestMonitor_NonRefReply(t *testing.T) {
+	mock := newMock(etf.Atom("bad"))
+	_, err := Monitor(mock, fakePid(1))
+	if err == nil {
+		t.Error("expected error for non-ref reply")
+	}
+}
+
+func TestDemonitor_OK(t *testing.T) {
+	mock := newMock(etf.Atom("true"))
+	if err := Demonitor(mock, fakeRef()); err != nil {
+		t.Errorf("Demonitor: %v", err)
+	}
+	if mock.calls[0].fun != "erlang:demonitor" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+func TestDemonitor_PassesFlushOption(t *testing.T) {
+	mock := newMock(etf.Atom("true"))
+	_ = Demonitor(mock, fakeRef())
+	args := mock.calls[0].args
+	if len(args) < 2 {
+		t.Fatal("expected 2 args: ref and options")
+	}
+	opts, ok := args[1].(etf.List)
+	if !ok || len(opts) == 0 {
+		t.Errorf("options should be non-empty list, got: %v", args[1])
+	}
+	if !isAtom(opts[0], "flush") {
+		t.Errorf("flush option missing, got: %v", opts[0])
+	}
+}
+
+func TestLink(t *testing.T) {
+	mock := newMock(etf.Atom("true"))
+	if err := Link(mock, fakePid(3)); err != nil {
+		t.Errorf("Link: %v", err)
+	}
+	if mock.calls[0].fun != "erlang:link" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+func TestUnlink(t *testing.T) {
+	mock := newMock(etf.Atom("true"))
+	if err := Unlink(mock, fakePid(3)); err != nil {
+		t.Errorf("Unlink: %v", err)
+	}
+	if mock.calls[0].fun != "erlang:unlink" {
+		t.Errorf("fun = %q", mock.calls[0].fun)
+	}
+}
+
+func TestParseDownMessage_Valid(t *testing.T) {
+	ref := fakeRef()
+	pid := fakePid(10)
+	term := etf.Tuple{
+		etf.Atom("DOWN"),
+		ref,
+		etf.Atom("process"),
+		pid,
+		etf.Atom("normal"),
+	}
+	msg, ok := ParseDownMessage(term)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if msg.Pid.ID != 10 {
+		t.Errorf("pid.ID = %d", msg.Pid.ID)
+	}
+	if !isAtom(msg.Reason, "normal") {
+		t.Errorf("Reason = %v", msg.Reason)
+	}
+}
+
+func TestParseDownMessage_WrongTag(t *testing.T) {
+	term := etf.Tuple{etf.Atom("UP"), fakeRef(), etf.Atom("process"), fakePid(1), etf.Atom("normal")}
+	_, ok := ParseDownMessage(term)
+	if ok {
+		t.Error("should not parse non-DOWN tuple")
+	}
+}
+
+func TestParseDownMessage_TooShort(t *testing.T) {
+	_, ok := ParseDownMessage(etf.Tuple{etf.Atom("DOWN")})
+	if ok {
+		t.Error("should not parse short tuple")
+	}
+}
+
+// ── Mailbox ───────────────────────────────────────────────────────────────────
+
+func TestMailbox_Push(t *testing.T) {
+	ch := make(chan interface{}, 10)
+	mb := NewMailboxFromChan(ch)
+	mb.Push(etf.Atom("hello"))
+	mb.Push(etf.Atom("world"))
+	if len(mb.Chan()) != 2 {
+		t.Errorf("expected 2 messages, got %d", len(mb.Chan()))
+	}
+	msg := <-mb.Chan()
+	if !isAtom(msg, "hello") {
+		t.Errorf("msg = %v", msg)
+	}
+}
+
+func TestMailbox_Close(t *testing.T) {
+	ch := make(chan interface{}, 4)
+	mb := NewMailboxFromChan(ch)
+	mb.Push(etf.Atom("msg"))
+	mb.Close()
+	// Channel should be closed after Close.
+	_, open := <-mb.Chan()
+	if open {
+		// The message is still in the buffer.
+	}
+	// Double-close should not panic.
+	mb.Close()
+}
+
+func TestMailbox_Poll(t *testing.T) {
+	// Simulate an Erlang mailbox that returns two messages then empty.
+	responses := []interface{}{
+		etf.Tuple{etf.Atom("ok"), etf.Atom("msg1")},
+		etf.Tuple{etf.Atom("ok"), etf.Atom("msg2")},
+		etf.Atom("empty"),
+		// subsequent polls return empty
+		etf.Atom("empty"),
+		etf.Atom("empty"),
+		etf.Atom("empty"),
+		etf.Atom("empty"),
+	}
+	mock := &mockCaller{responses: responses}
+	mb := NewMailbox(mock, "my_mailbox", 16, 10*time.Millisecond)
+
+	var got []interface{}
+	timeout := time.After(500 * time.Millisecond)
+	for len(got) < 2 {
+		select {
+		case msg := <-mb.Chan():
+			got = append(got, msg)
+		case <-timeout:
+			t.Fatal("timed out waiting for 2 messages")
+		}
+	}
+
+	mb.Close()
+
+	if len(got) != 2 {
+		t.Fatalf("got %d messages", len(got))
+	}
+	if !isAtom(got[0], "msg1") {
+		t.Errorf("msg[0] = %v", got[0])
+	}
+	if !isAtom(got[1], "msg2") {
+		t.Errorf("msg[1] = %v", got[1])
+	}
+}
+
+func TestMailbox_PollCallsCorrectFun(t *testing.T) {
+	mock := &mockCaller{responses: []interface{}{
+		etf.Atom("empty"),
+		etf.Atom("empty"),
+	}}
+	mb := NewMailbox(mock, "inbox", 4, 10*time.Millisecond)
+	time.Sleep(30 * time.Millisecond)
+	mb.Close()
+
+	for _, c := range mock.calls {
+		if c.fun != "erlang_mailbox:recv" {
+			t.Errorf("unexpected fun: %q", c.fun)
+		}
+		if len(c.args) < 1 || !isAtom(c.args[0], "inbox") {
+			t.Errorf("args = %v", c.args)
+		}
+	}
+}

--- a/package3/erlang/async/monitor.go
+++ b/package3/erlang/async/monitor.go
@@ -1,0 +1,94 @@
+package async
+
+import (
+	"fmt"
+
+	"mochi/package3/erlang/etf"
+)
+
+// Monitor calls erlang:monitor(process, Pid) and returns the monitor
+// reference. A {'DOWN', Ref, process, Pid, Reason} message will be sent
+// to the monitoring process (the runner) when the target exits.
+func Monitor(caller Caller, pid etf.Pid) (etf.Reference, error) {
+	v, err := caller.Call("erlang:monitor", []interface{}{etf.Atom("process"), pidArg(pid)})
+	if err != nil {
+		return etf.Reference{}, err
+	}
+	ref, ok := v.(etf.Reference)
+	if !ok {
+		return etf.Reference{}, fmt.Errorf("async: erlang:monitor returned non-ref: %T", v)
+	}
+	return ref, nil
+}
+
+// Demonitor calls erlang:demonitor(Ref). The flush option is included to
+// discard any pending DOWN message for this ref.
+func Demonitor(caller Caller, ref etf.Reference) error {
+	v, err := caller.Call("erlang:demonitor", []interface{}{ref, etf.List{etf.Atom("flush")}})
+	if err != nil {
+		return err
+	}
+	// demonitor returns `true` on success (the bool atom, not the atom ok).
+	if isAtom(v, "true") {
+		return nil
+	}
+	return expectOK(v)
+}
+
+// Link calls erlang:link(Pid) to establish a bidirectional link between the
+// runner process and Pid. Returns nil if linking succeeded (the BIF returns
+// `true`).
+func Link(caller Caller, pid etf.Pid) error {
+	v, err := caller.Call("erlang:link", []interface{}{pidArg(pid)})
+	if err != nil {
+		return err
+	}
+	if isAtom(v, "true") {
+		return nil
+	}
+	return expectOK(v)
+}
+
+// Unlink calls erlang:unlink(Pid).
+func Unlink(caller Caller, pid etf.Pid) error {
+	v, err := caller.Call("erlang:unlink", []interface{}{pidArg(pid)})
+	if err != nil {
+		return err
+	}
+	if isAtom(v, "true") {
+		return nil
+	}
+	return expectOK(v)
+}
+
+// DownMessage is the decoded form of a {'DOWN', Ref, process, Pid, Reason}
+// message received from the Erlang side when a monitored process exits.
+type DownMessage struct {
+	Ref    etf.Reference
+	Pid    etf.Pid
+	Reason interface{}
+}
+
+// ParseDownMessage attempts to parse an ETF term as a DOWN message.
+// Returns (msg, true) on success; (zero, false) if the shape does not match.
+func ParseDownMessage(v interface{}) (DownMessage, bool) {
+	tup, ok := v.(etf.Tuple)
+	if !ok || len(tup) != 5 {
+		return DownMessage{}, false
+	}
+	if !isAtom(tup[0], "DOWN") {
+		return DownMessage{}, false
+	}
+	ref, ok := tup[1].(etf.Reference)
+	if !ok {
+		return DownMessage{}, false
+	}
+	if !isAtom(tup[2], "process") {
+		return DownMessage{}, false
+	}
+	pid, ok := tup[3].(etf.Pid)
+	if !ok {
+		return DownMessage{}, false
+	}
+	return DownMessage{Ref: ref, Pid: pid, Reason: tup[4]}, true
+}

--- a/package3/erlang/async/process.go
+++ b/package3/erlang/async/process.go
@@ -1,0 +1,142 @@
+package async
+
+import (
+	"fmt"
+
+	"mochi/package3/erlang/etf"
+)
+
+// Spawn calls erlang:spawn(Module, Fun, Args) and returns the new Pid.
+// The spawned process runs independently; its lifetime is not tied to
+// the Port manager connection.
+func Spawn(caller Caller, module, fun string, args []interface{}) (etf.Pid, error) {
+	v, err := caller.Call("erlang:spawn", []interface{}{
+		etf.Atom(module),
+		etf.Atom(fun),
+		etf.List(args),
+	})
+	if err != nil {
+		return etf.Pid{}, err
+	}
+	pid, ok := v.(etf.Pid)
+	if !ok {
+		return etf.Pid{}, fmt.Errorf("async: erlang:spawn returned non-pid: %T", v)
+	}
+	return pid, nil
+}
+
+// SpawnLink calls erlang:spawn_link(Module, Fun, Args). The calling process
+// (the port runner) is linked to the spawned process.
+func SpawnLink(caller Caller, module, fun string, args []interface{}) (etf.Pid, error) {
+	v, err := caller.Call("erlang:spawn_link", []interface{}{
+		etf.Atom(module),
+		etf.Atom(fun),
+		etf.List(args),
+	})
+	if err != nil {
+		return etf.Pid{}, err
+	}
+	pid, ok := v.(etf.Pid)
+	if !ok {
+		return etf.Pid{}, fmt.Errorf("async: erlang:spawn_link returned non-pid: %T", v)
+	}
+	return pid, nil
+}
+
+// SpawnMonitor calls erlang:spawn_monitor(Module, Fun, Args) and returns the
+// Pid and its MonitorRef together. The Erlang side returns {Pid, Ref}.
+func SpawnMonitor(caller Caller, module, fun string, args []interface{}) (etf.Pid, etf.Reference, error) {
+	v, err := caller.Call("erlang:spawn_monitor", []interface{}{
+		etf.Atom(module),
+		etf.Atom(fun),
+		etf.List(args),
+	})
+	if err != nil {
+		return etf.Pid{}, etf.Reference{}, err
+	}
+	tup, ok := v.(etf.Tuple)
+	if !ok || len(tup) != 2 {
+		return etf.Pid{}, etf.Reference{}, fmt.Errorf("async: erlang:spawn_monitor unexpected reply: %v", v)
+	}
+	pid, ok := tup[0].(etf.Pid)
+	if !ok {
+		return etf.Pid{}, etf.Reference{}, fmt.Errorf("async: spawn_monitor: first element not pid: %T", tup[0])
+	}
+	ref, ok := tup[1].(etf.Reference)
+	if !ok {
+		return etf.Pid{}, etf.Reference{}, fmt.Errorf("async: spawn_monitor: second element not ref: %T", tup[1])
+	}
+	return pid, ref, nil
+}
+
+// Send calls erlang:send(Pid, Msg). The Erlang BIF returns Msg on success.
+// The return value is discarded; errors only surface for transport failures.
+func Send(caller Caller, pid etf.Pid, msg interface{}) error {
+	_, err := caller.Call("erlang:send", []interface{}{pidArg(pid), msg})
+	return err
+}
+
+// SendNamed calls erlang:send(Name, Msg) using a registered name atom.
+func SendNamed(caller Caller, name string, msg interface{}) error {
+	_, err := caller.Call("erlang:send", []interface{}{etf.Atom(name), msg})
+	return err
+}
+
+// Exit calls erlang:exit(Pid, Reason) to send an exit signal to the process.
+func Exit(caller Caller, pid etf.Pid, reason interface{}) error {
+	v, err := caller.Call("erlang:exit", []interface{}{pidArg(pid), reason})
+	if err != nil {
+		return err
+	}
+	return expectOK(v)
+}
+
+// IsAlive calls erlang:is_process_alive(Pid) and returns true when the
+// process is alive. The Erlang side returns `true` or `false` atoms.
+func IsAlive(caller Caller, pid etf.Pid) (bool, error) {
+	v, err := caller.Call("erlang:is_process_alive", []interface{}{pidArg(pid)})
+	if err != nil {
+		return false, err
+	}
+	switch {
+	case isAtom(v, "true"):
+		return true, nil
+	case isAtom(v, "false"):
+		return false, nil
+	default:
+		return false, fmt.Errorf("async: is_process_alive: unexpected reply: %v", v)
+	}
+}
+
+// ProcessInfo calls erlang:process_info(Pid, Key) and returns the value.
+// Common keys: "status", "message_queue_len", "current_function", "memory",
+// "reductions". The Erlang side returns {Key, Value} or `undefined`.
+// Returns (nil, false, nil) when the process is not alive or key is unknown.
+func ProcessInfo(caller Caller, pid etf.Pid, key string) (interface{}, bool, error) {
+	v, err := caller.Call("erlang:process_info", []interface{}{pidArg(pid), etf.Atom(key)})
+	if err != nil {
+		return nil, false, err
+	}
+	if isAtom(v, "undefined") {
+		return nil, false, nil
+	}
+	tup, ok := v.(etf.Tuple)
+	if !ok || len(tup) != 2 {
+		return nil, false, fmt.Errorf("async: process_info: unexpected reply: %v", v)
+	}
+	return tup[1], true, nil
+}
+
+// Self calls erlang:self() and returns the Pid of the current Erlang process
+// (the port runner). Useful for setting up monitors pointing back to the runner.
+func Self(caller Caller) (etf.Pid, error) {
+	v, err := caller.Call("erlang:self", []interface{}{})
+	if err != nil {
+		return etf.Pid{}, err
+	}
+	pid, ok := v.(etf.Pid)
+	if !ok {
+		return etf.Pid{}, fmt.Errorf("async: erlang:self returned non-pid: %T", v)
+	}
+	return pid, nil
+}

--- a/website/docs/implementation/0066/index.md
+++ b/website/docs/implementation/0066/index.md
@@ -26,8 +26,8 @@ A phase is LANDED only when its gate is green for every target in the runtime ma
 | 8 | mochi.lock `[[erlang-package]]` integration + --check mode | LANDED | 41faa0d | [phase-08](/docs/implementation/0066/phase-08-lockfile) |
 | 9 | TargetErlangPort emit (rebar3 app skeleton + mochi_port_driver.erl + priv/mochi_binary) | LANDED | 178280d | [phase-09](/docs/implementation/0066/phase-09-target-erlang-port) |
 | 10 | Hex.pm trusted publishing (OIDC flow + rebar3 hex publish) | LANDED | a66f1db | [phase-10](/docs/implementation/0066/phase-10-trusted-publish) |
-| 11 | OTP behavior bindings (gen_server call/cast, supervisor, application) | IN PROGRESS | — | [phase-11](/docs/implementation/0066/phase-11-otp-behaviors) |
-| 12 | Async process bridge (OTP process spawn/receive/send/monitor via Mochi async) | NOT STARTED | — | [phase-12](/docs/implementation/0066/phase-12-async-bridge) |
+| 11 | OTP behavior bindings (gen_server call/cast, supervisor, application) | LANDED | 42e7b50 | [phase-11](/docs/implementation/0066/phase-11-otp-behaviors) |
+| 12 | Async process bridge (OTP process spawn/receive/send/monitor via Mochi async) | IN PROGRESS | — | [phase-12](/docs/implementation/0066/phase-12-async-bridge) |
 | 13 | Distributed Erlang node bridge (C-node via erl_interface + `dist` capability) | NOT STARTED | — | [phase-13](/docs/implementation/0066/phase-13-dist-bridge) |
 
 ## Per-phase fields


### PR DESCRIPTION
Closes #23005

## Summary
- Adds `package3/erlang/async` with Go channel-based wrappers for OTP process operations
- Process: Spawn, SpawnLink, SpawnMonitor, Send, SendNamed, Exit, IsAlive, ProcessInfo, Self
- Monitor: Monitor, Demonitor, Link, Unlink, ParseDownMessage
- Mailbox: background polling goroutine that drains `erlang_mailbox:recv/1`; NewMailboxFromChan for tests

## Test plan
- [x] `go test ./package3/erlang/async/...` -- 33 tests, all green, -timeout 10s
- [x] Tracking doc updated: phase 11 LANDED (42e7b50), phase 12 IN PROGRESS