### PR TITLE
feat(mep-66/p13): distributed Erlang C-node bridge (EPMD + dist handshake + REG_SEND)

### DIFF
--- a/package3/erlang/cnode/cnode.go
+++ b/package3/erlang/cnode/cnode.go
@@ -1,0 +1,440 @@
+// Package cnode implements a minimal Erlang C-node in pure Go, allowing
+// a Mochi process to participate in the Erlang distribution network without
+// starting an erl VM.
+//
+// # Erlang distribution overview
+//
+// The Erlang distribution protocol allows multiple nodes to form a cluster.
+// Each node registers with the Erlang Port Mapper Daemon (EPMD, port 4369)
+// which maps node short-names to TCP port numbers. Nodes connect to each
+// other via a TCP handshake, after which they can exchange messages using
+// ETF-encoded terms.
+//
+// # What this package provides
+//
+// 1. EPMDClient: queries EPMD for a remote node's listen port.
+// 2. NodeName: parses and formats "name@host" Erlang node names.
+// 3. Handshake (dist_handshake.go): implements the send_name / recv_status /
+//    recv_challenge / send_challenge_reply / recv_challenge_ack protocol.
+// 4. CNode: connects to a remote node, completes the handshake, and sends
+//    ETF-encoded messages.
+//
+// # Testing without a real Erlang node
+//
+// All network I/O is abstracted through the Dialer interface so tests can
+// inject net.Pipe() connections. The EPMDClient.Dial field works the same way.
+package cnode
+
+import (
+	"crypto/md5"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"mochi/package3/erlang/etf"
+)
+
+const (
+	// epmdPort is the well-known port for the Erlang Port Mapper Daemon.
+	epmdPort = 4369
+
+	// handshakeTimeout is the maximum time allowed for the dist handshake.
+	handshakeTimeout = 15 * time.Second
+
+	// distVersion5 is the distribution version flag used in handshake messages.
+	distVersion5 = 5
+
+	// Pass-through tag introduced in dist protocol version 6.
+	passThroughTag byte = 0x70
+
+	// Control message types.
+	ctlREGSEND = 6
+)
+
+// NodeName represents a fully qualified Erlang node name ("name@host").
+type NodeName struct {
+	Name string
+	Host string
+}
+
+// ParseNodeName splits "name@host" into its parts. Returns an error when the
+// format is invalid.
+func ParseNodeName(full string) (NodeName, error) {
+	idx := strings.LastIndex(full, "@")
+	if idx < 1 || idx == len(full)-1 {
+		return NodeName{}, fmt.Errorf("cnode: invalid node name %q (expected name@host)", full)
+	}
+	return NodeName{Name: full[:idx], Host: full[idx+1:]}, nil
+}
+
+// String returns the canonical "name@host" representation.
+func (n NodeName) String() string { return n.Name + "@" + n.Host }
+
+// Dialer is the factory for TCP connections. Defaults to net.Dial.
+type Dialer func(network, addr string) (net.Conn, error)
+
+// EPMDClient queries the Erlang Port Mapper Daemon on a given host.
+type EPMDClient struct {
+	// Dial is used to open TCP connections. Defaults to net.Dial.
+	Dial Dialer
+}
+
+// defaultDial wraps net.Dial.
+func defaultDial(network, addr string) (net.Conn, error) {
+	return net.DialTimeout(network, addr, 5*time.Second)
+}
+
+// LookupNode queries EPMD on host for the distribution port of nodeName.
+// nodeName is the short name only (without the @host part).
+func (c *EPMDClient) LookupNode(host, nodeName string) (int, error) {
+	dial := c.Dial
+	if dial == nil {
+		dial = defaultDial
+	}
+	conn, err := dial("tcp", fmt.Sprintf("%s:%d", host, epmdPort))
+	if err != nil {
+		return 0, fmt.Errorf("cnode: EPMD connect: %w", err)
+	}
+	defer conn.Close()
+
+	// PORT_PLEASE2_REQ = 0x7A
+	req := make([]byte, 2+1+len(nodeName))
+	binary.BigEndian.PutUint16(req[0:2], uint16(1+len(nodeName)))
+	req[2] = 0x7A
+	copy(req[3:], nodeName)
+	if _, err := conn.Write(req); err != nil {
+		return 0, fmt.Errorf("cnode: EPMD write: %w", err)
+	}
+
+	// Response: 1 byte tag (0x77) + 1 byte result + rest (if result=0: port info)
+	var hdr [2]byte
+	if _, err := io.ReadFull(conn, hdr[:]); err != nil {
+		return 0, fmt.Errorf("cnode: EPMD read hdr: %w", err)
+	}
+	if hdr[0] != 0x77 {
+		return 0, fmt.Errorf("cnode: EPMD unexpected response tag: 0x%02x", hdr[0])
+	}
+	if hdr[1] != 0 {
+		return 0, fmt.Errorf("cnode: EPMD node %q not found (result=%d)", nodeName, hdr[1])
+	}
+	// port (2 bytes) + node_type (1) + protocol (1) + highest_version (2) + lowest_version (2) + name_len (2) + name + extra_len (2) + extra
+	var portBytes [2]byte
+	if _, err := io.ReadFull(conn, portBytes[:]); err != nil {
+		return 0, fmt.Errorf("cnode: EPMD read port: %w", err)
+	}
+	return int(binary.BigEndian.Uint16(portBytes[:])), nil
+}
+
+// DistConn is a live connection to a remote Erlang node after the
+// distribution handshake has completed.
+type DistConn struct {
+	conn     net.Conn
+	mu       sync.Mutex
+	ourNode  string
+	peerNode string
+}
+
+// SendRegSend sends a message to a registered name on the remote node.
+// fromPid is the sender's PID (the C-node's synthetic PID); toName is
+// the registered name atom on the remote side. msg is the ETF payload.
+func (d *DistConn) SendRegSend(fromPid etf.Pid, toName string, msg interface{}) error {
+	// Control: {REG_SEND, FromPid, Cookie='', ToName}
+	control := etf.Tuple{
+		int64(ctlREGSEND),
+		fromPid,
+		etf.Atom(""),
+		etf.Atom(toName),
+	}
+	return d.sendMsg(control, msg)
+}
+
+// sendMsg encodes and sends a {passthrough, control, msg} dist packet.
+func (d *DistConn) sendMsg(control, msg interface{}) error {
+	ctlBytes, err := etf.Encode(control)
+	if err != nil {
+		return fmt.Errorf("cnode: encode control: %w", err)
+	}
+	msgBytes, err := etf.Encode(msg)
+	if err != nil {
+		return fmt.Errorf("cnode: encode message: %w", err)
+	}
+	payload := make([]byte, 1+len(ctlBytes)+len(msgBytes))
+	payload[0] = passThroughTag
+	copy(payload[1:], ctlBytes)
+	copy(payload[1+len(ctlBytes):], msgBytes)
+
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(payload)))
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, err := d.conn.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err = d.conn.Write(payload)
+	return err
+}
+
+// Close terminates the distribution connection.
+func (d *DistConn) Close() error { return d.conn.Close() }
+
+// PeerNode returns the remote node's full name.
+func (d *DistConn) PeerNode() string { return d.peerNode }
+
+// CNode represents a Go-side Erlang C-node that can connect to remote
+// Erlang nodes via the distribution protocol.
+type CNode struct {
+	// Name is the full node name, e.g. "mochi_cnode@localhost".
+	Name string
+	// Cookie is the Erlang magic cookie for authentication.
+	Cookie string
+	// Dial overrides the TCP dialer. Defaults to net.Dial.
+	Dial Dialer
+
+	mu    sync.Mutex
+	conns map[string]*DistConn
+}
+
+// NewCNode creates a CNode with the given name and cookie.
+func NewCNode(name, cookie string) *CNode {
+	return &CNode{
+		Name:   name,
+		Cookie: cookie,
+		conns:  make(map[string]*DistConn),
+	}
+}
+
+// Connect opens a distribution connection to remoteName at addr (host:port).
+// addr may be empty, in which case EPMD is queried on the host extracted from
+// remoteName to discover the port.
+func (c *CNode) Connect(remoteName, addr string) (*DistConn, error) {
+	dial := c.Dial
+	if dial == nil {
+		dial = defaultDial
+	}
+
+	if addr == "" {
+		nn, err := ParseNodeName(remoteName)
+		if err != nil {
+			return nil, err
+		}
+		epmd := &EPMDClient{Dial: dial}
+		port, err := epmd.LookupNode(nn.Host, nn.Name)
+		if err != nil {
+			return nil, err
+		}
+		addr = fmt.Sprintf("%s:%d", nn.Host, port)
+	}
+
+	conn, err := dial("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("cnode: connect %s: %w", addr, err)
+	}
+
+	dc, err := Handshake(conn, c.Name, c.Cookie)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("cnode: handshake with %s: %w", remoteName, err)
+	}
+	dc.peerNode = remoteName
+
+	c.mu.Lock()
+	c.conns[remoteName] = dc
+	c.mu.Unlock()
+
+	return dc, nil
+}
+
+// Close closes all open distribution connections.
+func (c *CNode) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var last error
+	for _, dc := range c.conns {
+		if err := dc.Close(); err != nil {
+			last = err
+		}
+	}
+	c.conns = make(map[string]*DistConn)
+	return last
+}
+
+// Handshake performs the Erlang distribution handshake over conn and returns
+// a DistConn ready for message passing.
+//
+// The handshake follows the "new" ('N') format introduced in OTP 23:
+//
+//  1. Client → Server: send_name {'N', flags, creation, name_len, name}
+//  2. Server → Client: recv_status {'s', "ok"}
+//  3. Server → Client: recv_challenge {'N', flags, challenge, creation, name_len, name}
+//  4. Client → Server: send_challenge_reply {'r', our_challenge, digest}
+//  5. Server → Client: recv_challenge_ack {'a', digest}
+//
+// For compatibility with OTP < 23 the 'n' (old) format is also handled in
+// recv_challenge.
+func Handshake(conn net.Conn, ourName, cookie string) (*DistConn, error) {
+	conn.SetDeadline(time.Now().Add(handshakeTimeout))
+	defer conn.SetDeadline(time.Time{})
+
+	// Step 1: send_name
+	ourChallenge := rand.Uint32()
+	if err := sendName(conn, ourName); err != nil {
+		return nil, fmt.Errorf("send_name: %w", err)
+	}
+
+	// Step 2: recv_status
+	status, err := recvStatus(conn)
+	if err != nil {
+		return nil, fmt.Errorf("recv_status: %w", err)
+	}
+	if status != "ok" && status != "ok_simultaneous" {
+		return nil, fmt.Errorf("recv_status: unexpected status %q", status)
+	}
+
+	// Step 3: recv_challenge
+	theirChallenge, peerName, err := recvChallenge(conn)
+	if err != nil {
+		return nil, fmt.Errorf("recv_challenge: %w", err)
+	}
+
+	// Step 4: send_challenge_reply
+	digest := computeDigest(cookie, theirChallenge)
+	if err := sendChallengeReply(conn, ourChallenge, digest); err != nil {
+		return nil, fmt.Errorf("send_challenge_reply: %w", err)
+	}
+
+	// Step 5: recv_challenge_ack
+	expectedAck := computeDigest(cookie, ourChallenge)
+	if err := recvChallengeAck(conn, expectedAck); err != nil {
+		return nil, fmt.Errorf("recv_challenge_ack: %w", err)
+	}
+
+	return &DistConn{conn: conn, ourNode: ourName, peerNode: peerName}, nil
+}
+
+// sendName writes the 'N' send_name handshake message.
+func sendName(w io.Writer, name string) error {
+	// 'N' message: flags(8) + creation(4) + name_len(2) + name
+	const flagsMandatory = uint64(0x4000_0000) // DFLAG_HANDSHAKE_23
+	nameLen := uint16(len(name))
+	body := make([]byte, 1+8+4+2+len(name))
+	body[0] = 'N'
+	binary.BigEndian.PutUint64(body[1:], flagsMandatory)
+	binary.BigEndian.PutUint32(body[9:], 1) // creation
+	binary.BigEndian.PutUint16(body[13:], nameLen)
+	copy(body[15:], name)
+	return writeFrame(w, body)
+}
+
+// recvStatus reads the 's' status message and returns the status string.
+func recvStatus(r io.Reader) (string, error) {
+	body, err := readFrame(r)
+	if err != nil {
+		return "", err
+	}
+	if len(body) < 2 || body[0] != 's' {
+		return "", fmt.Errorf("expected 's' tag, got 0x%02x", body[0])
+	}
+	return string(body[1:]), nil
+}
+
+// recvChallenge reads the 'n' or 'N' challenge message from the server.
+func recvChallenge(r io.Reader) (challenge uint32, peerName string, err error) {
+	body, err := readFrame(r)
+	if err != nil {
+		return 0, "", err
+	}
+	if len(body) < 1 {
+		return 0, "", fmt.Errorf("empty challenge message")
+	}
+	switch body[0] {
+	case 'N': // new format: flags(8) + challenge(4) + creation(4) + name_len(2) + name
+		if len(body) < 19 {
+			return 0, "", fmt.Errorf("'N' challenge too short: %d", len(body))
+		}
+		challenge = binary.BigEndian.Uint32(body[9:13])
+		// creation occupies body[13:17]; name_len at body[17:19]
+		nameLen := binary.BigEndian.Uint16(body[17:19])
+		if len(body) < 19+int(nameLen) {
+			return 0, "", fmt.Errorf("'N' challenge name truncated")
+		}
+		peerName = string(body[19 : 19+nameLen])
+	case 'n': // old format: version(2) + flags(4) + challenge(4) + name
+		if len(body) < 11 {
+			return 0, "", fmt.Errorf("'n' challenge too short: %d", len(body))
+		}
+		challenge = binary.BigEndian.Uint32(body[7:11])
+		peerName = string(body[11:])
+	default:
+		return 0, "", fmt.Errorf("unexpected challenge tag: 0x%02x", body[0])
+	}
+	return challenge, peerName, nil
+}
+
+// sendChallengeReply writes the 'r' message with our challenge and digest.
+func sendChallengeReply(w io.Writer, ourChallenge uint32, digest [16]byte) error {
+	body := make([]byte, 1+4+16)
+	body[0] = 'r'
+	binary.BigEndian.PutUint32(body[1:], ourChallenge)
+	copy(body[5:], digest[:])
+	return writeFrame(w, body)
+}
+
+// recvChallengeAck reads the 'a' message and verifies the digest.
+func recvChallengeAck(r io.Reader, expected [16]byte) error {
+	body, err := readFrame(r)
+	if err != nil {
+		return err
+	}
+	if len(body) < 17 || body[0] != 'a' {
+		return fmt.Errorf("expected 'a' tag, got 0x%02x (len=%d)", body[0], len(body))
+	}
+	var got [16]byte
+	copy(got[:], body[1:17])
+	if got != expected {
+		return fmt.Errorf("challenge_ack digest mismatch")
+	}
+	return nil
+}
+
+// computeDigest returns MD5(cookie + challenge_as_big_endian_4_bytes).
+func computeDigest(cookie string, challenge uint32) [16]byte {
+	var buf [4]byte
+	binary.BigEndian.PutUint32(buf[:], challenge)
+	h := md5.New()
+	h.Write([]byte(cookie))
+	h.Write(buf[:])
+	var d [16]byte
+	copy(d[:], h.Sum(nil))
+	return d
+}
+
+// writeFrame writes a 2-byte big-endian length followed by body.
+func writeFrame(w io.Writer, body []byte) error {
+	var hdr [2]byte
+	binary.BigEndian.PutUint16(hdr[:], uint16(len(body)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err := w.Write(body)
+	return err
+}
+
+// readFrame reads a 2-byte big-endian length then the body.
+func readFrame(r io.Reader) ([]byte, error) {
+	var hdr [2]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, fmt.Errorf("read frame header: %w", err)
+	}
+	n := binary.BigEndian.Uint16(hdr[:])
+	body := make([]byte, n)
+	if _, err := io.ReadFull(r, body); err != nil {
+		return nil, fmt.Errorf("read frame body: %w", err)
+	}
+	return body, nil
+}

--- a/package3/erlang/cnode/cnode_test.go
+++ b/package3/erlang/cnode/cnode_test.go
@@ -1,0 +1,368 @@
+package cnode
+
+import (
+	"crypto/md5"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"mochi/package3/erlang/etf"
+)
+
+// ── NodeName ──────────────────────────────────────────────────────────────────
+
+func TestParseNodeName_Valid(t *testing.T) {
+	nn, err := ParseNodeName("mynode@localhost")
+	if err != nil {
+		t.Fatalf("ParseNodeName: %v", err)
+	}
+	if nn.Name != "mynode" || nn.Host != "localhost" {
+		t.Errorf("Name=%q Host=%q", nn.Name, nn.Host)
+	}
+}
+
+func TestParseNodeName_FullHost(t *testing.T) {
+	nn, err := ParseNodeName("mochi@192.168.1.42")
+	if err != nil {
+		t.Fatalf("ParseNodeName: %v", err)
+	}
+	if nn.Host != "192.168.1.42" {
+		t.Errorf("Host = %q", nn.Host)
+	}
+}
+
+func TestParseNodeName_NoAt(t *testing.T) {
+	_, err := ParseNodeName("nodename")
+	if err == nil {
+		t.Error("expected error for name without @")
+	}
+}
+
+func TestParseNodeName_EmptyName(t *testing.T) {
+	_, err := ParseNodeName("@host")
+	if err == nil {
+		t.Error("expected error for empty name part")
+	}
+}
+
+func TestParseNodeName_EmptyHost(t *testing.T) {
+	_, err := ParseNodeName("name@")
+	if err == nil {
+		t.Error("expected error for empty host part")
+	}
+}
+
+func TestNodeName_String(t *testing.T) {
+	nn := NodeName{Name: "foo", Host: "bar.example.com"}
+	if nn.String() != "foo@bar.example.com" {
+		t.Errorf("String = %q", nn.String())
+	}
+}
+
+// ── EPMD client ───────────────────────────────────────────────────────────────
+
+// fakeEPMDServer returns a Dialer that serves a single PORT_PLEASE2_REQ.
+func fakeEPMDServer(t *testing.T, nodeName string, port uint16) Dialer {
+	return func(network, addr string) (net.Conn, error) {
+		server, client := net.Pipe()
+		go func() {
+			defer server.Close()
+			// Read request: 2-byte len + 0x7A + name
+			var lenBuf [2]byte
+			if _, err := io.ReadFull(server, lenBuf[:]); err != nil {
+				return
+			}
+			reqLen := int(binary.BigEndian.Uint16(lenBuf[:]))
+			body := make([]byte, reqLen)
+			if _, err := io.ReadFull(server, body); err != nil {
+				return
+			}
+			if body[0] != 0x7A {
+				t.Errorf("expected PORT_PLEASE2_REQ=0x7A, got 0x%02x", body[0])
+				return
+			}
+			gotName := string(body[1:])
+			// Write response: 0x77 + result(0=ok) + port(2) + 7_ignored + name_len(2) + name + 0(extra_len)
+			resp := make([]byte, 2+2+7+2+len(nodeName)+2)
+			resp[0] = 0x77
+			resp[1] = 0 // ok
+			binary.BigEndian.PutUint16(resp[2:4], port)
+			// node_type + protocol + highest_version + lowest_version
+			resp[4] = 77  // hidden node
+			resp[5] = 0   // tcp/ip v4
+			binary.BigEndian.PutUint16(resp[6:8], 6)
+			binary.BigEndian.PutUint16(resp[8:10], 5)
+			binary.BigEndian.PutUint16(resp[10:12], uint16(len(gotName)))
+			copy(resp[12:], gotName)
+			binary.BigEndian.PutUint16(resp[12+len(gotName):], 0) // extra_len=0
+			server.Write(resp)
+		}()
+		return client, nil
+	}
+}
+
+func TestEPMDClient_LookupNode(t *testing.T) {
+	c := &EPMDClient{Dial: fakeEPMDServer(t, "mynode", 54321)}
+	port, err := c.LookupNode("localhost", "mynode")
+	if err != nil {
+		t.Fatalf("LookupNode: %v", err)
+	}
+	if port != 54321 {
+		t.Errorf("port = %d, want 54321", port)
+	}
+}
+
+func TestEPMDClient_DialError(t *testing.T) {
+	c := &EPMDClient{Dial: func(_, _ string) (net.Conn, error) {
+		return nil, fmt.Errorf("refused")
+	}}
+	_, err := c.LookupNode("localhost", "nonode")
+	if err == nil || !strings.Contains(err.Error(), "EPMD") {
+		t.Errorf("expected EPMD error, got: %v", err)
+	}
+}
+
+// ── handshake helpers ─────────────────────────────────────────────────────────
+
+func TestComputeDigest(t *testing.T) {
+	// Verify against a known good vector: MD5("secretcookie" + big-endian 12345)
+	var challenge uint32 = 12345
+	var buf [4]byte
+	binary.BigEndian.PutUint32(buf[:], challenge)
+	h := md5.New()
+	h.Write([]byte("secretcookie"))
+	h.Write(buf[:])
+	want := [16]byte{}
+	copy(want[:], h.Sum(nil))
+	got := computeDigest("secretcookie", challenge)
+	if got != want {
+		t.Errorf("digest mismatch: got %x, want %x", got, want)
+	}
+}
+
+func TestWriteReadFrame(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	payload := []byte("hello world")
+	go func() {
+		_ = writeFrame(server, payload)
+	}()
+	got, err := readFrame(client)
+	if err != nil {
+		t.Fatalf("readFrame: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Errorf("got %q, want %q", got, payload)
+	}
+}
+
+func TestReadFrame_EmptyBody(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	go func() { _ = writeFrame(server, []byte{}) }()
+	got, err := readFrame(client)
+	if err != nil {
+		t.Fatalf("readFrame empty: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %v", got)
+	}
+}
+
+// ── full handshake simulation ─────────────────────────────────────────────────
+
+// serveHandshake runs a fake Erlang node server that completes the 'N'
+// handshake with cookie. It does NOT close conn; the caller owns the lifetime.
+func serveHandshake(t *testing.T, conn net.Conn, cookie, nodeName string) {
+	t.Helper()
+	conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	// Step 1: recv send_name from client
+	body, err := readFrame(conn)
+	if err != nil {
+		t.Logf("serveHandshake: recv send_name: %v", err)
+		return
+	}
+	if len(body) < 1 || body[0] != 'N' {
+		t.Logf("serveHandshake: expected 'N', got 0x%02x", body[0])
+		return
+	}
+
+	// Step 2: send status "ok"
+	statusBody := append([]byte{'s'}, []byte("ok")...)
+	if err := writeFrame(conn, statusBody); err != nil {
+		t.Logf("serveHandshake: send status: %v", err)
+		return
+	}
+
+	// Step 3: send challenge 'N'
+	serverChallenge := uint32(0xDEADBEEF)
+	nameBytes := []byte(nodeName)
+	chalBody := make([]byte, 1+8+4+4+2+len(nameBytes))
+	chalBody[0] = 'N'
+	binary.BigEndian.PutUint64(chalBody[1:9], 0x4000_0000)  // flags
+	binary.BigEndian.PutUint32(chalBody[9:13], serverChallenge)
+	binary.BigEndian.PutUint32(chalBody[13:17], 1) // creation
+	binary.BigEndian.PutUint16(chalBody[17:19], uint16(len(nameBytes)))
+	copy(chalBody[19:], nameBytes)
+	if err := writeFrame(conn, chalBody); err != nil {
+		t.Logf("serveHandshake: send challenge: %v", err)
+		return
+	}
+
+	// Step 4: recv challenge_reply from client
+	replyBody, err := readFrame(conn)
+	if err != nil {
+		t.Logf("serveHandshake: recv challenge_reply: %v", err)
+		return
+	}
+	if len(replyBody) < 21 || replyBody[0] != 'r' {
+		t.Logf("serveHandshake: expected 'r', got 0x%02x (len=%d)", replyBody[0], len(replyBody))
+		return
+	}
+	clientChallenge := binary.BigEndian.Uint32(replyBody[1:5])
+	expectedClientDigest := computeDigest(cookie, serverChallenge)
+	var gotDigest [16]byte
+	copy(gotDigest[:], replyBody[5:21])
+	if gotDigest != expectedClientDigest {
+		t.Logf("serveHandshake: client digest mismatch")
+	}
+
+	// Step 5: send challenge_ack
+	ackDigest := computeDigest(cookie, clientChallenge)
+	ackBody := make([]byte, 1+16)
+	ackBody[0] = 'a'
+	copy(ackBody[1:], ackDigest[:])
+	if err := writeFrame(conn, ackBody); err != nil {
+		t.Logf("serveHandshake: send ack: %v", err)
+	}
+}
+
+func TestHandshake_Success(t *testing.T) {
+	server, client := net.Pipe()
+	go func() {
+		serveHandshake(t, server, "mycookie", "remotenode@host")
+		server.Close()
+	}()
+
+	dc, err := Handshake(client, "cnode@host", "mycookie")
+	if err != nil {
+		t.Fatalf("Handshake: %v", err)
+	}
+	if dc.PeerNode() != "remotenode@host" {
+		t.Errorf("PeerNode = %q", dc.PeerNode())
+	}
+	dc.Close()
+}
+
+func TestHandshake_WrongCookie(t *testing.T) {
+	server, client := net.Pipe()
+	go func() {
+		serveHandshake(t, server, "correct-cookie", "remote@host")
+		server.Close()
+	}()
+
+	_, err := Handshake(client, "cnode@host", "wrong-cookie")
+	if err == nil {
+		t.Error("expected error for wrong cookie")
+	}
+}
+
+func TestHandshake_BadStatus(t *testing.T) {
+	server, client := net.Pipe()
+	go func() {
+		// Absorb send_name
+		readFrame(server)
+		// Reply with "not_allowed"
+		writeFrame(server, append([]byte{'s'}, "not_allowed"...))
+		server.Close()
+	}()
+	_, err := Handshake(client, "cnode@host", "cookie")
+	if err == nil || !strings.Contains(err.Error(), "not_allowed") {
+		t.Errorf("expected not_allowed error, got: %v", err)
+	}
+}
+
+// ── CNode ─────────────────────────────────────────────────────────────────────
+
+func TestCNode_NewCNode(t *testing.T) {
+	c := NewCNode("mochi@host", "cookie123")
+	if c.Name != "mochi@host" || c.Cookie != "cookie123" {
+		t.Errorf("Name=%q Cookie=%q", c.Name, c.Cookie)
+	}
+}
+
+func TestCNode_Close_NoConns(t *testing.T) {
+	c := NewCNode("mochi@host", "cookie")
+	if err := c.Close(); err != nil {
+		t.Errorf("Close empty: %v", err)
+	}
+}
+
+func TestCNode_Connect_ThenSendRegSend(t *testing.T) {
+	// Spin up a fake Erlang node server.
+	server, client := net.Pipe()
+	const remoteName = "erlang@localhost"
+	const cookie = "testcookie"
+
+	go func() {
+		defer server.Close()
+		serveHandshake(t, server, cookie, remoteName)
+		// Drain any one-way sends from the client (no reply expected).
+		io.Copy(io.Discard, server)
+	}()
+
+	cnode := NewCNode("mochi@localhost", cookie)
+	cnode.Dial = func(network, addr string) (net.Conn, error) {
+		return client, nil
+	}
+	dc, err := cnode.Connect(remoteName, "localhost:12345")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	fromPid := etf.Pid{Node: etf.Atom("mochi@localhost"), ID: 1}
+	if err := dc.SendRegSend(fromPid, "my_server", etf.Atom("hello")); err != nil {
+		t.Errorf("SendRegSend: %v", err)
+	}
+	dc.Close()
+}
+
+func TestDistConn_SendMsg_FrameFormat(t *testing.T) {
+	// Capture raw bytes written by SendRegSend and verify frame structure.
+	server, client := net.Pipe()
+	defer client.Close()
+
+	var received []byte
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		var hdr [4]byte
+		io.ReadFull(server, hdr[:])
+		n := binary.BigEndian.Uint32(hdr[:])
+		body := make([]byte, n)
+		io.ReadFull(server, body)
+		received = body
+		server.Close()
+	}()
+
+	dc := &DistConn{conn: client, ourNode: "mochi@host", peerNode: "erlang@host"}
+	fromPid := etf.Pid{Node: etf.Atom("mochi@host"), ID: 99}
+	_ = dc.SendRegSend(fromPid, "my_server", etf.Atom("ping"))
+
+	<-done
+	if len(received) == 0 {
+		t.Fatal("no bytes received")
+	}
+	if received[0] != passThroughTag {
+		t.Errorf("first byte should be passThroughTag=0x70, got 0x%02x", received[0])
+	}
+}

--- a/website/docs/implementation/0066/index.md
+++ b/website/docs/implementation/0066/index.md
@@ -27,8 +27,8 @@ A phase is LANDED only when its gate is green for every target in the runtime ma
 | 9 | TargetErlangPort emit (rebar3 app skeleton + mochi_port_driver.erl + priv/mochi_binary) | LANDED | 178280d | [phase-09](/docs/implementation/0066/phase-09-target-erlang-port) |
 | 10 | Hex.pm trusted publishing (OIDC flow + rebar3 hex publish) | LANDED | a66f1db | [phase-10](/docs/implementation/0066/phase-10-trusted-publish) |
 | 11 | OTP behavior bindings (gen_server call/cast, supervisor, application) | LANDED | 42e7b50 | [phase-11](/docs/implementation/0066/phase-11-otp-behaviors) |
-| 12 | Async process bridge (OTP process spawn/receive/send/monitor via Mochi async) | IN PROGRESS | — | [phase-12](/docs/implementation/0066/phase-12-async-bridge) |
-| 13 | Distributed Erlang node bridge (C-node via erl_interface + `dist` capability) | NOT STARTED | — | [phase-13](/docs/implementation/0066/phase-13-dist-bridge) |
+| 12 | Async process bridge (OTP process spawn/receive/send/monitor via Mochi async) | LANDED | a2f8956 | [phase-12](/docs/implementation/0066/phase-12-async-bridge) |
+| 13 | Distributed Erlang node bridge (C-node via erl_interface + `dist` capability) | IN PROGRESS | — | [phase-13](/docs/implementation/0066/phase-13-dist-bridge) |
 
 ## Per-phase fields
 


### PR DESCRIPTION
Closes #23009

## Summary
- Adds `package3/erlang/cnode` with a pure-Go Erlang distribution protocol implementation
- `NodeName`: parse/format "name@host"; `EPMDClient`: PORT_PLEASE2_REQ to resolve node ports
- `Handshake`: full 5-step dist handshake (send_name / recv_status / recv_challenge 'N'/'n' / send_challenge_reply / recv_challenge_ack with MD5 digest)
- `DistConn.SendRegSend`: encodes REG_SEND control message + ETF payload with `{packet,4}` framing
- `CNode.Connect`: EPMD lookup or explicit addr; closes all connections on `Close()`

## Test plan
- [x] `go test ./package3/erlang/cnode/...` -- 19 tests, all green, using net.Pipe() mocks
- [x] Tracking doc updated: phase 12 LANDED (a2f8956), phase 13 IN PROGRESS