### PR TITLE
feat(mep-71/phase-16): Pyodide + WASI Preview 2 target support

### DIFF
--- a/package3/python/pyodide/doc.go
+++ b/package3/python/pyodide/doc.go
@@ -1,0 +1,29 @@
+// Package pyodide is the MEP-71 Phase 16 surface for WebAssembly Python
+// targets. It does three things, all of which the wheel resolver and
+// the install orchestrator dial in:
+//
+//  1. Recognize and rank the WASM platform tags PyPI + the Pyodide
+//     distribution publish: `pyodide_<year>_<rev>_wasm32`,
+//     `emscripten_<major>_<minor>_<patch>_wasm32`, and the (still
+//     experimental) `wasi_p2_wasm32` / `cp3XY_abi3_wasi_p2` shapes.
+//     Use ParsePlatformTag to lift one into a Tag with Kind and the
+//     vintage fields populated.
+//
+//  2. Select the right wheel for a given Target from a candidate
+//     list using Selector. A Target captures Python ABI tag + the
+//     wasm runtime (TargetPyodide vs TargetWASIPreview2) + an
+//     optional vintage floor (so installs can pin to >=pyodide_2024_0
+//     when a package only fixed a bug in that year's recompile).
+//
+//  3. Emit a WIT (WebAssembly Interface Type) world describing the
+//     Python surface a wheel exports under the WASI Preview 2
+//     component model. WIT.Render produces a `world ... { import:
+//     ... export: ... }` block the host can compose against. Sub-phase
+//     16.1 wires this into the wrapper synthesiser so `extern python`
+//     functions emit a real WIT export when the target is WASI.
+//
+// Sub-phases 16.1 (WIT emit in wrapper), 16.2 (live Pyodide index
+// client at pyodide.org/distribution), and 16.3 (mochi pkg install
+// --target=pyodide CLI verb) ship separately so the umbrella gate
+// stays offline.
+package pyodide

--- a/package3/python/pyodide/phase16_test.go
+++ b/package3/python/pyodide/phase16_test.go
@@ -1,0 +1,112 @@
+package pyodide
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPhase16Sentinel is the umbrella gate for Phase 16. The user-
+// facing goal is "resolve and install Python wheels for the right
+// wasm runtime, and emit a WIT world describing the surface a host
+// component can dial into". The gate proves both halves end-to-end
+// against representative inputs.
+func TestPhase16Sentinel(t *testing.T) {
+	t.Run("pyodide-vintage-pick", func(t *testing.T) {
+		// numpy publishes successive vintages every Pyodide release.
+		// The resolver should walk to the newest one that satisfies
+		// the floor.
+		candidates := []WheelCandidate{
+			{Filename: "numpy-2.0.0-cp312-cp312-pyodide_2024_0_wasm32.whl"},
+			{Filename: "numpy-2.0.0-cp312-cp312-pyodide_2024_1_wasm32.whl"},
+			{Filename: "numpy-2.0.0-cp312-cp312-pyodide_2025_0_wasm32.whl"},
+		}
+		s := Selector{Target: Target{
+			Runtime:    RuntimePyodide,
+			PythonABI:  "cp312",
+			MinVintage: Vintage{Year: 2024, Rev: 1},
+		}}
+		r, err := s.Select(candidates)
+		if err != nil {
+			t.Fatalf("Select: %v", err)
+		}
+		if r.Chosen == nil {
+			t.Fatal("expected a winner")
+		}
+		if !strings.Contains(r.Chosen.Filename, "pyodide_2025_0") {
+			t.Errorf("expected newest vintage, got %q", r.Chosen.Filename)
+		}
+	})
+
+	t.Run("wasi-server-side-pick", func(t *testing.T) {
+		candidates := []WheelCandidate{
+			{Filename: "demo-1.0-cp312-cp312-pyodide_2024_0_wasm32.whl"},
+			{Filename: "demo-1.0-cp312-cp312-wasi_p2_wasm32.whl"},
+		}
+		s := Selector{Target: Target{Runtime: RuntimeWASIPreview2, PythonABI: "cp312"}}
+		r, err := s.Select(candidates)
+		if err != nil {
+			t.Fatalf("Select: %v", err)
+		}
+		if r.Chosen == nil || r.ChosenTag.Kind != TagWASIPreview2 {
+			t.Errorf("expected wasi-p2 winner, got %+v", r)
+		}
+	})
+
+	t.Run("wit-end-to-end", func(t *testing.T) {
+		// A Python extern with a record param + record return -> WIT
+		// world that a host component would compose against.
+		world := WITWorld{
+			Package: "mochi:py-bridge",
+			Name:    "demo-bridge",
+			Records: []WITRecordDecl{
+				{Name: "request", Fields: []WITField{
+					{Name: "url", Type: WITType{Kind: WITString}},
+					{Name: "retries", Type: WITType{Kind: WITU8}},
+				}},
+				{Name: "response", Fields: []WITField{
+					{Name: "status", Type: WITType{Kind: WITU16}},
+					{Name: "body", Type: WITType{Kind: WITList, ListOf: &WITType{Kind: WITU8}}},
+				}},
+			},
+			Exports: []WITFunc{
+				{Name: "fetch", Params: []WITField{
+					{Name: "req", Type: WITType{Kind: WITRef, Name: "request"}},
+				}, Return: WITType{Kind: WITRef, Name: "response"}},
+			},
+		}
+		got, err := world.Render()
+		if err != nil {
+			t.Fatalf("Render: %v", err)
+		}
+		mustContain := []string{
+			"package mochi:py-bridge;",
+			"world demo-bridge {",
+			"  record request {",
+			"    url: string,",
+			"    retries: u8,",
+			"  record response {",
+			"    body: list<u8>,",
+			"  export fetch: func(req: request) -> response;",
+		}
+		for _, s := range mustContain {
+			if !strings.Contains(got, s) {
+				t.Errorf("WIT missing %q\n--- got ---\n%s", s, got)
+			}
+		}
+	})
+
+	t.Run("rejects-non-wasm-platforms", func(t *testing.T) {
+		// Manylinux wheels should not leak into a WASM resolve.
+		candidates := []WheelCandidate{
+			{Filename: "demo-1.0-cp312-cp312-manylinux_2_28_x86_64.whl"},
+		}
+		s := Selector{Target: Target{Runtime: RuntimePyodide, PythonABI: "cp312"}}
+		r, err := s.Select(candidates)
+		if err != nil {
+			t.Fatalf("Select: %v", err)
+		}
+		if r.Chosen != nil {
+			t.Errorf("expected no winner, got %+v", r.Chosen)
+		}
+	})
+}

--- a/package3/python/pyodide/platform.go
+++ b/package3/python/pyodide/platform.go
@@ -1,0 +1,143 @@
+package pyodide
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// TagKind identifies which wasm platform-tag family a string belongs
+// to. The selector branches on it to apply family-specific rules
+// (vintage gates for pyodide, ABI mode for wasi-p2).
+type TagKind int
+
+const (
+	TagUnknown TagKind = iota
+
+	// TagPyodide is the modern Pyodide distribution tag:
+	// `pyodide_<year>_<rev>_wasm32` (e.g. pyodide_2024_0_wasm32).
+	TagPyodide
+
+	// TagEmscripten is the legacy CPython-on-Emscripten tag:
+	// `emscripten_<major>_<minor>_<patch>_wasm32`
+	// (e.g. emscripten_3_1_45_wasm32).
+	TagEmscripten
+
+	// TagWASIPreview2 is the experimental WASI Preview 2 tag:
+	// `wasi_p2_wasm32` (no per-host vintage, the component model
+	// keeps ABI compatibility across host versions).
+	TagWASIPreview2
+)
+
+// String renders the tag kind for diagnostics.
+func (k TagKind) String() string {
+	switch k {
+	case TagPyodide:
+		return "pyodide"
+	case TagEmscripten:
+		return "emscripten"
+	case TagWASIPreview2:
+		return "wasi-p2"
+	default:
+		return "unknown"
+	}
+}
+
+// Tag is the parsed form of a wasm platform tag. Vintage is populated
+// only for TagPyodide; Emscripten is populated only for TagEmscripten.
+type Tag struct {
+	Raw        string
+	Kind       TagKind
+	Vintage    Vintage
+	Emscripten EmscriptenVersion
+}
+
+// EmscriptenVersion is the (major, minor, patch) the legacy CPython-on-
+// Emscripten wheels stamp in their platform tag.
+type EmscriptenVersion struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+// String renders the Emscripten version in dotted form.
+func (e EmscriptenVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d", e.Major, e.Minor, e.Patch)
+}
+
+// ParsePlatformTag lifts one of the three supported wasm tag families
+// into a Tag. Anything else returns TagUnknown + an error: the wheel
+// selector treats unknown tags as non-matches and the resolver
+// surfaces the rejection through a SkipReason.
+func ParsePlatformTag(raw string) (Tag, error) {
+	t := Tag{Raw: raw}
+	switch {
+	case strings.HasPrefix(raw, "pyodide_"):
+		if !strings.HasSuffix(raw, "_wasm32") {
+			return t, fmt.Errorf("pyodide: tag %q missing _wasm32 suffix", raw)
+		}
+		rest := strings.TrimSuffix(strings.TrimPrefix(raw, "pyodide_"), "_wasm32")
+		parts := strings.Split(rest, "_")
+		if len(parts) != 2 {
+			return t, fmt.Errorf("pyodide: tag %q must be pyodide_<year>_<rev>_wasm32", raw)
+		}
+		year, err := strconv.Atoi(parts[0])
+		if err != nil || year <= 0 {
+			return t, fmt.Errorf("pyodide: tag %q: bad year %q", raw, parts[0])
+		}
+		rev, err := strconv.Atoi(parts[1])
+		if err != nil || rev < 0 {
+			return t, fmt.Errorf("pyodide: tag %q: bad rev %q", raw, parts[1])
+		}
+		t.Kind = TagPyodide
+		t.Vintage = Vintage{Year: year, Rev: rev}
+		return t, nil
+
+	case strings.HasPrefix(raw, "emscripten_"):
+		if !strings.HasSuffix(raw, "_wasm32") {
+			return t, fmt.Errorf("pyodide: tag %q missing _wasm32 suffix", raw)
+		}
+		rest := strings.TrimSuffix(strings.TrimPrefix(raw, "emscripten_"), "_wasm32")
+		parts := strings.Split(rest, "_")
+		if len(parts) != 3 {
+			return t, fmt.Errorf("pyodide: tag %q must be emscripten_<major>_<minor>_<patch>_wasm32", raw)
+		}
+		maj, err := strconv.Atoi(parts[0])
+		if err != nil || maj <= 0 {
+			return t, fmt.Errorf("pyodide: tag %q: bad major %q", raw, parts[0])
+		}
+		min, err := strconv.Atoi(parts[1])
+		if err != nil || min < 0 {
+			return t, fmt.Errorf("pyodide: tag %q: bad minor %q", raw, parts[1])
+		}
+		pat, err := strconv.Atoi(parts[2])
+		if err != nil || pat < 0 {
+			return t, fmt.Errorf("pyodide: tag %q: bad patch %q", raw, parts[2])
+		}
+		t.Kind = TagEmscripten
+		t.Emscripten = EmscriptenVersion{Major: maj, Minor: min, Patch: pat}
+		return t, nil
+
+	case raw == "wasi_p2_wasm32" || raw == "wasi_p2":
+		t.Kind = TagWASIPreview2
+		return t, nil
+
+	default:
+		return t, fmt.Errorf("pyodide: unrecognised wasm platform tag %q", raw)
+	}
+}
+
+// SatisfiesRuntime reports whether t belongs to the family that
+// Runtime selects. TagEmscripten is treated as RuntimePyodide-
+// compatible: Pyodide is the only consumer of the legacy
+// emscripten_X_Y_Z_wasm32 tag in the wild today.
+func (t Tag) SatisfiesRuntime(r Runtime) bool {
+	switch r {
+	case RuntimePyodide:
+		return t.Kind == TagPyodide || t.Kind == TagEmscripten
+	case RuntimeWASIPreview2:
+		return t.Kind == TagWASIPreview2
+	default:
+		return false
+	}
+}

--- a/package3/python/pyodide/platform_test.go
+++ b/package3/python/pyodide/platform_test.go
@@ -1,0 +1,125 @@
+package pyodide
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParsePlatformTagPyodide(t *testing.T) {
+	tag, err := ParsePlatformTag("pyodide_2024_0_wasm32")
+	if err != nil {
+		t.Fatalf("ParsePlatformTag: %v", err)
+	}
+	if tag.Kind != TagPyodide {
+		t.Errorf("Kind = %v", tag.Kind)
+	}
+	if tag.Vintage != (Vintage{Year: 2024, Rev: 0}) {
+		t.Errorf("Vintage = %+v", tag.Vintage)
+	}
+	if tag.Raw != "pyodide_2024_0_wasm32" {
+		t.Errorf("Raw = %q", tag.Raw)
+	}
+}
+
+func TestParsePlatformTagEmscripten(t *testing.T) {
+	tag, err := ParsePlatformTag("emscripten_3_1_45_wasm32")
+	if err != nil {
+		t.Fatalf("ParsePlatformTag: %v", err)
+	}
+	if tag.Kind != TagEmscripten {
+		t.Errorf("Kind = %v", tag.Kind)
+	}
+	if tag.Emscripten != (EmscriptenVersion{Major: 3, Minor: 1, Patch: 45}) {
+		t.Errorf("Emscripten = %+v", tag.Emscripten)
+	}
+	if got := tag.Emscripten.String(); got != "3.1.45" {
+		t.Errorf("String = %q", got)
+	}
+}
+
+func TestParsePlatformTagWASI(t *testing.T) {
+	tag, err := ParsePlatformTag("wasi_p2_wasm32")
+	if err != nil {
+		t.Fatalf("ParsePlatformTag: %v", err)
+	}
+	if tag.Kind != TagWASIPreview2 {
+		t.Errorf("Kind = %v", tag.Kind)
+	}
+
+	tag, err = ParsePlatformTag("wasi_p2")
+	if err != nil {
+		t.Fatalf("ParsePlatformTag: %v", err)
+	}
+	if tag.Kind != TagWASIPreview2 {
+		t.Errorf("Kind = %v", tag.Kind)
+	}
+}
+
+func TestParsePlatformTagErrors(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{"manylinux_2_28_x86_64", "unrecognised wasm"},
+		{"pyodide_2024_0", "missing _wasm32"},
+		{"pyodide__wasm32", "must be pyodide"},
+		{"pyodide_abc_0_wasm32", "bad year"},
+		{"pyodide_2024_abc_wasm32", "bad rev"},
+		{"pyodide_-1_0_wasm32", "bad year"},
+		{"emscripten_3_1_45", "missing _wasm32"},
+		{"emscripten_3_1_wasm32", "must be emscripten"},
+		{"emscripten_abc_1_2_wasm32", "bad major"},
+		{"emscripten_3_x_2_wasm32", "bad minor"},
+		{"emscripten_3_1_x_wasm32", "bad patch"},
+		{"", "unrecognised wasm"},
+	}
+	for _, tc := range cases {
+		_, err := ParsePlatformTag(tc.raw)
+		if err == nil {
+			t.Errorf("ParsePlatformTag(%q) expected error", tc.raw)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("ParsePlatformTag(%q) error %q does not contain %q", tc.raw, err.Error(), tc.want)
+		}
+	}
+}
+
+func TestTagSatisfiesRuntime(t *testing.T) {
+	pyodide, _ := ParsePlatformTag("pyodide_2024_0_wasm32")
+	emscripten, _ := ParsePlatformTag("emscripten_3_1_45_wasm32")
+	wasi, _ := ParsePlatformTag("wasi_p2_wasm32")
+
+	if !pyodide.SatisfiesRuntime(RuntimePyodide) {
+		t.Error("pyodide should satisfy Pyodide")
+	}
+	if !emscripten.SatisfiesRuntime(RuntimePyodide) {
+		t.Error("emscripten should satisfy Pyodide")
+	}
+	if pyodide.SatisfiesRuntime(RuntimeWASIPreview2) {
+		t.Error("pyodide should NOT satisfy WASI")
+	}
+	if !wasi.SatisfiesRuntime(RuntimeWASIPreview2) {
+		t.Error("wasi should satisfy WASI")
+	}
+	if wasi.SatisfiesRuntime(RuntimePyodide) {
+		t.Error("wasi should NOT satisfy Pyodide")
+	}
+	if wasi.SatisfiesRuntime(RuntimeUnknown) {
+		t.Error("nothing should satisfy Unknown")
+	}
+}
+
+func TestTagKindString(t *testing.T) {
+	cases := map[TagKind]string{
+		TagUnknown:      "unknown",
+		TagPyodide:      "pyodide",
+		TagEmscripten:   "emscripten",
+		TagWASIPreview2: "wasi-p2",
+	}
+	for k, want := range cases {
+		if got := k.String(); got != want {
+			t.Errorf("%d.String() = %q, want %q", k, got, want)
+		}
+	}
+}

--- a/package3/python/pyodide/target.go
+++ b/package3/python/pyodide/target.go
@@ -1,0 +1,106 @@
+package pyodide
+
+import "fmt"
+
+// Runtime identifies which wasm Python runtime the install is for.
+// The two values cover today's PEP 425 + Pyodide distribution wheel
+// tag families; sub-phase 18.x will introduce abi2026-aware variants
+// once that transition lands.
+type Runtime int
+
+const (
+	// RuntimeUnknown is the zero value; Target.Validate rejects it.
+	RuntimeUnknown Runtime = iota
+
+	// RuntimePyodide selects browser-side Pyodide, which publishes
+	// `pyodide_<year>_<rev>_wasm32` (or legacy
+	// `emscripten_<major>_<minor>_<patch>_wasm32`) wheels through the
+	// pyodide.org distribution channel.
+	RuntimePyodide
+
+	// RuntimeWASIPreview2 selects server-side CPython compiled for
+	// WASI Preview 2 (`wasi_p2_wasm32` family). Still experimental
+	// in CPython 3.13; sub-phase 17 (free-threaded) will follow.
+	RuntimeWASIPreview2
+)
+
+// String renders the runtime enum for human-facing diagnostics. The
+// values are stable; tests + telemetry switch on them.
+func (r Runtime) String() string {
+	switch r {
+	case RuntimePyodide:
+		return "pyodide"
+	case RuntimeWASIPreview2:
+		return "wasi-p2"
+	default:
+		return "unknown"
+	}
+}
+
+// ParseRuntime accepts "pyodide" / "wasi-p2" / "wasip2" (case-insensitive
+// on the kebab variant) and rejects anything else. Empty input is an
+// error: the install orchestrator must spell the target explicitly.
+func ParseRuntime(s string) (Runtime, error) {
+	switch s {
+	case "pyodide":
+		return RuntimePyodide, nil
+	case "wasi-p2", "wasip2":
+		return RuntimeWASIPreview2, nil
+	case "":
+		return RuntimeUnknown, fmt.Errorf("pyodide: runtime must be specified")
+	default:
+		return RuntimeUnknown, fmt.Errorf("pyodide: unknown runtime %q (want pyodide|wasi-p2)", s)
+	}
+}
+
+// Target describes the install destination the wheel selector
+// matches against.
+//
+//   - Runtime picks the wasm family.
+//   - PythonABI is the CPython ABI tag the wheels were built against
+//     (`cp312`, `cp313`, `cp313t`, ...). Empty matches anything.
+//   - MinVintage gates Pyodide-vintage wheels: when set, the selector
+//     rejects any wheel whose vintage compares older. Use
+//     (year, rev) = (0, 0) to disable.
+type Target struct {
+	Runtime    Runtime
+	PythonABI  string
+	MinVintage Vintage
+}
+
+// Vintage is the (year, rev) pair the Pyodide distribution stamps on
+// every wheel under the `pyodide_<year>_<rev>_wasm32` platform tag.
+// Newer wheels are produced under a new vintage roughly every Pyodide
+// release; the resolver must let users pin a floor when one fix
+// requires the recompile.
+type Vintage struct {
+	Year int
+	Rev  int
+}
+
+// Zero reports whether v is the all-zero floor (i.e. "no minimum").
+func (v Vintage) Zero() bool { return v.Year == 0 && v.Rev == 0 }
+
+// Less reports whether v < other. The comparison is lexicographic
+// over (Year, Rev); (2024, 0) < (2024, 1) < (2025, 0).
+func (v Vintage) Less(other Vintage) bool {
+	if v.Year != other.Year {
+		return v.Year < other.Year
+	}
+	return v.Rev < other.Rev
+}
+
+// String renders v as `<year>_<rev>`, matching the Pyodide platform
+// tag fragment.
+func (v Vintage) String() string {
+	return fmt.Sprintf("%d_%d", v.Year, v.Rev)
+}
+
+// Validate checks Runtime is set. PythonABI is freeform on purpose so
+// downstream wheels for future ABI tags work without code changes.
+func (t Target) Validate() error {
+	if t.Runtime == RuntimeUnknown {
+		return fmt.Errorf("pyodide: target Runtime must be set")
+	}
+	return nil
+}

--- a/package3/python/pyodide/target_test.go
+++ b/package3/python/pyodide/target_test.go
@@ -1,0 +1,87 @@
+package pyodide
+
+import "testing"
+
+func TestRuntimeString(t *testing.T) {
+	cases := map[Runtime]string{
+		RuntimeUnknown:      "unknown",
+		RuntimePyodide:      "pyodide",
+		RuntimeWASIPreview2: "wasi-p2",
+	}
+	for r, want := range cases {
+		if got := r.String(); got != want {
+			t.Errorf("%d.String() = %q, want %q", r, got, want)
+		}
+	}
+}
+
+func TestParseRuntime(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Runtime
+		ok   bool
+	}{
+		{"pyodide", RuntimePyodide, true},
+		{"wasi-p2", RuntimeWASIPreview2, true},
+		{"wasip2", RuntimeWASIPreview2, true},
+		{"", RuntimeUnknown, false},
+		{"native", RuntimeUnknown, false},
+	}
+	for _, tc := range cases {
+		got, err := ParseRuntime(tc.in)
+		if tc.ok && err != nil {
+			t.Errorf("ParseRuntime(%q): unexpected error %v", tc.in, err)
+		}
+		if !tc.ok && err == nil {
+			t.Errorf("ParseRuntime(%q): expected error", tc.in)
+		}
+		if got != tc.want {
+			t.Errorf("ParseRuntime(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestVintageOrdering(t *testing.T) {
+	v2024_0 := Vintage{Year: 2024, Rev: 0}
+	v2024_1 := Vintage{Year: 2024, Rev: 1}
+	v2025_0 := Vintage{Year: 2025, Rev: 0}
+	if !v2024_0.Less(v2024_1) {
+		t.Error("2024_0 should < 2024_1")
+	}
+	if !v2024_1.Less(v2025_0) {
+		t.Error("2024_1 should < 2025_0")
+	}
+	if v2025_0.Less(v2024_0) {
+		t.Error("2025_0 should not < 2024_0")
+	}
+	if v2024_0.Less(v2024_0) {
+		t.Error("equal vintages should not Less")
+	}
+}
+
+func TestVintageZero(t *testing.T) {
+	if !(Vintage{}).Zero() {
+		t.Error("Vintage{} should be Zero")
+	}
+	if (Vintage{Year: 1, Rev: 0}).Zero() {
+		t.Error("Year=1 should not be Zero")
+	}
+	if (Vintage{Year: 0, Rev: 1}).Zero() {
+		t.Error("Rev=1 should not be Zero")
+	}
+}
+
+func TestVintageString(t *testing.T) {
+	if (Vintage{Year: 2024, Rev: 1}).String() != "2024_1" {
+		t.Errorf("vintage string mismatch")
+	}
+}
+
+func TestTargetValidate(t *testing.T) {
+	if err := (Target{Runtime: RuntimePyodide}).Validate(); err != nil {
+		t.Errorf("expected ok, got %v", err)
+	}
+	if err := (Target{}).Validate(); err == nil {
+		t.Error("expected error on unset runtime")
+	}
+}

--- a/package3/python/pyodide/wheel.go
+++ b/package3/python/pyodide/wheel.go
@@ -1,0 +1,158 @@
+package pyodide
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// WheelCandidate is one resolver-supplied wheel the selector ranks.
+// Filename is the canonical PEP 491 filename (i.e. what the
+// `<dist>-<ver>-<py>-<abi>-<platform>.whl` shape the simple-index
+// emits). URL is what the install loop downloads.
+type WheelCandidate struct {
+	Filename string
+	URL      string
+}
+
+// SelectionResult is what the selector returns: the winning candidate
+// plus a per-candidate reason map so the CLI can explain why each
+// rejected wheel did not match.
+type SelectionResult struct {
+	Chosen   *WheelCandidate
+	Reasons  map[string]string
+	ChosenTag Tag
+}
+
+// Selector picks the best wheel from candidates for target. Ordering:
+//
+//  1. Pyodide vintage wheels rank by descending Vintage (newer wins).
+//  2. Emscripten wheels rank by descending EmscriptenVersion.
+//  3. WASI Preview 2 wheels are unordered (there is no per-host
+//     vintage today; the component-model ABI is host-agnostic).
+//
+// MinVintage is enforced as a hard floor: any pyodide wheel older
+// than it is rejected with `older than MinVintage`. ABI mismatch is
+// also a hard reject. Anything that survives both filters competes
+// on the ranking above.
+type Selector struct {
+	Target Target
+}
+
+// Select runs the picker. It is deterministic: ties break on the
+// Filename string compare so two runs over the same input return the
+// same Chosen.
+func (s Selector) Select(candidates []WheelCandidate) (*SelectionResult, error) {
+	if err := s.Target.Validate(); err != nil {
+		return nil, err
+	}
+	result := &SelectionResult{Reasons: map[string]string{}}
+
+	type ranked struct {
+		cand WheelCandidate
+		tag  Tag
+	}
+	var pool []ranked
+
+	for _, c := range candidates {
+		_, platTag, err := splitWheelFilename(c.Filename)
+		if err != nil {
+			result.Reasons[c.Filename] = err.Error()
+			continue
+		}
+		abi := wheelABI(c.Filename)
+		if s.Target.PythonABI != "" && abi != s.Target.PythonABI {
+			result.Reasons[c.Filename] = fmt.Sprintf("abi %q != target %q", abi, s.Target.PythonABI)
+			continue
+		}
+		tag, err := ParsePlatformTag(platTag)
+		if err != nil {
+			result.Reasons[c.Filename] = err.Error()
+			continue
+		}
+		if !tag.SatisfiesRuntime(s.Target.Runtime) {
+			result.Reasons[c.Filename] = fmt.Sprintf("tag kind %q is not %q", tag.Kind, s.Target.Runtime)
+			continue
+		}
+		if tag.Kind == TagPyodide && !s.Target.MinVintage.Zero() && tag.Vintage.Less(s.Target.MinVintage) {
+			result.Reasons[c.Filename] = fmt.Sprintf("vintage %s older than min %s", tag.Vintage, s.Target.MinVintage)
+			continue
+		}
+		pool = append(pool, ranked{cand: c, tag: tag})
+	}
+
+	if len(pool) == 0 {
+		return result, nil
+	}
+
+	sort.SliceStable(pool, func(i, j int) bool {
+		a, b := pool[i].tag, pool[j].tag
+		// Pyodide vintage descending.
+		if a.Kind == TagPyodide && b.Kind == TagPyodide {
+			if a.Vintage.Less(b.Vintage) {
+				return false
+			}
+			if b.Vintage.Less(a.Vintage) {
+				return true
+			}
+			return pool[i].cand.Filename < pool[j].cand.Filename
+		}
+		// Emscripten version descending.
+		if a.Kind == TagEmscripten && b.Kind == TagEmscripten {
+			av, bv := a.Emscripten, b.Emscripten
+			if av.Major != bv.Major {
+				return av.Major > bv.Major
+			}
+			if av.Minor != bv.Minor {
+				return av.Minor > bv.Minor
+			}
+			if av.Patch != bv.Patch {
+				return av.Patch > bv.Patch
+			}
+			return pool[i].cand.Filename < pool[j].cand.Filename
+		}
+		// Mixed Pyodide + Emscripten: prefer Pyodide (it is the
+		// modern shape; emscripten_X_Y_Z_wasm32 only survives in
+		// legacy wheels).
+		if a.Kind == TagPyodide && b.Kind == TagEmscripten {
+			return true
+		}
+		if a.Kind == TagEmscripten && b.Kind == TagPyodide {
+			return false
+		}
+		// WASI Preview 2 (unordered) or any other tie: filename.
+		return pool[i].cand.Filename < pool[j].cand.Filename
+	})
+
+	winner := pool[0]
+	result.Chosen = &winner.cand
+	result.ChosenTag = winner.tag
+	return result, nil
+}
+
+func splitWheelFilename(name string) (prefix string, platform string, err error) {
+	base := strings.TrimSuffix(name, ".whl")
+	if base == name {
+		return "", "", fmt.Errorf("pyodide: %q does not end in .whl", name)
+	}
+	parts := strings.Split(base, "-")
+	if len(parts) < 5 {
+		return "", "", fmt.Errorf("pyodide: wheel %q is missing fields (want dist-ver-py-abi-plat)", name)
+	}
+	// PEP 491: <dist>-<ver>(-<build>)?-<py>-<abi>-<plat>. The
+	// platform tag is always the last hyphenated segment, even for
+	// pyodide_2024_0_wasm32 because PEP 491 escapes underscores in
+	// the platform tag (no extra hyphens).
+	platform = parts[len(parts)-1]
+	prefix = strings.Join(parts[:len(parts)-1], "-")
+	return prefix, platform, nil
+}
+
+func wheelABI(name string) string {
+	base := strings.TrimSuffix(name, ".whl")
+	parts := strings.Split(base, "-")
+	if len(parts) < 5 {
+		return ""
+	}
+	return parts[len(parts)-2]
+}

--- a/package3/python/pyodide/wheel_test.go
+++ b/package3/python/pyodide/wheel_test.go
@@ -1,0 +1,185 @@
+package pyodide
+
+import "testing"
+
+func TestSelectorRejectsUnsetRuntime(t *testing.T) {
+	var s Selector
+	_, err := s.Select(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSelectorPicksNewestVintage(t *testing.T) {
+	candidates := []WheelCandidate{
+		{Filename: "demo-1.0-cp312-cp312-pyodide_2024_0_wasm32.whl", URL: "u1"},
+		{Filename: "demo-1.0-cp312-cp312-pyodide_2025_0_wasm32.whl", URL: "u2"},
+		{Filename: "demo-1.0-cp312-cp312-pyodide_2024_1_wasm32.whl", URL: "u3"},
+	}
+	s := Selector{Target: Target{Runtime: RuntimePyodide, PythonABI: "cp312"}}
+	r, err := s.Select(candidates)
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if r.Chosen == nil {
+		t.Fatal("expected a winner")
+	}
+	if r.Chosen.URL != "u2" {
+		t.Errorf("URL = %q, want u2 (newest vintage)", r.Chosen.URL)
+	}
+	if r.ChosenTag.Vintage != (Vintage{Year: 2025, Rev: 0}) {
+		t.Errorf("ChosenTag.Vintage = %+v", r.ChosenTag.Vintage)
+	}
+}
+
+func TestSelectorRejectsBelowMinVintage(t *testing.T) {
+	candidates := []WheelCandidate{
+		{Filename: "demo-1.0-cp312-cp312-pyodide_2023_0_wasm32.whl"},
+		{Filename: "demo-1.0-cp312-cp312-pyodide_2024_1_wasm32.whl"},
+	}
+	s := Selector{Target: Target{
+		Runtime:    RuntimePyodide,
+		PythonABI:  "cp312",
+		MinVintage: Vintage{Year: 2024, Rev: 0},
+	}}
+	r, err := s.Select(candidates)
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if r.Chosen == nil {
+		t.Fatal("expected a winner")
+	}
+	if r.ChosenTag.Vintage != (Vintage{Year: 2024, Rev: 1}) {
+		t.Errorf("ChosenTag.Vintage = %+v", r.ChosenTag.Vintage)
+	}
+	reason := r.Reasons["demo-1.0-cp312-cp312-pyodide_2023_0_wasm32.whl"]
+	if reason == "" {
+		t.Error("expected rejection reason for 2023 wheel")
+	}
+}
+
+func TestSelectorRejectsABIMismatch(t *testing.T) {
+	candidates := []WheelCandidate{
+		{Filename: "demo-1.0-cp311-cp311-pyodide_2024_0_wasm32.whl"},
+	}
+	s := Selector{Target: Target{Runtime: RuntimePyodide, PythonABI: "cp312"}}
+	r, err := s.Select(candidates)
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if r.Chosen != nil {
+		t.Errorf("expected no chosen, got %+v", r.Chosen)
+	}
+	reason := r.Reasons["demo-1.0-cp311-cp311-pyodide_2024_0_wasm32.whl"]
+	if reason == "" {
+		t.Error("expected ABI rejection reason")
+	}
+}
+
+func TestSelectorRejectsWrongRuntime(t *testing.T) {
+	candidates := []WheelCandidate{
+		{Filename: "demo-1.0-cp312-cp312-wasi_p2_wasm32.whl"},
+	}
+	s := Selector{Target: Target{Runtime: RuntimePyodide, PythonABI: "cp312"}}
+	r, err := s.Select(candidates)
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if r.Chosen != nil {
+		t.Errorf("expected no chosen, got %+v", r.Chosen)
+	}
+}
+
+func TestSelectorPrefersPyodideOverEmscripten(t *testing.T) {
+	candidates := []WheelCandidate{
+		{Filename: "demo-1.0-cp312-cp312-emscripten_3_1_45_wasm32.whl"},
+		{Filename: "demo-1.0-cp312-cp312-pyodide_2024_0_wasm32.whl"},
+	}
+	s := Selector{Target: Target{Runtime: RuntimePyodide, PythonABI: "cp312"}}
+	r, err := s.Select(candidates)
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if r.Chosen == nil || r.ChosenTag.Kind != TagPyodide {
+		t.Errorf("expected pyodide preference, got %+v", r)
+	}
+}
+
+func TestSelectorEmscriptenSortsByVersion(t *testing.T) {
+	candidates := []WheelCandidate{
+		{Filename: "demo-1.0-cp312-cp312-emscripten_3_1_30_wasm32.whl"},
+		{Filename: "demo-1.0-cp312-cp312-emscripten_3_1_45_wasm32.whl"},
+		{Filename: "demo-1.0-cp312-cp312-emscripten_3_0_99_wasm32.whl"},
+	}
+	s := Selector{Target: Target{Runtime: RuntimePyodide, PythonABI: "cp312"}}
+	r, err := s.Select(candidates)
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if r.ChosenTag.Emscripten != (EmscriptenVersion{Major: 3, Minor: 1, Patch: 45}) {
+		t.Errorf("ChosenTag.Emscripten = %+v", r.ChosenTag.Emscripten)
+	}
+}
+
+func TestSelectorWASI(t *testing.T) {
+	candidates := []WheelCandidate{
+		{Filename: "demo-1.0-cp312-cp312-wasi_p2_wasm32.whl"},
+	}
+	s := Selector{Target: Target{Runtime: RuntimeWASIPreview2, PythonABI: "cp312"}}
+	r, err := s.Select(candidates)
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if r.Chosen == nil || r.ChosenTag.Kind != TagWASIPreview2 {
+		t.Errorf("expected wasi, got %+v", r)
+	}
+}
+
+func TestSelectorAcceptsEmptyABI(t *testing.T) {
+	candidates := []WheelCandidate{
+		{Filename: "demo-1.0-cp312-abi3-pyodide_2024_0_wasm32.whl"},
+	}
+	s := Selector{Target: Target{Runtime: RuntimePyodide}}
+	r, err := s.Select(candidates)
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if r.Chosen == nil {
+		t.Error("expected a winner when ABI is unconstrained")
+	}
+}
+
+func TestSelectorRejectsBadFilenames(t *testing.T) {
+	candidates := []WheelCandidate{
+		{Filename: "no-extension"},
+		{Filename: "too-short.whl"},
+		{Filename: "demo-1.0-cp312-cp312-unknown_tag.whl"},
+	}
+	s := Selector{Target: Target{Runtime: RuntimePyodide, PythonABI: "cp312"}}
+	r, err := s.Select(candidates)
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if r.Chosen != nil {
+		t.Error("expected no chosen")
+	}
+	if len(r.Reasons) != 3 {
+		t.Errorf("expected 3 reasons, got %d: %v", len(r.Reasons), r.Reasons)
+	}
+}
+
+func TestSelectorDeterministicTieBreak(t *testing.T) {
+	candidates := []WheelCandidate{
+		{Filename: "demo-1.0-cp312-cp312-pyodide_2024_0_wasm32.whl", URL: "a"},
+		{Filename: "alpha-1.0-cp312-cp312-pyodide_2024_0_wasm32.whl", URL: "b"},
+	}
+	s := Selector{Target: Target{Runtime: RuntimePyodide, PythonABI: "cp312"}}
+	r1, _ := s.Select(candidates)
+	r2, _ := s.Select(candidates)
+	if r1.Chosen.URL != r2.Chosen.URL {
+		t.Errorf("tie-break is not deterministic: %q vs %q", r1.Chosen.URL, r2.Chosen.URL)
+	}
+	if r1.Chosen.URL != "b" {
+		t.Errorf("expected alpha- (alphabetical) winner, got %q", r1.Chosen.URL)
+	}
+}

--- a/package3/python/pyodide/wit.go
+++ b/package3/python/pyodide/wit.go
@@ -1,0 +1,260 @@
+package pyodide
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// WITType is one node in the type half of the WIT IDL the WASI
+// component model uses. Only the variants the Mochi <-> Python type
+// table emits today are listed; future predicates (resource, stream,
+// future, list-of-resource) will land in sub-phase 16.1 as the
+// wrapper synthesiser grows.
+type WITType struct {
+	Kind     WITKind
+	Name     string   // record name (for KindRef / KindRecord)
+	ListOf   *WITType // element type (KindList)
+	Optional *WITType // inner type (KindOption)
+}
+
+// WITKind enumerates the WIT primitives + composites Phase 16 emits.
+type WITKind int
+
+const (
+	WITUnknown WITKind = iota
+	WITBool
+	WITS8
+	WITS16
+	WITS32
+	WITS64
+	WITU8
+	WITU16
+	WITU32
+	WITU64
+	WITF32
+	WITF64
+	WITChar
+	WITString
+	WITList
+	WITOption
+	WITRecord
+	WITRef
+)
+
+// Render emits the WIT type fragment for t. The emitter is total over
+// the kinds it claims to support; unknown kinds panic so a renderer
+// bug fails loudly during the umbrella gate.
+func (t WITType) Render() string {
+	switch t.Kind {
+	case WITBool:
+		return "bool"
+	case WITS8:
+		return "s8"
+	case WITS16:
+		return "s16"
+	case WITS32:
+		return "s32"
+	case WITS64:
+		return "s64"
+	case WITU8:
+		return "u8"
+	case WITU16:
+		return "u16"
+	case WITU32:
+		return "u32"
+	case WITU64:
+		return "u64"
+	case WITF32:
+		return "f32"
+	case WITF64:
+		return "f64"
+	case WITChar:
+		return "char"
+	case WITString:
+		return "string"
+	case WITRef:
+		if t.Name == "" {
+			panic("pyodide: WITRef must carry Name")
+		}
+		return t.Name
+	case WITList:
+		if t.ListOf == nil {
+			panic("pyodide: WITList must carry ListOf")
+		}
+		return "list<" + t.ListOf.Render() + ">"
+	case WITOption:
+		if t.Optional == nil {
+			panic("pyodide: WITOption must carry Optional")
+		}
+		return "option<" + t.Optional.Render() + ">"
+	default:
+		panic(fmt.Sprintf("pyodide: unhandled WIT kind %d", t.Kind))
+	}
+}
+
+// WITField is one field of a WITRecord.
+type WITField struct {
+	Name string
+	Type WITType
+}
+
+// WITRecordDecl is a top-level record declaration in a world.
+type WITRecordDecl struct {
+	Name   string
+	Fields []WITField
+}
+
+// Render emits the `record <name> { <fields> }` block.
+func (r WITRecordDecl) Render() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "  record %s {\n", r.Name)
+	for _, f := range r.Fields {
+		fmt.Fprintf(&b, "    %s: %s,\n", f.Name, f.Type.Render())
+	}
+	b.WriteString("  }\n")
+	return b.String()
+}
+
+// WITFunc is one exported (or imported) function. Params is in
+// declaration order. Return is the WIT result type; KindUnknown
+// means the function returns nothing.
+type WITFunc struct {
+	Name   string
+	Params []WITField
+	Return WITType
+}
+
+// Render emits a single `<name>: func(<params>) -> <return>` line.
+// Functions with Return.Kind == WITUnknown omit the result clause.
+func (f WITFunc) Render() string {
+	parts := make([]string, len(f.Params))
+	for i, p := range f.Params {
+		parts[i] = fmt.Sprintf("%s: %s", p.Name, p.Type.Render())
+	}
+	line := fmt.Sprintf("%s: func(%s)", f.Name, strings.Join(parts, ", "))
+	if f.Return.Kind != WITUnknown {
+		line += " -> " + f.Return.Render()
+	}
+	return line
+}
+
+// WITWorld is the unit the host imports / exports against. World
+// names follow WIT IDL casing (kebab-case).
+type WITWorld struct {
+	Package string // "mochi:py-bridge"
+	Name    string // world identifier
+	Records []WITRecordDecl
+	Imports []WITFunc
+	Exports []WITFunc
+}
+
+// Validate enforces the WIT identifier rules Phase 16 emits against.
+// Names must be non-empty kebab-case (ASCII lowercase + digits +
+// hyphens, starting with a letter). Records can collide on name only
+// if their fields match; Validate checks for clashes.
+func (w WITWorld) Validate() error {
+	if w.Package == "" {
+		return fmt.Errorf("pyodide: WITWorld Package must be non-empty")
+	}
+	if !isKebab(w.Name) {
+		return fmt.Errorf("pyodide: WITWorld Name %q is not kebab-case", w.Name)
+	}
+	seenRecord := map[string]struct{}{}
+	for _, r := range w.Records {
+		if !isKebab(r.Name) {
+			return fmt.Errorf("pyodide: record %q is not kebab-case", r.Name)
+		}
+		if _, dup := seenRecord[r.Name]; dup {
+			return fmt.Errorf("pyodide: duplicate record %q", r.Name)
+		}
+		seenRecord[r.Name] = struct{}{}
+		for _, f := range r.Fields {
+			if !isKebab(f.Name) {
+				return fmt.Errorf("pyodide: record %q field %q is not kebab-case", r.Name, f.Name)
+			}
+		}
+	}
+	seenFn := map[string]struct{}{}
+	for _, f := range append(append([]WITFunc{}, w.Imports...), w.Exports...) {
+		if !isKebab(f.Name) {
+			return fmt.Errorf("pyodide: function %q is not kebab-case", f.Name)
+		}
+		if _, dup := seenFn[f.Name]; dup {
+			return fmt.Errorf("pyodide: duplicate function %q", f.Name)
+		}
+		seenFn[f.Name] = struct{}{}
+		for _, p := range f.Params {
+			if !isKebab(p.Name) {
+				return fmt.Errorf("pyodide: function %q param %q is not kebab-case", f.Name, p.Name)
+			}
+		}
+	}
+	return nil
+}
+
+// Render emits the full `package ... world ... { ... }` block in
+// canonical form: records first (sorted by name), imports next
+// (sorted), exports last (sorted). The deterministic order is what
+// makes the golden tests in sub-phase 16.1 stable.
+func (w WITWorld) Render() (string, error) {
+	if err := w.Validate(); err != nil {
+		return "", err
+	}
+	recs := append([]WITRecordDecl{}, w.Records...)
+	sort.Slice(recs, func(i, j int) bool { return recs[i].Name < recs[j].Name })
+	imps := append([]WITFunc{}, w.Imports...)
+	sort.Slice(imps, func(i, j int) bool { return imps[i].Name < imps[j].Name })
+	exps := append([]WITFunc{}, w.Exports...)
+	sort.Slice(exps, func(i, j int) bool { return exps[i].Name < exps[j].Name })
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "package %s;\n\n", w.Package)
+	fmt.Fprintf(&b, "world %s {\n", w.Name)
+	for _, r := range recs {
+		b.WriteString(r.Render())
+	}
+	if len(recs) > 0 && (len(imps) > 0 || len(exps) > 0) {
+		b.WriteString("\n")
+	}
+	for _, f := range imps {
+		fmt.Fprintf(&b, "  import %s;\n", f.Render())
+	}
+	if len(imps) > 0 && len(exps) > 0 {
+		b.WriteString("\n")
+	}
+	for _, f := range exps {
+		fmt.Fprintf(&b, "  export %s;\n", f.Render())
+	}
+	b.WriteString("}\n")
+	return b.String(), nil
+}
+
+func isKebab(s string) bool {
+	if s == "" {
+		return false
+	}
+	prevHyphen := false
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+			prevHyphen = false
+		case r >= '0' && r <= '9':
+			if i == 0 {
+				return false
+			}
+			prevHyphen = false
+		case r == '-':
+			if i == 0 || i == len(s)-1 {
+				return false
+			}
+			if prevHyphen {
+				return false
+			}
+			prevHyphen = true
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/package3/python/pyodide/wit_test.go
+++ b/package3/python/pyodide/wit_test.go
@@ -1,0 +1,227 @@
+package pyodide
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWITTypePrimitives(t *testing.T) {
+	cases := map[WITKind]string{
+		WITBool:   "bool",
+		WITS8:     "s8",
+		WITS16:    "s16",
+		WITS32:    "s32",
+		WITS64:    "s64",
+		WITU8:     "u8",
+		WITU16:    "u16",
+		WITU32:    "u32",
+		WITU64:    "u64",
+		WITF32:    "f32",
+		WITF64:    "f64",
+		WITChar:   "char",
+		WITString: "string",
+	}
+	for k, want := range cases {
+		got := WITType{Kind: k}.Render()
+		if got != want {
+			t.Errorf("WITKind %v render = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestWITTypeListAndOption(t *testing.T) {
+	listOfString := WITType{Kind: WITList, ListOf: &WITType{Kind: WITString}}
+	if got := listOfString.Render(); got != "list<string>" {
+		t.Errorf("list<string> = %q", got)
+	}
+	optS32 := WITType{Kind: WITOption, Optional: &WITType{Kind: WITS32}}
+	if got := optS32.Render(); got != "option<s32>" {
+		t.Errorf("option<s32> = %q", got)
+	}
+	listOfOptF64 := WITType{Kind: WITList, ListOf: &WITType{Kind: WITOption, Optional: &WITType{Kind: WITF64}}}
+	if got := listOfOptF64.Render(); got != "list<option<f64>>" {
+		t.Errorf("nested render = %q", got)
+	}
+}
+
+func TestWITTypeRef(t *testing.T) {
+	if got := (WITType{Kind: WITRef, Name: "user-record"}).Render(); got != "user-record" {
+		t.Errorf("ref render = %q", got)
+	}
+}
+
+func TestWITTypePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on unknown kind")
+		}
+	}()
+	_ = WITType{}.Render()
+}
+
+func TestWITTypeListPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on list with no element")
+		}
+	}()
+	_ = WITType{Kind: WITList}.Render()
+}
+
+func TestWITTypeOptionPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on option with no inner")
+		}
+	}()
+	_ = WITType{Kind: WITOption}.Render()
+}
+
+func TestWITTypeRefPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on ref with no name")
+		}
+	}()
+	_ = WITType{Kind: WITRef}.Render()
+}
+
+func TestWITFuncRender(t *testing.T) {
+	f := WITFunc{
+		Name: "compute",
+		Params: []WITField{
+			{Name: "value-in", Type: WITType{Kind: WITS32}},
+			{Name: "label", Type: WITType{Kind: WITString}},
+		},
+		Return: WITType{Kind: WITF64},
+	}
+	got := f.Render()
+	want := "compute: func(value-in: s32, label: string) -> f64"
+	if got != want {
+		t.Errorf("render = %q, want %q", got, want)
+	}
+}
+
+func TestWITFuncRenderNoReturn(t *testing.T) {
+	f := WITFunc{Name: "ping"}
+	if got := f.Render(); got != "ping: func()" {
+		t.Errorf("render = %q", got)
+	}
+}
+
+func TestWITWorldValidate(t *testing.T) {
+	good := WITWorld{
+		Package: "mochi:py-bridge",
+		Name:    "demo-world",
+		Records: []WITRecordDecl{
+			{Name: "user-rec", Fields: []WITField{{Name: "id", Type: WITType{Kind: WITU64}}}},
+		},
+		Exports: []WITFunc{
+			{Name: "get-user", Return: WITType{Kind: WITRef, Name: "user-rec"}},
+		},
+	}
+	if err := good.Validate(); err != nil {
+		t.Errorf("good world: %v", err)
+	}
+
+	bad := []WITWorld{
+		{Package: "", Name: "x"},                                                                                   // empty package
+		{Package: "mochi", Name: "BadWorld"},                                                                       // non-kebab world
+		{Package: "mochi", Name: "x", Records: []WITRecordDecl{{Name: "Rec"}}},                                     // non-kebab record
+		{Package: "mochi", Name: "x", Records: []WITRecordDecl{{Name: "rec"}, {Name: "rec"}}},                      // dup record
+		{Package: "mochi", Name: "x", Records: []WITRecordDecl{{Name: "rec", Fields: []WITField{{Name: "ID"}}}}},   // non-kebab field
+		{Package: "mochi", Name: "x", Exports: []WITFunc{{Name: "Fn"}}},                                            // non-kebab fn
+		{Package: "mochi", Name: "x", Exports: []WITFunc{{Name: "fn"}, {Name: "fn"}}},                              // dup fn
+		{Package: "mochi", Name: "x", Exports: []WITFunc{{Name: "fn", Params: []WITField{{Name: "BadParam"}}}}},    // non-kebab param
+	}
+	for i, w := range bad {
+		if err := w.Validate(); err == nil {
+			t.Errorf("bad[%d] expected error", i)
+		}
+	}
+}
+
+func TestWITWorldRender(t *testing.T) {
+	w := WITWorld{
+		Package: "mochi:py-bridge",
+		Name:    "numpy-demo",
+		Records: []WITRecordDecl{
+			{Name: "vector", Fields: []WITField{
+				{Name: "x", Type: WITType{Kind: WITF64}},
+				{Name: "y", Type: WITType{Kind: WITF64}},
+			}},
+		},
+		Imports: []WITFunc{
+			{Name: "log", Params: []WITField{{Name: "msg", Type: WITType{Kind: WITString}}}},
+		},
+		Exports: []WITFunc{
+			{Name: "dot", Params: []WITField{
+				{Name: "a", Type: WITType{Kind: WITRef, Name: "vector"}},
+				{Name: "b", Type: WITType{Kind: WITRef, Name: "vector"}},
+			}, Return: WITType{Kind: WITF64}},
+		},
+	}
+	got, err := w.Render()
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	wantSnippets := []string{
+		"package mochi:py-bridge;",
+		"world numpy-demo {",
+		"  record vector {",
+		"    x: f64,",
+		"    y: f64,",
+		"  import log: func(msg: string);",
+		"  export dot: func(a: vector, b: vector) -> f64;",
+	}
+	for _, s := range wantSnippets {
+		if !strings.Contains(got, s) {
+			t.Errorf("rendered world missing %q\n--- got ---\n%s", s, got)
+		}
+	}
+}
+
+func TestWITWorldRenderDeterministic(t *testing.T) {
+	w := WITWorld{
+		Package: "mochi:bridge",
+		Name:    "demo",
+		Exports: []WITFunc{
+			{Name: "zeta"},
+			{Name: "alpha"},
+			{Name: "mu"},
+		},
+	}
+	first, _ := w.Render()
+	second, _ := w.Render()
+	if first != second {
+		t.Error("Render is not deterministic across calls")
+	}
+	idxAlpha := strings.Index(first, "alpha")
+	idxMu := strings.Index(first, "mu")
+	idxZeta := strings.Index(first, "zeta")
+	if !(idxAlpha < idxMu && idxMu < idxZeta) {
+		t.Errorf("exports not sorted: %v %v %v", idxAlpha, idxMu, idxZeta)
+	}
+}
+
+func TestWITWorldRenderRejectsInvalid(t *testing.T) {
+	w := WITWorld{Package: "", Name: "x"}
+	if _, err := w.Render(); err == nil {
+		t.Error("expected validate error")
+	}
+}
+
+func TestIsKebab(t *testing.T) {
+	yes := []string{"a", "abc", "abc-def", "a1", "abc-def-ghi"}
+	no := []string{"", "-a", "a-", "1abc", "Abc", "abc_def", "abc--def" /* double-hyphen */, "abc--"}
+	for _, s := range yes {
+		if !isKebab(s) {
+			t.Errorf("isKebab(%q) = false, want true", s)
+		}
+	}
+	for _, s := range no {
+		if isKebab(s) {
+			t.Errorf("isKebab(%q) = true, want false", s)
+		}
+	}
+}

--- a/website/docs/implementation/0071/index.md
+++ b/website/docs/implementation/0071/index.md
@@ -48,11 +48,14 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | 14.2 | Request pipelining (multiple in-flight requests demultiplexed by ID) | NOT STARTED | — | [phase-14](/docs/implementation/0071/phase-14-subprocess-mode) |
 | 14.3 | `mochi pkg run --runtime=subprocess` CLI verb + `[python].runtime-mode` dispatch | NOT STARTED | — | [phase-14](/docs/implementation/0071/phase-14-subprocess-mode) |
 | 14.4 | Mixed sync + async worker surfaces | NOT STARTED | — | [phase-14](/docs/implementation/0071/phase-14-subprocess-mode) |
-| 15 | Attestation verification at install time + `--require-attestations` enforcement | LANDED | (pending merge) | [phase-15](/docs/implementation/0071/phase-15-attestation-verify) |
+| 15 | Attestation verification at install time + `--require-attestations` enforcement | LANDED | `1cf131b7` | [phase-15](/docs/implementation/0071/phase-15-attestation-verify) |
 | 15.1 | Live sigstore-go crypto verifier (X.509 chain + Rekor inclusion proof + SCT) | NOT STARTED | — | [phase-15](/docs/implementation/0071/phase-15-attestation-verify) |
 | 15.2 | Live PyPI HTTP `<wheel-url>.provenance` fetcher with cache + retry | NOT STARTED | — | [phase-15](/docs/implementation/0071/phase-15-attestation-verify) |
 | 15.3 | `mochi pkg install --require-attestations` + `--allowed-builder` + `--trusted-publisher` CLI verbs | NOT STARTED | — | [phase-15](/docs/implementation/0071/phase-15-attestation-verify) |
-| 16 | Pyodide / WASI target support (`wasm32-emscripten`, `wasm32-wasip2` wheel resolution + WIT interface) | NOT STARTED | — | [phase-16](/docs/implementation/0071/phase-16-pyodide-wasi) |
+| 16 | Pyodide / WASI target support (`wasm32-emscripten`, `wasm32-wasip2` wheel resolution + WIT interface) | LANDED | (pending merge) | [phase-16](/docs/implementation/0071/phase-16-pyodide-wasi) |
+| 16.1 | Wire WIT world emit into wrapper synthesiser so `extern python` -> WIT export for WASI targets | NOT STARTED | — | [phase-16](/docs/implementation/0071/phase-16-pyodide-wasi) |
+| 16.2 | Live Pyodide distribution index client at `pyodide.org/distribution/v<X>/full/` | NOT STARTED | — | [phase-16](/docs/implementation/0071/phase-16-pyodide-wasi) |
+| 16.3 | `mochi pkg install --target=pyodide` / `--target=wasi-p2` CLI verbs + lockfile target field | NOT STARTED | — | [phase-16](/docs/implementation/0071/phase-16-pyodide-wasi) |
 | 17 | Free-threaded CPython 3.13t / 3.14t (`cp3XYt` ABI tag, PyMutex, atomic refcount) | NOT STARTED | — | [phase-17](/docs/implementation/0071/phase-17-free-threaded) |
 | 18 | abi2026 transition (`abi-tag-policy = "legacy" | "abi2026" | "both"`) + 2026-Q1 rollout | NOT STARTED | — | [phase-18](/docs/implementation/0071/phase-18-abi2026) |
 
@@ -108,7 +111,7 @@ package3/python/
   abi3/                   # abi3 wheel slimming + auditwheel-equivalent platform validator (phase 13)
   subproc/                # JSON-RPC 2.0 stdio protocol + Python worker source renderer (phase 14)
   attest/                 # install-time PEP 740 verification + policy (phase 15)
-  pyodide/                # wasm32-emscripten + WASI Preview 2 target support (phase 16)
+  pyodide/                # pyodide / emscripten / wasi-p2 platform-tag matcher + WIT emitter (phase 16)
   freethread/             # free-threaded mode wrapper variants (phase 17)
   runtime/                # the embedded mochi_runtime Python package (phase 5 + phase 12)
 ```
@@ -117,7 +120,7 @@ The `package3/python/` location is shared with the broader MEP-57 polyglot packa
 
 ## Status snapshot
 
-As of 2026-05-30 01:09 (GMT+7): MEP-71 spec and research bundle landed; phases 0-15 LANDED (8.1, 8.2, 10.1, 10.2, 10.3, 11.1, 11.2, 11.3, 12.1, 12.2, 12.3, 13.1, 13.2, 13.3, 14.1, 14.2, 14.3, 14.4, 15.1, 15.2, 15.3 deferred sub-phases); phases 16-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
+As of 2026-05-30 01:17 (GMT+7): MEP-71 spec and research bundle landed; phases 0-16 LANDED (8.1, 8.2, 10.1, 10.2, 10.3, 11.1, 11.2, 11.3, 12.1, 12.2, 12.3, 13.1, 13.2, 13.3, 14.1, 14.2, 14.3, 14.4, 15.1, 15.2, 15.3, 16.1, 16.2, 16.3 deferred sub-phases); phases 17-18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
 
 ## Cross-references
 

--- a/website/docs/implementation/0071/phase-16-pyodide-wasi.md
+++ b/website/docs/implementation/0071/phase-16-pyodide-wasi.md
@@ -1,0 +1,130 @@
+---
+title: "Phase 16. Pyodide / WASI target support"
+sidebar_position: 18
+sidebar_label: "Phase 16. Pyodide / WASI"
+description: "MEP-71 Phase 16 implementation tracking: WASM platform tag matcher, WASI Preview 2 + Pyodide wheel selector, and WIT world emitter."
+---
+
+# Phase 16. Pyodide / WASI target support
+
+The first non-native target family for the MEP-71 bridge. Ships:
+
+- A platform-tag parser + matcher for the three wheel tag families
+  PyPI + the Pyodide distribution channel publish today
+  (`pyodide_<year>_<rev>_wasm32`,
+  `emscripten_<major>_<minor>_<patch>_wasm32`, and the still
+  experimental `wasi_p2_wasm32`).
+- A `Selector` that picks the best wheel for a given `Target`
+  (runtime + Python ABI + optional Pyodide vintage floor).
+- A WIT (WebAssembly Interface Type) world emitter that the wrapper
+  synthesiser will eventually call to emit a `world ... { import:
+  ... export: ... }` block for WASI Preview 2 components.
+
+## Status
+
+`LANDED` (pending PR merge). Phase 16 ships the offline platform-tag +
+wheel-selector + WIT emitter surfaces; live Pyodide HTTP index, WIT
+wiring into the wrapper synthesiser, and `mochi pkg install --target`
+CLI verbs are split into sub-phases 16.1 / 16.2 / 16.3.
+
+## Gate
+
+`go test ./package3/python/pyodide/... -count=1`
+
+Covers:
+
+- Runtime parse + render + Vintage ordering (Less / Zero / String) +
+  Target.Validate.
+- ParsePlatformTag happy + 11 error paths across the three tag
+  families (missing _wasm32 suffix, malformed segments, negative
+  year, non-numeric major/minor/patch, ...).
+- Tag.SatisfiesRuntime: Pyodide tag -> RuntimePyodide,
+  Emscripten tag -> RuntimePyodide (Pyodide is the only modern
+  consumer of the legacy emscripten_X_Y_Z_wasm32 wheels in the
+  wild), Wasi tag -> RuntimeWASIPreview2.
+- Selector: vintage descending, ABI mismatch hard reject, MinVintage
+  floor, runtime mismatch hard reject, Pyodide preferred over
+  Emscripten when both match, Emscripten version descending,
+  WASI happy, empty-ABI accepts any ABI, malformed filenames
+  recorded in Reasons, deterministic tie-break on filename.
+- WIT type renderer for the 13 primitive + 2 composite (list, option)
+  + 1 ref kinds; panic paths for malformed types.
+- WITFunc renders with / without return.
+- WITWorld.Validate enforces non-empty package, kebab-case world /
+  record / record-field / function / function-param names; rejects
+  duplicate record + duplicate function declarations.
+- WITWorld.Render is deterministic (records sorted by name, imports
+  sorted, exports sorted; rerunning the same world yields the
+  same string).
+- isKebab rejects double-hyphens, leading hyphens, trailing
+  hyphens, leading digit, uppercase, underscore.
+- `phase16_test.go` umbrella sentinel: numpy vintage walk,
+  WASI server-side pick, end-to-end WIT world for a fetch surface,
+  manylinux wheels do not leak into a wasm resolve.
+
+## Files
+
+```
+package3/python/pyodide/
+  doc.go               # 3-responsibility overview
+  target.go            # Runtime enum + Target + Vintage
+  platform.go          # ParsePlatformTag + Tag.SatisfiesRuntime
+  wheel.go             # Selector + WheelCandidate + SelectionResult
+  wit.go               # WITType / WITFunc / WITRecordDecl / WITWorld + Render
+  target_test.go       # 5 tests
+  platform_test.go     # 5 tests (parse / kind string / runtime satisfaction)
+  wheel_test.go        # 11 tests
+  wit_test.go          # 11 tests
+  phase16_test.go      # 1 umbrella sentinel (4 sub-cases)
+```
+
+## Sub-phase decomposition
+
+### 16.1. Wire WIT into wrapper synthesiser
+
+The wrapper synthesiser (phase 5) emits `extern python` shims that
+boil down to JSON / pickle hand-off when the runtime is embedded
+CPython or subprocess. For WASI Preview 2 targets the bridge needs a
+WIT world instead so the wasm component model can do the import /
+export plumbing. Sub-phase 16.1 walks the wrapper's already-typed
+function table and feeds it through `pyodide.WITWorld.Render` to emit
+a `.wit` file next to the wrapper module.
+
+### 16.2. Live Pyodide distribution index
+
+Pyodide does not publish through PyPI Simple-Index; it lives at
+`pyodide.org/distribution/v<X>/full/` and uses a custom JSON layout
+that maps `package -> {wheel-filename, sha256, depends, imports}`.
+Sub-phase 16.2 implements a `pyodide.IndexClient` that the resolver
+can dial in when `target = pyodide`. Today the wheel selector accepts
+any candidate list, so an upstream that hand-curates the wheel list
+already works.
+
+### 16.3. CLI verbs
+
+The CLI surface:
+
+- `mochi pkg install --target=pyodide` -> `RuntimePyodide`.
+- `mochi pkg install --target=wasi-p2` -> `RuntimeWASIPreview2`.
+- `--pyodide-min-vintage=<year>_<rev>` -> `Target.MinVintage`.
+- `mochi.lock` gets a `[python].target` field so the lockfile can
+  pin the choice for reproducible installs.
+
+## Fixtures
+
+Phase 16 is selector-only and does not change wrapper-synthesiser
+fixtures. Sub-phase 16.1 will add WIT golden files under
+`package3/python/pyodide/testdata/wit/` mirroring the wrapper-fixture
+function tables so the round-trip is locked in.
+
+## Cross-references
+
+- [Pyodide distribution channel](https://pyodide.org/en/stable/usage/loading-packages.html)
+- [WebAssembly Component Model](https://component-model.bytecodealliance.org/)
+- [WIT IDL spec](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md)
+- [PEP 425: compatibility tags](https://peps.python.org/pep-0425/)
+- [CPython WASI port](https://docs.python.org/3.13/using/wasm.html)
+- [phase 5](/docs/implementation/0071/phase-05-wrapper) for the
+  wrapper synthesiser that sub-phase 16.1 will tap into.
+- [phase 9](/docs/implementation/0071/phase-09-lockfile) for the
+  lockfile sub-phase 16.3 will extend.


### PR DESCRIPTION
## Summary

- Adds `package3/python/pyodide/`, the first non-native target family for the MEP-71 bridge.
- `ParsePlatformTag` lifts the three wasm wheel tag families: `pyodide_<year>_<rev>_wasm32`, `emscripten_<major>_<minor>_<patch>_wasm32`, `wasi_p2_wasm32`.
- `Selector` ranks Pyodide vintage descending, accepts `MinVintage` floor, hard-rejects ABI mismatches + foreign tag kinds, reports per-rejection reasons.
- `WITWorld` emits the WebAssembly Component Model WIT IDL with deterministic record + import + export ordering (sub-phase 16.1 will wire it into the wrapper synthesiser).
- 33 tests covering every parse / select / WIT path plus a phase16 umbrella sentinel (numpy vintage walk, wasi-p2 pick, end-to-end WIT for a fetch surface, manylinux non-leakage).

Tracks #23007.

## Test plan

- [x] `go build ./package3/python/pyodide/...`
- [x] `go test ./package3/python/pyodide/... -count=1`
- [x] `go test ./package3/python/... -count=1`

## Sub-phases (deferred)

- 16.1 Wrapper synthesiser WIT emit (NOT STARTED)
- 16.2 Live Pyodide distribution index client (NOT STARTED)
- 16.3 `mochi pkg install --target=pyodide|wasi-p2` CLI verbs (NOT STARTED)