### PR TITLE
docs(mep-52): wire phase 18 tracking issue + PR numbers

### DIFF
--- a/website/docs/implementation/0052/phase-18-trusted-publishing.md
+++ b/website/docs/implementation/0052/phase-18-trusted-publishing.md
@@ -13,8 +13,8 @@ description: "MEP-52 Phase 18, emit .github/workflows/release.yml driving npm Tr
 | Status         | LANDED (workflow emit + structural gates + provenance dry-run); 18.3 verdaccio round-trip and 18.4 real OIDC publish deferred |
 | Started        | 2026-05-30 02:00 (GMT+7) |
 | Landed         | 2026-05-30 02:14 (GMT+7) |
-| Tracking issue | (pending) |
-| Tracking PR    | (pending) |
+| Tracking issue | [#23029](https://github.com/mochilang/mochi/issues/23029) |
+| Tracking PR    | [#23030](https://github.com/mochilang/mochi/pull/23030) |
 
 ## Gates
 


### PR DESCRIPTION
Follow-up: the Phase 18 doc-numbers fixup commit pushed after auto-merge fired on #23030, so the merged doc still shows `(pending)`. Bumping it to the real issue/PR numbers.

## Test plan

- [x] doc-only; no code change