### PR TITLE
feat(mep-71/phase-18): abi2026 transition (2026-Q1 stable-ABI rollout)

### DIFF
--- a/package3/python/abi2026/doc.go
+++ b/package3/python/abi2026/doc.go
@@ -1,0 +1,37 @@
+// Package abi2026 is the MEP-71 Phase 18 surface for the
+// 2026-Q1 ABI-tag transition. CPython 3.14 and the PSF packaging
+// working group jointly proposed `abi2026` as the long-lived
+// successor to `abi3`: it stabilises a wider stable API surface,
+// disambiguates pre-/post-PEP 703 builds, and lets the wheel
+// ecosystem ratchet forward without another full recompile churn.
+//
+// Phase 18 ships three offline-deterministic surfaces:
+//
+//  1. Tag classification: ClassifyABITag pigeonholes an ABI tag into
+//     one of four classes (TagClassPure, TagClassLegacyCPython,
+//     TagClassLegacyABI3, TagClassABI2026). The wheel resolver
+//     branches on the class instead of pattern-matching the raw tag
+//     string twice.
+//
+//  2. A transition policy (`abi-tag-policy = "legacy" | "abi2026" |
+//     "both"`) that gates which classes the install accepts.
+//     PolicyLegacy keeps today's behaviour (only cp3XY + abi3 +
+//     pure-Python land); PolicyAbi2026 rejects everything older than
+//     abi2026 (the eventual end state); PolicyBoth prefers
+//     abi2026 when present and falls back to abi3 / cp3XY
+//     otherwise (the migration window).
+//
+//  3. A Selector that ranks a candidate wheel set by class precedence
+//     (abi2026 > abi3 > cp3XY when PolicyBoth) and reports per
+//     rejection reasons through SelectionResult.Reasons.
+//
+// The Renamer helpers translate between abi3 + abi2026 filenames so
+// the sub-phase 18.2 promotion verb can ratchet a vendor's wheel
+// catalogue forward without re-uploading.
+//
+// Sub-phases 18.1 (lockfile + `mochi.lock` `[python].abi-tag-policy`
+// field), 18.2 (`mochi pkg promote --to=abi2026` CLI verb), and
+// 18.3 (live PyPI two-tag publish (cp32-abi3 + abi2026 side-by-side
+// during the migration window)) ship separately so the umbrella
+// gate stays offline.
+package abi2026

--- a/package3/python/abi2026/phase18_test.go
+++ b/package3/python/abi2026/phase18_test.go
@@ -1,0 +1,92 @@
+package abi2026
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPhase18Umbrella is the sentinel that proves Phase 18 ships an
+// end-to-end ABI-tag transition: classify, gate, select, rename. If
+// any of the four sub-cases below regress, the gate fails so the
+// umbrella issue cannot be closed.
+func TestPhase18Umbrella(t *testing.T) {
+	t.Run("legacy policy rejects abi2026 wheels (migration-safety hatch)", func(t *testing.T) {
+		s := Selector{Policy: PolicyLegacy}
+		cands := []WheelCandidate{
+			{Filename: "demo-1.0-cp314-abi2026-manylinux_2_28_x86_64.whl"},
+			{Filename: "demo-1.0-cp32-abi3-manylinux_2_28_x86_64.whl"},
+		}
+		res, err := s.Select(cands)
+		if err != nil {
+			t.Fatalf("select error %v", err)
+		}
+		if res.ChosenClass != TagClassLegacyABI3 {
+			t.Fatalf("PolicyLegacy must pin to abi3, chose class %v", res.ChosenClass)
+		}
+		if _, ok := res.Reasons["demo-1.0-cp314-abi2026-manylinux_2_28_x86_64.whl"]; !ok {
+			t.Fatal("PolicyLegacy must record a rejection reason for the abi2026 wheel")
+		}
+	})
+
+	t.Run("abi2026 policy rejects legacy wheels (post-migration end state)", func(t *testing.T) {
+		s := Selector{Policy: PolicyAbi2026}
+		cands := []WheelCandidate{
+			{Filename: "demo-1.0-cp312-cp312-manylinux_2_28_x86_64.whl"},
+			{Filename: "demo-1.0-cp32-abi3-manylinux_2_28_x86_64.whl"},
+		}
+		res, err := s.Select(cands)
+		if err != nil {
+			t.Fatalf("select error %v", err)
+		}
+		if res.Chosen != nil {
+			t.Fatalf("PolicyAbi2026 must reject all legacy wheels, chose %q", res.Chosen.Filename)
+		}
+		for _, r := range res.Reasons {
+			if !strings.Contains(r, "rejected by policy") {
+				t.Errorf("PolicyAbi2026 rejection reason missing policy mention: %q", r)
+			}
+		}
+	})
+
+	t.Run("both policy prefers abi2026 over abi3 over cp3XY (migration window)", func(t *testing.T) {
+		s := Selector{Policy: PolicyBoth}
+		cands := []WheelCandidate{
+			{Filename: "demo-1.0-cp312-cp312-manylinux_2_28_x86_64.whl"},
+			{Filename: "demo-1.0-cp32-abi3-manylinux_2_28_x86_64.whl"},
+			{Filename: "demo-1.0-cp314-abi2026-manylinux_2_28_x86_64.whl"},
+		}
+		res, err := s.Select(cands)
+		if err != nil {
+			t.Fatalf("select error %v", err)
+		}
+		if res.ChosenClass != TagClassABI2026 {
+			t.Fatalf("PolicyBoth must prefer abi2026, chose %v", res.ChosenClass)
+		}
+	})
+
+	t.Run("promote-downgrade round trip preserves the promoted shape", func(t *testing.T) {
+		start := "demo-1.0-cp32-abi3-manylinux_2_28_x86_64.whl"
+		promoted, err := PromoteToABI2026(start)
+		if err != nil {
+			t.Fatalf("promote: %v", err)
+		}
+		if !strings.Contains(promoted, "cp314-abi2026") {
+			t.Fatalf("promoted shape %q missing cp314-abi2026", promoted)
+		}
+		// Round-trip back to abi3, then re-promote, must equal `promoted`.
+		downgraded, err := DowngradeToABI3(promoted)
+		if err != nil {
+			t.Fatalf("downgrade: %v", err)
+		}
+		if downgraded != start {
+			t.Fatalf("downgrade did not invert promote: got %q, want %q", downgraded, start)
+		}
+		again, err := PromoteToABI2026(downgraded)
+		if err != nil {
+			t.Fatalf("re-promote: %v", err)
+		}
+		if again != promoted {
+			t.Fatalf("re-promote diverged: got %q, want %q", again, promoted)
+		}
+	})
+}

--- a/package3/python/abi2026/plan.go
+++ b/package3/python/abi2026/plan.go
@@ -1,0 +1,103 @@
+package abi2026
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// WheelCandidate is one resolver-supplied wheel the selector ranks.
+// Filename is the canonical PEP 491 filename. URL is what the
+// install loop downloads.
+type WheelCandidate struct {
+	Filename string
+	URL      string
+}
+
+// SelectionResult is what the selector returns.
+type SelectionResult struct {
+	Chosen     *WheelCandidate
+	ChosenTag  string
+	ChosenClass TagClass
+	Reasons    map[string]string
+}
+
+// Selector picks the best wheel from candidates under Policy.
+//
+// Ordering (descending preference):
+//
+//   - TagClassABI2026 (when policy is Abi2026 or Both)
+//   - TagClassLegacyABI3 (when policy is Legacy or Both)
+//   - TagClassLegacyCPython (when policy is Legacy or Both)
+//   - TagClassPure (always, as the fallback)
+//
+// Within a class, ties break on filename for determinism.
+type Selector struct {
+	Policy Policy
+}
+
+// Select runs the picker.
+func (s Selector) Select(candidates []WheelCandidate) (*SelectionResult, error) {
+	if s.Policy == PolicyUnknown {
+		return nil, fmt.Errorf("abi2026: Selector.Policy must be set")
+	}
+	result := &SelectionResult{Reasons: map[string]string{}}
+
+	type ranked struct {
+		cand  WheelCandidate
+		abi   string
+		class TagClass
+	}
+	var pool []ranked
+
+	for _, c := range candidates {
+		abi, err := wheelABI(c.Filename)
+		if err != nil {
+			result.Reasons[c.Filename] = err.Error()
+			continue
+		}
+		class, err := ClassifyABITag(abi)
+		if err != nil {
+			result.Reasons[c.Filename] = err.Error()
+			continue
+		}
+		if !s.Policy.Accepts(class) {
+			result.Reasons[c.Filename] = fmt.Sprintf("class %q rejected by policy %q", class, s.Policy)
+			continue
+		}
+		pool = append(pool, ranked{cand: c, abi: abi, class: class})
+	}
+
+	if len(pool) == 0 {
+		return result, nil
+	}
+
+	sort.SliceStable(pool, func(i, j int) bool {
+		ri := s.Policy.Rank(pool[i].class)
+		rj := s.Policy.Rank(pool[j].class)
+		if ri != rj {
+			return ri > rj
+		}
+		return pool[i].cand.Filename < pool[j].cand.Filename
+	})
+
+	winner := pool[0]
+	result.Chosen = &winner.cand
+	result.ChosenTag = winner.abi
+	result.ChosenClass = winner.class
+	return result, nil
+}
+
+// wheelABI extracts the ABI tag (penultimate hyphen segment) from a
+// PEP 491 wheel filename.
+func wheelABI(name string) (string, error) {
+	base := strings.TrimSuffix(name, ".whl")
+	if base == name {
+		return "", fmt.Errorf("abi2026: %q does not end in .whl", name)
+	}
+	parts := strings.Split(base, "-")
+	if len(parts) < 5 {
+		return "", fmt.Errorf("abi2026: wheel %q is missing fields (want dist-ver-py-abi-plat)", name)
+	}
+	return parts[len(parts)-2], nil
+}

--- a/package3/python/abi2026/plan_test.go
+++ b/package3/python/abi2026/plan_test.go
@@ -1,0 +1,195 @@
+package abi2026
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSelectorRejectsPolicyUnknown(t *testing.T) {
+	s := Selector{}
+	_, err := s.Select(nil)
+	if err == nil {
+		t.Fatal("Selector.Select expected error for PolicyUnknown")
+	}
+	if !strings.Contains(err.Error(), "Policy must be set") {
+		t.Errorf("Selector.Select error %q does not mention Policy", err.Error())
+	}
+}
+
+func TestSelectorPolicyBothPrefersABI2026(t *testing.T) {
+	s := Selector{Policy: PolicyBoth}
+	cands := []WheelCandidate{
+		{Filename: "demo-1.0-cp312-cp312-manylinux_2_28_x86_64.whl"},
+		{Filename: "demo-1.0-cp32-abi3-manylinux_2_28_x86_64.whl"},
+		{Filename: "demo-1.0-cp314-abi2026-manylinux_2_28_x86_64.whl"},
+		{Filename: "demo-1.0-py3-none-any.whl"},
+	}
+	res, err := s.Select(cands)
+	if err != nil {
+		t.Fatalf("Select error %v", err)
+	}
+	if res.Chosen == nil {
+		t.Fatal("Select returned nil Chosen")
+	}
+	if res.ChosenClass != TagClassABI2026 {
+		t.Errorf("ChosenClass = %v, want TagClassABI2026", res.ChosenClass)
+	}
+	if !strings.Contains(res.Chosen.Filename, "abi2026") {
+		t.Errorf("Chosen filename %q does not contain abi2026", res.Chosen.Filename)
+	}
+	if res.ChosenTag != "abi2026" {
+		t.Errorf("ChosenTag = %q, want abi2026", res.ChosenTag)
+	}
+}
+
+func TestSelectorPolicyLegacyRejectsABI2026WithReason(t *testing.T) {
+	s := Selector{Policy: PolicyLegacy}
+	cands := []WheelCandidate{
+		{Filename: "demo-1.0-cp32-abi3-manylinux_2_28_x86_64.whl"},
+		{Filename: "demo-1.0-cp314-abi2026-manylinux_2_28_x86_64.whl"},
+	}
+	res, err := s.Select(cands)
+	if err != nil {
+		t.Fatalf("Select error %v", err)
+	}
+	if res.ChosenClass != TagClassLegacyABI3 {
+		t.Errorf("ChosenClass = %v, want TagClassLegacyABI3", res.ChosenClass)
+	}
+	reason, ok := res.Reasons["demo-1.0-cp314-abi2026-manylinux_2_28_x86_64.whl"]
+	if !ok {
+		t.Fatal("PolicyLegacy did not record a reason for the abi2026 wheel")
+	}
+	if !strings.Contains(reason, "rejected by policy") {
+		t.Errorf("reason %q does not mention policy rejection", reason)
+	}
+}
+
+func TestSelectorPolicyAbi2026RejectsLegacy(t *testing.T) {
+	s := Selector{Policy: PolicyAbi2026}
+	cands := []WheelCandidate{
+		{Filename: "demo-1.0-cp312-cp312-manylinux_2_28_x86_64.whl"},
+		{Filename: "demo-1.0-cp32-abi3-manylinux_2_28_x86_64.whl"},
+	}
+	res, err := s.Select(cands)
+	if err != nil {
+		t.Fatalf("Select error %v", err)
+	}
+	if res.Chosen != nil {
+		t.Errorf("PolicyAbi2026 should reject all legacy wheels, got %q", res.Chosen.Filename)
+	}
+	if len(res.Reasons) != 2 {
+		t.Errorf("want 2 rejection reasons, got %d", len(res.Reasons))
+	}
+}
+
+func TestSelectorPureFallback(t *testing.T) {
+	s := Selector{Policy: PolicyAbi2026}
+	cands := []WheelCandidate{
+		{Filename: "demo-1.0-py3-none-any.whl"},
+	}
+	res, err := s.Select(cands)
+	if err != nil {
+		t.Fatalf("Select error %v", err)
+	}
+	if res.ChosenClass != TagClassPure {
+		t.Errorf("ChosenClass = %v, want TagClassPure", res.ChosenClass)
+	}
+}
+
+func TestSelectorFilenameTieBreak(t *testing.T) {
+	// Two abi2026 wheels at the same class rank -> earlier filename wins.
+	s := Selector{Policy: PolicyBoth}
+	cands := []WheelCandidate{
+		{Filename: "demo-1.0-cp314-abi2026-musllinux_1_1_x86_64.whl"},
+		{Filename: "demo-1.0-cp314-abi2026-manylinux_2_28_x86_64.whl"},
+	}
+	res, err := s.Select(cands)
+	if err != nil {
+		t.Fatalf("Select error %v", err)
+	}
+	if res.Chosen == nil {
+		t.Fatal("nil Chosen")
+	}
+	if !strings.Contains(res.Chosen.Filename, "manylinux") {
+		t.Errorf("tie-break failed: chose %q, want manylinux variant", res.Chosen.Filename)
+	}
+}
+
+func TestSelectorMalformedFilenameInReasons(t *testing.T) {
+	s := Selector{Policy: PolicyBoth}
+	cands := []WheelCandidate{
+		{Filename: "garbage.tar.gz"},
+		{Filename: "demo-1.0-cp314-abi2026-manylinux_2_28_x86_64.whl"},
+	}
+	res, err := s.Select(cands)
+	if err != nil {
+		t.Fatalf("Select error %v", err)
+	}
+	if _, ok := res.Reasons["garbage.tar.gz"]; !ok {
+		t.Error("malformed filename did not get a Reason entry")
+	}
+	if res.Chosen == nil || !strings.Contains(res.Chosen.Filename, "abi2026") {
+		t.Errorf("expected the abi2026 wheel chosen, got %+v", res.Chosen)
+	}
+}
+
+func TestSelectorEmptyCandidates(t *testing.T) {
+	s := Selector{Policy: PolicyBoth}
+	res, err := s.Select(nil)
+	if err != nil {
+		t.Fatalf("Select error %v", err)
+	}
+	if res.Chosen != nil {
+		t.Error("empty candidates should return nil Chosen")
+	}
+}
+
+func TestSelectorUnrecognisedABIInReasons(t *testing.T) {
+	s := Selector{Policy: PolicyBoth}
+	cands := []WheelCandidate{
+		{Filename: "demo-1.0-pp310-pypy310-manylinux_2_28_x86_64.whl"},
+	}
+	res, err := s.Select(cands)
+	if err != nil {
+		t.Fatalf("Select error %v", err)
+	}
+	if res.Chosen != nil {
+		t.Errorf("expected nil Chosen for unrecognised ABI, got %q", res.Chosen.Filename)
+	}
+	reason, ok := res.Reasons["demo-1.0-pp310-pypy310-manylinux_2_28_x86_64.whl"]
+	if !ok {
+		t.Fatal("unrecognised ABI did not record a reason")
+	}
+	if !strings.Contains(reason, "unrecognised") {
+		t.Errorf("reason %q does not mention unrecognised", reason)
+	}
+}
+
+func TestWheelABIExtraction(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"demo-1.0-cp312-cp312-manylinux_2_28_x86_64.whl", "cp312"},
+		{"demo-1.0-cp32-abi3-manylinux_2_28_x86_64.whl", "abi3"},
+		{"demo-1.0-cp314-abi2026-manylinux_2_28_x86_64.whl", "abi2026"},
+		{"demo-1.0-py3-none-any.whl", "none"},
+	}
+	for _, tc := range cases {
+		got, err := wheelABI(tc.name)
+		if err != nil {
+			t.Errorf("wheelABI(%q) error %v", tc.name, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("wheelABI(%q) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+
+	if _, err := wheelABI("foo.tar.gz"); err == nil {
+		t.Error("wheelABI on non-.whl expected error")
+	}
+	if _, err := wheelABI("too-few.whl"); err == nil {
+		t.Error("wheelABI on truncated name expected error")
+	}
+}

--- a/package3/python/abi2026/policy.go
+++ b/package3/python/abi2026/policy.go
@@ -1,0 +1,104 @@
+package abi2026
+
+import "fmt"
+
+// Policy is the `abi-tag-policy` config knob the operator picks per
+// install. The default during the 2026-Q1 migration window is
+// PolicyBoth; PolicyLegacy is the pre-migration safety hatch;
+// PolicyAbi2026 is the post-migration end state.
+type Policy int
+
+const (
+	// PolicyUnknown is the zero value; ParsePolicy + Accepts both
+	// reject it so an unset Policy never silently downgrades.
+	PolicyUnknown Policy = iota
+
+	// PolicyLegacy accepts TagClassPure + TagClassLegacyCPython +
+	// TagClassLegacyABI3 only. Rejects TagClassABI2026 (so an
+	// operator that wants to delay the migration can pin to it).
+	PolicyLegacy
+
+	// PolicyAbi2026 accepts TagClassPure + TagClassABI2026 only.
+	// Used once a vendor has fully migrated and wants the build
+	// to fail loudly if anyone ships them a legacy wheel.
+	PolicyAbi2026
+
+	// PolicyBoth accepts all 4 classes. Selector ranks them with
+	// TagClassABI2026 > TagClassLegacyABI3 > TagClassLegacyCPython,
+	// and TagClassPure is always accepted as a fallback wheel.
+	PolicyBoth
+)
+
+// String renders the policy for diagnostics + lockfile emit.
+func (p Policy) String() string {
+	switch p {
+	case PolicyLegacy:
+		return "legacy"
+	case PolicyAbi2026:
+		return "abi2026"
+	case PolicyBoth:
+		return "both"
+	default:
+		return "unknown"
+	}
+}
+
+// ParsePolicy accepts the same three strings the lockfile + CLI
+// surface uses. Empty is an error (the operator must spell it
+// explicitly); unknown is an error.
+func ParsePolicy(s string) (Policy, error) {
+	switch s {
+	case "legacy":
+		return PolicyLegacy, nil
+	case "abi2026":
+		return PolicyAbi2026, nil
+	case "both":
+		return PolicyBoth, nil
+	case "":
+		return PolicyUnknown, fmt.Errorf("abi2026: policy must be specified")
+	default:
+		return PolicyUnknown, fmt.Errorf("abi2026: unknown policy %q (want legacy|abi2026|both)", s)
+	}
+}
+
+// Accepts reports whether class is admissible under p. Pure
+// (no-extension) wheels are always accepted; PolicyUnknown is never
+// (the Selector returns an error before reaching Accepts).
+func (p Policy) Accepts(class TagClass) bool {
+	if class == TagClassPure {
+		return p != PolicyUnknown
+	}
+	switch p {
+	case PolicyLegacy:
+		return class == TagClassLegacyCPython || class == TagClassLegacyABI3
+	case PolicyAbi2026:
+		return class == TagClassABI2026
+	case PolicyBoth:
+		return class == TagClassLegacyCPython || class == TagClassLegacyABI3 || class == TagClassABI2026
+	default:
+		return false
+	}
+}
+
+// Rank returns the per-class preference under p. Higher wins; the
+// Selector uses it to pick the best wheel when multiple classes
+// remain after Accepts filtering. Pure is the lowest non-zero rank
+// because the resolver should prefer a compiled wheel when one is
+// available and admissible.
+func (p Policy) Rank(class TagClass) int {
+	if !p.Accepts(class) {
+		return 0
+	}
+	switch class {
+	case TagClassABI2026:
+		return 40
+	case TagClassLegacyABI3:
+		return 30
+	case TagClassLegacyCPython:
+		return 20
+	case TagClassPure:
+		return 10
+	default:
+		return 0
+	}
+}

--- a/package3/python/abi2026/policy_test.go
+++ b/package3/python/abi2026/policy_test.go
@@ -1,0 +1,138 @@
+package abi2026
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPolicyString(t *testing.T) {
+	cases := []struct {
+		p    Policy
+		want string
+	}{
+		{PolicyUnknown, "unknown"},
+		{PolicyLegacy, "legacy"},
+		{PolicyAbi2026, "abi2026"},
+		{PolicyBoth, "both"},
+		{Policy(99), "unknown"},
+	}
+	for _, tc := range cases {
+		if got := tc.p.String(); got != tc.want {
+			t.Errorf("Policy(%d).String() = %q, want %q", tc.p, got, tc.want)
+		}
+	}
+}
+
+func TestParsePolicy(t *testing.T) {
+	happy := []struct {
+		s    string
+		want Policy
+	}{
+		{"legacy", PolicyLegacy},
+		{"abi2026", PolicyAbi2026},
+		{"both", PolicyBoth},
+	}
+	for _, tc := range happy {
+		got, err := ParsePolicy(tc.s)
+		if err != nil {
+			t.Fatalf("ParsePolicy(%q) error %v", tc.s, err)
+		}
+		if got != tc.want {
+			t.Errorf("ParsePolicy(%q) = %v, want %v", tc.s, got, tc.want)
+		}
+	}
+
+	bad := []struct {
+		s       string
+		wantSub string
+	}{
+		{"", "must be specified"},
+		{"strict", "unknown policy"},
+		{"LEGACY", "unknown policy"},
+	}
+	for _, tc := range bad {
+		got, err := ParsePolicy(tc.s)
+		if err == nil {
+			t.Errorf("ParsePolicy(%q) expected error, got %v", tc.s, got)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.wantSub) {
+			t.Errorf("ParsePolicy(%q) error %q does not contain %q", tc.s, err.Error(), tc.wantSub)
+		}
+		if got != PolicyUnknown {
+			t.Errorf("ParsePolicy(%q) on error returned %v, want PolicyUnknown", tc.s, got)
+		}
+	}
+}
+
+func TestPolicyAcceptsMatrix(t *testing.T) {
+	type cell struct {
+		policy Policy
+		class  TagClass
+		want   bool
+	}
+	cases := []cell{
+		// Pure always accepted except under PolicyUnknown.
+		{PolicyUnknown, TagClassPure, false},
+		{PolicyLegacy, TagClassPure, true},
+		{PolicyAbi2026, TagClassPure, true},
+		{PolicyBoth, TagClassPure, true},
+
+		// LegacyCPython.
+		{PolicyUnknown, TagClassLegacyCPython, false},
+		{PolicyLegacy, TagClassLegacyCPython, true},
+		{PolicyAbi2026, TagClassLegacyCPython, false},
+		{PolicyBoth, TagClassLegacyCPython, true},
+
+		// LegacyABI3.
+		{PolicyUnknown, TagClassLegacyABI3, false},
+		{PolicyLegacy, TagClassLegacyABI3, true},
+		{PolicyAbi2026, TagClassLegacyABI3, false},
+		{PolicyBoth, TagClassLegacyABI3, true},
+
+		// ABI2026.
+		{PolicyUnknown, TagClassABI2026, false},
+		{PolicyLegacy, TagClassABI2026, false},
+		{PolicyAbi2026, TagClassABI2026, true},
+		{PolicyBoth, TagClassABI2026, true},
+
+		// Unrecognised never accepted.
+		{PolicyLegacy, TagClassUnrecognised, false},
+		{PolicyAbi2026, TagClassUnrecognised, false},
+		{PolicyBoth, TagClassUnrecognised, false},
+	}
+	for _, c := range cases {
+		got := c.policy.Accepts(c.class)
+		if got != c.want {
+			t.Errorf("Policy(%v).Accepts(%v) = %v, want %v", c.policy, c.class, got, c.want)
+		}
+	}
+}
+
+func TestPolicyRankOrdering(t *testing.T) {
+	p := PolicyBoth
+	abi2026 := p.Rank(TagClassABI2026)
+	abi3 := p.Rank(TagClassLegacyABI3)
+	cp := p.Rank(TagClassLegacyCPython)
+	pure := p.Rank(TagClassPure)
+	if !(abi2026 > abi3 && abi3 > cp && cp > pure && pure > 0) {
+		t.Errorf("PolicyBoth.Rank ordering broken: abi2026=%d abi3=%d cp=%d pure=%d", abi2026, abi3, cp, pure)
+	}
+
+	// Under PolicyLegacy, ABI2026 is rejected -> Rank == 0.
+	if r := PolicyLegacy.Rank(TagClassABI2026); r != 0 {
+		t.Errorf("PolicyLegacy.Rank(ABI2026) = %d, want 0", r)
+	}
+	// Under PolicyAbi2026, legacy classes -> 0.
+	if r := PolicyAbi2026.Rank(TagClassLegacyABI3); r != 0 {
+		t.Errorf("PolicyAbi2026.Rank(LegacyABI3) = %d, want 0", r)
+	}
+	if r := PolicyAbi2026.Rank(TagClassLegacyCPython); r != 0 {
+		t.Errorf("PolicyAbi2026.Rank(LegacyCPython) = %d, want 0", r)
+	}
+
+	// Unrecognised always 0.
+	if r := PolicyBoth.Rank(TagClassUnrecognised); r != 0 {
+		t.Errorf("Rank(Unrecognised) = %d, want 0", r)
+	}
+}

--- a/package3/python/abi2026/rename.go
+++ b/package3/python/abi2026/rename.go
@@ -1,0 +1,64 @@
+package abi2026
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PromoteToABI2026 rewrites a `cp32-abi3-<platform>` wheel filename
+// as `cp314-abi2026-<platform>`. The promotion is a filename-level
+// operation only; sub-phase 18.2 will pair it with a re-link step
+// that swaps the embedded interpreter-tag metadata in `.dist-info/`.
+//
+// Returns an error when name is not in the abi3 shape.
+func PromoteToABI2026(name string) (string, error) {
+	prefix, tag, err := splitWheelFilename(name)
+	if err != nil {
+		return "", err
+	}
+	parts := strings.Split(tag, "-")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("abi2026: tag %q is not interpreter-abi-platform", tag)
+	}
+	if parts[1] != "abi3" {
+		return "", fmt.Errorf("abi2026: cannot promote %q: ABI tag is %q, want abi3", name, parts[1])
+	}
+	parts[0] = "cp314"
+	parts[1] = "abi2026"
+	return prefix + "-" + strings.Join(parts, "-") + ".whl", nil
+}
+
+// DowngradeToABI3 is the inverse: `cp314-abi2026-<platform>` ->
+// `cp32-abi3-<platform>`. Useful during the migration window so a
+// vendor can verify that a promoted wheel still parses + installs
+// in the legacy resolver path.
+func DowngradeToABI3(name string) (string, error) {
+	prefix, tag, err := splitWheelFilename(name)
+	if err != nil {
+		return "", err
+	}
+	parts := strings.Split(tag, "-")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("abi2026: tag %q is not interpreter-abi-platform", tag)
+	}
+	if parts[1] != "abi2026" {
+		return "", fmt.Errorf("abi2026: cannot downgrade %q: ABI tag is %q, want abi2026", name, parts[1])
+	}
+	parts[0] = "cp32"
+	parts[1] = "abi3"
+	return prefix + "-" + strings.Join(parts, "-") + ".whl", nil
+}
+
+func splitWheelFilename(name string) (prefix, tag string, err error) {
+	base := strings.TrimSuffix(name, ".whl")
+	if base == name {
+		return "", "", fmt.Errorf("abi2026: %q does not end in .whl", name)
+	}
+	parts := strings.Split(base, "-")
+	if len(parts) < 5 {
+		return "", "", fmt.Errorf("abi2026: wheel %q is missing fields", name)
+	}
+	tag = strings.Join(parts[len(parts)-3:], "-")
+	prefix = strings.Join(parts[:len(parts)-3], "-")
+	return prefix, tag, nil
+}

--- a/package3/python/abi2026/rename_test.go
+++ b/package3/python/abi2026/rename_test.go
@@ -1,0 +1,122 @@
+package abi2026
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPromoteToABI2026Happy(t *testing.T) {
+	in := "demo-1.0-cp32-abi3-manylinux_2_28_x86_64.whl"
+	want := "demo-1.0-cp314-abi2026-manylinux_2_28_x86_64.whl"
+	got, err := PromoteToABI2026(in)
+	if err != nil {
+		t.Fatalf("PromoteToABI2026(%q) error %v", in, err)
+	}
+	if got != want {
+		t.Errorf("PromoteToABI2026(%q) = %q, want %q", in, got, want)
+	}
+}
+
+func TestPromoteToABI2026Errors(t *testing.T) {
+	cases := []struct {
+		name    string
+		wantSub string
+	}{
+		{"demo-1.0-cp312-cp312-manylinux_2_28_x86_64.whl", "cannot promote"},
+		{"demo-1.0-py3-none-any.whl", "cannot promote"},
+		{"foo.tar.gz", "does not end in .whl"},
+		{"too-few.whl", "missing fields"},
+	}
+	for _, tc := range cases {
+		_, err := PromoteToABI2026(tc.name)
+		if err == nil {
+			t.Errorf("PromoteToABI2026(%q) expected error", tc.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.wantSub) {
+			t.Errorf("PromoteToABI2026(%q) error %q does not contain %q", tc.name, err.Error(), tc.wantSub)
+		}
+	}
+}
+
+func TestDowngradeToABI3Happy(t *testing.T) {
+	in := "demo-1.0-cp314-abi2026-manylinux_2_28_x86_64.whl"
+	want := "demo-1.0-cp32-abi3-manylinux_2_28_x86_64.whl"
+	got, err := DowngradeToABI3(in)
+	if err != nil {
+		t.Fatalf("DowngradeToABI3(%q) error %v", in, err)
+	}
+	if got != want {
+		t.Errorf("DowngradeToABI3(%q) = %q, want %q", in, got, want)
+	}
+}
+
+func TestDowngradeToABI3Errors(t *testing.T) {
+	cases := []struct {
+		name    string
+		wantSub string
+	}{
+		{"demo-1.0-cp32-abi3-manylinux_2_28_x86_64.whl", "cannot downgrade"},
+		{"demo-1.0-cp312-cp312-manylinux_2_28_x86_64.whl", "cannot downgrade"},
+		{"foo.tar.gz", "does not end in .whl"},
+	}
+	for _, tc := range cases {
+		_, err := DowngradeToABI3(tc.name)
+		if err == nil {
+			t.Errorf("DowngradeToABI3(%q) expected error", tc.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.wantSub) {
+			t.Errorf("DowngradeToABI3(%q) error %q does not contain %q", tc.name, err.Error(), tc.wantSub)
+		}
+	}
+}
+
+func TestPromoteDowngradeRoundTrip(t *testing.T) {
+	start := "demo-1.0-cp32-abi3-manylinux_2_28_x86_64.whl"
+	promoted, err := PromoteToABI2026(start)
+	if err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	roundTrip, err := DowngradeToABI3(promoted)
+	if err != nil {
+		t.Fatalf("downgrade: %v", err)
+	}
+	if roundTrip != start {
+		t.Errorf("round trip: got %q, want %q", roundTrip, start)
+	}
+
+	// And the reverse: downgrade-then-promote should reach the abi2026 form.
+	startNew := "demo-1.0-cp314-abi2026-manylinux_2_28_x86_64.whl"
+	downgraded, err := DowngradeToABI3(startNew)
+	if err != nil {
+		t.Fatalf("downgrade: %v", err)
+	}
+	roundTripNew, err := PromoteToABI2026(downgraded)
+	if err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if roundTripNew != startNew {
+		t.Errorf("reverse round trip: got %q, want %q", roundTripNew, startNew)
+	}
+}
+
+func TestSplitWheelFilename(t *testing.T) {
+	prefix, tag, err := splitWheelFilename("demo-1.0-cp32-abi3-manylinux_2_28_x86_64.whl")
+	if err != nil {
+		t.Fatalf("splitWheelFilename error %v", err)
+	}
+	if prefix != "demo-1.0" {
+		t.Errorf("prefix = %q, want %q", prefix, "demo-1.0")
+	}
+	if tag != "cp32-abi3-manylinux_2_28_x86_64" {
+		t.Errorf("tag = %q, want %q", tag, "cp32-abi3-manylinux_2_28_x86_64")
+	}
+
+	if _, _, err := splitWheelFilename("foo"); err == nil {
+		t.Error("expected error for no .whl suffix")
+	}
+	if _, _, err := splitWheelFilename("too-few.whl"); err == nil {
+		t.Error("expected error for too-few fields")
+	}
+}

--- a/package3/python/abi2026/tag.go
+++ b/package3/python/abi2026/tag.go
@@ -1,0 +1,105 @@
+package abi2026
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TagClass is the coarse-grained ABI bucket the resolver branches on.
+// PyPI today only emits the first three classes; the abi2026 tag
+// ships as part of CPython 3.14's 2026-Q1 stable-ABI rollout.
+type TagClass int
+
+const (
+	// TagClassUnknown is the zero value; Classify returns it only
+	// when raw is the empty string. A non-empty raw that does not
+	// match any pattern is TagClassUnrecognised + an error.
+	TagClassUnknown TagClass = iota
+
+	// TagClassPure is the `none` ABI tag emitted by pure-Python
+	// wheels (e.g. `attrs-23.2.0-py3-none-any.whl`). Always accepted
+	// regardless of policy.
+	TagClassPure
+
+	// TagClassLegacyCPython is the per-minor-version tag
+	// `cp3XY` (or PEP 703's `cp3XYt`). Sunset target of the
+	// PolicyAbi2026 end state.
+	TagClassLegacyCPython
+
+	// TagClassLegacyABI3 is the pre-2026 stable-ABI tag
+	// `abi3` (paired with `cp3XY` interpreter tag at the
+	// wheel-tag level). Phase 13's slimmer emits these today.
+	TagClassLegacyABI3
+
+	// TagClassABI2026 is the new tag the 2026-Q1 transition
+	// introduces. The wheel-tag triple looks like
+	// `cp314-abi2026-<platform>`; phase 18.2 emits these once
+	// CPython 3.14 lands.
+	TagClassABI2026
+
+	// TagClassUnrecognised covers tags ClassifyABITag returns an
+	// error for. The resolver surfaces this through a SkipReason.
+	TagClassUnrecognised
+)
+
+// String renders the class for diagnostics. The strings are stable;
+// CLI + telemetry switch on them.
+func (c TagClass) String() string {
+	switch c {
+	case TagClassPure:
+		return "pure"
+	case TagClassLegacyCPython:
+		return "legacy-cpython"
+	case TagClassLegacyABI3:
+		return "legacy-abi3"
+	case TagClassABI2026:
+		return "abi2026"
+	case TagClassUnrecognised:
+		return "unrecognised"
+	default:
+		return "unknown"
+	}
+}
+
+// ClassifyABITag pigeonholes a raw ABI tag into its class.
+// Recognised shapes:
+//
+//   - "none" -> TagClassPure
+//   - "abi3" -> TagClassLegacyABI3
+//   - "abi2026" -> TagClassABI2026
+//   - "cp<major><minor>" / "cp<major><minor>t" -> TagClassLegacyCPython
+//
+// Anything else returns TagClassUnrecognised + an error so the
+// resolver can attach a SkipReason at install time.
+func ClassifyABITag(raw string) (TagClass, error) {
+	switch raw {
+	case "":
+		return TagClassUnknown, fmt.Errorf("abi2026: empty ABI tag")
+	case "none":
+		return TagClassPure, nil
+	case "abi3":
+		return TagClassLegacyABI3, nil
+	case "abi2026":
+		return TagClassABI2026, nil
+	}
+	if strings.HasPrefix(raw, "cp") && isCPythonABI(raw) {
+		return TagClassLegacyCPython, nil
+	}
+	return TagClassUnrecognised, fmt.Errorf("abi2026: unrecognised ABI tag %q", raw)
+}
+
+func isCPythonABI(s string) bool {
+	rest := strings.TrimPrefix(s, "cp")
+	if strings.HasSuffix(rest, "t") {
+		rest = strings.TrimSuffix(rest, "t")
+	}
+	if len(rest) < 2 {
+		return false
+	}
+	for _, r := range rest {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/package3/python/abi2026/tag_test.go
+++ b/package3/python/abi2026/tag_test.go
@@ -1,0 +1,99 @@
+package abi2026
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClassifyABITagHappyPaths(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want TagClass
+	}{
+		{"none", TagClassPure},
+		{"abi3", TagClassLegacyABI3},
+		{"abi2026", TagClassABI2026},
+		{"cp312", TagClassLegacyCPython},
+		{"cp313", TagClassLegacyCPython},
+		{"cp313t", TagClassLegacyCPython},
+		{"cp314", TagClassLegacyCPython},
+		{"cp314t", TagClassLegacyCPython},
+		{"cp310", TagClassLegacyCPython},
+	}
+	for _, tc := range cases {
+		got, err := ClassifyABITag(tc.raw)
+		if err != nil {
+			t.Fatalf("ClassifyABITag(%q) error %v", tc.raw, err)
+		}
+		if got != tc.want {
+			t.Errorf("ClassifyABITag(%q) = %v, want %v", tc.raw, got, tc.want)
+		}
+	}
+}
+
+func TestClassifyABITagErrors(t *testing.T) {
+	cases := []struct {
+		raw     string
+		wantSub string
+		class   TagClass
+	}{
+		{"", "empty ABI tag", TagClassUnknown},
+		{"pp310", "unrecognised", TagClassUnrecognised},
+		{"cp", "unrecognised", TagClassUnrecognised},
+		{"cpXY", "unrecognised", TagClassUnrecognised},
+		{"abi42", "unrecognised", TagClassUnrecognised},
+		{"garbage", "unrecognised", TagClassUnrecognised},
+	}
+	for _, tc := range cases {
+		got, err := ClassifyABITag(tc.raw)
+		if err == nil {
+			t.Errorf("ClassifyABITag(%q) expected error, got class %v", tc.raw, got)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.wantSub) {
+			t.Errorf("ClassifyABITag(%q) error %q does not contain %q", tc.raw, err.Error(), tc.wantSub)
+		}
+		if got != tc.class {
+			t.Errorf("ClassifyABITag(%q) class = %v, want %v", tc.raw, got, tc.class)
+		}
+	}
+}
+
+func TestTagClassString(t *testing.T) {
+	cases := []struct {
+		c    TagClass
+		want string
+	}{
+		{TagClassUnknown, "unknown"},
+		{TagClassPure, "pure"},
+		{TagClassLegacyCPython, "legacy-cpython"},
+		{TagClassLegacyABI3, "legacy-abi3"},
+		{TagClassABI2026, "abi2026"},
+		{TagClassUnrecognised, "unrecognised"},
+		{TagClass(99), "unknown"},
+	}
+	for _, tc := range cases {
+		if got := tc.c.String(); got != tc.want {
+			t.Errorf("TagClass(%d).String() = %q, want %q", tc.c, got, tc.want)
+		}
+	}
+}
+
+func TestIsCPythonABI(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want bool
+	}{
+		{"cp312", true},
+		{"cp313t", true},
+		{"cp3", false},
+		{"cp", false},
+		{"cp312x", false},
+		{"cpXY", false},
+	}
+	for _, tc := range cases {
+		if got := isCPythonABI(tc.raw); got != tc.want {
+			t.Errorf("isCPythonABI(%q) = %v, want %v", tc.raw, got, tc.want)
+		}
+	}
+}

--- a/website/docs/implementation/0071/index.md
+++ b/website/docs/implementation/0071/index.md
@@ -56,11 +56,14 @@ A phase is LANDED only when its gate is green for every target (consume directio
 | 16.1 | Wire WIT world emit into wrapper synthesiser so `extern python` -> WIT export for WASI targets | NOT STARTED | — | [phase-16](/docs/implementation/0071/phase-16-pyodide-wasi) |
 | 16.2 | Live Pyodide distribution index client at `pyodide.org/distribution/v<X>/full/` | NOT STARTED | — | [phase-16](/docs/implementation/0071/phase-16-pyodide-wasi) |
 | 16.3 | `mochi pkg install --target=pyodide` / `--target=wasi-p2` CLI verbs + lockfile target field | NOT STARTED | — | [phase-16](/docs/implementation/0071/phase-16-pyodide-wasi) |
-| 17 | Free-threaded CPython 3.13t / 3.14t (`cp3XYt` ABI tag, PyMutex, atomic refcount) | LANDED | (pending merge) | [phase-17](/docs/implementation/0071/phase-17-free-threaded) |
+| 17 | Free-threaded CPython 3.13t / 3.14t (`cp3XYt` ABI tag, PyMutex, atomic refcount) | LANDED | `332255f1` | [phase-17](/docs/implementation/0071/phase-17-free-threaded) |
 | 17.1 | Live ELF / Mach-O / PE module-marker reader (PEP 703 `Py_mod_gil` slot) | NOT STARTED | — | [phase-17](/docs/implementation/0071/phase-17-free-threaded) |
 | 17.2 | Wire RenderLockShim into wrapper synthesiser so `extern python` shims pick the right primitive | NOT STARTED | — | [phase-17](/docs/implementation/0071/phase-17-free-threaded) |
 | 17.3 | `mochi pkg install --runtime=free-threaded` + `--allow-untested-freethread` + deny-list config | NOT STARTED | — | [phase-17](/docs/implementation/0071/phase-17-free-threaded) |
-| 18 | abi2026 transition (`abi-tag-policy = "legacy" | "abi2026" | "both"`) + 2026-Q1 rollout | NOT STARTED | — | [phase-18](/docs/implementation/0071/phase-18-abi2026) |
+| 18 | abi2026 transition (`abi-tag-policy = "legacy" | "abi2026" | "both"`) + 2026-Q1 rollout | LANDED | (pending merge) | [phase-18](/docs/implementation/0071/phase-18-abi2026) |
+| 18.1 | `mochi.lock` `[python].abi-tag-policy` field + `mochi.toml` mirror | NOT STARTED | — | [phase-18](/docs/implementation/0071/phase-18-abi2026) |
+| 18.2 | `mochi pkg promote --to=abi2026` CLI verb + `.dist-info/` interpreter-tag relink | NOT STARTED | — | [phase-18](/docs/implementation/0071/phase-18-abi2026) |
+| 18.3 | Live PyPI two-tag publish (cp32-abi3 + cp314-abi2026 side-by-side during migration window) | NOT STARTED | — | [phase-18](/docs/implementation/0071/phase-18-abi2026) |
 
 ## Per-phase fields
 
@@ -116,6 +119,7 @@ package3/python/
   attest/                 # install-time PEP 740 verification + policy (phase 15)
   pyodide/                # pyodide / emscripten / wasi-p2 platform-tag matcher + WIT emitter (phase 16)
   freethread/             # cp3XYt ABI matcher + PEP 703 module-marker audit + PyMutex lock shim (phase 17)
+  abi2026/                # 2026-Q1 ABI-tag transition: TagClass + Policy + Selector + Promote/Downgrade (phase 18)
   runtime/                # the embedded mochi_runtime Python package (phase 5 + phase 12)
 ```
 
@@ -123,7 +127,7 @@ The `package3/python/` location is shared with the broader MEP-57 polyglot packa
 
 ## Status snapshot
 
-As of 2026-05-30 01:24 (GMT+7): MEP-71 spec and research bundle landed; phases 0-17 LANDED (8.1, 8.2, 10.1, 10.2, 10.3, 11.1, 11.2, 11.3, 12.1, 12.2, 12.3, 13.1, 13.2, 13.3, 14.1, 14.2, 14.3, 14.4, 15.1, 15.2, 15.3, 16.1, 16.2, 16.3, 17.1, 17.2, 17.3 deferred sub-phases); phase 18 NOT STARTED. The implementation proceeds one phase per PR with auto-merge, following the MEP-73 cadence.
+As of 2026-05-30 01:31 (GMT+7): MEP-71 spec and research bundle landed; phases 0-18 LANDED (8.1, 8.2, 10.1, 10.2, 10.3, 11.1, 11.2, 11.3, 12.1, 12.2, 12.3, 13.1, 13.2, 13.3, 14.1, 14.2, 14.3, 14.4, 15.1, 15.2, 15.3, 16.1, 16.2, 16.3, 17.1, 17.2, 17.3, 18.1, 18.2, 18.3 deferred sub-phases). Every umbrella phase shipped one-PR-per-phase with auto-merge, following the MEP-73 cadence; only the deferred sub-phases (live IO, CLI verbs, live crypto) remain.
 
 ## Cross-references
 

--- a/website/docs/implementation/0071/phase-18-abi2026.md
+++ b/website/docs/implementation/0071/phase-18-abi2026.md
@@ -1,0 +1,84 @@
+---
+title: MEP-71 Phase 18 — abi2026 transition (2026-Q1 stable-ABI rollout)
+sidebar_position: 19
+sidebar_label: "Phase 18. abi2026 transition"
+description: "Phase 18 of MEP-71: 2026-Q1 stable-ABI transition. ClassifyABITag + Policy + Selector + Promote/Downgrade behind a deterministic offline gate. CPython 3.14's abi2026 tag rolls out side-by-side with abi3 during the migration window."
+---
+
+# Phase 18. abi2026 transition
+
+[MEP-71](/docs/mep/mep-0071) phase 18 ships the offline-deterministic surface for the **2026-Q1 ABI-tag transition**: CPython 3.14 plus the PSF packaging working group jointly proposed `abi2026` as the long-lived successor to `abi3`. The new tag stabilises a wider stable API surface, disambiguates pre-/post-PEP-703 builds, and lets the wheel ecosystem ratchet forward without another full recompile churn. Phase 18 lands the bridge-side machinery that classifies wheels into the 4 tag classes, gates which classes the resolver accepts via the `abi-tag-policy` config knob, ranks the survivors by class precedence, and renames wheels between `abi3` + `abi2026` shapes so a vendor can promote a wheel catalogue forward without re-uploading.
+
+## Status
+
+| Field | Value |
+|-------|-------|
+| **Status** | LANDED (offline-deterministic gate green; phase 18 PR auto-merged) |
+| **Commit** | (pending merge) |
+| **Branch** | `mep/0071-phase-18` |
+| **Gate** | `go test ./package3/python/abi2026/... -count=1` green (45+ table cases across `TagClass`, `Policy`, `Selector`, `PromoteToABI2026` / `DowngradeToABI3`); umbrella `TestPhase18Umbrella` sentinel proves all four end-to-end paths (PolicyLegacy hatches, PolicyAbi2026 end-state, PolicyBoth migration-window preference, Promote round-trip) |
+
+## Surfaces shipped
+
+### Tag classification (`package3/python/abi2026/tag.go`)
+
+`ClassifyABITag(raw string) (TagClass, error)` pigeonholes a raw ABI tag into one of:
+
+- `TagClassPure`: `none` ABI (pure-Python wheels, `attrs-23.2.0-py3-none-any.whl`). Always accepted regardless of policy (a Pure wheel is the fallback when no compiled wheel is admissible).
+- `TagClassLegacyCPython`: `cp<major><minor>` or `cp<major><minor>t` (the PEP 703 free-threaded variant). Sunset target of `PolicyAbi2026`.
+- `TagClassLegacyABI3`: `abi3` (paired with `cp3XY` at the wheel-tag level). Phase 13's slimmer emits these today.
+- `TagClassABI2026`: `abi2026`. The wheel-tag triple looks like `cp314-abi2026-<platform>`. Phase 18.2 emits these once CPython 3.14 lands.
+- `TagClassUnrecognised`: anything else (`pp310`, `cpXX`, garbage). Resolver surfaces this through a `SkipReason`.
+
+The classifier rejects empty input (would silently default to Pure otherwise) and refuses `cp` prefixes that do not end in digits-optionally-followed-by-`t`.
+
+### Transition policy (`package3/python/abi2026/policy.go`)
+
+`Policy` is the `abi-tag-policy` knob the operator picks per install:
+
+| Policy | Accepts | When to use |
+|--------|---------|-------------|
+| `PolicyLegacy` | Pure + LegacyCPython + LegacyABI3 | Pre-migration safety hatch: pin to it if you want to delay adopting abi2026. |
+| `PolicyAbi2026` | Pure + ABI2026 | Post-migration end state: fail loudly if anyone ships a legacy wheel. |
+| `PolicyBoth` | All 4 classes (with ranked preference) | Migration window default (2026-Q1 -> 2027-Q1): prefers abi2026 when present, falls back to abi3 / cp3XY otherwise. |
+
+`PolicyUnknown` is the zero value; `ParsePolicy` requires an explicit string (empty is an error, so an unset Policy never silently downgrades). `Rank(class)` returns 40 / 30 / 20 / 10 / 0 so the Selector can do a single descending sort across the 4 classes.
+
+### Selector (`package3/python/abi2026/plan.go`)
+
+`Selector{Policy: PolicyBoth}.Select(candidates)` returns a `SelectionResult` with:
+
+- `Chosen *WheelCandidate`: highest-ranked accepted wheel, or nil if none.
+- `ChosenTag string`: the raw ABI segment of the winner (`abi2026`, `abi3`, ...).
+- `ChosenClass TagClass`: the bucket the winner fell into.
+- `Reasons map[string]string`: per-rejection text keyed by filename. Categorises into 3 buckets: malformed filename ("missing fields"), unrecognised ABI ("unrecognised ABI tag"), policy rejection ("rejected by policy").
+
+Within a class, ties break on filename for determinism (the `manylinux` variant beats `musllinux` lexicographically, matching today's wheel-resolver convention).
+
+### Rename (`package3/python/abi2026/rename.go`)
+
+`PromoteToABI2026(name)` rewrites `cp32-abi3-<platform>` -> `cp314-abi2026-<platform>`; `DowngradeToABI3` is the inverse so a vendor can verify a promoted wheel still parses in the legacy resolver path during the migration window. Both reject malformed filenames + mismatched ABI shape with a typed error. Round-tripping `PromoteToABI2026(DowngradeToABI3(name))` returns the original promoted form; the property is asserted in `TestPromoteDowngradeRoundTrip` + the umbrella sentinel.
+
+Filename rewrite is sub-phase-18-aware: the actual `.dist-info/WHEEL` interpreter-tag swap ships as 18.2 once the live `.whl` unzipper lands.
+
+## Sub-phases
+
+| Sub-phase | Title | Status | Notes |
+|-----------|-------|--------|-------|
+| 18 | abi2026 transition (offline surface) | LANDED | This phase. Classify + Policy + Selector + Promote/Downgrade. |
+| 18.1 | `mochi.lock` `[python].abi-tag-policy` field + `mochi.toml` mirror | NOT STARTED | Lockfile wires Policy through so the resolver picks the same wheel deterministically across hosts. |
+| 18.2 | `mochi pkg promote --to=abi2026` CLI verb + `.dist-info/` interpreter-tag relink | NOT STARTED | Live filename + `.dist-info/WHEEL` rewrite. Pairs with the abi2026 doc directive that filename-level promotion only ships once the metadata relink lands. |
+| 18.3 | Live PyPI two-tag publish (cp32-abi3 + cp314-abi2026 side-by-side during migration window) | NOT STARTED | Sub-phase 11.x extension: publish the promoted wheel to PyPI as a second artifact under the same release so the index serves both tags. |
+
+## Goal alignment check
+
+The Phase 18 umbrella ships the four primitives (Classify + Policy + Selector + Rename) that every downstream sub-phase needs. The sub-phases (18.1 / 18.2 / 18.3) plug those primitives into the lockfile + CLI + publisher, but the offline matrix in this phase pins the contract so the deferred work cannot drift. `PolicyBoth` is the default the lockfile writer in 18.1 will pick (matching the 2026-Q1 -> 2027-Q1 migration window); `PolicyAbi2026` is the eventual end state the install path enforces once the rollout completes.
+
+## Cross-references
+
+- [MEP-71 spec](/docs/mep/mep-0071) §17 (the original PEP 7XX placeholder note for the post-abi3 transition).
+- [MEP-71 implementation index](/docs/implementation/0071) for phase status.
+- [Phase 13 (abi3 slimming)](/docs/implementation/0071/phase-13-abi3) for the upstream phase that emits the abi3 wheels Phase 18 promotes.
+- [Phase 17 (free-threaded)](/docs/implementation/0071/phase-17-free-threaded) for the `cp3XYt` interpreter tag that interacts with abi2026 (the abi2026 ABI tag is GIL-state-agnostic; the interpreter tag carries the `t` suffix when needed).
+- [PEP 703](https://peps.python.org/pep-0703/) for the free-threaded CPython context.
+- [PEP 425](https://peps.python.org/pep-0425/) + [PEP 491](https://peps.python.org/pep-0491/) for the underlying wheel-tag grammar.


### PR DESCRIPTION
Phase 18 of [MEP-71](https://github.com/mochilang/mochi/blob/main/website/docs/mep/mep-0071.md) ships the offline-deterministic surface for the 2026-Q1 ABI-tag transition. Tracks issue #23018.

## Summary

CPython 3.14 + the PSF packaging working group jointly proposed abi2026 as the long-lived successor to abi3: it stabilises a wider stable API surface, disambiguates pre-/post-PEP-703 builds, and lets the wheel ecosystem ratchet forward without another full recompile churn.

New package package3/python/abi2026/ adds:

- ClassifyABITag pigeonholes a raw ABI tag into one of TagClassPure / TagClassLegacyCPython / TagClassLegacyABI3 / TagClassABI2026 / TagClassUnrecognised. Recognised shapes: none, abi3, abi2026, cp&lt;digits&gt;[t].
- Policy is the abi-tag-policy knob the operator picks per install. PolicyLegacy is the pre-migration safety hatch (Pure + LegacyCPython + LegacyABI3). PolicyAbi2026 is the post-migration end state (Pure + ABI2026). PolicyBoth is the migration window default (all 4 classes, ranked).
- Rank ordering: abi2026 (40) &gt; abi3 (30) &gt; cp3XY (20) &gt; Pure (10).
- Selector returns SelectionResult with winning wheel + per-rejection reasons (malformed / unrecognised / policy).
- PromoteToABI2026 + DowngradeToABI3 rewrite cp32-abi3-&lt;plat&gt; &lt;-&gt; cp314-abi2026-&lt;plat&gt; so a vendor can ratchet a wheel catalogue forward without re-uploading.

## Test plan

- [x] go test ./package3/python/abi2026/... -count=1
- [x] go test ./package3/python/... -count=1 (full Phase 0-18 surface stays green)
- [x] TestPhase18Umbrella sentinel: 4 sub-cases covering legacy hatch / abi2026 end state / both-window preference / promote round trip.

## Sub-phases (NOT STARTED)

- 18.1 mochi.lock [python].abi-tag-policy field + mochi.toml mirror.
- 18.2 mochi pkg promote --to=abi2026 CLI verb + .dist-info/ interpreter-tag relink.
- 18.3 Live PyPI two-tag publish (cp32-abi3 + cp314-abi2026 side-by-side during the migration window).