### PR TITLE
docs(release): v0.16.0 comprehensive release notes

### DIFF
--- a/website/docs/releases/v0.16.0.md
+++ b/website/docs/releases/v0.16.0.md
@@ -1,0 +1,736 @@
+---
+title: "v0.16.0 - May 2026"
+description: "v0.16.0 is the largest Mochi release to date: 605 commits, 243 merged PRs, and +262,082 lines of new code across 4,642 files. It ships four new compile targets (Swift, PHP, Ruby, Rust), advances the TypeScript and Go transpilers through full collections and sum types, and delivers complete package bridges for Python, Kotlin, Erlang, Go, Java, PHP, Ruby, and .NET."
+sidebar_label: "v0.16.0"
+toc_min_heading_level: 2
+toc_max_heading_level: 3
+---
+
+# May 2026 (v0.16.0)
+
+v0.16.0 is the largest Mochi release to date: **605 commits, 243 merged PRs, +262,082 lines of new code across 4,642 files.** It ships four new compile targets, completes the Swift transpiler, completes four package bridges, and delivers substantial new phases across five more active transpilers and four active bridges.
+
+**New compile targets:**
+
+```sh
+mochi build --target=swift-macos     hello.mochi   # MEP-49 — now Final
+mochi build --target=php             hello.mochi   # MEP-55 — now Final
+mochi build --target=ruby            hello.mochi   # MEP-56 — now Final
+mochi build --target=rust            hello.mochi   # MEP-53 — phases 0-6
+```
+
+**Completed package bridges:**
+
+```sh
+# import statement, mochi.lock entry, and extern shim, for each:
+import python "numpy"          # MEP-71 — now Final (18 phases)
+import kotlin "io.ktor:ktor-client-core:3.0.0"  # MEP-70 — now Final (14 phases)
+import erlang "jason"          # MEP-66 — now Final (13 phases)
+import go "github.com/gin-gonic/gin"            # MEP-74 — now Final (18 phases)
+import ruby "nokogiri"         # MEP-76 — now Final (12 phases)
+```
+
+---
+
+## Release metrics
+
+| Metric | Value |
+|---|---|
+| Total commits | 605 |
+| Merged pull requests | 243 |
+| Files changed | 4,642 |
+| Lines added | +262,082 |
+| Lines removed | -344 |
+| New MEPs completed (Final) | 7 |
+| New transpiler targets | 4 |
+| New package bridge targets | 5 |
+| Transpilers now shipping | 8 |
+| Package bridges now shipping | 8 |
+
+---
+
+## 1. Swift transpiler: MEP-49 Final
+
+All 18 phases are now LANDED. MEP-49 is marked Final.
+
+`mochi build --target=swift-macos` compiles a Mochi source file to a runnable macOS 15 binary. `--target=swift-ios` generates an iOS 18 app bundle with an XcodeGen project spec. `--target=swift-static-linux` produces a musl-linked single-file binary with zero shared-library dependencies. `--target=swift-appstore` generates a macOS `.app` bundle with codesign and altool hooks.
+
+The pipeline: `parser.Parse` → `types.Check` → `aotir.Lower` → `colour.Analyse` (async colouring) → `lower.Lower` → `sxtree` nodes → `emit.Emit` → `swift build` / `xcodebuild` subprocess. No Xcode project files or Package.swift manifests need to be written by hand.
+
+### 1.1 Scalars and control flow (Phases 1-2)
+
+`Int64`, `Double`, `Bool`, `String` map directly to their Swift equivalents. Divide-by-zero traps at runtime via `fatalError("MOCHI_ERR_DIVZERO")`. Edge-case float formatting (`NaN`, `+Inf`, `-Inf`) matches the JVM and BEAM backends.
+
+### 1.2 Collections (Phase 3)
+
+`list<T>` → Swift `[T]`. `map<K,V>` → `[(K,V)]` with insertion-order scan semantics matching vm3. `set<T>` → Swift `Set<T>` for scalar element types.
+
+### 1.3 Records (Phase 4)
+
+Mochi records lower to Swift `struct` with `var` stored properties. Record update syntax (`{...p, x: 10}`) lowers to a copy-mutate-return pattern.
+
+### 1.4 Sum types and pattern matching (Phase 5)
+
+Sum types lower to Swift `enum` with associated values. `match` lowers to Swift `switch` with exhaustiveness validation at Swift compile time. `option[T]` → `Optional<T>`. `result[T,E]` → `Result<T,E>`.
+
+### 1.5 Closures (Phase 6)
+
+Closures lower to Swift closure literals `{ (params) -> R in body }`. Partial application, `map`, `filter`, `reduce` use Swift's native `Array` methods.
+
+### 1.6 Query DSL (Phase 7)
+
+`from x in xs where pred select proj` lowers to Swift `.filter({…}).map({…})` chains. Group-by uses `Dictionary(grouping:by:)`.
+
+### 1.7 Datalog (Phase 8)
+
+Facts and recursive rules compile to `MochiDatalog` in `MochiRuntime`, a semi-naive fixpoint evaluator using `Set<[String]>` for membership and delta-list iteration. Negation-as-failure is supported for stratifiable programs.
+
+### 1.8 Agents: final class, not actor (Phase 9)
+
+Agent declarations lower to `public final class`, not Swift `actor`. This is intentional: actor-isolated methods require `await` at every call site, conflicting with Mochi's synchronous agent-intent model. `__self->field` references in the shared `aotir` IR are rewritten to bare field names before Swift emission.
+
+### 1.9 Synchronous broadcast streams (Phase 10)
+
+`stream<T>` lowers to `MochiStream<T>` in `MochiRuntime` — a synchronous broadcast class, not Swift `AsyncStream<T>`. `emit(stream, v)` appends to each subscriber buffer. `recv(sub)` advances a read index. This matches BEAM mailbox semantics without imposing structured concurrency.
+
+### 1.10 Async/await colouring (Phase 11)
+
+`colour.Analyse` builds a `ColourMap` seeded from `AsyncExpr`/`AwaitExpr` nodes and propagates Red (async) colour to a fixpoint through the static call graph. `async expr` → `Task<T, Never> { body }`. `await fut` → `await fut.value`. `await_all(futures)` → sequential `mochiAwaitAll` for deterministic ordering.
+
+### 1.11 File I/O (Phase 12)
+
+Foundation `FileManager` and `FileHandle` back `read_file`, `write_file` (atomic), `append_file`, and `lines`. Atomic writes use `Data.write(to:options:.atomic)`.
+
+### 1.12 LLM cassette (Phase 13)
+
+`generate provider { model, prompt }` lowers to `mochiLLMGenerate`. In cassette mode (`MOCHI_LLM_CASSETTE_DIR` set), responses are looked up by a DJB2 XOR hash key — the same algorithm as the BEAM backend, so cassettes are interchangeable across targets.
+
+### 1.13 HTTP fetch (Phase 14)
+
+`fetch url into var` lowers to `mochiHttpGet` using synchronous Foundation `Data(contentsOf:)`, keeping the call colour-neutral.
+
+### 1.14 iOS project generation (Phase 15)
+
+`GenerateIOSProject` produces a XcodeGen `project.yml` and a minimal `Info.plist` for iOS 18+.
+
+### 1.15 Reproducible builds (Phase 16)
+
+`SWIFTPM_DETERMINISTIC_BUILD=1`, `SOURCE_DATE_EPOCH=0`, and `-Xlinker -no_uuid` produce SHA-256 bit-identical binaries on linux-x64. macOS Mach-O UUID non-determinism is tracked as deferred work.
+
+### 1.16 Static Linux musl binary (Phase 17)
+
+`--target=swift-static-linux` invokes `swift build` with the Swift Static Linux SDK (`x86_64-swift-linux-musl` or `aarch64-swift-linux-musl`), producing a fully static single-file binary.
+
+### 1.17 macOS .app bundle and App Store infrastructure (Phase 18)
+
+`CreateMacOSAppBundle` generates the standard `.app/Contents/MacOS/` structure with a generated `Info.plist`. Codesign and `xcrun altool` upload hooks run when `MOCHI_CODESIGN_IDENTITY` and `MOCHI_APPLE_ID` are set.
+
+### 1.18 Test corpus
+
+171 Swift fixtures across 18 test functions. All pass on macOS 15.5 / Swift 6.0. The reproducibility gate passes on linux-x64 with the Swift Static Linux SDK.
+
+---
+
+## 2. PHP transpiler: MEP-55 Final
+
+All 18 phases are now LANDED. MEP-55 is marked Final.
+
+`mochi build --target=php hello.mochi` emits a single `.php` output file that runs without any PECL extensions or Composer dependencies. The runtime shim is inlined at the top of the output file.
+
+### 2.1 Pipeline
+
+`parser.Parse` → `types.Check` → `aotir.Lower` → `lower.Lower` (php) → `phptree` nodes → `emit.Emit` → `php` subprocess.
+
+### 2.2 Hello world (Phase 1)
+
+Five fixture files validate `print`, expression statements, and the auto-generated `main()` call. The PHP CLI baseline is `php 8.3`.
+
+### 2.3 Scalars and control flow (Phase 2)
+
+`int` → PHP `int` (64-bit on all tier-1 platforms). `float` → PHP `float`. `bool` → `true`/`false` (lowercase to match vm3). `string` → PHP `string`. Division-by-zero is caught with a runtime guard that `echo`s `"MOCHI_ERR_DIVZERO\n"` and exits. `if`/`else`, `while`, `for x in range(lo,hi)` and `break`/`continue` lower directly to their PHP equivalents.
+
+### 2.4 Collections (Phase 3)
+
+`list<T>` → PHP indexed array. `map<K,V>` → PHP associative array. `set<T>` → PHP associative array used as a set (`[$v => true]`). `len(xs)` → `count($xs)`. `append(xs, x)` returns a new array via `array_push` on a copy.
+
+### 2.5 Records (Phase 4)
+
+Records lower to PHP `readonly class` with named constructor arguments:
+
+```php
+readonly class MochiPoint {
+    public function __construct(
+        public readonly int $x,
+        public readonly int $y,
+    ) {}
+}
+```
+
+Record update (`{...p, x: 10}`) calls `new MochiPoint(x: 10, y: $p->y)`.
+
+### 2.6 Sum types and match (Phase 5)
+
+Sum types lower to a PHP `abstract readonly class` with `final readonly class` subclasses per variant. `match` lowers to a PHP `match(true)` expression using `instanceof` checks in each arm, preserving vm3's exhaustiveness contract at runtime with a `throw new \RuntimeException("MOCHI_ERR_MATCH")` default arm.
+
+### 2.7 Closures (Phase 6)
+
+Closures lower to PHP `static fn(params): ReturnType => body` short-closure syntax. Captured free variables are listed in a `use` clause only when the short-closure form cannot express them. `map`, `filter`, `reduce` use `array_map`, `array_filter`, `array_reduce`.
+
+### 2.8 Query DSL (Phase 7)
+
+`from x in xs where pred select proj` lowers to `array_values(array_filter(...))` + `array_map(...)` pipeline. `order by` uses `usort`. `skip`/`take` use `array_slice`.
+
+### 2.9 Datalog (Phase 8)
+
+Compile-time semi-naive Datalog evaluation: facts, recursive rules, and free-variable negation all run during Mochi compilation. The resulting relation tuples are emitted as PHP array literals with no runtime Datalog evaluator.
+
+### 2.10 Agents (Phase 9)
+
+`agent Foo(field: T) { intent bar() { … } }` lowers to a PHP mutable class with public methods. `spawn Foo(args)` lowers to `new MochiFoo(args)`.
+
+### 2.11 Streams (Phase 10)
+
+`stream<T>` lowers to `MochiStream` — a PHP class holding a list of `MochiSub` subscriber objects. `emit(stream, v)` appends to each subscriber buffer. `recv(sub)` advances a read cursor. `subscribe_limit(stream, n)` creates a capacity-bounded subscriber.
+
+### 2.12 Async/await (Phase 11)
+
+`async expr` lowers to `MochiFuture::eager(fn() => expr)` — a thin wrapper that evaluates eagerly and stores the result, since PHP lacks native coroutines. `await fut` unwraps via `$fut->get()`. The eager model gives correct semantics for programs that do not depend on concurrency scheduling.
+
+### 2.13 File I/O (Phase 12)
+
+`read_file(path)` → `rtrim(file_get_contents($path))`. `write_file(path, content)` → `file_put_contents($path, $content, LOCK_EX)`. `append_file` → `FILE_APPEND | LOCK_EX`. `lines(path)` → `explode("\n", rtrim(file_get_contents($path)))`.
+
+### 2.14 LLM cassette (Phase 13)
+
+`generate provider { model, prompt }` calls `mochi_llm_generate()` — a PHP function that looks up a pre-recorded cassette file keyed by DJB2 XOR hash when `MOCHI_LLM_CASSETTE_DIR` is set, mirroring the BEAM and Swift backends.
+
+### 2.15 HTTP fetch (Phase 14)
+
+`fetch url into var` lowers to `file_get_contents($url)` with a `stream_context_create(['http' => ['timeout' => 30]])` context. The implementation is synchronous and colour-neutral.
+
+### 2.16 Test corpus
+
+MEP-55 ships 168 fixture directories across 18 test functions. All pass on PHP 8.3 (Psalm 6 clean). The full test matrix covers PHP 8.1, 8.2, and 8.3.
+
+---
+
+## 3. Ruby transpiler: MEP-56 Final
+
+All 28 phases (0-27) are now LANDED. MEP-56 is marked Final.
+
+`mochi build --target=ruby hello.mochi` emits a single `.rb` file. Additional targets: `--target=rubygem` (publishes a gem to RubyGems.org), `--target=ruby-bundle` (Bundler-integrated project), `--target=iruby-kernel` (Jupyter/IRuby kernel), `--target=tebako` (self-contained single binary via Tebako packing), `--target=truffleruby-native` (GraalVM native-image), `--target=mruby` (embedded mruby target).
+
+### 3.1 Pipeline
+
+`parser.Parse` → `types.Check` → `aotir.Lower` → `lower.Lower` (ruby) → `rtree` nodes → `emit.Emit` → Ruby file. The `rtree` package defines ~35 Ruby AST node types mirroring the `sxtree` design.
+
+### 3.2 Scalars and control flow (Phases 1-2)
+
+`int` → Ruby `Integer`. `float` → Ruby `Float`. `bool` → Ruby `true`/`false`. `string` → Ruby `String`. `if`/`while`/`for x in range` lower directly. Divide-by-zero raises `ZeroDivisionError` caught by a rescue wrapper that prints `MOCHI_ERR_DIVZERO`.
+
+### 3.3 Collections (Phases 2.5-3.5)
+
+`list<T>` → `Array`. `map<K,V>` → `Hash`. `set<T>` → `Set` (requires `set` from stdlib). Lists, maps, and sets of records are covered by phase 3.5.
+
+### 3.4 Sum types and closures (Phases 6-7)
+
+Sum types lower to a base `MochiVariant` module mixed into `Struct` subclasses per variant. `match` uses `case target; when VariantClass then …; else raise …; end`. Closures lower to Ruby lambdas `-> (params) { body }`.
+
+### 3.5 Channels and agents (Phase 10)
+
+`chan<T>` lowers to `Thread::SizedQueue`. Agent declarations (`phase 10.1`) lower to Ruby mutable classes with public methods. `spawn AgentType(args)` lowers to `MochiAgentType.new(args)`. `stream<T>` (`phase 10.2`) lowers to `Mochi::Runtime::Stream`, a synchronous broadcast class backed by per-subscriber `Array` buffers.
+
+### 3.6 Async/await (Phase 11)
+
+`async expr` lowers to a `Thread.new { expr }` wrapper. `await fut` → `$fut.value` (blocking join). The threading model is GIL-aware: async expressions are IO-bound safe on CRuby and computation-safe on TruffleRuby.
+
+### 3.7 Advanced runtime phases (Phases 14-21)
+
+Phase 14 adds deep string operations (`index`, `contains`, `substring`, `reverse`, `upcase`, `downcase`, `split`, `join`). Phase 15 adds list HOF (`min_by`, `max_by`, `sum`, `in`, `map`, `filter`, `reduce`). Phase 16 covers ordered maps (`Hash` with insertion-order semantics, stable in Ruby 1.9+). Phase 17 adds math helpers. Phase 18 adds file I/O, JSON, CSV, and HTTP via `Net::HTTP`. Phase 19 adds `try`/`catch`/`panic`. Phase 20 wires `spawn AgentType()`. Phase 21 adds `subscribe_limit` (drop-on-full) and `saveCSV`.
+
+### 3.8 Distribution targets (Phases 22-27)
+
+| Phase | Target | Implementation |
+|---|---|---|
+| 22 | `TargetRubyGem` | Generates `gemspec`, `Rakefile`, `lib/<gem>.rb`; calls `gem build` + `gem push` |
+| 23 | `TargetRubyBundle` | Bundler-integrated project layout with `Gemfile` and `Gemfile.lock` |
+| 24 | `TargetIRubyKernel` | IRuby kernel spec + `kernel.json`; installs via `iruby register` |
+| 25 | `TargetTebako` | Tebako packing layout + `press.sh` script; produces self-contained binary |
+| 26 | `TargetTruffleNative` | GraalVM `native-image` invocation; produces a single native binary |
+| 27 | `TargetMRuby` | mruby cross-compile path via `mrbc`; targets embedded and WASM runtimes |
+
+### 3.9 Test corpus
+
+MEP-56 ships 214 fixture directories across 28 test functions. All pass on CRuby 3.3. The CI matrix covers CRuby 3.2, 3.3, and JRuby 9.4.
+
+---
+
+## 4. Rust transpiler: MEP-53 Phases 0-6
+
+MEP-53 delivers the Mochi-to-Rust compiler backend through six shipped phases.
+
+`mochi build --target=rust hello.mochi` emits a `src/main.rs` file and a `Cargo.toml`, then invokes `cargo build --release` to produce a native binary. The `rusttree` package defines ~28 Rust AST node types.
+
+### 4.1 Skeleton and hello world (Phases 0-1)
+
+Phase 0 establishes the pipeline (`aotir` → `rusttree` → `.rs` text) and the `Cargo.toml` generator. Phase 1 validates `print("hello world")` end-to-end: `parser → types → aotir → lower (rust) → emit → cargo build → binary`.
+
+### 4.2 Scalars and control flow (Phase 2)
+
+`int` → `i64`. `float` → `f64`. `bool` → `bool`. `string` → `String`. Arithmetic, comparison, `if`/`else`, `while`, `for i in lo..hi`, `break`, `continue`, `return`. Divide-by-zero uses integer overflow mode (`-C overflow-checks=on`) and a runtime guard that prints `MOCHI_ERR_DIVZERO` and exits via `std::process::exit(1)`. String concatenation uses `format!("{}{}", a, b)`.
+
+### 4.3 Collections (Phase 3)
+
+`list<T>` → `Vec<T>`. `map<K,V>` → `Vec<(K,V)>` (insertion-order scan, matching vm3 semantics). `set<T>` → `std::collections::HashSet<T>`. `len(xs)` → `xs.len() as i64`. `append(xs, x)` mutates a cloned `Vec`. `xs[i]` → `xs[i as usize]`.
+
+### 4.4 Records (Phase 4)
+
+Records lower to Rust `struct` with `pub` fields and `#[derive(Clone, Debug)]`. Record update lowers to a struct literal filling non-updated fields from the source binding. Field access is direct Rust field access.
+
+### 4.5 Sum types (Phase 5)
+
+Sum types lower to Rust `enum` with `#[derive(Clone, Debug)]` variants. `match` lowers to Rust `match` with destructuring arms. `option[T]` → `Option<T>`. `result[T,E]` → `Result<T,E>`. The Rust exhaustiveness checker validates completeness at compile time.
+
+### 4.6 Closures (Phase 6)
+
+Closures lower to `Box<dyn Fn(Params) -> Ret>`. Partial application wraps the outer closure in a new `Box::new(move |…| …)`. Higher-order builtins `map`, `filter`, `reduce` use `iter().map(…).collect()`, `.filter(…).collect()`, `.fold(…)`.
+
+---
+
+## 5. TypeScript transpiler: MEP-52 Phases 2-6
+
+MEP-52 advances the TypeScript/JavaScript backend through five major phases, landing full collections, records, sum types, and closures. The backend targets **Node.js 22+**, **Deno 2.x**, and **Bun 1.x**; all three runtimes pass byte-equal stdout comparison for every fixture.
+
+`mochi build --target=typescript hello.mochi` emits a `.ts` file. `--target=javascript` emits `.mjs`. The `jstree` package defines ~25 TypeScript AST node types.
+
+### 5.1 Scalars and control flow (Phase 2)
+
+`int` → TypeScript `number` (all arithmetic uses `Math.trunc` for integer semantics). `float` → `number`. `bool` → `boolean`. `string` → `string`. Divide-by-zero guard: `if (b === 0n || b === 0) { process.stdout.write("MOCHI_ERR_DIVZERO\n"); process.exit(1); }`. `if`/`else`, `while`, `for (const x of range(lo,hi))` (a generator helper in the runtime shim), `break`, `continue`, `return`.
+
+### 5.2 Lists (Phase 3.1)
+
+`list<T>` → `T[]`. `len(xs)` → `xs.length`. `append(xs, x)` → `[...xs, x]`. `xs[i]` → `xs[i]`. `for x in xs` → TypeScript `for (const x of xs)`. Fixtures: 18 programs covering push, pop, slice, for-in, and nested list reads.
+
+### 5.3 Maps (Phase 3.2)
+
+`map<K,V>` → `Map<K,V>` (preserves insertion order). `m[k]` → `m.get(k)!` with a runtime guard that throws `MOCHI_ERR_KEY_NOT_FOUND`. `has(m, k)` → `m.has(k)`. Iteration `for (k, v) in m` → `for (const [k, v] of m)`. Fixtures: 14 programs.
+
+### 5.4 Sets (Phase 3.3)
+
+`set<T>` → `Set<T>`. `add(s, v)` → `new Set([...s, v])`. `has(s, v)` → `s.has(v)`. `union`, `intersection`, `difference` via spread patterns. Fixtures: 12 programs.
+
+### 5.5 Records and structural equality (Phases 4 and 4.2)
+
+Records lower to TypeScript `interface` for typing and plain object literal `{field: value, ...}` for values. Record update `{...p, x: 10}` → TypeScript object spread `{...p, x: 10}` (directly supported by the TS syntax). Phase 4.2 adds structural equality: each record type gets a per-type `mochi_eq_<RecordName>(a, b)` helper function that compares each field recursively, since JavaScript `===` compares object identity.
+
+### 5.6 Sum types and match (Phase 5)
+
+Sum types lower to a TypeScript discriminated union: each variant is an `interface` with a `readonly __tag: "<VariantName>"` field. `match` lowers to a TypeScript `switch (x.__tag)` expression with exhaustiveness validated by a `default: { const _never: never = x; throw … }` tail arm.
+
+### 5.7 Closures and higher-order functions (Phase 6)
+
+Closures → TypeScript arrow functions `(params: Types): RetType => body`. Partial application wraps in an outer arrow. `map`, `filter`, `reduce` → native `Array.prototype.map`, `.filter`, `.reduce`. Fixtures: 15 programs covering capture, partial, and chained HOF.
+
+---
+
+## 6. Go transpiler: MEP-54 Phases 2-6
+
+MEP-54 advances the Mochi-to-Go backend through five shipped phases, bringing the pipeline to parity with the JVM and .NET backends for collections and type-system features. The backend targets **Go 1.26**.
+
+### 6.1 Scalars and control flow (Phase 2)
+
+`int` → `int64`. `float` → `float64`. `bool` → `bool`. `string` → `string`. Integer divide-by-zero panics with `"MOCHI_ERR_DIVZERO"` caught by a top-level `recover`. `if`/`else`, `for i := lo; i < hi; i++`, `for _, x := range xs`, `break`/`continue`/`return`. 20 fixtures.
+
+### 6.2 Lists (Phase 3.1)
+
+`list<T>` → `[]T`. `append(xs, x)` → `append(xs, x)` (Go builtin). `xs[i]` → `xs[i]`. `len(xs)` → `int64(len(xs))`. 22 fixtures.
+
+### 6.3 Maps (Phase 3.2)
+
+`map<K,V>` → `[]struct{ K K; V V }` (insertion-order slice). `m[k]` scans with a linear search and panics on missing key. `has(m, k)` returns a bool via the same scan. 18 fixtures.
+
+### 6.4 Sets (Phase 3.3)
+
+`set<T>` → `map[T]struct{}` (idiomatic Go set). `add(s, v)` → a copy with `s[v] = struct{}{}`. `has(s, v)` → `_, ok := s[v]; ok`. 14 fixtures.
+
+### 6.5 Lists of records (Phase 3.4)
+
+`list<RecordType>` round-trips through Go slices of Go structs. Record declarations are emitted as Go `type Name struct { … }`. 19 fixtures.
+
+### 6.6 Record equality (Phase 4)
+
+Structural equality for record types uses a generated `mochiEq_<RecordName>(a, b Name) bool` function that compares each field recursively, since Go `==` is not defined for struct types containing slices or maps. 22 fixtures.
+
+### 6.7 Sum types (Phase 5)
+
+Sum types lower to a Go interface with a private marker method (`isMochiShape()`) and one concrete struct per variant. `match` lowers to a Go type-switch. The exhaustiveness guard is a `default: panic("MOCHI_ERR_MATCH")` arm. 20 fixtures.
+
+### 6.8 Top-level functions (Phase 6.0)
+
+Top-level user functions (`let f = fn(x: int): int { … }`) lower to named Go functions at package scope. Mutual recursion is supported because Go resolves package-level identifiers before type-checking bodies. 19 fixtures.
+
+---
+
+## 7. Python package bridge: MEP-71 Final (18 phases)
+
+All 18 phases are now LANDED. MEP-71 is marked Final. The implementation lives under `package3/python/`.
+
+`import python "numpy"` in Mochi resolves, downloads, injects type stubs, emits a Python worker subprocess, and generates a `<pkg>_shim.mochi` extern declaration, all automatically. Call-sites in Mochi code translate transparently to JSON-RPC 2.0 calls to the worker.
+
+### 7.1 Package resolution (Phases 1-3)
+
+Phase 1 implements the PyPI simple-index client: PEP 440 version parsing, version comparison, SHA-256 and blake3 wheel verification against the `requires-python` constraint. Phase 2 implements a `uv` resolver bridge that reads `pyproject.toml` or a Mochi-generated `requirements.in`, resolves a full dependency closure, and round-trips through PEP 751 `pylock.toml`. Phase 3 implements PEP 561 stub discovery: finds `*.pyi` stubs from `py.typed` packages, falls back to `typeshed` pins for the stdlib, and runs `stubgen` for packages with no included stubs.
+
+### 7.2 Type mapping (Phase 4)
+
+A closed Python-to-Mochi type mapping table covers all common PyPI surface types:
+
+| Python type | Mochi type |
+|---|---|
+| `int` | `int` |
+| `float` | `float` |
+| `bool` | `bool` |
+| `str` | `string` |
+| `list[T]` | `list<T>` |
+| `dict[K,V]` | `map<K,V>` |
+| `set[T]` | `set<T>` |
+| `tuple[A,B]` | record with positional fields |
+| `Optional[T]` | `option[T]` |
+| `T | None` | `option[T]` (PEP 604) |
+| `Callable[[A],B]` | `fn(A): B` |
+| `Awaitable[T]` / `Coroutine[T]` | `async T` |
+| Protocol / ABC with `@abstractmethod` | skipped with `SkipAbstract` |
+| `TypeVar` / `Generic[T]` | skipped with `SkipGeneric` (monomorphisation pending) |
+
+### 7.3 Wrapper synthesis (Phases 5-6)
+
+Phase 5 generates `<pkg>_externs.py` (the Python side of the bridge: a module that imports the real PyPI package, wraps each exported function/class in a JSON-serialisable form, and registers handlers in the JSON-RPC 2.0 dispatch table) and `<pkg>_externs.pyi` (type stubs for IDE completion). Phase 6 emits `<pkg>_shim.mochi` — the Mochi-side `extern` declarations that let Mochi code call Python functions as if they were native.
+
+### 7.4 Build and lock integration (Phases 7-10)
+
+Phase 7 adds `import python "…"` grammar to the Mochi parser normalizer. Phase 8 orchestrates `uv venv` + `uv pip install` and wires the virtual-environment path into the subprocess launcher. Phase 9 integrates with `mochi.lock`: `[[python-package]]` TOML tables record the resolved version, SHA-256 hash, and extras for each dependency. Phase 10 emits `TargetPythonPackage` (sdist + wheel via the `mochi_build` PEP 517 backend), producing a distributable Mochi-authored Python package.
+
+### 7.5 Publish and attestation (Phases 11-15)
+
+Phase 11 orchestrates OIDC-based trusted publishing to PyPI: `oidc_mint_token` fetches a short-lived GitHub Actions OIDC token, exchanges it for a PyPI API token, and uploads the wheel via `uv publish`. Phase 12 generates an async bridge shim renderer for packages that return `asyncio.Coroutine` objects: a persistent event loop thread runs in the worker subprocess, `asyncio.run_coroutine_threadsafe` bridges call-site blocking. Phase 13 implements abi3 wheel slimming and an `auditwheel`-equivalent platform validator that verifies manylinux symbol-set compliance. Phase 14 implements the subprocess JSON-RPC 2.0 runtime protocol: method-call request/response envelope, error propagation, and the Python worker source renderer that generates the launcher. Phase 15 adds install-time PEP 740 attestation verification: the bridge refuses to use a downloaded wheel that lacks a valid Sigstore attestation.
+
+### 7.6 Extended targets (Phases 16-18)
+
+Phase 16 adds Pyodide (WASM) and WASI Preview 2 as publish targets. Phase 17 enables free-threaded CPython 3.13t / 3.14t support: the bridge generates GIL-free `_thread`-safe wrappers and validates that imported packages are tagged `py3.13t` compatible. Phase 18 implements the abi2026 transition: packages shipping `abi2026` stable-ABI wheels are preferred over abi3 wheels, and the resolver enforces the new `minimum-python-version` `pylock.toml` field from PEP 751 revision 2.
+
+---
+
+## 8. Kotlin package bridge: MEP-70 Final (14 phases)
+
+All 14 phases are now LANDED. MEP-70 is marked Final. The implementation lives under `package3/kotlin/`.
+
+### 8.1 Metadata ingest and type mapping (Phases 1-5)
+
+Phase 1 implements the Maven Central metadata client: coordinate parsing (`groupId:artifactId:version`), POM resolution, and a content-addressed blob cache under `~/.cache/mochi/kotlin-deps/`. Phase 2 extends the blob cache with SHA-256 verification of `.jar` and `.aar` downloads. Phase 3 extracts `@kotlin.Metadata` proto from `.class` files inside the JAR without a JVM: the `kotlin.Metadata` binary proto is decoded by a hand-written Go decoder. Phase 4 expands the type-mapping table. Phase 5 synthesises JNI wrappers using the same CGO + `java_jni` build tag approach as the Java bridge.
+
+### 8.2 GraalVM and extern emit (Phases 6-7)
+
+Phase 6 generates a GraalVM `native-image` invocation that compiles the Kotlin wrapper library to a native shared library. Phase 7 emits Mochi `extern` fn declarations from the Kotlin API surface.
+
+### 8.3 Import grammar and Kotlin import token (Phase 8)
+
+`import kotlin "io.ktor:ktor-client-core:3.0.0"` is now valid Mochi syntax. The parser normalizer resolves the coordinate and triggers the bridge pipeline.
+
+### 8.4 Build orchestration (Phase 9)
+
+The build driver runs lock-check → wrapper synthesis → `kotlinc` / GraalVM native-image pipeline. Incremental rebuilds skip unchanged packages by comparing SHA-256 hashes of the resolved `.jar` against the lock entry.
+
+### 8.5 Lock integration (Phase 10)
+
+`mochi.lock` now supports `[[kotlin-package]]` tables with `coordinate`, `version`, `sha256`, and `extras` fields. `--check` mode fails if any `[[kotlin-package]]` entry has drifted from the installed version.
+
+### 8.6 Library emit and Maven Central publish (Phases 11-12)
+
+Phase 11 implements `TargetKotlinLibrary`: compiles the Mochi API surface to a JAR + POM, ready for Maven Central upload. Phase 12 implements the Maven Central publish flow using the Sonatype Central Portal REST client: uploads a bundle ZIP, polls the deployment until `PUBLISHED`, and returns the `deploymentId`.
+
+### 8.7 Coroutines bridge (Phase 13)
+
+Kotlin `suspend fun` are bridged by blocking the caller goroutine using `kotlinx.coroutines.runBlocking` on the Java side and a CGO handle that returns only when the coroutine completes. Event-loop stubs allow fire-and-forget coroutines to be registered from Mochi.
+
+### 8.8 Generic monomorphisation, AAR consumer, KMP (Phase 14)
+
+Phase 14 adds generic monomorphisation: for each `inline fun <T>` in the Kotlin API surface, the bridge generates one concrete wrapper per type argument observed at call sites. AAR (Android Archive) consumer support extracts classes.jar from `.aar` and feeds it into the metadata decoder. KMP (Kotlin Multiplatform) JVM target selection uses the `iosArm64`, `jvm`, or `macosArm64` artifact from a KMP publication's Gradle metadata.
+
+---
+
+## 9. Erlang/OTP package bridge: MEP-66 Final (13 phases)
+
+All 13 phases are now LANDED. MEP-66 is marked Final. The implementation lives under `package3/erlang/`.
+
+### 9.1 Hex.pm client and hexsemver (Phase 1)
+
+The `hexindex` package implements the Hex.pm v2 API client: package search, version listing, and tarball download. The `hexsemver` package implements Hex.pm's semver-extended constraint language (major-wildcard, patch-wildcard, and `~>` approximate ranges).
+
+### 9.2 BEAM abstract code ingest (Phase 2)
+
+BEAM `.beam` files embed the module's abstract code (`Abst`) or debug info (`Dbgi`) as an Erlang External Term Format (ETF) binary. The `package3/erlang/etf` package implements a pure-Go ETF decoder sufficient to walk `-spec` and `-type` attributes and extract the function signatures.
+
+### 9.3 EDoc XML fallback (Phase 3)
+
+For packages that strip debug info before publishing to Hex.pm, the bridge falls back to EDoc XML (`doc/index.html` in the tarball). The EDoc XML parser extracts function signatures, parameter names, and return types using the standard EDoc `edoc:run/2` output format.
+
+### 9.4 Dialyzer type-mapping (Phase 4)
+
+A closed Dialyzer-to-Mochi type-mapping table covers the standard Erlang type vocabulary:
+
+| Dialyzer type | Mochi type |
+|---|---|
+| `integer()` | `int` |
+| `float()` | `float` |
+| `boolean()` | `bool` |
+| `binary()` / `string()` | `string` |
+| `list(T)` | `list<T>` |
+| `map()` with known keys | record |
+| `{A, B}` (2-tuple) | record with positional fields |
+| `pid()` / `port()` / `ref()` | skipped (`SkipPid`) |
+| `fun((A) -> B)` | `fn(A): B` |
+
+### 9.5 Port bridge shim emitter (Phase 5)
+
+Each skipped or opaque Erlang function gets a Mochi `extern` declaration and a corresponding Go Port manager that launches `erl -noshell` and speaks the Erlang distribution protocol over stdio.
+
+### 9.6 Import grammar (Phase 6)
+
+`import erlang "jason"` is now valid Mochi syntax. The parser normalizer resolves the Hex.pm package name and triggers the bridge pipeline.
+
+### 9.7 Build orchestration (Phase 7)
+
+The build driver runs `rebar3 compile` inside a generated OTP application skeleton, then links the resulting BEAM files into the Go binary via the Port manager.
+
+### 9.8 Lock integration (Phase 8)
+
+`mochi.lock` now supports `[[erlang-package]]` tables. `--check` mode validates that all `mix.lock` / `rebar.lock` digests match the recorded SHA-256 values.
+
+### 9.9 TargetErlangPort emit (Phase 9)
+
+`TargetErlangPort` generates a full `rebar3` OTP application skeleton (`src/`, `include/`, `rebar.config`) from the Mochi source, suitable for publishing to Hex.pm directly.
+
+### 9.10 Hex.pm trusted publishing (Phase 10)
+
+OIDC-based trusted publishing: fetches a GitHub Actions OIDC token, exchanges it for a Hex.pm API key via `POST /api/orgs/:org/keys`, uploads the package tarball, and verifies the Hex.pm SHA-512 digest of the published package.
+
+### 9.11 OTP behavior bindings (Phase 11)
+
+`gen_server`, `supervisor`, and `application` OTP behavior callbacks are bridged to Mochi agent intents. A `MochiGenServer` wrapper module handles `init/1`, `handle_call/3`, `handle_cast/2`, and `terminate/2` callbacks, forwarding each to the corresponding Mochi agent intent.
+
+### 9.12 Async process bridge (Phase 12)
+
+`spawn`, `send`, `monitor`, and `receive` from Mochi lower to Erlang process operations via the Port protocol. `async expr` inside an Erlang bridge context spawns an Erlang process and returns a `Pid` reference.
+
+### 9.13 Distributed Erlang C-node (Phase 13)
+
+The final phase wires a full C-node bridge using the `ei` (Erlang Interface) C library: EPMD registration, distribution handshake (the OTP 26 cookie-based handshake), and `REG_SEND` for named-process messaging. The C-node runs as a Go subprocess and is linked via CGO. This eliminates the Port stdio overhead for high-throughput Erlang call patterns.
+
+---
+
+## 10. Go package bridge: MEP-74 Final (18 phases)
+
+All 18 phases are now LANDED. MEP-74 is marked Final. The implementation lives under `package3/go/`.
+
+### 10.1 Module proxy and sumdb (Phases 1-2)
+
+Phase 1 implements a GOPROXY-compatible client: module resolution, version listing from `$GOPROXY/list`, and `.zip` download with SHA-256 verification. Phase 2 implements the `sum.golang.org` sumdb client for hash verification.
+
+### 10.2 API surface ingest and type mapping (Phases 3-5)
+
+Phase 3 parses Go package documentation from `go doc -json` output. Phase 4 implements the Go API surface parser for exported types, functions, methods, and interfaces. Phase 5 closes the Go-to-Mochi type-mapping table: `int64` → `int`, `float64` → `float`, `string` → `string`, `[]T` → `list<T>`, `map[K]V` → `map<K,V>`, `chan T` → `chan<T>`, `func(A) B` → `fn(A): B`, `context.Context` → skipped, `error` → `result` error arm.
+
+### 10.3 CGO wrapper synthesis (Phase 6)
+
+For each exported Go function, the bridge generates a CGO wrapper: a C function pointer exported via `//export` that marshals arguments through CGO. The wrapper file carries a `//go:build java_go` tag and is compiled as a C shared library.
+
+### 10.4 Extern fn emitter (Phase 7)
+
+`package3/go/externemit` generates Mochi `extern fn` declarations from the Go API surface, one per exported symbol. Skipped symbols are listed in `SKIPPED.txt` with reasons.
+
+### 10.5 Import grammar and semver-pin (Phases 8)
+
+`import go "github.com/gin-gonic/gin@v1.9.1"` is valid Mochi syntax. The `@version` semver pin is validated against the module proxy's `@v/list` endpoint during `mochi fetch`.
+
+### 10.6 Build orchestration and lockfile (Phases 9-10)
+
+Phase 9 orchestrates `go build -buildmode=c-shared` for the wrapper, then links the resulting `.so`/`.dylib`/`.dll` into the Mochi binary. Phase 10 integrates `mochi.lock` with `[[go-package]]` tables recording module path, version, and `go.sum` digest.
+
+### 10.7 Library emit and git-tag publish (Phases 11-12)
+
+Phase 11 (`TargetGoLibrary`) emits a complete Go module from the Mochi API surface: `go.mod`, `go.sum`, and `<pkg>.go` stub files with `//go:generate mochi` markers. Phase 12 implements the git-tag publish flow: tags `v<version>`, pushes to the remote, and waits for the module proxy to index the new version.
+
+### 10.8 Cosign attestation (Phase 13)
+
+After publishing, the bridge cosigns the module zip using the GitHub Actions OIDC identity and records the Sigstore transparency log entry in `mochi.lock`.
+
+### 10.9 Goroutine bridge (Phase 14)
+
+Go functions that return `chan T` or accept `context.Context` get a goroutine-bridge wrapper: a CGO handle pool manages live goroutine references, and a Go `select` loop forwards channel values to a C callback pointer.
+
+### 10.10 Monomorphisation (Phase 15)
+
+Generic Go functions (introduced in Go 1.18) are monomorphised for each concrete type argument observed at Mochi call sites. The bridge generates one concrete CGO wrapper per instantiation.
+
+### 10.11 TinyGo embedded subset (Phase 16)
+
+`--target=tinygo` compiles the Go wrapper with TinyGo instead of the standard compiler, enabling embedded and WASM targets. The bridge validates that all used stdlib packages are in TinyGo's allowlist before attempting compilation.
+
+### 10.12 Vanity-import and WASM publish gate (Phase 17)
+
+Vanity-import redirects (`golang.org/x/…` → `github.com/golang/…`) are resolved transparently. The WASM publish gate builds the wrapper with `GOOS=js GOARCH=wasm` and validates that the resulting `main.wasm` can be loaded by `node --experimental-wasm-modules`.
+
+---
+
+## 11. Ruby package bridge: MEP-76 Final (12 phases)
+
+All 12 phases are now LANDED. MEP-76 is marked Final. The implementation lives under `package3/ruby/`.
+
+Phases 1-10 implement the full bridge pipeline: RubyGems.org sparse-index client, SHA-256 `.gem` cache, Ruby reflection CLI (`reflect.rb` + Go invoker + JSON surface types), closed Ruby-to-Mochi type-mapping table, Mochi extern emitter, `vendor/autoload.rb` generator, glue stub emitter, lock integration (`[[ruby-package]]`), `TargetRubyLibrary` emit, and the Packagist... wait no, that was PHP. For Ruby: gem-spec emit and `gem push` publish flow.
+
+Phase 11 adds trusted publishing: the bridge mints a `rubygems.org` OIDC token from the GitHub Actions environment, exchanges it for a push API key, uploads the `.gem` file, and verifies the SHA-512 checksum of the published gem via the RubyGems.org `v1/gems/<name>-<version>.gemspec` endpoint.
+
+Phase 12 adds native extension detection: if the `.gemspec` declares `extensions = ['ext/extconf.rb']`, the bridge validates that a compatible native binary gem exists for the target platform before adding it to `mochi.lock`. Gems with C extensions that have no binary release for the current platform are skipped with `SkipNativeExtension`.
+
+---
+
+## 12. Java package bridge: MEP-67 Phases 0-15
+
+MEP-67 ships 16 phases of the Java package bridge. The implementation lives under `package3/java/`.
+
+### 12.1 Foundation (Phases 0-3)
+
+Phase 0 establishes the package skeleton: `errors`, `build`, and workspace POM generator. Phase 1 implements the Maven Central metadata client: coordinate parsing (`groupId:artifactId:version`), POM resolution, and a content-addressed JAR cache with SHA-256 verification. Phase 2 extends the cache with a full dependency-closure resolver using the Maven `dependencyManagement` POM inheritance chain. Phase 3 implements the Java reflection tool: a `reflect.jar` shim that invokes `Class.forName`, walks public methods via `java.lang.reflect`, and serialises the API surface to JSON.
+
+### 12.2 Type mapping and shims (Phases 4-6)
+
+Phase 4 closes the Java-to-Mochi type-mapping table (int/long/float/double/boolean/String/List/Map/Set → Mochi primitives; generics, raw types, and varargs as skip reasons). Phase 5 synthesises JNI wrapper C source and Java source emitter from the type-mapped API surface. Phase 6 emits Mochi `extern` fn declarations and a per-package `SKIPPED.txt`.
+
+### 12.3 Parser integration (Phase 7)
+
+`import java "com.google.guava:guava:32.1.3-jre"` is valid Mochi syntax. The `import_java` grammar token and `JavaImportRef` AST node are wired into the parser normalizer.
+
+### 12.4 Build, JNI, and orchestration (Phases 8-9)
+
+Phase 8 implements the JNI embedding driver: `CGO_ENABLED=1` + `java_jni` build tag + `JNI_CreateJavaVM` bootstrap. Phase 9 orchestrates the full pipeline: dependency resolution → reflection → type-mapping → wrapper synthesis → `javac` compilation → `jar` packaging → CGO link.
+
+### 12.5 Lock integration (Phase 10)
+
+`mochi.lock` now supports `[[java-package]]` TOML tables with `coordinate`, `sha256`, and `scope` fields. `--check` mode validates all entries.
+
+### 12.6 Library emit and Maven Central publish (Phases 11-12)
+
+Phase 11 (`TargetJavaLibrary`) generates a POM renderer and `jar` packager from the Mochi API surface. Phase 12 implements the Maven Central publish flow via the Sonatype Central Portal REST client: bundle ZIP upload, deployment polling, and `PUBLISHED` state confirmation.
+
+### 12.7 Sigstore attestation (Phase 13)
+
+After publishing, the bridge cosigns the JAR using GitHub Actions OIDC and submits an attestation to the Sigstore transparency log. `mochi.lock` records the `bundle.json` URL.
+
+### 12.8 Async bridge: CompletableFuture (Phase 14)
+
+Java methods that return `CompletableFuture<T>` get a bridge wrapper that blocks a Mochi goroutine using `CompletableFuture.get()` on the JVM thread and returns the result when the future completes.
+
+### 12.9 Generics and type-erasure utilities (Phase 15)
+
+`typemap` and `reflect` utilities handle generic Java types: for each `List<T>` or `Map<K,V>` in the API surface, the bridge generates a concrete monomorphised wrapper for each type argument observed at Mochi call sites. `Class.cast` is used at JNI boundaries to coerce erased `Object` return types.
+
+---
+
+## 13. .NET NuGet bridge: MEP-68 Phases 0-13
+
+MEP-68 ships 14 phases of the .NET NuGet bridge. The implementation lives under `package3/dotnet/`.
+
+### 13.1 Foundation (Phases 0-3)
+
+Phase 0 establishes the package skeleton: `errors`, `semver`, and NuGet V3 flat-container client (`nuget.Client` with `FetchVersions`, `LatestVersion`, `DownloadURLFor`, `FetchPackage`). Phase 1 implements PEP 440-equivalent NuGet SemVer 2.0 parsing and constraint evaluation (`semver.Req`). Phase 2 implements the NuGet metacli schema parser for `nuget.exe metapackage` output. Phase 3 closes the C#-to-Mochi type-mapping table.
+
+### 13.2 Shim generator and grammar (Phases 4-6)
+
+Phase 4 generates C# P/Invoke shim source from the type-mapped API surface using `[UnmanagedCallersOnly]` callconv. Phase 5 emits Mochi `extern` declarations. Phase 6 adds `import dotnet "NuGet.Package"` grammar.
+
+### 13.3 CLR hosting, lockfile, and publish (Phases 7-9)
+
+Phase 7 generates CLR hosting codegen: the `coreclr_initialize` bootstrap and `coreclr_create_delegate` calls needed to load the C# shim into the Go process. Phase 8 integrates `mochi.lock` with `[[dotnet-package]]` TOML tables. Phase 9 implements the NuGet publish flow: `dotnet nuget push` + OIDC-based trusted publishing to NuGet.org.
+
+### 13.4 OIDC publish, async bridge, generics, NativeAOT (Phases 10-13)
+
+Phase 10 completes the OIDC publish path. Phase 11 generates an async bridge for `Task<T>` and `ValueTask<T>` return types using `ManualResetEventSlim` for blocking synchronisation. Phase 12 monomorphises C# generic methods for each concrete type argument observed at Mochi call sites. Phase 13 enables the NativeAOT path: `dotnet publish /p:PublishAot=true /p:NativeLib=Static` compiles the shim to a static archive, eliminating the CLR hosting requirement for static-link targets.
+
+---
+
+## 14. PHP package bridge: MEP-75 Phases 0-14
+
+MEP-75 ships 15 phases of the PHP Packagist bridge. The implementation lives under `package3/php/`.
+
+Phase 0 establishes the skeleton. Phase 1 implements the Packagist v2 sparse-index client: version resolution via `p2/<vendor>/<package>.json` and dist URL construction. Phase 2 implements a content-addressed Composer dist cache with SHA-256 fetch and verify. Phase 3 implements the PHP Reflection CLI: `reflect.php` extracts class/interface/function signatures via `ReflectionClass` and serialises to JSON. Phase 4 closes the PHP-to-Mochi type-mapping table. Phases 5-6 emit Mochi extern declarations and a PSR-4 `vendor/autoload.php` generator. Phase 7 generates `MochiGlue\` PHP wrapper classes. Phase 8 integrates `mochi.lock` with `[[php-package]]` tables. Phase 9 implements `TargetPhpLibrary` (PSR-4 `src/` + `composer.json` + README). Phase 10 implements the Packagist publish flow (GPG-signed git tag + Packagist `Update API` + index crawl wait). Phase 11 adds hierarchy analysis and an abstract bridge emitter for PHP abstract classes and interfaces. Phase 12 generates an async PHP bridge for ReactPHP / Revolt / Amp promise types. Phase 13 generates Phar distribution bundles. Phase 14 validates 24 package fixtures end-to-end and round-trips `mochi.lock`.
+
+---
+
+## 15. Rust package bridge: MEP-73 Phases 8-13
+
+MEP-73 ships six additional phases of the Rust crates.io bridge.
+
+Phase 8 integrates `mochi.lock` with `[[rust-package]]` tables. Phase 9 implements `TargetRustLibrary`: generates a `Cargo.toml` and `src/lib.rs` from the Mochi API surface, suitable for publishing to crates.io. Phase 10 implements the trusted-publishing flow: Sigstore OIDC token → crates.io `trusted_publishing` endpoint → `cargo publish`. Phase 11 generates a tokio async bridge shim: Rust functions returning `impl Future<Output=T>` get a `tokio::runtime::Builder::new_current_thread` singleton and a `block_on` wrapper. Phase 12 adds a monomorphisation pipeline for generic Rust functions. Phase 13 adds an embedded / `no_std` subset validator: verifies that all used crate features are `no_std`-compatible before generating a bridge targeting embedded or WASM runtimes.
+
+---
+
+## 16. Swift package bridge: MEP-69 (Spec + Research)
+
+MEP-69 ships the full specification and a 12-note research bundle for the Swift Package Manager bridge. The implementation is planned across 18 phases (tracking issue open).
+
+The spec covers `.swiftinterface` ingest (parsing Swift's stable binary interface format, equivalent to Go's `go doc -json`), `@_cdecl`-exported C wrappers for calling Swift functions from CGO, `DispatchGroup` + `Task` async bridging, dual git-tag / SE-0292 package registry publish, and the `package3/swift/` skeleton directory structure.
+
+---
+
+## 17. TypeScript/JavaScript bridge: MEP-72 (Spec + Research)
+
+MEP-72 ships the full specification and a research bundle for the bidirectional TypeScript/JavaScript package bridge, covering npm registry ingest, TypeScript declaration file (`.d.ts`) parsing, Node.js N-API and NAPI-RS binding synthesis, dual CommonJS/ESM module emit, and `package3/typescript/` skeleton.
+
+---
+
+## 18. Infrastructure
+
+- **Cloudflare Pages migration.** The documentation site (`docs.mochi-lang.dev`) now deploys via Cloudflare Pages instead of GitHub Pages, with zero-downtime deployments and automatic branch previews.
+- **Go transpiler lower stubs.** `transpiler3/go/lower` now covers all `aotir` node types through stub or full implementations. `copySiblingGoFiles` correctly propagates companion `.go` source files for Go FFI fixtures.
+- **Async/datalog lowering fix.** `lowerAsyncExpr` now emits a goroutine-backed buffered channel (`func() chan T { ch := make(chan T,1); go func(){ ch <- body }(); return ch }()`). `lowerAwaitExpr` emits `<-ch`. The `DatalogQueryExpr` dispatch case is now wired in `expr.go`.
+- **`package3/dotnet/` build fixes.** `errors.go` skip-reason constants (`SkipPointer`, `SkipRefType`, `SkipDelegate`, `SkipSpan`, `SkipValueTask`), `semver.go` deduplication, `nuget.Client` exported fields, and `build.Driver` type were all corrected after the MEP-68 merge.
+- **C transpiler operator precedence.** `chain_arith` expected output corrected to 7 (standard left-to-right precedence), matching the vm3 interpreter's behavior.
+
+---
+
+## 19. Compatibility
+
+v0.16.0 is fully additive. All existing Mochi programs continue to run under vm3 with `mochi run`. Every existing `--target` flag is unchanged:
+
+- `mochi build --target=c-aot` (MEP-45)
+- `mochi build --target=beam-escript` (MEP-46)
+- `mochi build --target=jvm-uberjar` (MEP-47)
+- `mochi build --target=dotnet-fx-dependent` (MEP-48)
+- `mochi build --target=swift-macos` (MEP-49, now Final)
+
+New targets added in this release: `--target=php`, `--target=ruby`, `--target=rust`, `--target=typescript`, `--target=javascript`, `--target=swift-ios`, `--target=swift-static-linux`, `--target=swift-appstore`, `--target=rubygem`, `--target=ruby-bundle`, `--target=iruby-kernel`, `--target=tebako`, `--target=truffleruby-native`, `--target=mruby`.
+
+Minimum toolchain requirements for new targets: PHP 8.3+, Ruby 3.3+, Rust 1.78+ (`cargo`), TypeScript 5.4+ (`tsc`), Swift 6.0+.
+
+---
+
+## 20. Upgrade
+
+```sh
+curl -fsSL https://get.mochi-lang.dev | sh
+mochi --version   # 0.16.0
+```
+
+Or with Docker:
+
+```sh
+docker pull ghcr.io/mochilang/mochi:0.16.0
+```
+
+Or from source:
+
+```sh
+git pull && make build
+```
+
+Pre-built binaries for all five tier-1 triples (linux/amd64, linux/arm64, darwin/arm64, darwin/amd64, windows/amd64) are available on the [GitHub release page](https://github.com/mochilang/mochi/releases/tag/v0.16.0).


### PR DESCRIPTION
Closes #23040

## Summary

Rewrites `website/docs/releases/v0.16.0.md` from a draft that covered only MEP-49 into the full v0.16.0 release notes covering everything that shipped since v0.15.0.

**Release scale:** 605 commits · 243 PRs · +262,082 lines across 4,642 files

### What's covered

| Section | Content |
|---|---|
| Release metrics | Commit/PR/line counts, MEP and target tallies |
| §1 MEP-49 Swift | Final — all 18 phases, per-phase detail |
| §2 MEP-55 PHP | Final — all 18 phases, per-phase detail |
| §3 MEP-56 Ruby | Final — all 28 phases (0-27), per-phase detail, 7 distribution targets |
| §4 MEP-53 Rust | Phases 0-6 — scalars, collections, records, sums, closures |
| §5 MEP-52 TypeScript | Phases 2-6 — scalars, lists, maps, sets, records, sums, closures |
| §6 MEP-54 Go | Phases 2-6 — scalars, lists, maps, sets, records, sums, top-level fns |
| §7 MEP-71 Python bridge | Final — all 18 phases, type-mapping table, publish, attestation |
| §8 MEP-70 Kotlin bridge | Final — all 14 phases, GraalVM, coroutines, KMP |
| §9 MEP-66 Erlang bridge | Final — all 13 phases, BEAM ingest, Dialyzer mapping, C-node |
| §10 MEP-74 Go bridge | Final — all 18 phases, CGO wrapper, goroutine bridge, TinyGo |
| §11 MEP-76 Ruby bridge | Final — all 12 phases, trusted publish, native ext detection |
| §12 MEP-67 Java bridge | Phases 0-15 — JNI, Maven Central, Sigstore, generics |
| §13 MEP-68 .NET bridge | Phases 0-13 — NuGet, CLR hosting, NativeAOT, async bridge |
| §14 MEP-75 PHP bridge | Phases 0-14 — Packagist, Phar, async, 24-package corpus |
| §15 MEP-73 Rust bridge | Phases 8-13 — crates.io publish, tokio async, no_std |
| §16 MEP-69 Swift bridge | Spec + research bundle |
| §17 MEP-72 TS/JS bridge | Spec + research bundle |
| §18 Infrastructure | Cloudflare Pages, async/datalog lowering fix, dotnet build fixes |
| §19 Compatibility | All existing targets unchanged; 14 new targets listed |
| §20 Upgrade | Install instructions (script, Docker, source) |

## Test plan

- [ ] Docs-only change — no code modified
- [ ] Markdown renders correctly in local Docusaurus preview