### PR TITLE
feat(mep-67/p16): add MEP-67 spec and research bundle

### DIFF
--- a/website/docs/mep/mep-0067.md
+++ b/website/docs/mep/mep-0067.md
@@ -1,0 +1,216 @@
+---
+mep: 67
+title: "Mochi and Java package bridge: bidirectional Maven Central interop with JNI reflection ingest, auto-generated JNI wrapper, no-boilerplate import java syntax, Maven Central publish via Sonatype Central Portal, mochi.lock [[java-package]] pinning, and a content-addressed JAR cache under package3/java/"
+author: Mochi core
+status: Draft
+type: Standards Track
+created: 2026-05-30
+sidebar_position: 67
+sidebar_label: MEP 67. Mochi and Java package bridge
+description: "Bidirectional package interop between Mochi and the Maven Central ecosystem. Direction 1 (Mochi as Maven consumer): an `import java \"<groupId>:<artifactId>@<version>\" as <alias>` surface form auto-resolves through mochi.lock, fetches the JAR from Maven Central into a content-addressed blob store under `~/.cache/mochi/java-deps/`, runs a JVM reflection tool to extract the public API surface as JSON, walks that surface through a closed Java-to-Mochi type translation table (int/long/float/double/boolean/String/byte[]/List<T>/Map<K,V>/Optional<T>/CompletableFuture<T>/struct/enum plus a refusal set for raw Object, wildcards, inner classes, varargs, reflective types, and unchecked generics), synthesises JNI wrapper Java source via javac, and emits matching extern java type and extern java fn Mochi declarations. Direction 2 (Mochi as Maven producer): a TargetJavaLibrary build target packages the wrapper JAR and POM for upload to Maven Central via the Sonatype Central Portal API, with optional GPG signing and Sigstore attestation. The bridge is implemented in package3/java/ and extends MEP-57's mochi.toml plus mochi.lock infrastructure. A 16-phase delivery plan covers skeleton, Maven Central HTTP client with SHA-1 verification, content-addressed JAR cache, JVM reflection tool, type mapping table, Mochi extern shim emitter, import java grammar wiring, JNI embedding driver, build orchestration pipeline and javac driver, mochi.lock integration, TargetJavaLibrary emit, Maven Central publish flow, Sigstore attestation, async CompletableFuture bridge, generics and type-erasure handling, and spec update."
+---
+
+# MEP 67. Mochi and Java package bridge
+
+| Field    | Value |
+|----------|-------|
+| MEP      | 67 |
+| Title    | Mochi and Java package bridge |
+| Author   | Mochi core |
+| Status   | Draft |
+| Type     | Standards Track |
+| Created  | 2026-05-30 01:11 (GMT+7) |
+| Depends  | MEP-1 (Grammar, for the `import java` extension), MEP-2 (AST), MEP-4 (Type System), MEP-13 (ADTs and Match, for Result/Optional translation), MEP-57 (Mochi module and package system, for `mochi.toml`, `mochi.lock`, content-addressed object store, capability declarations, and OIDC trusted publishing) |
+| Research | [/docs/research/0067/](/docs/research/0067/) |
+| Tracking | [/docs/implementation/0067/](/docs/implementation/0067/) |
+
+## Abstract
+
+Mochi today (May 2026, after MEP-57's source-level package system reached Draft) bridges Go, Python, TypeScript, Rust, Ruby, Erlang, and Kotlin. Java is the next target. The Java ecosystem (Maven Central, 600,000+ artifacts as of May 2026) hosts foundational libraries for HTTP (OkHttp, Ktor), JSON (Gson, Jackson), database access (JDBC, Hibernate), cloud SDKs (AWS, GCP, Azure Java SDKs), machine learning (DL4J, Weka), Android components, and countless enterprise frameworks that have no equivalent in Mochi's standard library.
+
+MEP-67 specifies the **bidirectional Java bridge**: Mochi programs can consume any Maven Central JAR via `import java "groupId:artifactId@version" as alias` with no user-written boilerplate, and Mochi packages can publish JNI wrapper artifacts to Maven Central. The bridge operates through the JVM's JNI (Java Native Interface): the synthesised wrapper Java class exposes static JNI-callable methods that marshal arguments, dereference object handles, and return serialised values back to Go.
+
+Type information comes from Java reflection via a small embedded JAR tool: the tool loads the upstream JAR, enumerates its public classes, reflects all public methods and fields, and emits a JSON surface document. The surface is then walked through a closed Java-to-Mochi type table. Items outside the table are skipped with a structured `SkipReport` (15 skip reasons covering raw Object, wildcards, inner classes, varargs, reflective types, deprecated items, functional interfaces, and more). No running JVM is required at import-resolve time: the reflection tool runs as a one-shot `java -jar` subprocess.
+
+## Motivation
+
+1. **Maven Central hosts 600,000+ artifacts.** The Java/JVM ecosystem is the largest single package registry in the world by artifact count. Libraries like Guava, Apache Commons, Jackson, Log4j, Spring Boot, Hibernate, Kafka client, gRPC-Java, and Protobuf-Java are used by millions of projects. No Mochi interop path currently exists.
+
+2. **JNI is the canonical, stable foreign-function interface for the JVM.** JNI has been part of the JVM specification since Java 1.1. It operates at the C-level ABI: native methods declared in Java are dispatched to C functions whose signatures follow a predictable `Java_ClassName_methodName` naming convention. JNI is supported by every compliant JVM (HotSpot, OpenJ9, GraalVM, Android's ART) and does not require running with `--enable-preview` or any non-standard JVM flag.
+
+3. **Java reflection provides complete, authoritative type information at build time.** The `java.lang.reflect` API enumerates all public methods, fields, and constructors of a class, including generic type signatures. This is strictly more accurate than external annotation databases: the reflection output is derived from the actual compiled bytecode the end user ships.
+
+4. **The Maven coordinate system is the lingua franca of JVM dependency management.** `groupId:artifactId:version` (used by Maven, Gradle, sbt, Bazel rules_jvm_external, and Pants) is the universal identifier for JAR artifacts. Maven Central's HTTP API is stable, well-documented, and publicly accessible without authentication for read operations.
+
+5. **The Sonatype Central Portal is the authoritative publish path for Maven Central.** Since March 2024, Sonatype's Central Portal API (`central.sonatype.com`) is the GA publish path for Maven Central, replacing the legacy OSSRH Nexus. It accepts a deployment bundle ZIP and provides a status-polling API.
+
+## Specification
+
+### 1. Package layout
+
+All bridge code lives under `package3/java/`:
+
+```
+package3/java/
+  errors/      -- SkipReason, SkipReport, BridgeError
+  maven/       -- Coordinate, Client (Maven Central HTTP), Cache (SHA-256 keyed)
+  reflect/     -- Surface, ClassInfo, Tool (embedded JAR executor), Erasure
+  typemap/     -- Kind, Mapping, Map(), AsyncPolicy, AsyncMapping, GenericSignature
+  wrapper/     -- WrapClass, Synth, EmitJavaSource, FutureWrapMethod, EmitFutureWrapper
+  emit/        -- EmitShimMochi, EmitSkipReport, CollectSkips
+  build/       -- Driver, Workspace, Pipeline, RunJavac, TargetJavaLibrary, RenderPOM
+  jni/         -- Runtime (CGO, java_jni tag), FutureRuntime, stubs for non-CGO
+  lock/        -- JavaPackage, Encode, Decode, Check (mochi.lock [[java-package]])
+  publish/     -- BuildBundle, DryRun, Client (Central Portal), SignBundle (Sigstore)
+```
+
+### 2. Maven coordinate syntax
+
+Java imports use Maven coordinate notation extended with Mochi's `@version` pin:
+
+```mochi
+import java "com.google.guava:guava@33.0.0-jre" as guava
+import java "io.grpc:grpc-core@1.62.0" as grpc
+```
+
+The path format `groupId:artifactId@version` is validated at parse time by the `parser.JavaImportRef` function. The version is required (unlike `import go`, where stdlib imports omit the pin). An import without `as <alias>` is rejected with diagnostic P071.
+
+### 3. Type mapping table
+
+| Java type | Mochi Kind | FFI repr |
+|-----------|-----------|----------|
+| `int` | KindInt | `int` |
+| `long` | KindLong | `long` |
+| `float` | KindFloat | `float` |
+| `double` | KindDouble | `double` |
+| `boolean` | KindBool | `int` |
+| `void` | KindVoid | `void` |
+| `java.lang.String` | KindString | `String` |
+| `byte[]` | KindBytes | `byte[]` |
+| `java.lang.Integer` (boxed) | KindInt | `int` |
+| `java.lang.Long` (boxed) | KindLong | `long` |
+| `java.util.List<T>` | KindList | `String` (JSON) |
+| `java.util.Map<K,V>` | KindMap | `String` (JSON) |
+| `java.util.Optional<T>` | KindOptional | `String` (JSON) |
+| `java.util.concurrent.CompletableFuture<T>` | KindFuture | `String` (callback) |
+| Unknown class | KindHandle | `long` (JNI ref) |
+
+Skipped items (raw Object, wildcards `?`, inner classes, varargs, reflective types, deprecated, synchronised, volatile, native, generic without monomorphisation, functional interfaces) are logged as `SkipReport` entries with one of the 15 `SkipReason` constants.
+
+### 4. JNI wrapper pattern
+
+For each public class the synthesiser generates a Java class `MochiWrap_<ident>` with one static method per bridgeable method:
+
+```java
+public class MochiWrap_com_google_guava_Optional {
+    public static String MochiWrap_com_google_guava_Optional_get(long __handle) {
+        Object obj = MochiRuntime.deref(__handle);
+        return (String) ((com.google.common.base.Optional<String>)obj).get();
+    }
+}
+```
+
+Instance methods receive a `long __handle` first argument (a JNI global reference stored in a process-wide table); static methods are called directly. Return values are marshalled to JNI-compatible types (String for complex types, primitive types directly).
+
+### 5. Async bridge
+
+`CompletableFuture<T>` return types are bridged via a callback pattern:
+
+1. Go registers a `FutureCallback` in `jni.FutureRuntime` and gets back an `int64` handle.
+2. The generated wrapper Java method calls `.thenAccept(v -> MochiRuntime.callback(cbHandle, v))`.
+3. The Java callback invokes the JNI native method `MochiRuntime.callback`, which dispatches the Go callback in a new goroutine.
+
+The `AsyncPolicy` enum (`AsyncBlocking`, `AsyncGoroutine`) selects between blocking the calling goroutine and dispatching via the callback registry.
+
+### 6. mochi.lock integration
+
+Each resolved Java import adds a `[[java-package]]` entry:
+
+```toml
+[[java-package]]
+group = "com.google.guava"
+artifact = "guava"
+version = "33.0.0-jre"
+source = { kind = "maven" }
+jar-sha256 = "..."
+jar-sha1 = "..."
+surface-sha256 = "..."
+wrapper-sha256 = "..."
+dependencies = ["com.google.code.findbugs:jsr305@3.0.2"]
+```
+
+`mochi pkg lock --check` fails if `jar-sha256`, `jar-sha1`, `surface-sha256`, or `wrapper-sha256` drift from the locked values.
+
+### 7. Maven Central publish flow
+
+`mochi pkg publish --to=maven-central` assembles a Sonatype Central Portal upload bundle:
+
+1. `EmitTargetJavaLibrary` packages the wrapper `.class` files into a JAR and renders the POM.
+2. `BuildBundle` assembles the ZIP with JAR, POM, SHA-1, MD5, and optional GPG `.asc` signatures.
+3. `Client.Upload` POSTs the bundle to `https://central.sonatype.com/api/v1/publisher/upload`.
+4. `Client.PollUntilPublished` polls the deployment status until `PUBLISHED` or `FAILED`.
+5. `SignBundle` generates a Sigstore-keyless attestation bundle (in-toto v1.0 + Sigstore Bundle 0.3) binding the Maven coordinate and JAR SHA-256 to the CI OIDC token.
+
+## Phases
+
+### Target matrix
+
+| Phase | Description | PR | Status |
+|-------|-------------|-----|--------|
+| 0 | Skeleton: `errors/`, `build/` driver and workspace | #22870 | LANDED |
+| 1 | Maven Central HTTP client with SHA-1 verification | #22876 | LANDED |
+| 2 | Content-addressed JAR cache (SHA-256 keyed) | #22884 | LANDED |
+| 3 | JVM reflection tool (embedded JAR + mock executor) | #22893 | LANDED |
+| 4 | Type mapping table (15 SkipReasons, primitives, boxed, generics) | #22905 | LANDED |
+| 5 | JNI wrapper synthesiser (Synth + EmitJavaSource) | #22918 | LANDED |
+| 6 | Mochi extern shim emitter (EmitShimMochi, CollectSkips) | #22932 | LANDED |
+| 7 | `import java` grammar wiring (P070/P071 diagnostics, golden file) | #22944 | LANDED |
+| 8 | JNI embedding driver (CGO + `java_jni` tag, stub for non-CGO) | #22954 | LANDED |
+| 9 | Build orchestration pipeline and javac driver | #22967 | LANDED |
+| 10 | `mochi.lock` integration (`[[java-package]]` TOML table) | #22979 | LANDED |
+| 11 | TargetJavaLibrary emit (POM renderer, jar packager) | #22987 | LANDED |
+| 12 | Maven Central publish flow (bundle ZIP, Central Portal client) | #22991 | LANDED |
+| 13 | Sigstore attestation (in-toto v1.0 + Sigstore Bundle 0.3) | #22994 | LANDED |
+| 14 | Async bridge: CompletableFuture bridge (typemap, wrapper, jni) | #23000 | LANDED |
+| 15 | Generics and type-erasure utilities (GenericSignature, EraseType) | #23002 | LANDED |
+
+All 16 phases landed 2026-05-29 through 2026-05-30.
+
+## Non-goals
+
+- **No Kotlin-specific support.** Kotlin on the JVM uses Maven Central for distribution; MEP-70 covers Kotlin-specific bridge semantics (Kotlin metadata, coroutines). MEP-67 treats Kotlin JARs as plain Java JARs.
+- **No Android-specific support.** Android JARs use the Android SDK; MEP-67 targets standard JARs that run on a desktop JVM.
+- **No `unsafe` JNI.** Raw pointer operations, JNI `GetPrimitiveArrayCritical`, and `java.nio.ByteBuffer.allocateDirect` are outside scope.
+- **No dynamic class loading at Mochi compile time.** The reflection tool runs at build time; runtime class-loading is not tracked by the bridge.
+- **No support for `@FunctionalInterface` types** without an explicit opt-in. Functional interfaces require a lambda / method-reference synthesis step that is out of scope for the initial 16 phases.
+
+## Appendix: Fixture corpus
+
+The 20-artifact fixture corpus used for per-phase gate tests:
+
+| Coordinate | Purpose |
+|-----------|---------|
+| `com.google.guava:guava@33.0.0-jre` | Core utilities |
+| `com.fasterxml.jackson.core:jackson-databind@2.17.0` | JSON |
+| `io.grpc:grpc-core@1.62.0` | gRPC |
+| `org.slf4j:slf4j-api@2.0.12` | Logging |
+| `commons-lang:commons-lang@2.6` | String utilities |
+| `org.apache.commons:commons-math3@3.6.1` | Maths |
+| `org.apache.httpcomponents:httpclient@4.5.14` | HTTP client |
+| `com.squareup.okhttp3:okhttp@4.12.0` | HTTP client |
+| `com.google.protobuf:protobuf-java@3.25.3` | Protobuf |
+| `org.slf4j:slf4j-simple@2.0.12` | Logging impl |
+| `junit:junit@4.13.2` | Testing |
+| `org.mockito:mockito-core@5.10.0` | Mocking |
+| `org.postgresql:postgresql@42.7.3` | JDBC |
+| `mysql:mysql-connector-java@8.0.33` | JDBC |
+| `redis.clients:jedis@5.1.2` | Redis client |
+| `org.apache.kafka:kafka-clients@3.7.0` | Kafka |
+| `software.amazon.awssdk:s3@2.25.0` | AWS S3 |
+| `com.google.cloud:google-cloud-storage@2.36.0` | GCS |
+| `org.deeplearning4j:deeplearning4j-core@1.0.0-M2.1` | ML |
+| `javax.annotation:javax.annotation-api@1.3.2` | Annotations |
+
+## Acknowledgements
+
+MEP-67 draws on the prior art of MEP-73 (Rust bridge, rustdoc-JSON ingest, `package3/rust/` layout), MEP-70 (Kotlin bridge, Maven Central client, `package3/kotlin/` layout), MEP-76 (Ruby bridge, publish bundle pattern), and MEP-57 (mochi.lock design). The JNI embedding pattern is inspired by cgo's CGO build tag mechanism.

--- a/website/docs/research/0067/01-language-surface.md
+++ b/website/docs/research/0067/01-language-surface.md
@@ -1,0 +1,45 @@
+---
+title: "01. Language surface"
+sidebar_position: 2
+sidebar_label: "01. Language surface"
+description: "The import java surface form, mochi.toml java-dependencies table, CLI surface, and per-import alias resolution."
+---
+
+# 01. Language surface
+
+## Import syntax
+
+```mochi
+import java "com.google.guava:guava@33.0.0-jre" as guava
+import java "io.grpc:grpc-core@1.62.0" as grpc
+```
+
+The path format is `groupId:artifactId@version`. The version is required; an import without a pinned version is rejected with diagnostic P070 (invalid Java import path). An import without `as <alias>` is rejected with diagnostic P071 (missing alias).
+
+## mochi.toml
+
+Java dependencies declared in the manifest:
+
+```toml
+[java-dependencies]
+"com.google.guava:guava" = "33.0.0-jre"
+"io.grpc:grpc-core" = "1.62.0"
+```
+
+Each entry maps a `groupId:artifactId` key to a version string. The bridge validates the coordinate format at manifest parse time.
+
+## CLI surface
+
+```
+mochi pkg add java "com.google.guava:guava@33.0.0-jre"
+mochi pkg publish --to=maven-central
+mochi pkg lock --check
+```
+
+`mochi pkg add java` resolves the coordinate, fetches the JAR, runs reflection, synthesises the wrapper, and writes the `[[java-package]]` lock entry.
+
+`mochi pkg publish --to=maven-central` assembles the Sonatype Central Portal bundle and uploads it.
+
+## Alias resolution
+
+The alias following `as` becomes the Mochi namespace for all bridged classes. Within a Mochi source file, `guava.Optional` resolves to the bridged `com.google.common.base.Optional` class. Sub-namespacing uses dot notation matching the Java package hierarchy under the artifact's root package.

--- a/website/docs/research/0067/02-design-philosophy.md
+++ b/website/docs/research/0067/02-design-philosophy.md
@@ -1,0 +1,28 @@
+---
+title: "02. Design philosophy"
+sidebar_position: 3
+sidebar_label: "02. Design philosophy"
+description: "Why JNI over GraalVM polyglot, why Java reflection over annotation databases, and why KindHandle for unmappable types."
+---
+
+# 02. Design philosophy
+
+## Why JNI and not GraalVM polyglot
+
+GraalVM's Polyglot API can call Java from a guest language but requires running on GraalVM, not stock HotSpot or OpenJ9. MEP-67 targets any compliant JVM. JNI has been part of the JVM specification since Java 1.1 and is supported on every JVM Mochi is likely to encounter in production: HotSpot (OpenJDK), Eclipse OpenJ9, GraalVM (which also supports JNI alongside its polyglot API), and Android's ART.
+
+## Why JNI and not JNA or JNR-FFI
+
+JNA and JNR-FFI load native libraries from Java. MEP-67 goes the other direction: loading the JVM from a Go/Mochi binary. JNA/JNR-FFI do not provide a path to embed a JVM inside a Go process. The `libjvm` shared library plus JNI Invocation API is the only standard mechanism for that embedding.
+
+## Why Java reflection over annotation databases
+
+Third-party annotation databases (typedefs repositories, manually curated JSON schemas) go stale and have incomplete coverage. Java reflection (`java.lang.reflect`) operates directly on the compiled bytecode shipped in the JAR: the output is exactly as accurate as what the end user's code sees. There is no coverage gap and no schema drift.
+
+## Why KindHandle for unmappable types
+
+Rather than refusing the entire class when one method uses an unmappable return type, MEP-67 assigns the `KindHandle` kind (backed by a `long` JNI global reference) to the return value. The caller can pass the handle back to other bridged methods that accept it as a parameter. This preserves the usability of classes that mix mappable and unmappable APIs. The 15 `SkipReason` constants log which methods are excluded and why, giving users a clear picture of the bridge surface.
+
+## Why the closed type table
+
+An open type table (attempt to map every Java type) risks silent semantic mismatches. The closed table (15 base types, explicit refusal set) makes the boundary legible: if a Java type is not in the table, it either gets KindHandle or a SkipReport. Users can audit the SkipReport to decide whether to add a hand-written shim.

--- a/website/docs/research/0067/03-prior-art.md
+++ b/website/docs/research/0067/03-prior-art.md
@@ -1,0 +1,32 @@
+---
+title: "03. Prior-art bridges"
+sidebar_position: 4
+sidebar_label: "03. Prior-art bridges"
+description: "GraalVM polyglot, Jython, JRuby, GoBridge, JNA/JNR-FFI, and what MEP-67 borrows from each."
+---
+
+# 03. Prior-art bridges
+
+## GraalVM Polyglot
+
+GraalVM's Truffle/Polyglot layer lets guest languages call Java objects by reference. The object model is first-class: no serialisation, no handle table. The cost is JVM lock-in: the binary must run on GraalVM. MEP-67 borrows the idea of treating opaque Java objects as handles but defers to JNI global refs instead of Truffle object references.
+
+## Jython
+
+Jython is a Python interpreter implemented in Java. It achieves bidirectional interop by running Python on the JVM. MEP-67 cannot use this approach: Mochi compiles to Go, not to JVM bytecode. Jython's type coercions (Python list to java.util.List) inform MEP-67's JSON-wire encoding for List/Map/Optional: both choose serialisation over a shared heap representation.
+
+## JRuby
+
+JRuby compiles Ruby to JVM bytecode and inherits Java's type system at runtime. Like Jython it achieves interop by living on the JVM. The JRuby team's work on boxing/unboxing primitive types and the `java_import` syntax directly inspired MEP-67's `import java` surface form.
+
+## GoBridge (github.com/go-java)
+
+GoBridge attempted to call Java from Go via JNI Invocation API and CGO. The project stalled in 2018. MEP-67 improves on GoBridge by adding: a content-addressed JAR cache, a reflection-based surface extractor, type mapping with a SkipReport, lock file integration, and a publish path. The CGO JNI embedding pattern is essentially the same.
+
+## JNA / JNR-FFI
+
+Java Native Access and Java Native Runtime call C/native code from Java. They operate in the reverse direction from MEP-67. MEP-67 reviewed JNA's `NativeLibrary` design and its `Pointer`-as-handle approach when designing `KindHandle`. The lesson: an opaque pointer handle is a workable substitute for a full type bridge when only a subset of an API needs marshalling.
+
+## cglib / ByteBuddy
+
+Java bytecode generation libraries used by mocking frameworks. MEP-67 does not generate bytecode: it generates Java source and uses `javac`. This keeps the toolchain simple (no ASM dependency) and produces human-readable wrapper source.

--- a/website/docs/research/0067/04-maven-central-ingest.md
+++ b/website/docs/research/0067/04-maven-central-ingest.md
@@ -1,0 +1,31 @@
+---
+title: "04. Maven Central ingest"
+sidebar_position: 5
+sidebar_label: "04. Maven Central ingest"
+description: "Maven Central HTTP API, SHA-1 checksum verification, content-addressed JAR cache, and the reflection tool embedded-JAR approach."
+---
+
+# 04. Maven Central ingest
+
+## Maven Central HTTP API
+
+Maven Central exposes artifacts at a stable URL pattern:
+
+```
+https://repo1.maven.org/maven2/{groupId path}/{artifactId}/{version}/{artifactId}-{version}.jar
+https://repo1.maven.org/maven2/{groupId path}/{artifactId}/{version}/{artifactId}-{version}.jar.sha1
+```
+
+The `groupId` uses `.` as a separator in the coordinate but `/` in the URL path (`com.google.guava` becomes `com/google/guava`). MEP-67's `maven.Client` handles this translation.
+
+## SHA-1 checksum verification
+
+Maven Central publishes a `.jar.sha1` file alongside each JAR. The `maven.Client` fetches both, verifies the SHA-1, and rejects the JAR if the checksum does not match. SHA-256 is not published by Maven Central natively (it is an extension offered by some mirrors). The bridge computes SHA-256 locally after SHA-1 verification and records both in `mochi.lock`.
+
+## Content-addressed JAR cache
+
+Verified JARs are stored in `~/.cache/mochi/java-deps/<sha256>`. The atomic write pattern (write to `<sha256>.tmp`, then rename) prevents corrupt entries if the process is interrupted. A cache hit skips the network fetch entirely.
+
+## Reflection tool
+
+The reflection tool is a small Java program packaged as an executable JAR (embedded in the Go binary via `go:embed`). When invoked as `java -jar mochi-reflect.jar <jar-path>`, it loads the upstream JAR, enumerates public classes, reflects all public methods and fields, and emits a JSON surface document. The tool runs as a one-shot subprocess: no JVM is kept resident between reflect calls. The surface JSON SHA-256 is recorded in `mochi.lock` as `surface-sha256`.

--- a/website/docs/research/0067/05-type-mapping.md
+++ b/website/docs/research/0067/05-type-mapping.md
@@ -1,0 +1,44 @@
+---
+title: "05. Type mapping"
+sidebar_position: 6
+sidebar_label: "05. Type mapping"
+description: "The closed Java-to-Mochi type translation table, the 15 SkipReason constants, boxed-primitive collapse, JSON wire encoding, and the KindHandle fallback."
+---
+
+# 05. Type mapping
+
+## The closed table
+
+| Java type | Mochi Kind | FFI repr |
+|-----------|-----------|----------|
+| `int` | KindInt | `int` |
+| `long` | KindLong | `long` |
+| `float` | KindFloat | `float` |
+| `double` | KindDouble | `double` |
+| `boolean` | KindBool | `int` |
+| `void` | KindVoid | `void` |
+| `java.lang.String` | KindString | `String` |
+| `byte[]` | KindBytes | `byte[]` |
+| `java.lang.Integer` | KindInt | `int` |
+| `java.lang.Long` | KindLong | `long` |
+| `java.util.List<T>` | KindList | `String` (JSON) |
+| `java.util.Map<K,V>` | KindMap | `String` (JSON) |
+| `java.util.Optional<T>` | KindOptional | `String` (JSON) |
+| `java.util.concurrent.CompletableFuture<T>` | KindFuture | `String` (callback) |
+| Unknown class | KindHandle | `long` (JNI ref) |
+
+## Boxed-primitive collapse
+
+`java.lang.Integer` and `java.lang.Long` map to the same `KindInt`/`KindLong` as their primitive counterparts. The JNI wrapper unboxes the value (`.intValue()`, `.longValue()`) before returning it across the boundary.
+
+## JSON wire encoding
+
+`List<T>`, `Map<K,V>`, and `Optional<T>` are marshalled to JSON strings using `com.google.gson.Gson` (or `Jackson` if present) in the wrapper class. The Go side unmarshals the JSON string into the corresponding Mochi type. This avoids the complexity of a shared-heap object protocol at the cost of a serialisation round-trip per call.
+
+## The 15 SkipReasons
+
+Methods are skipped (not bridged) when they involve: `SkipRawObject`, `SkipWildcard`, `SkipInnerClass`, `SkipVarArgs`, `SkipReflectiveType`, `SkipDeprecated`, `SkipSynchronized`, `SkipVolatile`, `SkipNative`, `SkipUncheckedGeneric`, `SkipFunctionalInterface`, `SkipAnnotationType`, `SkipEnumOrdinal`, `SkipThrowable`, `SkipConstructorOnly`. Each skip is recorded in a `SkipReport` with the method name, class name, and reason constant.
+
+## KindHandle
+
+When a method returns a class that is not in the closed table and not in the skip set, the return type is mapped to `KindHandle`: a `long` holding a JNI global reference. The handle can be passed as the first argument to other bridged instance methods. The JVM manages the referenced object's lifetime; the bridge runtime releases the global reference when the Mochi GC finalises the handle.

--- a/website/docs/research/0067/06-maven-publish-flow.md
+++ b/website/docs/research/0067/06-maven-publish-flow.md
@@ -1,0 +1,42 @@
+---
+title: "06. Maven Central publish flow"
+sidebar_position: 7
+sidebar_label: "06. Maven Central publish flow"
+description: "Sonatype Central Portal API, deployment bundle ZIP structure, upload and poll cycle, and the dry-run validation path."
+---
+
+# 06. Maven Central publish flow
+
+## Sonatype Central Portal
+
+Since March 2024, the Sonatype Central Portal (`central.sonatype.com`) is the GA publish path for Maven Central. The legacy OSSRH Nexus endpoint still exists for existing publishers but is no longer the recommended path for new artifacts. MEP-67 targets the Central Portal exclusively.
+
+## Bundle ZIP structure
+
+A valid Central Portal bundle ZIP contains:
+
+```
+{groupId-path}/{artifactId}/{version}/{artifactId}-{version}.jar
+{groupId-path}/{artifactId}/{version}/{artifactId}-{version}.jar.sha1
+{groupId-path}/{artifactId}/{version}/{artifactId}-{version}.jar.md5
+{groupId-path}/{artifactId}/{version}/{artifactId}-{version}.pom
+{groupId-path}/{artifactId}/{version}/{artifactId}-{version}.pom.sha1
+{groupId-path}/{artifactId}/{version}/{artifactId}-{version}.pom.md5
+# optional:
+{groupId-path}/{artifactId}/{version}/{artifactId}-{version}.jar.asc
+{groupId-path}/{artifactId}/{version}/{artifactId}-{version}.pom.asc
+```
+
+`BuildBundle` assembles this ZIP from the wrapper JAR and rendered POM.
+
+## Upload and poll
+
+`Client.Upload` POSTs the bundle as a `multipart/form-data` body to `https://central.sonatype.com/api/v1/publisher/upload`. The response contains a deployment ID. `Client.PollUntilPublished` polls `https://central.sonatype.com/api/v1/publisher/status?id={id}` until the state reaches `PUBLISHED` or `FAILED`.
+
+## Dry-run validation
+
+`DryRun` validates the bundle ZIP without uploading: it checks that required files are present, that SHA-1 and MD5 hashes match the artifact bytes, and that the POM is well-formed XML. The dry-run gate runs in CI before the actual upload step.
+
+## POM rendering
+
+`RenderPOM` produces a minimal Maven POM with `<groupId>`, `<artifactId>`, `<version>`, `<name>`, `<description>`, and `<dependencies>`. The wrapper artifact's group ID is derived by prepending `dev.mochi.java-bridge.` to the upstream group ID, ensuring it lives in a Mochi-controlled Maven coordinate namespace.

--- a/website/docs/research/0067/07-sigstore-attestation.md
+++ b/website/docs/research/0067/07-sigstore-attestation.md
@@ -1,0 +1,34 @@
+---
+title: "07. Sigstore attestation"
+sidebar_position: 8
+sidebar_label: "07. Sigstore attestation"
+description: "in-toto v1.0 predicate schema, Sigstore Bundle 0.3 format, canonical JSON, OIDC token exchange, and base64-RawURL encoding."
+---
+
+# 07. Sigstore attestation
+
+## in-toto v1.0 predicate
+
+MEP-67 uses the in-toto v1.0 Statement schema with a Maven-specific predicate type:
+
+```
+https://maven.apache.org/spec/MavenCentralPublish/v1
+```
+
+The predicate binds the Maven coordinate (`groupId:artifactId:version`) to the JAR SHA-256 digest and the CI OIDC token. The `Subject` field contains the artifact filename and its `sha256` digest.
+
+## Sigstore Bundle 0.3
+
+The bundle media type is `application/vnd.dev.sigstore.bundle.v0.3+json`. The bundle JSON contains the in-toto statement, the OIDC-derived signing certificate chain from Fulcio, and the Rekor transparency log inclusion proof.
+
+## Canonical JSON
+
+`marshalSortedJSON` produces canonical JSON by sorting object keys alphabetically at every level. This ensures the attestation bytes are stable across Go versions and JSON library implementations, which matters for Rekor log verification.
+
+## OIDC token exchange
+
+The CI OIDC token (from `ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN` in GitHub Actions) is exchanged with Fulcio for an ephemeral signing certificate. Fulcio logs the exchange in the Certificate Transparency log. MEP-67 passes the raw OIDC token to `SignBundle`; the caller is responsible for obtaining the token from the CI environment.
+
+## EncodeBundleHeader
+
+`EncodeBundleHeader` base64-RawURL-encodes the bundle bytes for inclusion in the Maven Central upload request header `X-Sigstore-Attestation`. This follows the Central Portal's attestation upload protocol documented in the Sonatype Central Portal API reference (May 2025 revision).

--- a/website/docs/research/0067/08-jni-bridge-protocol.md
+++ b/website/docs/research/0067/08-jni-bridge-protocol.md
@@ -1,0 +1,30 @@
+---
+title: "08. JNI bridge protocol"
+sidebar_position: 9
+sidebar_label: "08. JNI bridge protocol"
+description: "JNI calling convention, global object references, CGO embedding of the JVM, the java_jni build tag, and latency vs GraalVM polyglot."
+---
+
+# 08. JNI bridge protocol
+
+## JNI calling convention
+
+JNI native methods follow a predictable C symbol naming convention:
+
+```
+Java_{ClassName}_{methodName}
+```
+
+where `ClassName` uses `_` instead of `.` and `/`. The wrapper Java class declares static native methods; the Go side provides the implementations via CGO. The JNI method descriptor string encodes parameter and return types in the JVM's internal type notation.
+
+## Global object references
+
+The JVM garbage collector can move objects; a raw JNI `jobject` is only valid on the thread that received it and within the current JNI frame. To pass Java objects between calls, MEP-67 promotes them to JNI global references (`NewGlobalRef`) and stores them in a process-wide handle table keyed by `int64`. `KindHandle` return values carry the table key. The bridge releases global references (`DeleteGlobalRef`) when the handle is finalised.
+
+## CGO JVM embedding
+
+The `jni.Runtime.New` function calls `JNI_CreateJavaVM` from `libjvm` via CGO. The JVM is started with the bridge's wrapper JAR (and the upstream JAR) on the classpath. Only one JVM can be created per process (JNI Invocation API constraint); subsequent `New` calls return the existing `*Runtime`. The `java_jni` build tag guards all CGO code; the stub file (`jni_stub.go`) compiles without CGO and returns `ErrJNIUnavailable`.
+
+## Latency
+
+JNI method dispatch costs approximately 50-200 ns per call on HotSpot x86_64, compared to 5-20 ns for a C function call via CGO alone. For methods that return complex types via JSON serialisation the serialisation cost dominates. For methods returning primitives (int, long, boolean) the JNI overhead is the dominant cost. Applications with tight call loops should batch work on the Java side and return aggregated results.

--- a/website/docs/research/0067/09-mochi-lock.md
+++ b/website/docs/research/0067/09-mochi-lock.md
@@ -1,0 +1,46 @@
+---
+title: "09. mochi.lock integration"
+sidebar_position: 10
+sidebar_label: "09. mochi.lock integration"
+description: "The [[java-package]] TOML table schema, four-hash verification, --check mode drift detection, and dependency chain encoding."
+---
+
+# 09. mochi.lock integration
+
+## Schema
+
+Each resolved Java import adds a `[[java-package]]` entry to `mochi.lock`:
+
+```toml
+[[java-package]]
+group = "com.google.guava"
+artifact = "guava"
+version = "33.0.0-jre"
+source = { kind = "maven" }
+jar-sha256 = "..."
+jar-sha1 = "..."
+surface-sha256 = "..."
+wrapper-sha256 = "..."
+dependencies = ["com.google.code.findbugs:jsr305@3.0.2"]
+```
+
+The `source.kind` field accepts `"maven"`, `"git"`, and `"path"`. Only `"maven"` is supported in the initial 16 phases.
+
+## Four-hash verification
+
+`mochi pkg lock --check` compares the four hashes in the lock file against freshly computed values:
+
+- `jar-sha256`: SHA-256 of the downloaded JAR bytes.
+- `jar-sha1`: SHA-1 of the downloaded JAR bytes (also verified against Maven Central's `.sha1` file).
+- `surface-sha256`: SHA-256 of the JSON surface document produced by the reflection tool.
+- `wrapper-sha256`: SHA-256 of the synthesised Java wrapper source.
+
+If any hash drifts, `Check` returns a `CheckError` listing the artifact, field, expected value, and actual value. The check exits non-zero, blocking CI.
+
+## Deterministic encoding
+
+`Encode` sorts `[[java-package]]` entries by `group + artifact` before serialising to TOML. This makes the lock file byte-stable across runs where the resolution order differs.
+
+## Dependency chain
+
+The `dependencies` array encodes the transitive JAR dependencies discovered by inspecting the POM. Dependencies are listed in `groupId:artifactId@version` notation. The lock file records only the direct declared dependencies of each artifact; transitive closure is stored by including entries for each transitive dependency in the `[[java-package]]` list.

--- a/website/docs/research/0067/10-async-bridge.md
+++ b/website/docs/research/0067/10-async-bridge.md
@@ -1,0 +1,43 @@
+---
+title: "10. Async CompletableFuture bridge"
+sidebar_position: 11
+sidebar_label: "10. Async CompletableFuture bridge"
+description: "The FutureRuntime callback registry, AsyncPolicy enum, Java thenAccept to JNI-native dispatch chain, and goroutine scheduling."
+---
+
+# 10. Async CompletableFuture bridge
+
+## The problem
+
+`CompletableFuture<T>` is the standard Java async primitive. It completes on a Java thread pool thread, not on the calling goroutine. The bridge must deliver the completion value to Go code without blocking a JVM thread indefinitely or requiring Go code to busy-poll.
+
+## FutureRuntime callback registry
+
+`jni.FutureRuntime` is a registry that maps `int64` handles to `FutureCallback` functions. When a Mochi caller invokes a method that returns a `CompletableFuture<T>`, the bridge:
+
+1. Allocates a `FutureCallback` closure that will send the value to a Go channel.
+2. Registers the closure in `FutureRuntime`, receiving an `int64` handle.
+3. Passes the handle to the wrapper Java method.
+
+## Java-side wiring
+
+The generated wrapper Java method adds a `thenAccept` completion handler:
+
+```java
+future.thenAccept(v -> MochiRuntime.callback(cbHandle, v.toString()));
+```
+
+`MochiRuntime.callback` is a JNI native method declared in the wrapper class. When the future completes, the Java thread pool invokes this native method.
+
+## AsyncPolicy
+
+`AsyncPolicy` selects the Go-side dispatch strategy:
+
+- `AsyncBlocking`: the calling goroutine blocks on a channel until the callback fires.
+- `AsyncGoroutine`: a new goroutine is launched; the callback sends to a buffered channel the caller selects from.
+
+`AsyncBlocking` is simpler but holds a goroutine for the duration of the Java operation. `AsyncGoroutine` is preferred for operations that may complete after a significant delay.
+
+## Goroutine safety
+
+The JNI native callback fires on a JVM thread, which is not a goroutine. CGO runtime handles the transition (`runtime.LockOSThread` is called inside the CGO dispatch). The `FutureRuntime.Invoke` method dispatches the Go callback in a new goroutine to avoid executing Go code on a JVM-owned thread stack beyond what CGO allows.

--- a/website/docs/research/0067/11-generics-erasure.md
+++ b/website/docs/research/0067/11-generics-erasure.md
@@ -1,0 +1,37 @@
+---
+title: "11. Generics and type erasure"
+sidebar_position: 12
+sidebar_label: "11. Generics and type erasure"
+description: "Java type erasure at the bytecode level, GenericSignature parser, EraseType/ErasedParams utilities, and the monomorphisation strategy."
+---
+
+# 11. Generics and type erasure
+
+## Type erasure
+
+Java compiles generic types to their erased form: `List<String>` becomes `List` in bytecode. The JVM has no runtime knowledge of the type parameter. Reflection on `Method.getGenericReturnType()` returns the pre-erasure generic type string if the class was compiled with debug information; otherwise it returns the erased type.
+
+## GenericSignature
+
+`typemap.GenericSignature` parses JVM generic type descriptor strings of the form `ClassName<Param1,Param2>`. It supports:
+
+- Raw types (`List` with no params, `IsRaw() == true`)
+- Single-param types (`List<String>`, `Optional<Integer>`)
+- Two-param types (`Map<String,Integer>`)
+- Nested generics (`Map<String,List<Integer>>`, handled by `splitTopLevelParams` which tracks bracket depth)
+- Wildcard detection (`WildcardErased() == true` when any param contains `?`)
+
+## EraseType / ErasedParams
+
+`reflect.EraseType(name string) string` strips the `<...>` suffix from a Java type name, returning the raw class name. `ErasedParams` returns the top-level type parameter strings. `NormaliseTypeName` converts JVM internal notation (`$` inner-class separator and `[]` array suffix) to the form used in the reflection surface JSON.
+
+## Monomorphisation strategy
+
+For the type table, MEP-67 monomorphises only the supported generic containers:
+
+- `List<T>`: T must be in the closed table or the method is skipped with `SkipUncheckedGeneric`.
+- `Map<K,V>`: K and V must both be in the closed table.
+- `Optional<T>`: T must be in the closed table.
+- `CompletableFuture<T>`: T must be in the closed table.
+
+This conservative strategy avoids the complexity of full parametric polymorphism while covering the most common generic APIs in Maven Central.

--- a/website/docs/research/0067/12-risks-and-alternatives.md
+++ b/website/docs/research/0067/12-risks-and-alternatives.md
@@ -1,0 +1,34 @@
+---
+title: "12. Risks and alternatives"
+sidebar_position: 13
+sidebar_label: "12. Risks and alternatives"
+description: "Risk register and rejected alternatives for MEP-67."
+---
+
+# 12. Risks and alternatives
+
+## Risk register
+
+**JVM version fragility.** The JNI Invocation API is stable but `--add-opens` requirements vary across Java 9-21 for reflection on internal packages. MEP-67 targets the public reflection API only (`java.lang.reflect.*`) and does not access internal JDK packages. Risk: low for JARs that expose only public APIs; medium for JARs that use internal JDK classes internally (not exposed to reflection surface).
+
+**JNI global-ref leaks.** Each `KindHandle` value holds a JNI global reference. If the Mochi GC does not finalise handles promptly (or if the user accumulates large numbers of handle values), the JVM heap may fill with unreachable Java objects. Mitigation: explicit `Close()` method on handle types; future MEP to integrate with Mochi's finaliser infrastructure.
+
+**Java 17+ module access restrictions.** Java 9 introduced the module system; Java 17 enforces strong encapsulation by default. Reflection on non-exported packages requires `--add-opens`. MEP-67's reflection tool only reflects exported packages (those accessible to external callers), so the risk applies only to JARs that use reflection internally.
+
+**Maven Central publish latency.** Central Portal validation can take 10-30 minutes for large bundles. `PollUntilPublished` defaults to a 60-minute timeout with 30-second poll intervals.
+
+**GPG key management.** Optional GPG signing requires a pre-existing GPG key registered with Sonatype. The bridge documents the key setup but does not automate it. Sigstore keyless signing is the recommended path for new publishers.
+
+**CompletableFuture thread-pool interactions.** Java's default `ForkJoinPool.commonPool()` sizes itself to `Runtime.availableProcessors() - 1`. In a process that also runs Go's runtime scheduler, this can lead to over-subscription. Mitigation: document that users should set `java.util.concurrent.ForkJoinPool.common.parallelism` to a small value.
+
+## Rejected alternatives
+
+**GraalVM polyglot as default.** Requires GraalVM; breaks on HotSpot, OpenJ9, and Android ART. Rejected in favour of JNI which works on all JVMs.
+
+**JNA instead of JNI.** JNA calls native libraries from Java, not the reverse. Not applicable to embedding a JVM in a Go process.
+
+**Annotation-database instead of reflection.** Annotation databases (e.g. manually curated JSON schema repos) go stale and have incomplete coverage. Rejected in favour of runtime reflection which is always authoritative.
+
+**Jython/JRuby approach (run Mochi on the JVM).** Would require compiling Mochi to JVM bytecode. Incompatible with MEP-67's goal of keeping Mochi as a Go-compiled language and adding Java as a bridge target.
+
+**Full generics support.** Tracking all type parameters through JVM signature descriptors, Kotlin metadata, and inner-class relationships is a multi-year project. Rejected for the initial 16 phases in favour of the conservative monomorphisation strategy.

--- a/website/docs/research/0067/index.md
+++ b/website/docs/research/0067/index.md
@@ -1,0 +1,33 @@
+---
+title: "MEP-67 research bundle"
+sidebar_position: 1
+sidebar_label: "Overview"
+description: "Twelve research notes covering the design space behind MEP-67: language surface, design philosophy, prior art, Maven Central ingest, type mapping, Maven publish flow, Sigstore attestation, JNI bridge protocol, mochi.lock integration, async CompletableFuture bridge, generics and type erasure, and risks."
+---
+
+# MEP-67 research bundle
+
+This bundle is the informative companion to [MEP-67](/docs/mep/mep-0067). It documents the design space the bridge sits in: prior art, the choices considered and rejected, the trade-offs accepted, and the open risks. The bundle is meant to be read alongside the spec, not in place of it.
+
+## Notes
+
+| Note | Subject |
+|------|---------|
+| [01. Language surface](01-language-surface.md) | The `import java "groupId:artifactId@version" as alias` import shape, the `mochi.toml` `[java-dependencies]` table, the CLI surface (`mochi pkg add java`, `mochi pkg publish --to=maven-central`), and the per-import alias/sub-namespace resolution rule. |
+| [02. Design philosophy](02-design-philosophy.md) | Why a bidirectional bridge, why JNI over GraalVM polyglot or Jython, why Java reflection over manual annotations, why the `KindHandle` opaque-reference strategy for unmappable types. |
+| [03. Prior-art bridges](03-prior-art.md) | GraalVM Polyglot, Jython, JRuby, Kotlin/Native, GoBridge (github.com/go-java), JNA/JNR-FFI, cglib. What each gets right and what MEP-67 borrows. |
+| [04. Maven Central ingest](04-maven-central-ingest.md) | The Maven Central HTTP API (search.maven.org v2), SHA-1 checksum verification, the content-addressed JAR cache layout under `~/.cache/mochi/java-deps/`, and the reflection tool embedded-JAR approach. |
+| [05. Type mapping](05-type-mapping.md) | The closed translation table from Java types to Mochi kinds, the 15 SkipReason constants, the boxed-primitive collapse strategy, the JSON wire encoding for List/Map/Optional, and the KindHandle opaque-reference fallback. |
+| [06. Maven Central publish flow](06-maven-publish-flow.md) | The Sonatype Central Portal API (GA March 2024), the deployment bundle ZIP structure (JAR, POM, SHA-1, MD5, GPG .asc), the upload + poll status cycle, and the dry-run validation path. |
+| [07. Sigstore attestation](07-sigstore-attestation.md) | The in-toto v1.0 predicate schema, the Sigstore Bundle 0.3 format, canonical JSON for byte-stable attestation, OIDC token exchange with Fulcio, and the `EncodeBundleHeader` base64-RawURL encoding. |
+| [08. JNI bridge protocol](08-jni-bridge-protocol.md) | The JNI calling convention (`Java_ClassName_methodName`), global object references and the handle table, CGO embedding of the JVM via `libjvm.so`, the `java_jni` build tag strategy, and latency vs GraalVM polyglot. |
+| [09. mochi.lock integration](09-mochi-lock.md) | The `[[java-package]]` TOML table schema, the four-hash verification scheme (jar-sha256, jar-sha1, surface-sha256, wrapper-sha256), the `--check` mode drift detection gate, and the dependency chain encoding. |
+| [10. Async CompletableFuture bridge](10-async-bridge.md) | The callback registry pattern in `jni.FutureRuntime`, the `AsyncPolicy` enum (AsyncBlocking vs AsyncGoroutine), the Java thenAccept→JNI-native dispatch chain, and the goroutine scheduling interaction. |
+| [11. Generics and type erasure](11-generics-erasure.md) | Java type erasure at the bytecode level, the `GenericSignature` parser for JVM generic descriptor strings, the `EraseType`/`ErasedParams` utilities, and the monomorphisation strategy for List/Map/Optional. |
+| [12. Risks and alternatives](12-risks-and-alternatives.md) | The risk register (JVM version fragility, JNI global-ref leaks, reflection access module restrictions in Java 17+, Maven Central publish latency, GPG key management, CompletableFuture thread-pool interactions) and rejected alternatives (GraalVM polyglot default, JNA instead of JNI, Jython, annotation-database instead of reflection). |
+
+## Cross-references
+
+- [MEP-67 spec](/docs/mep/mep-0067) -- the normative document.
+- [MEP-57](/docs/mep/mep-0057) -- the source-level package system whose manifest and lockfile the bridge extends.
+- [Implementation tracking](/docs/implementation/0067/) -- the per-phase delivery status.

--- a/website/src/data/meps.json
+++ b/website/src/data/meps.json
@@ -472,6 +472,14 @@
     "slug": "/docs/mep/mep-0066"
   },
   {
+    "number": 67,
+    "title": "Mochi and Java package bridge: bidirectional Maven Central interop with JNI reflection ingest, auto-generated JNI wrapper, no-boilerplate import java syntax, Maven Central publish via Sonatype Central Portal, mochi.lock [[java-package]] pinning, and a content-addressed JAR cache under package3/java/",
+    "status": "Draft",
+    "type": "Standards Track",
+    "description": "Bidirectional package interop between Mochi and the Maven Central ecosystem. Direction 1 (Mochi as Maven consumer): an `import java \"<groupId>:<artifactId>@<version>\" as <alias>` surface form auto-resolves through mochi.lock, fetches the JAR from Maven Central into a content-addressed blob store under `~/.cache/mochi/java-deps/`, runs a JVM reflection tool to extract the public API surface as JSON, walks that surface through a closed Java-to-Mochi type translation table (int/long/float/double/boolean/String/byte[]/List<T>/Map<K,V>/Optional<T>/CompletableFuture<T>/struct/enum plus a refusal set for raw Object, wildcards, inner classes, varargs, reflective types, and unchecked generics), synthesises JNI wrapper Java source via javac, and emits matching extern java type and extern java fn Mochi declarations. Direction 2 (Mochi as Maven producer): a TargetJavaLibrary build target packages the wrapper JAR and POM for upload to Maven Central via the Sonatype Central Portal API, with optional GPG signing and Sigstore attestation. The bridge is implemented in package3/java/ and extends MEP-57's mochi.toml plus mochi.lock infrastructure. A 16-phase delivery plan covers skeleton, Maven Central HTTP client with SHA-1 verification, content-addressed JAR cache, JVM reflection tool, type mapping table, Mochi extern shim emitter, import java grammar wiring, JNI embedding driver, build orchestration pipeline and javac driver, mochi.lock integration, TargetJavaLibrary emit, Maven Central publish flow, Sigstore attestation, async CompletableFuture bridge, generics and type-erasure handling, and spec update.",
+    "slug": "/docs/mep/mep-0067"
+  },
+  {
     "number": 71,
     "title": "Mochi and Python package bridge: bidirectional PyPI interop with PEP 561 stub ingest, auto-generated cffi/cpython wrapper, no-boilerplate import python syntax, PyPI publish via Trusted Publishing + PEP 740 attestations, pylock.toml + mochi.lock dual pinning, and a content-addressed Python wheel cache under package3/python/",
     "status": "Draft",

--- a/website/src/data/research-sidebar.json
+++ b/website/src/data/research-sidebar.json
@@ -253,6 +253,24 @@
     ]
   },
   {
+    "label": "MEP-0067",
+    "items": [
+      "research/0067/index",
+      "research/0067/language-surface",
+      "research/0067/design-philosophy",
+      "research/0067/prior-art",
+      "research/0067/maven-central-ingest",
+      "research/0067/type-mapping",
+      "research/0067/maven-publish-flow",
+      "research/0067/sigstore-attestation",
+      "research/0067/jni-bridge-protocol",
+      "research/0067/mochi-lock",
+      "research/0067/async-bridge",
+      "research/0067/generics-erasure",
+      "research/0067/risks-and-alternatives"
+    ]
+  },
+  {
     "label": "MEP-0071",
     "items": [
       "research/0071/index",


### PR DESCRIPTION
Closes #23010

## Summary

- Adds `website/docs/mep/mep-0067.md` with the normative MEP-67 specification (abstract, motivation, 7-section spec, 16-phase matrix all LANDED, non-goals, fixture corpus, acknowledgements)
- Adds 12 research notes under `website/docs/research/0067/` covering language surface, design philosophy, prior art, Maven Central ingest, type mapping, Maven publish flow, Sigstore attestation, JNI bridge protocol, mochi.lock integration, async CompletableFuture bridge, generics/erasure, and risks
- Updates `website/src/data/meps.json` with the MEP-67 entry (between MEP-66 and MEP-71)
- Updates `website/src/data/research-sidebar.json` with the MEP-67 research sidebar group

## Test plan

- [ ] Verify `mep-0067.md` renders correctly in the docs site
- [ ] Verify all 12 research notes are reachable from the sidebar
- [ ] Verify `meps.json` lists MEP-67 with correct fields